### PR TITLE
DR-117: Implement credential generation and testConnected in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ services:
 
 before_script:
   - psql -U postgres -f db/create-data-repo-db
+  - scripts/make_service_account_credentials.sh /tmp/sacreds.json
+  - export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sacreds.json
+
+script:
+  - ./gradlew check
+  - ./gradlew testConnected
 
 deploy:
   provider: script

--- a/scripts/make_service_account_credentials.sh
+++ b/scripts/make_service_account_credentials.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Precondition: env var SERVICE_ACCOUNT_PK is set with the private key of the
+# travis-access service account.
+#
+# This script generates the full credential file for GCP filling in the private
+# key on th eway.
+#
+# $1 - output file
+#
+
+outfile=$1
+
+if [ -z "$outfile" ]; then
+    echo "ERROR: No output file specified"
+    exit 1
+fi
+
+if [ -z "$SERVICE_ACCOUNT_PK" ]; then
+    echo "ERROR: Environment variable SERVICE_ACCOUNT_PK is undefined"
+    exit 1
+fi
+
+cat > $outfile <<EOF
+{
+  "type": "service_account",
+  "project_id": "broad-jade-dev",
+  "private_key_id": "7ec01cc1fb49293f082dc6eee2fa4f0479e2f305",
+  "private_key": "$SERVICE_ACCOUNT_PK",
+  "client_email": "travis-access@broad-jade-dev.iam.gserviceaccount.com",
+  "client_id": "102180013040579229956",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/travis-access%40broad-jade-dev.iam.gserviceaccount.com"
+}
+EOF

--- a/scripts/test.json
+++ b/scripts/test.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "broad-jade-dev",
+  "private_key_id": "7ec01cc1fb49293f082dc6eee2fa4f0479e2f305",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDeyZKnTYyCBSHz\nPBQrLyQ3izGle8WEVSe9Tg7xDZjVNvvN36N/F10bWAV0St1SULRpInZlUNXWMQ3l\n+Kx5bqxgjISAgcwKe7lWDXIQo3ls8Fmej+80S22PZWiPZwsMM679+hZHy/U0yA+i\nxUlYOKnJmmWBR+8l8EOE1Lp2cTTvu0KcY7YhF8vdOy4tFpYkxvbhlZnASx0iLXbA\nEkYx5DBMBTQS5jEiK45VFi2aOEKPidBJS6sbFrV9VmP2EIWIBZni9ZNBHdAZX9/7\n4rTM/BXHl1O0HOYGzuMm/BvvJpRzt9JXp52XkXohwVFJ+RyJE0Z9A6c+RrXUejbH\nQLfsPN8VAgMBAAECggEAD9buBdYWJNJfmQ8O8gkOfqJ3W6gioWd6hVOM7WeFk7cu\njPMXCTysgnquHJgMB0O0p/rqxwZJxcpEDjMxdArB17V14DsaOi6UvUEEeJle0zd9\nb7AVFjc8qWLQ3c06NFpiWS1UMzOVkfSdY/m53rtcmvhOujPWlXBxJHsJbM1csaSR\nMvytNrNlhEngTDiaUxgkGri17QizRsDbEQv0NT/VyULbbaNkgYH3Xa4/ubX+E083\n5axwTN5WfqiNwOFlLjj1MfmdICbHsjpvr2wx3gyW4vjRtxdFaTcaLaOp7Kb0nkpO\nVMQcP7QjKTjdPrA4d2Pf3wNbmCMSReUfKAnGv6r1awKBgQD8rfwXxFDnqRm8wKsE\n4FDKGHCWWsYYsIN4jKurjFBQ/G2MQsiP2xCEqUp2ztEacK+QLRP1Lam1uWL3hvk1\nKGuup66lkONiltQ5lO7NVVe5c1VfJeRcEjZRebnQ8v/kQBBV0iqbht817SQL+Mcp\ncA05C/slgnteC/4nYhcRAxJUAwKBgQDhtwfRKZ7MtLol9LxNLx5lG7taRevZz9qg\nSJtqltnWn/bGvsqiBmLTaIN4mlsNyXUQdFNK8H6yoLQGoYTrP0K0KAfSlnA5UKa9\nrXoOMA48isaZ7ziJ7cFJXEipocBfUHmolKC/KBuRvFiRdpWv+wjJBJ78VfqD4CSJ\nFPOn/DgxBwKBgQD429pnBgCwyIkCr7c/zDWFdWCdlLV55470kYcaI82Ola7G75dc\np2KzZZBjRvoG0mj21I7NcLWutvFT3GlhA3haweduRS7OEMLgG2C+dok5qu+wED/C\ntmUtBXgO5OVFxhrQi3dPShxYnkBcUh7FHwjG4Jfvr30VeTZNT3xsUtwgRQKBgFau\nQ4I/yYwzm4kYA3hgr/uEOt7gG0L6X6tONuEoLWAO7mZEvuyaJzmo2VRncrBIvXwk\nMBiHYyCWNoyVWsY89RDajqaAv3hDUMVm6YipS85UPRDAnaXaeHAD0KPUSlxQO2hS\nK6k9bdj5y8mREMsUTLtl2uhs3FforB84vJm2cp3hAoGASky8Z4GTCG+OTAav34oo\nuZwBWuxWwCU/DdqomPOfXvd74rgB0Oh79/bL97ryfLJz6PTwHjNEMIkd25MjNjmM\nf8Iz76JiqzBKAulWnmGGqRt36RktG+AsGi74pPIV6GoNyYVEp8ejewJYRSLHUmIY\nuI8lUBCZk3IPlKKRke3fRZ8=\n-----END PRIVATE KEY-----\n",
+  "client_email": "travis-access@broad-jade-dev.iam.gserviceaccount.com",
+  "client_id": "102180013040579229956",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/travis-access%40broad-jade-dev.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
Hand-created service account for the dev account (travis-access)
Put private key from that account into travis
Added script to build the whole credentials json file injecting the private key
Run that script and explicitly run testConnected target in travis.