### PR TITLE
DR-692 bulk endpoint

### DIFF
--- a/src/main/java/bio/terra/app/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/app/controller/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package bio.terra.app.controller;
 
 import bio.terra.common.exception.BadRequestException;
+import bio.terra.common.exception.ConflictException;
 import bio.terra.common.exception.DataRepoException;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.exception.NotFoundException;
@@ -49,6 +50,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NotImplementedException.class)
     @ResponseStatus(HttpStatus.NOT_IMPLEMENTED)
     public ErrorModel notImplementedHandler(DataRepoException ex) {
+        return buildErrorModel(ex, ex.getErrorDetails());
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorModel conflictHandler(DataRepoException ex) {
         return buildErrorModel(ex, ex.getErrorDetails());
     }
 

--- a/src/main/java/bio/terra/common/DaoKeyHolder.java
+++ b/src/main/java/bio/terra/common/DaoKeyHolder.java
@@ -25,6 +25,10 @@ public class DaoKeyHolder extends GeneratedKeyHolder {
         return null;
     }
 
+    public String getString(String fieldName) {
+        return getField(fieldName, String.class);
+    }
+
     public <T> T getField(String fieldName, Class<T> type) {
         Map<String, Object> keys = getKeys();
         if (keys != null) {

--- a/src/main/java/bio/terra/common/exception/ConflictException.java
+++ b/src/main/java/bio/terra/common/exception/ConflictException.java
@@ -1,0 +1,28 @@
+package bio.terra.common.exception;
+
+import java.util.List;
+
+/**
+ * This exception maps to HttpStatus.CONFLICT in the GlobalExceptionHandler.
+ */
+public abstract class ConflictException extends DataRepoException {
+    public ConflictException(String message) {
+        super(message);
+    }
+
+    public ConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ConflictException(Throwable cause) {
+        super(cause);
+    }
+
+    public ConflictException(String message, List<String> errorDetails) {
+        super(message, errorDetails);
+    }
+
+    public ConflictException(String message, Throwable cause, List<String> errorDetails) {
+        super(message, cause, errorDetails);
+    }
+}

--- a/src/main/java/bio/terra/service/filedata/FSFile.java
+++ b/src/main/java/bio/terra/service/filedata/FSFile.java
@@ -12,6 +12,7 @@ public class FSFile extends FSItem {
     private String gspath;
     private String mimeType;
     private String bucketResourceId;
+    private String loadTag;
 
     public UUID getDatasetId() {
         return datasetId;
@@ -90,6 +91,15 @@ public class FSFile extends FSItem {
         return this;
     }
 
+    public String getLoadTag() {
+        return loadTag;
+    }
+
+    public FSFile loadTag(String loadTag) {
+        this.loadTag = loadTag;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -100,9 +110,11 @@ public class FSFile extends FSItem {
 
         return new EqualsBuilder()
             .appendSuper(super.equals(o))
+            .append(datasetId, fsFile.datasetId)
             .append(gspath, fsFile.gspath)
             .append(mimeType, fsFile.mimeType)
             .append(bucketResourceId, fsFile.bucketResourceId)
+            .append(loadTag, fsFile.loadTag)
             .isEquals();
     }
 
@@ -110,18 +122,22 @@ public class FSFile extends FSItem {
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
             .appendSuper(super.hashCode())
+            .append(datasetId)
             .append(gspath)
             .append(mimeType)
             .append(bucketResourceId)
+            .append(loadTag)
             .toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
+            .append("datasetId", datasetId)
             .append("gspath", gspath)
             .append("mimeType", mimeType)
             .append("bucketResourceId", bucketResourceId)
+            .append("loadTag", loadTag)
             .toString();
     }
 }

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -8,6 +8,7 @@ import bio.terra.service.filedata.exception.FileSystemCorruptException;
 import bio.terra.service.filedata.flight.delete.FileDeleteFlight;
 import bio.terra.service.filedata.flight.ingest.FileIngestFlight;
 import bio.terra.service.dataset.Dataset;
+import bio.terra.service.load.flight.LoadMapKeys;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.model.DRSChecksum;
 import bio.terra.model.DirectoryDetailModel;
@@ -66,6 +67,7 @@ public class FileService {
         return jobService
             .newJob(description, FileIngestFlight.class, fileLoad, userReq)
             .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
+            .addParameter(LoadMapKeys.LOAD_TAG, loadTag)
             .submit();
     }
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -1,13 +1,16 @@
 package bio.terra.service.filedata.flight.ingest;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
-import bio.terra.service.filedata.google.firestore.FireStoreDao;
-import bio.terra.service.filedata.google.firestore.FireStoreUtils;
 import bio.terra.service.dataset.Dataset;
-import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.firestore.FireStoreUtils;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.load.LoadService;
+import bio.terra.service.load.flight.LoadLockStep;
+import bio.terra.service.load.flight.LoadUnlockStep;
 import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -32,6 +35,7 @@ public class FileIngestFlight extends Flight {
         GcsPdao gcsPdao = (GcsPdao)appContext.getBean("gcsPdao");
         DatasetService datasetService = (DatasetService)appContext.getBean("datasetService");
         DataLocationService locationService = (DataLocationService)appContext.getBean("dataLocationService");
+        LoadService loadService = (LoadService)appContext.getBean("loadService");
         ApplicationConfiguration appConfig =
             (ApplicationConfiguration)appContext.getBean("applicationConfiguration");
 
@@ -48,6 +52,7 @@ public class FileIngestFlight extends Flight {
         RetryRuleRandomBackoff fileSystemRetry = new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
 
         // The flight plan:
+        // 0. Lock the load tag - only one flight operating on a load tag at a time
         // 1. Generate the new file id and store it in the working map. We need to allocate the file id before any
         //    other operation so that it is persisted in the working map. In particular, IngestFileDirectoryStep undo
         //    needs to know the file id in order to clean up.
@@ -63,11 +68,14 @@ public class FileIngestFlight extends Flight {
         //    time of the actual file in GCS. That ensures that the file info we return on REST API (and DRS) lookups
         //    matches what users will see when they examine the GCS object. When the file entry is (atomically)
         //    created in the file firestore collection, the file becomes visible for REST API lookups.
+        // 6. Unlock the load tag
+        addStep(new LoadLockStep(loadService));
         addStep(new IngestFileIdStep());
         addStep(new IngestFileDirectoryStep(fileDao, fireStoreUtils, dataset), fileSystemRetry);
         addStep(new IngestFilePrimaryDataLocationStep(fileDao, dataset, locationService));
         addStep(new IngestFilePrimaryDataStep(fileDao, dataset, gcsPdao));
         addStep(new IngestFileFileStep(fileDao, fileService, dataset), fileSystemRetry);
+        addStep(new LoadUnlockStep(loadService));
     }
 
 }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileFileStep.java
@@ -48,7 +48,8 @@ public class IngestFileFileStep implements Step {
             .gspath(fsFileInfo.getGspath())
             .checksumCrc32c(fsFileInfo.getChecksumCrc32c())
             .checksumMd5(fsFileInfo.getChecksumMd5())
-            .size(fsFileInfo.getSize());
+            .size(fsFileInfo.getSize())
+            .loadTag(fileLoadModel.getLoadTag());
 
         try {
             fileDao.createFileMetadata(dataset, newFile);

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -318,7 +318,8 @@ public class FireStoreDao {
             .description(fireStoreFile.getDescription())
             .gspath(fireStoreFile.getGspath())
             .mimeType(fireStoreFile.getMimeType())
-            .bucketResourceId(fireStoreFile.getBucketResourceId());
+            .bucketResourceId(fireStoreFile.getBucketResourceId())
+            .loadTag(fireStoreFile.getLoadTag());
 
         return fsFile;
     }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFile.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFile.java
@@ -17,6 +17,7 @@ public class FireStoreFile {
     private String mimeType;
     private String description;
     private String bucketResourceId;
+    private String loadTag;
     // fields filled in from FSFileInfo after the file ingest
     private String fileCreatedDate;
     private String gspath;
@@ -108,18 +109,28 @@ public class FireStoreFile {
         return this;
     }
 
+    public String getLoadTag() {
+        return loadTag;
+    }
+
+    public FireStoreFile loadTag(String loadTag) {
+        this.loadTag = loadTag;
+        return this;
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
             .append("fileId", fileId)
+            .append("mimeType", mimeType)
+            .append("description", description)
+            .append("bucketResourceId", bucketResourceId)
+            .append("loadTag", loadTag)
             .append("fileCreatedDate", fileCreatedDate)
             .append("gspath", gspath)
             .append("checksumCrc32c", checksumCrc32c)
             .append("checksumMd5", checksumMd5)
             .append("size", size)
-            .append("mimeType", mimeType)
-            .append("description", description)
-            .append("bucketResourceId", bucketResourceId)
             .toString();
     }
 }

--- a/src/main/java/bio/terra/service/load/Load.java
+++ b/src/main/java/bio/terra/service/load/Load.java
@@ -1,0 +1,59 @@
+package bio.terra.service.load;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.util.UUID;
+
+public class Load {
+    private UUID id;
+    private String loadTag;
+    private boolean locked;
+    private String lockingFlightId;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Load id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getLoadTag() {
+        return loadTag;
+    }
+
+    public Load loadTag(String loadTag) {
+        this.loadTag = loadTag;
+        return this;
+    }
+
+    public boolean isLocked() {
+        return locked;
+    }
+
+    public Load locked(boolean locked) {
+        this.locked = locked;
+        return this;
+    }
+
+    public String getLockingFlightId() {
+        return lockingFlightId;
+    }
+
+    public Load lockingFlightId(String lockingFlightId) {
+        this.lockingFlightId = lockingFlightId;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
+            .append("id", id)
+            .append("loadTag", loadTag)
+            .append("locked", locked)
+            .append("lockingFlightId", lockingFlightId)
+            .toString();
+    }
+}

--- a/src/main/java/bio/terra/service/load/LoadDao.java
+++ b/src/main/java/bio/terra/service/load/LoadDao.java
@@ -64,7 +64,7 @@ public class LoadDao {
             return; // nothing to unlock
         }
 
-        if (StringUtils.equals(load.getLockingFlightId(), flightId)) {
+        if (!StringUtils.equals(load.getLockingFlightId(), flightId)) {
             conflictThrow(load);
         }
         updateLoad(load.getId(), false, null);

--- a/src/main/java/bio/terra/service/load/LoadDao.java
+++ b/src/main/java/bio/terra/service/load/LoadDao.java
@@ -1,0 +1,128 @@
+package bio.terra.service.load;
+
+
+import bio.terra.common.DaoKeyHolder;
+import bio.terra.service.load.exception.LoadLockFailureException;
+import bio.terra.service.load.exception.LoadLockedException;
+import org.apache.commons.codec.binary.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Repository
+public class LoadDao {
+    private final Logger logger = LoggerFactory.getLogger("bio.terra.service.snapshot.SnapshotDao");
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public LoadDao(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public Load lockLoad(String loadTag, String flightId) {
+        Load load = lookupLoadByTag(loadTag);
+        if (load == null) {
+            load = createLoad(loadTag, flightId);
+        }
+
+        if (load.isLocked()) {
+            if (StringUtils.equals(flightId, load.getLockingFlightId())) {
+                // we already have it locked
+                return load;
+            } else {
+                // another flight has it locked
+                conflictThrow(load);
+            }
+        }
+
+        // Lock the load for our use and validate
+        updateLoad(load.getId(), true, flightId);
+        load = lookupLoadByTag(loadTag);
+        if (load != null && load.isLocked() && StringUtils.equals(load.getLockingFlightId(), flightId)) {
+            return load;
+        }
+        throw new LoadLockFailureException("Internal error: failed to lock a load!");
+    }
+
+    // To support idempotent steps, this method will not complain if the load no longer exists or if
+    // it is already unlocked. It throws if the lock is held by a different flight or if the unlock operation
+    // fails for some reason.
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void unlockLoad(String loadTag, String flightId) {
+        Load load = lookupLoadByTag(loadTag);
+        if (load == null || !load.isLocked()) {
+            return; // nothing to unlock
+        }
+
+        if (StringUtils.equals(load.getLockingFlightId(), flightId)) {
+            conflictThrow(load);
+        }
+        updateLoad(load.getId(), false, null);
+        load = lookupLoadByTag(loadTag);
+        if (load == null || load.isLocked() || load.getLockingFlightId() != null) {
+            throw new LoadLockFailureException("Internal error: failed to unlock a load!");
+        }
+    }
+
+    private void conflictThrow(Load load) {
+        throw new LoadLockedException("Load " + load.getLoadTag() +
+            " is locked by flight " + load.getLockingFlightId());
+    }
+
+    // Creates a new load and locks it on behalf of this flight
+    private Load createLoad(String loadTag, String flightId) {
+        String sql = "INSERT INTO load (load_tag, locked, locking_flight_id)" +
+            " VALUES (:load_tag, true, :flight_id)";
+        MapSqlParameterSource params = new MapSqlParameterSource()
+            .addValue("load_tag", loadTag)
+            .addValue("flight_id", flightId);
+        DaoKeyHolder keyHolder = new DaoKeyHolder();
+        jdbcTemplate.update(sql, params, keyHolder);
+        Load load = new Load()
+            .id(keyHolder.getId())
+            .loadTag(keyHolder.getString("load_tag"))
+            .locked(keyHolder.getField("locked", Boolean.class))
+            .lockingFlightId(keyHolder.getString("locking_flight_id"));
+
+        return load;
+    }
+
+    // Updates the load to either lock or unlock it
+    private void updateLoad(UUID loadId, boolean lock, String flightId) {
+        String sql = "UPDATE load SET locked = :locked, locking_flight_id = :flight_id WHERE id = :id";
+        MapSqlParameterSource params = new MapSqlParameterSource()
+            .addValue("locked", lock)
+            .addValue("flight_id", flightId)
+            .addValue("id", loadId);
+        jdbcTemplate.update(sql, params);
+    }
+
+
+    // Returns null if not found
+    private Load lookupLoadByTag(String loadTag) {
+        try {
+            String sql = "SELECT * FROM load WHERE load_tag = :load_tag";
+            MapSqlParameterSource params = new MapSqlParameterSource().addValue("load_tag", loadTag);
+            Load load = jdbcTemplate.queryForObject(sql, params, (rs, rowNum) ->
+                new Load()
+                    .id(rs.getObject("id", UUID.class))
+                    .loadTag(rs.getString("load_tag"))
+                    .locked(rs.getBoolean("locked"))
+                    .lockingFlightId(rs.getString("locking_flight_id")));
+            return load;
+        } catch (EmptyResultDataAccessException ex) {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/bio/terra/service/load/LoadFile.java
+++ b/src/main/java/bio/terra/service/load/LoadFile.java
@@ -1,0 +1,87 @@
+package bio.terra.service.load;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.util.UUID;
+
+public class LoadFile {
+    public enum State {
+        NOT_TRIED,
+        SUCCEEDED,
+        FAILED
+    }
+
+    private UUID loadId;
+    private String sourcePath;
+    private String targetPath;
+    private LoadFile.State state;
+    private String fileId;
+    private String error;
+
+    public UUID getLoadId() {
+        return loadId;
+    }
+
+    public LoadFile loadId(UUID loadId) {
+        this.loadId = loadId;
+        return this;
+    }
+
+    public String getSourcePath() {
+        return sourcePath;
+    }
+
+    public LoadFile sourcePath(String sourcePath) {
+        this.sourcePath = sourcePath;
+        return this;
+    }
+
+    public String getTargetPath() {
+        return targetPath;
+    }
+
+    public LoadFile targetPath(String targetPath) {
+        this.targetPath = targetPath;
+        return this;
+    }
+
+    public State getState() {
+        return state;
+    }
+
+    public LoadFile state(State state) {
+        this.state = state;
+        return this;
+    }
+
+    public String getFileId() {
+        return fileId;
+    }
+
+    public LoadFile fileId(String fileId) {
+        this.fileId = fileId;
+        return this;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public LoadFile error(String error) {
+        this.error = error;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
+            .append("loadId", loadId)
+            .append("sourcePath", sourcePath)
+            .append("targetPath", targetPath)
+            .append("state", state)
+            .append("fileId", fileId)
+            .append("error", error)
+            .toString();
+    }
+}

--- a/src/main/java/bio/terra/service/load/LoadService.java
+++ b/src/main/java/bio/terra/service/load/LoadService.java
@@ -1,0 +1,34 @@
+package bio.terra.service.load;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class LoadService {
+    /**
+     * @param inputTag  may be null or blank
+     * @return either valid inputTag or generated date-time tag.
+     */
+    public String computeLoadTag(String inputTag) {
+        if (StringUtils.isEmpty(inputTag)) {
+            return "load-at-" + Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT);
+        }
+        return inputTag;
+    }
+
+
+    /*
+    Entrypoints for steps:
+    lock load tag - will create the tag if it doesn't exist
+    unlock load tag
+
+    Add steps for use in dataset and file flights
+     */
+
+
+
+}

--- a/src/main/java/bio/terra/service/load/LoadService.java
+++ b/src/main/java/bio/terra/service/load/LoadService.java
@@ -1,6 +1,11 @@
 package bio.terra.service.load;
 
+import bio.terra.service.load.exception.LoadLockFailureException;
+import bio.terra.service.load.flight.LoadMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -9,6 +14,21 @@ import java.time.format.DateTimeFormatter;
 
 @Component
 public class LoadService {
+    private final LoadDao loadDao;
+
+    @Autowired
+    public LoadService(LoadDao loadDao) {
+        this.loadDao = loadDao;
+    }
+
+    public void lockLoad(String loadTag, String flightId) {
+        loadDao.lockLoad(loadTag, flightId);
+    }
+
+    public void unlockLoad(String loadTag, String flightId) {
+        loadDao.unlockLoad(loadTag, flightId);
+    }
+
     /**
      * @param inputTag  may be null or blank
      * @return either valid inputTag or generated date-time tag.
@@ -20,15 +40,16 @@ public class LoadService {
         return inputTag;
     }
 
-
-    /*
-    Entrypoints for steps:
-    lock load tag - will create the tag if it doesn't exist
-    unlock load tag
-
-    Add steps for use in dataset and file flights
-     */
-
-
-
+    public String getLoadTag(FlightContext context) {
+        FlightMap inputParameters = context.getInputParameters();
+        String loadTag = inputParameters.get(LoadMapKeys.LOAD_TAG, String.class);
+        if (StringUtils.isEmpty(loadTag)) {
+            FlightMap workingMap = context.getWorkingMap();
+            loadTag = workingMap.get(LoadMapKeys.LOAD_TAG, String.class);
+            if (StringUtils.isEmpty(loadTag)) {
+                throw new LoadLockFailureException("Expected LOAD_TAG in working map or inputs, but did not find it");
+            }
+        }
+        return loadTag;
+    }
 }

--- a/src/main/java/bio/terra/service/load/exception/LoadLockFailureException.java
+++ b/src/main/java/bio/terra/service/load/exception/LoadLockFailureException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.load.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class LoadLockFailureException extends InternalServerErrorException {
+    public LoadLockFailureException(String message) {
+        super(message);
+    }
+
+    public LoadLockFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LoadLockFailureException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/load/exception/LoadLockedException.java
+++ b/src/main/java/bio/terra/service/load/exception/LoadLockedException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.load.exception;
+
+import bio.terra.common.exception.ConflictException;
+
+public class LoadLockedException extends ConflictException {
+    public LoadLockedException(String message) {
+        super(message);
+    }
+
+    public LoadLockedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LoadLockedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/load/flight/LoadLockStep.java
+++ b/src/main/java/bio/terra/service/load/flight/LoadLockStep.java
@@ -1,0 +1,31 @@
+package bio.terra.service.load.flight;
+
+import bio.terra.service.load.LoadService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+// This step is meant to be shared by dataset and filesystem flights for locking the load tag.
+// It expects to find LoadMapKeys.LOAD_TAG in the working map.
+
+public class LoadLockStep implements Step {
+    private final LoadService loadService;
+
+    public LoadLockStep(LoadService loadService) {
+        this.loadService = loadService;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext context) {
+        String loadTag = loadService.getLoadTag(context);
+        loadService.lockLoad(loadTag, context.getFlightId());
+        return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) {
+        String loadTag = loadService.getLoadTag(context);
+        loadService.unlockLoad(loadTag, context.getFlightId());
+        return StepResult.getStepResultSuccess();
+    }
+}

--- a/src/main/java/bio/terra/service/load/flight/LoadMapKeys.java
+++ b/src/main/java/bio/terra/service/load/flight/LoadMapKeys.java
@@ -1,0 +1,8 @@
+package bio.terra.service.load.flight;
+
+public final class LoadMapKeys {
+    private LoadMapKeys() {
+
+    }
+    public static final String LOAD_TAG = "loadTag";
+}

--- a/src/main/java/bio/terra/service/load/flight/LoadUnlockStep.java
+++ b/src/main/java/bio/terra/service/load/flight/LoadUnlockStep.java
@@ -1,0 +1,30 @@
+package bio.terra.service.load.flight;
+
+import bio.terra.service.load.LoadService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+// This step is meant to be shared by dataset and filesystem flights for locking the load tag.
+// It expects to find LoadMapKeys.LOAD_TAG in the working map.
+
+public class LoadUnlockStep implements Step {
+    private final LoadService loadService;
+
+    public LoadUnlockStep(LoadService loadService) {
+        this.loadService = loadService;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext context) {
+        String loadTag = loadService.getLoadTag(context);
+        loadService.unlockLoad(loadTag, context.getFlightId());
+        return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) {
+        // No undo for unlock
+        return StepResult.getStepResultSuccess();
+    }
+}

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public class SnapshotDao {
+public class  SnapshotDao {
     private final Logger logger = LoggerFactory.getLogger("bio.terra.service.snapshot.SnapshotDao");
 
     private final NamedParameterJdbcTemplate jdbcTemplate;

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -882,6 +882,152 @@ paths:
           schema:
             $ref: '#/definitions/ErrorModel'
 
+  '/api/repository/v1/datasets/{id}/files/bulk':
+    post:
+      description: |-
+        Load many files into the dataset file system; async returns a BulkLoadResultModel
+        Note that this endpoint is not a single transaction. Some files may be loaded and
+        others may fail. Each file load is atomic; the file will either be loaded into the
+        dataset file system or it will not exist.
+      operationId: bulkFileLoad
+      tags:
+      - repository
+      consumes:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/Id'
+      - in: body
+        name: bulkFileLoad
+        description: Bulk file load request
+        schema:
+          $ref: '#/definitions/BulkLoadRequestModel'
+      responses:
+        202:
+          description: Job status of bulk load job & url for polling in the response header
+          schema:
+            $ref: '#/definitions/JobModel'
+          headers:
+            location:
+              type: string
+              description: url for the job polling
+        200:
+          description: Redirect for bulk load complete
+          schema:
+            $ref: '#/definitions/JobModel'
+          headers:
+            location:
+              type: string
+              description: url for the job result
+        400:
+          description: Bad request - invalid ingest request, badly formed
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        403:
+          description: No permission to ingest
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        409:
+          description: Someone else is using the load tag
+          schema:
+            $ref: '#/definitions/ErrorModel'
+
+  '/api/repository/v1/datasets/{id}/files/bulk/{loadTag}':
+    get:
+      description: |-
+        Retrieve the results of a bulk file load. The results of each bulk load are stored
+        in the dataset. They can be queried directly or retrieved with this paginated
+        interface.
+      operationId: bulkFileResultsGet
+      tags:
+      - repository
+      consumes:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/Id'
+      - $ref: '#/parameters/LoadTag'
+      - in: query
+        name: jobId
+        type: string
+        description: The job id associated with the load
+      - in: query
+        name: offset
+        type: integer
+        default: 0
+        description: The number of items to skip before starting to collect the result set.
+      - in: query
+        name: limit
+        type: integer
+        description: The numbers of items to return.
+        default: 10
+      responses:
+        202:
+          description: Job status of bulk load result retrieval
+          schema:
+            $ref: '#/definitions/JobModel'
+          headers:
+            location:
+              type: string
+              description: url for the job polling
+        200:
+          description: Redirect for bulk load result retrieval complete
+          schema:
+            $ref: '#/definitions/JobModel'
+          headers:
+            location:
+              type: string
+              description: url for the job result
+        400:
+          description: Bad request
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        403:
+          description: No permission to access bulk file results
+          schema:
+            $ref: '#/definitions/ErrorModel'
+
+    delete:
+      description: |-
+        Delete results from the bulk file load table of the dataset.
+        If jobId is specified, then only the results for the loadTag plus that jobId are
+        deleted. Otherwise, all results associated with the loadTag are deleted.
+      operationId: bulkFileResultsDelete
+      tags:
+      - repository
+      consumes:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/Id'
+      - $ref: '#/parameters/LoadTag'
+      - in: query
+        name: jobId
+        type: string
+        description: The job id associated with the load
+      responses:
+        202:
+          description: Job status of bulk load result deletion
+          schema:
+            $ref: '#/definitions/JobModel'
+          headers:
+            location:
+              type: string
+              description: url for the job polling
+        200:
+          description: Redirect for bulk load result deletion complete
+          schema:
+            $ref: '#/definitions/JobModel'
+          headers:
+            location:
+              type: string
+              description: url for the job result
+        400:
+          description: Bad request
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        403:
+          description: No permission to access bulk file results
+          schema:
+            $ref: '#/definitions/ErrorModel'
+
   '/api/repository/v1/datasets/{id}/files/{fileid}':
     get:
       description: Lookup metadata for one file
@@ -1911,6 +2057,132 @@ definitions:
       client-specified tag for a data or file load. If no id is specified, we use the
       string form of the job create time as the tag.
 
+  BulkLoadRequestModel:
+    description: |-
+      Body of a bulk file load request. We provide two ways of specifying the files to
+      load. One is to include an array of BulkLoadFileModel objects in this
+      object. The other is to provide a file containing the JSON form of a
+      BulkLoadFileModel. While we expect users to pick one or the other, the code will
+      process both inputs and load all of the files. If neither is specified, it runs
+      really, really fast!
+      The results of a bulk load are always stored into the dataset tabular data store
+      and can be retrieved directly from there, or via the GET .../bulk/{loadTag}
+      They can be cleaned up with the DELETE .../bulk/{loadTag}
+    type: object
+    required:
+      - profileId
+      - loadTag
+    properties:
+      profileId:
+        $ref: '#/definitions/UniqueIdProperty'
+        description: The profile id to use for these files
+      loadTag:
+        $ref: '#/definitions/LoadTagModel'
+      maxFailedFileLoads:
+        type: integer
+        default: 0
+        description: max number of failed file loads before stopping
+      returnArrayResults:
+        type: boolean
+        default: false
+        description: |-
+          If true, return the load results in an array in the result model.
+          Otherwise, only return the summary statistics. It is always possible
+          to get the results from the 
+      loadControlFile:
+        type: string
+        description: |-
+          gs:// path to a text file in a bucket. The file must be accessible to the DR
+          Manager. Each line of the file is interpreted as the JSON form of one
+          BulkLoadFileModel. For example, one line might look like
+            '{ "sourcePath":"gs:/bucket/path/file", "targetPath":"/target/path/file" }'
+      loadArray:
+        type: array
+        description: Array files to load
+        items:
+          $ref: '#/definitions/BulkLoadFileModel'
+
+  BulkLoadFileModel:
+    description: Describes one file within a bulk file load
+    type: object
+    required:
+      - sourcePath
+      - targetPath
+    properties:
+      sourcePath:
+        type: string
+        description: gs URL of the source file to load
+      targetPath:
+        type: string
+        description: |
+          Full path within the dataset where the file should be placed.
+          The path must start with /.
+      mimeType:
+        type: string
+        description: |-
+          A string providing the mime-type of the Data Object.
+          For example, "application/json".
+      description:
+        type: string
+        description: |-
+          A human readable description of the contents of the Data Object.
+
+  BulkLoadResultModel:
+    description: |-
+      Returned when the bulk file load job finishes.
+    type: object
+    properties:
+      loadTag:
+        $ref: '#/definitions/LoadTagModel'
+      jobId:
+        type: string
+      totalFiles:
+        type: integer
+      succeededFiles:
+        type: integer
+      failedFiles:
+        type: integer
+      notTriedFiles:
+        type: integer
+      loadFileResults:
+        type: array
+        items:
+          $ref: '#/definitions/BulkLoadFileResultModel'
+        description: |-
+          This array is present only if requested by setting returnArrayResults true in
+          the BulkLoadRequestModel.
+
+  BulkLoadFileResultModel:
+    description: Describes the status result of one file within a bulk file load
+    type: object
+    required:
+      - sourcePath
+      - targetPath
+    properties:
+      sourcePath:
+        type: string
+        description: gs URL of the source file to load
+      targetPath:
+        type: string
+        description: |
+          Full path within the dataset where the file should be placed.
+          The path must start with /.
+      state:
+        $ref: '#/definitions/BulkLoadFileState'
+      fileId:
+        type: string
+        description: The fileId of the loaded file; non-null if state is SUCCEEDED
+      error:
+        type: string
+        description: The error message if state is FAILED
+
+  BulkLoadFileState:
+    type: string
+    enum:
+      - succeeded
+      - failed
+      - not_tried
+      
   ## Snapshot Definitions ##
 
   SnapshotRequestModel:

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1377,6 +1377,12 @@ parameters:
     type: integer
     default: 0
     in: query
+  LoadTag:
+    name: loadtag
+    description: a load tag
+    required: true
+    type: string
+    in: path
 
 ##########################################################################################
 # DEFINITIONS

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1727,10 +1727,7 @@ definitions:
           - upsert
           - append
       load_tag:
-        type: string
-        description: |
-          client-specified tag for this load. If no id is specified, we use the
-          string form of the job create time as the tag.
+        $ref: '#/definitions/LoadTagModel'
       max_bad_records:
         type: integer
         default: 0
@@ -1779,7 +1776,7 @@ definitions:
       path:
         type: string
       load_tag:
-        type: string
+        $ref: '#/definitions/LoadTagModel'
       row_count:
         type: integer
         format: int64
@@ -1818,6 +1815,8 @@ definitions:
       profileId:
         $ref: '#/definitions/UniqueIdProperty'
         description: The profile id to use for this file
+      loadTag:
+        $ref: '#/definitions/LoadTagModel'
       description:
         type: string
         description: |-
@@ -1881,6 +1880,8 @@ definitions:
       accessUrl:
         type: string
         description: URL of the file in cloud storage
+      loadTag:
+        $ref: '#/definitions/LoadTagModel'
 
   DirectoryDetailModel:
     description: Directory in the data repository
@@ -1897,6 +1898,12 @@ definitions:
         description: Array of directory contents
         items:
           $ref: '#/definitions/FileModel'
+
+  LoadTagModel:
+    type: string
+    description: |
+      client-specified tag for a data or file load. If no id is specified, we use the
+      string form of the job create time as the tag.
 
   ## Snapshot Definitions ##
 

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -16,4 +16,5 @@
     <include file="changesets/20190606_billingprofiles.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20190609_datasetresource.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20190801_primarykey.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20200102_loadtables.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20200102_loadtables.yaml
+++ b/src/main/resources/db/changesets/20200102_loadtables.yaml
@@ -40,8 +40,8 @@ databaseChangeLog:
                   type: ${uuid_type}
                   constraints:
                     nullable: false
-                    foreignKeyName: fk_load_file_load_tag
-                    references: load_tag(id)
+                    foreignKeyName: fk_load_file_load
+                    references: load(id)
                     deleteCascade: true
               - column:
                   name: sourcePath

--- a/src/main/resources/db/changesets/20200102_loadtables.yaml
+++ b/src/main/resources/db/changesets/20200102_loadtables.yaml
@@ -1,0 +1,69 @@
+databaseChangeLog:
+  - changeSet:
+      id: load_tables
+      author: dd
+      changes:
+        - createTable:
+            tableName: load
+            remarks: |
+              One row per unique load tag. Used to lock the load; only one thread operating on a load tag at a time.
+            columns:
+              - column:
+                  name: id
+                  type: ${uuid_type}
+                  defaultValueComputed: ${uuid_function}
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: load_tag
+                  type: text
+                  constraints:
+                    unique: true
+                    nullable: false
+              - column:
+                  name: locked
+                  type: boolean
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locking_flight_id
+                  type: text
+
+        - createTable:
+            tableName: load_file
+            remarks: |
+              One row per file in a load tag. Maintains state of the file load.
+            columns:
+              - column:
+                  name: load_id
+                  type: ${uuid_type}
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_load_file_load_tag
+                    references: load_tag(id)
+                    deleteCascade: true
+              - column:
+                  name: sourcePath
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: targetPath
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: state
+                  type: text
+                  remarks: NOT_TRIED, SUCCEEDED, FAILED
+              - column:
+                  name: fileId
+                  type: text
+                  remarks: if the state is SUCCEEDED, this column will contain the loaded file id
+              - column:
+                  name: error
+                  type: text
+                  remarks: if state is FAILED, this column will contain the error message
+
+

--- a/src/test/java/bio/terra/service/load/LoadUnitTest.java
+++ b/src/test/java/bio/terra/service/load/LoadUnitTest.java
@@ -1,0 +1,94 @@
+package bio.terra.service.load;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.load.exception.LoadLockFailureException;
+import bio.terra.service.load.exception.LoadLockedException;
+import bio.terra.service.load.flight.LoadMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class LoadUnitTest {
+    private static final String tag1 = "myLoadTag1";
+    private static final String tag2 = "myLoadTag2";
+    private static final String flight1 = "myFlightId1";
+    private static final String flight2 = "myFlightId2";
+
+    @Autowired
+    private LoadService loadService;
+
+    @Test
+    public void loadLocKTest() throws Exception {
+        loadService.lockLoad(tag1, flight1);
+        // Relock of the same (tag, flight) should work
+        loadService.lockLoad(tag1, flight1);
+        loadService.lockLoad(tag2, flight2);
+        loadService.unlockLoad(tag2, flight2);
+        loadService.unlockLoad(tag1, flight1);
+        // Duplicate unlock should work
+        loadService.unlockLoad(tag1, flight1);
+    }
+
+    @Test(expected = LoadLockedException.class)
+    public void alreadyLockedTest() throws Exception {
+        loadService.lockLoad(tag1, flight1);
+        loadService.lockLoad(tag1, flight2);
+    }
+
+    @Test(expected = LoadLockedException.class)
+    public void cannotUnlockTest() throws Exception {
+        loadService.lockLoad(tag1, flight1);
+        loadService.unlockLoad(tag1, flight2);
+    }
+
+    @Test
+    public void computeLoadTagTest() throws Exception {
+        String loadTag = loadService.computeLoadTag(null);
+        assertThat("generated load tag", loadTag, startsWith("load-at-"));
+        loadTag = loadService.computeLoadTag(tag1);
+        assertThat("pass through load tag", loadTag, equalTo(tag1));
+    }
+
+    @Test
+    public void getLoadTagTest() throws Exception {
+        // Should get tag from working map
+        FlightMap inputParams = new FlightMap();
+        FlightContext flightContext = new FlightContext(inputParams, null, null);
+        FlightMap workingMap = flightContext.getWorkingMap();
+        workingMap.put(LoadMapKeys.LOAD_TAG, tag1);
+
+        String loadTag = loadService.getLoadTag(flightContext);
+        assertThat("working map load tag", loadTag, equalTo(tag1));
+
+        // Should get from input Params
+        FlightMap inputParams1 = new FlightMap();
+        inputParams1.put(LoadMapKeys.LOAD_TAG, tag1);
+        flightContext = new FlightContext(inputParams1, null, null);
+        workingMap = flightContext.getWorkingMap();
+        workingMap.put(LoadMapKeys.LOAD_TAG, tag2);
+
+        loadTag = loadService.getLoadTag(flightContext);
+        assertThat("input params load tag", loadTag, equalTo(tag1));
+    }
+
+    @Test(expected = LoadLockFailureException.class)
+    public void getLoadTagFailTest() throws Exception {
+        FlightMap inputParams = new FlightMap();
+        FlightContext flightContext = new FlightContext(inputParams, null, null);
+        loadService.getLoadTag(flightContext);
+    }
+}


### PR DESCRIPTION
**For early review:**
I coded up the bulk file endpoints and would like a sanity check before I get too far into the implementation. The endpoints are:

#### POST /api/repository/v1/datasets/{id}/files/bulk
This is the main bulk load interface.

#### GET /api/repository/v1/datasets/{id}/files/bulk/{loadTag}?jobId={jobId}&offset={offset}&limit={limit}
Enumerate the results of a load. This provides a paginated interface over a BigQuery query on the table holding historic bulk load results. It can be further filtered by a specific load job id.

#### DELETE /api/repository/v1/datasets/{id}/files/bulk/{loadTag}?jobId={jobId}
Delete load results from BigQuery; either all results for a loadTag or the results for a specific loadTag and jobId

There are two areas where I'd particularly like feedback:
1. The POST has two ways to provide files: either directly in an array in the body and by providing a path to a file in GCS. We could pick one way. I chose the semantic of consuming all files provided, rather than choosing one or the other.
2. The load result has two ways to provide file status: either in the response body or by performing a GET on the load result. You choose to receive the in-body array by setting a flag in the POST request. We could choose one. I am concerned about returning really large results directly in the response.





