### PR TITLE
DR-785 Create a "live view" per table on dataset creation

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -17,7 +17,7 @@ You'll want to follow all the steps below and stop once you have updated to the 
 ### Create the data repo db and user
 
     psql -f db/create-data-repo-db
-    
+
 ### Clear the database
 
     psql -f db/truncate-tables datarepo drmanager
@@ -33,8 +33,8 @@ part of the build, but are handy during development:
 To remove all database tables and clear liquibase history, run:
 
     ./gradlew dropAll
-    
-To perform an upgrade to your current schema, run: 
+
+To perform an upgrade to your current schema, run:
 
     ./gradlew update
 

--- a/src/main/java/bio/terra/common/PdaoConstant.java
+++ b/src/main/java/bio/terra/common/PdaoConstant.java
@@ -6,8 +6,6 @@ public final class PdaoConstant {
     private PdaoConstant() {}
 
     public static final String PDAO_PREFIX = "datarepo_";
-    public static final String RAW_DATA_PREFIX = PDAO_PREFIX + "raw_";
-    public static final String SOFT_DELETE_PREFIX = PDAO_PREFIX + "sd_";
     public static final String PDAO_ROW_ID_COLUMN = PDAO_PREFIX + "row_id";
     public static final String PDAO_ROW_ID_TABLE = PDAO_PREFIX + "row_ids";
     public static final String PDAO_TABLE_ID_COLUMN = PDAO_PREFIX + "table_id";

--- a/src/main/java/bio/terra/common/PdaoConstant.java
+++ b/src/main/java/bio/terra/common/PdaoConstant.java
@@ -2,16 +2,13 @@ package bio.terra.common;
 
 public final class PdaoConstant {
 
-    private PdaoConstant() {
-    }
+    // checkstyle will complain if you remove this.
+    private PdaoConstant() {}
 
     public static final String PDAO_PREFIX = "datarepo_";
-    public static final String STAGING_TABLE_PREFIX = "staging_table_";
-    public static final String TARGET_TABLE_PREFIX = "target_table_";
+    public static final String RAW_DATA_PREFIX = PDAO_PREFIX + "raw_";
+    public static final String SOFT_DELETE_PREFIX = PDAO_PREFIX + "sd_";
     public static final String PDAO_ROW_ID_COLUMN = PDAO_PREFIX + "row_id";
     public static final String PDAO_ROW_ID_TABLE = PDAO_PREFIX + "row_ids";
     public static final String PDAO_TABLE_ID_COLUMN = PDAO_PREFIX + "table_id";
-    public static final String STAGING_TABLE_ROW_ID_COLUMN = PDAO_PREFIX + STAGING_TABLE_PREFIX + "row_id";
-    public static final String TARGET_TABLE_ROW_ID_COLUMN = PDAO_PREFIX + TARGET_TABLE_PREFIX + "row_id";
-
 }

--- a/src/main/java/bio/terra/service/dataset/AssetDao.java
+++ b/src/main/java/bio/terra/service/dataset/AssetDao.java
@@ -2,7 +2,6 @@ package bio.terra.service.dataset;
 
 import bio.terra.app.configuration.DataRepoJdbcConfiguration;
 import bio.terra.common.DaoKeyHolder;
-import bio.terra.common.Table;
 import bio.terra.common.Column;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;

--- a/src/main/java/bio/terra/service/dataset/AssetDao.java
+++ b/src/main/java/bio/terra/service/dataset/AssetDao.java
@@ -89,7 +89,7 @@ public class AssetDao {
 
     // also retrieves dependent objects
     public List<AssetSpecification> retrieveAssetSpecifications(Dataset dataset) {
-        Map<UUID, Table> allTables = dataset.getTablesById();
+        Map<UUID, DatasetTable> allTables = dataset.getTablesById();
         Map<UUID, Column> allColumns = dataset.getAllColumnsById();
         Map<UUID, DatasetRelationship> allRelationships = dataset.getRelationshipsById();
 
@@ -119,7 +119,7 @@ public class AssetDao {
     private Collection<AssetTable> retrieveAssetTablesAndColumns(AssetSpecification spec,
                                                                  UUID rootTableId,
                                                                  UUID rootColumnId,
-                                                                 Map<UUID, Table> allTables,
+                                                                 Map<UUID, DatasetTable> allTables,
                                                                  Map<UUID, Column> allColumns) {
         Map<UUID, AssetTable> tables = new HashMap<>();
         String sql = "SELECT asset_column.id, asset_column.dataset_column_id, dataset_column.table_id " +

--- a/src/main/java/bio/terra/service/dataset/AssetTable.java
+++ b/src/main/java/bio/terra/service/dataset/AssetTable.java
@@ -1,7 +1,6 @@
 package bio.terra.service.dataset;
 
 import bio.terra.common.Column;
-import bio.terra.common.Table;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
@@ -10,14 +9,14 @@ import java.util.List;
 import java.util.Optional;
 
 public class AssetTable {
-    private Table datasetTable;
+    private DatasetTable datasetTable;
     private List<AssetColumn> columns = new ArrayList<>();
 
-    public Table getTable() {
+    public DatasetTable getTable() {
         return datasetTable;
     }
 
-    public AssetTable datasetTable(Table datasetTable) {
+    public AssetTable datasetTable(DatasetTable datasetTable) {
         this.datasetTable = datasetTable;
         return this;
     }

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -79,8 +79,8 @@ public class Dataset implements FSContainerInterface {
         return columns;
     }
 
-    public Map<UUID, Table> getTablesById() {
-        Map<UUID, Table> tables = new HashMap<>();
+    public Map<UUID, DatasetTable> getTablesById() {
+        Map<UUID, DatasetTable> tables = new HashMap<>();
         getTables().forEach(table -> tables.put(table.getId(), table));
         return tables;
     }

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -2,7 +2,6 @@ package bio.terra.service.dataset;
 
 import bio.terra.common.Column;
 import bio.terra.service.filedata.FSContainerInterface;
-import bio.terra.common.Table;
 import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -180,7 +180,7 @@ public final class DatasetJsonConversion {
         assetModel.getTables().forEach(tblMod -> {
             boolean processingRootTable = false;
             String tableName = tblMod.getName();
-            Table datasetTable = tables.get(tableName);
+            DatasetTable datasetTable = tables.get(tableName);
             //not sure if we need to set the id on the new table
             AssetTable newAssetTable = new AssetTable().datasetTable(datasetTable);
             if (assetModel.getRootTable().equals(tableName)) {

--- a/src/main/java/bio/terra/service/dataset/DatasetTable.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTable.java
@@ -8,12 +8,18 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Specific class for modeling dataset tables. Includes primary key info.
+ * Specific class for modeling dataset tables.
+ *
+ * Includes extra info to capture:
+ *   1. Primary keys
+ *   2. Names of helper tables used when building "live views"
  */
 public class DatasetTable implements Table {
 
     private UUID id;
     private String name;
+    private String rawTableName;
+    private String softDeleteTableName;
     private List<Column> columns = Collections.emptyList();
     private List<Column> primaryKey = Collections.emptyList();
 
@@ -32,6 +38,24 @@ public class DatasetTable implements Table {
 
     public DatasetTable name(String name) {
         this.name = name;
+        return this;
+    }
+
+    public String getRawTableName() {
+        return rawTableName;
+    }
+
+    public DatasetTable rawTableName(String name) {
+        this.rawTableName = name;
+        return this;
+    }
+
+    public String getSoftDeleteTableName() {
+        return softDeleteTableName;
+    }
+
+    public DatasetTable softDeleteTableName(String name) {
+        this.softDeleteTableName = name;
         return this;
     }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -28,10 +28,12 @@ public class DatasetTableDao {
     private static final Logger logger = LoggerFactory.getLogger(DatasetTableDao.class);
 
     private static final String sqlInsertTable = "INSERT INTO dataset_table " +
-        "(name, dataset_id, primary_key) VALUES (:name, :dataset_id, :primary_key)";
+        "(name, raw_table_name, soft_delete_table_name, dataset_id, primary_key) " +
+        "VALUES (:name, :raw_table_name, :soft_delete_table_name, :dataset_id, :primary_key)";
     private static final String sqlInsertColumn = "INSERT INTO dataset_column " +
         "(table_id, name, type, array_of) VALUES (:table_id, :name, :type, :array_of)";
-    private static final String sqlSelectTable = "SELECT id, name, primary_key FROM dataset_table " +
+    private static final String sqlSelectTable =
+        "SELECT id, name, raw_table_name, soft_delete_table_name, primary_key FROM dataset_table " +
         "WHERE dataset_id = :dataset_id";
     private static final String sqlSelectColumn = "SELECT id, name, type, array_of FROM dataset_column " +
         "WHERE table_id = :table_id";
@@ -53,6 +55,8 @@ public class DatasetTableDao {
 
         for (DatasetTable table : tableList) {
             params.addValue("name", table.getName());
+            params.addValue("raw_table_name", table.getRawTableName());
+            params.addValue("soft_delete_table_name", table.getSoftDeleteTableName());
 
             List<String> naturalKeyStringList = table.getPrimaryKey()
                 .stream()
@@ -92,7 +96,9 @@ public class DatasetTableDao {
         return jdbcTemplate.query(sqlSelectTable, params, (rs, rowNum) -> {
             DatasetTable table = new DatasetTable()
                 .id(rs.getObject("id", UUID.class))
-                .name(rs.getString("name"));
+                .name(rs.getString("name"))
+                .rawTableName(rs.getString("raw_table_name"))
+                .softDeleteTableName(rs.getString("soft_delete_table_name"));
 
             List<String> primaryKey = DaoUtils.getStringList(rs, "primary_key");
             List<Column> columns = retrieveColumns(table);

--- a/src/main/java/bio/terra/service/dataset/DatasetUtils.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetUtils.java
@@ -1,0 +1,53 @@
+package bio.terra.service.dataset;
+
+import bio.terra.common.PdaoConstant;
+import bio.terra.model.DatasetRequestModel;
+import org.apache.commons.lang3.StringUtils;
+import org.stringtemplate.v4.ST;
+
+import java.util.UUID;
+
+public final class DatasetUtils {
+
+    // Only allow usage of static methods.
+    private DatasetUtils() {}
+
+    private static final String auxTableNamePattern =
+        PdaoConstant.PDAO_PREFIX + "<auxId>_<table>_<randomSuffix>";
+
+    /**
+     * Generate a semi-random name for an 'auxiliary' BigQuery table
+     * to support a user-defined table.
+     *
+     * 'Auxiliary' tables can store helper information during ingest / at runtime.
+     * For example: staging tables, "raw" data tables, soft-delete lists.
+     *
+     * @param table user-defined table to generate an aux name for
+     * @param infixId identifier to include in the aux table name, to help distinguish
+     *                it in the BigQuery UI
+     */
+    public static String generateAuxTableName(DatasetTable table, String infixId) {
+        ST nameTemplate = new ST(auxTableNamePattern);
+        nameTemplate.add("table", table.getName());
+        nameTemplate.add("auxId", infixId);
+        nameTemplate.add("randomSuffix", StringUtils.replaceChars(UUID.randomUUID().toString(), '-', '_'));
+        return nameTemplate.render();
+    }
+
+    /**
+     * Convert a dataset request into a fully-populated dataset model.
+     *
+     * Names for "raw" and "soft-delete" tables will be generated and injected into
+     * the model after it is parsed from the base request. Since those generated names
+     * are semi-random, calling this method twice on the same request will produce
+     * different results.
+     */
+    public static Dataset convertRequestWithGeneratedNames(DatasetRequestModel request) {
+        Dataset baseDataset = DatasetJsonConversion.datasetRequestToDataset(request);
+        baseDataset.getTables().forEach(t -> {
+            t.rawTableName(generateAuxTableName(t, "raw"));
+            t.softDeleteTableName(generateAuxTableName(t, "sd"));
+        });
+        return baseDataset;
+    }
+}

--- a/src/main/java/bio/terra/service/dataset/RelationshipDao.java
+++ b/src/main/java/bio/terra/service/dataset/RelationshipDao.java
@@ -1,7 +1,6 @@
 package bio.terra.service.dataset;
 
 import bio.terra.common.DaoKeyHolder;
-import bio.terra.common.Table;
 import bio.terra.common.Column;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;

--- a/src/main/java/bio/terra/service/dataset/RelationshipDao.java
+++ b/src/main/java/bio/terra/service/dataset/RelationshipDao.java
@@ -56,7 +56,7 @@ public class RelationshipDao {
 
     private List<DatasetRelationship> retrieveDatasetRelationships(
             List<UUID> columnIds,
-            Map<UUID, Table> tables,
+            Map<UUID, DatasetTable> tables,
             Map<UUID, Column> columns) {
         String sql = "SELECT id, name, from_table, from_column, to_table, to_column "
                 + "FROM dataset_relationship WHERE from_column IN (:columns) OR to_column IN (:columns)";

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.dataset.flight.create;
 
+import bio.terra.common.PdaoConstant;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.dataset.Dataset;
@@ -9,10 +10,12 @@ import bio.terra.model.DatasetSummaryModel;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.FlightUtils;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 
 import java.util.UUID;
+
 
 public class CreateDatasetMetadataStep implements Step {
 
@@ -24,9 +27,20 @@ public class CreateDatasetMetadataStep implements Step {
         this.datasetRequest = datasetRequest;
     }
 
+    public static Dataset setUtilityTableNames(Dataset dataset) {
+        dataset.getTables().forEach(t -> {
+            String rawDataName = FlightUtils.randomizeName(PdaoConstant.RAW_DATA_PREFIX + t.getName());
+            String sdListName = FlightUtils.randomizeName(PdaoConstant.SOFT_DELETE_PREFIX + t.getName());
+            t.rawTableName(rawDataName);
+            t.softDeleteTableName(sdListName);
+        });
+        return dataset;
+    }
+
     @Override
     public StepResult doStep(FlightContext context) {
-        Dataset newDataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
+        Dataset newDataset = setUtilityTableNames(
+            DatasetJsonConversion.datasetRequestToDataset(datasetRequest));
         UUID datasetId = datasetDao.create(newDataset);
         FlightMap workingMap = context.getWorkingMap();
         workingMap.put(DatasetWorkingMapKeys.DATASET_ID, datasetId);

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
@@ -1,7 +1,7 @@
 package bio.terra.service.dataset.flight.create;
 
-import bio.terra.common.PdaoConstant;
 import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.dataset.DatasetUtils;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetJsonConversion;
@@ -10,7 +10,6 @@ import bio.terra.model.DatasetSummaryModel;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.FlightUtils;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 
@@ -27,20 +26,9 @@ public class CreateDatasetMetadataStep implements Step {
         this.datasetRequest = datasetRequest;
     }
 
-    public static Dataset setUtilityTableNames(Dataset dataset) {
-        dataset.getTables().forEach(t -> {
-            String rawDataName = FlightUtils.randomizeName(PdaoConstant.RAW_DATA_PREFIX + t.getName());
-            String sdListName = FlightUtils.randomizeName(PdaoConstant.SOFT_DELETE_PREFIX + t.getName());
-            t.rawTableName(rawDataName);
-            t.softDeleteTableName(sdListName);
-        });
-        return dataset;
-    }
-
     @Override
     public StepResult doStep(FlightContext context) {
-        Dataset newDataset = setUtilityTableNames(
-            DatasetJsonConversion.datasetRequestToDataset(datasetRequest));
+        Dataset newDataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         UUID datasetId = datasetDao.create(newDataset);
         FlightMap workingMap = context.getWorkingMap();
         workingMap.put(DatasetWorkingMapKeys.DATASET_ID, datasetId);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestInsertIntoDatasetTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestInsertIntoDatasetTableStep.java
@@ -5,6 +5,7 @@ import bio.terra.common.Table;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestResponseModel;
 import bio.terra.common.PdaoLoadStatistics;
+import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.dataset.DatasetService;
@@ -24,7 +25,7 @@ public class IngestInsertIntoDatasetTableStep implements Step {
     @Override
     public StepResult doStep(FlightContext context) {
         Dataset dataset = IngestUtils.getDataset(context, datasetService);
-        Table targetTable = IngestUtils.getDatasetTable(context, dataset);
+        DatasetTable targetTable = IngestUtils.getDatasetTable(context, dataset);
         String stagingTableName = IngestUtils.getStagingTableName(context);
 
         IngestRequestModel ingestRequest = IngestUtils.getIngestRequestModel(context);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestInsertIntoDatasetTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestInsertIntoDatasetTableStep.java
@@ -1,7 +1,6 @@
 package bio.terra.service.dataset.flight.ingest;
 
 import bio.terra.service.dataset.Dataset;
-import bio.terra.common.Table;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestResponseModel;
 import bio.terra.common.PdaoLoadStatistics;

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestSetupStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestSetupStep.java
@@ -1,15 +1,13 @@
 package bio.terra.service.dataset.flight.ingest;
 
-import bio.terra.common.PdaoConstant;
-import bio.terra.common.Table;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.DatasetUtils;
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.FlightUtils;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import liquibase.util.StringUtils;
 
 
 /**
@@ -49,9 +47,8 @@ public class IngestSetupStep implements Step {
         Dataset dataset = IngestUtils.getDataset(context, datasetService);
         IngestUtils.putDatasetName(context, dataset.getName());
 
-        Table targetTable = IngestUtils.getDatasetTable(context, dataset);
-        String baseName = PdaoConstant.PDAO_PREFIX + StringUtils.substring(targetTable.getName(), 0, 10);
-        String sgName = FlightUtils.randomizeNameInfix(baseName, "_st_");
+        DatasetTable targetTable = IngestUtils.getDatasetTable(context, dataset);
+        String sgName = DatasetUtils.generateAuxTableName(targetTable, "st");
         IngestUtils.putStagingTableName(context, sgName);
 
         return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -1,7 +1,6 @@
 package bio.terra.service.snapshot;
 
 import bio.terra.service.filedata.FSContainerInterface;
-import bio.terra.common.Table;
 
 import java.time.Instant;
 import java.util.Collections;

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -72,8 +72,8 @@ public class Snapshot implements FSContainerInterface {
         return this;
     }
 
-    public Optional<Table> getTableById(UUID id) {
-        for (Table tryTable : getTables()) {
+    public Optional<SnapshotTable> getTableById(UUID id) {
+        for (SnapshotTable tryTable : getTables()) {
             if (tryTable.getId().equals(id)) {
                 return Optional.of(tryTable);
             }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotMapTable.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotMapTable.java
@@ -1,6 +1,6 @@
 package bio.terra.service.snapshot;
 
-import bio.terra.common.Table;
+import bio.terra.service.dataset.DatasetTable;
 
 import java.util.Collections;
 import java.util.List;
@@ -8,8 +8,8 @@ import java.util.UUID;
 
 public class SnapshotMapTable {
     private UUID id;
-    private Table fromTable;
-    private Table toTable;
+    private DatasetTable fromTable;
+    private SnapshotTable toTable;
     private List<SnapshotMapColumn> snapshotMapColumns = Collections.emptyList();
 
     public UUID getId() {
@@ -21,20 +21,20 @@ public class SnapshotMapTable {
         return this;
     }
 
-    public Table getFromTable() {
+    public DatasetTable getFromTable() {
         return fromTable;
     }
 
-    public SnapshotMapTable fromTable(Table fromTable) {
+    public SnapshotMapTable fromTable(DatasetTable fromTable) {
         this.fromTable = fromTable;
         return this;
     }
 
-    public Table getToTable() {
+    public SnapshotTable getToTable() {
         return toTable;
     }
 
-    public SnapshotMapTable toTable(Table toTable) {
+    public SnapshotMapTable toTable(SnapshotTable toTable) {
         this.toTable = toTable;
         return this;
     }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotMapTableDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotMapTableDao.java
@@ -75,7 +75,7 @@ public class SnapshotMapTableDao {
                 }
 
                 UUID toTableId = UUID.fromString(rs.getString("to_table_id"));
-                Optional<Table> snapshotTable = snapshot.getTableById(toTableId);
+                Optional<SnapshotTable> snapshotTable = snapshot.getTableById(toTableId);
                 if (!snapshotTable.isPresent()) {
                     throw new CorruptMetadataException(
                             "Snapshot table referenced by snapshot source map table was not found!");

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -634,8 +634,8 @@ public class BigQueryPdao implements PrimaryDataAccess {
             "WHERE R." + PDAO_TABLE_ID_COLUMN + " = '<fromTableId>' AND " +
             "R." + PDAO_ROW_ID_COLUMN + " = F." + PDAO_ROW_ID_COLUMN + " AND <joinClause>) " +
             "SELECT " + PDAO_TABLE_ID_COLUMN + "," + PDAO_ROW_ID_COLUMN + " FROM merged_table WHERE " +
-            PDAO_ROW_ID_COLUMN + " NOT IN (SELECT " + PDAO_ROW_ID_COLUMN +
-            " FROM `<project>.<snapshot>." + PDAO_ROW_ID_TABLE + "`)";
+            PDAO_ROW_ID_COLUMN + " NOT IN " +
+            "(SELECT " + PDAO_ROW_ID_COLUMN + " FROM `<project>.<snapshot>." + PDAO_ROW_ID_TABLE + "`)";
 
     private static final String matchNonArrayTemplate =
         "T.<toColumn> = F.<fromColumn>";

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -111,7 +111,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
     private static final String liveViewTemplate =
         "SELECT R.* FROM `<project>.<dataset>.<rawTable>` R " +
             "LEFT OUTER JOIN `<project>.<dataset>.<sdTable>` S USING (" + PDAO_ROW_ID_COLUMN + ") " +
-            "WHERE D." + PDAO_ROW_ID_COLUMN + " IS NULL";
+            "WHERE S." + PDAO_ROW_ID_COLUMN + " IS NULL";
 
     private TableInfo buildLiveView(String bigQueryProject, String datasetName, DatasetTable table) {
         ST liveViewSql = new ST(liveViewTemplate);
@@ -410,14 +410,14 @@ public class BigQueryPdao implements PrimaryDataAccess {
             "SELECT <columns; separator=\",\"> FROM `<project>.<dataset>.<stagingTable>`";
 
     public void insertIntoDatasetTable(Dataset dataset,
-                                     Table targetTable,
+                                     DatasetTable targetTable,
                                      String stagingTableName) {
         BigQueryProject bigQueryProject = bigQueryProjectForDataset(dataset);
 
         ST sqlTemplate = new ST(insertIntoDatasetTableTemplate);
         sqlTemplate.add("project", bigQueryProject.getProjectId());
         sqlTemplate.add("dataset", prefixName(dataset.getName()));
-        sqlTemplate.add("targetTable", targetTable.getName());
+        sqlTemplate.add("targetTable", targetTable.getRawTableName());
         sqlTemplate.add("stagingTable", stagingTableName);
         sqlTemplate.add("columns", PDAO_ROW_ID_COLUMN);
         targetTable.getColumns().forEach(column -> sqlTemplate.add("columns", column.getName()));

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -734,7 +734,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             sqlTemplate.add("project", projectId);
             sqlTemplate.add("dataset", datasetBqDatasetName);
             sqlTemplate.add("snapshot", snapshotName);
-            sqlTemplate.add("mapTable", mapTable.getFromTable().getName());
+            sqlTemplate.add("mapTable", mapTable.getFromTable().getRawTableName());
             sqlTemplate.add("tableId", mapTable.getFromTable().getId().toString());
             table.getColumns().forEach(c -> {
                 sqlTemplate.add("columns", c.getName());

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -633,7 +633,9 @@ public class BigQueryPdao implements PrimaryDataAccess {
             "`<project>.<dataset>.<fromTableName>` F, `<project>.<snapshot>." + PDAO_ROW_ID_TABLE + "` R " +
             "WHERE R." + PDAO_TABLE_ID_COLUMN + " = '<fromTableId>' AND " +
             "R." + PDAO_ROW_ID_COLUMN + " = F." + PDAO_ROW_ID_COLUMN + " AND <joinClause>) " +
-            "SELECT " + PDAO_TABLE_ID_COLUMN + "," + PDAO_ROW_ID_COLUMN + " FROM merged_table";
+            "SELECT " + PDAO_TABLE_ID_COLUMN + "," + PDAO_ROW_ID_COLUMN + " FROM merged_table WHERE " +
+            PDAO_ROW_ID_COLUMN + " NOT IN (SELECT " + PDAO_ROW_ID_COLUMN +
+            " FROM `<project>.<snapshot>." + PDAO_ROW_ID_TABLE + "`)";
 
     private static final String matchNonArrayTemplate =
         "T.<toColumn> = F.<fromColumn>";
@@ -745,7 +747,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             String tableName = table.getName();
             String sql = sqlTemplate.render();
 
-            logger.info("Creating view" + snapshotName + "." + tableName + " as " + sql);
+            logger.info("Creating view " + snapshotName + "." + tableName + " as " + sql);
             TableId tableId = TableId.of(snapshotName, tableName);
             TableInfo tableInfo = TableInfo.of(tableId, ViewDefinition.of(sql));
             bigQuery.create(tableInfo);

--- a/src/main/java/bio/terra/stairway/FlightUtils.java
+++ b/src/main/java/bio/terra/stairway/FlightUtils.java
@@ -2,10 +2,7 @@ package bio.terra.stairway;
 
 import bio.terra.model.ErrorModel;
 import bio.terra.service.job.JobMapKeys;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
-
-import java.util.UUID;
 
 /**
  * Common methods for building flights
@@ -37,15 +34,6 @@ public final class FlightUtils {
         FlightMap workingMap = context.getWorkingMap();
         workingMap.put(JobMapKeys.RESPONSE.getKeyName(), responseObject);
         workingMap.put(JobMapKeys.STATUS_CODE.getKeyName(), responseStatus);
-    }
-
-    public static String randomizeName(String baseName) {
-        String name = baseName + UUID.randomUUID().toString();
-        return StringUtils.replaceChars(name, '-', '_');
-    }
-
-    public static String randomizeNameInfix(String baseName, String infix) {
-        return randomizeName(baseName + infix);
     }
 }
 

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -18,4 +18,5 @@
     <include file="changesets/20190801_primarykey.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20200102_loadtables.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20200130_dropcardinality.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20200305_trackliveviews.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20200305_trackliveviews.yaml
+++ b/src/main/resources/db/changesets/20200305_trackliveviews.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: trackliveviews
+      author: danmoran
+      changes:
+        - addColumn:
+            tableName: dataset_table
+            columns:
+              - column:
+                  name: raw_table_name
+                  type: text
+              - column:
+                  name: soft_delete_table_name
+                  type: text
+        - sql:
+            comment: Backfill
+            sql: >
+              UPDATE dataset_table SET raw_table_name = name,
+              soft_delete_table_name = 'datarepo_sd_' || name
+        - addNotNullConstraint:
+            tableName: dataset_table
+            columnName: raw_table_name
+        - addNotNullConstraint:
+            tableName: dataset_table
+            columnName: soft_delete_table_name

--- a/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
@@ -516,7 +516,7 @@ public class SnapshotOperationTest {
         }
     }
 
-    private static final String queryForCountTemlate =
+    private static final String queryForCountTemplate =
         "SELECT COUNT(*) FROM `<project>.<snapshot>.<table>`";
 
     // Get the count of rows in a table or view
@@ -527,7 +527,7 @@ public class SnapshotOperationTest {
         String bigQueryProjectId = bigQueryProject.getProjectId();
         BigQuery bigQuery = bigQueryProject.getBigQuery();
 
-        ST sqlTemplate = new ST(queryForCountTemlate);
+        ST sqlTemplate = new ST(queryForCountTemplate);
         sqlTemplate.add("project", bigQueryProjectId);
         sqlTemplate.add("snapshot", snapshotName);
         sqlTemplate.add("table", tableName);

--- a/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
@@ -1,6 +1,7 @@
 package bio.terra.app.controller;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.TestUtils;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.JsonLoader;
@@ -17,9 +18,7 @@ import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotSourceModel;
 import bio.terra.model.SnapshotSummaryModel;
-import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetDao;
-import bio.terra.service.dataset.DatasetDataProject;
 import bio.terra.service.iam.IamService;
 import bio.terra.service.resourcemanagement.BillingProfile;
 import bio.terra.service.resourcemanagement.DataLocationService;
@@ -160,7 +159,8 @@ public class SnapshotOperationTest {
     public void testMinimal() throws Exception {
         DatasetSummaryModel datasetSummary = setupMinimalDataset();
         String datasetName = PDAO_PREFIX + datasetSummary.getName();
-        BigQueryProject bigQueryProject = bigQueryProjectForDatasetName(datasetSummary.getName());
+        BigQueryProject bigQueryProject = TestUtils.bigQueryProjectForDatasetName(
+            datasetDao, dataLocationService, datasetSummary.getName());
         long datasetParticipants = queryForCount(datasetName, "participant", bigQueryProject);
         assertThat("dataset participants loaded properly", datasetParticipants, equalTo(2L));
         long datasetSamples = queryForCount(datasetName, "sample", bigQueryProject);
@@ -182,7 +182,8 @@ public class SnapshotOperationTest {
     public void testArrayStruct() throws Exception {
         DatasetSummaryModel datasetSummary = setupArrayStructDataset();
         String datasetName = PDAO_PREFIX + datasetSummary.getName();
-        BigQueryProject bigQueryProject = bigQueryProjectForDatasetName(datasetSummary.getName());
+        BigQueryProject bigQueryProject = TestUtils.bigQueryProjectForDatasetName(
+            datasetDao, dataLocationService, datasetSummary.getName());
         long datasetParticipants = queryForCount(datasetName, "participant", bigQueryProject);
         assertThat("dataset participants loaded properly", datasetParticipants, equalTo(2L));
         long datasetSamples = queryForCount(datasetName, "sample", bigQueryProject);
@@ -308,12 +309,6 @@ public class SnapshotOperationTest {
 
     private void loadJsonData(String datasetId, String tableName, String resourcePath) throws Exception {
         loadData(datasetId, tableName, resourcePath, IngestRequestModel.FormatEnum.JSON);
-    }
-
-    private BigQueryProject bigQueryProjectForDatasetName(String datasetName) {
-        Dataset dataset = datasetDao.retrieveByName(datasetName);
-        DatasetDataProject dataProject = dataLocationService.getOrCreateProject(dataset);
-        return BigQueryProject.get(dataProject.getGoogleProjectId());
     }
 
     private void loadData(String datasetId,

--- a/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotOperationTest.java
@@ -1,5 +1,6 @@
 package bio.terra.app.controller;
 
+import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.JsonLoader;
@@ -10,6 +11,7 @@ import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.DeleteResponseModel;
 import bio.terra.model.EnumerateSnapshotModel;
 import bio.terra.model.ErrorModel;
+import bio.terra.model.IngestRequestModel;
 import bio.terra.model.JobModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotRequestModel;
@@ -26,19 +28,13 @@ import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import bio.terra.service.tabulardata.google.BigQueryProject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.BigQueryError;
-import com.google.cloud.bigquery.CsvOptions;
 import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.FieldValueList;
-import com.google.cloud.bigquery.FormatOptions;
-import com.google.cloud.bigquery.Job;
-import com.google.cloud.bigquery.JobId;
-import com.google.cloud.bigquery.JobStatus;
 import com.google.cloud.bigquery.QueryJobConfiguration;
-import com.google.cloud.bigquery.TableDataWriteChannel;
-import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
-import com.google.cloud.bigquery.WriteChannelConfiguration;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
@@ -57,10 +53,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.stringtemplate.v4.ST;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -108,6 +102,7 @@ public class SnapshotOperationTest {
     @Autowired private DataLocationService dataLocationService;
     @Autowired private GoogleResourceConfiguration googleResourceConfiguration;
     @Autowired private ConnectedOperations connectedOperations;
+    @Autowired private ConnectedTestConfiguration testConfig;
 
     @MockBean
     private IamService samService;
@@ -116,6 +111,7 @@ public class SnapshotOperationTest {
     private List<String> createdDatasetIds;
     private String snapshotOriginalName;
     private BillingProfile billingProfile;
+    private Storage storage = StorageOptions.getDefaultInstance().getService();
 
     @Before
     public void setup() throws Exception {
@@ -145,7 +141,7 @@ public class SnapshotOperationTest {
     @Test
     public void testHappyPath() throws Exception {
         DatasetSummaryModel datasetSummary = createTestDataset("snapshot-test-dataset.json");
-        loadCsvData(datasetSummary.getName(), "thetable", "snapshot-test-dataset-data.csv");
+        loadCsvData(datasetSummary.getId(), "thetable", "snapshot-test-dataset-data.csv");
 
         SnapshotRequestModel snapshotRequest = makeSnapshotTestRequest(datasetSummary, "snapshot-test-snapshot.json");
         MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_thp_");
@@ -218,7 +214,7 @@ public class SnapshotOperationTest {
     @Test
     public void testEnumeration() throws Exception {
         DatasetSummaryModel datasetSummary = createTestDataset("snapshot-test-dataset.json");
-        loadCsvData(datasetSummary.getName(), "thetable", "snapshot-test-dataset-data.csv");
+        loadCsvData(datasetSummary.getId(), "thetable", "snapshot-test-dataset-data.csv");
         SnapshotRequestModel snapshotRequest = makeSnapshotTestRequest(datasetSummary, "snapshot-test-snapshot.json");
 
         // Other unit tests exercise the array bounds, so here we don't fuss with that here.
@@ -262,7 +258,7 @@ public class SnapshotOperationTest {
     @Test
     public void testBadData() throws Exception {
         DatasetSummaryModel datasetSummary = createTestDataset("snapshot-test-dataset.json");
-        loadCsvData(datasetSummary.getName(), "thetable", "snapshot-test-dataset-data.csv");
+        loadCsvData(datasetSummary.getId(), "thetable", "snapshot-test-dataset-data.csv");
         SnapshotRequestModel badDataRequest = makeSnapshotTestRequest(datasetSummary,
                 "snapshot-test-snapshot-baddata.json");
 
@@ -273,15 +269,15 @@ public class SnapshotOperationTest {
 
     private DatasetSummaryModel setupMinimalDataset() throws Exception {
         DatasetSummaryModel datasetSummary = createTestDataset("dataset-minimal.json");
-        loadCsvData(datasetSummary.getName(), "participant", "dataset-minimal-participant.csv");
-        loadCsvData(datasetSummary.getName(), "sample", "dataset-minimal-sample.csv");
+        loadCsvData(datasetSummary.getId(), "participant", "dataset-minimal-participant.csv");
+        loadCsvData(datasetSummary.getId(), "sample", "dataset-minimal-sample.csv");
         return  datasetSummary;
     }
 
     private DatasetSummaryModel setupArrayStructDataset() throws Exception {
         DatasetSummaryModel datasetSummary = createTestDataset("dataset-array-struct.json");
-        loadJsonData(datasetSummary.getName(), "participant", "dataset-array-struct-participant.json");
-        loadJsonData(datasetSummary.getName(), "sample", "dataset-array-struct-sample.json");
+        loadJsonData(datasetSummary.getId(), "participant", "dataset-array-struct-participant.json");
+        loadJsonData(datasetSummary.getId(), "sample", "dataset-array-struct-sample.json");
         return  datasetSummary;
     }
 
@@ -306,13 +302,12 @@ public class SnapshotOperationTest {
         return datasetSummaryModel;
     }
 
-    private void loadCsvData(String datasetName, String tableName, String resourcePath) throws Exception {
-        FormatOptions csvOptions = CsvOptions.newBuilder().setSkipLeadingRows(1).build();
-        loadData(datasetName, tableName, resourcePath, csvOptions);
+    private void loadCsvData(String datasetId, String tableName, String resourcePath) throws Exception {
+        loadData(datasetId, tableName, resourcePath, IngestRequestModel.FormatEnum.CSV);
     }
 
-    private void loadJsonData(String datasetName, String tableName, String resourcePath) throws Exception {
-        loadData(datasetName, tableName, resourcePath, FormatOptions.json());
+    private void loadJsonData(String datasetId, String tableName, String resourcePath) throws Exception {
+        loadData(datasetId, tableName, resourcePath, IngestRequestModel.FormatEnum.JSON);
     }
 
     private BigQueryProject bigQueryProjectForDatasetName(String datasetName) {
@@ -321,40 +316,29 @@ public class SnapshotOperationTest {
         return BigQueryProject.get(dataProject.getGoogleProjectId());
     }
 
-    private void loadData(String datasetName,
+    private void loadData(String datasetId,
                           String tableName,
                           String resourcePath,
-                          FormatOptions options) throws Exception {
-        String snapshotName = PDAO_PREFIX + datasetName;
-        String location = "US";
-        TableId tableId = TableId.of(snapshotName, tableName);
-        BigQueryProject bigQueryProject = bigQueryProjectForDatasetName(datasetName);
-        BigQuery bigQuery = bigQueryProject.getBigQuery();
+                          IngestRequestModel.FormatEnum format) throws Exception {
 
-        WriteChannelConfiguration writeChannelConfiguration =
-            WriteChannelConfiguration.newBuilder(tableId).setFormatOptions(options).build();
+        String bucket = testConfig.getIngestbucket();
+        BlobInfo stagingBlob = BlobInfo.newBuilder(bucket, resourcePath).build();
+        byte[] data = IOUtils.toByteArray(jsonLoader.getClassLoader().getResource(resourcePath));
 
-        // The location must be specified; other fields can be auto-detected.
-        JobId jobId = JobId.newBuilder().setLocation(location).build();
-        TableDataWriteChannel writer = bigQuery.writer(jobId, writeChannelConfiguration);
+        IngestRequestModel ingestRequest = new IngestRequestModel()
+            .table(tableName)
+            .format(format)
+            .path("gs://" + stagingBlob.getBucket() + "/" + stagingBlob.getName());
 
-        // Write data to writer
-        try (OutputStream stream = Channels.newOutputStream(writer);
-             InputStream csvStream = jsonLoader.getClassLoader().getResourceAsStream(resourcePath)) {
-            IOUtils.copy(csvStream, stream);
+        if (format.equals(IngestRequestModel.FormatEnum.CSV)) {
+            ingestRequest.csvSkipLeadingRows(1);
         }
 
-        // Get load job
-        Job job = writer.getJob();
-        job = job.waitFor();
-        JobStatus jobStatus = job.getStatus();
-        List<BigQueryError> jobErrors = jobStatus.getExecutionErrors();
-        if (jobErrors != null && jobErrors.size() != 0) {
-            System.out.println("Errors loading dataset data: ");
-            for (BigQueryError bqError : jobErrors) {
-                System.out.println(bqError.toString());
-            }
-            fail("Failed to load dataset data");
+        try {
+            storage.create(stagingBlob, data);
+            connectedOperations.ingestTableSuccess(datasetId, ingestRequest);
+        } finally {
+            storage.delete(stagingBlob.getBlobId());
         }
     }
 
@@ -532,6 +516,9 @@ public class SnapshotOperationTest {
         }
     }
 
+    private static final String queryForCountTemlate =
+        "SELECT COUNT(*) FROM `<project>.<snapshot>.<table>`";
+
     // Get the count of rows in a table or view
     private long queryForCount(
         String snapshotName,
@@ -539,11 +526,13 @@ public class SnapshotOperationTest {
         BigQueryProject bigQueryProject) throws Exception {
         String bigQueryProjectId = bigQueryProject.getProjectId();
         BigQuery bigQuery = bigQueryProject.getBigQuery();
-        StringBuilder builder = new StringBuilder();
-        builder.append("SELECT COUNT(*) FROM `")
-                .append(bigQueryProjectId).append('.').append(snapshotName).append('.').append(tableName).append('`');
-        String sql = builder.toString();
-        QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(sql).build();
+
+        ST sqlTemplate = new ST(queryForCountTemlate);
+        sqlTemplate.add("project", bigQueryProjectId);
+        sqlTemplate.add("snapshot", snapshotName);
+        sqlTemplate.add("table", tableName);
+
+        QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(sqlTemplate.render()).build();
         TableResult result = bigQuery.query(queryConfig);
         FieldValueList row = result.iterateAll().iterator().next();
         FieldValue countValue = row.get(0);

--- a/src/test/java/bio/terra/common/TestUtils.java
+++ b/src/test/java/bio/terra/common/TestUtils.java
@@ -1,7 +1,12 @@
 package bio.terra.common;
 
 import bio.terra.model.DRSAccessMethod;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.dataset.DatasetDataProject;
 import bio.terra.service.iam.IamResourceType;
+import bio.terra.service.resourcemanagement.DataLocationService;
+import bio.terra.service.tabulardata.google.BigQueryProject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +80,14 @@ public final class TestUtils {
         }
 
         return httpPathString;
+    }
+
+    public static BigQueryProject bigQueryProjectForDatasetName(
+        DatasetDao datasetDao, DataLocationService dataLocationService, String datasetName) {
+
+        Dataset dataset = datasetDao.retrieveByName(datasetName);
+        DatasetDataProject dataProject = dataLocationService.getOrCreateProject(dataset);
+        return BigQueryProject.get(dataProject.getGoogleProjectId());
     }
 }
 

--- a/src/test/java/bio/terra/service/DatasetUtilsTest.java
+++ b/src/test/java/bio/terra/service/DatasetUtilsTest.java
@@ -1,0 +1,59 @@
+package bio.terra.service;
+
+import bio.terra.common.PdaoConstant;
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.DatasetUtils;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class DatasetUtilsTest {
+
+    @Autowired
+    private JsonLoader jsonLoader;
+
+    @Test
+    public void generateAuxTableNameTest() {
+        DatasetTable testTable = new DatasetTable().name("my_cool_table");
+        String auxName1 = DatasetUtils.generateAuxTableName(testTable, "test");
+        String auxName2 = DatasetUtils.generateAuxTableName(testTable, "test");
+
+        for (String name : Arrays.asList(auxName1, auxName2)) {
+            Assert.assertThat(name, Matchers.startsWith(PdaoConstant.PDAO_PREFIX));
+            Assert.assertThat(name, Matchers.containsString(testTable.getName()));
+            Assert.assertThat(name, Matchers.containsString("test"));
+            Assert.assertThat(name, Matchers.not(Matchers.containsString("-")));
+        }
+
+        Assert.assertNotEquals(auxName1, auxName2);
+    }
+
+    @Test
+    public void convertDatasetTest() throws Exception {
+        UUID fakeProfileId = UUID.randomUUID();
+        DatasetRequestModel datasetRequest = jsonLoader.loadObject(
+            "ingest-test-dataset.json", DatasetRequestModel.class).defaultProfileId(fakeProfileId.toString());
+        Dataset convertedDataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
+        for (DatasetTable table : convertedDataset.getTables()) {
+            Assert.assertNotNull(table.getRawTableName());
+            Assert.assertNotNull(table.getSoftDeleteTableName());
+        }
+    }
+}

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -56,7 +56,12 @@ public class DatasetDaoTest {
 
     private UUID createDataset(DatasetRequestModel datasetRequest, String newName) {
         datasetRequest.name(newName).defaultProfileId(billingProfile.getId().toString());
-        return datasetDao.create(DatasetJsonConversion.datasetRequestToDataset(datasetRequest));
+        Dataset dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
+        dataset.getTables().forEach(t -> {
+            t.rawTableName(t.getName() + "_raw");
+            t.softDeleteTableName(t.getName() + "_sd");
+        });
+        return datasetDao.create(dataset);
     }
 
     private UUID createDataset(String datasetFile) throws IOException {

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -56,11 +56,7 @@ public class DatasetDaoTest {
 
     private UUID createDataset(DatasetRequestModel datasetRequest, String newName) {
         datasetRequest.name(newName).defaultProfileId(billingProfile.getId().toString());
-        Dataset dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
-        dataset.getTables().forEach(t -> {
-            t.rawTableName(t.getName() + "_raw");
-            t.softDeleteTableName(t.getName() + "_sd");
-        });
+        Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         return datasetDao.create(dataset);
     }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -77,7 +77,12 @@ public class DatasetServiceTest {
 
     private UUID createDataset(DatasetRequestModel datasetRequest, String newName) {
         datasetRequest.name(newName).defaultProfileId(billingProfile.getId().toString());
-        return datasetDao.create(DatasetJsonConversion.datasetRequestToDataset(datasetRequest));
+        Dataset dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
+        dataset.getTables().forEach(t -> {
+            t.softDeleteTableName(t.getName() + "_sd");
+            t.rawTableName(t.getName() + "_raw");
+        });
+        return datasetDao.create(dataset);
     }
 
     private UUID createDataset(String datasetFile) throws IOException {

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -77,11 +77,7 @@ public class DatasetServiceTest {
 
     private UUID createDataset(DatasetRequestModel datasetRequest, String newName) {
         datasetRequest.name(newName).defaultProfileId(billingProfile.getId().toString());
-        Dataset dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
-        dataset.getTables().forEach(t -> {
-            t.softDeleteTableName(t.getName() + "_sd");
-            t.rawTableName(t.getName() + "_raw");
-        });
+        Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         return datasetDao.create(dataset);
     }
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -9,8 +9,8 @@ import bio.terra.common.MetadataEnumeration;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.common.Table;
 import bio.terra.model.SnapshotRequestModel;
-import bio.terra.service.dataset.DatasetJsonConversion;
 import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.dataset.DatasetUtils;
 import bio.terra.service.resourcemanagement.ProfileDao;
 import org.junit.After;
 import org.junit.Before;
@@ -67,11 +67,7 @@ public class SnapshotDaoTest {
         datasetRequest
             .name(datasetRequest.getName() + UUID.randomUUID().toString())
             .defaultProfileId(profileId.toString());
-        dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
-        dataset.getTables().forEach(t -> {
-            t.softDeleteTableName(t.getName() + "_sd");
-            t.rawTableName(t.getName() + "_raw");
-        });
+        dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         datasetId = datasetDao.create(dataset);
         dataset = datasetDao.retrieve(datasetId);
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -67,7 +67,12 @@ public class SnapshotDaoTest {
         datasetRequest
             .name(datasetRequest.getName() + UUID.randomUUID().toString())
             .defaultProfileId(profileId.toString());
-        datasetId = datasetDao.create(DatasetJsonConversion.datasetRequestToDataset(datasetRequest));
+        dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequest);
+        dataset.getTables().forEach(t -> {
+            t.softDeleteTableName(t.getName() + "_sd");
+            t.rawTableName(t.getName() + "_raw");
+        });
+        datasetId = datasetDao.create(dataset);
         dataset = datasetDao.retrieve(datasetId);
 
         snapshotRequest = jsonLoader.loadObject("snapshot-test-snapshot.json", SnapshotRequestModel.class)

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -22,8 +22,6 @@ import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import bio.terra.service.dataset.DatasetService;
 import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.FieldValue;
-import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableId;


### PR DESCRIPTION
And use the live view to drive snapshot population.

I tried to set this up to both:
1. Make the switch from raw data -> live view transparent to current consumers of dataset metadata (primarily the UI), and
2. Be backwards-compatible with existing datasets that don't have a live view defined

The way I implemented 2) effectively disables soft-deletion for existing datasets (i.e. V2F, the Broad epi demo, and our 1st pass at ClinVar). Monster doesn't plan to push more data into any of those datasets so I think it should be ok.