### PR TITLE
DR-264 - Add debugging to catch enum bug

### DIFF
--- a/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
@@ -72,7 +72,7 @@ public class GlobalExceptionHandler {
     private ErrorModel buildErrorModel(Throwable ex) {
         logger.error("Global exception handler: catch stack");
         for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
-            logger.error("   cause: " + ex.toString());
+            logger.error("   cause: " + cause.toString());
         }
         return new ErrorModel().message(ex.getMessage());
     }

--- a/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/controller/GlobalExceptionHandler.java
@@ -67,7 +67,13 @@ public class GlobalExceptionHandler {
 
     // This method takes throwable so it can be shared by the JobResponseException handler:
     // the type returned from getCause() is a Throwable.
+    // This error handler logs the complete error list so we can debug the underlying causes
+    // of errors. We do not want to return that to the client, but need it for our own debugging.
     private ErrorModel buildErrorModel(Throwable ex) {
+        logger.error("Global exception handler: catch stack");
+        for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
+            logger.error("   cause: " + ex.toString());
+        }
         return new ErrorModel().message(ex.getMessage());
     }
 

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -507,6 +507,10 @@ public class BigQueryPdao implements PrimaryDataAccess {
         }
 
         // DEBUG: dump the row id table
+        debugDumpRowIdTable(datasetName);
+    }
+
+    private void debugDumpRowIdTable(String datasetName) {
         StringBuilder builder = new StringBuilder();
         builder.append("SELECT ")
             .append(PDAO_TABLE_ID_COLUMN).append(",").append(PDAO_ROW_ID_COLUMN)
@@ -522,8 +526,9 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 logger.info("tableid=" + row.get(0).getStringValue() + "  rowid=" + row.get(1).getStringValue());
             }
         } catch (InterruptedException ie) {
-            throw new PdaoException("Validate row ids query unexpectedly interrupted", ie);
+            throw new PdaoException("Debug dump row id query unexpectedly interrupted", ie);
         }
+
     }
 
     /**
@@ -564,6 +569,8 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 for (String rowId : rowIds) {
                     logger.error(" rowIdIn: " + rowId);
                 }
+
+                debugDumpRowIdTable(datasetName);
 
                 throw new PdaoException("Invalid row ids supplied");
             }

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -179,7 +179,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 }
             }
         } catch (InterruptedException ie) {
-            throw new PdaoException("Append query unexpectedly interrupted", ie);
+            throw new PdaoException("Map values to rows query unexpectedly interrupted", ie);
         }
 
         return rowIdMatch;
@@ -538,6 +538,12 @@ public class BigQueryPdao implements PrimaryDataAccess {
             FieldValueList row = result.iterateAll().iterator().next();
             FieldValue countValue = row.get(0);
             if (countValue.getLongValue() != rowIds.size()) {
+                logger.error("Invalid row ids supplied: rowIds=" + rowIds.size() +
+                " count=" + countValue.getLongValue());
+                for (String rowId : rowIds) {
+                    logger.error(" rowIdIn: " + rowId);
+                }
+
                 throw new PdaoException("Invalid row ids supplied");
             }
         } catch (InterruptedException ie) {

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -539,7 +539,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             FieldValue countValue = row.get(0);
             if (countValue.getLongValue() != rowIds.size()) {
                 logger.error("Invalid row ids supplied: rowIds=" + rowIds.size() +
-                " count=" + countValue.getLongValue());
+                    " count=" + countValue.getLongValue());
                 for (String rowId : rowIds) {
                     logger.error(" rowIdIn: " + rowId);
                 }

--- a/src/test/java/bio/terra/controller/DatasetOperationTest.java
+++ b/src/test/java/bio/terra/controller/DatasetOperationTest.java
@@ -36,8 +36,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -77,7 +75,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class DatasetOperationTest {
     private static final boolean deleteOnTeardown = true;
 
-    private Logger logger = LoggerFactory.getLogger("bio.terra.controller.DatasetOperationTest");
+    // private Logger logger = LoggerFactory.getLogger("bio.terra.controller.DatasetOperationTest");
 
     // TODO: MORE TESTS to be done when we can ingest data:
     // - test more complex studies with relationships

--- a/src/test/java/bio/terra/controller/DatasetOperationTest.java
+++ b/src/test/java/bio/terra/controller/DatasetOperationTest.java
@@ -36,6 +36,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -75,6 +77,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class DatasetOperationTest {
     private static final boolean deleteOnTeardown = true;
 
+    private Logger logger = LoggerFactory.getLogger("bio.terra.controller.DatasetOperationTest");
 
     // TODO: MORE TESTS to be done when we can ingest data:
     // - test more complex studies with relationships
@@ -204,18 +207,47 @@ public class DatasetOperationTest {
         // but ours should be in order in the enumeration. So we do a merge waiting until we match
         // by id and then comparing contents.
         int compareIndex = 0;
-        for (DatasetSummaryModel anEnumeratedArray : enumeratedArray) {
-            if (anEnumeratedArray.getId().equals(datasetList.get(compareIndex).getId())) {
+        for (DatasetSummaryModel anEnumeratedDataset : enumeratedArray) {
+            if (anEnumeratedDataset.getId().equals(datasetList.get(compareIndex).getId())) {
+                // FOR DEBUG: do the assertion test explicitly and dump the data if it doesn't match.
+                if (!anEnumeratedDataset.equals(datasetList.get(compareIndex))) {
+                    dumpEnumState("dataset compare", compareIndex, datasetList, enumeratedArray);
+                }
                 assertThat("Enumeration summary matches create summary",
-                        anEnumeratedArray, equalTo(datasetList.get(compareIndex)));
+                        anEnumeratedDataset, equalTo(datasetList.get(compareIndex)));
                 compareIndex++;
             }
+        }
+        if (compareIndex != 5) {
+            dumpEnumState("index check", compareIndex, datasetList, enumeratedArray);
         }
         assertThat("we found all datasets", compareIndex, equalTo(5));
 
         for (int i = 0; i < 5; i++) {
             deleteTestDataset(enumeratedArray[i].getId());
         }
+    }
+
+    private void dumpEnumState(String context,
+                               int compareIndex,
+                               List<DatasetSummaryModel> datasetList,
+                               DatasetSummaryModel[] enumeratedArray) {
+        logger.error("== DEBUG DUMP FROM DATASET TEST ENUMERATION ==");
+        logger.error("context=" + context);
+        logger.error("compareIndex=" + compareIndex);
+        logger.error("createList:");
+        int index = 0;
+        for (DatasetSummaryModel dataset : datasetList) {
+            logger.error("[" + index + "] " + dataset.toString());
+            index++;
+        }
+        logger.error("enumList:");
+        index = 0;
+        for (DatasetSummaryModel dataset : enumeratedArray) {
+            logger.error("[" + index + "] " + dataset.toString());
+            index++;
+        }
+        logger.error("== END DEBUG DUMP ==");
     }
 
     @Test

--- a/src/test/java/bio/terra/controller/DatasetOperationTest.java
+++ b/src/test/java/bio/terra/controller/DatasetOperationTest.java
@@ -209,45 +209,17 @@ public class DatasetOperationTest {
         int compareIndex = 0;
         for (DatasetSummaryModel anEnumeratedDataset : enumeratedArray) {
             if (anEnumeratedDataset.getId().equals(datasetList.get(compareIndex).getId())) {
-                // FOR DEBUG: do the assertion test explicitly and dump the data if it doesn't match.
-                if (!anEnumeratedDataset.equals(datasetList.get(compareIndex))) {
-                    dumpEnumState("dataset compare", compareIndex, datasetList, enumeratedArray);
-                }
                 assertThat("Enumeration summary matches create summary",
                         anEnumeratedDataset, equalTo(datasetList.get(compareIndex)));
                 compareIndex++;
             }
         }
-        if (compareIndex != 5) {
-            dumpEnumState("index check", compareIndex, datasetList, enumeratedArray);
-        }
+
         assertThat("we found all datasets", compareIndex, equalTo(5));
 
         for (int i = 0; i < 5; i++) {
             deleteTestDataset(enumeratedArray[i].getId());
         }
-    }
-
-    private void dumpEnumState(String context,
-                               int compareIndex,
-                               List<DatasetSummaryModel> datasetList,
-                               DatasetSummaryModel[] enumeratedArray) {
-        logger.error("== DEBUG DUMP FROM DATASET TEST ENUMERATION ==");
-        logger.error("context=" + context);
-        logger.error("compareIndex=" + compareIndex);
-        logger.error("createList:");
-        int index = 0;
-        for (DatasetSummaryModel dataset : datasetList) {
-            logger.error("[" + index + "] " + dataset.toString());
-            index++;
-        }
-        logger.error("enumList:");
-        index = 0;
-        for (DatasetSummaryModel dataset : enumeratedArray) {
-            logger.error("[" + index + "] " + dataset.toString());
-            index++;
-        }
-        logger.error("== END DEBUG DUMP ==");
     }
 
     @Test


### PR DESCRIPTION
This code change does not fix the bug. It adds a debug dump if the bug shows up, logging enough information for us to figure out why things failed.
