### PR TITLE
DR-890 bulk ingest integration test

### DIFF
--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -8,6 +8,8 @@ import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.model.AssetModel;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
+import bio.terra.model.BulkLoadArrayRequestModel;
+import bio.terra.model.BulkLoadArrayResultModel;
 import bio.terra.model.ConfigGroupModel;
 import bio.terra.model.ConfigListModel;
 import bio.terra.model.ConfigModel;
@@ -45,6 +47,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @Component
 public class DataRepoFixtures {
@@ -383,6 +386,35 @@ public class DataRepoFixtures {
         assertThat("ingestFile is successful", response.getStatusCode(), equalTo(HttpStatus.OK));
         assertTrue("ingestFile response is present", response.getResponseObject().isPresent());
         return response.getResponseObject().get();
+    }
+
+    public BulkLoadArrayResultModel bulkLoadArray(
+        TestConfiguration.User user,
+        String datasetId,
+        BulkLoadArrayRequestModel requestModel) throws Exception {
+
+        String json = TestUtils.mapToJson(requestModel);
+
+        DataRepoResponse<JobModel> launchResponse = dataRepoClient.post(
+            user,
+            "/api/repository/v1/datasets/" + datasetId + "/files/bulk/array",
+            json,
+            JobModel.class);
+        assertTrue("bulkLoadArray launch succeeded", launchResponse.getStatusCode().is2xxSuccessful());
+        assertTrue("bulkloadArray launch response is present", launchResponse.getResponseObject().isPresent());
+
+        DataRepoResponse<BulkLoadArrayResultModel> response =
+            dataRepoClient.waitForResponse(user, launchResponse, BulkLoadArrayResultModel.class);
+        if (response.getStatusCode().is2xxSuccessful()) {
+            assertThat("bulkLoadArray is successful", response.getStatusCode(), equalTo(HttpStatus.OK));
+            assertTrue("ingestFile response is present", response.getResponseObject().isPresent());
+            return response.getResponseObject().get();
+        } else {
+            ErrorModel errorModel = response.getErrorObject().orElse(null);
+            logger.error("bulkLoadArray failed: " + errorModel);
+            fail();
+            return null; // Make findbugs happy
+        }
     }
 
     public DataRepoResponse<FileModel> getFileByIdRaw(

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -17,7 +17,6 @@ import com.google.cloud.storage.StorageOptions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -81,9 +80,6 @@ public class FileTest extends UsersBase {
 
     // DR-612 filesystem corruption test; use a non-existent file to make sure everything errors
     // Do file ingests in parallel using a filename that will cause failure
-    // TODO: DR-643 needs to be fixed before this test will work reliably.
-    //  So for now it has to stay ignored
-    @Ignore
     @Test
     public void fileParallelFailedLoadTest() throws Exception {
         List<DataRepoResponse<JobModel>> responseList = new ArrayList<>();

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -121,8 +121,8 @@ public class EncodeFixture {
         // Read one line at a time - unpack into pojo
         // Ingest the files, substituting the file ids
         // Generate JSON and write the line to scratch
-        String rndtail = UUID.randomUUID().toString() + ".json";
-        String loaddata = "scratch/lf_loaddata" + rndtail;
+        String rndSuffix = UUID.randomUUID().toString() + ".json";
+        String loadData = "scratch/lf_loaddata" + rndSuffix;
 
         // For a bigger test use encodetest/file.json (1000+ files)
         // For normal testing encodetest/file_small.json (10 files)
@@ -161,7 +161,7 @@ public class EncodeFixture {
             resultMap.put(fileResult.getSourcePath(), fileResult);
         }
 
-        try (GcsChannelWriter writer = new GcsChannelWriter(storage, testConfiguration.getIngestbucket(), loaddata)) {
+        try (GcsChannelWriter writer = new GcsChannelWriter(storage, testConfiguration.getIngestbucket(), loadData)) {
             for (EncodeFileIn encodeFileIn : inArray) {
                 BulkLoadFileResultModel resultModel = resultMap.get(encodeFileIn.getFile_gs_path());
                 String bamFileId = (resultModel == null) ? null : resultModel.getFileId();
@@ -173,14 +173,14 @@ public class EncodeFixture {
             }
         }
 
-        return loaddata;
+        return loadData;
     }
 
-    public void deleteLoadFile(TestConfiguration.User user, String loaddata) {
+    public void deleteLoadFile(TestConfiguration.User user, String loadData) {
         String userToken = authService.getDirectAccessAuthToken(user.getEmail());
         Storage storage = dataRepoFixtures.getStorage(userToken);
         Blob targetBlob = storage.get(
-            BlobId.of(testConfiguration.getIngestbucket(), loaddata));
+            BlobId.of(testConfiguration.getIngestbucket(), loadData));
         targetBlob.delete();
     }
 


### PR DESCRIPTION
Rewrite the EncodeFixture to use array bulk file load. The DrsTest uses the fixture.
This should make this test run about 10x faster.

Also enabled a parallel, single file load test that was disabled due to DR-643.