### PR TITLE
DR-781 Set Spring to use proxied requests as primary

### DIFF
--- a/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
@@ -4,7 +4,6 @@ import bio.terra.app.configuration.ApplicationConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;

--- a/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
@@ -4,15 +4,12 @@ import bio.terra.app.configuration.ApplicationConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
 
-@Primary
-@Profile("!terra")
 @Component
 public class LocalAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
     private Logger logger = LoggerFactory.getLogger(LocalAuthenticatedUserRequestFactory.class);

--- a/src/main/java/bio/terra/service/iam/ProxiedAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/ProxiedAuthenticatedUserRequestFactory.java
@@ -1,12 +1,14 @@
 package bio.terra.service.iam;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
 
+@Primary
 @Profile({"terra", "dev", "integration"})
 @Component
 public class ProxiedAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {


### PR DESCRIPTION
By setting `ProxiedAuthenticatedUserRequest` which performs logging as `@Primary`, the logs should correctly record who the real authorized user was instead of a dummy user.

The `!terra` profile needs to be removed otherwise a dummy user will be used in all environments that are not prod.