### PR TITLE
DR-799 Check for empty Vault password in db-connect script.

### DIFF
--- a/ops/db-connect.sh
+++ b/ops/db-connect.sh
@@ -9,5 +9,11 @@ echo $VAULT_PATH
 PW=$( vault read -format=json $VAULT_PATH | \
       jq -r .data.datarepopassword )
 
+if [ -z "$PW" ]
+then
+  echo "Vault password is empty"
+  exit 1 # error
+fi
+
 kubectl --namespace ${SUFFIX} run psql -it --serviceaccount=${SUFFIX}-jade-datarepo-api --restart=Never --rm --image postgres:9.6 -- \
     psql "postgresql://drmanager:${PW}@${SUFFIX}-jade-gcloud-sqlproxy.${SUFFIX}/${DB}"


### PR DESCRIPTION
Small change to prevent the script from spinning up a psql pod if the Vault password is empty. This happened to me while debugging my dev-mm deployment today.