### PR TITLE
DR-103 dataset migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ hs_err_pid*
 
 # IntelliJ files *
 .idea/
+*.iml
 
 # build results
 out/

--- a/src/main/java/bio/terra/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/configuration/ApplicationConfiguration.java
@@ -2,6 +2,8 @@ package bio.terra.configuration;
 
 import bio.terra.stairway.Stairway;
 import bio.terra.upgrade.Migrate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -14,8 +16,10 @@ import java.util.concurrent.Executors;
 
 @Configuration
 public class ApplicationConfiguration {
+    private Logger logger = LoggerFactory.getLogger("bio.terra.configuration.ApplicationConfiguration");
 
-    @Value("db.stairway.forceClean")
+
+    @Value("${db.stairway.forceClean}")
     private String stairwayForceClean;
 
     @Bean("stairway")
@@ -24,6 +28,8 @@ public class ApplicationConfiguration {
         ExecutorService executorService = Executors.newFixedThreadPool(2);
         DataSource dataSource = jdbcConfiguration.getDataSource();
         boolean forceClean = Boolean.parseBoolean(stairwayForceClean);
+        logger.debug("ApplicationConfiguration stairwayForceClean is '" + stairwayForceClean +
+                "'; forceClean is " + forceClean);
         return new Stairway(executorService, dataSource, forceClean, applicationContext);
     }
 

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -308,6 +308,7 @@ paths:
       - $ref: '#/parameters/Id'
       responses: ## successful responses return the type of model specified by the job
         default:
+          description: Successful responses return the type of model specified by the job; otherwise, ErrorModel
           schema:
             type: object
 
@@ -548,53 +549,18 @@ definitions:
 
   ## Dataset Definitions ##
 
-  DatasetModel:
-    description: |
-      complete dataset
-      Schema is the shape of the resulting dataset: the table names and columns in the
-      tables. The datatypes are derived from the underlying data.
-      DatasetData provides the rows from the asset that are to be included in the
-      dataset. DatasetMapping instructs how to map columns from tables on the columns
-      in the dataset schema.
-    type: object
-    required:
-      - id
-      - name
-      - tables
-      - source
-      - createdDate
-    properties:
-      id:
-        $ref: '#/definitions/UniqueIdProperty'
-      name:
-        $ref: '#/definitions/ObjectNameProperty'
-      description:
-        type: string
-        description: Description of the dataset
-      tables:
-        type: array
-        items:
-          $ref: '#/definitions/TableModel'
-      source:
-        type: array
-        items:
-          $ref: '#/definitions/DatasetSourceModel'
-      createdDate:
-        type: string
-        description: Date the dataset was created
-
   DatasetRequestModel:
     description: |
-      complete dataset save the dataset id, for dataset creation
-      Schema is the shape of the resulting dataset: the table names and columns in the
-      tables. The datatypes are derived from the underlying data.
-      DatasetData provides the rows from the asset that are to be included in the
-      dataset. DatasetMapping instructs how to map columns from tables on the columns
-      in the dataset schema.
+      Request for creating a dataset.
+      For now, the API only supports datasets defined as a single study asset and
+      row ids for the root table of that asset. The dataset has exactly the tables
+      and columns of the asset.
+      In the future, we will need to extend this to handle cross-study datasets
+      from disparate assets, so we will need to support column and datatype
+      mapping from asset tables to the target dataset tables.
     type: object
     required:
       - name
-      - tables
       - source
     properties:
       name:
@@ -602,14 +568,32 @@ definitions:
       description:
         type: string
         description: Description of the dataset
-      tables:
-        type: array
-        items:
-          $ref: '#/definitions/TableModel'
       source:
         type: array
         items:
-          $ref: '#/definitions/DatasetSourceModel'
+          $ref: '#/definitions/DatasetRequestSourceModel'
+
+  DatasetRequestSourceModel:
+    description: |
+      The datasource identifies the study and asset from which to source the data.
+      It specifies a field name and a set of values used to identify the rows to include.
+    type: object
+    required:
+      - studyName
+      - assetName
+      - fieldName
+      - rows
+    properties:
+      studyName:
+        $ref: '#/definitions/ObjectNameProperty'
+      assetName:
+        $ref: '#/definitions/ObjectNameProperty'
+      fieldName:
+        $ref: '#/definitions/ObjectNameProperty'
+      values:
+        type: array
+        items:
+          type: string
 
   DatasetSummaryModel:
     description: |
@@ -630,62 +614,46 @@ definitions:
         type: string
         description: Date the dataset was created
 
+  DatasetModel:
+    description: |
+      DatasetModel returns detailed data about an existing dataset.
+    type: object
+    required:
+      - id
+      - name
+      - source
+      - createdDate
+    properties:
+      id:
+        $ref: '#/definitions/UniqueIdProperty'
+      name:
+        $ref: '#/definitions/ObjectNameProperty'
+      description:
+        type: string
+        description: Description of the dataset
+      createdDate:
+        type: string
+        description: Date the dataset was created
+      source:
+        type: array
+        items:
+          $ref: '#/definitions/DatasetSourceModel'
+      tables:
+        type: array
+        items:
+          $ref: '#/definitions/TableModel'
+
   DatasetSourceModel:
     description: |
-      The datasource identifies the study from which to source the data and how to map that data into the
-      dataset schema. If the dataset is immutable, then you must provide the asset of the study to use and the set
-      of row ids of the root table of that asset to include in the dataset. If the dataset is passthru, then you
-      must not specify an asset or rows.
+      DatasetSourceModel returns data about the source for an existing dataset
     type: object
     required:
       - study
-      - mapping
+      - asset
     properties:
       study:
-        $ref: '#/definitions/ObjectNameProperty'
+        $ref: '#/definitions/StudySummaryModel'
       asset:
-        $ref: '#/definitions/ObjectNameProperty'
-      rows:
-        type: array
-        items:
-          type: string
-      mapping:
-        type: array
-        items:
-          $ref: '#/definitions/DatasetMappingModel'
-
-  DatasetMappingModel:
-    description: |
-      Mapping of asset table and columns to target dataset table and columns. The from_table is a table
-      in the asset. The to_table has to be the name of a table in the dataset schema. And, perhaps
-      obviously, the columns have to be valid references in their appropriate tables. The DR Manager computes the
-      datatype of the target column based on the source columns. If no mapping is specified for a dataset table,
-      then we match by table name and column name. That allows no specification for the typical case where the
-      names all match and all columns are included.
-    type: object
-    required:
-      - from_table
-      - to_table
-      - column_map
-    properties:
-      from_table:
-        $ref: '#/definitions/ObjectNameProperty'
-      to_table:
-        $ref: '#/definitions/ObjectNameProperty'
-      column_map:
-        type: array
-        items:
-          $ref: '#/definitions/DatasetMapColumnsModel'
-
-  DatasetMapColumnsModel:
-    description: Column to column mapping
-    required:
-      - from_column
-      - to_column
-    properties:
-      from_column:
-        $ref: '#/definitions/ObjectNameProperty'
-      to_column:
         $ref: '#/definitions/ObjectNameProperty'
 
   JobModel:
@@ -701,7 +669,7 @@ definitions:
         $ref: '#/definitions/UniqueIdProperty'
       description:
         type: string
-        description: Description of the job's flight # from description flight input parameter
+        description: Description of the job's flight from description flight input parameter
       job_status:
         description: Status of job
         type: string

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -308,7 +308,6 @@ paths:
       - $ref: '#/parameters/Id'
       responses: ## successful responses return the type of model specified by the job
         default:
-          description: Successful responses return the type of model specified by the job; otherwise, ErrorModel
           schema:
             type: object
 
@@ -549,18 +548,53 @@ definitions:
 
   ## Dataset Definitions ##
 
+  DatasetModel:
+    description: |
+      complete dataset
+      Schema is the shape of the resulting dataset: the table names and columns in the
+      tables. The datatypes are derived from the underlying data.
+      DatasetData provides the rows from the asset that are to be included in the
+      dataset. DatasetMapping instructs how to map columns from tables on the columns
+      in the dataset schema.
+    type: object
+    required:
+      - id
+      - name
+      - tables
+      - source
+      - createdDate
+    properties:
+      id:
+        $ref: '#/definitions/UniqueIdProperty'
+      name:
+        $ref: '#/definitions/ObjectNameProperty'
+      description:
+        type: string
+        description: Description of the dataset
+      tables:
+        type: array
+        items:
+          $ref: '#/definitions/TableModel'
+      source:
+        type: array
+        items:
+          $ref: '#/definitions/DatasetSourceModel'
+      createdDate:
+        type: string
+        description: Date the dataset was created
+
   DatasetRequestModel:
     description: |
-      Request for creating a dataset.
-      For now, the API only supports datasets defined as a single study asset and
-      row ids for the root table of that asset. The dataset has exactly the tables
-      and columns of the asset.
-      In the future, we will need to extend this to handle cross-study datasets
-      from disparate assets, so we will need to support column and datatype
-      mapping from asset tables to the target dataset tables.
+      complete dataset save the dataset id, for dataset creation
+      Schema is the shape of the resulting dataset: the table names and columns in the
+      tables. The datatypes are derived from the underlying data.
+      DatasetData provides the rows from the asset that are to be included in the
+      dataset. DatasetMapping instructs how to map columns from tables on the columns
+      in the dataset schema.
     type: object
     required:
       - name
+      - tables
       - source
     properties:
       name:
@@ -568,32 +602,14 @@ definitions:
       description:
         type: string
         description: Description of the dataset
+      tables:
+        type: array
+        items:
+          $ref: '#/definitions/TableModel'
       source:
         type: array
         items:
-          $ref: '#/definitions/DatasetRequestSourceModel'
-
-  DatasetRequestSourceModel:
-    description: |
-      The datasource identifies the study and asset from which to source the data.
-      It specifies a field name and a set of values used to identify the rows to include.
-    type: object
-    required:
-      - studyName
-      - assetName
-      - fieldName
-      - rows
-    properties:
-      studyName:
-        $ref: '#/definitions/ObjectNameProperty'
-      assetName:
-        $ref: '#/definitions/ObjectNameProperty'
-      fieldName:
-        $ref: '#/definitions/ObjectNameProperty'
-      values:
-        type: array
-        items:
-          type: string
+          $ref: '#/definitions/DatasetSourceModel'
 
   DatasetSummaryModel:
     description: |
@@ -614,46 +630,62 @@ definitions:
         type: string
         description: Date the dataset was created
 
-  DatasetModel:
-    description: |
-      DatasetModel returns detailed data about an existing dataset.
-    type: object
-    required:
-      - id
-      - name
-      - source
-      - createdDate
-    properties:
-      id:
-        $ref: '#/definitions/UniqueIdProperty'
-      name:
-        $ref: '#/definitions/ObjectNameProperty'
-      description:
-        type: string
-        description: Description of the dataset
-      createdDate:
-        type: string
-        description: Date the dataset was created
-      source:
-        type: array
-        items:
-          $ref: '#/definitions/DatasetSourceModel'
-      tables:
-        type: array
-        items:
-          $ref: '#/definitions/TableModel'
-
   DatasetSourceModel:
     description: |
-      DatasetSourceModel returns data about the source for an existing dataset
+      The datasource identifies the study from which to source the data and how to map that data into the
+      dataset schema. If the dataset is immutable, then you must provide the asset of the study to use and the set
+      of row ids of the root table of that asset to include in the dataset. If the dataset is passthru, then you
+      must not specify an asset or rows.
     type: object
     required:
       - study
-      - asset
+      - mapping
     properties:
       study:
-        $ref: '#/definitions/StudySummaryModel'
+        $ref: '#/definitions/ObjectNameProperty'
       asset:
+        $ref: '#/definitions/ObjectNameProperty'
+      rows:
+        type: array
+        items:
+          type: string
+      mapping:
+        type: array
+        items:
+          $ref: '#/definitions/DatasetMappingModel'
+
+  DatasetMappingModel:
+    description: |
+      Mapping of asset table and columns to target dataset table and columns. The from_table is a table
+      in the asset. The to_table has to be the name of a table in the dataset schema. And, perhaps
+      obviously, the columns have to be valid references in their appropriate tables. The DR Manager computes the
+      datatype of the target column based on the source columns. If no mapping is specified for a dataset table,
+      then we match by table name and column name. That allows no specification for the typical case where the
+      names all match and all columns are included.
+    type: object
+    required:
+      - from_table
+      - to_table
+      - column_map
+    properties:
+      from_table:
+        $ref: '#/definitions/ObjectNameProperty'
+      to_table:
+        $ref: '#/definitions/ObjectNameProperty'
+      column_map:
+        type: array
+        items:
+          $ref: '#/definitions/DatasetMapColumnsModel'
+
+  DatasetMapColumnsModel:
+    description: Column to column mapping
+    required:
+      - from_column
+      - to_column
+    properties:
+      from_column:
+        $ref: '#/definitions/ObjectNameProperty'
+      to_column:
         $ref: '#/definitions/ObjectNameProperty'
 
   JobModel:
@@ -669,7 +701,7 @@ definitions:
         $ref: '#/definitions/UniqueIdProperty'
       description:
         type: string
-        description: Description of the job's flight from description flight input parameter
+        description: Description of the job's flight # from description flight input parameter
       job_status:
         description: Status of job
         type: string

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -9,7 +9,9 @@
     <property name="uuid_function" value="sys_guid()" dbms="oracle"/>
 
     <property name="identifier_type" value="varchar(63)"/>
+    <property name="description_type" value="varchar(2047)"/>
 
     <include file="changesets/20181203_studytable.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20190117_createddates.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20190214_datasets.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20190214_datasets.yaml
+++ b/src/main/resources/db/changesets/20190214_datasets.yaml
@@ -1,10 +1,10 @@
 databaseChangeLog:
   - changeSet:
-      id: study_init
-      author: jhert
+      id: dataset_tables
+      author: dd
       changes:
         - createTable:
-            tableName: study
+            tableName: dataset
             columns:
               - column:
                   name: id
@@ -26,7 +26,7 @@ databaseChangeLog:
                     nullable: true
 
         - createTable:
-            tableName: study_table
+            tableName: dataset_table
             columns:
               - column:
                   name: id
@@ -36,12 +36,12 @@ databaseChangeLog:
                     primaryKey: true
                     nullable: false
               - column:
-                  name: study_id
+                  name: dataset_id
                   type: ${uuid_type}
                   constraints:
                     nullable: false
-                    foreignKeyName: fk_study_table_study
-                    references: study(id)
+                    foreignKeyName: fk_dataset_table_dataset
+                    references: dataset(id)
                     deleteCascade: true
               - column:
                   name: name
@@ -50,7 +50,7 @@ databaseChangeLog:
                     nullable: false
 
         - createTable:
-            tableName: study_column
+            tableName: dataset_column
             columns:
               - column:
                   name: id
@@ -64,8 +64,8 @@ databaseChangeLog:
                   type: ${uuid_type}
                   constraints:
                     nullable: false
-                    foreignKeyName: fk_study_column_study_table
-                    references: study_table(id)
+                    foreignKeyName: fk_dataset_column_dataset_table
+                    references: dataset_table(id)
                     deleteCascade: true
               - column:
                   name: name
@@ -75,7 +75,7 @@ databaseChangeLog:
                   type: varchar(127)
 
         - createTable:
-            tableName: study_relationship
+            tableName: dataset_source
             columns:
               - column:
                   name: id
@@ -85,63 +85,67 @@ databaseChangeLog:
                     primaryKey: true
                     nullable: false
               - column:
-                  name: name
-                  type: ${identifier_type}
-              - column:
-                  name: from_cardinality
-                  type: varchar(32)
-              - column:
-                  name: to_cardinality
-                  type: varchar(32)
-              - column:
-                  name: from_column
+                  name: dataset_id
                   type: ${uuid_type}
                   constraints:
                     nullable: false
-                    foreignKeyName: fk_study_relationship_study_column_from
-                    references: study_column(id)
+                    foreignKeyName: fk_dataset_source_dataset
+                    references: dataset(id)
                     deleteCascade: true
-              - column:
-                  name: to_column
-                  type: ${uuid_type}
-                  constraints:
-                    nullable: false
-                    foreignKeyName: fk_study_relationship_study_column_to
-                    references: study_column(id)
-                    deleteCascade: true
-
-        - createTable:
-            tableName: asset_specification
-            columns:
-              - column:
-                  name: id
-                  type: ${uuid_type}
-                  defaultValueComputed: ${uuid_function}
-                  constraints:
-                    primaryKey: true
-                    nullable: false
               - column:
                   name: study_id
                   type: ${uuid_type}
                   constraints:
                     nullable: false
-                    foreignKeyName: fk_asset_specification_study
+                    foreignKeyName: fk_dataset_source_study
                     references: study(id)
                     deleteCascade: true
               - column:
-                  name: name
-                  type: ${identifier_type}
-              - column:
-                  name: root_table_id
+                  name: asset_id
                   type: ${uuid_type}
                   constraints:
                     nullable: false
-                    foreignKeyName: fk_asset_specification_study_table
+                    foreignKeyName: fk_dataset_source_asset_specification
+                    references: asset_specification(id)
+                    deleteCascade: true
+
+        - createTable:
+            tableName: dataset_map_table
+            columns:
+              - column:
+                  name: id
+                  type: ${uuid_type}
+                  defaultValueComputed: ${uuid_function}
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: source_id
+                  type: ${uuid_type}
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_dataset_map_dataset_source
+                    references: dataset_source(id)
+                    deleteCascade: true
+              - column:
+                  name: from_table_id
+                  type: ${uuid_type}
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_dataset_map_study_table
                     references: study_table(id)
                     deleteCascade: true
+              - column:
+                  name: to_table_id
+                  type: ${uuid_type}
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_dataset_map_dataset_table
+                    references: dataset_table(id)
+                    deleteCascade: true
 
         - createTable:
-            tableName: asset_column
+            tableName: dataset_map_column
             columns:
               - column:
                   name: id
@@ -151,45 +155,26 @@ databaseChangeLog:
                     primaryKey: true
                     nullable: false
               - column:
-                  name: asset_id
+                  name: map_table_id
                   type: ${uuid_type}
                   constraints:
                     nullable: false
-                    foreignKeyName: fk_asset_column_asset_specification
-                    references: asset_specification(id)
+                    foreignKeyName: fk_dataset_map_column_dataset_map_table
+                    references: dataset_map_table(id)
                     deleteCascade: true
               - column:
-                  name: study_column_id
+                  name: from_column_id
                   type: ${uuid_type}
                   constraints:
                     nullable: false
-                    foreignKeyName: fk_asset_column_study_column
+                    foreignKeyName: fk_dataset_map_column_study_column
                     references: study_column(id)
                     deleteCascade: true
-
-        - createTable:
-            tableName: asset_relationship
-            columns:
               - column:
-                  name: id
-                  type: ${uuid_type}
-                  defaultValueComputed: ${uuid_function}
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: asset_id
+                  name: to_column_id
                   type: ${uuid_type}
                   constraints:
                     nullable: false
-                    foreignKeyName: fk_asset_relationship_asset_specification
-                    references: asset_specification(id)
-                    deleteCascade: true
-              - column:
-                  name: relationship_id
-                  type: ${uuid_type}
-                  constraints:
-                    nullable: false
-                    foreignKeyName: fk_asset_relationship_study_relationship
-                    references: study_relationship(id)
+                    foreignKeyName: fk_dataset_map_column_dataset_column
+                    references: dataset_column(id)
                     deleteCascade: true

--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -22,8 +22,8 @@ appender("File-Appender", FileAppender) {
     }
 }
 
-// You can set different logging configuration. This would set all loggers in the Stairway
-// package to log at debug level.
+// You can set different logging configuration. For example, uncommenting the next line
+// will set all loggers in the Stairway package to log at debug level:
 // logger("bio.terra.stairway", DEBUG)
 
 // root sets the default logging level and appenders


### PR DESCRIPTION
Implement the dataset tables as per the ER diagram I sent out. Changes are:
- changelog.xml - added a new type 'description_type' rather than put varchar(2047) in two places.
- 20181203_studytable.yaml - changed to use the new type. No semantic change, so doesn't affect existing databases.
- 20190214_datasets.yaml - dataset table definitions

During testing, I found a bug with how I had plumbed in the db.stairway.forceClean flag and fixed that:
 - ApplicationConfiguration.java - the fix
 - logback.groovy - clarified a comment that Rori had asked about in a previous code review

Lastly, added *.iml to the .gitignore, so it would stop complaining about that IntelliJ file showing up.