### PR TITLE
DR-786 Bump swagger-codegen and google-cloud-bigquery versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ build/
 src/generated/
 .swagger-codegen/
 .swagger-codegen-ignore
+pom.xml
 
 # gradle files
 .gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-        classpath('io.swagger:swagger-codegen:2.3.1')
+        classpath('io.swagger:swagger-codegen:2.4.11')
         classpath('gradle.plugin.com.srcclr:gradle:3.1.0')
     }
 }
@@ -115,7 +115,7 @@ dependencies {
     compile 'com.google.apis:google-api-services-cloudbilling:v1-rev20200106-1.30.3'
     compile 'com.google.apis:google-api-services-cloudresourcemanager:v1-rev549-1.25.0'
     compile 'com.google.apis:google-api-services-serviceusage:v1beta1-rev206-1.25.0'
-    compile 'com.google.cloud:google-cloud-bigquery:1.91.0'
+    compile 'com.google.cloud:google-cloud-bigquery:1.108.1'
     compile 'com.google.cloud:google-cloud-storage:1.92.0'
     compile 'com.google.cloud:google-cloud-firestore:1.22.0'
     compile 'io.springfox:springfox-swagger-ui:2.9.2'

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -6,8 +6,6 @@ import java.util.regex.Pattern;
 
 public final class ValidationUtils {
 
-    private static final String VALID_NAME_REGEX = "[a-zA-Z0-9_]{1,63}";
-
     // pattern taken from https://stackoverflow.com/questions/8204680/java-regex-email
     private static final Pattern VALID_EMAIL_REGEX = Pattern.compile("[a-z0-9!#$%&'*+/=?^_`{|}~-]+" +
             "(?:.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?",
@@ -23,10 +21,6 @@ public final class ValidationUtils {
 
     public static <T> boolean hasDuplicates(List<T> list) {
         return !(list.size() == new HashSet(list).size());
-    }
-
-    public static boolean isValidName(String name) {
-        return Pattern.matches(VALID_NAME_REGEX, name);
     }
 
     public static boolean isValidDescription(String name) {

--- a/src/main/java/bio/terra/service/dataset/AssetModelValidator.java
+++ b/src/main/java/bio/terra/service/dataset/AssetModelValidator.java
@@ -32,8 +32,6 @@ public class AssetModelValidator implements Validator {
     private void validateAssetName(String assetName, Errors errors) {
         if (assetName == null) {
             errors.rejectValue("name", "AssetNameMissing");
-        } else if (!ValidationUtils.isValidName(assetName)) {
-            errors.rejectValue("name", "AssetNameInvalid");
         }
     }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -69,11 +69,10 @@ public class DatasetRequestValidator implements Validator {
     }
 
     private void validateDatasetName(String datasetName, Errors errors) {
+        // NOTE: We used to manually check the name against a pattern here, but the latest
+        // versions of Swagger codegen now auto-generate an equivalent check.
         if (datasetName == null) {
             errors.rejectValue("name", "DatasetNameMissing");
-        } else if (!ValidationUtils.isValidName(datasetName)) {
-            errors.rejectValue("name", "DatasetNameInvalid",
-                "Invalid dataset name " + datasetName);
         }
     }
 

--- a/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
@@ -2,7 +2,6 @@ package bio.terra.service.dataset;
 
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.IngestRequestModel;
-import bio.terra.common.ValidationUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -22,9 +21,6 @@ public class IngestRequestValidator implements Validator {
         if (name == null) {
             errors.rejectValue("name", "TableNameMissing",
                 "Ingest requires a table name");
-        } else if (!ValidationUtils.isValidName(name)) {
-            errors.rejectValue("name", "TableNameInvalid",
-                "Invalid table name " + name);
         }
     }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotRequestValidator.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotRequestValidator.java
@@ -33,8 +33,6 @@ public class SnapshotRequestValidator implements Validator {
     private void validateSnapshotName(String snapshotName, Errors errors) {
         if (snapshotName == null) {
             errors.rejectValue("name", "SnapshotNameMissing");
-        } else if (!ValidationUtils.isValidName(snapshotName)) {
-            errors.rejectValue("name", "SnapshotNameInvalid");
         }
     }
 
@@ -52,13 +50,9 @@ public class SnapshotRequestValidator implements Validator {
                 String assetName = source.getAssetName();
                 if (datasetName == null) {
                     errors.rejectValue("contents", "SnapshotDatasetNameMissing");
-                } else if (!ValidationUtils.isValidName(datasetName)) {
-                    errors.rejectValue("contents", "SnapshotDatasetNameInvalid");
                 }
                 if (assetName == null) {
                     errors.rejectValue("contents", "SnapshotAssetNameMissing");
-                } else if (!ValidationUtils.isValidName(assetName)) {
-                    errors.rejectValue("contents", "SnapshotAssetNameInvalid");
                 }
             });
         }

--- a/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
@@ -255,18 +255,18 @@ public class DatasetValidationsTest {
     @Test
     public void testDatasetNameInvalid() throws Exception {
         ErrorModel errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name("no spaces"));
-        checkValidationErrorModel("datasetNameInvalid", errorModel, new String[]{"DatasetNameInvalid"});
+        checkValidationErrorModel("datasetNameInvalid", errorModel, new String[]{"Pattern"});
 
         errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name("no-dashes"));
-        checkValidationErrorModel("datasetNameInvalid", errorModel, new String[]{"DatasetNameInvalid"});
+        checkValidationErrorModel("datasetNameInvalid", errorModel, new String[]{"Pattern"});
 
         errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(""));
-        checkValidationErrorModel("datasetNameInvalid", errorModel, new String[]{"DatasetNameInvalid"});
+        checkValidationErrorModel("datasetNameInvalid", errorModel, new String[]{"Size", "Pattern"});
 
         // Make a 64 character string, it should be considered too long by the validation.
         String tooLong = StringUtils.repeat("a", 64);
         errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(tooLong));
-        checkValidationErrorModel("datasetNameInvalid", errorModel, new String[]{"DatasetNameInvalid"});
+        checkValidationErrorModel("datasetNameInvalid", errorModel, new String[]{"Size"});
     }
 
     @Test
@@ -339,7 +339,7 @@ public class DatasetValidationsTest {
             errorModel.getMessage(), containsString("Validation errors - see error details"));
         for (int i = 0; i < messageCodes.length; i++) {
             String code = messageCodes[i];
-            assertThat(context + ": correct message code (" + i + ")",
+            assertThat(context + ": correct message code (" + code + ")",
                 /**
                  * The global exception handler logs in this format:
                  *

--- a/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
@@ -12,6 +12,7 @@ import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -27,6 +28,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static bio.terra.common.fixtures.DatasetFixtures.buildAsset;
 import static bio.terra.common.fixtures.DatasetFixtures.buildAssetParticipantTable;
@@ -36,6 +38,7 @@ import static bio.terra.common.fixtures.DatasetFixtures.buildParticipantSampleRe
 import static bio.terra.common.fixtures.DatasetFixtures.buildSampleTerm;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -335,20 +338,21 @@ public class DatasetValidationsTest {
                                            String[] messageCodes) {
         List<String> details = errorModel.getErrorDetail();
         int requiredDetailSize = messageCodes.length;
-        assertThat("Got the expected error details", details.size(), equalTo(requiredDetailSize));
-        assertThat("Main message is right",
+        assertThat(context + ": got the expected error details",
+            details.size(), equalTo(requiredDetailSize));
+        assertThat(context + ": main message is right",
             errorModel.getMessage(), containsString("Validation errors - see error details"));
-        for (int i = 0; i < messageCodes.length; i++) {
-            String code = messageCodes[i];
-            assertThat(context + ": correct message code (" + code + ")",
-                /**
-                 * The global exception handler logs in this format:
-                 *
-                 * <fieldName>: '<messageCode>' (<defaultMessage>)
-                 *
-                 * We check to see if the code is wrapped in quotes to prevent matching on substrings.
-                 */
-                details.get(i), containsString("'" + messageCodes[i] + "'"));
-        }
+        /*
+         * The global exception handler logs in this format:
+         *
+         * <fieldName>: '<messageCode>' (<defaultMessage>)
+         *
+         * We check to see if the code is wrapped in quotes to prevent matching on substrings.
+         */
+        List<Matcher<? super String>> expectedMatches = Arrays.stream(messageCodes)
+            .map(code -> containsString("'" + code + "'"))
+            .collect(Collectors.toList());
+        assertThat(context + ": detail codes are right",
+            details, containsInAnyOrder(expectedMatches));
     }
 }


### PR DESCRIPTION
We need to bump these two libraries to implement support for partitioned tables.
* `google-cloud-bigquery` to get support for setting partition options on table creation
* `swagger-codegen` to fix a problem where `int64` properties were generating `Integer`s instead of `Long`s (a problem for exposing int-partitioning options in the API)

Bumping `swagger-codegen` broke some other behavior. I made what looked like minimal fixes to me. I'll comment explanations / justifications inline.