### PR TITLE
first pass at fixing this

### DIFF
--- a/src/main/java/bio/terra/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/configuration/ApplicationConfiguration.java
@@ -1,6 +1,7 @@
 package bio.terra.configuration;
 
 import bio.terra.stairway.Stairway;
+import bio.terra.upgrade.Migrate;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +15,8 @@ import java.util.concurrent.Executors;
 public class ApplicationConfiguration {
 
     @Bean("stairway")
-    public Stairway getStairway(StairwayJdbcConfiguration jdbcConfiguration, ApplicationContext applicationContext) {
+    public Stairway getStairway(Migrate migrate, ApplicationContext applicationContext) {
+        StairwayJdbcConfiguration jdbcConfiguration = migrate.getStairwayJdbcConfiguration();
         ExecutorService executorService = Executors.newFixedThreadPool(2);
         DataSource dataSource = jdbcConfiguration.getDataSource();
         return new Stairway(executorService, dataSource, true, applicationContext);

--- a/src/main/java/bio/terra/upgrade/Migrate.java
+++ b/src/main/java/bio/terra/upgrade/Migrate.java
@@ -48,4 +48,12 @@ public class Migrate {
             throw new MigrateException("Failed to migrate database from " + changesetFile, ex);
         }
     }
+
+    public StairwayJdbcConfiguration getStairwayJdbcConfiguration() {
+        return stairwayJdbcConfiguration;
+    }
+
+    public DataRepoJdbcConfiguration getDataRepoJdbcConfiguration() {
+        return dataRepoJdbcConfiguration;
+    }
 }


### PR DESCRIPTION
We might just want this to be a temporary fix. If there is 1 way for modules to get stairway or datarepo jdbc configurations that ensures that migrations are run before the configurations are used, it should prevent the issue that we are running into. 

Stairway is trying to use the flight table before it is created because the modules are loading in the wrong order. There doesn't seem to be an explicit link dependency-wise between Migrate and the getStairway bean to ensure that things run in the right order.