### PR TITLE
DR-552: add a validation query so the connection pool can recover from failure

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 server.contextPath=
 server.port=8080
+spring.datasource.tomcat.test-on-borrow=true
+spring.datasource.tomcat.validation-query=SELECT 1
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 spring.liquibase.enabled=false
 spring.profiles.active=google
@@ -35,4 +37,3 @@ google.projectCreateTimeoutSeconds=600
 google.coreBillingAccount=00708C-45D19D-27AAFA
 google.parentResourceType=folder
 google.parentResourceId=270278425081
-


### PR DESCRIPTION
I tried testing by autowiring the jdbc configuration and messing with the datasource, but I couldn't reproduce the same issue that we were experiencing. I was able to reproduce this locally by restarting postgres while the server was running. These properties resolve the problem.