### PR TITLE
DR-706 include rowid in snapshot

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -700,8 +700,8 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     private static final String createViewsTemplate =
-        "SELECT ROW_ID_COLUMN, <columns; separator=\",\"> FROM (" +
-            "SELECT S." + PDAO_ROW_ID_COLUMN + " AS ROW_ID_COLUMN, <mappedColumns; separator=\",\"> FROM `<project>.<dataset>.<mapTable>` S, " +
+        "SELECT " + PDAO_ROW_ID_COLUMN + ", <columns; separator=\",\"> FROM (" +
+            "SELECT S." + PDAO_ROW_ID_COLUMN + ", <mappedColumns; separator=\",\"> FROM `<project>.<dataset>.<mapTable>` S, " +
             "`<project>.<snapshot>." + PDAO_ROW_ID_TABLE + "` R WHERE " +
             "S." + PDAO_ROW_ID_COLUMN + " = R." + PDAO_ROW_ID_COLUMN + " AND " +
             "R." + PDAO_TABLE_ID_COLUMN + " = '<tableId>')";

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -700,8 +700,8 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     private static final String createViewsTemplate =
-        "SELECT S." + PDAO_ROW_ID_COLUMN + ", <columns; separator=\",\"> FROM (" +
-            "SELECT <mappedColumns; separator=\",\"> FROM `<project>.<dataset>.<mapTable>` S, " +
+        "SELECT ROW_ID_COLUMN, <columns; separator=\",\"> FROM (" +
+            "SELECT S." + PDAO_ROW_ID_COLUMN + " AS ROW_ID_COLUMN, <mappedColumns; separator=\",\"> FROM `<project>.<dataset>.<mapTable>` S, " +
             "`<project>.<snapshot>." + PDAO_ROW_ID_TABLE + "` R WHERE " +
             "S." + PDAO_ROW_ID_COLUMN + " = R." + PDAO_ROW_ID_COLUMN + " AND " +
             "R." + PDAO_TABLE_ID_COLUMN + " = '<tableId>')";

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -701,7 +701,8 @@ public class BigQueryPdao implements PrimaryDataAccess {
 
     private static final String createViewsTemplate =
         "SELECT " + PDAO_ROW_ID_COLUMN + ", <columns; separator=\",\"> FROM (" +
-            "SELECT S." + PDAO_ROW_ID_COLUMN + ", <mappedColumns; separator=\",\"> FROM `<project>.<dataset>.<mapTable>` S, " +
+            "SELECT S." + PDAO_ROW_ID_COLUMN + ", <mappedColumns; separator=\",\"> " +
+            "FROM `<project>.<dataset>.<mapTable>` S, " +
             "`<project>.<snapshot>." + PDAO_ROW_ID_TABLE + "` R WHERE " +
             "S." + PDAO_ROW_ID_COLUMN + " = R." + PDAO_ROW_ID_COLUMN + " AND " +
             "R." + PDAO_TABLE_ID_COLUMN + " = '<tableId>')";

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -700,7 +700,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     private static final String createViewsTemplate =
-        "SELECT <columns; separator=\",\"> FROM (" +
+        "SELECT S." + PDAO_ROW_ID_COLUMN + ", <columns; separator=\",\"> FROM (" +
             "SELECT <mappedColumns; separator=\",\"> FROM `<project>.<dataset>.<mapTable>` S, " +
             "`<project>.<snapshot>." + PDAO_ROW_ID_TABLE + "` R WHERE " +
             "S." + PDAO_ROW_ID_COLUMN + " = R." + PDAO_ROW_ID_COLUMN + " AND " +


### PR DESCRIPTION
Added the PDAO_ROW_ID_COLUMN=datarepo_row_id to the SQL view template for snapshot creation.

This means datasets can't have a column with the same name. I think it's unlikely that particular conflict would come up, but we could always add an explicit check on dataset creation in the future.