### PR TITLE
DR-614 service restructuring

### DIFF
--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -357,7 +357,7 @@ public class RepositoryApiController implements RepositoryApi {
             IamResourceType.DATASNAPSHOT,
             id,
             IamAction.READ_DATA);
-        SnapshotModel snapshotModel = snapshotService.retrieveSnapshotModel(UUID.fromString(id));
+        SnapshotModel snapshotModel = snapshotService.retrieveModel(UUID.fromString(id));
         return new ResponseEntity<>(snapshotModel, HttpStatus.OK);
     }
 

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -19,7 +19,6 @@ public class Dataset implements FSContainerInterface {
     private List<DatasetTable> tables = Collections.emptyList();
     private List<DatasetRelationship> relationships = Collections.emptyList();
     private List<AssetSpecification> assetSpecifications = Collections.emptyList();
-    private DatasetDataProject dataProject = new DatasetDataProject();
 
     public Dataset() {
         datasetSummary = new DatasetSummary();
@@ -158,21 +157,4 @@ public class Dataset implements FSContainerInterface {
         return this;
     }
 
-    public DatasetDataProject getDataProject() {
-        return dataProject;
-    }
-
-    public Dataset dataProject(DatasetDataProject dataProject) {
-        this.dataProject = dataProject;
-        return this;
-    }
-
-    public String getDataProjectId() {
-        return dataProject.getGoogleProjectId();
-    }
-
-    public Dataset dataProjectId(String dataProjectId) {
-        dataProject.googleProjectId(dataProjectId);
-        return this;
-    }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -58,7 +58,7 @@ public final class DatasetJsonConversion {
                 .additionalProfileIds(uuidsToStrings(dataset.getAdditionalProfileIds()));
     }
 
-    public static DatasetModel datasetModelFromDataset(Dataset dataset) {
+    public static DatasetModel populateDatasetModelFromDataset(Dataset dataset) {
         return new DatasetModel()
                 .id(dataset.getId().toString())
                 .name(dataset.getName())
@@ -66,8 +66,7 @@ public final class DatasetJsonConversion {
                 .defaultProfileId(dataset.getDefaultProfileId().toString())
                 .additionalProfileIds(uuidsToStrings(dataset.getAdditionalProfileIds()))
                 .createdDate(dataset.getCreatedDate().toString())
-                .schema(datasetSpecificationModelFromDatasetSchema(dataset))
-                .dataProject(dataset.getDataProjectId());
+                .schema(datasetSpecificationModelFromDatasetSchema(dataset));
     }
 
     public static DatasetSpecificationModel datasetSpecificationModelFromDatasetSchema(Dataset dataset) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -53,7 +53,7 @@ public class DatasetService {
 
     public Dataset retrieve(UUID id) {
         Dataset dataset = datasetDao.retrieve(id);
-        return dataset.dataProject(dataLocationService.getProjectForDataset(dataset));
+        return dataset.dataProject(dataLocationService.getOrCreateProjectForDataset(dataset));
     }
 
     public DatasetModel retrieveModel(UUID id) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -53,6 +53,11 @@ public class DatasetService {
             .submitAndWait(DatasetSummaryModel.class);
     }
 
+    /** Fetch existing Dataset object and populate the associated existing cloud project.
+     * If either the Dataset object or the associated cloud project does not exist, throws a runtime exception.
+     * @param id in UUID format
+     * @return a Dataset populated with a valid cloud project
+     */
     public Dataset retrieve(UUID id) {
         Dataset dataset = datasetDao.retrieve(id);
         Optional<DatasetDataProject> optDataProject = dataLocationService.getProjectForDataset(dataset);
@@ -63,6 +68,10 @@ public class DatasetService {
         }
     }
 
+    /** Convenience wrapper around fetching an existing Dataset object and converting it to a Model object.
+     * @param id in UUID formant
+     * @return a DatasetModel = API output-friendly representation of the Dataset
+     */
     public DatasetModel retrieveModel(UUID id) {
         Dataset dataset = retrieve(id);
         return DatasetJsonConversion.datasetModelFromDataset(dataset);

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -60,7 +60,7 @@ public class DatasetService {
      */
     public Dataset retrieve(UUID id) {
         Dataset dataset = datasetDao.retrieve(id);
-        Optional<DatasetDataProject> optDataProject = dataLocationService.getProjectForDataset(dataset);
+        Optional<DatasetDataProject> optDataProject = dataLocationService.getProject(dataset);
         if (optDataProject.isPresent()) {
             return dataset.dataProject(optDataProject.get());
         } else {

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
@@ -41,7 +41,7 @@ public class CreateDatasetPrimaryDataStep implements Step {
 
         // get or create a cloud project for the dataset
         // and update the project reference on the dataset object
-        dataset.dataProject(dataLocationService.getOrCreateProjectForDataset(dataset));
+        dataset.dataProject(dataLocationService.getOrCreateProject(dataset));
 
         pdao.createDataset(dataset);
 
@@ -56,7 +56,7 @@ public class CreateDatasetPrimaryDataStep implements Step {
         Dataset dataset = getDatasetWithoutProject(context);
 
         // get the cloud project for the dataset if it exists
-        Optional<DatasetDataProject> optDataProject = dataLocationService.getProjectForDataset(dataset);
+        Optional<DatasetDataProject> optDataProject = dataLocationService.getProject(dataset);
         if (optDataProject.isPresent()) {
             // and update the project reference on the dataset object
             dataset.dataProject(optDataProject.get());

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
@@ -36,6 +36,9 @@ public class CreateDatasetPrimaryDataStep implements Step {
 
     @Override
     public StepResult doStep(FlightContext context) {
+        // Note that there can be only one project for a Dataset. This requirement is enforced in DataLocationService,
+        // where getOrCreateProject first checks for an existing project before trying to create a new one.
+        // The below logic would not work correctly if this one-to-one mapping were ever violated.
         Dataset dataset = getDataset(context);
         dataLocationService.getOrCreateProject(dataset);
         pdao.createDataset(dataset);

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetPrimaryDataStep.java
@@ -1,36 +1,50 @@
 package bio.terra.service.dataset.flight.create;
 
+import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.dataset.DatasetDataProject;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.common.PrimaryDataAccess;
 import bio.terra.service.job.JobMapKeys;
-import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import org.springframework.http.HttpStatus;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public class CreateDatasetPrimaryDataStep implements Step {
     private final PrimaryDataAccess pdao;
-    private final DatasetService datasetService;
+    private final DatasetDao datasetDao;
+    private final DataLocationService dataLocationService;
 
-    public CreateDatasetPrimaryDataStep(PrimaryDataAccess pdao, DatasetService datasetService) {
+    public CreateDatasetPrimaryDataStep(
+        PrimaryDataAccess pdao, DatasetDao datasetDao, DataLocationService dataLocationService) {
         this.pdao = pdao;
-        this.datasetService = datasetService;
+        this.datasetDao = datasetDao;
+        this.dataLocationService = dataLocationService;
     }
 
-    Dataset getDataset(FlightContext context) {
+    private Dataset getDatasetWithoutProject(FlightContext context) {
         FlightMap workingMap = context.getWorkingMap();
         UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
-        return datasetService.retrieve(datasetId);
+        return datasetDao.retrieve(datasetId);
     }
 
     @Override
     public StepResult doStep(FlightContext context) {
-        pdao.createDataset(getDataset(context));
+        // fetch the dataset object, unpopulated with cloud project information
+        Dataset dataset = getDatasetWithoutProject(context);
+
+        // get or create a cloud project for the dataset
+        // and update the project reference on the dataset object
+        dataset.dataProject(dataLocationService.getOrCreateProjectForDataset(dataset));
+
+        pdao.createDataset(dataset);
+
         FlightMap map = context.getWorkingMap();
         map.put(JobMapKeys.STATUS_CODE.getKeyName(), HttpStatus.CREATED);
         return StepResult.getStepResultSuccess();
@@ -38,7 +52,19 @@ public class CreateDatasetPrimaryDataStep implements Step {
 
     @Override
     public StepResult undoStep(FlightContext context) {
-        pdao.deleteDataset(getDataset(context));
+        // fetch the dataset object, unpopulated with cloud project information
+        Dataset dataset = getDatasetWithoutProject(context);
+
+        // get the cloud project for the dataset if it exists
+        Optional<DatasetDataProject> optDataProject = dataLocationService.getProjectForDataset(dataset);
+        if (optDataProject.isPresent()) {
+            // and update the project reference on the dataset object
+            dataset.dataProject(optDataProject.get());
+
+            // there can only be primary data to delete if a cloud project exists for the dataset
+            pdao.deleteDataset(dataset);
+        }
+
         return StepResult.getStepResultSuccess();
     }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -4,6 +4,7 @@ import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.service.iam.IamService;
+import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.job.JobMapKeys;
@@ -21,6 +22,7 @@ public class DatasetCreateFlight extends Flight {
         ApplicationContext appContext = (ApplicationContext) applicationContext;
         DatasetDao datasetDao = (DatasetDao) appContext.getBean("datasetDao");
         DatasetService datasetService = (DatasetService) appContext.getBean("datasetService");
+        DataLocationService dataLocationService = (DataLocationService) appContext.getBean("dataLocationService");
         BigQueryPdao bigQueryPdao = (BigQueryPdao) appContext.getBean("bigQueryPdao");
         IamService iamClient = (IamService) appContext.getBean("iamService");
 
@@ -32,7 +34,8 @@ public class DatasetCreateFlight extends Flight {
 
         addStep(new CreateDatasetMetadataStep(datasetDao, datasetRequest));
         // TODO: create dataset data project step
-        addStep(new CreateDatasetPrimaryDataStep(bigQueryPdao, datasetService));
+        // right now the cloud project is created as part of the PrimaryDataStep below
+        addStep(new CreateDatasetPrimaryDataStep(bigQueryPdao, datasetDao, dataLocationService));
         addStep(new CreateDatasetAuthzResource(iamClient, bigQueryPdao, datasetService, userReq));
     }
 

--- a/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
+++ b/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
@@ -5,6 +5,5 @@ import java.util.UUID;
 // The container interface gives the file system code a way to treat Dataset and Snapshot objects
 // with a single set of code.
 public interface FSContainerInterface {
-    String getDataProjectId();
     UUID getId();
 }

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -97,12 +97,12 @@ public class FileService {
     }
 
     FSItem lookupSnapshotFSItem(String snapshotId, String fileId, int depth) {
-        Snapshot snapshot = snapshotService.retrieveSnapshot(UUID.fromString(snapshotId));
+        Snapshot snapshot = snapshotService.retrieve(UUID.fromString(snapshotId));
         return fileDao.retrieveById(snapshot, fileId, depth, true);
     }
 
     FSItem lookupSnapshotFSItemByPath(String snapshotId, String path, int depth) {
-        Snapshot snapshot = snapshotService.retrieveSnapshot(UUID.fromString(snapshotId));
+        Snapshot snapshot = snapshotService.retrieve(UUID.fromString(snapshotId));
         return fileDao.retrieveByPath(snapshot, path, depth, true);
     }
 

--- a/src/main/java/bio/terra/service/filedata/flight/FileMapKeys.java
+++ b/src/main/java/bio/terra/service/filedata/flight/FileMapKeys.java
@@ -4,6 +4,7 @@ public final class FileMapKeys {
     private FileMapKeys() {
 
     }
+    public static final String DATASET_ID = "datasetId";
     public static final String FILE_ID = "fileId";
     public static final String FILE_INFO = "fileInfo";
     public static final String BUCKET_INFO = "bucketInfo";

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataLocationStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataLocationStep.java
@@ -29,7 +29,7 @@ public class IngestFilePrimaryDataLocationStep implements Step {
     public StepResult doStep(FlightContext context) {
         FlightMap inputParameters = context.getInputParameters();
         FileLoadModel fileLoadModel = inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
-        GoogleBucketResource bucketForFile = locationService.getBucketForFile(fileLoadModel.getProfileId());
+        GoogleBucketResource bucketForFile = locationService.getOrCreateBucketForFile(fileLoadModel.getProfileId());
         FlightMap workingMap = context.getWorkingMap();
         workingMap.put(FileMapKeys.BUCKET_INFO, bucketForFile);
         return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
@@ -1,8 +1,10 @@
 package bio.terra.service.filedata.google.firestore;
 
+import bio.terra.service.dataset.DatasetDataProject;
 import bio.terra.service.filedata.exception.FileSystemCorruptException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import bio.terra.service.dataset.Dataset;
+import bio.terra.service.resourcemanagement.DataLocationService;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.DocumentReference;
@@ -27,14 +29,17 @@ public class FireStoreDependencyDao {
     private static final String DEPENDENCY_COLLECTION_NAME = "-dependencies";
 
     private FireStoreUtils fireStoreUtils;
+    private DataLocationService dataLocationService;
 
     @Autowired
-    public FireStoreDependencyDao(FireStoreUtils fireStoreUtils) {
+    public FireStoreDependencyDao(FireStoreUtils fireStoreUtils, DataLocationService dataLocationService) {
         this.fireStoreUtils = fireStoreUtils;
+        this.dataLocationService = dataLocationService;
     }
 
     public boolean fileHasSnapshotReference(Dataset dataset, String fileId) {
-        FireStoreProject fireStoreProject = FireStoreProject.get(dataset.getDataProjectId());
+        DatasetDataProject dataProject = dataLocationService.getProjectOrThrow(dataset);
+        FireStoreProject fireStoreProject = FireStoreProject.get(dataProject.getGoogleProjectId());
         String dependencyCollectionName = getDatasetDependencyId(dataset.getId().toString());
         CollectionReference depColl = fireStoreProject.getFirestore().collection(dependencyCollectionName);
         Query query = depColl.whereEqualTo("fileId", fileId);
@@ -42,7 +47,8 @@ public class FireStoreDependencyDao {
     }
 
     public boolean datasetHasSnapshotReference(Dataset dataset) {
-        FireStoreProject fireStoreProject = FireStoreProject.get(dataset.getDataProjectId());
+        DatasetDataProject dataProject = dataLocationService.getProjectOrThrow(dataset);
+        FireStoreProject fireStoreProject = FireStoreProject.get(dataProject.getGoogleProjectId());
         String dependencyCollectionName = getDatasetDependencyId(dataset.getId().toString());
         CollectionReference depColl = fireStoreProject.getFirestore().collection(dependencyCollectionName);
         // check to see if the datasets collection contains any dependencies
@@ -65,7 +71,8 @@ public class FireStoreDependencyDao {
     }
 
     public List<String> getDatasetSnapshotFileIds(Dataset dataset, String snapshotId) {
-        FireStoreProject fireStoreProject = FireStoreProject.get(dataset.getDataProjectId());
+        DatasetDataProject dataProject = dataLocationService.getProjectOrThrow(dataset);
+        FireStoreProject fireStoreProject = FireStoreProject.get(dataProject.getGoogleProjectId());
         String dependencyCollectionName = getDatasetDependencyId(dataset.getId().toString());
         CollectionReference depColl = fireStoreProject.getFirestore().collection(dependencyCollectionName);
         Query query = depColl.whereEqualTo("snapshotId", snapshotId);
@@ -102,7 +109,8 @@ public class FireStoreDependencyDao {
     }
 
     public void deleteSnapshotFileDependencies(Dataset dataset, String snapshotId) {
-        FireStoreProject fireStoreProject = FireStoreProject.get(dataset.getDataProjectId());
+        DatasetDataProject dataProject = dataLocationService.getProjectOrThrow(dataset);
+        FireStoreProject fireStoreProject = FireStoreProject.get(dataProject.getGoogleProjectId());
         String dependencyCollectionName = getDatasetDependencyId(dataset.getId().toString());
         CollectionReference depColl = fireStoreProject.getFirestore().collection(dependencyCollectionName);
         Query query = depColl.whereEqualTo("snapshotId", snapshotId);
@@ -124,7 +132,8 @@ public class FireStoreDependencyDao {
     }
 
     public void storeSnapshotFileDependency(Dataset dataset, String snapshotId, String fileId) {
-        FireStoreProject fireStoreProject = FireStoreProject.get(dataset.getDataProjectId());
+        DatasetDataProject dataProject = dataLocationService.getProjectOrThrow(dataset);
+        FireStoreProject fireStoreProject = FireStoreProject.get(dataProject.getGoogleProjectId());
         String dependencyCollectionName = getDatasetDependencyId(dataset.getId().toString());
         CollectionReference depColl = fireStoreProject.getFirestore().collection(dependencyCollectionName);
 
@@ -169,7 +178,8 @@ public class FireStoreDependencyDao {
     }
 
     public void removeSnapshotFileDependency(Dataset dataset, String snapshotId, String fileId) {
-        FireStoreProject fireStoreProject = FireStoreProject.get(dataset.getDataProjectId());
+        DatasetDataProject dataProject = dataLocationService.getProjectOrThrow(dataset);
+        FireStoreProject fireStoreProject = FireStoreProject.get(dataProject.getGoogleProjectId());
         String dependencyCollectionName = getDatasetDependencyId(dataset.getId().toString());
         CollectionReference depColl = fireStoreProject.getFirestore().collection(dependencyCollectionName);
 

--- a/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
@@ -82,7 +82,7 @@ public class DataLocationService {
         return resourceService.getOrCreateProject(googleProjectRequest);
     }
 
-    public GoogleBucketResource getBucketForFile(String profileId) {
+    public GoogleBucketResource getOrCreateBucketForFile(String profileId) {
         // Every bucket needs to live in a project, so we get a project first (one will be created if it can't be found)
         GoogleProjectResource projectResource = getProjectForFile(profileId);
         BillingProfile profile = profileService.getProfileById(UUID.fromString(profileId));

--- a/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
@@ -178,6 +178,9 @@ public class DataLocationService {
 
     /** Fetch existing DatasetDataProject for the Dataset.
      * Create a new one if none exists already.
+     * Note that there can be only one project for a Dataset. This is assumed throughout the application logic, most of
+     * which currently resides in the Flights, and they would not work correctly if this one-to-one mapping were ever
+     * violated. For this reason, the check for an existing project below needs to stay at the beginning of this method.
      * @param dataset
      * @return a populated and valid DatasetDataProject
      */

--- a/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
@@ -14,6 +14,7 @@ import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectRequest;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleResourceService;
+import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -125,7 +126,7 @@ public class DataLocationService {
 
     // TODO: DRY this up
 
-    public DatasetDataProject getProjectForDataset(Dataset dataset) {
+    public DatasetDataProject getOrCreateProjectForDataset(Dataset dataset) {
         DatasetDataProjectSummary datasetDataProjectSummary = null;
         GoogleProjectResource googleProjectResource;
         GoogleProjectRequest googleProjectRequest = new GoogleProjectRequest()
@@ -155,4 +156,5 @@ public class DataLocationService {
         return new DatasetDataProject(datasetDataProjectSummary)
             .googleProjectResource(googleProjectResource);
     }
+
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/DataLocationService.java
@@ -98,13 +98,12 @@ public class DataLocationService {
 
     /** Fetch existing SnapshotDataProject for the Snapshot.
      * Create a new one if none exists already.
-     *
      * @param snapshot
      * @return a populated and valid SnapshotDataProject
      */
-    public SnapshotDataProject getOrCreateProjectForSnapshot(Snapshot snapshot) {
+    public SnapshotDataProject getOrCreateProject(Snapshot snapshot) {
         // check if for an existing SnapshotDataProject first, and return here if found one
-        Optional<SnapshotDataProject> existingDataProject = getProjectForSnapshot(snapshot);
+        Optional<SnapshotDataProject> existingDataProject = getProject(snapshot);
         if (existingDataProject.isPresent()) {
             return existingDataProject.get();
         }
@@ -129,11 +128,10 @@ public class DataLocationService {
 
     /** Fetch existing SnapshotDataProject for the Snapshot.
      * Delete it if it's invalid, that is, the referenced cloud resource doesn't exist.
-     *
      * @param snapshot
      * @return a populated SnapshotDataProject if one exists, empty if not
      */
-    public Optional<SnapshotDataProject> getProjectForSnapshot(Snapshot snapshot) {
+    public Optional<SnapshotDataProject> getProject(Snapshot snapshot) {
         SnapshotDataProjectSummary snapshotDataProjectSummary = null;
         try {
             // first, check if SnapshotDataProjectSummary (= mapping btw Snapshot ID and cloud Project ID) exists
@@ -163,13 +161,12 @@ public class DataLocationService {
 
     /** Fetch existing DatasetDataProject for the Dataset.
      * Create a new one if none exists already.
-     *
      * @param dataset
      * @return a populated and valid DatasetDataProject
      */
-    public DatasetDataProject getOrCreateProjectForDataset(Dataset dataset) {
+    public DatasetDataProject getOrCreateProject(Dataset dataset) {
         // check if for an existing DatasetDataProject first, and return here if found one
-        Optional<DatasetDataProject> existingDataProject = getProjectForDataset(dataset);
+        Optional<DatasetDataProject> existingDataProject = getProject(dataset);
         if (existingDataProject.isPresent()) {
             return existingDataProject.get();
         }
@@ -197,11 +194,10 @@ public class DataLocationService {
 
     /** Fetch existing DatasetDataProject for the Dataset.
      * Delete it if it's invalid, that is, the referenced cloud resource doesn't exist.
-     *
      * @param dataset
      * @return a populated DatasetDataProject if one exists, empty if not
      */
-    public Optional<DatasetDataProject> getProjectForDataset(Dataset dataset) {
+    public Optional<DatasetDataProject> getProject(Dataset dataset) {
         DatasetDataProjectSummary datasetDataProjectSummary = null;
         try {
             // first, check if DatasetDataProjectSummary (= mapping btw Dataset ID and cloud Project ID) exists

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -17,7 +17,6 @@ public class Snapshot implements FSContainerInterface {
     private List<SnapshotTable> tables = Collections.emptyList();
     private List<SnapshotSource> snapshotSources = Collections.emptyList();
     private UUID profileId;
-    private SnapshotDataProject dataProject = new SnapshotDataProject();
 
     public UUID getId() {
         return id;
@@ -88,24 +87,6 @@ public class Snapshot implements FSContainerInterface {
 
     public Snapshot profileId(UUID profileId) {
         this.profileId = profileId;
-        return this;
-    }
-
-    public SnapshotDataProject getDataProject() {
-        return dataProject;
-    }
-
-    public Snapshot dataProject(SnapshotDataProject dataProject) {
-        this.dataProject = dataProject;
-        return this;
-    }
-
-    public String getDataProjectId() {
-        return dataProject.getGoogleProjectId();
-    }
-
-    public Snapshot dataProjectId(String projectId) {
-        dataProject.googleProjectId(projectId);
         return this;
     }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -141,7 +141,7 @@ public class SnapshotService {
      */
     public Snapshot retrieve(UUID id) {
         Snapshot snapshot = snapshotDao.retrieveSnapshot(id);
-        Optional<SnapshotDataProject> optDataProject = dataLocationService.getProjectForSnapshot(snapshot);
+        Optional<SnapshotDataProject> optDataProject = dataLocationService.getProject(snapshot);
         if (optDataProject.isPresent()) {
             return snapshot.dataProject(optDataProject.get());
         } else {
@@ -156,7 +156,7 @@ public class SnapshotService {
      */
     public Snapshot retrieveByName(String name) {
         Snapshot snapshot = snapshotDao.retrieveSnapshotByName(name);
-        Optional<SnapshotDataProject> optDataProject = dataLocationService.getProjectForSnapshot(snapshot);
+        Optional<SnapshotDataProject> optDataProject = dataLocationService.getProject(snapshot);
         if (optDataProject.isPresent()) {
             return snapshot.dataProject(optDataProject.get());
         } else {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -131,7 +131,7 @@ public class SnapshotService {
      */
     public SnapshotModel retrieveSnapshotModel(UUID id) {
         Snapshot snapshot = snapshotDao.retrieveSnapshot(id);
-        snapshot.dataProject(dataLocationService.getProjectForSnapshot(snapshot));
+        snapshot.dataProject(dataLocationService.getOrCreateProjectForSnapshot(snapshot));
         return makeSnapshotModelFromSnapshot(snapshot);
     }
 
@@ -142,7 +142,7 @@ public class SnapshotService {
      */
     public Snapshot retrieveSnapshot(UUID id) {
         Snapshot snapshot = snapshotDao.retrieveSnapshot(id);
-        return snapshot.dataProject(dataLocationService.getProjectForSnapshot(snapshot));
+        return snapshot.dataProject(dataLocationService.getOrCreateProjectForSnapshot(snapshot));
     }
 
     /**
@@ -152,7 +152,7 @@ public class SnapshotService {
      */
     public Snapshot retrieveSnapshotByName(String name) {
         Snapshot snapshot = snapshotDao.retrieveSnapshotByName(name);
-        return snapshot.dataProject(dataLocationService.getProjectForSnapshot(snapshot));
+        return snapshot.dataProject(dataLocationService.getOrCreateProjectForSnapshot(snapshot));
     }
 
     /**

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -125,23 +125,21 @@ public class SnapshotService {
         return makeSummaryModelFromSummary(snapshotSummary);
     }
 
-    /**
-     * Return the output form of snapshot
-     * @param id
-     * @return snapshot model
+    /** Convenience wrapper around fetching an existing Snapshot object and converting it to a Model object.
+     * @param id in UUID formant
+     * @return a SnapshotModel = API output-friendly representation of the Snapshot
      */
-    public SnapshotModel retrieveSnapshotModel(UUID id) {
-        Snapshot snapshot = snapshotDao.retrieveSnapshot(id);
-        snapshot.dataProject(dataLocationService.getOrCreateProjectForSnapshot(snapshot));
+    public SnapshotModel retrieveModel(UUID id) {
+        Snapshot snapshot = retrieve(id);
         return makeSnapshotModelFromSnapshot(snapshot);
     }
 
-    /**
-     * Return the snapshot
-     * @param id
-     * @return snapshot
+    /** Fetch existing Snapshot object using the id and populate the associated existing cloud project.
+     * If either the Snapshot object or the associated cloud project does not exist, throws a runtime exception.
+     * @param id in UUID format
+     * @return a Snapshot populated with a valid cloud project
      */
-    public Snapshot retrieveSnapshot(UUID id) {
+    public Snapshot retrieve(UUID id) {
         Snapshot snapshot = snapshotDao.retrieveSnapshot(id);
         Optional<SnapshotDataProject> optDataProject = dataLocationService.getProjectForSnapshot(snapshot);
         if (optDataProject.isPresent()) {
@@ -151,14 +149,19 @@ public class SnapshotService {
         }
     }
 
-    /**
-     * Return the snapshot
+    /** Fetch existing Snapshot object using the name and populate the associated existing cloud project.
+     * If either the Snapshot object or the associated cloud project does not exist, throws a runtime exception.
      * @param name
-     * @return snapshot
+     * @return a Snapshot populated with a valid cloud project
      */
-    public Snapshot retrieveSnapshotByName(String name) {
+    public Snapshot retrieveByName(String name) {
         Snapshot snapshot = snapshotDao.retrieveSnapshotByName(name);
-        return snapshot.dataProject(dataLocationService.getOrCreateProjectForSnapshot(snapshot));
+        Optional<SnapshotDataProject> optDataProject = dataLocationService.getProjectForSnapshot(snapshot);
+        if (optDataProject.isPresent()) {
+            return snapshot.dataProject(optDataProject.get());
+        } else {
+            throw new CorruptMetadataException("Snapshot project invalid for name: " + name);
+        }
     }
 
     /**

--- a/src/main/java/bio/terra/service/snapshot/flight/create/AuthorizeSnapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/AuthorizeSnapshot.java
@@ -57,7 +57,7 @@ public class AuthorizeSnapshot implements Step {
     public StepResult doStep(FlightContext context) {
         FlightMap workingMap = context.getWorkingMap();
         UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-        Snapshot snapshot = snapshotService.retrieveSnapshot(snapshotId);
+        Snapshot snapshot = snapshotService.retrieve(snapshotId);
 
         // This returns the policy email created by Google to correspond to the readers list in SAM
         String readersPolicyEmail = sam.createSnapshotResource(userReq, snapshotId, snapshotReq.getReaders());

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreComputeStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreComputeStep.java
@@ -25,7 +25,7 @@ public class CreateSnapshotFireStoreComputeStep implements Step {
 
     @Override
     public StepResult doStep(FlightContext context) {
-        Snapshot snapshot = snapshotService.retrieveSnapshotByName(snapshotReq.getName());
+        Snapshot snapshot = snapshotService.retrieveByName(snapshotReq.getName());
         fileDao.snapshotCompute(snapshot);
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
@@ -44,7 +44,7 @@ public class CreateSnapshotFireStoreDataStep implements Step {
     @Override
     public StepResult doStep(FlightContext context) {
         // We need a complete snapshot; use the snapshotService to get one.
-        Snapshot snapshot = snapshotService.retrieveSnapshotByName(snapshotReq.getName());
+        Snapshot snapshot = snapshotService.retrieveByName(snapshotReq.getName());
 
         // Build the snapshot file system and record the file dependencies
         // The algorithm is:
@@ -82,7 +82,7 @@ public class CreateSnapshotFireStoreDataStep implements Step {
     @Override
     public StepResult undoStep(FlightContext context) {
         // Remove the snapshot file system and any file dependencies created
-        Snapshot snapshot = snapshotService.retrieveSnapshotByName(snapshotReq.getName());
+        Snapshot snapshot = snapshotService.retrieveByName(snapshotReq.getName());
         fileDao.deleteFilesFromSnapshot(snapshot);
         for (SnapshotSource snapshotSource : snapshot.getSnapshotSources()) {
             Dataset dataset = datasetService.retrieve(snapshotSource.getDataset().getId());

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPrimaryDataStep.java
@@ -44,7 +44,7 @@ public class DeleteSnapshotPrimaryDataStep implements Step {
     @Override
     public StepResult doStep(FlightContext context) {
         try {
-            Snapshot snapshot = snapshotService.retrieveSnapshot(snapshotId);
+            Snapshot snapshot = snapshotService.retrieve(snapshotId);
             bigQueryPdao.deleteSnapshot(snapshot);
 
             // Remove snapshot file references from the underlying datasets

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -73,12 +73,12 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     public BigQueryProject bigQueryProjectForDataset(Dataset dataset) {
-        DatasetDataProject projectForDataset = dataLocationService.getOrCreateProjectForDataset(dataset);
+        DatasetDataProject projectForDataset = dataLocationService.getOrCreateProject(dataset);
         return BigQueryProject.get(projectForDataset.getGoogleProjectId());
     }
 
     private BigQueryProject bigQueryProjectForSnapshot(Snapshot snapshot) {
-        SnapshotDataProject projectForSnapshot = dataLocationService.getOrCreateProjectForSnapshot(snapshot);
+        SnapshotDataProject projectForSnapshot = dataLocationService.getOrCreateProject(snapshot);
         return BigQueryProject.get(projectForSnapshot.getGoogleProjectId());
     }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -73,7 +73,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     public BigQueryProject bigQueryProjectForDataset(Dataset dataset) {
-        DatasetDataProject projectForDataset = dataLocationService.getProjectForDataset(dataset);
+        DatasetDataProject projectForDataset = dataLocationService.getOrCreateProjectForDataset(dataset);
         return BigQueryProject.get(projectForDataset.getGoogleProjectId());
     }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -78,7 +78,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     private BigQueryProject bigQueryProjectForSnapshot(Snapshot snapshot) {
-        SnapshotDataProject projectForSnapshot = dataLocationService.getProjectForSnapshot(snapshot);
+        SnapshotDataProject projectForSnapshot = dataLocationService.getOrCreateProjectForSnapshot(snapshot);
         return BigQueryProject.get(projectForSnapshot.getGoogleProjectId());
     }
 

--- a/src/test/java/bio/terra/app/controller/DatasetTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetTest.java
@@ -123,12 +123,13 @@ public class DatasetTest {
         UUID id = UUID.fromString("8d2e052c-e1d1-4a29-88ed-26920907791f");
         DatasetRequestModel req = DatasetFixtures.buildDatasetRequest();
         Dataset dataset = DatasetJsonConversion.datasetRequestToDataset(req);
+        String datasetProjectId = "foo-bar-baz";
         dataset
             .id(id)
-            .createdDate(Instant.now())
-            .dataProjectId("foo-bar-baz");
+            .createdDate(Instant.now());
 
-        when(datasetService.retrieveModel(eq(id))).thenReturn(DatasetJsonConversion.datasetModelFromDataset(dataset));
+        when(datasetService.retrieveModel(eq(id)))
+            .thenReturn(DatasetJsonConversion.populateDatasetModelFromDataset(dataset).dataProject(datasetProjectId));
         assertThat("Dataset retrieve returns 200",
                 mvc.perform(get("/api/repository/v1/datasets/{id}", id.toString()))
                         .andReturn().getResponse().getStatus(),

--- a/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
@@ -317,7 +317,7 @@ public class SnapshotOperationTest {
 
     private BigQueryProject bigQueryProjectForDatasetName(String datasetName) {
         Dataset dataset = datasetDao.retrieveByName(datasetName);
-        DatasetDataProject dataProject = dataLocationService.getProjectForDataset(dataset);
+        DatasetDataProject dataProject = dataLocationService.getOrCreateProjectForDataset(dataset);
         return BigQueryProject.get(dataProject.getGoogleProjectId());
     }
 

--- a/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
@@ -317,7 +317,7 @@ public class SnapshotOperationTest {
 
     private BigQueryProject bigQueryProjectForDatasetName(String datasetName) {
         Dataset dataset = datasetDao.retrieveByName(datasetName);
-        DatasetDataProject dataProject = dataLocationService.getOrCreateProjectForDataset(dataset);
+        DatasetDataProject dataProject = dataLocationService.getOrCreateProject(dataset);
         return BigQueryProject.get(dataProject.getGoogleProjectId());
     }
 

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
@@ -421,7 +421,7 @@ public class EncodeFileTest {
 
     private String getFileRefIdFromSnapshot(SnapshotSummaryModel snapshotSummary) {
         Snapshot snapshot = snapshotDao.retrieveSnapshotByName(snapshotSummary.getName());
-        SnapshotDataProject dataProject = dataLocationService.getOrCreateProjectForSnapshot(snapshot);
+        SnapshotDataProject dataProject = dataLocationService.getOrCreateProject(snapshot);
         BigQueryProject bigQueryProject = BigQueryProject.get(dataProject.getGoogleProjectId());
 
         StringBuilder builder = new StringBuilder()

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
@@ -421,7 +421,7 @@ public class EncodeFileTest {
 
     private String getFileRefIdFromSnapshot(SnapshotSummaryModel snapshotSummary) {
         Snapshot snapshot = snapshotDao.retrieveSnapshotByName(snapshotSummary.getName());
-        SnapshotDataProject dataProject = dataLocationService.getProjectForSnapshot(snapshot);
+        SnapshotDataProject dataProject = dataLocationService.getOrCreateProjectForSnapshot(snapshot);
         BigQueryProject bigQueryProject = BigQueryProject.get(dataProject.getGoogleProjectId());
 
         StringBuilder builder = new StringBuilder()

--- a/src/test/java/bio/terra/service/resourcemanagement/OneProjectPerProfileIdSelectorTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/OneProjectPerProfileIdSelectorTest.java
@@ -119,7 +119,7 @@ public class OneProjectPerProfileIdSelectorTest {
             connectedOperations.launchCreateSnapshot(datasetSummaryModel, "snapshot-test-snapshot.json", "");
         SnapshotSummaryModel snapshotSummaryModel = connectedOperations.handleCreateSnapshotSuccessCase(response);
         SnapshotModel snapshotModel = connectedOperations.getSnapshot(snapshotSummaryModel.getId());
-        Snapshot snapshot = snapshotService.retrieveSnapshot(UUID.fromString(snapshotModel.getId()));
+        Snapshot snapshot = snapshotService.retrieve(UUID.fromString(snapshotModel.getId()));
 
         // TODO: we can test this once configuring firestore is programatic
 

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -90,7 +90,7 @@ public class BigQueryPdaoTest {
             .name(datasetName());
         dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
         UUID datasetId = datasetDao.create(dataset);
-        dataset.dataProject(dataLocationService.getOrCreateProjectForDataset(dataset));
+        dataset.dataProject(dataLocationService.getOrCreateProject(dataset));
         logger.info("Created dataset in setup: {}", datasetId);
     }
 

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -14,6 +14,7 @@ import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.iam.IamService;
+import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import bio.terra.service.dataset.DatasetService;
 import com.google.cloud.bigquery.FieldValueList;
@@ -65,6 +66,7 @@ public class BigQueryPdaoTest {
     @Autowired private GoogleResourceConfiguration googleResourceConfiguration;
     @Autowired private ConnectedOperations connectedOperations;
     @Autowired private DatasetService datasetService;
+    @Autowired private DataLocationService dataLocationService;
 
     @MockBean
     private IamService samService;
@@ -88,7 +90,7 @@ public class BigQueryPdaoTest {
             .name(datasetName());
         dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
         UUID datasetId = datasetDao.create(dataset);
-        dataset = datasetService.retrieve(datasetId);
+        dataset.dataProject(dataLocationService.getOrCreateProjectForDataset(dataset));
         logger.info("Created dataset in setup: {}", datasetId);
     }
 

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -6,6 +6,7 @@ import bio.terra.service.dataset.DatasetDao;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetDataProject;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.IngestRequestModel;
@@ -90,7 +91,7 @@ public class BigQueryPdaoTest {
             .name(datasetName());
         dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
         UUID datasetId = datasetDao.create(dataset);
-        dataset.dataProject(dataLocationService.getOrCreateProject(dataset));
+        dataLocationService.getOrCreateProject(dataset);
         logger.info("Created dataset in setup: {}", datasetId);
     }
 
@@ -298,10 +299,11 @@ public class BigQueryPdaoTest {
             Assert.assertThat(snapshot.getTables().size(), is(equalTo(3)));
 
             BigQueryProject bigQueryProject = bigQueryPdao.bigQueryProjectForDataset(dataset);
+            DatasetDataProject dataProject = dataLocationService.getProjectOrThrow(dataset);
             String tableName = "participant";
             List<String> rowIds = getRowIds(dataset,
                 tableName,
-                dataset.getDataProjectId(),
+                dataProject.getGoogleProjectId(),
                 bigQueryProject);
             int originalNumOfRows = rowIds.size();
 
@@ -315,7 +317,7 @@ public class BigQueryPdaoTest {
             // assert the changed row is soft deleted
             List<String> softDeletedRowIds = getSoftDeletedRowIds(dataset,
                 tableName,
-                dataset.getDataProjectId(),
+                dataProject.getGoogleProjectId(),
                 bigQueryProject);
             Assert.assertThat("On upsert the changed row is soft deleted",
                 softDeletedRowIds.size(),
@@ -324,7 +326,7 @@ public class BigQueryPdaoTest {
             // assert only the new row is added
             rowIds = getRowIds(dataset,
                 tableName,
-                dataset.getDataProjectId(),
+                dataProject.getGoogleProjectId(),
                 bigQueryProject);
             // originalNumOfRows + 2 for the new row being added and the chnaged row being added
             Assert.assertThat("On upsert that # of rows being added accounts for the soft delete",


### PR DESCRIPTION
Some restructuring around DatasetService, SnapshotService, and DataLocationService. These changes came about because of a bug around Google project names that are too long and fail to be created. We had a group design discussion about what should be addressed as part of this ticket and what to leave for later. Notes from that are here:
https://docs.google.com/document/d/1u1kOos1vv9Jq53p61ct-UPGCsOkjZ27a38Y2sMRnWRc

1. Split DataLocationService Google project fetch/creation into two separate methods, getProject and getOrCreateProject for both Dataset and Snapshot.
2. Chanaged DatasetService and SnapshotService retrieve* methods to not create a new project if one does not already exist.
3. Removed DataProject property and get/set methods from both Dataset and Snapshot. Replaced calls to the get/set methods with calls to DataLocationService.get[OrCreate]Project instead. Note that the Model classes still contain the project id, so places where the Model is generated from a Dataset or Snapshot now call DataLocationService.getProject to populate the project id property.
4. Renamed a few methods for clarity. Made SnapshotService retrieve* method names more consistent with those in DatasetService. Removed argument type from DataLocationService get[OrCreate]Project method names, because they are already included in the method signature. Changed DataLocationService.getBucketForFile to getOrCreateBucketForFile.
5. Added logging where Jackson fails to deserialize an exception.
6. Added a new connected test for a project name that we fail to create because the string is too long for GCP.
