### PR TITLE
DR-370 Handle array columns of FILEREF

### DIFF
--- a/src/main/java/bio/terra/flight/dataset/create/CreateDatasetPrimaryDataStep.java
+++ b/src/main/java/bio/terra/flight/dataset/create/CreateDatasetPrimaryDataStep.java
@@ -93,7 +93,7 @@ public class CreateDatasetPrimaryDataStep implements Step {
                             dataset.getName(),
                             mapTable.getFromTable().getName(),
                             mapTable.getFromTable().getId().toString(),
-                            mapColumn.getFromColumn().getName());
+                            mapColumn.getFromColumn());
 
                         dependencyDao.storeDatasetFileDependencies(
                             datasetSource.getStudy().getId().toString(),

--- a/src/main/java/bio/terra/flight/study/ingest/IngestValidateRefsStep.java
+++ b/src/main/java/bio/terra/flight/study/ingest/IngestValidateRefsStep.java
@@ -42,7 +42,7 @@ public class IngestValidateRefsStep implements Step {
         List<String> invalidRefIds = new ArrayList<>();
         for (Column column : table.getColumns()) {
             if (StringUtils.equalsIgnoreCase(column.getType(), "FILEREF")) {
-                List<String> refIdArray = bigQueryPdao.getRefIds(study.getName(), stagingTableName, column.getName());
+                List<String> refIdArray = bigQueryPdao.getRefIds(study.getName(), stagingTableName, column);
                 List<String> badRefIds =
                     fileDao.validateRefIds(study.getId().toString(), refIdArray, FSObject.FSObjectType.FILE);
                 if (badRefIds != null) {

--- a/src/main/java/bio/terra/metadata/Column.java
+++ b/src/main/java/bio/terra/metadata/Column.java
@@ -9,6 +9,17 @@ public class Column {
     private String type;
     private boolean arrayOf;
 
+    public Column() {
+    }
+
+    public Column(Column fromColumn) {
+        this.id = fromColumn.id;
+        this.table = fromColumn.table;
+        this.name = fromColumn.name;
+        this.type = fromColumn.type;
+        this.arrayOf = fromColumn.arrayOf;
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/bio/terra/service/DatasetService.java
+++ b/src/main/java/bio/terra/service/DatasetService.java
@@ -212,15 +212,12 @@ public class DatasetService {
             List<DatasetMapColumn> mapColumnList = new ArrayList<>();
 
             for (AssetColumn assetColumn : assetTable.getColumns()) {
-                Column column = new Column()
-                        .table(table)
-                        .name(assetColumn.getStudyColumn().getName())
-                        .type(assetColumn.getStudyColumn().getType());
+                Column column = new Column(assetColumn.getStudyColumn());
                 columnList.add(column);
 
                 mapColumnList.add(new DatasetMapColumn()
-                        .fromColumn(assetColumn.getStudyColumn())
-                        .toColumn(column));
+                    .fromColumn(assetColumn.getStudyColumn())
+                    .toColumn(column));
             }
 
             table.name(assetTable.getTable().getName())
@@ -290,8 +287,9 @@ public class DatasetService {
 
     private ColumnModel makeColumnModelFromColumn(Column column) {
         return new ColumnModel()
-                .name(column.getName())
-                .datatype(column.getType());
+            .name(column.getName())
+            .datatype(column.getType())
+            .arrayOf(column.isArrayOf());
     }
 
     public List<DatasetSummaryModel> getDatasetsReferencingStudy(UUID studyId) {

--- a/src/test/java/bio/terra/controller/EncodeFileOut.java
+++ b/src/test/java/bio/terra/controller/EncodeFileOut.java
@@ -1,5 +1,8 @@
 package bio.terra.controller;
 
+import java.util.ArrayList;
+import java.util.List;
+
 // POJO for mapping to and from /jade-testdata/encodetest/file.json
 public class EncodeFileOut {
     private String file_id;
@@ -22,6 +25,7 @@ public class EncodeFileOut {
     private String file_format_subtype;
     private String file_ref;
     private String file_index_ref;
+    private List<String> file_array;
     private long file_size_mb;
     private String labs_generating_data;
     private String md5sum;
@@ -59,6 +63,13 @@ public class EncodeFileOut {
         file_format_subtype = encodeFileIn.getFile_format_subtype();
         file_ref = bamRef;
         file_index_ref = bamiRef;
+        file_array = new ArrayList<>();
+        if (bamRef != null) {
+            file_array.add(bamRef);
+        }
+        if (bamiRef != null) {
+            file_array.add(bamiRef);
+        }
         file_size_mb = encodeFileIn.getFile_size_mb();
         labs_generating_data = encodeFileIn.getLabs_generating_data();
         md5sum = encodeFileIn.getMd5sum();
@@ -250,6 +261,15 @@ public class EncodeFileOut {
 
     public EncodeFileOut file_index_ref(String file_index_ref) {
         this.file_index_ref = file_index_ref;
+        return this;
+    }
+
+    public List<String> getFile_array() {
+        return file_array;
+    }
+
+    public EncodeFileOut file_array(List<String> file_array) {
+        this.file_array = file_array;
         return this;
     }
 

--- a/src/test/resources/encodefiletest-study.json
+++ b/src/test/resources/encodefiletest-study.json
@@ -37,6 +37,7 @@
                     {"name": "file_format_subtype", "datatype": "string"},
                     {"name": "file_ref", "datatype": "fileref"},
                     {"name": "file_index_ref", "datatype": "fileref"},
+                    {"name": "file_array", "datatype": "fileref", "array_of": true},
                     {"name": "file_size_mb", "datatype": "integer"},
                     {"name": "labs_generating_data", "datatype": "string"},
                     {"name": "md5sum", "datatype": "string"},


### PR DESCRIPTION
Big Changes:
- Changes in BigQueryPdao for 3 cases to special-case FILEREF array columns
- Added a FILEREF array into the encode test and populate it with the pair of .bam and .bami files

Minor changes:
- I needed to pass the column and not just the name in several places, so I could have the array flag.
- There were two bugs where the array flag was not being passed through to columns and models. I added a constructor to Column in hopes of avoiding missing that in the future.

