### PR TITLE
WIP Add a new 'overwrite' ingest strategy.

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -28,13 +28,15 @@ public class DatasetIngestFlight extends Flight {
         addStep(new IngestLoadTableStep(datasetService, bigQueryPdao));
         addStep(new IngestRowIdsStep(datasetService, bigQueryPdao));
         addStep(new IngestValidateRefsStep(datasetService, bigQueryPdao, fileDao));
-        if (ingestStrategy == IngestRequestModel.StrategyEnum.UPSERT) {
-            addStep(new IngestEvaluateOverlapStep(datasetService, bigQueryPdao));
-            addStep(new IngestSoftDeleteChangedRowsService(datasetService, bigQueryPdao));
-            addStep(new IngestUpsertIntoDatasetTableStep(datasetService, bigQueryPdao));
-        } else {
-            // 'append' strategy.
+        if (ingestStrategy == IngestRequestModel.StrategyEnum.APPEND) {
             addStep(new IngestInsertIntoDatasetTableStep(datasetService, bigQueryPdao));
+        } else {
+            addStep(new IngestEvaluateOverlapStep(datasetService, bigQueryPdao));
+            addStep(new IngestSoftDeleteChangedRowsStep(datasetService, bigQueryPdao));
+            if (ingestStrategy == IngestRequestModel.StrategyEnum.OVERWRITE) {
+                addStep(new IngestSoftDeleteMissingRowsStep(datasetService, bigQueryPdao));
+            }
+            addStep(new IngestUpsertIntoDatasetTableStep(datasetService, bigQueryPdao));
         }
         addStep(new IngestCleanupStep(datasetService, bigQueryPdao));
     }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCleanupStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCleanupStep.java
@@ -39,7 +39,7 @@ public class IngestCleanupStep implements Step {
         try {
             Dataset dataset = IngestUtils.getDataset(context, datasetService);
 
-            // overlappingTableName is null when the ingest strategy is not upsert.
+            // overlappingTableName is null when the ingest strategy is `append`.
             // Don't try to delete the table name if it is null
             overlappingTableName = IngestUtils.getOverlappingTableName(context);
             if (overlappingTableName != null && bigQueryPdao.tableExists(dataset, overlappingTableName)) {

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestSetupStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestSetupStep.java
@@ -64,13 +64,16 @@ public class IngestSetupStep implements Step {
 
         IngestRequestModel.StrategyEnum ingestStrategy = ingestRequestModel.getStrategy();
 
-        if (ingestStrategy == IngestRequestModel.StrategyEnum.UPSERT) {
+        if (ingestStrategy != IngestRequestModel.StrategyEnum.APPEND) {
             List<Column> primaryKey = dataset
                 .getTableByName(targetTable.getName()).orElseThrow(IllegalStateException::new)
                 .getPrimaryKey();
             if (primaryKey.size() < 1) {
                 throw new InvalidIngestStrategyException(
-                    "Cannot use ingestStrategy `upsert` on table with no primary key: " + targetTable.getName());
+                    new StringBuilder().append("Cannot use ingestStrategy `")
+                        .append(ingestStrategy.name())
+                        .append("` on table with no primary key: ")
+                        .append(targetTable.getName()).toString());
             }
 
             Schema overlappingTableSchema = bigQueryPdao.buildOverlappingTableSchema();

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestSoftDeleteChangedRowsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestSoftDeleteChangedRowsStep.java
@@ -1,0 +1,38 @@
+package bio.terra.service.dataset.flight.ingest;
+
+import bio.terra.common.Table;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.tabulardata.google.BigQueryPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+public class IngestSoftDeleteChangedRowsStep implements Step {
+    private DatasetService datasetService;
+    private BigQueryPdao bigQueryPdao;
+
+    public IngestSoftDeleteChangedRowsStep(DatasetService datasetService, BigQueryPdao bigQueryPdao) {
+        this.datasetService = datasetService;
+        this.bigQueryPdao = bigQueryPdao;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext context) {
+        Dataset dataset = IngestUtils.getDataset(context, datasetService);
+        Table targetTable = IngestUtils.getDatasetTable(context, dataset);
+        String overlappingTableName = IngestUtils.getOverlappingTableName(context);
+
+        bigQueryPdao.softDeleteChangedOverlappingRows(dataset,
+            targetTable,
+            overlappingTableName);
+
+        return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) {
+        // TODO: Add undo for softdeleted rows
+        return StepResult.getStepResultSuccess();
+    }
+}

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1109,7 +1109,7 @@ paths:
         - repository
       parameters:
         - name: name
-          description: name of the configuration to 
+          description: name of the configuration to
           required: true
           in: path
           type: string
@@ -1732,6 +1732,7 @@ definitions:
         enum:
           - upsert
           - append
+          - overwrite
       load_tag:
         $ref: '#/definitions/LoadTagModel'
       max_bad_records:
@@ -2223,7 +2224,7 @@ definitions:
       Counted fault is used to insert a fixed number of faults. A "fault test" is one
       call to the fault manager for a named fault. The skipFor lets you get the system to
       a certain stable point where you want to begin inserting faults. Insert gives the
-      total number of faults to trigger. The rate gives the percentage of the time to 
+      total number of faults to trigger. The rate gives the percentage of the time to
       insert the fault. A value of 50 would insert the fault half
       the time. A value of 20 would insert the fault 20% of the time . The rateStyle
       describes whether the fault will be fixed or random. In our 20 example, if the rate style

--- a/src/test/resources/ingest-test-updated-sample.json
+++ b/src/test/resources/ingest-test-updated-sample.json
@@ -1,0 +1,5 @@
+{"id":"sample1","participant_ids":["participant_1"],"date_collected":"2019-02-27","derived_from":null}
+{"id":"sample2","participant_ids":["participant_2"],"date_collected":"2019-02-27","derived_from":"sample1"}
+{"id":"sample3","participant_ids":["participant_3"],"date_collected":"2019-02-27","derived_from":null}
+{"id":"sample5","participant_ids":["participant_2","participant_5"],"date_collected":"2019-02-27","derived_from":null}
+{"id":"sample7","participant_ids":[],"date_collected":"2019-02-27","derived_from":"sample2"}


### PR DESCRIPTION
WIP because I still can't figure out how to run connected tests locally.

The datasets that Monster pulls from will occasionally remove/redact records. Our workflows currently don't have a good way to detect when that happens, because they just pull & process whatever happens to be available at the time. The "upsert" ingest strategy doesn't help us because it only acts on new and updated rows.

Rather than build an out-of-band comparison into our pipeline, I talked with @thathert about the possibility of adding a 3rd ingest strategy. The new strategy soft-deletes all rows that are changed or unrepresented in the new tabular data (as opposed to upsert, which only soft-deletes the changed rows). "Changed" and "unrepresented" are determined using the primary key columns of the table.

I thought the code changes might be small enough to get away with skipping a design doc, but I can write a 1-pager for the internet historians if that'd be helpful. I'm also happy to discuss in person. Some questions on my mind are:
1. Is "overwrite" a good name for the strategy? I also considered "reset".
2. Will there ever be a strategy that truly overwrites the _entire_ table, regardless of primary keys? If so, should the name of this strategy mention keys?