### PR TITLE
DR-828 Check for unique constraint violation before deleting Snapshot metadata.

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -1,5 +1,7 @@
 package bio.terra.service.snapshot.flight.create;
 
+import bio.terra.common.DaoUtils;
+import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
 import bio.terra.stairway.FlightUtils;
@@ -13,6 +15,9 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 
 import java.util.UUID;
@@ -21,6 +26,8 @@ public class CreateSnapshotMetadataStep implements Step {
     private SnapshotDao snapshotDao;
     private SnapshotService snapshotService;
     private SnapshotRequestModel snapshotReq;
+
+    private static Logger logger = LoggerFactory.getLogger(CreateSnapshotMetadataStep.class);
 
     public CreateSnapshotMetadataStep(
         SnapshotDao snapshotDao, SnapshotService snapshotService, SnapshotRequestModel snapshotReq) {
@@ -39,6 +46,16 @@ public class CreateSnapshotMetadataStep implements Step {
             SnapshotSummaryModel response = snapshotService.makeSummaryModelFromSummary(snapshotSummary);
             FlightUtils.setResponse(context, response, HttpStatus.CREATED);
             return StepResult.getStepResultSuccess();
+        } catch (DataAccessException daEx) {
+            // check if the metadata creation failed because of a PK violation
+            // this happens when trying to create a snapshot with the same name as one that already exists
+            if (DaoUtils.isUniqueViolationException(daEx, "snapshot_name_key")) {
+                // in this case, we don't want to delete the metadata in the undo step
+                // so, set the SNAPSHOT_ID key in the context map to true, indicating to the undo step that the
+                // snapshot already exists.
+                context.getWorkingMap().put(JobMapKeys.SNAPSHOT_ID.getKeyName(), Boolean.TRUE);
+            }
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, daEx);
         } catch (SnapshotNotFoundException ex) {
             FlightUtils.setErrorResponse(context, ex.toString(), HttpStatus.BAD_REQUEST);
             return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
@@ -47,8 +64,15 @@ public class CreateSnapshotMetadataStep implements Step {
 
     @Override
     public StepResult undoStep(FlightContext context) {
-        String snapshotName = snapshotReq.getName();
-        snapshotDao.deleteByName(snapshotName);
+        // if this step failed because there is already a snapshot with this name, then don't delete the metadata
+        Boolean snapshotIdExists = context.getWorkingMap().get(JobMapKeys.SNAPSHOT_ID.getKeyName(), Boolean.class);
+        if (snapshotIdExists != null && snapshotIdExists.booleanValue()) {
+            logger.debug("Snapshot creation failed because of a PK violation. Not deleting metadata.");
+        } else {
+            logger.debug("Snapshot creation failed for a reason other than a PK violation. Deleting metadata.");
+            String snapshotName = snapshotReq.getName();
+            snapshotDao.deleteByName(snapshotName);
+        }
         return StepResult.getStepResultSuccess();
     }
 


### PR DESCRIPTION
In the create metadata step of snapshot creation, the insert into the snapshot table in PostGres may fail if there is already a snapshot with the same name. In this case, we don't want to delete the metadata in the undo direction.

I set a flag in the context working map, and then changed the undo direction to check the flag before deleting anything.

This came up while I was working on the POC. From the CLI particularly, it's really easy to run the same snapshot creation command twice, and then the snapshot would become unusable because its metadata was deleted.