### PR TITLE
DR-169 stairway exceptions

### DIFF
--- a/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import bio.terra.exception.BadRequestException;
 import bio.terra.exception.InternalServerErrorException;
 import bio.terra.exception.NotFoundException;
 import bio.terra.model.ErrorModel;
+import bio.terra.service.exception.JobResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -46,6 +47,16 @@ public class GlobalExceptionHandler {
         return buildErrorModel(ex);
     }
 
+    // -- job response exception -- we use the JobResponseException to wrap non-runtime exceptions
+    // returned from flights. So at this level, we catch the JobResponseException and retrieve the
+    // original exception from inside it and use that to construct the error model.
+    @ExceptionHandler(JobResponseException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorModel jobResponseExceptionHandler(Exception ex) {
+        Throwable nestedException = ex.getCause();
+        return buildErrorModel(nestedException);
+    }
+
     // -- catchall - log so we can understand what we have missed in the handlers above
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -54,7 +65,7 @@ public class GlobalExceptionHandler {
         return buildErrorModel(ex);
     }
 
-    private ErrorModel buildErrorModel(Exception ex) {
+    private ErrorModel buildErrorModel(Throwable ex) {
         return new ErrorModel().message(ex.getMessage());
     }
 

--- a/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
@@ -58,7 +58,7 @@ public class GlobalExceptionHandler {
     }
 
     // -- catchall - log so we can understand what we have missed in the handlers above
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler(Throwable.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorModel catchallHandler(Exception ex) {
         logger.info("Catchall exception caught: {} of {}", ex.getClass().getName(), ex.toString());

--- a/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
@@ -58,13 +58,15 @@ public class GlobalExceptionHandler {
     }
 
     // -- catchall - log so we can understand what we have missed in the handlers above
-    @ExceptionHandler(Throwable.class)
+    @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorModel catchallHandler(Exception ex) {
         logger.info("Catchall exception caught: {} of {}", ex.getClass().getName(), ex.toString());
         return buildErrorModel(ex);
     }
 
+    // This method takes throwable so it can be shared by the JobResponseException handler:
+    // the type returned from getCause() is a Throwable.
     private ErrorModel buildErrorModel(Throwable ex) {
         return new ErrorModel().message(ex.getMessage());
     }

--- a/src/main/java/bio/terra/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/controller/RepositoryApiController.java
@@ -153,6 +153,6 @@ public class RepositoryApiController implements RepositoryApi {
 
     @Override
     public ResponseEntity<Object> retrieveJobResult(@PathVariable("id") String id) {
-        return jobService.retrieveJobResult(id);
+        return jobService.retrieveJobResultResponse(id);
     }
 }

--- a/src/main/java/bio/terra/flight/FlightUtils.java
+++ b/src/main/java/bio/terra/flight/FlightUtils.java
@@ -4,7 +4,6 @@ import bio.terra.model.ErrorModel;
 import bio.terra.service.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.FlightState;
 import org.springframework.http.HttpStatus;
 
 /**
@@ -39,69 +38,4 @@ public final class FlightUtils {
         workingMap.put(JobMapKeys.STATUS_CODE.getKeyName(), responseStatus);
     }
 
-    /**
-     *
-     * There are four cases to handle here:
-     * <ol>
-     *     <li> Flight is still running. We set the flag in the flight respponse and return.</li>
-     *     <li> Successful flight: resultMap RESPONSE is the target class</li>
-     *     <li> Failed flight: responseMap RESPONSE is an ErrorModel</li>
-     *     <li> Failed flight: no RESPONSE filled in (unhandled exception). We generate
-     *     an error response.</li>
-     * </ol>
-     * @param flightState state of a flight returned from Stairway
-     * @return FlightResponse object
-     */
-    public static FlightResponse makeFlightResponse(FlightState flightState) {
-        FlightResponse flightResponse = new FlightResponse();
-
-        if (!flightState.getCompleted().isPresent()) {
-            return flightResponse;
-        }
-
-        FlightMap resultMap = flightState.getResultMap().orElse(null);
-        if (resultMap == null) {
-            throw new IllegalStateException("No result map returned from flight");
-        }
-        HttpStatus returnedStatus = resultMap.get(JobMapKeys.STATUS_CODE.getKeyName(), HttpStatus.class);
-        Object returnedModel = resultMap.get(JobMapKeys.RESPONSE.getKeyName(), Object.class);
-
-        switch (flightState.getFlightStatus()) {
-            case FATAL:
-            case ERROR:
-                // If the flight failed without supplying a status code and response, then we generate one
-                // from the flight error. This handles the case of thrown errors that the step code does
-                // not handle.
-                if (returnedStatus == null) {
-                    returnedStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-                }
-                if (returnedModel == null) {
-                    String msg = flightState.getErrorMessage().orElse("Job failed with no error message!");
-                    returnedModel = new ErrorModel().message(msg);
-                }
-                break;
-
-            case RUNNING:
-                // This should never happen
-                throw new IllegalStateException("Job marked running but has completion time");
-
-            case SUCCESS:
-                if (returnedStatus == null) {
-                    // Error: this is a flight coding bug where the status code was not filled in properly.
-                    throw new IllegalStateException("No status code returned from flight");
-                }
-                break;
-
-            default:
-                throw new IllegalStateException("Switch default should never be taken");
-        }
-
-        flightResponse
-            .flightComplete(true)
-            .responsePresent(returnedModel != null)
-            .errorResponse(returnedModel instanceof ErrorModel)
-            .response(returnedModel)
-            .statusCode(returnedStatus);
-        return flightResponse;
-    }
 }

--- a/src/main/java/bio/terra/pdao/PrimaryDataAccess.java
+++ b/src/main/java/bio/terra/pdao/PrimaryDataAccess.java
@@ -29,7 +29,7 @@ import java.util.List;
  *     </ol>
  * </ul>
  *
- * All implementation-specific exceptions should be caught by the implementation and wrapped
+ * All implementation-specific exception should be caught by the implementation and wrapped
  * in PdaoException.
  */
 public interface PrimaryDataAccess {

--- a/src/main/java/bio/terra/pdao/PrimaryDataAccess.java
+++ b/src/main/java/bio/terra/pdao/PrimaryDataAccess.java
@@ -29,7 +29,7 @@ import java.util.List;
  *     </ol>
  * </ul>
  *
- * All implementation-specific exception should be caught by the implementation and wrapped
+ * All implementation-specific exceptions should be caught by the implementation and wrapped
  * in PdaoException.
  */
 public interface PrimaryDataAccess {

--- a/src/main/java/bio/terra/service/JobService.java
+++ b/src/main/java/bio/terra/service/JobService.java
@@ -1,10 +1,9 @@
 package bio.terra.service;
 
-import bio.terra.flight.FlightResponse;
-import bio.terra.flight.FlightUtils;
-import bio.terra.model.ErrorModel;
 import bio.terra.model.JobModel;
 import bio.terra.service.exception.InvalidResultStateException;
+import bio.terra.service.exception.JobNotCompleteException;
+import bio.terra.service.exception.JobResponseException;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.FlightStatus;
@@ -20,6 +19,18 @@ import java.util.List;
 
 @Component
 public class JobService {
+    // Little class to return HttpStatus when retrieving job result
+    private static class HttpStatusContainer {
+        private HttpStatus statusCode;
+
+        public HttpStatus getStatusCode() {
+            return statusCode;
+        }
+
+        public void setStatusCode(HttpStatus statusCode) {
+            this.statusCode = statusCode;
+        }
+    }
 
     private final Stairway stairway;
     private final FastDateFormat modelDateFormat;
@@ -44,13 +55,12 @@ public class JobService {
         HttpStatus statusCode = HttpStatus.ACCEPTED;
 
         if (flightState.getCompleted().isPresent()) {
-            // When the flight is completed, we want to put the status code from the flight
-            // into the job model.
             FlightMap resultMap = getResultMap(flightState);
+            // The STATUS_CODE return only needs to be used to return alternate success responses.
+            // If it is not present, then we set it to the default OK status.
             statusCode = resultMap.get(JobMapKeys.STATUS_CODE.getKeyName(), HttpStatus.class);
             if (statusCode == null) {
-                // Error: this is a flight coding bug where the status code was not filled in properly.
-                throw new InvalidResultStateException("No status code returned from flight");
+                statusCode = HttpStatus.OK;
             }
 
             completedDate = modelDateFormat.format(flightState.getCompleted().get());
@@ -111,18 +121,82 @@ public class JobService {
                 .body(jobModel);
     }
 
-    public ResponseEntity<Object> retrieveJobResult(String jobId) {
-        FlightState flightState = stairway.getFlightState(jobId);
-        FlightResponse flightResponse = FlightUtils.makeFlightResponse(flightState);
+    /**
+     * The following code exposes two methods:
+     * <ul>
+     *     <li>{@see retrieveJobResult} is for synchronous endpoints that use flights. It returns a properly typed
+     *     response object. See StudyService for a usage example.</li>
+     *     <li>{@see retrieveJobResultResponse} is for the generic job result endpoint. It returns a ResponseEntity
+     *     containing the returned RESPONSE and STATUS_CODE. See the jobs endpoint in RepositoryApiController to
+     *     see usage.</li>
+     * </ul>
+     * If should only be called on complete flights. Any service that uses flights and is synchronous
+     * can use this to handle the returned flight state.
+     * There are four cases to handle here:
+     * <ol>
+     *     <li> Flight is still running. Throw an JobNotComplete exception</li>
+     *     <li> Successful flight: extract the resultMap RESPONSE as the target class. If a statusContainer
+     *     is present, we try to retrieve the STATUS_CODE from the resultMap and store it in the container.
+     *     That allows flight steps used in async REST API endpoints to set alternate success status codes.
+     *     The status code defaults to OK, if it is not set in the resultMap.</li>
+     *     <li> Failed flight: if there is an exception, throw it. Note that we can only throw RuntimeExceptions
+     *     to be handled by the global exception handler. Non-runtime exceptions require throw clauses on
+     *     the controller methods; those are not present in the swagger-generated code, so it introduces a
+     *     mismatch. Instead, in this code if the caught exception is not a runtime exception, then we
+     *     throw JobResponseException passing in the Throwable to the exception. In the global exception
+     *     handler, we retrieve the Throwable and use the error text from that in the error model</li>
+     *     <li> Failed flight: no exception present. We throw InvalidResultState exception</li>
+     * </ol>
+     * @param jobId to process
+     * @return object of the result class pulled from the result map
+     */
+    public <T> T retrieveJobResult(String jobId, Class<T> resultClass) {
+        return retrieveJobResultWorker(jobId, resultClass, null);
+    }
 
-        // If the flight isn't done, we call that a bad request.
-        if (!flightResponse.isFlightComplete()) {
-            ErrorModel errorRunning = new ErrorModel()
-                    .message("Attempt to retrieve job result before job is complete; job id: " + jobId);
-            flightResponse.response(errorRunning).statusCode(HttpStatus.BAD_REQUEST);
+    public ResponseEntity retrieveJobResultResponse(String jobId) {
+        HttpStatusContainer statusContainer = new HttpStatusContainer();
+        Object responseBody = retrieveJobResultWorker(jobId, Object.class, statusContainer);
+        return new ResponseEntity(responseBody, statusContainer.getStatusCode());
+    }
+
+    private <T> T retrieveJobResultWorker(String jobId, Class<T> resultClass, HttpStatusContainer statusContainer) {
+        FlightState flightState = stairway.getFlightState(jobId);
+        FlightMap resultMap = flightState.getResultMap().orElse(null);
+        if (resultMap == null) {
+            throw new InvalidResultStateException("No result map returned from flight");
         }
 
-        return new ResponseEntity<>(flightResponse.getResponse(), flightResponse.getStatusCode());
+        switch (flightState.getFlightStatus()) {
+            case FATAL:
+            case ERROR:
+                if (flightState.getException().isPresent()) {
+                    Exception exception = flightState.getException().get();
+                    if (exception instanceof RuntimeException) {
+                        throw (RuntimeException)exception;
+                    } else {
+                        throw new JobResponseException("wrap non-runtime exception", exception);
+                    }
+                }
+                throw new InvalidResultStateException("Failed operation with no exception reported");
+
+            case SUCCESS:
+                if (statusContainer != null) {
+                    HttpStatus statusCode = resultMap.get(JobMapKeys.STATUS_CODE.getKeyName(), HttpStatus.class);
+                    if (statusCode == null) {
+                        statusCode = HttpStatus.OK;
+                    }
+                    statusContainer.setStatusCode(statusCode);
+                }
+                return resultMap.get(JobMapKeys.RESPONSE.getKeyName(), resultClass);
+
+            case RUNNING:
+                throw new JobNotCompleteException("Attempt to retrieve job result before job is complete; job id: "
+                    + flightState.getFlightId());
+
+            default:
+                throw new InvalidResultStateException("Impossible case reached");
+        }
     }
 
     private FlightMap getResultMap(FlightState flightState) {

--- a/src/main/java/bio/terra/service/exception/JobNotCompleteException.java
+++ b/src/main/java/bio/terra/service/exception/JobNotCompleteException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.exception;
+
+import bio.terra.exception.BadRequestException;
+
+public class JobNotCompleteException extends BadRequestException {
+    public JobNotCompleteException(String message) {
+        super(message);
+    }
+
+    public JobNotCompleteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public JobNotCompleteException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/exception/JobResponseException.java
+++ b/src/main/java/bio/terra/service/exception/JobResponseException.java
@@ -1,0 +1,15 @@
+package bio.terra.service.exception;
+
+public class JobResponseException extends RuntimeException {
+    public JobResponseException(String message) {
+        super(message);
+    }
+
+    public JobResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public JobResponseException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/stairway/FlightState.java
+++ b/src/main/java/bio/terra/stairway/FlightState.java
@@ -14,7 +14,7 @@ public class FlightState {
     private Timestamp submitted;
     private Optional<Timestamp> completed;
     private Optional<FlightMap> resultMap;  // filled in when flightStatus is SUCCESS
-    private Optional<String> errorMessage;  // filled in when flightStatus is ERROR or FATAL
+    private Optional<Exception> exception;  // filled in when flightStatus is ERROR or FATAL
 
     public FlightState() {
     }
@@ -73,11 +73,13 @@ public class FlightState {
         this.resultMap = resultMap;
     }
 
-    public Optional<String> getErrorMessage() {
-        return errorMessage;
+    public Optional<Exception> getException() {
+        return exception;
     }
 
-    public void setErrorMessage(Optional<String> errorMessage) {
-        this.errorMessage = errorMessage;
+    public FlightState setException(Optional<Exception> exception) {
+        this.exception = exception;
+        return this;
     }
+
 }

--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -143,6 +143,7 @@ public class Stairway {
      * Get the state of a specific flight
      * If the flight is complete and still in our in-memory map, we remove it.
      * The logic is that if getFlightState is called, then either the wait
+     * finished or we are polling and won't perform a wait.
      *
      * @param flightId
      * @return FlightState

--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -29,7 +29,8 @@ import java.util.concurrent.ThreadPoolExecutor;
  * There are two techniques you can use to wait for a flight. One is polling by calling getFlightState. That
  * reads the flight state from the stairway database so will report correct state for as long as the flight
  * lives in the database. (Since we haven't implemented pruning, that means forever.) If you poll in this way,
- * then you must explicitly call releaseFlight() so that the in-memory resources for the flight are freed.
+ * then the in-memory resources are released on the first call to getFlightState that reports the flight has
+ * completed in some way.
  *
  * The other technique is to poll the flight future using the isDone() method or block waiting for the
  * flight to complete using the waitForFlight() method. In this case, the in-memory resources are freed
@@ -140,12 +141,18 @@ public class Stairway {
 
     /**
      * Get the state of a specific flight
+     * If the flight is complete and still in our in-memory map, we remove it.
+     * The logic is that if getFlightState is called, then either the wait
      *
      * @param flightId
      * @return FlightState
      */
     public FlightState getFlightState(String flightId) {
-        return database.getFlightState(flightId);
+        FlightState flightState = database.getFlightState(flightId);
+        if (flightState.getFlightStatus() != FlightStatus.RUNNING) {
+            releaseFlight(flightId);
+        }
+        return flightState;
     }
 
     /**
@@ -161,13 +168,7 @@ public class Stairway {
         return database.getFlights(offset, limit);
     }
 
-    /**
-     * Remove the task context for a completed flight. If the flight is not complete or does not
-     * exist, the code simply returns.
-     *
-     * @param flightId
-     */
-    public void releaseFlight(String flightId) {
+    private void releaseFlight(String flightId) {
         TaskContext taskContext = taskContextMap.get(flightId);
         if (taskContext != null) {
             if (taskContext.getFutureResult().isDone()) {

--- a/src/main/java/bio/terra/stairway/StepResult.java
+++ b/src/main/java/bio/terra/stairway/StepResult.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public class StepResult {
     private StepStatus stepStatus;
-    private Optional<Throwable> throwable;
+    private Optional<Exception> exception;
 
     // Static version of success result
     private static StepResult stepResultSuccess = new StepResult(StepStatus.STEP_RESULT_SUCCESS);
@@ -15,43 +15,33 @@ public class StepResult {
         return stepResultSuccess;
     }
 
-    public StepResult(StepStatus stepStatus, Throwable throwable) {
+    public StepResult(StepStatus stepStatus, Exception exception) {
         this.stepStatus = stepStatus;
-        this.throwable = Optional.ofNullable(throwable);
+        this.exception = Optional.ofNullable(exception);
     }
 
     public StepResult(StepStatus stepStatus) {
         this.stepStatus = stepStatus;
-        this.throwable = Optional.empty();
+        this.exception = Optional.empty();
     }
 
     public StepStatus getStepStatus() {
         return stepStatus;
     }
 
-    public Optional<Throwable> getThrowable() {
-        return throwable;
+    public Optional<Exception> getException() {
+        return exception;
     }
 
     public boolean isSuccess() {
         return (stepStatus == StepStatus.STEP_RESULT_SUCCESS);
     }
 
-    /**
-     * Convert the optional throwable into a optional string
-     */
-    public Optional<String> getErrorMessage() {
-        if (getThrowable().isPresent()) {
-            return Optional.of(getThrowable().get().toString());
-        }
-        return Optional.empty();
-    }
-
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
                 .append("stepStatus", stepStatus)
-                .append("throwable", throwable)
+                .append("exception", exception)
                 .toString();
     }
 }

--- a/src/main/java/bio/terra/stairway/exception/RetryException.java
+++ b/src/main/java/bio/terra/stairway/exception/RetryException.java
@@ -1,0 +1,15 @@
+package bio.terra.stairway.exception;
+
+public class RetryException extends RuntimeException {
+    public RetryException(String message) {
+        super(message);
+    }
+
+    public RetryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RetryException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/resources/db.stairway/changesets/20190118_base.yaml
+++ b/src/main/resources/db.stairway/changesets/20190118_base.yaml
@@ -36,7 +36,8 @@ databaseChangeLog:
                   type: text
                   remarks: contains FlightStatus enum values
               - column:
-                  name: error_message
+                  name: exception
+                  remarks: contains JSON-serialized Exception
                   type: text
 
         - createTable:
@@ -73,8 +74,9 @@ databaseChangeLog:
                   type: boolean
                   remarks: null = not done; true = success; false = failure
               - column:
-                  name: error_message
+                  name: exception
                   type: text
+                  remarks: contains JSON-serialized Exception
               - column:
                   name: status
                   type: text

--- a/src/test/java/bio/terra/fixtures/FlightStates.java
+++ b/src/test/java/bio/terra/fixtures/FlightStates.java
@@ -40,7 +40,7 @@ public final class FlightStates {
         flightState.setInputParameters(resultMap); // unused
         flightState.setResultMap(Optional.of(resultMap));
         flightState.setCompleted(Optional.of(Timestamp.from(Instant.now())));
-        flightState.setErrorMessage(Optional.empty());
+        flightState.setException(Optional.empty());
         return flightState;
     }
 
@@ -58,7 +58,7 @@ public final class FlightStates {
         flightState.setInputParameters(resultMap);
         flightState.setResultMap(Optional.of(resultMap));
         flightState.setCompleted(Optional.empty());
-        flightState.setErrorMessage(Optional.empty());
+        flightState.setException(Optional.empty());
         return flightState;
     }
 
@@ -76,7 +76,7 @@ public final class FlightStates {
         flightState.setInputParameters(resultMap);
         flightState.setResultMap(Optional.of(resultMap));
         flightState.setCompleted(Optional.of(completedTime));
-        flightState.setErrorMessage(Optional.empty());
+        flightState.setException(Optional.empty());
         return flightState;
     }
 }

--- a/src/test/java/bio/terra/flight/study/create/StudyCreateFlightTest.java
+++ b/src/test/java/bio/terra/flight/study/create/StudyCreateFlightTest.java
@@ -110,9 +110,9 @@ public class StudyCreateFlightTest {
 
         FlightState result = stairway.getFlightState(flightId);
         assertNotEquals(result.getFlightStatus(), FlightStatus.SUCCESS);
-        Optional<String> errorMessage = result.getErrorMessage();
+        Optional<Exception> errorMessage = result.getException();
         assertTrue(errorMessage.isPresent());
-        assertThat(errorMessage.get(), containsString("TestTriggerUndoStep"));
+        assertThat(errorMessage.get().getMessage(), containsString("TestTriggerUndoStep"));
 
         boolean deletedSomething = studyDao.deleteByName(studyName);
         assertFalse(deletedSomething);

--- a/src/test/java/bio/terra/service/JobServiceTest.java
+++ b/src/test/java/bio/terra/service/JobServiceTest.java
@@ -70,7 +70,7 @@ public class JobServiceTest {
     }
 
     private void testResultRetrieval(List<String> fids) {
-        ResponseEntity<Object> result = jobService.retrieveJobResult(fids.get(2));
+        ResponseEntity<Object> result = jobService.retrieveJobResultResponse(fids.get(2));
         Assert.assertThat(result.getStatusCode(), is(equalTo(HttpStatus.I_AM_A_TEAPOT)));
         String resultDesc = (String) result.getBody();
         Assert.assertThat(resultDesc, is(equalTo(makeDescription(2))));
@@ -105,7 +105,7 @@ public class JobServiceTest {
 
     @Test(expected = FlightNotFoundException.class)
     public void testBadIdRetrieveResult() {
-        jobService.retrieveJobResult("abcdef");
+        jobService.retrieveJobResultResponse("abcdef");
     }
 
     private void validateJobModel(JobModel jm, int index, List<String> fids) {
@@ -122,7 +122,6 @@ public class JobServiceTest {
 
         String flightId = stairway.submit(JobServiceTestFlight.class, inputs);
         stairway.waitForFlight(flightId);
-        stairway.releaseFlight(flightId);
         return flightId;
     }
 

--- a/src/test/java/bio/terra/stairway/DatabaseOperationsTest.java
+++ b/src/test/java/bio/terra/stairway/DatabaseOperationsTest.java
@@ -101,7 +101,7 @@ public class DatabaseOperationsTest {
         Assert.assertThat(recoveredFlight.getStepIndex(), is(equalTo(2)));
         Assert.assertThat(recoveredFlight.isDoing(), is(false));
         Assert.assertThat(recoveredFlight.getResult().isSuccess(), is(false));
-        Assert.assertThat(recoveredFlight.getResult().getThrowable().get().toString(), containsString(errString));
+        Assert.assertThat(recoveredFlight.getResult().getException().get().toString(), containsString(errString));
         Assert.assertThat(recoveredFlight.getFlightStatus(), is(FlightStatus.RUNNING));
 
         FlightMap recoveredWork = recoveredFlight.getWorkingMap();
@@ -125,11 +125,11 @@ public class DatabaseOperationsTest {
         Assert.assertThat(flightState.getFlightId(), is(flightId));
         Assert.assertThat(flightState.getFlightStatus(), is(FlightStatus.ERROR));
         Assert.assertTrue(flightState.getResultMap().isPresent());
-        Assert.assertTrue(flightState.getErrorMessage().isPresent());
+        Assert.assertTrue(flightState.getException().isPresent());
 
         FlightMap outputParams = flightState.getResultMap().get();
         checkOutputs(outputParams);
-        Assert.assertThat(flightState.getErrorMessage().get(), containsString(errString));
+        Assert.assertThat(flightState.getException().get().toString(), containsString(errString));
     }
 
     private Database createDatabase(boolean forceCleanStart) {
@@ -141,7 +141,7 @@ public class DatabaseOperationsTest {
         Assert.assertThat(flightState.getFlightStatus(), is(FlightStatus.RUNNING));
         Assert.assertFalse(flightState.getCompleted().isPresent());
         Assert.assertFalse(flightState.getResultMap().isPresent());
-        Assert.assertFalse(flightState.getErrorMessage().isPresent());
+        Assert.assertFalse(flightState.getException().isPresent());
     }
 
     private void checkInputs(FlightMap inputMap) {

--- a/src/test/java/bio/terra/stairway/FlightStateTest.java
+++ b/src/test/java/bio/terra/stairway/FlightStateTest.java
@@ -44,7 +44,7 @@ public class FlightStateTest {
         result.setSubmitted(timestamp);
         result.setCompleted(Optional.of(timestamp));
         result.setResultMap(Optional.of(outputs));
-        result.setErrorMessage(Optional.of(errString));
+        result.setException(Optional.of(new RuntimeException(errString)));
     }
 
     @Test
@@ -56,10 +56,10 @@ public class FlightStateTest {
 
         Assert.assertTrue(result.getCompleted().isPresent());
         Assert.assertTrue(result.getResultMap().isPresent());
-        Assert.assertTrue(result.getErrorMessage().isPresent());
+        Assert.assertTrue(result.getException().isPresent());
 
         Assert.assertThat(result.getCompleted().get(), is(timestamp));
-        Assert.assertThat(result.getErrorMessage().get(), is(errString));
+        Assert.assertThat(result.getException().get().getMessage(), is(errString));
 
         FlightMap outputMap = result.getResultMap().get();
         Assert.assertThat(outputMap.get(fkey, Double.class), is(dubValue));

--- a/src/test/java/bio/terra/stairway/RecoveryTest.java
+++ b/src/test/java/bio/terra/stairway/RecoveryTest.java
@@ -153,9 +153,10 @@ public class RecoveryTest {
         stairway2.waitForFlight(flightId);
         FlightState result = stairway2.getFlightState(flightId);
         Assert.assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.ERROR)));
-        Assert.assertTrue(result.getErrorMessage().isPresent());
+        Assert.assertTrue(result.getException().isPresent());
         // The exception is thrown by TestStepTriggerUndo
-        Assert.assertThat(result.getErrorMessage().get(), is(containsString("TestStepTriggerUndo")));
+        Assert.assertThat(result.getException().get().getMessage(),
+            is(containsString("TestStepTriggerUndo")));
 
         Assert.assertTrue(result.getResultMap().isPresent());
         Integer value = result.getResultMap().get().get("value", Integer.class);

--- a/src/test/java/bio/terra/stairway/RetryTest.java
+++ b/src/test/java/bio/terra/stairway/RetryTest.java
@@ -45,7 +45,7 @@ public class RetryTest {
         stairway.waitForFlight(flightId);
         FlightState result = stairway.getFlightState(flightId);
         Assert.assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.SUCCESS)));
-        Assert.assertFalse(result.getErrorMessage().isPresent());
+        Assert.assertFalse(result.getException().isPresent());
     }
 
     @Test
@@ -89,7 +89,7 @@ public class RetryTest {
         stairway.waitForFlight(flightId);
         FlightState result = stairway.getFlightState(flightId);
         Assert.assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.SUCCESS)));
-        Assert.assertFalse(result.getErrorMessage().isPresent());
+        Assert.assertFalse(result.getException().isPresent());
     }
 
     @Test
@@ -108,7 +108,7 @@ public class RetryTest {
         stairway.waitForFlight(flightId);
         FlightState result = stairway.getFlightState(flightId);
         Assert.assertThat(result.getFlightStatus(), is(equalTo(FlightStatus.ERROR)));
-        Assert.assertTrue(result.getErrorMessage().isPresent());
+        Assert.assertTrue(result.getException().isPresent());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class RetryTest {
         Assert.assertTrue(endTime.isBefore(endRange));
 
         Assert.assertThat(result.getFlightStatus(), is(FlightStatus.SUCCESS));
-        Assert.assertFalse(result.getErrorMessage().isPresent());
+        Assert.assertFalse(result.getException().isPresent());
     }
 
 }

--- a/src/test/java/bio/terra/stairway/ScenarioTest.java
+++ b/src/test/java/bio/terra/stairway/ScenarioTest.java
@@ -59,7 +59,7 @@ public class ScenarioTest {
         stairway.waitForFlight(flightId);
         FlightState result = stairway.getFlightState(flightId);
         Assert.assertThat(result.getFlightStatus(), is(FlightStatus.SUCCESS));
-        Assert.assertFalse(result.getErrorMessage().isPresent());
+        Assert.assertFalse(result.getException().isPresent());
 
         // Should be released
         try {
@@ -89,10 +89,10 @@ public class ScenarioTest {
         // Handle results
         FlightState result = stairway.getFlightState(flightId);
         Assert.assertThat(result.getFlightStatus(), is(FlightStatus.ERROR));
-        Assert.assertTrue(result.getErrorMessage().isPresent());
+        Assert.assertTrue(result.getException().isPresent());
 
         // The error text thrown by TestStepExistence
-        Assert.assertThat(result.getErrorMessage().get(), containsString("already exists"));
+        Assert.assertThat(result.getException().get().getMessage(), containsString("already exists"));
     }
 
     @Test
@@ -123,8 +123,8 @@ public class ScenarioTest {
         stairway.waitForFlight(flightId);
         FlightState result = stairway.getFlightState(flightId);
         Assert.assertThat(result.getFlightStatus(), is(FlightStatus.ERROR));
-        Assert.assertTrue(result.getErrorMessage().isPresent());
-        Assert.assertThat(result.getErrorMessage().get(), containsString("already exists"));
+        Assert.assertTrue(result.getException().isPresent());
+        Assert.assertThat(result.getException().get().getMessage(), containsString("already exists"));
 
         // We expect the non-existent filename to have been deleted
         File file = new File(filename);

--- a/src/test/java/bio/terra/stairway/StepResultTest.java
+++ b/src/test/java/bio/terra/stairway/StepResultTest.java
@@ -17,8 +17,8 @@ public class StepResultTest {
     public void testStepResultSuccess() {
         StepResult result = StepResult.getStepResultSuccess();
         Assert.assertThat(result.getStepStatus(), is(StepStatus.STEP_RESULT_SUCCESS));
-        Optional<Throwable> throwable = result.getThrowable();
-        Assert.assertFalse(throwable.isPresent());
+        Optional<Exception> exception = result.getException();
+        Assert.assertFalse(exception.isPresent());
     }
 
     @Test
@@ -26,10 +26,10 @@ public class StepResultTest {
         StepResult result = new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL,
                 new IllegalArgumentException(bad));
         Assert.assertThat(result.getStepStatus(), is(StepStatus.STEP_RESULT_FAILURE_FATAL));
-        Optional<Throwable> throwable = result.getThrowable();
-        Assert.assertTrue(throwable.isPresent());
-        Assert.assertTrue(throwable.get() instanceof IllegalArgumentException);
-        Assert.assertThat(throwable.get().getMessage(), is(bad));
+        Optional<Exception> exception = result.getException();
+        Assert.assertTrue(exception.isPresent());
+        Assert.assertTrue(exception.get() instanceof IllegalArgumentException);
+        Assert.assertThat(exception.get().getMessage(), is(bad));
     }
 
 }

--- a/src/test/java/bio/terra/stairway/TestStepRetry.java
+++ b/src/test/java/bio/terra/stairway/TestStepRetry.java
@@ -1,6 +1,6 @@
 package bio.terra.stairway;
 
-import bio.terra.stairway.exception.FlightException;
+import bio.terra.stairway.exception.RetryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,8 +22,7 @@ public class TestStepRetry implements Step {
         if (timesFailed < timesToFail) {
             timesFailed++;
             logger.debug(" - failure_retry");
-            Throwable throwable = new FlightException("step retry failed");
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, throwable);
+            throw new RetryException("step retry failed");
         }
         logger.debug(" - success");
         return StepResult.getStepResultSuccess();

--- a/src/test/java/bio/terra/stairway/TestStepTriggerUndo.java
+++ b/src/test/java/bio/terra/stairway/TestStepTriggerUndo.java
@@ -9,7 +9,7 @@ public class TestStepTriggerUndo implements Step {
         // This step sets the stop controller to 0 to cause the
         // stop step to sleep. Then it returns a fatal error.
         TestStopController.setControl(0);
-        return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, new FlightException("TestStepTriggerUndo"));
+        throw new FlightException("TestStepTriggerUndo");
     }
 
     @Override


### PR DESCRIPTION
- change stairway database to JSON-serialize exceptions instead of message text
- change flight status to return exception
- change JobService to throw returned exceptions on error
- add JobService method to handle flight status and either throw or return the desired class; that is now used by StudyService for the case of REST API endpoint that is synchronous and uses stairway
- have stairway catch exceptions from steps and, based on the exception, generate the proper step result. This saves us from writing repetitive try-catch in our steps.
