### PR TITLE
Add generic application context to stairway and flight constructors

### DIFF
--- a/src/main/java/bio/terra/stairway/Flight.java
+++ b/src/main/java/bio/terra/stairway/Flight.java
@@ -32,14 +32,20 @@ public class Flight implements Callable<FlightResult> {
     private List<StepRetry> steps;
     private Database database;
     private FlightContext flightContext;
+    private Object applicationContext;
 
-    public Flight(FlightMap inputParameters) {
+    public Flight(FlightMap inputParameters, Object applicationContext) {
         flightContext = new FlightContext(inputParameters, this.getClass().getName());
+        this.applicationContext = applicationContext;
         steps = new LinkedList<>();
     }
 
     public FlightContext context() {
         return flightContext;
+    }
+
+    public Object getApplicationContext() {
+        return applicationContext;
     }
 
     public void setDatabase(Database database) {

--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -48,9 +48,10 @@ public class Stairway {
     private ExecutorService threadPool;
     private DataSource dataSource;
     private Database database;
+    private Object applicationContext;
 
     public Stairway(ExecutorService threadPool) {
-        this(threadPool, null, true);
+        this(threadPool, null, true, null);
     }
 
     /**
@@ -63,9 +64,11 @@ public class Stairway {
      */
     public Stairway(ExecutorService threadPool,
                     DataSource dataSource,
-                    boolean forceCleanStart) {
+                    boolean forceCleanStart,
+                    Object applicationContext) {
         this.threadPool = threadPool;
         this.dataSource = dataSource;
+        this.applicationContext = applicationContext;
         this.taskContextMap = new ConcurrentHashMap<>();
         this.database = new Database(dataSource, forceCleanStart);
         if (!forceCleanStart) {
@@ -188,8 +191,8 @@ public class Stairway {
         try {
             // Find the flightClass constructor that takes the input parameter map and
             // use it to make the flight.
-            Constructor constructor = flightClass.getConstructor(FlightMap.class);
-            Flight flight = (Flight)constructor.newInstance(inputParameters);
+            Constructor constructor = flightClass.getConstructor(FlightMap.class, Object.class);
+            Flight flight = (Flight)constructor.newInstance(inputParameters, applicationContext);
             return flight;
         } catch (InvocationTargetException |
                 NoSuchMethodException |
@@ -229,6 +232,7 @@ public class Stairway {
                 .append("threadPool", threadPool)
                 .append("dataSource", dataSource)
                 .append("database", database)
+                .append("applicationContext", applicationContext)
                 .toString();
     }
 }

--- a/src/test/java/bio/terra/stairway/FlightTest.java
+++ b/src/test/java/bio/terra/stairway/FlightTest.java
@@ -8,7 +8,7 @@ public class FlightTest {
     @Test(expected = StairwayExecutionException.class)
     public void testInvalidStepIndex() {
         FlightMap sham = new FlightMap();
-        Flight flight = new Flight(sham);
+        Flight flight = new Flight(sham, null);
         flight.context().setStepIndex(-5);
         flight.call();
     }

--- a/src/test/java/bio/terra/stairway/RecoveryTest.java
+++ b/src/test/java/bio/terra/stairway/RecoveryTest.java
@@ -92,7 +92,7 @@ public class RecoveryTest {
     @Test
     public void successTest() throws Exception {
         // Start with a clean and shiny database environment.
-        Stairway stairway1 = new Stairway(executorService, dataSource, true);
+        Stairway stairway1 = new Stairway(executorService, dataSource, true, null);
 
         FlightMap inputs = new FlightMap();
         Integer initialValue = Integer.valueOf(0);
@@ -112,7 +112,7 @@ public class RecoveryTest {
 
         // Simulate a restart with a new thread pool and stairway. Set control so this one does not sleep
         TestStopController.setControl(1);
-        Stairway stairway2 = new Stairway(executorService, dataSource, false);
+        Stairway stairway2 = new Stairway(executorService, dataSource, false, null);
 
         // Wait for recovery to complete
         FlightResult result = stairway2.getResult(flightId);
@@ -124,7 +124,7 @@ public class RecoveryTest {
     @Test
     public void undoTest() throws Exception {
         // Start with a clean and shiny database environment.
-        Stairway stairway1 = new Stairway(executorService, dataSource, true);
+        Stairway stairway1 = new Stairway(executorService, dataSource, true, null);
 
         FlightMap inputs = new FlightMap();
         Integer initialValue = Integer.valueOf(2);
@@ -145,7 +145,7 @@ public class RecoveryTest {
 
         // Simulate a restart with a new thread pool and stairway. Reset control so this one does not sleep
         TestStopController.setControl(1);
-        Stairway stairway2 = new Stairway(executorService, dataSource, false);
+        Stairway stairway2 = new Stairway(executorService, dataSource, false, null);
 
         // Wait for recovery to complete
         FlightResult result = stairway2.getResult(flightId);

--- a/src/test/java/bio/terra/stairway/TestFlight.java
+++ b/src/test/java/bio/terra/stairway/TestFlight.java
@@ -2,8 +2,8 @@ package bio.terra.stairway;
 
 public class TestFlight extends Flight {
 
-    public TestFlight(FlightMap inputParameters) {
-        super(inputParameters);
+    public TestFlight(FlightMap inputParameters, Object applicationContext) {
+        super(inputParameters, applicationContext);
 
         // Pull out our parameters and feed them in to the step classes.
         String filename = inputParameters.get("filename", String.class);

--- a/src/test/java/bio/terra/stairway/TestFlightRecovery.java
+++ b/src/test/java/bio/terra/stairway/TestFlightRecovery.java
@@ -2,8 +2,8 @@ package bio.terra.stairway;
 
 public class TestFlightRecovery extends Flight {
 
-    public TestFlightRecovery(FlightMap inputParameters) {
-        super(inputParameters);
+    public TestFlightRecovery(FlightMap inputParameters, Object applicationContext) {
+        super(inputParameters, applicationContext);
 
         // Step 1 - increment
         addStep(new TestStepIncrement());

--- a/src/test/java/bio/terra/stairway/TestFlightRecoveryUndo.java
+++ b/src/test/java/bio/terra/stairway/TestFlightRecoveryUndo.java
@@ -2,8 +2,8 @@ package bio.terra.stairway;
 
 public class TestFlightRecoveryUndo extends Flight {
 
-    public TestFlightRecoveryUndo(FlightMap inputParameters) {
-        super(inputParameters);
+    public TestFlightRecoveryUndo(FlightMap inputParameters, Object applicationContext) {
+        super(inputParameters, applicationContext);
 
         // Step 0 - increment
         addStep(new TestStepIncrement());

--- a/src/test/java/bio/terra/stairway/TestFlightRetry.java
+++ b/src/test/java/bio/terra/stairway/TestFlightRetry.java
@@ -4,8 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 
 public class TestFlightRetry extends Flight {
 
-    public TestFlightRetry(FlightMap inputParameters) {
-        super(inputParameters);
+    public TestFlightRetry(FlightMap inputParameters, Object applicationContext) {
+        super(inputParameters, applicationContext);
 
         RetryRule retryRule;
 

--- a/src/test/java/bio/terra/stairway/TestFlightUndo.java
+++ b/src/test/java/bio/terra/stairway/TestFlightUndo.java
@@ -2,8 +2,8 @@ package bio.terra.stairway;
 
 public class TestFlightUndo extends Flight {
 
-    public TestFlightUndo(FlightMap inputParameters) {
-        super(inputParameters);
+    public TestFlightUndo(FlightMap inputParameters, Object applicationContext) {
+        super(inputParameters, applicationContext);
 
         // Pull out our parameters and feed them in to the step classes.
         String filename = inputParameters.get("filename", String.class);


### PR DESCRIPTION
Jeremy noticed that there is no way to pass application context into flights. Everything had to go through inputParameters and would get serialized. That does not make sense for passing in things like singleton DAO classes or other beans.

This PR adds an Object parameter called applicationContext to the Stairway constructor and to the Flight constructor. When you construct a Stairway, you pass some object as the application context. When Stairway constructs Flights, it passes the input parameters and the application context in to the flight.

We have some alternatives for what to pass as application context. One choice is to pass the Spring application context will would allow resolve-by-name for all beans in the application. That seems like overkill (and it is an ugly interface). I think we'd do better to make an object that is a collection of what our flights need and pass that.

An alternate implementation would be to make Stairway generic and provide the class type of the context. That makes handling the Flight creation complicated, so if you all are OK with it, we can just cast the Object in the Flight constructors.
