### PR TITLE
DR-666 faults

### DIFF
--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -521,6 +521,14 @@ public class RepositoryApiController implements RepositoryApi {
         return new ResponseEntity<>(configModelList, HttpStatus.OK);
     }
 
+    @Override
+    public ResponseEntity<Void> setFault(@PathVariable("name") String name,
+                                         @Valid @RequestParam(value = "enable", required = false, defaultValue = "true")
+                                             Boolean enable) {
+        configurationService.setFault(name, enable);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
     private void validiateOffsetAndLimit(Integer offset, Integer limit) {
         String errors = "";
         offset = (offset == null) ? offset = 0 : offset;

--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -6,6 +6,7 @@ import bio.terra.app.utils.ControllerUtils;
 import bio.terra.common.ValidationUtils;
 import bio.terra.controller.RepositoryApi;
 import bio.terra.model.ConfigGroupModel;
+import bio.terra.model.ConfigListModel;
 import bio.terra.model.ConfigModel;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestModel;
@@ -504,8 +505,8 @@ public class RepositoryApiController implements RepositoryApi {
     }
 
     @Override
-    public ResponseEntity<List<ConfigModel>> getConfigList() {
-        List<ConfigModel> configModelList = configurationService.getConfigList();
+    public ResponseEntity<ConfigListModel> getConfigList() {
+        ConfigListModel configModelList = configurationService.getConfigList();
         return new ResponseEntity<>(configModelList, HttpStatus.OK);
     }
 
@@ -516,8 +517,8 @@ public class RepositoryApiController implements RepositoryApi {
     }
 
     @Override
-    public ResponseEntity<List<ConfigModel>> setConfigList(@Valid @RequestBody ConfigGroupModel configModel) {
-        List<ConfigModel> configModelList = configurationService.setConfig(configModel);
+    public ResponseEntity<ConfigListModel> setConfigList(@Valid @RequestBody ConfigGroupModel configModel) {
+        ConfigListModel configModelList = configurationService.setConfig(configModel);
         return new ResponseEntity<>(configModelList, HttpStatus.OK);
     }
 

--- a/src/main/java/bio/terra/service/configuration/ConfigBase.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigBase.java
@@ -29,7 +29,7 @@ public abstract class ConfigBase {
         throw new InvalidConfigTypeException("Config is not a parameter: " + configEnum.name());
     }
 
-    public void validateType(ConfigModel.ConfigTypeEnum expectedConfigType) {
+    void validateType(ConfigModel.ConfigTypeEnum expectedConfigType) {
         if (configType != expectedConfigType) {
             throw new ValidationException("Mismatched config type: " + getName() +
                 " is a " + configType.name() +

--- a/src/main/java/bio/terra/service/configuration/ConfigBase.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigBase.java
@@ -1,5 +1,6 @@
 package bio.terra.service.configuration;
 
+import bio.terra.app.controller.exception.ValidationException;
 import bio.terra.model.ConfigModel;
 import bio.terra.service.configuration.exception.InvalidConfigTypeException;
 
@@ -26,6 +27,14 @@ public abstract class ConfigBase {
 
     public <T> T getCurrentValue() {
         throw new InvalidConfigTypeException("Config is not a parameter: " + configEnum.name());
+    }
+
+    public void validateType(ConfigModel.ConfigTypeEnum expectedConfigType) {
+        if (configType != expectedConfigType) {
+            throw new ValidationException("Mismatched config type: " + getName() +
+                " is a " + configType.name() +
+                "; and is not a " + expectedConfigType.name());
+        }
     }
 
     abstract void reset();

--- a/src/main/java/bio/terra/service/configuration/ConfigEnum.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigEnum.java
@@ -7,7 +7,11 @@ import org.apache.commons.lang3.StringUtils;
 public enum ConfigEnum {
     SAM_RETRY_INITIAL_WAIT_SECONDS,
     SAM_RETRY_MAXIMUM_WAIT_SECONDS,
-    SAM_OPERATION_TIMEOUT_SECONDS;
+    SAM_OPERATION_TIMEOUT_SECONDS,
+
+    // Faults to test the fault system
+    UNIT_TEST_SIMPLE_FAULT,
+    UNIT_TEST_COUNTED_FAULT;
 
     public static ConfigEnum lookupByApiName(String apiName) {
         for (ConfigEnum config : values()) {

--- a/src/main/java/bio/terra/service/configuration/ConfigEnum.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigEnum.java
@@ -3,11 +3,19 @@ package bio.terra.service.configuration;
 import bio.terra.service.configuration.exception.ConfigNotFoundException;
 import org.apache.commons.lang3.StringUtils;
 
-// TODO: when we move to OpenAPI V3, we can put this an enum in the swagger and get it out of here.
+
+/**
+ * NOTE: the string form of the enumerations are used in tests. A simple IntelliJ rename will not work properly.
+ */
+// TODO: when we move to OpenAPI V3, we can put this an enum in the swagger and use the enums in the caller
 public enum ConfigEnum {
+    // -- parameters --
     SAM_RETRY_INITIAL_WAIT_SECONDS,
     SAM_RETRY_MAXIMUM_WAIT_SECONDS,
     SAM_OPERATION_TIMEOUT_SECONDS,
+
+    // -- faults --
+    SAM_TIMEOUT_FAULT,
 
     // Faults to test the fault system
     UNIT_TEST_SIMPLE_FAULT,

--- a/src/main/java/bio/terra/service/configuration/ConfigFault.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigFault.java
@@ -6,9 +6,6 @@ import bio.terra.model.ConfigModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Sub-classes must implement:
-// get()
-// setFaultConfig()
 public abstract class ConfigFault extends ConfigBase {
     private final Logger logger = LoggerFactory.getLogger(ConfigFault.class);
 
@@ -57,10 +54,7 @@ public abstract class ConfigFault extends ConfigBase {
 
     @Override
     void validate(ConfigModel configModel) {
-        if (configModel.getConfigType() != ConfigModel.ConfigTypeEnum.FAULT) {
-            throw new ValidationException("Mismatched config: " + getName() +
-                " is a FAULT; request is a " + configModel.getConfigType().name());
-        }
+        super.validateType(ConfigModel.ConfigTypeEnum.FAULT);
 
         if (configModel.getFault() == null) {
             throw new ValidationException("ConfigFaultModel must be specified");

--- a/src/main/java/bio/terra/service/configuration/ConfigFault.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigFault.java
@@ -1,0 +1,79 @@
+package bio.terra.service.configuration;
+
+import bio.terra.app.controller.exception.ValidationException;
+import bio.terra.model.ConfigFaultModel;
+import bio.terra.model.ConfigModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// Sub-classes must implement:
+// get()
+// setFaultConfig()
+public abstract class ConfigFault extends ConfigBase {
+    private final Logger logger = LoggerFactory.getLogger(ConfigFault.class);
+
+    private final ConfigFaultModel.FaultTypeEnum faultType;
+    private final boolean originalEnabled;
+    private boolean enabled;
+
+    // -- Instance methods --
+    ConfigFault(ConfigEnum configEnum,
+                ConfigFaultModel.FaultTypeEnum faultType,
+                boolean enabled) {
+        super(ConfigModel.ConfigTypeEnum.FAULT, configEnum);
+        this.faultType = faultType;
+        this.originalEnabled = enabled;
+        this.enabled = enabled;
+    }
+
+    @Override
+    synchronized void reset() {
+        enabled = originalEnabled;
+        resetFaultConfig();
+    }
+
+    boolean isEnabled() {
+        return enabled;
+    }
+
+    void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    synchronized ConfigModel set(ConfigModel configModel) {
+        validate(configModel);
+        ConfigModel prior = get();
+
+        ConfigFaultModel faultModel = configModel.getFault();
+        setFaultConfig(faultModel);
+
+        // Set the enabled last so the common case of
+        logger.info("Setting fault " + getName() + ": from=" + isEnabled() + "; new=" + faultModel.isEnabled());
+        enabled = faultModel.isEnabled();
+        return prior;
+    }
+
+
+    @Override
+    void validate(ConfigModel configModel) {
+        if (configModel.getConfigType() != ConfigModel.ConfigTypeEnum.FAULT) {
+            throw new ValidationException("Mismatched config: " + getName() +
+                " is a FAULT; request is a " + configModel.getConfigType().name());
+        }
+
+        if (configModel.getFault() == null) {
+            throw new ValidationException("ConfigFaultModel must be specified");
+        }
+
+        if (configModel.getFault().getFaultType() != faultType) {
+            throw new ValidationException("Mismatched fault type: " + getName() +
+                " is a FAULT of type " + faultType +
+                "; request is of type " + configModel.getFault().getFaultType().name());
+        }
+    }
+
+    abstract boolean testInsertFault();
+    abstract void setFaultConfig(ConfigFaultModel faultModel);
+    abstract void resetFaultConfig();
+}

--- a/src/main/java/bio/terra/service/configuration/ConfigFault.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigFault.java
@@ -36,7 +36,7 @@ public abstract class ConfigFault extends ConfigBase {
         return enabled;
     }
 
-    void setEnabled(boolean enabled) {
+    synchronized void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
 

--- a/src/main/java/bio/terra/service/configuration/ConfigFaultCounted.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigFaultCounted.java
@@ -1,0 +1,130 @@
+package bio.terra.service.configuration;
+
+import bio.terra.app.controller.exception.ValidationException;
+import bio.terra.model.ConfigFaultCountedModel;
+import bio.terra.model.ConfigFaultModel;
+import bio.terra.model.ConfigModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Random;
+
+public class ConfigFaultCounted extends ConfigFault {
+    private final Logger logger = LoggerFactory.getLogger(ConfigFaultCounted.class);
+
+    private final ConfigFaultCountedModel originalCountedModel;
+
+    // This state is synchronized because it is referenced in synchronized code and findbugs
+    // wants it to be consistently synchronized everywhere...
+    private ConfigFaultCountedModel countedModel;
+
+    // Access to this state must be synchronized so that multiple threads do not mess it up.
+    private boolean doneSkipping;
+    private int skippedCounter;
+    private boolean doneInserting;
+    private int insertCounter;
+    private Random random;
+    private int every;
+    private int everyCounter;
+
+    // -- Instance methods --
+    ConfigFaultCounted(ConfigEnum configEnum,
+                       ConfigFaultModel.FaultTypeEnum faultType,
+                       boolean enabled,
+                       ConfigFaultCountedModel countedModel) {
+        super(configEnum, faultType, enabled);
+        this.originalCountedModel = countedModel;
+        this.countedModel = countedModel;
+        initCounters();
+    }
+
+    @Override
+    synchronized ConfigModel get() {
+        ConfigFaultModel faultCounted = new ConfigFaultModel()
+            .faultType(ConfigFaultModel.FaultTypeEnum.SIMPLE)
+            .enabled(isEnabled())
+            .counted(countedModel);
+
+        return new ConfigModel()
+            .configType(ConfigModel.ConfigTypeEnum.FAULT)
+            .name(getName())
+            .fault(faultCounted);
+    }
+
+    @Override
+    synchronized void setFaultConfig(ConfigFaultModel faultModel) {
+        if (faultModel.getCounted() == null) {
+            throw new ValidationException("Set of a counted fault requires a counted fault model");
+        }
+        countedModel = faultModel.getCounted();
+        initCounters();
+    }
+
+    @Override
+    synchronized void resetFaultConfig() {
+        countedModel = originalCountedModel;
+        initCounters();
+    }
+
+    @Override
+    synchronized boolean testInsertFault() {
+        if (!isEnabled()) {
+            return false;
+        }
+
+        if (!doneSkipping) {
+            skippedCounter++;
+            if (skippedCounter >= countedModel.getSkipFor()) {
+                doneSkipping = true;
+            }
+            return false;
+        }
+
+        if (!doneInserting) {
+            switch (countedModel.getRateStyle()) {
+                case RANDOM:
+                    if (random.nextInt(100) < countedModel.getRate()) {
+                        return doInsert();
+                    }
+                    break;
+
+                case FIXED:
+                    everyCounter++;
+                    if (everyCounter >= every) {
+                        everyCounter = 0;
+                        return doInsert();
+                    }
+                    break;
+            }
+        }
+        return false;
+    }
+
+    private boolean doInsert() {
+        if (countedModel.getInsert() < 0 || insertCounter < countedModel.getInsert()) {
+            insertCounter++;
+            return true;
+        }
+        return false;
+    }
+
+    private synchronized void initCounters() {
+        doneSkipping = (countedModel.getSkipFor() == 0);
+        skippedCounter = 0;
+        doneInserting = false;
+        insertCounter = 0;
+        switch (countedModel.getRateStyle()) {
+            case RANDOM:
+                if (random == null) {
+                    random = new Random();
+                }
+                break;
+
+            case FIXED:
+                every = 100 / countedModel.getRate();
+                everyCounter = 0;
+                break;
+        }
+    }
+
+}

--- a/src/main/java/bio/terra/service/configuration/ConfigFaultCounted.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigFaultCounted.java
@@ -42,7 +42,7 @@ public class ConfigFaultCounted extends ConfigFault {
     @Override
     synchronized ConfigModel get() {
         ConfigFaultModel faultCounted = new ConfigFaultModel()
-            .faultType(ConfigFaultModel.FaultTypeEnum.SIMPLE)
+            .faultType(ConfigFaultModel.FaultTypeEnum.COUNTED)
             .enabled(isEnabled())
             .counted(countedModel);
 

--- a/src/main/java/bio/terra/service/configuration/ConfigFaultCounted.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigFaultCounted.java
@@ -53,10 +53,15 @@ public class ConfigFaultCounted extends ConfigFault {
     }
 
     @Override
-    synchronized void setFaultConfig(ConfigFaultModel faultModel) {
-        if (faultModel.getCounted() == null) {
+    void validate(ConfigModel configModel) {
+        super.validate(configModel);
+        if (configModel.getFault().getCounted() == null) {
             throw new ValidationException("Set of a counted fault requires a counted fault model");
         }
+    }
+
+    @Override
+    synchronized void setFaultConfig(ConfigFaultModel faultModel) {
         countedModel = faultModel.getCounted();
         initCounters();
     }

--- a/src/main/java/bio/terra/service/configuration/ConfigFaultSimple.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigFaultSimple.java
@@ -1,0 +1,45 @@
+package bio.terra.service.configuration;
+
+import bio.terra.model.ConfigFaultModel;
+import bio.terra.model.ConfigModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfigFaultSimple extends ConfigFault {
+    private final Logger logger = LoggerFactory.getLogger(ConfigFaultSimple.class);
+
+    // -- Instance methods --
+    ConfigFaultSimple(ConfigEnum configEnum,
+                      ConfigFaultModel.FaultTypeEnum faultType,
+                      boolean enabled) {
+        super(configEnum, faultType, enabled);
+    }
+
+    @Override
+    ConfigModel get() {
+        ConfigFaultModel faultSimple = new ConfigFaultModel()
+            .faultType(ConfigFaultModel.FaultTypeEnum.SIMPLE)
+            .enabled(isEnabled());
+
+        return new ConfigModel()
+            .configType(ConfigModel.ConfigTypeEnum.FAULT)
+            .name(getName())
+            .fault(faultSimple);
+    }
+
+    // For the simple case, there is no fault configuration beyond enabled,
+    // so there is not much to do for set or reset
+
+    @Override
+    void setFaultConfig(ConfigFaultModel faultModel) {
+    }
+
+    @Override
+    void resetFaultConfig() {
+    }
+
+    @Override
+    boolean testInsertFault() {
+        return isEnabled();
+    }
+}

--- a/src/main/java/bio/terra/service/configuration/FaultFunction.java
+++ b/src/main/java/bio/terra/service/configuration/FaultFunction.java
@@ -1,0 +1,10 @@
+package bio.terra.service.configuration;
+
+/**
+ * FaultFunction provides a lambda target for a function with no parameters and no return value.
+ */
+
+@FunctionalInterface
+public interface FaultFunction {
+    void apply() throws Exception;
+}

--- a/src/main/java/bio/terra/service/configuration/exception/ConfigNotAFaultException.java
+++ b/src/main/java/bio/terra/service/configuration/exception/ConfigNotAFaultException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.configuration.exception;
+
+
+import bio.terra.common.exception.BadRequestException;
+
+public class ConfigNotAFaultException extends BadRequestException {
+    public ConfigNotAFaultException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public ConfigNotAFaultException(String message) {
+        super(message);
+    }
+
+    public ConfigNotAFaultException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCleanupStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCleanupStep.java
@@ -39,8 +39,10 @@ public class IngestCleanupStep implements Step {
         try {
             Dataset dataset = IngestUtils.getDataset(context, datasetService);
 
+            // overlappingTableName is null when the ingest strategy is not upsert.
+            // Don't try to delete the table name if it is null
             overlappingTableName = IngestUtils.getOverlappingTableName(context);
-            if (bigQueryPdao.tableExists(dataset, overlappingTableName)) {
+            if (overlappingTableName != null && bigQueryPdao.tableExists(dataset, overlappingTableName)) {
                 bigQueryPdao.deleteDatasetTable(dataset, overlappingTableName);
             }
         } catch (Exception ex) {

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1078,7 +1078,7 @@ paths:
 
 # -- Configuration Control Endpoints --
 
-  '/api/repository/v1/config/{name}':
+  '/api/repository/v1/configs/{name}':
     get:
       description: Get one configuration
       operationId: getConfig
@@ -1130,7 +1130,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorModel'
 
-  '/api/repository/v1/config':
+  '/api/repository/v1/configs':
     put:
       description: Set the a group of configurations
       operationId: setConfigList
@@ -1145,9 +1145,7 @@ paths:
         200:
           description: previous settings
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/ConfigModel'
+            $ref: '#/definitions/ConfigListModel'
         400:
           description: invalid configuration model
           schema:
@@ -1158,7 +1156,7 @@ paths:
             $ref: '#/definitions/ErrorModel'
 
     get:
-      description: Get the named configuration
+      description: Get all configurations
       operationId: getConfigList
       tags:
         - repository
@@ -1166,11 +1164,9 @@ paths:
         200:
           description: all configurations
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/ConfigModel'
+            $ref: '#/definitions/ConfigListModel'
 
-  '/api/repository/v1/config/reset':
+  '/api/repository/v1/configs/reset':
     put:
       description: Reset the configuration to original settings
       operationId: resetConfig
@@ -2263,6 +2259,18 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/ConfigModel'
+
+  ConfigListModel:
+    description: Result list of configuration settings
+    properties:
+      total:
+        type: integer
+        description: Total number of configs
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/ConfigModel'
+
 
 ##########################################################################################
 # DRS DEFINITIONS

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1100,6 +1100,36 @@ paths:
           schema:
             $ref: '#/definitions/ErrorModel'
 
+    put:
+      description: |
+        Enable or disable the named fault. Performing the put on a config that
+        is not a fault is an error.
+      operationId: setFault
+      tags:
+        - repository
+      parameters:
+        - name: name
+          description: name of the configuration to 
+          required: true
+          in: path
+          type: string
+        - in: query
+          name: enable
+          type: boolean
+          default: true
+          description: whether to enable (default) or disable the fault
+      responses:
+        204:
+          description: fault was en/dis-abled successfully - no content
+        400:
+          description: configuration name is not a fault
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        404:
+          description: unknown configuration name
+          schema:
+            $ref: '#/definitions/ErrorModel'
+
   '/api/repository/v1/config':
     put:
       description: Set the a group of configurations
@@ -2145,13 +2175,72 @@ definitions:
           - fault
           - parameter
           - logging
+      fault:
+        $ref: '#/definitions/ConfigFaultModel'
       parameter:
         $ref: '#/definitions/ConfigParameterModel'
+
   # TODO: add the other configuration types
-  #      fault:
-  #        $ref: '#/definitions/ConfigFaultModel'
   #      logging:
   #        $ref: '#/definitions/ConfigLoggingModel'
+
+  ConfigFaultModel:
+    description: Fault control parameters
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          If the fault is enabled, then is in effect. Fault points cause insert
+          faults. Typical usage is that faults are disabled on system start and explicitly
+          enabled by test code or via the setFault endpoint.
+      faultType:
+        type: string
+        enum:
+          - simple
+          - counted
+        description: |
+          A simple fault has no parameters. It is just enabled or disabled. This type of
+          fault is typically used when the desired behavior of the fault is too complex
+          for expression in the fault types and custom code is needed to get the right
+          failure behavior.
+
+          A counted fault is used to insert some number of faults in a pattern. See the
+          ConfigFaultCountedModel for details.
+      counted:
+        $ref: '#/definitions/ConfigFaultCountedModel'
+
+  ConfigFaultCountedModel:
+    description: |
+      Counted fault is used to insert a fixed number of faults. A "fault test" is one
+      call to the fault manager for a named fault. The skipFor lets you get the system to
+      a certain stable point where you want to begin inserting faults. Insert gives the
+      total number of faults to trigger. The rate gives the percentage of the time to 
+      insert the fault. A value of 50 would insert the fault half
+      the time. A value of 20 would insert the fault 20% of the time . The rateStyle
+      describes whether the fault will be fixed or random. In our 20 example, if the rate style
+      is fixed, the fault would be skipped 4 times, inserted once, skipped 4 times, inserted once, etc.
+      It uses integer math - you've been warned. If the rate style is random, a random number
+      is generated to determine whether the fault is inserted with a probability of 0.2.
+    properties:
+      skipFor:
+        type: integer
+        description: number of fault tests to skip before beginning fault insertion
+      insert:
+        type: integer
+        description: total number of times to insert the fault; -1 means insert forever
+      rate:
+        type: integer
+        description: |
+          insert a fault rate percent of the time. If rate is 100, the
+          fault will always be inserted regardless of rate.
+      rateStyle:
+        type: string
+        enum:
+          - fixed
+          - random
+        description: |
+          fixed style means insert the fault; skip for rate-1; ...
+          random style means randomly insert the fault with probability of 1:<rate>
 
   ConfigParameterModel:
     description: The value of the parameter

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -73,6 +73,12 @@ public class DataRepoClient {
         return makeDataRepoRequest(path, HttpMethod.POST, entity, responseClass);
     }
 
+    public <T> DataRepoResponse<T> put(TestConfiguration.User user, String path, String json, Class<T> responseClass)
+        throws Exception {
+        HttpEntity<String> entity = new HttpEntity<>(json, getHeaders(user));
+        return makeDataRepoRequest(path, HttpMethod.PUT, entity, responseClass);
+    }
+
     public <T> DataRepoResponse<T> delete(TestConfiguration.User user, String path, Class<T> responseClass)
         throws Exception {
         HttpEntity<String> entity = new HttpEntity<>(getHeaders(user));
@@ -167,7 +173,6 @@ public class DataRepoClient {
             }
             drResponse.setErrorModel(Optional.empty());
         } else {
-
             S errorObject = objectMapper.readValue(response.getBody(), errorClass);
             drResponse.setErrorModel(Optional.of(errorObject));
             drResponse.setResponseObject(Optional.empty());

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -54,8 +54,7 @@ public class IngestTest extends UsersBase {
         super.setup();
         datasetSummaryModel = dataRepoFixtures.createDataset(steward(), "ingest-test-dataset.json");
         datasetId = datasetSummaryModel.getId();
-        dataRepoFixtures.addDatasetPolicyMember(
-            steward(), datasetId, IamRole.CUSTODIAN, custodian().getEmail());
+        dataRepoFixtures.addDatasetPolicyMember(steward(), datasetId, IamRole.CUSTODIAN, custodian().getEmail());
     }
 
     @After

--- a/src/test/java/bio/terra/integration/SimpleScenarioFaultTests.java
+++ b/src/test/java/bio/terra/integration/SimpleScenarioFaultTests.java
@@ -1,0 +1,180 @@
+package bio.terra.integration;
+
+import bio.terra.common.category.Integration;
+import bio.terra.common.configuration.TestConfiguration;
+import bio.terra.model.ConfigFaultCountedModel;
+import bio.terra.model.ConfigFaultModel;
+import bio.terra.model.ConfigGroupModel;
+import bio.terra.model.ConfigModel;
+import bio.terra.model.ConfigParameterModel;
+import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.model.IngestResponseModel;
+import bio.terra.model.SnapshotSummaryModel;
+import bio.terra.service.iam.IamRole;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+// This test provides a method that performs a simple scenario of creating a dataset, ingesting some rows,
+// making a snapshot, and then deleting everything.
+//
+// The tests that drive that method can configure faults to test underlying mechanisms.
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles({"google", "integrationtest"})
+@AutoConfigureMockMvc
+@Category(Integration.class)
+public class SimpleScenarioFaultTests extends UsersBase {
+    private final Logger logger = LoggerFactory.getLogger(SimpleScenarioFaultTests.class);
+
+    @Autowired
+    private DataRepoFixtures dataRepoFixtures;
+
+    @Autowired
+    private DataRepoClient dataRepoClient;
+
+    @Autowired
+    private TestConfiguration testConfig;
+
+    private String datasetId;
+    private String snapshotId;
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    // This is belts and suspenders, since we try to do these deletes in the scenario.
+    // However, since we are testing faults, there might be failures...
+    @After
+    public void teardown() throws Exception {
+        // Don't interrupt cleanup with the fault
+        dataRepoFixtures.setFault(steward(), "SAM_TIMEOUT_FAULT", false);
+        if (snapshotId != null) {
+            dataRepoFixtures.deleteSnapshot(custodian(), snapshotId);
+        }
+
+        if (datasetId != null) {
+            dataRepoFixtures.deleteDataset(steward(), datasetId);
+        }
+    }
+
+    @Test
+    public void testSamTimeout() throws Exception {
+        dataRepoFixtures.setFault(steward(), "SAM_TIMEOUT_FAULT", true);
+        simpleScenario();
+
+        // The rest of this is here not so much to test the fault as to validate the configuration test
+        // infrastructure in a live environment.
+        dataRepoFixtures.resetConfig(steward());
+
+        ConfigGroupModel configGroupModel = new ConfigGroupModel()
+            .label("simpleScenarioFaultTests - random SAM timeout fault");
+
+
+        configGroupModel.addGroupItem(
+            new ConfigModel()
+                .configType(ConfigModel.ConfigTypeEnum.PARAMETER)
+                .name("SAM_RETRY_INITIAL_WAIT_SECONDS")
+                .parameter(new ConfigParameterModel().value("10")));
+
+        configGroupModel.addGroupItem(
+            new ConfigModel()
+                .configType(ConfigModel.ConfigTypeEnum.PARAMETER)
+                .name("SAM_RETRY_MAXIMUM_WAIT_SECONDS")
+                .parameter(new ConfigParameterModel().value("30")));
+
+        configGroupModel.addGroupItem(
+            new ConfigModel()
+                .configType(ConfigModel.ConfigTypeEnum.PARAMETER)
+                .name("SAM_OPERATION_TIMEOUT_SECONDS")
+                .parameter(new ConfigParameterModel().value("300")));
+
+        configGroupModel.addGroupItem(
+            new ConfigModel()
+                .configType(ConfigModel.ConfigTypeEnum.FAULT)
+                .name("SAM_TIMEOUT_FAULT")
+                .fault(new ConfigFaultModel()
+                    .faultType(ConfigFaultModel.FaultTypeEnum.COUNTED)
+                    .enabled(true)
+                    .counted(new ConfigFaultCountedModel()
+                        .insert(-1)
+                        .rate(20)
+                        .rateStyle(ConfigFaultCountedModel.RateStyleEnum.RANDOM)
+                        .skipFor(0))));
+
+        List<ConfigModel> configList = dataRepoFixtures.setConfigList(steward(), configGroupModel).getItems();
+        printConfigList("prior", configList);
+
+        simpleScenario();
+
+        configList = dataRepoFixtures.getConfigList(steward()).getItems();
+        printConfigList("current", configList);
+    }
+
+    private void printConfigList(String label, List<ConfigModel> configModelList) {
+        int index = 0;
+        logger.info("Config model list - " + label);
+        for (ConfigModel configModel : configModelList) {
+            logger.info("Config model [" + index + "]: " + configModel);
+            index++;
+        }
+    }
+
+    private void simpleScenario() throws Exception {
+        // TODO: Since dataset creation and add policy is sync, it doesn't survive the fault. So for now, turn it off
+        //  for those operations.
+        dataRepoFixtures.setFault(steward(), "SAM_TIMEOUT_FAULT", false);
+        DatasetSummaryModel datasetSummaryModel = dataRepoFixtures.createDataset(steward(), "ingest-test-dataset.json");
+        datasetId = datasetSummaryModel.getId();
+        dataRepoFixtures.addDatasetPolicyMember(steward(), datasetId, IamRole.CUSTODIAN, custodian().getEmail());
+        dataRepoFixtures.setFault(steward(), "SAM_TIMEOUT_FAULT", true);
+
+        IngestRequestModel ingestRequest = dataRepoFixtures.buildSimpleIngest(
+            "participant", "ingest-test/ingest-test-participant.json", IngestRequestModel.StrategyEnum.APPEND);
+        IngestResponseModel ingestResponse = dataRepoFixtures.ingestJsonData(steward(), datasetId, ingestRequest);
+        assertThat("correct participant row count", ingestResponse.getRowCount(), equalTo(5L));
+
+        ingestRequest = dataRepoFixtures.buildSimpleIngest(
+            "sample", "ingest-test/ingest-test-sample.json", IngestRequestModel.StrategyEnum.APPEND);
+        ingestResponse = dataRepoFixtures.ingestJsonData(steward(), datasetId, ingestRequest);
+        assertThat("correct sample row count", ingestResponse.getRowCount(), equalTo(7L));
+
+        ingestRequest = dataRepoFixtures.buildSimpleIngest(
+            "file", "ingest-test/ingest-test-file.json", IngestRequestModel.StrategyEnum.APPEND);
+        ingestResponse = dataRepoFixtures.ingestJsonData(steward(), datasetId, ingestRequest);
+        assertThat("correct file row count", ingestResponse.getRowCount(), equalTo(1L));
+
+        SnapshotSummaryModel snapshotSummary =
+            dataRepoFixtures.createSnapshot(custodian(), datasetSummaryModel, "ingest-test-snapshot.json");
+        snapshotId = snapshotSummary.getId();
+
+        // TODO: ditto from above
+        dataRepoFixtures.setFault(steward(), "SAM_TIMEOUT_FAULT", false);
+        if (snapshotId != null) {
+            dataRepoFixtures.deleteSnapshot(custodian(), snapshotId);
+            snapshotId = null;
+        }
+
+        if (datasetId != null) {
+            dataRepoFixtures.deleteDataset(steward(), datasetId);
+            datasetId = null;
+        }
+        dataRepoFixtures.setFault(steward(), "SAM_TIMEOUT_FAULT", true);
+    }
+}


### PR DESCRIPTION
_What a perfect Jira ID for fault insertion!!_

This PR adds faults to the configuration. There are two kinds of faults so far:
1. SIMPLE - just the boolean state: is the fault enabled or not
2. COUNTED - a general counted fault. For a COUNTED fault you configure:
  - skipFor - number of fault tests to ignore to start with
  - insert - number of faults to insert
  - rate - percentage of fault tests that should generate a fault
  - rateStyle - style can be:
    - FIXED - if rate is 25% then a fault is inserted every 4th test
    - RANDOM - if rate is 25% then a fault is inserted randomly 1/4 of the time.

You will see two UNIT_TEST faults in ConfigEnum that are used to test the fault code itself.
There is one real fault added: SAM_TIMEOUT_FAULT. When enabled it triggers a fake ApiException that looks like a timeout.

The fault insertion is able to use a lambda - and that is how I coded it - or it could be passed a method to make the fault code less intrusive.

Look at SimpleScenarioFaultTests to get an idea of how the fault API is used.