### PR TITLE
DR-20 integration test

### DIFF
--- a/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
@@ -50,7 +50,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorModel catchallHandler(Exception ex) {
-        logger.info("Catchall exception caught: {} of {}", ex.getClass().getName(), ex.toString());
+        logger.error("Exception caught by catchall hander", ex);
         return buildErrorModel(ex);
     }
 

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -605,7 +605,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             case "DATETIME":  return LegacySQLTypeName.DATETIME;
             case "FILEREF":   return LegacySQLTypeName.STRING;
             case "FLOAT":     return LegacySQLTypeName.FLOAT;
-            case "FLOAT64":   return LegacySQLTypeName.INTEGER;  // match the SQL type
+            case "FLOAT64":   return LegacySQLTypeName.FLOAT;  // match the SQL type
             case "INTEGER":   return LegacySQLTypeName.INTEGER;
             case "INT64":     return LegacySQLTypeName.INTEGER;  // match the SQL type
             case "NUMERIC":   return LegacySQLTypeName.NUMERIC;

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -605,6 +605,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             case "DATETIME":  return LegacySQLTypeName.DATETIME;
             case "FILEREF":   return LegacySQLTypeName.STRING;
             case "FLOAT":     return LegacySQLTypeName.FLOAT;
+            case "FLOAT64":   return LegacySQLTypeName.INTEGER;  // match the SQL type
             case "INTEGER":   return LegacySQLTypeName.INTEGER;
             case "INT64":     return LegacySQLTypeName.INTEGER;  // match the SQL type
             case "NUMERIC":   return LegacySQLTypeName.NUMERIC;

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -606,11 +606,11 @@ public class BigQueryPdao implements PrimaryDataAccess {
             case "FILEREF":   return LegacySQLTypeName.STRING;
             case "FLOAT":     return LegacySQLTypeName.FLOAT;
             case "INTEGER":   return LegacySQLTypeName.INTEGER;
+            case "INT64":     return LegacySQLTypeName.INTEGER;  // match the SQL type
             case "NUMERIC":   return LegacySQLTypeName.NUMERIC;
             //case "RECORD":    return LegacySQLTypeName.RECORD;
             case "STRING":    return LegacySQLTypeName.STRING;
-            // One special to match the Postgres type
-            case "TEXT":    return LegacySQLTypeName.STRING;
+            case "TEXT":      return LegacySQLTypeName.STRING;   // match the Postgres type
             case "TIME":      return LegacySQLTypeName.TIME;
             case "TIMESTAMP": return LegacySQLTypeName.TIMESTAMP;
             default: throw new IllegalArgumentException("Unknown datatype '" + datatype + "'");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,6 @@ db.stairway.forceClean=true
 oauth.schemeName=googleoauth
 oauth.loginEndpoint=https://accounts.google.com/o/oauth2/auth
 oauth.scopes=openid,email,profile
+integrationtest.port=8080
+integrationtest.server=localhost
+integrationtest.protocol=http

--- a/src/test/java/bio/terra/category/Integration.java
+++ b/src/test/java/bio/terra/category/Integration.java
@@ -1,0 +1,7 @@
+package bio.terra.category;
+
+/**
+ * Integration test category.
+ */
+public interface Integration {
+}

--- a/src/test/java/bio/terra/controller/StudyConnectedTest.java
+++ b/src/test/java/bio/terra/controller/StudyConnectedTest.java
@@ -1,0 +1,64 @@
+package bio.terra.controller;
+
+import bio.terra.category.Connected;
+import bio.terra.fixtures.JsonLoader;
+import bio.terra.fixtures.Names;
+import bio.terra.model.DeleteResponseModel;
+import bio.terra.model.StudyRequestModel;
+import bio.terra.model.StudySummaryModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Connected.class)
+public class StudyConnectedTest {
+    @Autowired private MockMvc mvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private JsonLoader jsonLoader;
+
+    @Test
+    public void testCreateOmopStudy() throws Exception {
+        StudyRequestModel studyRequest = jsonLoader.loadObject("it-study-omop.json", StudyRequestModel.class);
+        studyRequest.name(Names.randomizeName(studyRequest.getName()));
+
+        MvcResult result = mvc.perform(post("/api/repository/v1/studies")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studyRequest)))
+            .andExpect(status().isCreated())
+            .andReturn();
+        MockHttpServletResponse response = result.getResponse();
+        assertThat("create omop study successfully", response.getStatus(), equalTo(HttpStatus.CREATED.value()));
+        StudySummaryModel studySummaryModel =
+            objectMapper.readValue(response.getContentAsString(), StudySummaryModel.class);
+
+        result = mvc.perform(delete("/api/repository/v1/studies/" + studySummaryModel.getId())).andReturn();
+        response = result.getResponse();
+        assertThat("delete omop study successfully", response.getStatus(), equalTo(HttpStatus.OK.value()));
+        DeleteResponseModel responseModel =
+            objectMapper.readValue(response.getContentAsString(), DeleteResponseModel.class);
+        assertTrue("Valid delete response object state enumeration",
+            (responseModel.getObjectState() == DeleteResponseModel.ObjectStateEnum.DELETED ||
+                responseModel.getObjectState() == DeleteResponseModel.ObjectStateEnum.NOT_FOUND));
+    }
+
+}

--- a/src/test/java/bio/terra/controller/StudyTest.java
+++ b/src/test/java/bio/terra/controller/StudyTest.java
@@ -5,6 +5,7 @@ import bio.terra.controller.exception.ApiException;
 import bio.terra.dao.StudyDao;
 import bio.terra.dao.exception.StudyNotFoundException;
 import bio.terra.fixtures.FlightStates;
+import bio.terra.fixtures.JsonLoader;
 import bio.terra.flight.study.create.StudyCreateFlight;
 import bio.terra.metadata.Study;
 import bio.terra.model.StudyJsonConversion;
@@ -14,7 +15,6 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
 import bio.terra.stairway.Stairway;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -57,7 +57,8 @@ public class StudyTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-
+    @Autowired
+    private JsonLoader jsonLoader;
 
     private static final String testFlightId = "test-flight-id";
 
@@ -90,8 +91,7 @@ public class StudyTest {
         when(stairway.getFlightState(eq(testFlightId)))
                 .thenReturn(flightState);
 
-        ClassLoader classLoader = getClass().getClassLoader();
-        String studyJSON = IOUtils.toString(classLoader.getResourceAsStream("study-minimal.json"));
+        String studyJSON = jsonLoader.loadJson("study-minimal.json");
         mvc.perform(post("/api/repository/v1/studies")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(studyJSON))

--- a/src/test/java/bio/terra/fixtures/JsonLoader.java
+++ b/src/test/java/bio/terra/fixtures/JsonLoader.java
@@ -1,0 +1,31 @@
+package bio.terra.fixtures;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonLoader {
+    private ClassLoader classLoader;
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    public JsonLoader(ObjectMapper objectMapper) {
+        this.classLoader = getClass().getClassLoader();
+        this.objectMapper = objectMapper;
+    }
+
+    public String loadJson(String resourcePath) throws Exception {
+        return IOUtils.toString(classLoader.getResourceAsStream(resourcePath));
+    }
+
+    public <T> T loadObject(String resourcePath, Class<T> resourceClass) throws Exception {
+        String json = loadJson(resourcePath);
+        return objectMapper.readerFor(resourceClass).readValue(json);
+    }
+
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+}

--- a/src/test/java/bio/terra/fixtures/Names.java
+++ b/src/test/java/bio/terra/fixtures/Names.java
@@ -1,0 +1,19 @@
+package bio.terra.fixtures;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.UUID;
+
+public final class Names {
+    private Names() {
+    }
+
+    public static String randomizeName(String baseName) {
+        String name = baseName + UUID.randomUUID().toString();
+        return StringUtils.replaceChars(name, '-', '_');
+    }
+
+    public static String randomizeNameInfix(String baseName, String infix) {
+        return randomizeName(baseName + infix);
+    }
+}

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -3,7 +3,7 @@ package bio.terra.integration;
 import bio.terra.model.DeleteResponseModel;
 import bio.terra.model.ErrorModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -20,14 +20,8 @@ import java.util.Optional;
  */
 @Component
 public class DataRepoClient {
-    @Value("${integrationtest.port}")
-    private String testPort;
-
-    @Value("${integrationtest.server}")
-    private String testServer;
-
-    @Value("${integrationtest.protocol}")
-    private String testProtocol;
+    @Autowired
+    private DataRepoConfiguration dataRepoConfiguration;
 
     private RestTemplate restTemplate;
     private ObjectMapper objectMapper;
@@ -86,6 +80,10 @@ public class DataRepoClient {
     }
 
     private String makeUrl(String path) {
-        return String.format("%s://%s:%s%s", testProtocol, testServer, testPort, path);
+        return String.format("%s://%s:%s%s",
+            dataRepoConfiguration.getProtocol(),
+            dataRepoConfiguration.getServer(),
+            dataRepoConfiguration.getPort(),
+            path);
     }
 }

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -45,41 +45,33 @@ public class DataRepoClient {
 
     public <T> DataRepoResponse<T> get(String path, Class<T> responseClass) throws Exception {
         HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response = restTemplate.exchange(
-            makeUrl(path),
-            HttpMethod.GET,
-            entity,
-            String.class);
-
-        return makeDataRepoResponse(response, responseClass);
+        return makeDataRepoRequest(path, HttpMethod.GET, entity, responseClass);
     }
 
     public <T> DataRepoResponse<T> post(String path, String json, Class<T> responseClass) throws Exception {
         HttpEntity<String> entity = new HttpEntity<>(json, headers);
-        ResponseEntity<String> response = restTemplate.exchange(
-            makeUrl(path),
-            HttpMethod.POST,
-            entity,
-            String.class);
-
-        return makeDataRepoResponse(response, responseClass);
+        return makeDataRepoRequest(path, HttpMethod.POST, entity, responseClass);
     }
 
     public DataRepoResponse<DeleteResponseModel> delete(String path) throws Exception {
         HttpEntity<String> entity = new HttpEntity<>(headers);
+        return makeDataRepoRequest(path, HttpMethod.DELETE, entity, DeleteResponseModel.class);
+    }
+
+    private <T> DataRepoResponse<T> makeDataRepoRequest(String path,
+                                                        HttpMethod method,
+                                                        HttpEntity entity,
+                                                        Class<T> responseClass) throws Exception {
+
         ResponseEntity<String> response = restTemplate.exchange(
             makeUrl(path),
-            HttpMethod.DELETE,
+            method,
             entity,
             String.class);
 
-        return makeDataRepoResponse(response, DeleteResponseModel.class);
-    }
-
-    private <T> DataRepoResponse<T> makeDataRepoResponse(ResponseEntity<String> response,
-                                                         Class<T> responseClass) throws Exception {
         DataRepoResponse<T> drResponse = new DataRepoResponse<>();
         drResponse.setStatusCode(response.getStatusCode());
+
         if (response.getStatusCode().is2xxSuccessful()) {
             T responseObject = objectMapper.readValue(response.getBody(), responseClass);
             drResponse.setResponseObject(Optional.of(responseObject));
@@ -92,8 +84,6 @@ public class DataRepoClient {
 
         return drResponse;
     }
-
-
 
     private String makeUrl(String path) {
         return String.format("%s://%s:%s%s", testProtocol, testServer, testPort, path);

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -1,0 +1,101 @@
+package bio.terra.integration;
+
+import bio.terra.model.DeleteResponseModel;
+import bio.terra.model.ErrorModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * This class holds a Spring RestTemplate
+ */
+@Component
+public class DataRepoClient {
+    @Value("${integrationtest.port}")
+    private String testPort;
+
+    @Value("${integrationtest.server}")
+    private String testServer;
+
+    @Value("${integrationtest.protocol}")
+    private String testProtocol;
+
+    private RestTemplate restTemplate;
+    private ObjectMapper objectMapper;
+    private HttpHeaders headers;
+
+    public DataRepoClient() {
+        restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new DataRepoClientErrorHandler());
+        objectMapper = new ObjectMapper();
+
+        headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON_UTF8));
+    }
+
+    public <T> DataRepoResponse<T> get(String path, Class<T> responseClass) throws Exception {
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+            makeUrl(path),
+            HttpMethod.GET,
+            entity,
+            String.class);
+
+        return makeDataRepoResponse(response, responseClass);
+    }
+
+    public <T> DataRepoResponse<T> post(String path, String json, Class<T> responseClass) throws Exception {
+        HttpEntity<String> entity = new HttpEntity<>(json, headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+            makeUrl(path),
+            HttpMethod.POST,
+            entity,
+            String.class);
+
+        return makeDataRepoResponse(response, responseClass);
+    }
+
+    public DataRepoResponse<DeleteResponseModel> delete(String path) throws Exception {
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+            makeUrl(path),
+            HttpMethod.DELETE,
+            entity,
+            String.class);
+
+        return makeDataRepoResponse(response, DeleteResponseModel.class);
+    }
+
+    private <T> DataRepoResponse<T> makeDataRepoResponse(ResponseEntity<String> response,
+                                                         Class<T> responseClass) throws Exception {
+        DataRepoResponse<T> drResponse = new DataRepoResponse<>();
+        drResponse.setStatusCode(response.getStatusCode());
+        if (response.getStatusCode().is2xxSuccessful()) {
+            T responseObject = objectMapper.readValue(response.getBody(), responseClass);
+            drResponse.setResponseObject(Optional.of(responseObject));
+            drResponse.setErrorModel(Optional.empty());
+        } else {
+            ErrorModel errorModel = objectMapper.readValue(response.getBody(), ErrorModel.class);
+            drResponse.setErrorModel(Optional.of(errorModel));
+            drResponse.setResponseObject(Optional.empty());
+        }
+
+        return drResponse;
+    }
+
+
+
+    private String makeUrl(String path) {
+        return String.format("%s://%s:%s%s", testProtocol, testServer, testPort, path);
+    }
+}

--- a/src/test/java/bio/terra/integration/DataRepoClientErrorHandler.java
+++ b/src/test/java/bio/terra/integration/DataRepoClientErrorHandler.java
@@ -1,0 +1,19 @@
+package bio.terra.integration;
+
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import java.io.IOException;
+
+// Error handler that does nothing, so we can let the tests process the status code as they wish
+public class DataRepoClientErrorHandler implements ResponseErrorHandler {
+    @Override
+    public boolean hasError(ClientHttpResponse response) throws IOException {
+        return false;
+    }
+
+    @Override
+    public void handleError(ClientHttpResponse response) throws IOException {
+
+    }
+}

--- a/src/test/java/bio/terra/integration/DataRepoConfiguration.java
+++ b/src/test/java/bio/terra/integration/DataRepoConfiguration.java
@@ -1,0 +1,38 @@
+package bio.terra.integration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "integrationtest")
+public class DataRepoConfiguration {
+    private String port;
+    private String server;
+    private String protocol;
+
+    public String getPort() {
+        return port;
+    }
+
+    public String getServer() {
+        return server;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    public void setServer(String server) {
+        this.server = server;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+}

--- a/src/test/java/bio/terra/integration/DataRepoResponse.java
+++ b/src/test/java/bio/terra/integration/DataRepoResponse.java
@@ -1,0 +1,47 @@
+package bio.terra.integration;
+
+import bio.terra.model.ErrorModel;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+
+/**
+ * This class is returned by the data repo client.
+ * The idea is to make it simple for callers to assert the properties of the response.
+ * The object contains:
+ * <ul>
+ *     <li>status code from the response</li>
+ *     <li>if the status code is success, then it will contain the deserialized object of class T</li>
+ *     <li>if the status code is failure, then it will contain the deserialized object of ErrorModel</li>
+ * </ul>
+ * Errors deserializing the response are thrown from the data repo client.
+ */
+public class DataRepoResponse<T> {
+    private HttpStatus statusCode;
+    private Optional<ErrorModel> errorModel;
+    private Optional<T> responseObject;
+
+    public HttpStatus getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(HttpStatus statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public Optional<ErrorModel> getErrorModel() {
+        return errorModel;
+    }
+
+    public void setErrorModel(Optional<ErrorModel> errorModel) {
+        this.errorModel = errorModel;
+    }
+
+    public Optional<T> getResponseObject() {
+        return responseObject;
+    }
+
+    public void setResponseObject(Optional<T> responseObject) {
+        this.responseObject = responseObject;
+    }
+}

--- a/src/test/java/bio/terra/integration/StudyTest.java
+++ b/src/test/java/bio/terra/integration/StudyTest.java
@@ -1,0 +1,85 @@
+package bio.terra.integration;
+
+import bio.terra.category.Integration;
+import bio.terra.fixtures.JsonLoader;
+import bio.terra.model.DeleteResponseModel;
+import bio.terra.model.StudyModel;
+import bio.terra.model.StudySummaryModel;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Category(Integration.class)
+public class StudyTest {
+    private static final String omopStudyName = "it_study_omop";
+    private static final String omopStudyDesc =
+        "OMOP schema based on BigQuery schema from https://github.com/OHDSI/CommonDataModel/wiki";
+
+    @Autowired
+    private DataRepoClient dataRepoClient;
+
+    @Autowired
+    private JsonLoader jsonLoader;
+
+    @Test
+    public void studyHappyPath() throws Exception {
+        String studyJson = jsonLoader.loadJson("it-study-omop.json");
+        DataRepoResponse<StudySummaryModel> postResponse = dataRepoClient.post(
+            "/api/repository/v1/studies",
+            studyJson,
+            StudySummaryModel.class);
+
+        assertThat("study is successfully created", postResponse.getStatusCode(), equalTo(HttpStatus.CREATED));
+        assertTrue("study create response is present", postResponse.getResponseObject().isPresent());
+        StudySummaryModel summaryModel = postResponse.getResponseObject().get();
+        assertThat(summaryModel.getName(), equalTo(omopStudyName));
+        assertThat(summaryModel.getDescription(), equalTo(omopStudyDesc));
+
+        String studyPath = "/api/repository/v1/studies/" + summaryModel.getId();
+        DataRepoResponse<StudyModel> getResponse = dataRepoClient.get(studyPath, StudyModel.class);
+        postResponse = null;
+
+        assertThat("study is successfully retrieved", getResponse.getStatusCode(), equalTo(HttpStatus.OK));
+        assertTrue("study get response is present", getResponse.getResponseObject().isPresent());
+        StudyModel studyModel = getResponse.getResponseObject().get();
+        assertThat(studyModel.getName(), equalTo(omopStudyName));
+        assertThat(studyModel.getDescription(), equalTo(omopStudyDesc));
+        getResponse = null;
+
+        DataRepoResponse<StudySummaryModel[]> enumResponse = dataRepoClient.get(
+            "/api/repository/v1/studies?offset=0&items=1000",
+            StudySummaryModel[].class);
+
+        assertThat("study enumeration is successful", enumResponse.getStatusCode(), equalTo(HttpStatus.OK));
+        assertTrue("study get response is present", enumResponse.getResponseObject().isPresent());
+        StudySummaryModel[] summaryArray = enumResponse.getResponseObject().get();
+        boolean found = false;
+        for (StudySummaryModel oneStudy : summaryArray) {
+            if (oneStudy.getId().equals(studyModel.getId())) {
+                assertThat(oneStudy.getName(), equalTo(omopStudyName));
+                assertThat(oneStudy.getDescription(), equalTo(omopStudyDesc));
+                found = true;
+                break;
+            }
+        }
+        assertTrue("study was found in enumeration", found);
+        enumResponse = null;
+
+        DataRepoResponse<DeleteResponseModel> deleteResponse = dataRepoClient.delete(studyPath);
+        assertThat("study delete is successful", deleteResponse.getStatusCode(), equalTo(HttpStatus.OK));
+        assertTrue("study delete response is present", deleteResponse.getResponseObject().isPresent());
+        DeleteResponseModel deleteModel = deleteResponse.getResponseObject().get();
+        assertThat(deleteModel.getObjectState(), equalTo(DeleteResponseModel.ObjectStateEnum.DELETED));
+    }
+
+}

--- a/src/test/resources/it-study-omop.json
+++ b/src/test/resources/it-study-omop.json
@@ -668,7 +668,7 @@
                     },
                     {
                         "name": "admitted_from_concept_id",
-                        "datatype": "INT64 /*Changed from admitting_source_* */"
+                        "datatype": "INT64"
                     },
                     {
                         "name": "admitted_from_source_value",
@@ -757,7 +757,7 @@
                     },
                     {
                         "name": "modifier_source_value",
-                        "datatype": "STRING "
+                        "datatype": "STRING"
                     }
                 ]
             },
@@ -1090,11 +1090,11 @@
                     },
                     {
                         "name": "note_event_id",
-                        "datatype": "INT64 "
+                        "datatype": "INT64"
                     },
                     {
                         "name": "note_event_field_concept_id",
-                        "datatype": "INT64 "
+                        "datatype": "INT64"
                     },
                     {
                         "name": "note_date",
@@ -1166,7 +1166,7 @@
                         "datatype": "STRING"
                     },
                     {
-                        "name": "\"offset\"",
+                        "name": "snippet_offset",
                         "datatype": "STRING"
                     },
                     {
@@ -1284,11 +1284,11 @@
                     },
                     {
                         "name": "observation_event_id",
-                        "datatype": "INT64 "
+                        "datatype": "INT64"
                     },
                     {
                         "name": "obs_event_field_concept_id",
-                        "datatype": "INT64 "
+                        "datatype": "INT64"
                     },
                     {
                         "name": "value_as_datetime",
@@ -1700,7 +1700,7 @@
                     },
                     {
                         "name": "cost_event_field_concept_id",
-                        "datatype": "INT64 "
+                        "datatype": "INT64"
                     },
                     {
                         "name": "cost_concept_id",

--- a/src/test/resources/it-study-omop.json
+++ b/src/test/resources/it-study-omop.json
@@ -1,0 +1,4247 @@
+{
+    "name": "it_study_omop",
+    "description": "OMOP schema based on BigQuery schema from https://github.com/OHDSI/CommonDataModel/wiki",
+    "schema": {
+        "tables": [
+            {
+                "name": "concept",
+                "columns": [
+                    {
+                        "name": "concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "concept_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "domain_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "vocabulary_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "concept_class_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "standard_concept",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "concept_code",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "valid_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "valid_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "invalid_reason",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "vocabulary",
+                "columns": [
+                    {
+                        "name": "vocabulary_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "vocabulary_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "vocabulary_reference",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "vocabulary_version",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "vocabulary_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "domain",
+                "columns": [
+                    {
+                        "name": "domain_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "domain_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "domain_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "concept_class",
+                "columns": [
+                    {
+                        "name": "concept_class_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "concept_class_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "concept_class_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "concept_relationship",
+                "columns": [
+                    {
+                        "name": "concept_id_1",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "concept_id_2",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "relationship_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "valid_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "valid_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "invalid_reason",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "relationship",
+                "columns": [
+                    {
+                        "name": "relationship_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "relationship_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "is_hierarchical",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "defines_ancestry",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "reverse_relationship_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "relationship_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "concept_synonym",
+                "columns": [
+                    {
+                        "name": "concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "concept_synonym_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "language_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "concept_ancestor",
+                "columns": [
+                    {
+                        "name": "ancestor_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "descendant_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "min_levels_of_separation",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "max_levels_of_separation",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "source_to_concept_map",
+                "columns": [
+                    {
+                        "name": "source_code",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "source_vocabulary_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "source_code_description",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "target_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "target_vocabulary_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "valid_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "valid_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "invalid_reason",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "drug_strength",
+                "columns": [
+                    {
+                        "name": "drug_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "ingredient_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "amount_value",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "amount_unit_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "numerator_value",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "numerator_unit_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "denominator_value",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "denominator_unit_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "box_size",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "valid_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "valid_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "invalid_reason",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "cdm_source",
+                "columns": [
+                    {
+                        "name": "cdm_source_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "cdm_source_abbreviation",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "cdm_holder",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "source_description",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "source_documentation_reference",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "cdm_etl_reference",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "source_release_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "cdm_release_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "cdm_version",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "vocabulary_version",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "metadata",
+                "columns": [
+                    {
+                        "name": "metadata_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "metadata_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "value_as_string",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "value_as_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "metadata_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "metadata_datetime",
+                        "datatype": "DATETIME"
+                    }
+                ]
+            },
+            {
+                "name": "person",
+                "columns": [
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "gender_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "year_of_birth",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "month_of_birth",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "day_of_birth",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "birth_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "death_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "race_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "ethnicity_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "location_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "care_site_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "gender_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "gender_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "race_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "race_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "ethnicity_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "ethnicity_source_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "observation_period",
+                "columns": [
+                    {
+                        "name": "observation_period_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "observation_period_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "observation_period_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "period_type_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "specimen",
+                "columns": [
+                    {
+                        "name": "specimen_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "specimen_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "specimen_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "specimen_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "specimen_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "quantity",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "unit_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "anatomic_site_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "disease_status_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "specimen_source_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "specimen_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "unit_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "anatomic_site_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "disease_status_source_value",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "visit_occurrence",
+                "columns": [
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "visit_start_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "visit_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "visit_end_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "visit_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "care_site_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "visit_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "admitted_from_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "admitted_from_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "discharge_to_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "discharge_to_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "preceding_visit_occurrence_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "visit_detail",
+                "columns": [
+                    {
+                        "name": "visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "visit_detail_start_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "visit_detail_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "visit_detail_end_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "visit_detail_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "care_site_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "discharge_to_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "admitted_from_concept_id",
+                        "datatype": "INT64 /*Changed from admitting_source_* */"
+                    },
+                    {
+                        "name": "admitted_from_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "visit_detail_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "visit_detail_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "discharge_to_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "preceding_visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_parent_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "procedure_occurrence",
+                "columns": [
+                    {
+                        "name": "procedure_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "procedure_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "procedure_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "procedure_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "procedure_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "modifier_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "quantity",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "procedure_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "procedure_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "modifier_source_value",
+                        "datatype": "STRING "
+                    }
+                ]
+            },
+            {
+                "name": "drug_exposure",
+                "columns": [
+                    {
+                        "name": "drug_exposure_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "drug_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "drug_exposure_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "drug_exposure_start_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "drug_exposure_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "drug_exposure_end_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "verbatim_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "drug_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "stop_reason",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "refills",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "quantity",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "days_supply",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "sig",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "route_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "lot_number",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "drug_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "drug_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "route_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "dose_unit_source_value",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "device_exposure",
+                "columns": [
+                    {
+                        "name": "device_exposure_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "device_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "device_exposure_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "device_exposure_start_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "device_exposure_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "device_exposure_end_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "device_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "unique_device_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "quantity",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "device_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "device_source_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "condition_occurrence",
+                "columns": [
+                    {
+                        "name": "condition_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "condition_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "condition_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "condition_start_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "condition_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "condition_end_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "condition_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "condition_status_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "stop_reason",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "condition_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "condition_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "condition_status_source_value",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "measurement",
+                "columns": [
+                    {
+                        "name": "measurement_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "measurement_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "measurement_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "measurement_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "measurement_time",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "measurement_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "operator_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "value_as_number",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "value_as_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "unit_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "range_low",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "range_high",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "measurement_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "measurement_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "unit_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "value_source_value",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "note",
+                "columns": [
+                    {
+                        "name": "note_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "note_event_id",
+                        "datatype": "INT64 "
+                    },
+                    {
+                        "name": "note_event_field_concept_id",
+                        "datatype": "INT64 "
+                    },
+                    {
+                        "name": "note_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "note_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "note_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "note_class_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "note_title",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "note_text",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "encoding_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "language_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "note_source_value",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "note_nlp",
+                "columns": [
+                    {
+                        "name": "note_nlp_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "note_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "section_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "snippet",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "\"offset\"",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "lexical_variant",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "note_nlp_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "nlp_system",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "nlp_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "nlp_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "term_exists",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "term_temporal",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "term_modifiers",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "note_nlp_source_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "observation",
+                "columns": [
+                    {
+                        "name": "observation_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "observation_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "observation_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "observation_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "observation_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "value_as_number",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "value_as_string",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "value_as_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "qualifier_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "unit_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "observation_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "observation_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "unit_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "qualifier_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "observation_event_id",
+                        "datatype": "INT64 "
+                    },
+                    {
+                        "name": "obs_event_field_concept_id",
+                        "datatype": "INT64 "
+                    },
+                    {
+                        "name": "value_as_datetime",
+                        "datatype": "DATETIME"
+                    }
+                ]
+            },
+            {
+                "name": "survey_conduct",
+                "columns": [
+                    {
+                        "name": "survey_conduct_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "survey_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "survey_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "survey_start_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "survey_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "survey_end_datetime",
+                        "datatype": "DATETIME"
+                    },
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "assisted_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "respondent_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "timing_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "collection_method_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "assisted_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "respondent_type_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "timing_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "collection_method_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "survey_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "survey_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "survey_source_identifier",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "validated_survey_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "validated_survey_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "survey_version_number",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "visit_occurrence_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "visit_detail_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "response_visit_occurrence_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "fact_relationship",
+                "columns": [
+                    {
+                        "name": "domain_concept_id_1",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "fact_id_1",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "domain_concept_id_2",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "fact_id_2",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "relationship_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "location",
+                "columns": [
+                    {
+                        "name": "location_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "address_1",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "address_2",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "city",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "state",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "zip",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "county",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "country",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "location_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "latitude",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "longitude",
+                        "datatype": "FLOAT64"
+                    }
+                ]
+            },
+            {
+                "name": "location_history",
+                "columns": [
+                    {
+                        "name": "location_history_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "location_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "relationship_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "domain_id",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "entity_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "end_date",
+                        "datatype": "date"
+                    }
+                ]
+            },
+            {
+                "name": "care_site",
+                "columns": [
+                    {
+                        "name": "care_site_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "care_site_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "place_of_service_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "location_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "care_site_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "place_of_service_source_value",
+                        "datatype": "STRING"
+                    }
+                ]
+            },
+            {
+                "name": "provider",
+                "columns": [
+                    {
+                        "name": "provider_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "provider_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "npi",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "dea",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "specialty_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "care_site_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "year_of_birth",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "gender_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "provider_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "specialty_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "specialty_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "gender_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "gender_source_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "payer_plan_period",
+                "columns": [
+                    {
+                        "name": "payer_plan_period_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "contract_person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "payer_plan_period_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "payer_plan_period_end_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "payer_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "plan_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "contract_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "sponsor_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "stop_reason_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "payer_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "payer_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "plan_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "plan_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "contract_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "contract_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "sponsor_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "sponsor_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "family_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "stop_reason_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "stop_reason_source_concept_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "cost",
+                "columns": [
+                    {
+                        "name": "cost_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "cost_event_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "cost_event_field_concept_id",
+                        "datatype": "INT64 "
+                    },
+                    {
+                        "name": "cost_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "cost_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "currency_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "cost",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "incurred_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "billed_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "paid_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "revenue_code_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "drg_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "cost_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "cost_source_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "revenue_code_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "drg_source_value",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "payer_plan_period_id",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "drug_era",
+                "columns": [
+                    {
+                        "name": "drug_era_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "drug_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "drug_era_start_datetime",
+                        "datatype": "datetime"
+                    },
+                    {
+                        "name": "drug_era_end_datetime",
+                        "datatype": "datetime"
+                    },
+                    {
+                        "name": "drug_exposure_count",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "gap_days",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "dose_era",
+                "columns": [
+                    {
+                        "name": "dose_era_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "drug_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "unit_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "dose_value",
+                        "datatype": "FLOAT64"
+                    },
+                    {
+                        "name": "dose_era_start_datetime",
+                        "datatype": "datetime"
+                    },
+                    {
+                        "name": "dose_era_end_datetime",
+                        "datatype": "datetime"
+                    }
+                ]
+            },
+            {
+                "name": "condition_era",
+                "columns": [
+                    {
+                        "name": "condition_era_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "person_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "condition_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "condition_era_start_datetime",
+                        "datatype": "datetime"
+                    },
+                    {
+                        "name": "condition_era_end_datetime",
+                        "datatype": "datetime"
+                    },
+                    {
+                        "name": "condition_occurrence_count",
+                        "datatype": "INT64"
+                    }
+                ]
+            },
+            {
+                "name": "cohort",
+                "columns": [
+                    {
+                        "name": "cohort_definition_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "subject_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "cohort_start_date",
+                        "datatype": "date"
+                    },
+                    {
+                        "name": "cohort_end_date",
+                        "datatype": "date"
+                    }
+                ]
+            },
+            {
+                "name": "cohort_definition",
+                "columns": [
+                    {
+                        "name": "cohort_definition_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "cohort_definition_name",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "cohort_definition_description",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "definition_type_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "cohort_definition_syntax",
+                        "datatype": "STRING"
+                    },
+                    {
+                        "name": "subject_concept_id",
+                        "datatype": "INT64"
+                    },
+                    {
+                        "name": "cohort_initiation_date",
+                        "datatype": "date"
+                    }
+                ]
+            }
+        ],
+        "relationships": [
+            {
+                "name": "fpk_concept_domain",
+                "from": {
+                    "table": "domain",
+                    "column": "domain_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "domain_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_vocabulary",
+                "from": {
+                    "table": "vocabulary",
+                    "column": "vocabulary_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "vocabulary_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_class",
+                "from": {
+                    "table": "concept",
+                    "column": "concept_class_id",
+                    "cardinality": "one_or_many"
+                },
+                "to": {
+                    "table": "concept_class",
+                    "column": "concept_class_id",
+                    "cardinality": "one"
+                }
+            },
+            {
+                "name": "fpk_vocabulary_concept",
+                "from": {
+                    "table": "vocabulary",
+                    "column": "vocabulary_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_domain_concept",
+                "from": {
+                    "table": "domain",
+                    "column": "domain_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_class_concept",
+                "from": {
+                    "table": "concept_class",
+                    "column": "concept_class_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_relationship_c_1",
+                "from": {
+                    "table": "concept_relationship",
+                    "column": "concept_id_1",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_relationship_c_2",
+                "from": {
+                    "table": "concept_relationship",
+                    "column": "concept_id_2",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_relationship_id",
+                "from": {
+                    "table": "concept_relationship",
+                    "column": "relationship_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "relationship",
+                    "column": "relationship_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_relationship_concept",
+                "from": {
+                    "table": "relationship",
+                    "column": "relationship_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_relationship_reverse",
+                "from": {
+                    "table": "relationship",
+                    "column": "reverse_relationship_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "relationship",
+                    "column": "relationship_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_synonym_concept",
+                "from": {
+                    "table": "concept_synonym",
+                    "column": "concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_synonym_language_concept",
+                "from": {
+                    "table": "concept_synonym",
+                    "column": "language_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_ancestor_concept_1",
+                "from": {
+                    "table": "concept_ancestor",
+                    "column": "ancestor_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_concept_ancestor_concept_2",
+                "from": {
+                    "table": "concept_ancestor",
+                    "column": "descendant_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_source_to_concept_map_v_1",
+                "from": {
+                    "table": "source_to_concept_map",
+                    "column": "source_vocabulary_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "vocabulary",
+                    "column": "vocabulary_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_source_to_concept_map_v_2",
+                "from": {
+                    "table": "source_to_concept_map",
+                    "column": "target_vocabulary_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "vocabulary",
+                    "column": "vocabulary_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_source_to_concept_map_c_1",
+                "from": {
+                    "table": "source_to_concept_map",
+                    "column": "target_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_strength_concept_1",
+                "from": {
+                    "table": "drug_strength",
+                    "column": "drug_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_strength_concept_2",
+                "from": {
+                    "table": "drug_strength",
+                    "column": "ingredient_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_strength_unit_1",
+                "from": {
+                    "table": "drug_strength",
+                    "column": "amount_unit_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_strength_unit_2",
+                "from": {
+                    "table": "drug_strength",
+                    "column": "numerator_unit_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_strength_unit_3",
+                "from": {
+                    "table": "drug_strength",
+                    "column": "denominator_unit_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_metadata_concept",
+                "from": {
+                    "table": "metadata",
+                    "column": "metadata_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_metadata_type_concept",
+                "from": {
+                    "table": "metadata",
+                    "column": "metadata_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_person_gender_concept",
+                "from": {
+                    "table": "person",
+                    "column": "gender_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_person_race_concept",
+                "from": {
+                    "table": "person",
+                    "column": "race_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_person_ethnicity_concept",
+                "from": {
+                    "table": "person",
+                    "column": "ethnicity_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_person_gender_concept_s",
+                "from": {
+                    "table": "person",
+                    "column": "gender_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_person_race_concept_s",
+                "from": {
+                    "table": "person",
+                    "column": "race_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_person_ethnicity_concept_s",
+                "from": {
+                    "table": "person",
+                    "column": "ethnicity_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_person_location",
+                "from": {
+                    "table": "person",
+                    "column": "location_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "location",
+                    "column": "location_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_person_provider",
+                "from": {
+                    "table": "person",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_person_care_site",
+                "from": {
+                    "table": "person",
+                    "column": "care_site_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "care_site",
+                    "column": "care_site_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_period_person",
+                "from": {
+                    "table": "observation_period",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_period_concept",
+                "from": {
+                    "table": "observation_period",
+                    "column": "period_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_specimen_person",
+                "from": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "specimen",
+                    "column": "person_id",
+                    "cardinality": "zero_or_many"
+                }
+            },
+            {
+                "name": "fpk_specimen_concept",
+                "from": {
+                    "table": "specimen",
+                    "column": "specimen_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_specimen_type_concept",
+                "from": {
+                    "table": "specimen",
+                    "column": "specimen_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_specimen_unit_concept",
+                "from": {
+                    "table": "specimen",
+                    "column": "unit_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_specimen_site_concept",
+                "from": {
+                    "table": "specimen",
+                    "column": "anatomic_site_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_specimen_status_concept",
+                "from": {
+                    "table": "specimen",
+                    "column": "disease_status_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_visit_person",
+                "from": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_occurrence",
+                    "column": "person_id",
+                    "cardinality": "zero_or_many"
+                }
+            },
+            {
+                "name": "fpk_visit_concept",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "visit_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_visit_type_concept",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "visit_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_visit_provider",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "zero_or_many"
+                }
+            },
+            {
+                "name": "fpk_visit_care_site",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "care_site_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "care_site",
+                    "column": "care_site_id",
+                    "cardinality": "zero_or_many"
+                }
+            },
+            {
+                "name": "fpk_visit_concept_s",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "visit_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_visit_discharge",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "discharge_to_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_visit_preceding",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "preceding_visit_occurrence_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_v_detail_person",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_v_detail_concept",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_v_detail_type_concept",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_v_detail_provider",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_v_detail_care_site",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "care_site_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "care_site",
+                    "column": "care_site_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_v_detail_discharge",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "discharge_to_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_v_detail_concept_s",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_v_detail_preceding",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "preceding_visit_detail_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_v_detail_parent",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_parent_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpd_v_detail_visit",
+                "from": {
+                    "table": "visit_detail",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_procedure_person",
+                "from": {
+                    "table": "procedure_occurrence",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_procedure_concept",
+                "from": {
+                    "table": "procedure_occurrence",
+                    "column": "procedure_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_procedure_type_concept",
+                "from": {
+                    "table": "procedure_occurrence",
+                    "column": "procedure_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_procedure_modifier",
+                "from": {
+                    "table": "procedure_occurrence",
+                    "column": "modifier_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_procedure_provider",
+                "from": {
+                    "table": "procedure_occurrence",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_procedure_visit",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "procedure_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "zero_or_many"
+                }
+            },
+            {
+                "name": "fpk_procedure_v_detail",
+                "from": {
+                    "table": "procedure_occurrence",
+                    "column": "visit_detail_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_procedure_concept_s",
+                "from": {
+                    "table": "procedure_occurrence",
+                    "column": "procedure_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_person",
+                "from": {
+                    "table": "drug_exposure",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_concept",
+                "from": {
+                    "table": "drug_exposure",
+                    "column": "drug_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_type_concept",
+                "from": {
+                    "table": "drug_exposure",
+                    "column": "drug_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_route_concept",
+                "from": {
+                    "table": "drug_exposure",
+                    "column": "route_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_provider",
+                "from": {
+                    "table": "drug_exposure",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_visit",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "drug_exposure",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "zero_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_v_detail",
+                "from": {
+                    "table": "drug_exposure",
+                    "column": "visit_detail_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_concept_s",
+                "from": {
+                    "table": "drug_exposure",
+                    "column": "drug_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_device_person",
+                "from": {
+                    "table": "device_exposure",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_device_concept",
+                "from": {
+                    "table": "device_exposure",
+                    "column": "device_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_device_type_concept",
+                "from": {
+                    "table": "device_exposure",
+                    "column": "device_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_device_provider",
+                "from": {
+                    "table": "device_exposure",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_device_visit",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "device_exposure",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "zero_or_many"
+                }
+            },
+            {
+                "name": "fpk_device_v_detail",
+                "from": {
+                    "table": "device_exposure",
+                    "column": "visit_detail_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_device_concept_s",
+                "from": {
+                    "table": "device_exposure",
+                    "column": "device_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_person",
+                "from": {
+                    "table": "condition_occurrence",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_concept",
+                "from": {
+                    "table": "condition_occurrence",
+                    "column": "condition_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_type_concept",
+                "from": {
+                    "table": "condition_occurrence",
+                    "column": "condition_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_status_concept",
+                "from": {
+                    "table": "condition_occurrence",
+                    "column": "condition_status_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_provider",
+                "from": {
+                    "table": "condition_occurrence",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_visit",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "condition_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "zero_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_v_detail",
+                "from": {
+                    "table": "condition_occurrence",
+                    "column": "visit_detail_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_concept_s",
+                "from": {
+                    "table": "condition_occurrence",
+                    "column": "condition_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_person",
+                "from": {
+                    "table": "measurement",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_concept",
+                "from": {
+                    "table": "measurement",
+                    "column": "measurement_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_type_concept",
+                "from": {
+                    "table": "measurement",
+                    "column": "measurement_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_operator",
+                "from": {
+                    "table": "measurement",
+                    "column": "operator_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_value",
+                "from": {
+                    "table": "measurement",
+                    "column": "value_as_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_unit",
+                "from": {
+                    "table": "measurement",
+                    "column": "unit_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_provider",
+                "from": {
+                    "table": "measurement",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_visit",
+                "from": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one_or_many"
+                },
+                "to": {
+                    "table": "measurement",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "zero_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_v_detail",
+                "from": {
+                    "table": "measurement",
+                    "column": "visit_detail_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_measurement_concept_s",
+                "from": {
+                    "table": "measurement",
+                    "column": "measurement_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_person",
+                "from": {
+                    "table": "note",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_type_concept",
+                "from": {
+                    "table": "note",
+                    "column": "note_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_class_concept",
+                "from": {
+                    "table": "note",
+                    "column": "note_class_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_encoding_concept",
+                "from": {
+                    "table": "note",
+                    "column": "encoding_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_language_concept",
+                "from": {
+                    "table": "note",
+                    "column": "language_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_provider",
+                "from": {
+                    "table": "note",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_visit",
+                "from": {
+                    "table": "note",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "zero_or_many"
+                },
+                "to": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "zero_or_one"
+                }
+            },
+            {
+                "name": "fpk_note_v_detail",
+                "from": {
+                    "table": "note",
+                    "column": "visit_detail_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_nlp_note",
+                "from": {
+                    "table": "note_nlp",
+                    "column": "note_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "note",
+                    "column": "note_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_nlp_section_concept",
+                "from": {
+                    "table": "note_nlp",
+                    "column": "section_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_nlp_concept",
+                "from": {
+                    "table": "note_nlp",
+                    "column": "note_nlp_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_note_nlp_concept_s",
+                "from": {
+                    "table": "note_nlp",
+                    "column": "note_nlp_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_person",
+                "from": {
+                    "table": "observation",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_concept",
+                "from": {
+                    "table": "observation",
+                    "column": "observation_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_type_concept",
+                "from": {
+                    "table": "observation",
+                    "column": "observation_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_value",
+                "from": {
+                    "table": "observation",
+                    "column": "value_as_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_qualifier",
+                "from": {
+                    "table": "observation",
+                    "column": "qualifier_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_unit",
+                "from": {
+                    "table": "observation",
+                    "column": "unit_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_provider",
+                "from": {
+                    "table": "observation",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_visit",
+                "from": {
+                    "table": "observation",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "zero_or_many"
+                },
+                "to": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one"
+                }
+            },
+            {
+                "name": "fpk_observation_v_detail",
+                "from": {
+                    "table": "observation",
+                    "column": "visit_detail_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_observation_concept_s",
+                "from": {
+                    "table": "observation",
+                    "column": "observation_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_survey_person",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_survey_concept",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "survey_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_survey_provider",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "provider_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "provider",
+                    "column": "provider_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_survey_assist",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "assisted_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_respondent_type",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "respondent_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_survey_timing",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "timing_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_collection_method",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "collection_method_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_survey_source",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "survey_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_validation",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "validated_survey_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_survey_visit",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_survey_v_detail",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "visit_detail_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_detail",
+                    "column": "visit_detail_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_response_visit",
+                "from": {
+                    "table": "survey_conduct",
+                    "column": "response_visit_occurrence_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "visit_occurrence",
+                    "column": "visit_occurrence_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_fact_domain_1",
+                "from": {
+                    "table": "fact_relationship",
+                    "column": "domain_concept_id_1",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_fact_domain_2",
+                "from": {
+                    "table": "fact_relationship",
+                    "column": "domain_concept_id_2",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_fact_relationship",
+                "from": {
+                    "table": "fact_relationship",
+                    "column": "relationship_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_location_history",
+                "from": {
+                    "table": "location_history",
+                    "column": "location_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "location",
+                    "column": "location_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_relationship_type",
+                "from": {
+                    "table": "location_history",
+                    "column": "relationship_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_care_site_place",
+                "from": {
+                    "table": "care_site",
+                    "column": "place_of_service_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_care_site_location",
+                "from": {
+                    "table": "care_site",
+                    "column": "location_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "location",
+                    "column": "location_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_provider_specialty",
+                "from": {
+                    "table": "provider",
+                    "column": "specialty_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_provider_care_site",
+                "from": {
+                    "table": "provider",
+                    "column": "care_site_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "care_site",
+                    "column": "care_site_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_provider_gender",
+                "from": {
+                    "table": "provider",
+                    "column": "gender_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_provider_specialty_s",
+                "from": {
+                    "table": "provider",
+                    "column": "specialty_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_provider_gender_s",
+                "from": {
+                    "table": "provider",
+                    "column": "gender_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_payer_plan_period",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_contract_person",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "contract_person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_payer_concept",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "payer_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_plan_concept_id",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "plan_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_contract_concept",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "contract_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_sponsor_concept",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "sponsor_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_stop_reason_concept",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "stop_reason_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_payer_s",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "payer_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_plan_s",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "plan_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_contract_s",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "contract_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_sponsor_s",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "sponsor_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_stop_reason_s",
+                "from": {
+                    "table": "payer_plan_period",
+                    "column": "stop_reason_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_cost_person",
+                "from": {
+                    "table": "cost",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_cost_concept",
+                "from": {
+                    "table": "cost",
+                    "column": "cost_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_cost_type",
+                "from": {
+                    "table": "cost",
+                    "column": "cost_type_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_cost_currency",
+                "from": {
+                    "table": "cost",
+                    "column": "currency_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_revenue_concept",
+                "from": {
+                    "table": "cost",
+                    "column": "revenue_code_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drg_concept",
+                "from": {
+                    "table": "cost",
+                    "column": "drg_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_cost_s",
+                "from": {
+                    "table": "cost",
+                    "column": "cost_source_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_cost_period",
+                "from": {
+                    "table": "cost",
+                    "column": "payer_plan_period_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "payer_plan_period",
+                    "column": "payer_plan_period_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_era_person",
+                "from": {
+                    "table": "drug_era",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_drug_era_concept",
+                "from": {
+                    "table": "drug_era",
+                    "column": "drug_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_dose_era_person",
+                "from": {
+                    "table": "dose_era",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_dose_era_concept",
+                "from": {
+                    "table": "dose_era",
+                    "column": "drug_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_dose_era_unit_concept",
+                "from": {
+                    "table": "dose_era",
+                    "column": "unit_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_era_person",
+                "from": {
+                    "table": "condition_era",
+                    "column": "person_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "person",
+                    "column": "person_id",
+                    "cardinality": "one_or_many"
+                }
+            },
+            {
+                "name": "fpk_condition_era_concept",
+                "from": {
+                    "table": "condition_era",
+                    "column": "condition_concept_id",
+                    "cardinality": "one"
+                },
+                "to": {
+                    "table": "concept",
+                    "column": "concept_id",
+                    "cardinality": "one_or_many"
+                }
+            }
+        ],
+        "assets": [
+            {
+                "name": "person_visit",
+                "tables": [
+                    {
+                        "name": "person",
+                        "columns": []
+                    },
+                    {
+                        "name": "visit_occurrence",
+                        "columns": []
+                    },
+                    {
+                        "name": "provider",
+                        "columns": []
+                    },
+                    {
+                        "name": "care_site",
+                        "columns": []
+                    },
+                    {
+                        "name": "specimen",
+                        "columns": []
+                    },
+                    {
+                        "name": "procedure_occurrence",
+                        "columns": []
+                    },
+                    {
+                        "name": "device_exposure",
+                        "columns": []
+                    },
+                    {
+                        "name": "condition_occurrence",
+                        "columns": []
+                    },
+                    {
+                        "name": "measurement",
+                        "columns": []
+                    },
+                    {
+                        "name": "note",
+                        "columns": []
+                    },
+                    {
+                        "name": "observation",
+                        "columns": []
+                    },
+                    {
+                        "name": "drug_exposure",
+                        "columns": []
+                    }
+                ],
+                "rootTable": "person",
+                "rootColumn": "person_id",
+                "follow": [
+                    "fpk_visit_person",
+                    "fpk_visit_provider",
+                    "fpk_visit_care_site",
+                    "fpk_specimen_person",
+                    "fpk_procedure_visit",
+                    "fpk_device_visit",
+                    "fpk_condition_visit",
+                    "fpk_measurement_visit",
+                    "fpk_note_visit",
+                    "fpk_drug_visit"
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This PR provides the groundwork for integration tests:
- DataRepoClient, DataRepoClientErrorHandler, and DataRepoResponse provide an interface for doing post, get, and delete to the Jade repo. They handle the process of unpacking the response into either ErrorModel or desired object.
- JsonLoader - common code for loading class path files and turning them into objects
- Names - common code for randomizing object names
- it-study-omop.json is a fairly complete OMOP schema with all relationships
- StudyTest - the one and only integration test: happy path create, get, enumerate, delete a the omop study.
- StudyConnectedTest - create and delete the omop study; I used this to debug the json and validator changes. Let me know if you think it is redundant.
- StudyRequestValidator - made bug fixes and added messages to allow me to debug my omop schema. Added DR-257 to record the additional work needed on the validators.
- application.properties - added properties to supply the integration test server, port, and protocol

I tested this by having `GOOGLE_APPLICATION_CREDENTIALS` set in a shell and then doing `gradle bootRun` to make a server. Then in IntelliJ, running the StudyTest.