### PR TITLE
DR-801 Change default GCR tag to getGitHash.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,8 +241,7 @@ def getGitHash = { ->
 jib {
     extraDirectories.paths = ['build/gen-expanded']
     to {
-        image = "gcr.io/broad-jade-dev/jade-data-repo"
-        tags = [(System.env.GCR_TAG ?: getGitHash())]
+        image = "gcr.io/broad-jade-dev/jade-data-repo:"+(System.env.GCR_TAG ?: getGitHash())
     }
 }
 // jib expects all classes to be under app/classes in the resulting image. this, combined with the extraDirectories

--- a/build.gradle
+++ b/build.gradle
@@ -229,11 +229,20 @@ jar {
     from sourceSets.generated.output
 }
 
+def getGitHash = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 jib {
     extraDirectories.paths = ['build/gen-expanded']
     to {
         image = "gcr.io/broad-jade-dev/jade-data-repo"
-        tags = [(System.env.GCR_TAG ?: "latest")]
+        tags = [(System.env.GCR_TAG ?: getGitHash())]
     }
 }
 // jib expects all classes to be under app/classes in the resulting image. this, combined with the extraDirectories
@@ -261,15 +270,6 @@ liquibase {
             logLevel 'debug'
         }
     }
-}
-
-def getGitHash = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--short', 'HEAD'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
 }
 
 

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -106,9 +106,9 @@ public class GcsPdao {
             // so I changed exported the timeouts to application.properties to allow for tuning
             // and I am changing this to copy chunks.
             CopyWriter writer = sourceBlob.copyTo(BlobId.of(bucketResource.getName(), targetPath));
-            while (!writer.isDone()) {
-                writer.copyChunk();
-            }
+//            while (!writer.isDone()) {
+//                writer.copyChunk();
+//            }
             Blob targetBlob = writer.getResult();
 
             // MD5 is computed per-component. So if there are multiple components, the MD5 here is

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -106,9 +106,9 @@ public class GcsPdao {
             // so I changed exported the timeouts to application.properties to allow for tuning
             // and I am changing this to copy chunks.
             CopyWriter writer = sourceBlob.copyTo(BlobId.of(bucketResource.getName(), targetPath));
-//            while (!writer.isDone()) {
-//                writer.copyChunk();
-//            }
+            while (!writer.isDone()) {
+                writer.copyChunk();
+            }
             Blob targetBlob = writer.getResult();
 
             // MD5 is computed per-component. So if there are multiple components, the MD5 here is


### PR DESCRIPTION
Changed the default container tag to use the most recent git commit hash, instead of latest. The way to specify a custom container tag is unchanged -- set the GCR_TAG environment variable. Also added the workaround for a bug/feature in the Jib Grade plugin that automatically adds the latest tag if no other tag is specified.

Links from @smark88 about the Jib Gradle plugin bug/feature. Workaround is at the bottom of the second link.
https://github.com/GoogleContainerTools/jib/issues/1226
https://github.com/GoogleContainerTools/jib/issues/1427

I tested this locally with these commands, and checked the tags in GCR console:
./gradle :jib
GCR_TAG=marikoTESTING ./gradlew :jib
