### PR TITLE
DR-309 pod security policies and service account

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ def getGitHash = { ->
 
 
 docker {
-    name "gcr.io/broad-jade-dev/${bootJar.baseName}:${System.env.TAG}"
+    name "gcr.io/broad-jade-dev/${bootJar.baseName}:${System.env.GCR_TAG ?: "latest"}"
     copySpec.from(tasks.unpack.outputs).into("dependency")
     buildArgs(['DEPENDENCY': "dependency"])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ dependencies {
     compile 'org.liquibase:liquibase-core:3.6.3'         // For upgrade
     compile 'org.postgresql:postgresql:42.2.5'           // Postgres jdbc driver
     compile 'org.slf4j:slf4j-api:1.7.25'                 // Logging facade
-    compile "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
+    compile "org.springframework.boot:spring-boot-starter-web"
     compile 'org.springframework:spring-jdbc:5.1.6.RELEASE'
     compile 'org.broadinstitute.dsde.workbench:sam-client_2.12:0.1-37bc074'
 
@@ -130,7 +130,7 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-    testCompile "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
+    testCompile "org.springframework.boot:spring-boot-starter-test"
     testCompile 'org.postgresql:postgresql:42.2.5'
 
     generatedCompile 'org.springframework.boot:spring-boot-starter-web'
@@ -246,7 +246,7 @@ def getGitHash = { ->
 
 
 docker {
-    name "gcr.io/broad-jade-dev/${bootJar.baseName}:latest${System.env.GOOGLE_CLOUD_PROJECT}"
+    name "gcr.io/broad-jade-dev/${bootJar.baseName}:${System.env.TAG}"
     copySpec.from(tasks.unpack.outputs).into("dependency")
     buildArgs(['DEPENDENCY': "dependency"])
 }

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -63,7 +63,10 @@ kubectl --namespace data-repo create secret generic sa-key --from-file="sa-key.j
 vault read -field=value secret/dsde/datarepo/dev/common/server.crt > "${SCRATCH}/server.crt"
 vault read -field=value secret/dsde/datarepo/dev/common/server.key > "${SCRATCH}/server.key"
 kubectl get secret tls-cert && kubectl delete secret tls-cert
-kubectl --namespace=data-repo create secret tls tls-cert --cert=${SCRATCH}/server.crt --key=${SCRATCH}/server.key
+kubectl --namespace=data-repo create secret generic server-key --from-file=${SCRATCH}/server.key
+kubectl --namespace=data-repo create secret generic server-cert --from-file=${SCRATCH}/server.crt
+
+sleep 5
 
 # create or update postgres pod + service
 kubectl apply -f "${WD}/k8s/pods/psql-pod.yaml"

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -40,47 +40,52 @@ command -v consul-template >/dev/null 2>&1 || {
 # make a temporary directory for rendering, we'll delete it later
 mkdir -p $SCRATCH
 
-kubectl get namespace data-repo && kubectl delete namespace data-repo
+kubectl get namespace data-repo 2>/dev/null && kubectl delete namespace data-repo
 
 # create a data-repo namespace to put everything in
 kubectl apply -f "${WD}/k8s/namespace.yaml"
 
-# create the pod security policies and service accounts
-kubectl apply --namespace data-repo -f "${WD}/k8s/psp"
+# create the pod security policies and service account
+kubectl apply --namespace data-repo -f "${WD}/k8s/psp/service-account.yaml"
+
+# TODO: I have a hunch that this only works on terraformed CIS k8s clusters, leaving commented out for now
+#kubectl apply --namespace data-repo -f "${WD}/k8s/psp"
 
 # render secrets, create or update on kubernetes
 consul-template -template "${WD}/k8s/secrets/api-secrets.yaml.ctmpl:${SCRATCH}/api-secrets.yaml" -once
 kubectl apply -f "${SCRATCH}/api-secrets.yaml"
 
-sleep 10
+# TODO: use kubectl waits instead of sleeps
+echo 'waiting 5 sec for secrets to be ready'
+sleep 5
 
 # update the service account key
 vault read "secret/dsde/firecloud/${ENVIRONMENT}/datarepo/sa-key${GOOGLE_CLOUD_PROJECT}.json" -format=json | jq .data  > "${SCRATCH}/sa-key.json"
-kubectl --namespace data-repo get secret sa-key && kubectl --namespace data-repo delete secret sa-key
+kubectl --namespace data-repo get secret sa-key 2>/dev/null && kubectl --namespace data-repo delete secret sa-key
 kubectl --namespace data-repo create secret generic sa-key --from-file="sa-key.json=${SCRATCH}/sa-key.json"
 
 # set the tsl certificate
 vault read -field=value secret/dsde/datarepo/dev/common/server.crt > "${SCRATCH}/server.crt"
 vault read -field=value secret/dsde/datarepo/dev/common/server.key > "${SCRATCH}/server.key"
-kubectl get secret tls-cert && kubectl delete secret tls-cert
+kubectl get secret server-key 2>/dev/null && kubectl delete secret server-key
+kubectl get secret server-cert 2>/dev/null && kubectl delete secret server-cert
 kubectl --namespace=data-repo create secret generic server-key --from-file=${SCRATCH}/server.key
 kubectl --namespace=data-repo create secret generic server-cert --from-file=${SCRATCH}/server.crt
-
-sleep 5
 
 # create or update postgres pod + service
 kubectl apply -f "${WD}/k8s/pods/psql-pod.yaml"
 kubectl apply -f "${WD}/k8s/services/psql-service.yaml"
 
 # wait for the db to be ready so that we can run commands against it
+echo 'waiting 5 sec for database to be up'
+sleep 5
+# TODO: add readiness probe to postgres pod def to check for port 5432 to be available
 kubectl wait --for=condition=Ready -f "${WD}/k8s/pods/psql-pod.yaml"
-
-echo 'waiting for 10 sec'
-sleep 10
 
 # create the right databases/user/extensions (TODO: moving this to be the APIs responsibility soon)
 cat "${WD}/../db/create-data-repo-db" | \
-    kubectl --namespace data-repo run psql -i --serviceaccount=jade-sa --restart=Never --rm --image=postgres:9.6 -- psql -h postgres-service.data-repo -U postgres
+    kubectl --namespace data-repo run psql -i --serviceaccount=jade-sa --restart=Never --rm --image=postgres:9.6 -- \
+    psql -h postgres-service.data-repo -U postgres
 
 # build a docker container and push it to gcr
 ${WD}/../gradlew dockerPush
@@ -89,10 +94,17 @@ ${WD}/../gradlew dockerPush
 kubectl apply -f "${WD}/k8s/deployments/api-deployment.yaml"
 kubectl apply -f "${WD}/k8s/services/api-service.yaml"
 
-kubectl --namespace data-repo set image deployments/api-deployment "data-repo-api-container=gcr.io/broad-jade-dev/jade-data-repo:latest${GOOGLE_CLOUD_PROJECT}"
+kubectl --namespace data-repo set image deployments/api-deployment \
+    "data-repo-api-container=gcr.io/broad-jade-dev/jade-data-repo:latest${GOOGLE_CLOUD_PROJECT}"
 
 # create or update oidc proxy pod + service, probably need to render secrets
 kubectl apply -f "${WD}/k8s/deployments/oidc-proxy-deployment.yaml"
 kubectl apply -f "${WD}/k8s/services/oidc-proxy-service.yaml"
 
 rm -r $SCRATCH
+
+# try to deploy the ui, assuming that the jade-data-repo-ui directory is a sibling of this jade-data-repo directory
+UI_DEPLOY="${WD}/../../jade-data-repo-ui/ops/deploy.sh"
+if test -f "$UI_DEPLOY"; then
+    bash $UI_DEPLOY
+fi

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -23,8 +23,14 @@ fi
 # the paths we'll use will be relative to this script
 WD=$( dirname "${BASH_SOURCE[0]}" )
 NOW=$(date +%Y-%m-%d_%H-%M-%S)
-TAG="${GOOGLE_CLOUD_PROJECT}_${NOW}"
+DATA_REPO_TAG="${GOOGLE_CLOUD_PROJECT}_${NOW}"
 SCRATCH=/tmp/deploy-scratch
+
+# Install jq
+command -v jq >/dev/null 2>&1 || {
+    echo "jq not found, installing";
+    brew install jq;
+}
 
 # Install kubectl
 command -v kubectl >/dev/null 2>&1 || {
@@ -32,12 +38,28 @@ command -v kubectl >/dev/null 2>&1 || {
     brew install kubernetes-cli;
 }
 
+# Make sure kubectl is at least the right version to support `kubectl wait ...`
+KUBECTL_VERSION=$(kubectl version --output=json --client=True | jq -r .clientVersion.gitVersion)
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+if version_gt "v1.14.0" $KUBECTL_VERSION; then
+    echo "kubectl needs to be at least version 1.14.0, trying to update"
+    brew upgrade kubernetes-cli
+fi
+
 # Install consul-template (note this didn't work with 0.20.0, I kept getting 403 errors)
 command -v consul-template >/dev/null 2>&1 || {
     echo "consul-template not found, installing";
     curl https://releases.hashicorp.com/consul-template/0.19.5/consul-template_0.19.5_darwin_386.tgz | tar xzv;
     mv consul-template /usr/local/bin/;
 }
+
+# Make sure kubectl is pointing at the right project
+KUBECTL_CONTEXT=$(kubectl config current-context)
+if [[ $KUBECTL_CONTEXT != *${GOOGLE_CLOUD_PROJECT}* ]]; then
+    echo "the kubernetes context (${KUBECTL_CONTEXT}) does not match your GOOGLE_CLOUD_PROJECT: ${GOOGLE_CLOUD_PROJECT}"
+    echo "the easiest way to change it is using the context menu after clicking on the Docker icon in your top bar"
+    exit 1
+fi
 
 # make a temporary directory for rendering, we'll delete it later
 mkdir -p $SCRATCH
@@ -91,10 +113,10 @@ cat "${WD}/../db/create-data-repo-db" | \
 kubectl apply -f "${WD}/k8s/deployments/"
 
 # build a docker container and push it to gcr
-TAG=$TAG ${WD}/../gradlew dockerPush
+GCR_TAG=$DATA_REPO_TAG ${WD}/../gradlew dockerPush
 
 kubectl --namespace data-repo set image deployments/api-deployment \
-    "data-repo-api-container=gcr.io/broad-jade-dev/jade-data-repo:${TAG}"
+    "data-repo-api-container=gcr.io/broad-jade-dev/jade-data-repo:${DATA_REPO_TAG}"
 
 # try to deploy the ui, assuming that the jade-data-repo-ui directory is a sibling of this jade-data-repo directory
 UI_DIR="${WD}/../../jade-data-repo-ui"

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -22,6 +22,8 @@ fi
 
 # the paths we'll use will be relative to this script
 WD=$( dirname "${BASH_SOURCE[0]}" )
+NOW=$(date +%Y-%m-%d_%H-%M-%S)
+TAG="${GOOGLE_CLOUD_PROJECT}_${NOW}"
 SCRATCH=/tmp/deploy-scratch
 
 # Install kubectl
@@ -46,10 +48,10 @@ kubectl get namespace data-repo 2>/dev/null && kubectl delete namespace data-rep
 kubectl apply -f "${WD}/k8s/namespace.yaml"
 
 # create the pod security policies and service account
-kubectl apply --namespace data-repo -f "${WD}/k8s/psp/service-account.yaml"
+#kubectl apply --namespace data-repo -f "${WD}/k8s/psp/service-account.yaml"
 
 # TODO: I have a hunch that this only works on terraformed CIS k8s clusters, leaving commented out for now
-#kubectl apply --namespace data-repo -f "${WD}/k8s/psp"
+kubectl apply --namespace data-repo -f "${WD}/k8s/psp"
 
 # render secrets, create or update on kubernetes
 consul-template -template "${WD}/k8s/secrets/api-secrets.yaml.ctmpl:${SCRATCH}/api-secrets.yaml" -once
@@ -61,24 +63,21 @@ sleep 5
 
 # update the service account key
 vault read "secret/dsde/firecloud/${ENVIRONMENT}/datarepo/sa-key${GOOGLE_CLOUD_PROJECT}.json" -format=json | jq .data  > "${SCRATCH}/sa-key.json"
-kubectl --namespace data-repo get secret sa-key 2>/dev/null && kubectl --namespace data-repo delete secret sa-key
 kubectl --namespace data-repo create secret generic sa-key --from-file="sa-key.json=${SCRATCH}/sa-key.json"
 
 # set the tsl certificate
 vault read -field=value secret/dsde/datarepo/dev/common/server.crt > "${SCRATCH}/server.crt"
 vault read -field=value secret/dsde/datarepo/dev/common/server.key > "${SCRATCH}/server.key"
-kubectl get secret server-key 2>/dev/null && kubectl delete secret server-key
-kubectl get secret server-cert 2>/dev/null && kubectl delete secret server-cert
 kubectl --namespace=data-repo create secret generic server-key --from-file=${SCRATCH}/server.key
 kubectl --namespace=data-repo create secret generic server-cert --from-file=${SCRATCH}/server.crt
 
 # create or update postgres pod + service
+kubectl apply -f "${WD}/k8s/services"
 kubectl apply -f "${WD}/k8s/pods/psql-pod.yaml"
-kubectl apply -f "${WD}/k8s/services/psql-service.yaml"
 
 # wait for the db to be ready so that we can run commands against it
-echo 'waiting 5 sec for database to be up'
-sleep 5
+echo 'waiting 10 sec for database to be up'
+sleep 10
 # TODO: add readiness probe to postgres pod def to check for port 5432 to be available
 kubectl wait --for=condition=Ready -f "${WD}/k8s/pods/psql-pod.yaml"
 
@@ -87,24 +86,21 @@ cat "${WD}/../db/create-data-repo-db" | \
     kubectl --namespace data-repo run psql -i --serviceaccount=jade-sa --restart=Never --rm --image=postgres:9.6 -- \
     psql -h postgres-service.data-repo -U postgres
 
-# build a docker container and push it to gcr
-${WD}/../gradlew dockerPush
+# create deployments
+kubectl apply -f "${WD}/k8s/deployments/"
 
-# create or update the api pod + service
-kubectl apply -f "${WD}/k8s/deployments/api-deployment.yaml"
-kubectl apply -f "${WD}/k8s/services/api-service.yaml"
+# build a docker container and push it to gcr
+TAG=$TAG ${WD}/../gradlew dockerPush
 
 kubectl --namespace data-repo set image deployments/api-deployment \
-    "data-repo-api-container=gcr.io/broad-jade-dev/jade-data-repo:latest${GOOGLE_CLOUD_PROJECT}"
-
-# create or update oidc proxy pod + service, probably need to render secrets
-kubectl apply -f "${WD}/k8s/deployments/oidc-proxy-deployment.yaml"
-kubectl apply -f "${WD}/k8s/services/oidc-proxy-service.yaml"
-
-rm -r $SCRATCH
+    "data-repo-api-container=gcr.io/broad-jade-dev/jade-data-repo:${TAG}"
 
 # try to deploy the ui, assuming that the jade-data-repo-ui directory is a sibling of this jade-data-repo directory
-UI_DEPLOY="${WD}/../../jade-data-repo-ui/ops/deploy.sh"
-if test -f "$UI_DEPLOY"; then
-    bash $UI_DEPLOY
+UI_DIR="${WD}/../../jade-data-repo-ui"
+if test -d "$UI_DIR"; then
+    pushd $UI_DIR
+    ./ops/deploy.sh
+    popd
 fi
+
+rm -r $SCRATCH

--- a/ops/k8s/deployments/api-deployment.yaml
+++ b/ops/k8s/deployments/api-deployment.yaml
@@ -14,6 +14,7 @@ spec:
         app: data-repo
         component: data-repo-api
     spec:
+      serviceAccountName: jade-sa
       volumes:
       - name: google-cloud-key
         secret:

--- a/ops/k8s/deployments/oidc-proxy-deployment.yaml
+++ b/ops/k8s/deployments/oidc-proxy-deployment.yaml
@@ -24,6 +24,7 @@ spec:
           secretName: server-key
       containers:
       - name: oidc-proxy-container
+        # Based on the latest security review this is the recommended version of the proxy to use.
         image: broadinstitute/openidc-proxy:bernick_tcell
         volumeMounts:
         - name: server-cert

--- a/ops/k8s/deployments/oidc-proxy-deployment.yaml
+++ b/ops/k8s/deployments/oidc-proxy-deployment.yaml
@@ -14,9 +14,10 @@ spec:
         app: data-repo
         component: data-repo-oidc-proxy
     spec:
+      serviceAccountName: jade-sa
       containers:
       - name: oidc-proxy-container
-        image: broadinstitute/openidc-proxy:db_ldap_2_3_3
+        image: broadinstitute/openidc-proxy:bernick_tcell
         env:
           - name: PROXY_URL
             value: 'http://ui-service.data-repo:80/'

--- a/ops/k8s/deployments/oidc-proxy-deployment.yaml
+++ b/ops/k8s/deployments/oidc-proxy-deployment.yaml
@@ -15,9 +15,23 @@ spec:
         component: data-repo-oidc-proxy
     spec:
       serviceAccountName: jade-sa
+      volumes:
+      - name: server-cert
+        secret:
+          secretName: server-cert
+      - name: server-key
+        secret:
+          secretName: server-key
       containers:
       - name: oidc-proxy-container
         image: broadinstitute/openidc-proxy:bernick_tcell
+        volumeMounts:
+        - name: server-cert
+          mountPath: /etc/ssl/certs/server.crt
+          subPath: server.crt
+        - name: server-key
+          mountPath: /etc/ssl/private/server.key
+          subPath: server.key
         env:
           - name: PROXY_URL
             value: 'http://ui-service.data-repo:80/'

--- a/ops/k8s/pods/psql-pod.yaml
+++ b/ops/k8s/pods/psql-pod.yaml
@@ -7,6 +7,7 @@ metadata:
     app: data-repo
     component: data-repo-db
 spec:
+  serviceAccountName: jade-sa
   hostname: postgres
   containers:
     - name: postgres

--- a/ops/k8s/psp/pod-running-policy.yaml
+++ b/ops/k8s/psp/pod-running-policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: pod-running-policy
+  labels:
+    name: dev
+spec:
+  privileged: false  # Don't allow privileged pods!
+  # The rest fills in some required fields.
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*'

--- a/ops/k8s/psp/role.yml
+++ b/ops/k8s/psp/role.yml
@@ -1,0 +1,10 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: use-pod-security-policy-role
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs: ["use"]
+  resourceNames:
+    - pod-running-policy 

--- a/ops/k8s/psp/rolebinding1.yml
+++ b/ops/k8s/psp/rolebinding1.yml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jade-sa-use-pod-security-policy
+subjects:
+- kind: ServiceAccount
+  name: jade-sa
+roleRef:
+  kind: Role
+  name: use-pod-security-policy-role
+  apiGroup: rbac.authorization.k8s.io

--- a/ops/k8s/psp/service-account.yaml
+++ b/ops/k8s/psp/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jade-sa


### PR DESCRIPTION
This is the work needed to get us ready for CIS k8s deploys. I wasn't able to use the pod security policy piece on my local k8s where I wasn't using the terraformed cluster so I left that part commented out of the deploy.sh script. Hopefully Mark can advise on what the error is and get us set up with terraformed clusters in our local projects.