### PR TITLE
DR-264 dataset test bug

### DIFF
--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -521,8 +521,9 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 logger.info("tableid=" + row.get(0).getStringValue() + "  rowid=" + row.get(1).getStringValue());
             }
         } catch (InterruptedException ie) {
-            throw new PdaoException("Validate row ids query unexpectedly interrupted", ie);
+            throw new PdaoException("Debug dump row id query unexpectedly interrupted", ie);
         }
+
     }
 
     /**
@@ -563,6 +564,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 for (String rowId : rowIds) {
                     logger.error(" rowIdIn: " + rowId);
                 }
+
                 throw new PdaoException("Invalid row ids supplied");
             }
         } catch (InterruptedException ie) {

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -569,9 +569,6 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 for (String rowId : rowIds) {
                     logger.error(" rowIdIn: " + rowId);
                 }
-
-                debugDumpRowIdTable(datasetName);
-
                 throw new PdaoException("Invalid row ids supplied");
             }
         } catch (InterruptedException ie) {

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -511,7 +511,6 @@ public class BigQueryPdao implements PrimaryDataAccess {
         } catch (InterruptedException e) {
             throw new IllegalStateException("Insert root row ids unexpectedly interrupted", e);
         } catch (BigQueryException ex) {
-            logger.error(ex.toString());
             throw new PdaoException("Failure inserting root row ids", ex);
         }
     }

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -506,11 +506,6 @@ public class BigQueryPdao implements PrimaryDataAccess {
             }
         }
 
-        // DEBUG: dump the row id table
-        debugDumpRowIdTable(datasetName);
-    }
-
-    private void debugDumpRowIdTable(String datasetName) {
         StringBuilder builder = new StringBuilder();
         builder.append("SELECT ")
             .append(PDAO_TABLE_ID_COLUMN).append(",").append(PDAO_ROW_ID_COLUMN)
@@ -526,9 +521,8 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 logger.info("tableid=" + row.get(0).getStringValue() + "  rowid=" + row.get(1).getStringValue());
             }
         } catch (InterruptedException ie) {
-            throw new PdaoException("Debug dump row id query unexpectedly interrupted", ie);
+            throw new PdaoException("Validate row ids query unexpectedly interrupted", ie);
         }
-
     }
 
     /**

--- a/src/test/java/bio/terra/controller/DatasetOperationTest.java
+++ b/src/test/java/bio/terra/controller/DatasetOperationTest.java
@@ -36,8 +36,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/bio/terra/controller/DatasetOperationTest.java
+++ b/src/test/java/bio/terra/controller/DatasetOperationTest.java
@@ -36,6 +36,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -208,7 +210,7 @@ public class DatasetOperationTest {
         for (DatasetSummaryModel anEnumeratedDataset : enumeratedArray) {
             if (anEnumeratedDataset.getId().equals(datasetList.get(compareIndex).getId())) {
                 assertThat("Enumeration summary matches create summary",
-                        anEnumeratedDataset, equalTo(datasetList.get(compareIndex)));
+                    anEnumeratedDataset, equalTo(datasetList.get(compareIndex)));
                 compareIndex++;
             }
         }


### PR DESCRIPTION
This PR is a real fix for the bug. It removes the use of InsertAll (streaming load) and performs literal inserts with an INSERT statement (non-streaming load).

As with the mapValuesToRows code, there are size limits that we won't want to live with, but I hope it is sufficient for now. We will have to redo it when we decide how we _really_ want to do assets and what we want the UI role to be in computing row ids.
