### PR TITLE
DR-135 Move stairway forceClean control to application properties

### DIFF
--- a/src/main/java/bio/terra/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/configuration/ApplicationConfiguration.java
@@ -2,6 +2,7 @@ package bio.terra.configuration;
 
 import bio.terra.stairway.Stairway;
 import bio.terra.upgrade.Migrate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,15 +15,16 @@ import java.util.concurrent.Executors;
 @Configuration
 public class ApplicationConfiguration {
 
+    @Value("db.stairway.forceClean")
+    private String stairwayForceClean;
+
     @Bean("stairway")
     public Stairway getStairway(Migrate migrate, ApplicationContext applicationContext) {
         StairwayJdbcConfiguration jdbcConfiguration = migrate.getStairwayJdbcConfiguration();
         ExecutorService executorService = Executors.newFixedThreadPool(2);
         DataSource dataSource = jdbcConfiguration.getDataSource();
-        // TODO: this magic "true" here is forcing clean starts from stairway. I find it useful now at this stage,
-        // but think we should drive it from configuration based on environment (always do it locally and in dev, not
-        // in staging or prod).
-        return new Stairway(executorService, dataSource, true, applicationContext);
+        boolean forceClean = Boolean.parseBoolean(stairwayForceClean);
+        return new Stairway(executorService, dataSource, forceClean, applicationContext);
     }
 
     @Bean("jdbcTemplate")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,4 +11,5 @@ db.stairway.uri=jdbc:postgresql://127.0.0.1:5432/stairway
 db.stairway.username=drmanager
 db.stairway.password=drpasswd
 db.stairway.changesetFile=src/main/resources/db.stairway/changelog.xml
+db.stairway.forceClean=true
 spring.profiles.active=bigquery

--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -24,7 +24,7 @@ appender("File-Appender", FileAppender) {
 
 // You can set different logging configuration. This would set all loggers in the Stairway
 // package to log at debug level.
-logger("bio.terra.stairway", DEBUG)
+// logger("bio.terra.stairway", DEBUG)
 
 // root sets the default logging level and appenders
 root(INFO, ["Console-Appender", "File-Appender"])


### PR DESCRIPTION
Small PR to add an application property and plumb it in to the stairway bean so we have
control for initializing the stairway database.