### PR TITLE
DR-579 - Add enumerated flag to the DirectoryDetailModel and fill it in

### DIFF
--- a/src/main/java/bio/terra/service/FileService.java
+++ b/src/main/java/bio/terra/service/FileService.java
@@ -135,8 +135,9 @@ public class FileService {
         } else if (fsItem instanceof FSDir) {
             fileModel.fileType(FileModelType.DIRECTORY);
             FSDir fsDir = (FSDir)fsItem;
-            DirectoryDetailModel directoryDetail = new DirectoryDetailModel().contents(new ArrayList<>());
+            DirectoryDetailModel directoryDetail = new DirectoryDetailModel().enumerated(fsDir.isEnumerated());
             if (fsDir.isEnumerated()) {
+                directoryDetail.contents(new ArrayList<>());
                 for (FSItem fsContentsItem : fsDir.getContents()) {
                     FileModel itemModel = fileModelFromFSItem(fsContentsItem);
                     directoryDetail.addContentsItem(itemModel);

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1781,6 +1781,12 @@ definitions:
     description: Directory in the data repository
     type: object
     properties:
+      enumerated:
+        type: boolean
+        description: |
+          Indicates whether or not the directory has been enumerated. True means the directory has been enumerated.
+          The contents property describes the contents. An empty array indicates and empty directory. False means
+          the directory has not been enumerated. If the contents property is present, it should be ignored.
       contents:
         type: array
         description: Array of directory contents


### PR DESCRIPTION
With the current REST API, a client can't tell the difference between an empty directory and a directory that didn't get enumerated (because we stopped at depth = N).

We were already maintaining the isEnumerated state internally. This passes that state out into the DirectoryDetailModel.
