### PR TITLE
version lock spring-boot-starter-web

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,8 @@ dependencies {
     compile 'org.liquibase:liquibase-core:3.8.0'         // For upgrade
     compile 'org.postgresql:postgresql:42.2.8'           // Postgres jdbc driver
     compile 'org.slf4j:slf4j-api:1.7.28'                 // Logging facade
-    compile "org.springframework.boot:spring-boot-starter-web"
+    compile "org.springframework.boot:spring-boot-starter-web:2.2.4.RELEASE"
+
     compile 'org.springframework:spring-jdbc:5.1.9.RELEASE'
     compile 'org.broadinstitute.dsde.workbench:sam-client_2.12:0.1-9435410-SNAP'
 


### PR DESCRIPTION
This version bumps jackson-databind, springweb, and springweb mvc. They all have vulnerabilities according to source clear.