### PR TITLE
DR-614 Service restructuring

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -54,7 +54,7 @@ public class DatasetService {
 
     public Dataset retrieve(UUID id) {
         Dataset dataset = datasetDao.retrieve(id);
-        return dataset.dataProject(dataLocationService.getProjectForDataset(dataset));
+        return dataset.dataProject(dataLocationService.getOrCreateProjectForDataset(dataset));
     }
 
     public DatasetModel retrieveModel(UUID id) {

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
@@ -1,10 +1,12 @@
 package bio.terra.service.dataset.flight.create;
 
-import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
-import bio.terra.service.dataset.Dataset;
 import bio.terra.common.PrimaryDataAccess;
-import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetDataProject;
 import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -16,10 +18,14 @@ import java.util.UUID;
 public class CreateDatasetPrimaryDataStep implements Step {
     private final PrimaryDataAccess pdao;
     private final DatasetService datasetService;
+    private final DataLocationService dataLocationService;
 
-    public CreateDatasetPrimaryDataStep(PrimaryDataAccess pdao, DatasetService datasetService) {
+    public CreateDatasetPrimaryDataStep(PrimaryDataAccess pdao,
+                                        DatasetService datasetService,
+                                        DataLocationService dataLocationService) {
         this.pdao = pdao;
         this.datasetService = datasetService;
+        this.dataLocationService = dataLocationService;
     }
 
     Dataset getDataset(FlightContext context) {
@@ -38,10 +44,15 @@ public class CreateDatasetPrimaryDataStep implements Step {
 
     @Override
     public StepResult undoStep(FlightContext context) {
-        try {
+        // check if project was created
+        UUID datasetId = context.getWorkingMap().get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
+        DatasetDataProject datasetProject = dataLocationService.getProjectForDatasetId(datasetId);
+        if (datasetProject != null) {
+            // if there is no project associated with this dataset, then there won't be primary data to delete,
+            // so no need to call the below method.
+            // also the below method will try to create a project if one doesn't already exist, and we don't
+            // want to do that in the undo direction.
             pdao.deleteDataset(getDataset(context));
-        } catch (Exception ex) {
-            System.out.println("exception caught 21. "+ex.getMessage()+", "+ex.getClass().getCanonicalName());
         }
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
@@ -38,7 +38,11 @@ public class CreateDatasetPrimaryDataStep implements Step {
 
     @Override
     public StepResult undoStep(FlightContext context) {
-        pdao.deleteDataset(getDataset(context));
+        try {
+            pdao.deleteDataset(getDataset(context));
+        } catch (Exception ex) {
+            System.out.println("exception caught 21. "+ex.getMessage()+", "+ex.getClass().getCanonicalName());
+        }
         return StepResult.getStepResultSuccess();
     }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
@@ -13,6 +13,7 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import org.springframework.http.HttpStatus;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public class CreateDatasetPrimaryDataStep implements Step {
@@ -46,8 +47,8 @@ public class CreateDatasetPrimaryDataStep implements Step {
     public StepResult undoStep(FlightContext context) {
         // check if project was created
         UUID datasetId = context.getWorkingMap().get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
-        DatasetDataProject datasetProject = dataLocationService.getProjectForDatasetId(datasetId);
-        if (datasetProject != null) {
+        Optional<DatasetDataProject> datasetProject = dataLocationService.getProjectForDatasetId(datasetId);
+        if (datasetProject.isPresent()) {
             // if there is no project associated with this dataset, then there won't be primary data to delete,
             // so no need to call the below method.
             // also the below method will try to create a project if one doesn't already exist, and we don't

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -3,6 +3,7 @@ package bio.terra.service.dataset.flight.create;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.job.JobMapKeys;
@@ -23,6 +24,7 @@ public class DatasetCreateFlight extends Flight {
         DatasetService datasetService = (DatasetService) appContext.getBean("datasetService");
         BigQueryPdao bigQueryPdao = (BigQueryPdao) appContext.getBean("bigQueryPdao");
         SamClientService samClient = (SamClientService) appContext.getBean("samClientService");
+        DataLocationService dataLocationService = (DataLocationService) appContext.getBean("dataLocationService");
 
         // get data from inputs that steps need
         AuthenticatedUserRequest userReq = inputParameters.get(
@@ -32,7 +34,7 @@ public class DatasetCreateFlight extends Flight {
 
         addStep(new CreateDatasetMetadataStep(datasetDao, datasetRequest));
         // TODO: create dataset data project step
-        addStep(new CreateDatasetPrimaryDataStep(bigQueryPdao, datasetService));
+        addStep(new CreateDatasetPrimaryDataStep(bigQueryPdao, datasetService, dataLocationService));
         addStep(new CreateDatasetAuthzResource(samClient, bigQueryPdao, datasetService, userReq));
     }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
@@ -162,7 +162,8 @@ public class DataLocationService {
                 dataProjectDao.retrieveDatasetDataProject(datasetId);
             GoogleProjectResource googleProjectResource =
                 resourceService.getProjectResourceById(datasetDataProjectSummary.getProjectResourceId());
-            DatasetDataProject datasetDataProject = new DatasetDataProject(datasetDataProjectSummary).googleProjectResource(googleProjectResource);
+            DatasetDataProject datasetDataProject =
+                new DatasetDataProject(datasetDataProjectSummary).googleProjectResource(googleProjectResource);
             return Optional.of(datasetDataProject);
         } catch (DataProjectNotFoundException | GoogleResourceNotFoundException e) {
             return Optional.empty();

--- a/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
@@ -19,12 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 @Component
 public class DataLocationService {
@@ -161,15 +156,16 @@ public class DataLocationService {
 
     // only return the project if it already exists
     // otherwise, return null
-    public DatasetDataProject getProjectForDatasetId(UUID datasetId) {
+    public Optional<DatasetDataProject> getProjectForDatasetId(UUID datasetId) {
         try {
             DatasetDataProjectSummary datasetDataProjectSummary =
                 dataProjectDao.retrieveDatasetDataProject(datasetId);
             GoogleProjectResource googleProjectResource =
                 resourceService.getProjectResourceById(datasetDataProjectSummary.getProjectResourceId());
-            return new DatasetDataProject(datasetDataProjectSummary).googleProjectResource(googleProjectResource);
+            DatasetDataProject datasetDataProject = new DatasetDataProject(datasetDataProjectSummary).googleProjectResource(googleProjectResource);
+            return Optional.of(datasetDataProject);
         } catch (DataProjectNotFoundException | GoogleResourceNotFoundException e) {
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -73,7 +73,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     public BigQueryProject bigQueryProjectForDataset(Dataset dataset) {
-        DatasetDataProject projectForDataset = dataLocationService.getProjectForDataset(dataset);
+        DatasetDataProject projectForDataset = dataLocationService.getOrCreateProjectForDataset(dataset);
         return BigQueryProject.get(projectForDataset.getGoogleProjectId());
     }
 

--- a/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/src/main/java/bio/terra/stairway/FlightDao.java
@@ -390,7 +390,7 @@ public class FlightDao {
             }
             return getObjectMapper().readValue(exceptionJson, Exception.class);
         } catch (IOException ex) {
-            logger.error("JACKSON deserialization failed. JSON:"+exceptionJson);
+            logger.error("JACKSON deserialization failed. JSON:" + exceptionJson);
             throw new DatabaseOperationException("Failed to convert JSON to exception", ex);
         }
     }

--- a/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/src/main/java/bio/terra/stairway/FlightDao.java
@@ -57,7 +57,7 @@ public class FlightDao {
     private static String FLIGHT_TABLE = "flight";
     private static String FLIGHT_LOG_TABLE = "flightlog";
 
-    private static Logger logger = LoggerFactory.getLogger("bio.terra.stairway");
+    private static Logger logger = LoggerFactory.getLogger(Stairway.class);
     private static ObjectMapper objectMapper;
     private final NamedParameterJdbcTemplate jdbcTemplate;
     private final StairwayJdbcConfiguration jdbcConfiguration;

--- a/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
@@ -314,7 +314,7 @@ public class SnapshotOperationTest {
 
     private BigQueryProject bigQueryProjectForDatasetName(String datasetName) {
         Dataset dataset = datasetDao.retrieveByName(datasetName);
-        DatasetDataProject dataProject = dataLocationService.getProjectForDataset(dataset);
+        DatasetDataProject dataProject = dataLocationService.getOrCreateProjectForDataset(dataset);
         return BigQueryProject.get(dataProject.getGoogleProjectId());
     }
 


### PR DESCRIPTION
1. If the project creation fails because the name is too long for GCP, the reported exception was a JACKSON deserialization failure. I added the GoogleJsonException to the list of exceptions that need to be rewritten because of the problem with JACKSON, so the reported exception is now the correct one ("project create failed").

2. If the CreateDataset flight finds that the project doesn't exist, it tries to create it. This is the correct behavior in doStep, but undoStep was also trying to create new project. Now, the undoStep first checks if an associated project exists before attempting to call datasetService.retrieve, which tries to create it if it doesn't exist already.
    a. Renamed existing method getProjectForDataset->getOrCreateProjectForDataset on the DataLocationService class to better describe the behavior.
    b. Added a new method called getProjectForDatasetId on the same class to look up existing projects only, not create new ones.

3. Added unit test for project creation failure in CreateDataset flight.
