### PR TITLE
DR-588 Fix bug generating DRS IDs.

### DIFF
--- a/src/main/java/bio/terra/service/DrsService.java
+++ b/src/main/java/bio/terra/service/DrsService.java
@@ -148,7 +148,7 @@ public class DrsService {
     private DRSObject makeCommonDrsObject(FSItem fsObject, String snapshotId) {
         // Compute the time once; used for both created and updated times as per DRS spec for immutable objects
         String theTime = fsObject.getCreatedDate().toString();
-        DrsId drsId = makeDrsId(fsObject, snapshotId);
+        DrsId drsId = drsIdService.makeDrsId(fsObject, snapshotId);
 
         return new DRSObject()
             .id(drsId.toDrsObjectId())
@@ -173,7 +173,7 @@ public class DrsService {
     }
 
     private DRSContentsObject makeDrsContentsObject(FSItem fsObject, String snapshotId) {
-        DrsId drsId = makeDrsId(fsObject, snapshotId);
+        DrsId drsId = drsIdService.makeDrsId(fsObject, snapshotId);
 
         List<String> drsUris = new ArrayList<>();
         drsUris.add(drsId.toDrsUri());
@@ -191,13 +191,6 @@ public class DrsService {
         }
 
         return contentsObject;
-    }
-
-    private DrsId makeDrsId(FSItem fsObject, String snapshotId) {
-        return DrsId.builder()
-            .snapshotId(snapshotId)
-            .fsObjectId(fsObject.getFileId().toString())
-            .build();
     }
 
     private String makeHttpsFromGs(String gspath) {


### PR DESCRIPTION
The DRSService was making DRS IDs that didn't include the DNS path.
This removes the bad code and points the service at the proper code for building the ids.

(I have no idea *what* I was thinking!)
