### PR TITLE
DR-81: adds in dao methods to the StudyCreateFlight

### DIFF
--- a/src/main/java/bio/terra/dao/StudyDao.java
+++ b/src/main/java/bio/terra/dao/StudyDao.java
@@ -55,34 +55,22 @@ public class StudyDao {
     }
 
     @Transactional
-    public void delete(UUID id) {
-        jdbcTemplate.update("DELETE FROM study WHERE id = :id",
+    public boolean delete(UUID id) {
+        int rowsAffected = jdbcTemplate.update("DELETE FROM study WHERE id = :id",
                 new MapSqlParameterSource().addValue("id", id));
-
+        return rowsAffected > 0;
     }
 
-    public Study retrieve(UUID id) {
-        Study study = jdbcTemplate.queryForObject(
-                "SELECT id, name, description, created_date FROM study WHERE id = :id",
-                //this is a hack for check style. if the lambda params are on the next line it fails indentation check
-                new MapSqlParameterSource().addValue("id", id), (
-                        rs, rowNum) -> new Study()
-                        .setId(UUID.fromString(rs.getString("id")))
-                        .setName(rs.getString("name"))
-                        .setDescription(rs.getString("description"))
-                        .setCreatedDate(Instant.from(rs.getObject("created_date", OffsetDateTime.class))));
-        // needed for fix bugs. but really can't be null
-        if (study != null) {
-            tableDao.retrieve(study);
-            relationshipDao.retrieve(study);
-            assetDao.retrieve(study);
-        }
-        return study;
+    @Transactional
+    public boolean deleteByName(String studyName) {
+        int rowsAffected = jdbcTemplate.update("DELETE FROM study WHERE name = :name",
+                new MapSqlParameterSource().addValue("name", studyName));
+        return rowsAffected > 0;
     }
 
-    public Optional<Study> retrieveByName(String studyName) {
-        String sql = "SELECT id, name, description, created_date FROM study WHERE name = :name";
-        MapSqlParameterSource params = new MapSqlParameterSource().addValue("name", studyName);
+    public Optional<Study> retrieve(UUID id) {
+        String sql = "SELECT id, name, description, created_date FROM study WHERE id = :id";
+        MapSqlParameterSource params = new MapSqlParameterSource().addValue("id", id);
         try {
             Study study = jdbcTemplate.queryForObject(sql, params, (rs, rowNum) ->
                     new Study()

--- a/src/main/java/bio/terra/flight/study/create/CreateStudyMetadataStep.java
+++ b/src/main/java/bio/terra/flight/study/create/CreateStudyMetadataStep.java
@@ -10,8 +10,6 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 
-import java.util.Optional;
-
 public class CreateStudyMetadataStep implements Step {
 
     private StudyDao studyDao;
@@ -37,10 +35,7 @@ public class CreateStudyMetadataStep implements Step {
         FlightMap inputParameters = context.getInputParameters();
         StudyRequestModel studyRequest = inputParameters.get("request", StudyRequestModel.class);
         String studyName = studyRequest.getName();
-        Optional<Study> study = studyDao.retrieveByName(studyName);
-        if (study.isPresent()) {
-            studyDao.delete(study.get().getId());
-        }
+        studyDao.deleteByName(studyName);
         return StepResult.getStepResultSuccess();
     }
 }

--- a/src/test/java/bio/terra/dao/DaoTest.java
+++ b/src/test/java/bio/terra/dao/DaoTest.java
@@ -49,7 +49,7 @@ public class DaoTest {
             studyRequest.setName(studyRequest.getName() + UUID.randomUUID().toString());
             study = StudyJsonConversion.studyRequestToStudy(studyRequest);
             studyId = studyDao.create(study);
-            fromDB = studyDao.retrieve(studyId);
+            fromDB = studyDao.retrieve(studyId).get();
         }
     }
 


### PR DESCRIPTION
This updates the flight, repo metadata step, and tests. For the undo I needed to add a new `retreiveByName` method to the StudyDao that mimics the behavior from `retrieve` but uses the study name instead of an id.