### PR TITLE
DR-350 preliminaries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,6 @@ dependencies {
     // but the groovy config is... well... groovy.
     runtime group: 'org.codehaus.groovy', name: 'groovy', version: '2.5.6'
 
-
     // Findbugs annotations, so we can selectively suppress findbugs findings
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
 

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryConfiguration.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryConfiguration.java
@@ -3,6 +3,7 @@ package bio.terra.pdao.bigquery;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -14,13 +15,28 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 @Profile("google")
 public class BigQueryConfiguration {
+    // TODO: This is temporary. When we do the resource manager, the project id will via there
+    // for a given study. This project id is used here and in the file system (FireStore) to
+    // allocate the accessing instance.
+
+    @Value("${google.projectid}")
+    private String projectId;
+
+    @Bean("googleProjectId")
+    public String googleProjectId() {
+        return projectId;
+    }
+
     @Bean("bigQueryProjectId")
     public String bigQueryProjectId() {
-        return BigQueryOptions.getDefaultProjectId();
+        return projectId;
     }
 
     @Bean("bigQuery")
     public BigQuery bigQuery() {
-        return BigQueryOptions.getDefaultInstance().getService();
+        return BigQueryOptions.newBuilder()
+            .setProjectId(projectId)
+            .build()
+            .getService();
     }
 }

--- a/src/main/resources/application-dd.properties
+++ b/src/main/resources/application-dd.properties
@@ -1,0 +1,4 @@
+datarepo.gcs.bucket=jadedatarepodd_data
+google.projectid=broad-jade-dd
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,4 +29,4 @@ integrationtest.ingestbucket=jade-testdata
 sam.basePath=https://sam.dsde-dev.broadinstitute.org
 sam.stewardsGroupEmail=JadeStewards-dev@dev.test.firecloud.org
 userEmail=harry.potter@test.firecloud.org
-
+google.projectid=broad-jade-dev


### PR DESCRIPTION
FireStore needs a project id and it doesn't get it automagically like BigQuery. So, I added an application property for the project id and plumbed it into the BigQuery configuration. That is not the right place for it in the long term, but when we make the resource manager, it will be handling project ids and we can rip out this temporary code.

In addition, I added an application-dd.properties so that I can use environment variable spring_profiles_include=dd and have it use my properties. I figured out some other things to make it easier to test in IntelliJ. I'll write them up in an email.

So a very PR for starters. Think of it as an amuse-bouche.