### PR TITLE
Fix double prefixing bug

### DIFF
--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -75,7 +75,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         try {
             // For idempotency, if we find the study exists, we assume that we started to
             // create it before and failed in the middle. We delete it and re-create it from scratch.
-            if (studyExists(studyName)) {
+            if (studyExists(study.getName())) {
                 deleteStudy(study);
             }
 


### PR DESCRIPTION
Not sure when this crept in, but one study existence check was re-prefixing an already prefixed name.
