### PR TITLE
DR-739 Suppress spurious RCN redundant nullcheck warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ dependencies {
     testCompile group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
     testCompile "org.springframework.boot:spring-boot-starter-test"
     testCompile 'org.postgresql:postgresql:42.2.8'
+    testCompile 'com.google.code.findbugs:annotations:3.0.1u2'
 
     generatedCompile 'org.springframework.boot:spring-boot-starter-web'
     generatedCompile 'io.springfox:springfox-swagger2:2.7.0'

--- a/src/main/java/bio/terra/stairway/FlightDao.java
+++ b/src/main/java/bio/terra/stairway/FlightDao.java
@@ -3,6 +3,8 @@ package bio.terra.stairway;
 import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.DatabaseSetupException;
 import bio.terra.stairway.exception.FlightNotFoundException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -27,6 +29,9 @@ import java.util.Map;
  * assumes Postgres.
  * <p>
  */
+@SuppressFBWarnings(
+    value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+    justification = "Spurious RCN check; related to Java 11")
 class FlightDao {
 
     private static String FLIGHT_TABLE = "flight";

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -15,6 +15,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -115,6 +116,9 @@ public class FileTest extends UsersBase {
     }
 
     @Test
+    @SuppressFBWarnings(
+        value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+        justification = "Spurious RCN check; related to Java 11")
     public void fileUnauthorizedPermissionsTest() throws Exception {
 
         String gsPath = "gs://" + testConfiguration.getIngestbucket();

--- a/src/test/java/bio/terra/service/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/iam/AccessTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -56,6 +57,9 @@ import static org.junit.Assert.fail;
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "integrationtest"})
 @Category(Integration.class)
+@SuppressFBWarnings(
+    value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+    justification = "Spurious RCN check; related to Java 11")
 public class AccessTest extends UsersBase {
     private static final Logger logger = LoggerFactory.getLogger(AccessTest.class);
 


### PR DESCRIPTION
This PR suppresses spurious findbugs "redundant nullcheck warning". There is one spot in Stairway and three in tests. I had to make the annotation available to testCompile in our gradle file.

From what I've found on the InterWeb...  javac is generating new bytecode for Java11 that triggers the warning from findbugs.

I do have Java 11 installed on my system. However, it is not set for use in the project and it is not the default Java, so I really don't understand why this is showing up with findbugs. In any case, I don't think it is a bad thing to add the warning suppression for these handful of cases as a way to get around the problem.