### PR TITLE
Fix ingest NPE, and add more tests

### DIFF
--- a/src/main/java/bio/terra/flight/dataset/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/flight/dataset/ingest/DatasetIngestFlight.java
@@ -1,6 +1,5 @@
 package bio.terra.flight.dataset.ingest;
 
-import bio.terra.exception.BadRequestException;
 import bio.terra.filesystem.FireStoreDao;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.pdao.bigquery.BigQueryPdao;
@@ -33,13 +32,9 @@ public class DatasetIngestFlight extends Flight {
             addStep(new IngestEvaluateOverlapStep(datasetService, bigQueryPdao));
             addStep(new IngestSoftDeleteChangedRowsService(datasetService, bigQueryPdao));
             addStep(new IngestUpsertIntoDatasetTableStep(datasetService, bigQueryPdao));
-        } else if (ingestStrategy == IngestRequestModel.StrategyEnum.APPEND) {
-            addStep(new IngestInsertIntoDatasetTableStep(datasetService, bigQueryPdao));
         } else {
-            throw new BadRequestException(
-                "The dataset ingest flight expects the ingest request to have a strategy of  `upsert` or `append`" +
-                    " but was "
-                    + ingestStrategy.toString());
+            // 'append' strategy.
+            addStep(new IngestInsertIntoDatasetTableStep(datasetService, bigQueryPdao));
         }
         addStep(new IngestCleanupStep(datasetService, bigQueryPdao));
     }

--- a/src/main/java/bio/terra/flight/dataset/ingest/IngestEvaluateOverlapStep.java
+++ b/src/main/java/bio/terra/flight/dataset/ingest/IngestEvaluateOverlapStep.java
@@ -24,7 +24,7 @@ public class IngestEvaluateOverlapStep implements Step {
         String stagingTableName = IngestUtils.getStagingTableName(context);
         String overlappingTableName = IngestUtils.getOverlappingTableName(context);
 
-        bigQueryPdao.getOverlappingRows(dataset, targetTable, stagingTableName, overlappingTableName);
+        bigQueryPdao.loadOverlapTable(dataset, targetTable, stagingTableName, overlappingTableName);
 
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/flight/dataset/ingest/IngestSetupStep.java
+++ b/src/main/java/bio/terra/flight/dataset/ingest/IngestSetupStep.java
@@ -26,7 +26,8 @@ import liquibase.util.StringUtils;
 import java.util.List;
 
 /**
- *  * The setup step required to generate the staging file name.
+ * The setup step required to generate the staging file name.
+ *
  * You might ask, "why can't you do that in the staging table step?"
  * The answer is that we need a step boundary so that the staging
  * table name is written to the database. Otherwise, on a failure of
@@ -44,7 +45,6 @@ import java.util.List;
  * Second, it stores away the dataset name. Several steps only need the dataset name
  * and not the dataset object.
  */
-
 public class IngestSetupStep implements Step {
     private DatasetService datasetService;
     private BigQueryPdao bigQueryPdao;
@@ -74,8 +74,7 @@ public class IngestSetupStep implements Step {
             if (primaryKey.size() < 1) {
                 // TODO: add test
                 throw new BadRequestException(
-                    "The dataset ingest flight expects ingestStrategy `upsert` or `append` but was "
-                        + ingestStrategy.toString());
+                    "Cannot use ingestStrategy `upsert` on table with no primary key: " + targetTable.getName());
             }
 
             Schema overlappingTableSchema = bigQueryPdao.buildOverlappingTableSchema();
@@ -99,10 +98,10 @@ public class IngestSetupStep implements Step {
             BlobId blobId = BlobId.of(gsParts.getBucket(), gsParts.getPath());
             Blob blob = storage.get(blobId);
             if (!blob.exists()) {
-                throw new IngestFileNotFoundException("Ingest source file not found: '" + requestModel.getPath());
+                throw new IngestFileNotFoundException("Ingest source file not found: " + requestModel.getPath());
             }
         } catch (StorageException ex) {
-            throw new InvalidUriException("Failed to access ingest source file: '" + requestModel.getPath(), ex);
+            throw new InvalidUriException("Failed to access ingest source file: " + requestModel.getPath(), ex);
         }
 
         return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/flight/dataset/ingest/IngestSetupStep.java
+++ b/src/main/java/bio/terra/flight/dataset/ingest/IngestSetupStep.java
@@ -97,7 +97,7 @@ public class IngestSetupStep implements Step {
             Storage storage = StorageOptions.getDefaultInstance().getService();
             BlobId blobId = BlobId.of(gsParts.getBucket(), gsParts.getPath());
             Blob blob = storage.get(blobId);
-            if (!blob.exists()) {
+            if (!blob.exists()) { // NPE is here
                 throw new IngestFileNotFoundException("Ingest source file not found: " + requestModel.getPath());
             }
         } catch (StorageException ex) {

--- a/src/main/java/bio/terra/flight/dataset/ingest/IngestSetupStep.java
+++ b/src/main/java/bio/terra/flight/dataset/ingest/IngestSetupStep.java
@@ -16,7 +16,6 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.google.cloud.bigquery.Schema;
-import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;

--- a/src/main/java/bio/terra/flight/dataset/ingest/IngestUpsertIntoDatasetTableStep.java
+++ b/src/main/java/bio/terra/flight/dataset/ingest/IngestUpsertIntoDatasetTableStep.java
@@ -28,7 +28,15 @@ public class IngestUpsertIntoDatasetTableStep implements Step {
         String stagingTableName = IngestUtils.getStagingTableName(context);
         String overlappingTableName = IngestUtils.getOverlappingTableName(context);
 
+        bigQueryPdao.upsertIntoDatasetTable(dataset, targetTable, stagingTableName, overlappingTableName);
+
         IngestRequestModel ingestRequest = IngestUtils.getIngestRequestModel(context);
+        // FIXME: Using the initial load stats is misleading in the upsert case.
+        //  Ideally we'd report separate numbers for:
+        //    1. Number of new rows added
+        //    2. Number of rows updated
+        //    3. Number of rows unchanged
+        //  The append case could use the same model, with the existing counts all going into bin 1.
         PdaoLoadStatistics loadStatistics = IngestUtils.getIngestStatistics(context);
 
         IngestResponseModel ingestResponse = new IngestResponseModel()
@@ -40,8 +48,6 @@ public class IngestUpsertIntoDatasetTableStep implements Step {
             .badRowCount(loadStatistics.getBadRecords())
             .rowCount(loadStatistics.getRowCount());
         context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), ingestResponse);
-
-        bigQueryPdao.upsertIntoDatasetTable(dataset, targetTable, stagingTableName, overlappingTableName);
 
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/flight/exception/InvalidIngestStrategyException.java
+++ b/src/main/java/bio/terra/flight/exception/InvalidIngestStrategyException.java
@@ -1,0 +1,9 @@
+package bio.terra.flight.exception;
+
+import bio.terra.exception.BadRequestException;
+
+public class InvalidIngestStrategyException extends BadRequestException {
+    public InvalidIngestStrategyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/pdao/bigquery/BigQueryPdao.java
@@ -402,10 +402,10 @@ public class BigQueryPdao implements PrimaryDataAccess {
         bigQueryProject.query(sql.toString());
     }
 
-    public void getOverlappingRows(Dataset dataset,
-                                    Table targetTable,
-                                    String stagingTableName,
-                                    String overlappingTableName) {
+    public void loadOverlapTable(Dataset dataset,
+                                 Table targetTable,
+                                 String stagingTableName,
+                                 String overlappingTableName) {
         /*
          * INSERT INTO overlappingTableName
          * (STAGING_TABLE_ID_COLUMN, TARGET_TABLE_ID_COLUMN)

--- a/src/test/java/bio/terra/integration/AccessTest.java
+++ b/src/test/java/bio/terra/integration/AccessTest.java
@@ -9,6 +9,7 @@ import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateDatasetModel;
 import bio.terra.model.FileModel;
+import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestResponseModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotSummaryModel;
@@ -84,11 +85,13 @@ public class AccessTest extends UsersBase {
 
     @Test
     public void checkShared() throws  Exception {
-        dataRepoFixtures.ingestJsonData(
-            steward(), datasetId, "participant", "ingest-test/ingest-test-participant.json");
+        IngestRequestModel request = dataRepoFixtures.buildSimpleIngest(
+            "participant", "ingest-test/ingest-test-participant.json", IngestRequestModel.StrategyEnum.APPEND);
+        dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
 
-        dataRepoFixtures.ingestJsonData(
-            steward(), datasetId, "sample", "ingest-test/ingest-test-sample.json");
+        request = dataRepoFixtures.buildSimpleIngest(
+            "sample", "ingest-test/ingest-test-sample.json", IngestRequestModel.StrategyEnum.APPEND);
+        dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
 
         DatasetModel dataset = dataRepoFixtures.getDataset(steward(), datasetId);
         String datasetBqSnapshotName = "datarepo_" + dataset.getName();
@@ -182,11 +185,10 @@ public class AccessTest extends UsersBase {
             writer.write(ByteBuffer.wrap(json.getBytes(StandardCharsets.UTF_8)));
         }
 
+        IngestRequestModel request = dataRepoFixtures.buildSimpleIngest(
+            "file", targetPath, IngestRequestModel.StrategyEnum.APPEND);
         IngestResponseModel ingestResponseModel = dataRepoFixtures.ingestJsonData(
-            steward(),
-            datasetSummaryModel.getId(),
-            "file",
-            targetPath);
+            steward(), datasetSummaryModel.getId(), request);
 
         assertThat("1 Row was ingested", ingestResponseModel.getRowCount(), equalTo(1L));
 

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -252,7 +252,14 @@ public class DataRepoFixtures {
 
     public DataRepoResponse<JobModel> ingestJsonDataLaunch(
         TestConfiguration.User user, String datasetId, String tableName, String filePath) throws Exception {
-        String ingestBody = buildSimpleIngest(tableName, filePath);
+        return ingestJsonDataLaunch(user, datasetId, tableName, filePath, IngestRequestModel.StrategyEnum.APPEND);
+    }
+
+    public DataRepoResponse<JobModel> ingestJsonDataLaunch(
+        TestConfiguration.User user, String datasetId,
+        String tableName, String filePath, IngestRequestModel.StrategyEnum strategy) throws Exception {
+
+        String ingestBody = buildSimpleIngest(tableName, filePath, strategy);
         return dataRepoClient.post(
             user,
             "/api/repository/v1/datasets/" + datasetId + "/ingest",
@@ -262,7 +269,14 @@ public class DataRepoFixtures {
 
     public IngestResponseModel ingestJsonData(
         TestConfiguration.User user, String datasetId, String tableName, String filePath) throws Exception {
-        DataRepoResponse<JobModel> launchResp = ingestJsonDataLaunch(user, datasetId, tableName, filePath);
+        return ingestJsonData(user, datasetId, tableName, filePath, IngestRequestModel.StrategyEnum.APPEND);
+    }
+
+    public IngestResponseModel ingestJsonData(
+        TestConfiguration.User user, String datasetId,
+        String tableName, String filePath, IngestRequestModel.StrategyEnum strategy) throws Exception {
+
+        DataRepoResponse<JobModel> launchResp = ingestJsonDataLaunch(user, datasetId, tableName, filePath, strategy);
         assertTrue("ingest launch succeeded", launchResp.getStatusCode().is2xxSuccessful());
         assertTrue("ingest launch response is present", launchResp.getResponseObject().isPresent());
         DataRepoResponse<IngestResponseModel> response = dataRepoClient.waitForResponse(
@@ -417,13 +431,13 @@ public class DataRepoFixtures {
         return storageOptions.getService();
     }
 
-    private String buildSimpleIngest(String table, String filename) throws Exception {
+    private String buildSimpleIngest(String table, String filename, IngestRequestModel.StrategyEnum strategy) throws Exception {
         String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + filename;
         IngestRequestModel ingestRequest = new IngestRequestModel()
             .format(IngestRequestModel.FormatEnum.JSON)
             .table(table)
-            .path(gsPath);
-        ingestRequest.setStrategy(IngestRequestModel.StrategyEnum.APPEND);
+            .path(gsPath)
+            .strategy(strategy);
 
         return objectMapper.writeValueAsString(ingestRequest);
     }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -258,8 +258,12 @@ public class DataRepoFixtures {
     public DataRepoResponse<JobModel> ingestJsonDataLaunch(
         TestConfiguration.User user, String datasetId,
         String tableName, String filePath, IngestRequestModel.StrategyEnum strategy) throws Exception {
+        return ingestJsonDataLaunch(user, datasetId, buildSimpleIngest(tableName, filePath, strategy));
+    }
 
-        String ingestBody = buildSimpleIngest(tableName, filePath, strategy);
+    public DataRepoResponse<JobModel> ingestJsonDataLaunch(
+        TestConfiguration.User user, String datasetId, IngestRequestModel request) throws Exception {
+        String ingestBody = objectMapper.writeValueAsString(request);
         return dataRepoClient.post(
             user,
             "/api/repository/v1/datasets/" + datasetId + "/ingest",
@@ -431,16 +435,14 @@ public class DataRepoFixtures {
         return storageOptions.getService();
     }
 
-    private String buildSimpleIngest(
+    private IngestRequestModel buildSimpleIngest(
         String table, String filename, IngestRequestModel.StrategyEnum strategy) throws Exception {
         String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + filename;
-        IngestRequestModel ingestRequest = new IngestRequestModel()
+        return new IngestRequestModel()
             .format(IngestRequestModel.FormatEnum.JSON)
             .table(table)
             .path(gsPath)
             .strategy(strategy);
-
-        return objectMapper.writeValueAsString(ingestRequest);
     }
 
     public DataRepoResponse<DeleteResponseModel> deleteProfile(

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -431,7 +431,8 @@ public class DataRepoFixtures {
         return storageOptions.getService();
     }
 
-    private String buildSimpleIngest(String table, String filename, IngestRequestModel.StrategyEnum strategy) throws Exception {
+    private String buildSimpleIngest(
+        String table, String filename, IngestRequestModel.StrategyEnum strategy) throws Exception {
         String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + filename;
         IngestRequestModel ingestRequest = new IngestRequestModel()
             .format(IngestRequestModel.FormatEnum.JSON)

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -251,17 +251,6 @@ public class DataRepoFixtures {
     }
 
     public DataRepoResponse<JobModel> ingestJsonDataLaunch(
-        TestConfiguration.User user, String datasetId, String tableName, String filePath) throws Exception {
-        return ingestJsonDataLaunch(user, datasetId, tableName, filePath, IngestRequestModel.StrategyEnum.APPEND);
-    }
-
-    public DataRepoResponse<JobModel> ingestJsonDataLaunch(
-        TestConfiguration.User user, String datasetId,
-        String tableName, String filePath, IngestRequestModel.StrategyEnum strategy) throws Exception {
-        return ingestJsonDataLaunch(user, datasetId, buildSimpleIngest(tableName, filePath, strategy));
-    }
-
-    public DataRepoResponse<JobModel> ingestJsonDataLaunch(
         TestConfiguration.User user, String datasetId, IngestRequestModel request) throws Exception {
         String ingestBody = objectMapper.writeValueAsString(request);
         return dataRepoClient.post(
@@ -272,15 +261,9 @@ public class DataRepoFixtures {
     }
 
     public IngestResponseModel ingestJsonData(
-        TestConfiguration.User user, String datasetId, String tableName, String filePath) throws Exception {
-        return ingestJsonData(user, datasetId, tableName, filePath, IngestRequestModel.StrategyEnum.APPEND);
-    }
+        TestConfiguration.User user, String datasetId, IngestRequestModel request) throws Exception {
 
-    public IngestResponseModel ingestJsonData(
-        TestConfiguration.User user, String datasetId,
-        String tableName, String filePath, IngestRequestModel.StrategyEnum strategy) throws Exception {
-
-        DataRepoResponse<JobModel> launchResp = ingestJsonDataLaunch(user, datasetId, tableName, filePath, strategy);
+        DataRepoResponse<JobModel> launchResp = ingestJsonDataLaunch(user, datasetId, request);
         assertTrue("ingest launch succeeded", launchResp.getStatusCode().is2xxSuccessful());
         assertTrue("ingest launch response is present", launchResp.getResponseObject().isPresent());
         DataRepoResponse<IngestResponseModel> response = dataRepoClient.waitForResponse(
@@ -435,7 +418,7 @@ public class DataRepoFixtures {
         return storageOptions.getService();
     }
 
-    private IngestRequestModel buildSimpleIngest(
+    public IngestRequestModel buildSimpleIngest(
         String table, String filename, IngestRequestModel.StrategyEnum strategy) throws Exception {
         String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + filename;
         return new IngestRequestModel()

--- a/src/test/java/bio/terra/integration/EncodeFixture.java
+++ b/src/test/java/bio/terra/integration/EncodeFixture.java
@@ -8,6 +8,7 @@ import bio.terra.integration.configuration.TestConfiguration;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.FileModel;
+import bio.terra.model.IngestRequestModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.SamClientService;
@@ -67,8 +68,12 @@ public class EncodeFixture {
         String targetPath = loadFiles(datasetSummary.getId(), billingProfile.getId(), steward, stewardStorage);
 
         // Load the tables
-        dataRepoFixtures.ingestJsonData(steward, datasetId, "file", targetPath);
-        dataRepoFixtures.ingestJsonData(steward, datasetId, "donor", "encodetest/donor.json");
+        IngestRequestModel request = dataRepoFixtures.buildSimpleIngest(
+            "file", targetPath, IngestRequestModel.StrategyEnum.APPEND);
+        dataRepoFixtures.ingestJsonData(steward, datasetId, request);
+        request = dataRepoFixtures.buildSimpleIngest(
+            "donor", "encodetest/donor.json", IngestRequestModel.StrategyEnum.APPEND);
+        dataRepoFixtures.ingestJsonData(steward, datasetId, request);
 
         // Delete the scratch blob
         Blob scratchBlob = stewardStorage.get(BlobId.of(testConfiguration.getIngestbucket(), targetPath));

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -3,6 +3,7 @@ package bio.terra.integration;
 import bio.terra.category.Integration;
 import bio.terra.integration.configuration.TestConfiguration;
 import bio.terra.model.FileModel;
+import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestResponseModel;
 import bio.terra.model.JobModel;
 import bio.terra.model.DatasetSummaryModel;
@@ -98,8 +99,10 @@ public class FileTest extends UsersBase {
             writer.write(ByteBuffer.wrap(json.getBytes(StandardCharsets.UTF_8)));
         }
 
+        IngestRequestModel request = dataRepoFixtures.buildSimpleIngest(
+            "file", targetPath, IngestRequestModel.StrategyEnum.APPEND);
         IngestResponseModel ingestResponseModel = dataRepoFixtures.ingestJsonData(
-            steward(), datasetId, "file", targetPath);
+            steward(), datasetId, request);
 
         assertThat("1 Row was ingested", ingestResponseModel.getRowCount(), equalTo(1L));
 

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -162,7 +162,7 @@ public class IngestTest extends UsersBase {
             steward(), datasetId, request);
         DataRepoResponse<IngestResponseModel> ingestResponse = dataRepoClient.waitForResponse(
             steward(), ingestJobResponse, IngestResponseModel.class);
-        assertThat("ingest failed", ingestResponse.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
+        assertThat("ingest failed", ingestResponse.getStatusCode(), equalTo(HttpStatus.NOT_FOUND));
         assertThat("failure is explained",
             ingestResponse.getErrorObject().orElseThrow(IllegalStateException::new).getMessage(),
             containsString("file not found"));

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -127,27 +127,27 @@ public class IngestTest extends UsersBase {
     @Test
     public void ingestAppendNoPkTest() throws Exception {
         IngestResponseModel ingestResponse = dataRepoFixtures.ingestJsonData(
-            steward(), datasetId, "sample", "ingest-test/ingest-test-sample.json");
-        assertThat("correct sample row count", ingestResponse.getRowCount(), equalTo(7L));
+            steward(), datasetId, "file", "ingest-test/ingest-test-file.json");
+        assertThat("correct file row count", ingestResponse.getRowCount(), equalTo(1L));
         ingestResponse = dataRepoFixtures.ingestJsonData(
-            steward(), datasetId, "sample", "ingest-test/ingest-test-sample.json");
-        assertThat("correct sample row count", ingestResponse.getRowCount(), equalTo(14L));
+            steward(), datasetId, "file", "ingest-test/ingest-test-file.json");
+        assertThat("correct file row count", ingestResponse.getRowCount(), equalTo(2L));
     }
 
     @Test
     public void ingestUpsertNoPkTest() throws Exception {
         IngestResponseModel ingestOne = dataRepoFixtures.ingestJsonData(
-            steward(), datasetId, "sample", "ingest-test/ingest-test-sample.json");
-        assertThat("correct sample row count", ingestOne.getRowCount(), equalTo(7L));
+            steward(), datasetId, "file", "ingest-test/ingest-test-file.json");
+        assertThat("correct file row count", ingestOne.getRowCount(), equalTo(1L));
         DataRepoResponse<JobModel> upsertJobResponse = dataRepoFixtures.ingestJsonDataLaunch(
-            steward(), datasetId, "sample", "ingest-test/ingest-test-sample.json",
+            steward(), datasetId, "file", "ingest-test/ingest-test-file.json",
             IngestRequestModel.StrategyEnum.UPSERT);
         DataRepoResponse<IngestResponseModel> ingestResponse = dataRepoClient.waitForResponse(
             steward(), upsertJobResponse, IngestResponseModel.class);
         assertThat("ingest failed", ingestResponse.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
         assertThat("failure is explained",
             ingestResponse.getErrorObject().orElseThrow(IllegalStateException::new).getMessage(),
-            containsString("primary key"));
+            containsString("no primary key"));
     }
 
     @Test

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -136,7 +136,8 @@ public class IngestTest extends UsersBase {
             steward(), datasetId, "sample", "ingest-test/ingest-test-sample.json");
         assertThat("correct sample row count", ingestOne.getRowCount(), equalTo(7L));
         DataRepoResponse<JobModel> upsertJobResponse = dataRepoFixtures.ingestJsonDataLaunch(
-            steward(), datasetId, "sample", "ingest-test/ingest-test-sample.json", IngestRequestModel.StrategyEnum.UPSERT);
+            steward(), datasetId, "sample", "ingest-test/ingest-test-sample.json",
+            IngestRequestModel.StrategyEnum.UPSERT);
         DataRepoResponse<IngestResponseModel> ingestResponse = dataRepoClient.waitForResponse(
             steward(), upsertJobResponse, IngestResponseModel.class);
         assertThat("ingest failed", ingestResponse.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -87,6 +87,7 @@ public class IngestTest extends UsersBase {
                 "participant",
                 "ingest-test/ingest-test-updated-participant.json",
                 IngestRequestModel.StrategyEnum.UPSERT);
+        // FIXME: Ideally we'd be able to assert on the # of rows added, updated, and left unchanged.
         assertThat("correct participant row count", ingestResponse.getRowCount(), equalTo(6L));
     }
 
@@ -131,7 +132,7 @@ public class IngestTest extends UsersBase {
         assertThat("correct file row count", ingestResponse.getRowCount(), equalTo(1L));
         ingestResponse = dataRepoFixtures.ingestJsonData(
             steward(), datasetId, "file", "ingest-test/ingest-test-file.json");
-        assertThat("correct file row count", ingestResponse.getRowCount(), equalTo(2L));
+        assertThat("correct file row count", ingestResponse.getRowCount(), equalTo(1L));
     }
 
     @Test

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -156,7 +156,8 @@ public class IngestTest extends UsersBase {
         IngestRequestModel request = new IngestRequestModel()
             .format(IngestRequestModel.FormatEnum.JSON)
             .path("gs://" + testConfig.getIngestbucket() + "/totally-legit-file.json")
-            .table("file");
+            .table("file")
+            .strategy(IngestRequestModel.StrategyEnum.APPEND);
         DataRepoResponse<JobModel> ingestJobResponse = dataRepoFixtures.ingestJsonDataLaunch(
             steward(), datasetId, request);
         DataRepoResponse<IngestResponseModel> ingestResponse = dataRepoClient.waitForResponse(

--- a/src/test/java/bio/terra/integration/SnapshotTest.java
+++ b/src/test/java/bio/terra/integration/SnapshotTest.java
@@ -4,6 +4,7 @@ import bio.terra.category.Integration;
 import bio.terra.fixtures.JsonLoader;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateSnapshotModel;
+import bio.terra.model.IngestRequestModel;
 import bio.terra.model.JobModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotSummaryModel;
@@ -55,10 +56,13 @@ public class SnapshotTest extends UsersBase {
         datasetId = datasetSummaryModel.getId();
         dataRepoFixtures.addDatasetPolicyMember(
             steward(), datasetId, SamClientService.DataRepoRole.CUSTODIAN, custodian().getEmail());
-        dataRepoFixtures.ingestJsonData(
-            steward(), datasetId, "participant", "ingest-test/ingest-test-participant.json");
-        dataRepoFixtures.ingestJsonData(
-            steward(), datasetId, "sample", "ingest-test/ingest-test-sample.json");
+
+        IngestRequestModel request = dataRepoFixtures.buildSimpleIngest(
+            "participant", "ingest-test/ingest-test-participant.json", IngestRequestModel.StrategyEnum.APPEND);
+        dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
+        request = dataRepoFixtures.buildSimpleIngest(
+            "sample", "ingest-test/ingest-test-sample.json", IngestRequestModel.StrategyEnum.APPEND);
+        dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
     }
 
     @After

--- a/src/test/resources/ingest-test-dataset.json
+++ b/src/test/resources/ingest-test-dataset.json
@@ -20,16 +20,14 @@
           {"name": "participant_ids", "datatype": "string", "array_of": true},
           {"name": "date_collected", "datatype": "date"},
           {"name": "derived_from", "datatype": "string"}
-        ],
-        "primaryKey": ["id"]
+        ]
       },
       {
         "name": "file",
         "columns": [
           {"name": "id", "datatype": "string"},
           {"name": "derived_from", "datatype": "string", "array_of": true}
-        ],
-        "primaryKey": ["id"]
+        ]
       }
     ],
     "relationships": [

--- a/src/test/resources/ingest-test-dataset.json
+++ b/src/test/resources/ingest-test-dataset.json
@@ -20,7 +20,8 @@
           {"name": "participant_ids", "datatype": "string", "array_of": true},
           {"name": "date_collected", "datatype": "date"},
           {"name": "derived_from", "datatype": "string"}
-        ]
+        ],
+        "primaryKey": ["id"]
       },
       {
         "name": "file",


### PR DESCRIPTION
I hit an NPE trying to ingest tabular data in prod yesterday. The line number for the exception didn't make much sense, so I'm just trying stuff out with integration tests to see if I can reproduce.