### PR TITLE
TLS termination at INGRESS and mounted apache config

### DIFF
--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -89,9 +89,9 @@ vault read "secret/dsde/datarepo/${ENVIRONMENT}/sa-key${GOOGLE_CLOUD_PROJECT}.js
 kubectl --namespace data-repo create secret generic sa-key --from-file="sa-key.json=${SCRATCH}/sa-key.json"
 
 # set the tsl certificate
-vault read -field=value secret/dsde/datarepo/${ENVIRONMENT}/common/server.crt > "${SCRATCH}/server.crt"
-vault read -field=value secret/dsde/datarepo/${ENVIRONMENT}/common/server.key > "${SCRATCH}/server.key"
-kubectl --namespace=data-repo create secret generic wildcard.datarepo.broadinstitute.org --from-file=${SCRATCH}/server.key --from-file=${SCRATCH}/server.crt
+vault read -field=value secret/dsde/datarepo/${ENVIRONMENT}/common/server.crt > "${SCRATCH}/tls.crt"
+vault read -field=value secret/dsde/datarepo/${ENVIRONMENT}/common/server.key > "${SCRATCH}/tls.key"
+kubectl --namespace=data-repo create secret generic wildcard.datarepo.broadinstitute.org --from-file=${SCRATCH}/tls.key --from-file=${SCRATCH}/tls.crt
 
 
 # create or update postgres pod + service
@@ -114,7 +114,7 @@ kubectl apply -f "${WD}/k8s/deployments/"
 
 # build a docker container and push it to gcr
 pushd ${WD}/..
-GCR_TAG=$DATA_REPO_TAG ./gradlew dockerPush
+GCR_TAG=$DATA_REPO_TAG .x/gradlew dockerPush
 popd
 
 kubectl --namespace data-repo set image deployments/api-deployment \

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -32,6 +32,12 @@ command -v jq >/dev/null 2>&1 || {
     brew install jq;
 }
 
+# Install node
+#command -v node >/dev/null 2>&1 || {
+#    echo "node not found, installing";
+#    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && source ~/.bash_profile && nvm install 10.15.1 && nvm use 10.15.1;
+#}
+
 # Install kubectl
 command -v kubectl >/dev/null 2>&1 || {
     echo "kubectl not found, installing";

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -114,7 +114,7 @@ kubectl apply -f "${WD}/k8s/deployments/"
 
 # build a docker container and push it to gcr
 pushd ${WD}/..
-GCR_TAG=$DATA_REPO_TAG .x/gradlew dockerPush
+GCR_TAG=$DATA_REPO_TAG ./gradlew dockerPush
 popd
 
 kubectl --namespace data-repo set image deployments/api-deployment \

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -75,6 +75,9 @@ kubectl get namespace data-repo 2>/dev/null && kubectl delete namespace data-rep
 # create a data-repo namespace to put everything in
 kubectl apply -f "${WD}/k8s/namespace.yaml"
 
+#configMap site.conf
+kubectl create --namespace data-repo configmap siteconf --from-file=site.conf=site.conf
+
 # create the pod security policies and service account
 kubectl apply --namespace data-repo -f "${WD}/k8s/psp/service-account.yaml"
 

--- a/ops/k8s/deployments/network-policy.yaml
+++ b/ops/k8s/deployments/network-policy.yaml
@@ -1,0 +1,16 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-outbound
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      service: oidc
+      environment: integration
+      project: datarepo
+  egress:
+  - {}
+  policyTypes:
+  - Egress

--- a/ops/k8s/deployments/oidc-proxy-deployment.yaml
+++ b/ops/k8s/deployments/oidc-proxy-deployment.yaml
@@ -19,6 +19,14 @@ spec:
       - name: oidc-proxy-container
         # Based on the latest security review this is the recommended version of the proxy to use.
         image: broadinstitute/openidc-proxy:bernick_tcell
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          timeoutSeconds: 10
+          failureThreshold: 3
         env:
           - name: PROXY_URL
             value: 'http://ui-service.data-repo:80/'

--- a/ops/k8s/deployments/oidc-proxy-deployment.yaml
+++ b/ops/k8s/deployments/oidc-proxy-deployment.yaml
@@ -7,10 +7,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      service: oidc
+      environment: integration
+      project: datarepo
       component: data-repo-oidc-proxy
   template:
     metadata:
       labels:
+        service: oidc
+        environment: integration
+        project: datarepo
         app: data-repo
         component: data-repo-oidc-proxy
     spec:

--- a/ops/k8s/deployments/oidc-proxy-deployment.yaml
+++ b/ops/k8s/deployments/oidc-proxy-deployment.yaml
@@ -29,9 +29,17 @@ spec:
           httpGet:
             path: /status
             port: 80
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /status
+            port: 80
           initialDelaySeconds: 30
-          periodSeconds: 20
-          timeoutSeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
           failureThreshold: 3
         env:
           - name: PROXY_URL
@@ -45,10 +53,18 @@ spec:
           - name: LOG_LEVEL
             value: 'debug'
           - name: SERVER_NAME
-            value: 'jade.datarepo-dev.broadinstitute.org'
+            value: 'jade.datarepo-integration.broadinstitute.org'
           - name: REMOTE_USER_CLAIM
             value: 'sub'
           - name: ENABLE_STACKDRIVER
             value: 'yes'
           - name: FILTER2
             value: 'AddOutputFilterByType DEFLATE application/json text/plain text/html application/javascript application/x-javascript'
+        volumeMounts:
+          - mountPath: /etc/apache2/sites-available/site.conf
+            name: config
+            subPath: site.conf
+      volumes:
+        - name: "config"
+          configMap:
+            name: "siteconf"

--- a/ops/k8s/deployments/oidc-proxy-deployment.yaml
+++ b/ops/k8s/deployments/oidc-proxy-deployment.yaml
@@ -15,24 +15,10 @@ spec:
         component: data-repo-oidc-proxy
     spec:
       serviceAccountName: jade-sa
-      volumes:
-      - name: server-cert
-        secret:
-          secretName: server-cert
-      - name: server-key
-        secret:
-          secretName: server-key
       containers:
       - name: oidc-proxy-container
         # Based on the latest security review this is the recommended version of the proxy to use.
         image: broadinstitute/openidc-proxy:bernick_tcell
-        volumeMounts:
-        - name: server-cert
-          mountPath: /etc/ssl/certs/server.crt
-          subPath: server.crt
-        - name: server-key
-          mountPath: /etc/ssl/private/server.key
-          subPath: server.key
         env:
           - name: PROXY_URL
             value: 'http://ui-service.data-repo:80/'

--- a/ops/k8s/deployments/site.conf
+++ b/ops/k8s/deployments/site.conf
@@ -1,0 +1,222 @@
+ServerAdmin ${SERVER_ADMIN}
+ServerName ${SERVER_NAME}
+ServerTokens ProductOnly
+TraceEnable off
+
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogLevel ${LOG_LEVEL}
+
+Header unset X-Frame-Options
+Header always set X-Frame-Options SAMEORIGIN
+
+ProxyTimeout ${PROXY_TIMEOUT}
+LDAPCacheTTL ${LDAP_CACHE_TTL}
+LDAPRetries 5
+LDAPRetryDelay 1
+LDAPConnectionPoolTTL 30
+OIDCOAuthTokenIntrospectionInterval 60
+
+#<VirtualHost _default_:${HTTPD_PORT}>
+#    ErrorLog /dev/stdout
+#    CustomLog "/dev/stdout" combined
+#    Redirect 307 / https://${SERVER_NAME}/
+#</VirtualHost>
+##########
+<VirtualHost _default_:${HTTPD_PORT}>
+    ServerAdmin ${SERVER_ADMIN}
+    ServerName ${SERVER_NAME}
+    ErrorLog /dev/stdout
+    CustomLog "/dev/stdout" combined
+    RewriteEngine On
+    RewriteCond  %{HTTP:X-Forwarded-Proto} !https
+    RewriteCond %{REQUEST_URI}  !^/(version|status) [NC]
+    RewriteRule (.*) https://${SERVER_NAME}%{REQUEST_URI}
+
+    DocumentRoot /app
+
+    <Directory "/app">
+        AllowOverride All
+        Options -Indexes
+
+        Order allow,deny
+        Allow from all
+    </Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog "/dev/stdout" combined
+
+    <Location ${PROXY_PATH}>
+        Header unset Access-Control-Allow-Origin
+        Header always set Access-Control-Allow-Origin "*"
+        Header unset Access-Control-Allow-Headers
+        Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin,x-app-id"
+        Header unset Access-Control-Allow-Methods
+        Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        Header unset Access-Control-Max-Age
+        Header always set Access-Control-Max-Age 1728000
+
+
+                RewriteEngine On
+                RewriteCond %{REQUEST_METHOD} OPTIONS
+                RewriteRule ^(.*)$ $1 [R=204,L]
+
+                <Limit OPTIONS>
+                    Require all granted
+                </Limit>
+
+                ${AUTH_TYPE}
+                ${AUTH_LDAP_URL}
+                ${AUTH_LDAP_GROUP_ATTR}
+                ${AUTH_LDAP_BIND_DN}
+                ${AUTH_LDAP_BIND_PASSWORD}
+                ${AUTH_REQUIRE}
+
+                <Limit OPTIONS>
+                    Require all granted
+                </Limit>
+
+                ProxyPass ${PROXY_URL}
+                ProxyPassReverse ${PROXY_URL}
+
+                ${FILTER}
+            </Location>
+        </VirtualHost>
+
+
+
+        ##########
+        <VirtualHost _default_:${SSL_HTTPD_PORT}>
+
+            DocumentRoot /app
+
+            <Directory "/app">
+                AllowOverride All
+                Options -Indexes
+
+                Order allow,deny
+                Allow from all
+            </Directory>
+
+            ErrorLog /dev/stdout
+            CustomLog "/dev/stdout" combined
+
+            SSLEngine on
+            SSLProxyEngine on
+            SSLProtocol ${SSL_PROTOCOL}
+            SSLCipherSuite ${SSL_CIPHER_SUITE}
+            SSLCertificateFile "/etc/ssl/certs/server.crt"
+            SSLCertificateKeyFile "/etc/ssl/private/server.key"
+            SSLCertificateChainFile "/etc/ssl/certs/ca-bundle.crt"
+
+                <Location ${PROXY_PATH}>
+                    Header unset Access-Control-Allow-Origin
+                    Header always set Access-Control-Allow-Origin "*"
+                    Header unset Access-Control-Allow-Headers
+                    Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin"
+                    Header unset Access-Control-Allow-Methods
+                    Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+                    Header unset Access-Control-Max-Age
+                    Header always set Access-Control-Max-Age 1728000
+
+                    RewriteEngine On
+                    RewriteCond %{REQUEST_METHOD} OPTIONS
+                    RewriteRule ^(.*)$ $1 [R=204,L]
+
+                    <Limit OPTIONS>
+                        Require all granted
+                    </Limit>
+
+                    ${AUTH_TYPE}
+                    ${AUTH_LDAP_URL}
+                    ${AUTH_LDAP_GROUP_ATTR}
+                    ${AUTH_LDAP_BIND_DN}
+                    ${AUTH_LDAP_BIND_PASSWORD}
+                    ${AUTH_REQUIRE}
+
+                    <Limit OPTIONS>
+                        Require all granted
+                    </Limit>
+
+                    ProxyPass ${PROXY_URL}
+                    ProxyPassReverse ${PROXY_URL}
+
+                    ${FILTER}
+                </Location>
+
+                <Location ${PROXY_PATH2}>
+                    Header unset Access-Control-Allow-Origin
+                    Header always set Access-Control-Allow-Origin "*"
+                    Header unset Access-Control-Allow-Headers
+                    Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin"
+                    Header unset Access-Control-Allow-Methods
+                    Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+                    Header unset Access-Control-Max-Age
+                    Header always set Access-Control-Max-Age 1728000
+
+                    RewriteEngine On
+                    RewriteCond %{REQUEST_METHOD} OPTIONS
+                    RewriteRule ^(.*)$ $1 [R=204,L]
+
+                    <Limit OPTIONS>
+                        Require all granted
+                    </Limit>
+
+                            ${AUTH_TYPE2}
+                            ${AUTH_LDAP_URL2}
+                            ${AUTH_LDAP_GROUP_ATTR2}
+                            ${AUTH_LDAP_BIND_DN2}
+                            ${AUTH_LDAP_BIND_PASSWORD2}
+                            ${AUTH_REQUIRE2}
+
+                            <Limit OPTIONS>
+                                Require all granted
+                            </Limit>
+
+                            ProxyPass ${PROXY_URL2}
+                            ProxyPassReverse ${PROXY_URL2}
+
+                            ${FILTER2}
+                        </Location>
+
+                        <Location ${PROXY_PATH3}>
+                            Header unset Access-Control-Allow-Origin
+                            Header always set Access-Control-Allow-Origin "*"
+                            Header unset Access-Control-Allow-Headers
+                            Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin"
+                            Header unset Access-Control-Allow-Methods
+                            Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+                            Header unset Access-Control-Max-Age
+                            Header always set Access-Control-Max-Age 1728000
+
+                            RewriteEngine On
+                            RewriteCond %{REQUEST_METHOD} OPTIONS
+                            RewriteRule ^(.*)$ $1 [R=204,L]
+
+                            <Limit OPTIONS>
+                                Require all granted
+                            </Limit>
+
+                            ${AUTH_TYPE3}
+                            ${AUTH_LDAP_URL3}
+                            ${AUTH_LDAP_GROUP_ATTR3}
+                            ${AUTH_LDAP_BIND_DN3}
+                            ${AUTH_LDAP_BIND_PASSWORD3}
+                            ${AUTH_REQUIRE3}
+
+                            <Limit OPTIONS>
+                                Require all granted
+                            </Limit>
+
+                            ProxyPass ${PROXY_URL3}
+                            ProxyPassReverse ${PROXY_URL3}
+
+                            ${FILTER3}
+                        </Location>
+                        <Location ${CALLBACK_PATH}>
+                            AuthType openid-connect
+                            Require valid-user
+                        </Location>
+
+                    </VirtualHost>
+
+                    # The end

--- a/ops/k8s/secrets/api-secrets.yaml.ctmpl
+++ b/ops/k8s/secrets/api-secrets.yaml.ctmpl
@@ -1,6 +1,6 @@
 {{ with $environment := env "ENVIRONMENT" }}
 {{ with $project := env "GOOGLE_CLOUD_PROJECT" }}
-{{ with secret (printf "secret/dsde/firecloud/%s/datarepo/api-secrets.json" $environment) }}
+{{ with secret (printf "secret/dsde/datarepo/%s/api-secrets.json" $environment) }}
 
 apiVersion: v1
 kind: Secret

--- a/ops/k8s/services/oidc-ingress.yaml
+++ b/ops/k8s/services/oidc-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: oidc-ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "jade-k8-100"
+  namespace: data-repo
+spec:
+  tls:
+    - hosts:
+      - datarepo.datarepo-integration.broadinstitute.org
+      secretName: wildwildcard.datarepo.broadinstitute.org
+  backend:
+    serviceName: oidc-proxy-service
+    servicePort: http
+  rules:
+  - host: "datarepo.datarepo-integration.broadinstitute.org"
+    http:
+      paths:
+      - backend:
+          serviceName: oidc-proxy-service
+          servicePort: http

--- a/ops/k8s/services/oidc-ingress.yaml
+++ b/ops/k8s/services/oidc-ingress.yaml
@@ -15,8 +15,3 @@ spec:
     servicePort: http
   rules:
   - host: "jade.datarepo-integration.broadinstitute.org"
-    http:
-      paths:
-      - backend:
-          serviceName: oidc-proxy-service
-          servicePort: http

--- a/ops/k8s/services/oidc-ingress.yaml
+++ b/ops/k8s/services/oidc-ingress.yaml
@@ -8,13 +8,13 @@ metadata:
 spec:
   tls:
     - hosts:
-      - datarepo.datarepo-integration.broadinstitute.org
-      secretName: wildwildcard.datarepo.broadinstitute.org
+      - jade.datarepo-integration.broadinstitute.org
+      secretName: wildcard.datarepo.broadinstitute.org
   backend:
     serviceName: oidc-proxy-service
     servicePort: http
   rules:
-  - host: "datarepo.datarepo-integration.broadinstitute.org"
+  - host: "jade.datarepo-integration.broadinstitute.org"
     http:
       paths:
       - backend:

--- a/ops/k8s/services/oidc-proxy-service.yaml
+++ b/ops/k8s/services/oidc-proxy-service.yaml
@@ -4,9 +4,6 @@ metadata:
   namespace: data-repo
   name: oidc-proxy-service
 spec:
-  type: LoadBalancer
-  selector:
-    component: data-repo-oidc-proxy
   ports:
   - protocol: TCP
     name: http
@@ -16,3 +13,8 @@ spec:
     name: https
     port: 443
     targetPort: 443
+  type: NodePort
+  selector:
+    service: oidc
+    environment: integration
+    project: datarepo

--- a/ops/site.conf
+++ b/ops/site.conf
@@ -16,12 +16,6 @@ LDAPRetryDelay 1
 LDAPConnectionPoolTTL 30
 OIDCOAuthTokenIntrospectionInterval 60
 
-#<VirtualHost _default_:${HTTPD_PORT}>
-#    ErrorLog /dev/stdout
-#    CustomLog "/dev/stdout" combined
-#    Redirect 307 / https://${SERVER_NAME}/
-#</VirtualHost>
-##########
 <VirtualHost _default_:${HTTPD_PORT}>
     ServerAdmin ${SERVER_ADMIN}
     ServerName ${SERVER_NAME}
@@ -30,7 +24,6 @@ OIDCOAuthTokenIntrospectionInterval 60
     RewriteEngine On
     RewriteCond  %{HTTP:X-Forwarded-Proto} !https
     RewriteCond %{REQUEST_URI}  !^/(version|status) [NC]
-    RewriteRule (.*) https://${SERVER_NAME}%{REQUEST_URI}
 
     DocumentRoot /app
 
@@ -82,9 +75,6 @@ OIDCOAuthTokenIntrospectionInterval 60
             </Location>
         </VirtualHost>
 
-
-
-        ##########
         <VirtualHost _default_:${SSL_HTTPD_PORT}>
 
             DocumentRoot /app


### PR DESCRIPTION
This will move the TLS termination up form the reverse proxy to the INGRESS LB now using a global static ip and terraform managed DNS.

Mounts site.conf to odic 

Concerns moving forward are hard coded things in the k8 configs. 

network-policy.yaml
```environment: integration```
oidc-proxy-deployment.yaml
```value: 'jade.datarepo-integration.broadinstitute.org'```
oidc-ingress.yaml
```    - hosts:
      - jade.datarepo-integration.broadinstitute.org
      secretName: wildcard.datarepo.broadinstitute.org
  backend:
    serviceName: oidc-proxy-service
    servicePort: http
  rules:
  - host: "jade.datarepo-integration.broadinstitute.org"
```
oidc-proxy-service.yaml
```    environment: integration
```
