### PR TITLE
sourceclear

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     compile 'io.springfox:springfox-swagger2:2.7.0'
     compile 'org.apache.commons:commons-dbcp2:2.5.0'     // For database connection support
     compile 'org.apache.commons:commons-lang3:3.8.1'
-    compile 'org.apache.directory.studio:org.apache.commons.io:2.4'
+    compile 'org.apache.directory.studio:org.apache.commons.io:2.5'
     compile 'org.liquibase:liquibase-core:3.6.3'         // For upgrade
     compile 'org.postgresql:postgresql:42.2.5'           // Postgres jdbc driver
     compile 'org.slf4j:slf4j-api:1.7.25'                 // Logging facade


### PR DESCRIPTION
2.4 is vulnerable to a deserialization problem