### PR TITLE
DR-523: pass root table and column to response

### DIFF
--- a/src/main/java/bio/terra/model/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/model/DatasetJsonConversion.java
@@ -230,21 +230,23 @@ public final class DatasetJsonConversion {
 
     public static AssetModel assetModelFromAssetSpecification(AssetSpecification spec) {
         return new AssetModel()
-                .name(spec.getName())
-                .tables(spec.getAssetTables()
-                        .stream()
-                        .map(table ->
-                                new AssetTableModel()
-                                        .name(table.getTable().getName())
-                                        .columns(table.getColumns()
-                                                .stream()
-                                                .map(column -> column.getDatasetColumn().getName())
-                                                .collect(Collectors.toList())))
-                        .collect(Collectors.toList()))
-                .follow(spec.getAssetRelationships()
-                        .stream()
-                        .map(assetRelationship -> assetRelationship.getDatasetRelationship().getName())
-                        .collect(Collectors.toList()));
+            .name(spec.getName())
+            .rootTable(spec.getRootTable().getTable().getName())
+            .rootColumn(spec.getRootColumn().getDatasetColumn().getName())
+            .tables(spec.getAssetTables()
+                    .stream()
+                    .map(table ->
+                            new AssetTableModel()
+                                    .name(table.getTable().getName())
+                                    .columns(table.getColumns()
+                                            .stream()
+                                            .map(column -> column.getDatasetColumn().getName())
+                                            .collect(Collectors.toList())))
+                    .collect(Collectors.toList()))
+            .follow(spec.getAssetRelationships()
+                    .stream()
+                    .map(assetRelationship -> assetRelationship.getDatasetRelationship().getName())
+                    .collect(Collectors.toList()));
     }
 
     private static List<String> uuidsToStrings(List<UUID> uuids) {


### PR DESCRIPTION
Noticed this when writing a rolldown script. We have the data from the DAO, just need to pass it to the model.