### PR TITLE
adds a data-repo namespace

### DIFF
--- a/ops/kubernetes/namespace.yaml
+++ b/ops/kubernetes/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: data-repo
+  labels:
+    name: data-repo

--- a/ops/local/pods/api-pod.yaml
+++ b/ops/local/pods/api-pod.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: data-repo-api
+  namespace: data-repo
   labels:
     app: data-repo
     component: data-repo-api

--- a/ops/local/pods/oidc-proxy-no-ldap-pod.yaml
+++ b/ops/local/pods/oidc-proxy-no-ldap-pod.yaml
@@ -12,7 +12,7 @@ spec:
     image: broadinstitute/openidc-proxy:db_ldap_2_3_3
     env:
       - name: PROXY_URL
-        value: 'http://api-service.data-repo:8080/'
+        value: 'http://ui-service.data-repo:80/'
       - name: PROXY_URL2
         value: 'http://api-service.data-repo:8080/api'
       - name: PROXY_URL3

--- a/ops/local/pods/oidc-proxy-no-ldap-pod.yaml
+++ b/ops/local/pods/oidc-proxy-no-ldap-pod.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: oidc-proxy-pod
+  namespace: data-repo
   labels:
     app: data-repo
     component: data-repo-oidc-proxy
@@ -11,11 +12,11 @@ spec:
     image: broadinstitute/openidc-proxy:db_ldap_2_3_3
     env:
       - name: PROXY_URL
-        value: 'http://api-service:8080/'
+        value: 'http://api-service.data-repo:8080/'
       - name: PROXY_URL2
-        value: 'http://api-service:8080/api'
+        value: 'http://api-service.data-repo:8080/api'
       - name: PROXY_URL3
-        value: 'http://api-service:8080/register'
+        value: 'http://api-service.data-repo:8080/register'
       - name: CALLBACK_URI
         value: 'https://mini.broadinstitute.org/oauth2callback'
       - name: LOG_LEVEL

--- a/ops/local/pods/psql-pod.yaml
+++ b/ops/local/pods/psql-pod.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: postgres
+  namespace: data-repo
   labels:
     app: data-repo
     component: data-repo-db

--- a/ops/local/secrets/api-secrets.yaml.ctmpl
+++ b/ops/local/secrets/api-secrets.yaml.ctmpl
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: api-secrets
+  namespace: data-repo
 data:
   datarepo-uri: {{ .Data.datarepoUri | base64Encode }}
   datarepo-username: {{ .Data.datarepoUsername | base64Encode }}

--- a/ops/local/services/api-service.yaml
+++ b/ops/local/services/api-service.yaml
@@ -1,6 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
+  namespace: data-repo
   name: api-service
 spec:
   selector:

--- a/ops/local/services/oidc-proxy-service.yaml
+++ b/ops/local/services/oidc-proxy-service.yaml
@@ -1,6 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
+  namespace: data-repo
   name: oidc-proxy-service
 spec:
   selector:

--- a/ops/local/services/psql-service.yaml
+++ b/ops/local/services/psql-service.yaml
@@ -1,6 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
+  namespace: data-repo
   name: postgres-service
 spec:
   selector:


### PR DESCRIPTION
One of the security requirements for us to use Kubernetes is that we'll use namespaces. This defines a way to group things in the cluster so that they can only talk to each other. 