### PR TITLE
DR-826 Check whether RESTORE_IPS is defined

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -119,7 +119,9 @@ jobs:
       - name: "Post test cleanup"
         if: always()
         run: |
-          # restore the original list of authorized IPs
-          gcloud container clusters update ${CLUSTER_NAME} \
-            --enable-master-authorized-networks \
-            --master-authorized-networks ${RESTORE_IPS}
+          # restore the original list of authorized IPs if they exist
+          if [ ! -z "${RESTORE_IPS}"]; then
+            gcloud container clusters update ${CLUSTER_NAME} \
+              --enable-master-authorized-networks \
+              --master-authorized-networks ${RESTORE_IPS}
+          fi


### PR DESCRIPTION
Quick fix to make sure that the test cleanup step always succeeds.