### PR TITLE
DR-565 access boolean flags

### DIFF
--- a/src/main/java/bio/terra/controller/AuthenticatedUserRequest.java
+++ b/src/main/java/bio/terra/controller/AuthenticatedUserRequest.java
@@ -12,8 +12,6 @@ public class AuthenticatedUserRequest {
     private String subjectId;
     private Optional<String> token;
     private UUID reqId;
-    private boolean canListJobs;
-    private boolean canDeleteJobs;
 
     public AuthenticatedUserRequest() {
         this.reqId = UUID.randomUUID();
@@ -66,24 +64,6 @@ public class AuthenticatedUserRequest {
 
     public AuthenticatedUserRequest reqId(UUID reqId) {
         this.reqId = reqId;
-        return this;
-    }
-
-    public boolean getCanListJobs() {
-        return canListJobs;
-    }
-
-    public AuthenticatedUserRequest canListJobs(boolean canListJobs) {
-        this.canListJobs = canListJobs;
-        return this;
-    }
-
-    public boolean getCanDeleteJobs() {
-        return canDeleteJobs;
-    }
-
-    public AuthenticatedUserRequest canDeleteJobs(boolean canDeleteJobs) {
-        this.canDeleteJobs = canDeleteJobs;
         return this;
     }
 

--- a/src/main/java/bio/terra/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/controller/RepositoryApiController.java
@@ -482,19 +482,6 @@ public class RepositoryApiController implements RepositoryApi {
     }
 
     // -- jobs --
-    private void setManageJobFlags(AuthenticatedUserRequest userReq) {
-        userReq.canListJobs(samService.isAuthorized(
-            userReq,
-            SamClientService.ResourceType.DATAREPO,
-            appConfig.getResourceId(),
-            SamClientService.DataRepoAction.LIST_JOBS));
-        userReq.canDeleteJobs(samService.isAuthorized(
-            userReq,
-            SamClientService.ResourceType.DATAREPO,
-            appConfig.getResourceId(),
-            SamClientService.DataRepoAction.DELETE_JOBS));
-    }
-
     private ResponseEntity<JobModel> jobToResponse(JobModel job) {
         if (job.getJobStatus() == JobModel.JobStatusEnum.RUNNING) {
             return ResponseEntity
@@ -515,35 +502,26 @@ public class RepositoryApiController implements RepositoryApi {
             @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
             @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
         validiateOffsetAndLimit(offset, limit);
-        AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-        setManageJobFlags(userReq);
-        // TODO this should be set in job servicev (during refactor)
-        // -- put setter in the calls also when is this even getting set when the job is created in the first place?
-        List<JobModel> results = jobService.enumerateJobs(offset, limit, userReq);
+        List<JobModel> results = jobService.enumerateJobs(offset, limit, getAuthenticatedInfo());
         return new ResponseEntity<>(results, HttpStatus.OK);
     }
 
     @Override
     public ResponseEntity<JobModel> retrieveJob(@PathVariable("id") String id) {
-        AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-        setManageJobFlags(userReq);
-        JobModel job = jobService.retrieveJob(id, userReq);
+        JobModel job = jobService.retrieveJob(id, getAuthenticatedInfo());
         return jobToResponse(job);
     }
 
     @Override
     public ResponseEntity<Object> retrieveJobResult(@PathVariable("id") String id) {
-        AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-        setManageJobFlags(userReq);
-        JobService.JobResultWithStatus<Object> resultHolder = jobService.retrieveJobResult(id, Object.class, userReq);
+        JobService.JobResultWithStatus<Object> resultHolder =
+            jobService.retrieveJobResult(id, Object.class, getAuthenticatedInfo());
         return ResponseEntity.status(resultHolder.getStatusCode()).body(resultHolder.getResult());
     }
 
     @Override
     public ResponseEntity<Void> deleteJob(@PathVariable("id") String id) {
-        AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-        setManageJobFlags(userReq);
-        jobService.releaseJob(id, userReq);
+        jobService.releaseJob(id, getAuthenticatedInfo());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/bio/terra/service/JobService.java
+++ b/src/main/java/bio/terra/service/JobService.java
@@ -129,7 +129,7 @@ public class JobService {
     }
 
     public void releaseJob(String jobId, AuthenticatedUserRequest userReq) {
-        if (userReq!=null) {
+        if (userReq != null) {
             // currently, this check will be true for stewards only
             boolean canDeleteAnyJob = samService.isAuthorized(
                 userReq,
@@ -197,7 +197,7 @@ public class JobService {
     public List<JobModel> enumerateJobs(
         int offset, int limit, AuthenticatedUserRequest userReq) {
         boolean canListAnyJob = true;
-        if (userReq!=null) {
+        if (userReq != null) {
             // currently, this check will be true for stewards only
             canListAnyJob = samService.isAuthorized(
                 userReq,
@@ -225,7 +225,7 @@ public class JobService {
 
     public JobModel retrieveJob(String jobId, AuthenticatedUserRequest userReq) {
         boolean canListAnyJob = true;
-        if (userReq!=null) {
+        if (userReq != null) {
             // currently, this check will be true for stewards only
             canListAnyJob = samService.isAuthorized(
                 userReq,
@@ -267,7 +267,7 @@ public class JobService {
         Class<T> resultClass,
         AuthenticatedUserRequest userReq) {
         boolean canListAnyJob = true;
-        if (userReq!=null) {
+        if (userReq != null) {
             // currently, this check will be true for stewards only
             canListAnyJob = samService.isAuthorized(
                 userReq,

--- a/src/main/java/bio/terra/stairway/Stairway.java
+++ b/src/main/java/bio/terra/stairway/Stairway.java
@@ -125,19 +125,15 @@ public class Stairway {
         launchFlight(flight);
     }
 
-    public void verifyListFlightAccess(String flightId, UserRequestInfo userRequestInfo) {
-        if (userRequestInfo != null && !userRequestInfo.canListJobs()) {
-            verifyUserAccess(flightId, userRequestInfo);
-        }
-    }
-
-    public void verifyDeleteFlightAccess(String flightId, UserRequestInfo userRequestInfo) {
-        if (userRequestInfo != null && !userRequestInfo.canDeleteJobs()) {
-            verifyUserAccess(flightId, userRequestInfo);
-        }
-    }
-
-    private void verifyUserAccess(String flightId, UserRequestInfo userRequestInfo) {
+    /**
+     * Check that a user has access to a flight. Currently, this just checks that the user
+     * is the owner of the flight.
+     *
+     * @param flightId id of flight to check
+     * @param userRequestInfo subset of information about the user that can be used to determine access
+     * @throws RuntimeException if the user does not have access to the flight
+     */
+    public void verifyUserAccess(String flightId, UserRequestInfo userRequestInfo) {
         boolean hasAccess;
         try {
             hasAccess = flightDao.ownsFlight(flightId, userRequestInfo.getSubjectId());

--- a/src/main/java/bio/terra/stairway/UserRequestInfo.java
+++ b/src/main/java/bio/terra/stairway/UserRequestInfo.java
@@ -7,8 +7,6 @@ public class UserRequestInfo {
     private String name;
     private String subjectId;
     private UUID requestId;
-    private boolean canListJobs;
-    private boolean canDeleteJobs;
 
     public String getName() {
         return name;
@@ -34,24 +32,6 @@ public class UserRequestInfo {
 
     public UserRequestInfo requestId(UUID reqId) {
         this.requestId = reqId;
-        return this;
-    }
-
-    public boolean canListJobs() {
-        return canListJobs;
-    }
-
-    public UserRequestInfo canListJobs(boolean canListJobs) {
-        this.canListJobs = canListJobs;
-        return this;
-    }
-
-    public boolean canDeleteJobs() {
-        return canDeleteJobs;
-    }
-
-    public UserRequestInfo canDeleteJobs(boolean canDeleteJobs) {
-        this.canDeleteJobs = canDeleteJobs;
         return this;
     }
 

--- a/src/test/java/bio/terra/flight/dataset/create/DatasetCreateFlightTest.java
+++ b/src/test/java/bio/terra/flight/dataset/create/DatasetCreateFlightTest.java
@@ -67,7 +67,7 @@ public class DatasetCreateFlightTest {
     private Dataset dataset;
     private BillingProfileModel billingProfileModel;
     private UserRequestInfo testUser =
-        new UserRequestInfo().subjectId("StairwayUnit").name("stairway@unit.com").canListJobs(true).canDeleteJobs(true);
+        new UserRequestInfo().subjectId("StairwayUnit").name("stairway@unit.com");
 
     private DatasetRequestModel makeDatasetRequest(String datasetName, String profileId) throws IOException {
         DatasetRequestModel datasetRequest = jsonLoader.loadObject("dataset-minimal.json",

--- a/src/test/java/bio/terra/service/JobServiceTest.java
+++ b/src/test/java/bio/terra/service/JobServiceTest.java
@@ -31,9 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 public class JobServiceTest {
     private AuthenticatedUserRequest testUser = new AuthenticatedUserRequest()
         .subjectId("StairwayUnit")
-        .email("stairway@unit.com")
-        .canListJobs(true)
-        .canDeleteJobs(true);
+        .email("stairway@unit.com");
 
     @Autowired
     private Stairway stairway;
@@ -138,9 +136,7 @@ public class JobServiceTest {
             inputs,
             new UserRequestInfo()
                 .subjectId(testUser.getSubjectId())
-                .name(testUser.getEmail())
-                .canListJobs(testUser.getCanListJobs())
-                .canDeleteJobs(testUser.getCanDeleteJobs()));
+                .name(testUser.getEmail()));
         stairway.waitForFlight(flightId);
         return flightId;
     }

--- a/src/test/java/bio/terra/service/JobServiceTest.java
+++ b/src/test/java/bio/terra/service/JobServiceTest.java
@@ -77,21 +77,21 @@ public class JobServiceTest {
 
     private void testSingleRetrieval(List<String> fids) {
 //        RepositoryApiController.HttpStatusContainer statContainer = new RepositoryApiController.HttpStatusContainer();
-        JobModel response = jobService.retrieveJob(fids.get(2), testUser);
+        JobModel response = jobService.retrieveJob(fids.get(2), null);
         Assert.assertNotNull(response);
         validateJobModel(response, 2, fids);
     }
 
     private void testResultRetrieval(List<String> fids) {
         JobService.JobResultWithStatus<String> resultHolder =
-            jobService.retrieveJobResult(fids.get(2), String.class, testUser);
+            jobService.retrieveJobResult(fids.get(2), String.class, null);
         Assert.assertThat(resultHolder.getStatusCode(), is(equalTo(HttpStatus.I_AM_A_TEAPOT)));
         Assert.assertThat(resultHolder.getResult(), is(equalTo(makeDescription(2))));
     }
 
     // Get some range and compare it with the fids
     private void testEnumRange(List<String> fids, int offset, int limit, List<ResourceAndAccessPolicy> resourceIds) {
-        List<JobModel> jobList = jobService.enumerateJobs(offset, limit, testUser);
+        List<JobModel> jobList = jobService.enumerateJobs(offset, limit, null);
         Assert.assertNotNull(jobList);
         int index = offset;
         for (JobModel job : jobList) {
@@ -102,19 +102,19 @@ public class JobServiceTest {
 
     // Get some range and make sure we got the number we expected
     private void testEnumCount(int count, int offset, int length, List<ResourceAndAccessPolicy> resourceIds) {
-        List<JobModel> jobList = jobService.enumerateJobs(offset, length, testUser);
+        List<JobModel> jobList = jobService.enumerateJobs(offset, length, null);
         Assert.assertNotNull(jobList);
         Assert.assertThat(jobList.size(), is(count));
     }
 
     @Test(expected = FlightNotFoundException.class)
     public void testBadIdRetrieveJob() {
-        jobService.retrieveJob("abcdef", testUser);
+        jobService.retrieveJob("abcdef", null);
     }
 
     @Test(expected = FlightNotFoundException.class)
     public void testBadIdRetrieveResult() {
-        jobService.retrieveJobResult("abcdef", Object.class, testUser);
+        jobService.retrieveJobResult("abcdef", Object.class, null);
     }
 
     private void validateJobModel(JobModel jm, int index, List<String> fids) {

--- a/src/test/java/bio/terra/service/SamClientServiceTest.java
+++ b/src/test/java/bio/terra/service/SamClientServiceTest.java
@@ -37,7 +37,7 @@ public class SamClientServiceTest {
     private SamClientService sam;
 
     private AuthenticatedUserRequest testUser = new AuthenticatedUserRequest()
-            .email("blah").subjectId("myId").token(Optional.of("blah")).canListJobs(true).canDeleteJobs(true);
+            .email("blah").subjectId("myId").token(Optional.of("blah"));
 
     @Test(expected = ApiException.class)
     public void testCreateDatasetResourceException() throws Exception {

--- a/src/test/java/bio/terra/stairway/DatabaseOperationsTest.java
+++ b/src/test/java/bio/terra/stairway/DatabaseOperationsTest.java
@@ -35,9 +35,7 @@ import static org.hamcrest.CoreMatchers.is;
 public class DatabaseOperationsTest {
     private UserRequestInfo testUser = new UserRequestInfo()
         .subjectId("StairwayUnit")
-        .name("stairway@unit.com")
-        .canListJobs(true)
-        .canDeleteJobs(true);
+        .name("stairway@unit.com");
 
     @Autowired
     private StairwayJdbcConfiguration jdbcConfiguration;

--- a/src/test/java/bio/terra/stairway/RecoveryTest.java
+++ b/src/test/java/bio/terra/stairway/RecoveryTest.java
@@ -62,9 +62,7 @@ public class RecoveryTest {
     private ExecutorService executorService;
     private UserRequestInfo testUser = new UserRequestInfo()
         .subjectId("StairwayUnit")
-        .name("stairway@unit.com")
-        .canListJobs(true)
-        .canDeleteJobs(true);
+        .name("stairway@unit.com");
 
     @Autowired
     private StairwayJdbcConfiguration jdbcConfiguration;

--- a/src/test/java/bio/terra/stairway/RetryTest.java
+++ b/src/test/java/bio/terra/stairway/RetryTest.java
@@ -27,9 +27,7 @@ public class RetryTest {
     private Stairway stairway;
     private UserRequestInfo testUser = new UserRequestInfo()
         .subjectId("StairwayUnit")
-        .name("stairway@unit.com")
-        .canListJobs(true)
-        .canDeleteJobs(true);
+        .name("stairway@unit.com");
 
     @Autowired
     private StairwayJdbcConfiguration jdbcConfiguration;

--- a/src/test/java/bio/terra/stairway/ScenarioTest.java
+++ b/src/test/java/bio/terra/stairway/ScenarioTest.java
@@ -32,9 +32,7 @@ public class ScenarioTest {
     private Logger logger = LoggerFactory.getLogger("bio.terra.stairway");
     private UserRequestInfo testUser = new UserRequestInfo()
         .subjectId("StairwayUnit")
-        .name("stairway@unit.com")
-        .canListJobs(true)
-        .canDeleteJobs(true);
+        .name("stairway@unit.com");
 
     @Autowired
     private StairwayJdbcConfiguration jdbcConfiguration;

--- a/src/test/java/bio/terra/stairway/StairwayTest.java
+++ b/src/test/java/bio/terra/stairway/StairwayTest.java
@@ -22,9 +22,7 @@ public class StairwayTest {
     private Stairway stairway;
     private UserRequestInfo testUser = new UserRequestInfo()
         .subjectId("StairwayUnit")
-        .name("stairway@unit.com")
-        .canListJobs(true)
-        .canDeleteJobs(true);
+        .name("stairway@unit.com");
 
     @Autowired
     private StairwayJdbcConfiguration jdbcConfiguration;


### PR DESCRIPTION
This work was done by Rori and Mariko pair programming.

1. Moved SAM calls from RepositoryAPIController to JobService.
2. Moved the boolean flag check from Stairway to JobService.
3. Removed the flags from the AuthenticatedUserRequest and UserRequestInfo objects.
4. Replaced testUser with null in JobServiceTest to bypass the SAM check during testing.
5. Fixed checkstyleMain errors by adding spaces before/after equality checks.