### PR TITLE
DR-389 Fixed up study delete validation; moved file tests

### DIFF
--- a/src/main/java/bio/terra/flight/study/delete/DeleteStudyPrimaryDataStep.java
+++ b/src/main/java/bio/terra/flight/study/delete/DeleteStudyPrimaryDataStep.java
@@ -42,6 +42,7 @@ public class DeleteStudyPrimaryDataStep implements Step {
         bigQueryPdao.deleteStudy(study);
         gcsPdao.deleteFilesFromStudy(study);
         fileDao.deleteFilesFromStudy(study.getId().toString());
+
         FlightMap map = context.getWorkingMap();
         map.put(JobMapKeys.STATUS_CODE.getKeyName(), HttpStatus.NO_CONTENT);
         return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/flight/study/delete/DeleteStudyValidateStep.java
+++ b/src/main/java/bio/terra/flight/study/delete/DeleteStudyValidateStep.java
@@ -1,19 +1,25 @@
 package bio.terra.flight.study.delete;
 
 import bio.terra.controller.exception.ValidationException;
+import bio.terra.dao.DatasetDao;
 import bio.terra.filesystem.FireStoreDependencyDao;
+import bio.terra.filesystem.exception.FileSystemCorruptException;
+import bio.terra.metadata.DatasetSummary;
 import bio.terra.service.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 
+import java.util.List;
 import java.util.UUID;
 
 public class DeleteStudyValidateStep implements Step {
+    private DatasetDao datasetDao;
     private FireStoreDependencyDao dependencyDao;
 
-    public DeleteStudyValidateStep(FireStoreDependencyDao dependencyDao) {
+    public DeleteStudyValidateStep(DatasetDao datasetDao, FireStoreDependencyDao dependencyDao) {
+        this.datasetDao = datasetDao;
         this.dependencyDao = dependencyDao;
     }
 
@@ -21,8 +27,14 @@ public class DeleteStudyValidateStep implements Step {
     public StepResult doStep(FlightContext context) {
         FlightMap inputParameters = context.getInputParameters();
         UUID studyId = inputParameters.get(JobMapKeys.REQUEST.getKeyName(), UUID.class);
+        List<DatasetSummary> datasets = datasetDao.retrieveDatasetsForStudy(studyId);
+        if (datasets.size() != 0) {
+            throw new ValidationException("Can not delete a study being used by datasets");
+        }
+        // Sanity check - validate that there are no stray file references. There should be none left
+        // if there are no datasets returned from retrieveDatasetsForStudy.
         if (dependencyDao.studyHasDatasetReference(studyId.toString())) {
-            throw new ValidationException("Can not delete study being used by datasets");
+            throw new FileSystemCorruptException("File system has study dependencies; metadata does not");
         }
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/flight/study/delete/DeleteStudyValidateStep.java
+++ b/src/main/java/bio/terra/flight/study/delete/DeleteStudyValidateStep.java
@@ -34,7 +34,7 @@ public class DeleteStudyValidateStep implements Step {
         // Sanity check - validate that there are no stray file references. There should be none left
         // if there are no datasets returned from retrieveDatasetsForStudy.
         if (dependencyDao.studyHasDatasetReference(studyId.toString())) {
-            throw new FileSystemCorruptException("File system has study dependencies; metadata does not");
+            throw new FileSystemCorruptException("File system has dataset dependencies; metadata does not");
         }
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/flight/study/delete/StudyDeleteFlight.java
+++ b/src/main/java/bio/terra/flight/study/delete/StudyDeleteFlight.java
@@ -1,5 +1,6 @@
 package bio.terra.flight.study.delete;
 
+import bio.terra.dao.DatasetDao;
 import bio.terra.dao.StudyDao;
 import bio.terra.filesystem.FireStoreDependencyDao;
 import bio.terra.filesystem.FireStoreFileDao;
@@ -18,13 +19,14 @@ public class StudyDeleteFlight extends Flight {
         // get the required daos to pass into the steps
         ApplicationContext appContext = (ApplicationContext) applicationContext;
         StudyDao studyDao = (StudyDao)appContext.getBean("studyDao");
+        DatasetDao datasetDao = (DatasetDao)appContext.getBean("datasetDao");
         BigQueryPdao bigQueryPdao = (BigQueryPdao)appContext.getBean("bigQueryPdao");
         GcsPdao gcsPdao = (GcsPdao)appContext.getBean("gcsPdao");
         FireStoreDependencyDao dependencyDao = (FireStoreDependencyDao)appContext.getBean("fireStoreDependencyDao");
         FireStoreFileDao fileDao = (FireStoreFileDao)appContext.getBean("fireStoreFileDao");
         SamClientService samClient = (SamClientService)appContext.getBean("samClientService");
 
-        addStep(new DeleteStudyValidateStep(dependencyDao));
+        addStep(new DeleteStudyValidateStep(datasetDao, dependencyDao));
         addStep(new DeleteStudyPrimaryDataStep(bigQueryPdao, gcsPdao, fileDao, studyDao));
         addStep(new DeleteStudyMetadataStep(studyDao));
         addStep(new DeleteStudyAuthzResource(samClient));

--- a/src/test/java/bio/terra/filesystem/EncodeFileIn.java
+++ b/src/test/java/bio/terra/filesystem/EncodeFileIn.java
@@ -1,7 +1,7 @@
-package bio.terra.controller;
+package bio.terra.filesystem;
 
 // POJO for mapping to and from /jade-testdata/encodetest/file.json
-public class EncodeFileOut {
+public class EncodeFileIn {
     private String file_id;
     private String assay_type;
     private String biosamples;
@@ -20,8 +20,8 @@ public class EncodeFileOut {
     private boolean file_available_in_gcs;
     private String file_format;
     private String file_format_subtype;
-    private String file_ref;
-    private String file_index_ref;
+    private String file_gs_path;
+    private String file_index_gs_path;
     private long file_size_mb;
     private String labs_generating_data;
     private String md5sum;
@@ -35,49 +35,11 @@ public class EncodeFileOut {
     private String replicate_ids;
     private String target_of_assay;
 
-    public EncodeFileOut() {
-    }
-
-    public EncodeFileOut(EncodeFileIn encodeFileIn, String bamRef, String bamiRef) {
-        file_id = encodeFileIn.getFile_id();
-        assay_type = encodeFileIn.getAssay_type();
-        biosamples = encodeFileIn.getBiosamples();
-        biosample_term_id = encodeFileIn.getBiosample_term_id();
-        biosample_type = encodeFileIn.getBiosample_type();
-        cell_type = encodeFileIn.getCell_type();
-        data_quality_category = encodeFileIn.getData_quality_category();
-        data_source = encodeFileIn.getData_source();
-        data_type = encodeFileIn.getData_type();
-        date_file_created = encodeFileIn.getDate_file_created();
-        derived_from_exp = encodeFileIn.getDerived_from_exp();
-        derived_from_ref = encodeFileIn.getDerived_from_ref();
-        dna_library_ids = encodeFileIn.getDna_library_ids();
-        donor_id = encodeFileIn.getDonor_id();
-        experiments = encodeFileIn.getExperiments();
-        file_available_in_gcs = encodeFileIn.isFile_available_in_gcs();
-        file_format = encodeFileIn.getFile_format();
-        file_format_subtype = encodeFileIn.getFile_format_subtype();
-        file_ref = bamRef;
-        file_index_ref = bamiRef;
-        file_size_mb = encodeFileIn.getFile_size_mb();
-        labs_generating_data = encodeFileIn.getLabs_generating_data();
-        md5sum = encodeFileIn.getMd5sum();
-        more_info = encodeFileIn.getMore_info();
-        paired_end_sequencing = encodeFileIn.isPaired_end_sequencing();
-        percent_aligned_reads = encodeFileIn.getPercent_aligned_reads();
-        percent_duplicated_reads = encodeFileIn.getPercent_duplicated_reads();
-        read_count = encodeFileIn.getRead_count();
-        read_length = encodeFileIn.getRead_length();
-        reference_genome_assembly = encodeFileIn.getReference_genome_assembly();
-        replicate_ids = encodeFileIn.getReplicate_ids();
-        target_of_assay = encodeFileIn.getTarget_of_assay();
-    }
-
     public String getFile_id() {
         return file_id;
     }
 
-    public EncodeFileOut file_id(String file_id) {
+    public EncodeFileIn file_id(String file_id) {
         this.file_id = file_id;
         return this;
     }
@@ -86,7 +48,7 @@ public class EncodeFileOut {
         return assay_type;
     }
 
-    public EncodeFileOut assay_type(String assay_type) {
+    public EncodeFileIn assay_type(String assay_type) {
         this.assay_type = assay_type;
         return this;
     }
@@ -95,7 +57,7 @@ public class EncodeFileOut {
         return biosamples;
     }
 
-    public EncodeFileOut biosamples(String biosamples) {
+    public EncodeFileIn biosamples(String biosamples) {
         this.biosamples = biosamples;
         return this;
     }
@@ -104,7 +66,7 @@ public class EncodeFileOut {
         return biosample_term_id;
     }
 
-    public EncodeFileOut biosample_term_id(String biosample_term_id) {
+    public EncodeFileIn biosample_term_id(String biosample_term_id) {
         this.biosample_term_id = biosample_term_id;
         return this;
     }
@@ -113,7 +75,7 @@ public class EncodeFileOut {
         return biosample_type;
     }
 
-    public EncodeFileOut biosample_type(String biosample_type) {
+    public EncodeFileIn biosample_type(String biosample_type) {
         this.biosample_type = biosample_type;
         return this;
     }
@@ -122,7 +84,7 @@ public class EncodeFileOut {
         return cell_type;
     }
 
-    public EncodeFileOut cell_type(String cell_type) {
+    public EncodeFileIn cell_type(String cell_type) {
         this.cell_type = cell_type;
         return this;
     }
@@ -131,7 +93,7 @@ public class EncodeFileOut {
         return data_quality_category;
     }
 
-    public EncodeFileOut data_quality_category(String data_quality_category) {
+    public EncodeFileIn data_quality_category(String data_quality_category) {
         this.data_quality_category = data_quality_category;
         return this;
     }
@@ -140,7 +102,7 @@ public class EncodeFileOut {
         return data_source;
     }
 
-    public EncodeFileOut data_source(String data_source) {
+    public EncodeFileIn data_source(String data_source) {
         this.data_source = data_source;
         return this;
     }
@@ -149,7 +111,7 @@ public class EncodeFileOut {
         return data_type;
     }
 
-    public EncodeFileOut data_type(String data_type) {
+    public EncodeFileIn data_type(String data_type) {
         this.data_type = data_type;
         return this;
     }
@@ -158,7 +120,7 @@ public class EncodeFileOut {
         return date_file_created;
     }
 
-    public EncodeFileOut date_file_created(String date_file_created) {
+    public EncodeFileIn date_file_created(String date_file_created) {
         this.date_file_created = date_file_created;
         return this;
     }
@@ -167,7 +129,7 @@ public class EncodeFileOut {
         return derived_from_exp;
     }
 
-    public EncodeFileOut derived_from_exp(String derived_from_exp) {
+    public EncodeFileIn derived_from_exp(String derived_from_exp) {
         this.derived_from_exp = derived_from_exp;
         return this;
     }
@@ -176,7 +138,7 @@ public class EncodeFileOut {
         return derived_from_ref;
     }
 
-    public EncodeFileOut derived_from_ref(String derived_from_ref) {
+    public EncodeFileIn derived_from_ref(String derived_from_ref) {
         this.derived_from_ref = derived_from_ref;
         return this;
     }
@@ -185,7 +147,7 @@ public class EncodeFileOut {
         return dna_library_ids;
     }
 
-    public EncodeFileOut dna_library_ids(String dna_library_ids) {
+    public EncodeFileIn dna_library_ids(String dna_library_ids) {
         this.dna_library_ids = dna_library_ids;
         return this;
     }
@@ -194,7 +156,7 @@ public class EncodeFileOut {
         return donor_id;
     }
 
-    public EncodeFileOut donor_id(String donor_id) {
+    public EncodeFileIn donor_id(String donor_id) {
         this.donor_id = donor_id;
         return this;
     }
@@ -203,7 +165,7 @@ public class EncodeFileOut {
         return experiments;
     }
 
-    public EncodeFileOut experiments(String experiments) {
+    public EncodeFileIn experiments(String experiments) {
         this.experiments = experiments;
         return this;
     }
@@ -212,7 +174,7 @@ public class EncodeFileOut {
         return file_available_in_gcs;
     }
 
-    public EncodeFileOut file_available_in_gcs(boolean file_available_in_gcs) {
+    public EncodeFileIn file_available_in_gcs(boolean file_available_in_gcs) {
         this.file_available_in_gcs = file_available_in_gcs;
         return this;
     }
@@ -221,7 +183,7 @@ public class EncodeFileOut {
         return file_format;
     }
 
-    public EncodeFileOut file_format(String file_format) {
+    public EncodeFileIn file_format(String file_format) {
         this.file_format = file_format;
         return this;
     }
@@ -230,26 +192,26 @@ public class EncodeFileOut {
         return file_format_subtype;
     }
 
-    public EncodeFileOut file_format_subtype(String file_format_subtype) {
+    public EncodeFileIn file_format_subtype(String file_format_subtype) {
         this.file_format_subtype = file_format_subtype;
         return this;
     }
 
-    public String getFile_ref() {
-        return file_ref;
+    public String getFile_gs_path() {
+        return file_gs_path;
     }
 
-    public EncodeFileOut file_ref(String file_ref) {
-        this.file_ref = file_ref;
+    public EncodeFileIn file_gs_path(String file_gs_path) {
+        this.file_gs_path = file_gs_path;
         return this;
     }
 
-    public String getFile_index_ref() {
-        return file_index_ref;
+    public String getFile_index_gs_path() {
+        return file_index_gs_path;
     }
 
-    public EncodeFileOut file_index_ref(String file_index_ref) {
-        this.file_index_ref = file_index_ref;
+    public EncodeFileIn file_index_gs_path(String file_index_gs_path) {
+        this.file_index_gs_path = file_index_gs_path;
         return this;
     }
 
@@ -257,7 +219,7 @@ public class EncodeFileOut {
         return file_size_mb;
     }
 
-    public EncodeFileOut file_size_mb(long file_size_mb) {
+    public EncodeFileIn file_size_mb(long file_size_mb) {
         this.file_size_mb = file_size_mb;
         return this;
     }
@@ -266,7 +228,7 @@ public class EncodeFileOut {
         return labs_generating_data;
     }
 
-    public EncodeFileOut labs_generating_data(String labs_generating_data) {
+    public EncodeFileIn labs_generating_data(String labs_generating_data) {
         this.labs_generating_data = labs_generating_data;
         return this;
     }
@@ -275,7 +237,7 @@ public class EncodeFileOut {
         return md5sum;
     }
 
-    public EncodeFileOut md5sum(String md5sum) {
+    public EncodeFileIn md5sum(String md5sum) {
         this.md5sum = md5sum;
         return this;
     }
@@ -284,7 +246,7 @@ public class EncodeFileOut {
         return more_info;
     }
 
-    public EncodeFileOut more_info(String more_info) {
+    public EncodeFileIn more_info(String more_info) {
         this.more_info = more_info;
         return this;
     }
@@ -293,7 +255,7 @@ public class EncodeFileOut {
         return paired_end_sequencing;
     }
 
-    public EncodeFileOut paired_end_sequencing(boolean paired_end_sequencing) {
+    public EncodeFileIn paired_end_sequencing(boolean paired_end_sequencing) {
         this.paired_end_sequencing = paired_end_sequencing;
         return this;
     }
@@ -302,7 +264,7 @@ public class EncodeFileOut {
         return percent_aligned_reads;
     }
 
-    public EncodeFileOut percent_aligned_reads(double percent_aligned_reads) {
+    public EncodeFileIn percent_aligned_reads(double percent_aligned_reads) {
         this.percent_aligned_reads = percent_aligned_reads;
         return this;
     }
@@ -311,7 +273,7 @@ public class EncodeFileOut {
         return percent_duplicated_reads;
     }
 
-    public EncodeFileOut percent_duplicated_reads(double percent_duplicated_reads) {
+    public EncodeFileIn percent_duplicated_reads(double percent_duplicated_reads) {
         this.percent_duplicated_reads = percent_duplicated_reads;
         return this;
     }
@@ -320,7 +282,7 @@ public class EncodeFileOut {
         return read_count;
     }
 
-    public EncodeFileOut read_count(long read_count) {
+    public EncodeFileIn read_count(long read_count) {
         this.read_count = read_count;
         return this;
     }
@@ -329,7 +291,7 @@ public class EncodeFileOut {
         return read_length;
     }
 
-    public EncodeFileOut read_length(long read_length) {
+    public EncodeFileIn read_length(long read_length) {
         this.read_length = read_length;
         return this;
     }
@@ -338,7 +300,7 @@ public class EncodeFileOut {
         return reference_genome_assembly;
     }
 
-    public EncodeFileOut reference_genome_assembly(String reference_genome_assembly) {
+    public EncodeFileIn reference_genome_assembly(String reference_genome_assembly) {
         this.reference_genome_assembly = reference_genome_assembly;
         return this;
     }
@@ -347,7 +309,7 @@ public class EncodeFileOut {
         return replicate_ids;
     }
 
-    public EncodeFileOut replicate_ids(String replicate_ids) {
+    public EncodeFileIn replicate_ids(String replicate_ids) {
         this.replicate_ids = replicate_ids;
         return this;
     }
@@ -356,7 +318,7 @@ public class EncodeFileOut {
         return target_of_assay;
     }
 
-    public EncodeFileOut target_of_assay(String target_of_assay) {
+    public EncodeFileIn target_of_assay(String target_of_assay) {
         this.target_of_assay = target_of_assay;
         return this;
     }

--- a/src/test/java/bio/terra/filesystem/EncodeFileOut.java
+++ b/src/test/java/bio/terra/filesystem/EncodeFileOut.java
@@ -1,7 +1,7 @@
-package bio.terra.controller;
+package bio.terra.filesystem;
 
 // POJO for mapping to and from /jade-testdata/encodetest/file.json
-public class EncodeFileIn {
+public class EncodeFileOut {
     private String file_id;
     private String assay_type;
     private String biosamples;
@@ -20,8 +20,8 @@ public class EncodeFileIn {
     private boolean file_available_in_gcs;
     private String file_format;
     private String file_format_subtype;
-    private String file_gs_path;
-    private String file_index_gs_path;
+    private String file_ref;
+    private String file_index_ref;
     private long file_size_mb;
     private String labs_generating_data;
     private String md5sum;
@@ -35,11 +35,49 @@ public class EncodeFileIn {
     private String replicate_ids;
     private String target_of_assay;
 
+    public EncodeFileOut() {
+    }
+
+    public EncodeFileOut(EncodeFileIn encodeFileIn, String bamRef, String bamiRef) {
+        file_id = encodeFileIn.getFile_id();
+        assay_type = encodeFileIn.getAssay_type();
+        biosamples = encodeFileIn.getBiosamples();
+        biosample_term_id = encodeFileIn.getBiosample_term_id();
+        biosample_type = encodeFileIn.getBiosample_type();
+        cell_type = encodeFileIn.getCell_type();
+        data_quality_category = encodeFileIn.getData_quality_category();
+        data_source = encodeFileIn.getData_source();
+        data_type = encodeFileIn.getData_type();
+        date_file_created = encodeFileIn.getDate_file_created();
+        derived_from_exp = encodeFileIn.getDerived_from_exp();
+        derived_from_ref = encodeFileIn.getDerived_from_ref();
+        dna_library_ids = encodeFileIn.getDna_library_ids();
+        donor_id = encodeFileIn.getDonor_id();
+        experiments = encodeFileIn.getExperiments();
+        file_available_in_gcs = encodeFileIn.isFile_available_in_gcs();
+        file_format = encodeFileIn.getFile_format();
+        file_format_subtype = encodeFileIn.getFile_format_subtype();
+        file_ref = bamRef;
+        file_index_ref = bamiRef;
+        file_size_mb = encodeFileIn.getFile_size_mb();
+        labs_generating_data = encodeFileIn.getLabs_generating_data();
+        md5sum = encodeFileIn.getMd5sum();
+        more_info = encodeFileIn.getMore_info();
+        paired_end_sequencing = encodeFileIn.isPaired_end_sequencing();
+        percent_aligned_reads = encodeFileIn.getPercent_aligned_reads();
+        percent_duplicated_reads = encodeFileIn.getPercent_duplicated_reads();
+        read_count = encodeFileIn.getRead_count();
+        read_length = encodeFileIn.getRead_length();
+        reference_genome_assembly = encodeFileIn.getReference_genome_assembly();
+        replicate_ids = encodeFileIn.getReplicate_ids();
+        target_of_assay = encodeFileIn.getTarget_of_assay();
+    }
+
     public String getFile_id() {
         return file_id;
     }
 
-    public EncodeFileIn file_id(String file_id) {
+    public EncodeFileOut file_id(String file_id) {
         this.file_id = file_id;
         return this;
     }
@@ -48,7 +86,7 @@ public class EncodeFileIn {
         return assay_type;
     }
 
-    public EncodeFileIn assay_type(String assay_type) {
+    public EncodeFileOut assay_type(String assay_type) {
         this.assay_type = assay_type;
         return this;
     }
@@ -57,7 +95,7 @@ public class EncodeFileIn {
         return biosamples;
     }
 
-    public EncodeFileIn biosamples(String biosamples) {
+    public EncodeFileOut biosamples(String biosamples) {
         this.biosamples = biosamples;
         return this;
     }
@@ -66,7 +104,7 @@ public class EncodeFileIn {
         return biosample_term_id;
     }
 
-    public EncodeFileIn biosample_term_id(String biosample_term_id) {
+    public EncodeFileOut biosample_term_id(String biosample_term_id) {
         this.biosample_term_id = biosample_term_id;
         return this;
     }
@@ -75,7 +113,7 @@ public class EncodeFileIn {
         return biosample_type;
     }
 
-    public EncodeFileIn biosample_type(String biosample_type) {
+    public EncodeFileOut biosample_type(String biosample_type) {
         this.biosample_type = biosample_type;
         return this;
     }
@@ -84,7 +122,7 @@ public class EncodeFileIn {
         return cell_type;
     }
 
-    public EncodeFileIn cell_type(String cell_type) {
+    public EncodeFileOut cell_type(String cell_type) {
         this.cell_type = cell_type;
         return this;
     }
@@ -93,7 +131,7 @@ public class EncodeFileIn {
         return data_quality_category;
     }
 
-    public EncodeFileIn data_quality_category(String data_quality_category) {
+    public EncodeFileOut data_quality_category(String data_quality_category) {
         this.data_quality_category = data_quality_category;
         return this;
     }
@@ -102,7 +140,7 @@ public class EncodeFileIn {
         return data_source;
     }
 
-    public EncodeFileIn data_source(String data_source) {
+    public EncodeFileOut data_source(String data_source) {
         this.data_source = data_source;
         return this;
     }
@@ -111,7 +149,7 @@ public class EncodeFileIn {
         return data_type;
     }
 
-    public EncodeFileIn data_type(String data_type) {
+    public EncodeFileOut data_type(String data_type) {
         this.data_type = data_type;
         return this;
     }
@@ -120,7 +158,7 @@ public class EncodeFileIn {
         return date_file_created;
     }
 
-    public EncodeFileIn date_file_created(String date_file_created) {
+    public EncodeFileOut date_file_created(String date_file_created) {
         this.date_file_created = date_file_created;
         return this;
     }
@@ -129,7 +167,7 @@ public class EncodeFileIn {
         return derived_from_exp;
     }
 
-    public EncodeFileIn derived_from_exp(String derived_from_exp) {
+    public EncodeFileOut derived_from_exp(String derived_from_exp) {
         this.derived_from_exp = derived_from_exp;
         return this;
     }
@@ -138,7 +176,7 @@ public class EncodeFileIn {
         return derived_from_ref;
     }
 
-    public EncodeFileIn derived_from_ref(String derived_from_ref) {
+    public EncodeFileOut derived_from_ref(String derived_from_ref) {
         this.derived_from_ref = derived_from_ref;
         return this;
     }
@@ -147,7 +185,7 @@ public class EncodeFileIn {
         return dna_library_ids;
     }
 
-    public EncodeFileIn dna_library_ids(String dna_library_ids) {
+    public EncodeFileOut dna_library_ids(String dna_library_ids) {
         this.dna_library_ids = dna_library_ids;
         return this;
     }
@@ -156,7 +194,7 @@ public class EncodeFileIn {
         return donor_id;
     }
 
-    public EncodeFileIn donor_id(String donor_id) {
+    public EncodeFileOut donor_id(String donor_id) {
         this.donor_id = donor_id;
         return this;
     }
@@ -165,7 +203,7 @@ public class EncodeFileIn {
         return experiments;
     }
 
-    public EncodeFileIn experiments(String experiments) {
+    public EncodeFileOut experiments(String experiments) {
         this.experiments = experiments;
         return this;
     }
@@ -174,7 +212,7 @@ public class EncodeFileIn {
         return file_available_in_gcs;
     }
 
-    public EncodeFileIn file_available_in_gcs(boolean file_available_in_gcs) {
+    public EncodeFileOut file_available_in_gcs(boolean file_available_in_gcs) {
         this.file_available_in_gcs = file_available_in_gcs;
         return this;
     }
@@ -183,7 +221,7 @@ public class EncodeFileIn {
         return file_format;
     }
 
-    public EncodeFileIn file_format(String file_format) {
+    public EncodeFileOut file_format(String file_format) {
         this.file_format = file_format;
         return this;
     }
@@ -192,26 +230,26 @@ public class EncodeFileIn {
         return file_format_subtype;
     }
 
-    public EncodeFileIn file_format_subtype(String file_format_subtype) {
+    public EncodeFileOut file_format_subtype(String file_format_subtype) {
         this.file_format_subtype = file_format_subtype;
         return this;
     }
 
-    public String getFile_gs_path() {
-        return file_gs_path;
+    public String getFile_ref() {
+        return file_ref;
     }
 
-    public EncodeFileIn file_gs_path(String file_gs_path) {
-        this.file_gs_path = file_gs_path;
+    public EncodeFileOut file_ref(String file_ref) {
+        this.file_ref = file_ref;
         return this;
     }
 
-    public String getFile_index_gs_path() {
-        return file_index_gs_path;
+    public String getFile_index_ref() {
+        return file_index_ref;
     }
 
-    public EncodeFileIn file_index_gs_path(String file_index_gs_path) {
-        this.file_index_gs_path = file_index_gs_path;
+    public EncodeFileOut file_index_ref(String file_index_ref) {
+        this.file_index_ref = file_index_ref;
         return this;
     }
 
@@ -219,7 +257,7 @@ public class EncodeFileIn {
         return file_size_mb;
     }
 
-    public EncodeFileIn file_size_mb(long file_size_mb) {
+    public EncodeFileOut file_size_mb(long file_size_mb) {
         this.file_size_mb = file_size_mb;
         return this;
     }
@@ -228,7 +266,7 @@ public class EncodeFileIn {
         return labs_generating_data;
     }
 
-    public EncodeFileIn labs_generating_data(String labs_generating_data) {
+    public EncodeFileOut labs_generating_data(String labs_generating_data) {
         this.labs_generating_data = labs_generating_data;
         return this;
     }
@@ -237,7 +275,7 @@ public class EncodeFileIn {
         return md5sum;
     }
 
-    public EncodeFileIn md5sum(String md5sum) {
+    public EncodeFileOut md5sum(String md5sum) {
         this.md5sum = md5sum;
         return this;
     }
@@ -246,7 +284,7 @@ public class EncodeFileIn {
         return more_info;
     }
 
-    public EncodeFileIn more_info(String more_info) {
+    public EncodeFileOut more_info(String more_info) {
         this.more_info = more_info;
         return this;
     }
@@ -255,7 +293,7 @@ public class EncodeFileIn {
         return paired_end_sequencing;
     }
 
-    public EncodeFileIn paired_end_sequencing(boolean paired_end_sequencing) {
+    public EncodeFileOut paired_end_sequencing(boolean paired_end_sequencing) {
         this.paired_end_sequencing = paired_end_sequencing;
         return this;
     }
@@ -264,7 +302,7 @@ public class EncodeFileIn {
         return percent_aligned_reads;
     }
 
-    public EncodeFileIn percent_aligned_reads(double percent_aligned_reads) {
+    public EncodeFileOut percent_aligned_reads(double percent_aligned_reads) {
         this.percent_aligned_reads = percent_aligned_reads;
         return this;
     }
@@ -273,7 +311,7 @@ public class EncodeFileIn {
         return percent_duplicated_reads;
     }
 
-    public EncodeFileIn percent_duplicated_reads(double percent_duplicated_reads) {
+    public EncodeFileOut percent_duplicated_reads(double percent_duplicated_reads) {
         this.percent_duplicated_reads = percent_duplicated_reads;
         return this;
     }
@@ -282,7 +320,7 @@ public class EncodeFileIn {
         return read_count;
     }
 
-    public EncodeFileIn read_count(long read_count) {
+    public EncodeFileOut read_count(long read_count) {
         this.read_count = read_count;
         return this;
     }
@@ -291,7 +329,7 @@ public class EncodeFileIn {
         return read_length;
     }
 
-    public EncodeFileIn read_length(long read_length) {
+    public EncodeFileOut read_length(long read_length) {
         this.read_length = read_length;
         return this;
     }
@@ -300,7 +338,7 @@ public class EncodeFileIn {
         return reference_genome_assembly;
     }
 
-    public EncodeFileIn reference_genome_assembly(String reference_genome_assembly) {
+    public EncodeFileOut reference_genome_assembly(String reference_genome_assembly) {
         this.reference_genome_assembly = reference_genome_assembly;
         return this;
     }
@@ -309,7 +347,7 @@ public class EncodeFileIn {
         return replicate_ids;
     }
 
-    public EncodeFileIn replicate_ids(String replicate_ids) {
+    public EncodeFileOut replicate_ids(String replicate_ids) {
         this.replicate_ids = replicate_ids;
         return this;
     }
@@ -318,7 +356,7 @@ public class EncodeFileIn {
         return target_of_assay;
     }
 
-    public EncodeFileIn target_of_assay(String target_of_assay) {
+    public EncodeFileOut target_of_assay(String target_of_assay) {
         this.target_of_assay = target_of_assay;
         return this;
     }

--- a/src/test/java/bio/terra/filesystem/EncodeFileTest.java
+++ b/src/test/java/bio/terra/filesystem/EncodeFileTest.java
@@ -1,4 +1,4 @@
-package bio.terra.controller;
+package bio.terra.filesystem;
 
 import bio.terra.category.Connected;
 import bio.terra.fixtures.ConnectedOperations;

--- a/src/test/java/bio/terra/filesystem/FileOperationTest.java
+++ b/src/test/java/bio/terra/filesystem/FileOperationTest.java
@@ -1,4 +1,4 @@
-package bio.terra.controller;
+package bio.terra.filesystem;
 
 import bio.terra.category.Connected;
 import bio.terra.fixtures.ConnectedOperations;


### PR DESCRIPTION
I hooked up the metadata-based study-dataset dependency check.
I changed the filesystem-level dependency check to be a corruption detection: if there are stray file dependencies we will detect them and barf.

I also brought all of the filesystem tests together in the `filesystem` package, moving some from the `controller` package.
