### PR TITLE
DR-540 drs https access

### DIFF
--- a/src/main/java/bio/terra/service/DrsService.java
+++ b/src/main/java/bio/terra/service/DrsService.java
@@ -198,7 +198,7 @@ public class DrsService {
             String gsBucket = gsuri.getAuthority();
             String gsPath = StringUtils.removeStart(gsuri.getPath(), "/");
             String encodedPath = URLEncoder.encode(gsPath, StandardCharsets.UTF_8.toString());
-            return String.format("https://%s/%s?alt=media", gsBucket, encodedPath);
+            return String.format("https://www.googleapis.com/storage/v1/b/%s/o/%s?alt=media", gsBucket, encodedPath);
         } catch (UnsupportedEncodingException ex) {
             throw new InternalServerErrorException("Failed to urlencode file path", ex);
         }

--- a/src/test/java/bio/terra/integration/AccessTest.java
+++ b/src/test/java/bio/terra/integration/AccessTest.java
@@ -4,8 +4,6 @@ import bio.terra.category.Integration;
 import bio.terra.controller.AuthenticatedUserRequest;
 import bio.terra.integration.auth.AuthService;
 import bio.terra.integration.configuration.TestConfiguration;
-import bio.terra.model.DRSAccessMethod;
-import bio.terra.model.DRSAccessURL;
 import bio.terra.model.DRSObject;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetSummaryModel;
@@ -38,7 +36,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -227,13 +224,10 @@ public class AccessTest extends UsersBase {
 
         // Step 6. Use DRS API to lookup the file by DRS ID (pulled out of the URI).
         DRSObject drsObject = dataRepoFixtures.drsGetObject(reader(), drsObjectId);
-        List<DRSAccessMethod> accessMethods = drsObject.getAccessMethods();
-        assertThat("access method is not null and length 1", accessMethods.size(), equalTo(1));
+        String gsuri = TestUtils.validateDrsAccessMethods(drsObject.getAccessMethods());
 
-        // Step 7. Pull out the gs path try to read the file as reader and discoverer
-        DRSAccessURL accessUrl = accessMethods.get(0).getAccessUrl();
-
-        String[] strings = accessUrl.getUrl().split("/", 4);
+        // Step 7. Try to read the file of the gs path as reader and discoverer
+        String[] strings = gsuri.split("/", 4);
 
         String bucketName = strings[2];
         String blobName = strings[3];

--- a/src/test/java/bio/terra/integration/DrsTest.java
+++ b/src/test/java/bio/terra/integration/DrsTest.java
@@ -3,7 +3,6 @@ package bio.terra.integration;
 import bio.terra.category.Integration;
 import bio.terra.integration.auth.AuthService;
 import bio.terra.integration.configuration.TestConfiguration;
-import bio.terra.model.DRSAccessMethod;
 import bio.terra.model.DRSChecksum;
 import bio.terra.model.DRSObject;
 import bio.terra.model.FSObjectModel;
@@ -67,9 +66,7 @@ public class DrsTest extends UsersBase {
         DRSObject drsObject = dataRepoFixtures.drsGetObject(reader(), drsObjectId);
         validateDrsObject(drsObject, drsObjectId);
         assertNull("Contents of file is null", drsObject.getContents());
-        assertThat("One access method", drsObject.getAccessMethods().size(), equalTo(1));
-        DRSAccessMethod accessMethod = drsObject.getAccessMethods().get(0);
-        assertThat("Access method is gs", accessMethod.getType(), equalTo(DRSAccessMethod.TypeEnum.GS));
+        TestUtils.validateDrsAccessMethods(drsObject.getAccessMethods());
 
         // We don't have a DRS URI for a directory, so we back into it by computing the parent path
         // and using the non-DRS interface to get that file. Then we use that to build the

--- a/src/test/java/bio/terra/integration/TestUtils.java
+++ b/src/test/java/bio/terra/integration/TestUtils.java
@@ -1,12 +1,21 @@
 package bio.terra.integration;
 
+import bio.terra.model.DRSAccessMethod;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public final class TestUtils {
     private static Logger logger = LoggerFactory.getLogger(TestUtils.class);
@@ -27,5 +36,27 @@ public final class TestUtils {
             tries++;
         }
         return false;
+    }
+
+    public static String validateDrsAccessMethods(List<DRSAccessMethod> accessMethods) {
+        assertThat("Two access methods", accessMethods.size(), equalTo(2));
+
+        String gsuri = StringUtils.EMPTY;
+        boolean gotGs = false;
+        boolean gotHttps = false;
+        for (DRSAccessMethod accessMethod : accessMethods) {
+            if (accessMethod.getType() == DRSAccessMethod.TypeEnum.GS) {
+                assertFalse("have not seen GS yet", gotGs);
+                gotGs = true;
+                gsuri = accessMethod.getAccessUrl().getUrl();
+            } else if (accessMethod.getType() == DRSAccessMethod.TypeEnum.HTTPS) {
+                assertFalse("have not seen HTTPS yet", gotHttps);
+                gotHttps = true;
+            } else {
+                fail("Invalid access method");
+            }
+        }
+        assertTrue("got both access methods", gotGs && gotHttps);
+        return gsuri;
     }
 }


### PR DESCRIPTION
Add an https access method to the DRS file response. It turns out that using the https link is much simpler for scripting when the script is not running on GCP.
