### PR TITLE
Dockerize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,14 @@ cache:
 language: java
 
 jdk:
-  - oraclejdk8
-  - openjdk8
+- oraclejdk8
+- openjdk8
+
+services:
+- docker
+
+deploy:
+  provider: script
+  script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin && ./gradlew dockerPush
+  on:
+    branch: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ cache:
 language: java
 
 jdk:
-- oraclejdk8
-- openjdk8
+  - oraclejdk8
+  - openjdk8
 
 services:
 - docker
@@ -19,4 +19,4 @@ deploy:
   provider: script
   script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin && ./gradlew dockerPush
   on:
-    branch: docker
+    branch: develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8-jdk-alpine
+VOLUME /tmp
+ARG DEPENDENCY=target/dependency
+COPY ${DEPENDENCY}/BOOT-INF/lib /app/lib
+COPY ${DEPENDENCY}/META-INF /app/META-INF
+COPY ${DEPENDENCY}/BOOT-INF/classes /app
+ENTRYPOINT ["java","-cp","app:app/lib/*","bio.terra.Main"]

--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,15 @@ buildscript {
     }
 }
 
+plugins {
+  id "com.palantir.docker" version "0.20.1"
+}
+
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
+apply plugin: 'com.palantir.docker'
 
 group 'bio.terra'
 version '0.1'
@@ -87,6 +92,12 @@ task generateApi {
     }
 }
 
+task unpack(type: Copy) {
+    dependsOn bootJar
+    from(zipTree(tasks.bootJar.outputs.files.singleFile))
+    into("build/dependency")
+}
+
 clean.doFirst {
     delete("${projectDir}/$openapiTargetFolder")
 }
@@ -111,6 +122,12 @@ bootRun {
 
 jar {
     from sourceSets.generated.output
+}
+
+docker {
+    name "${project.group}/${bootJar.baseName}"
+    copySpec.from(tasks.unpack.outputs).into("dependency")
+    buildArgs(['DEPENDENCY': "dependency"])
 }
 
 compileGeneratedJava.dependsOn generateApi

--- a/build.gradle
+++ b/build.gradle
@@ -133,9 +133,18 @@ def getGitHash = { ->
     return stdout.toString().trim()
 }
 
+def getGitBranch = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 // was ${project.group} here, can we make a bio.terra org in docker hub?
 docker {
-    name "jhert/${bootJar.baseName}:${getGitHash()}"
+    name "jhert/${bootJar.baseName}:${getGitBranch()}-${getGitHash()}"
     copySpec.from(tasks.unpack.outputs).into("dependency")
     buildArgs(['DEPENDENCY': "dependency"])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -133,18 +133,9 @@ def getGitHash = { ->
     return stdout.toString().trim()
 }
 
-def getGitBranch = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
-}
-
-// was ${project.group} here, can we make a bio.terra org in docker hub?
+// TODO: don't have access to broadinstitute to create a repository, or is there a better place?
 docker {
-    name "jhert/${bootJar.baseName}:${getGitBranch()}-${getGitHash()}"
+    name "jhert/${bootJar.baseName}:${getGitHash()}"
     copySpec.from(tasks.unpack.outputs).into("dependency")
     buildArgs(['DEPENDENCY': "dependency"])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -124,8 +124,18 @@ jar {
     from sourceSets.generated.output
 }
 
+def getGitHash = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+// was ${project.group} here, can we make a bio.terra org in docker hub?
 docker {
-    name "${project.group}/${bootJar.baseName}"
+    name "jhert/${bootJar.baseName}:${getGitHash()}"
     copySpec.from(tasks.unpack.outputs).into("dependency")
     buildArgs(['DEPENDENCY': "dependency"])
 }


### PR DESCRIPTION
This PR does a few things related to docker:

- adds a Dockerfile following the Spring Boot documentation
- adds build steps in gradle to build a docker image and to push an image to a repository
- adds a deployment configuration for TravisCI that pushes an image to Docker Hub when the `develop` branch is updated.

This isn't ready to merge yet. It is configured to push to the `jade-data-repo` repository under my Docker Hub user account `jhert`. Travis is able to do this because I have provided my Docker Hub login credentials to TravisCI in the Repository Settings following their recommendations:

https://docs.travis-ci.com/user/docker/#pushing-a-docker-image-to-a-registry

> The best way to define an environment variable depends on what type of information it will contain, and when you need to change it:
> ...
> if it does contain sensitive information, but is the same for all branches – add it to your Repository Settings

I don't think this should be tied to my account or my credentials, so we'll need to figure out where the repo should go and how we authenticate with docker hub. AllOfUs looks like it uses a service account to deploy from CircleCI. Any reasons to not follow this approach?

While figuring that out I'd like a review of the different steps here and to see if how this looks from a security standpoint. 