### PR TITLE
DR-901 Loosen restrictions on relationship and asset names

### DIFF
--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1688,7 +1688,7 @@ definitions:
 
   ObjectNameProperty:
     description: |
-      Table, column, and relationship names follow this pattern. This should be used for the name of any object in the
+      Dataset, table, and column names follow this pattern. This should be used for the name of any object in the
       system. It enforces BigQuery naming rules except it disallows a leading underscore so we avoid collisions with
       any extra columns the DR adds. For table names, this is shorter than what BigQuery allows.
     type: string
@@ -1958,7 +1958,7 @@ definitions:
       table:
         $ref: '#/definitions/ObjectNameProperty'
       column:
-        type: string
+        $ref: '#/definitions/ObjectNameProperty'
 
   RelationshipModel:
     description: |
@@ -1971,7 +1971,8 @@ definitions:
       - to
     properties:
       name:
-        $ref: '#/definitions/ObjectNameProperty'
+        type: string
+        minLength: 1
       from:
         $ref: '#/definitions/RelationshipTermModel'
       to:
@@ -2007,7 +2008,8 @@ definitions:
       - rootColumn
     properties:
       name:
-        $ref: '#/definitions/ObjectNameProperty'
+        type: string
+        minLength: 1
       tables:
         type: array
         items:

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -23,4 +23,5 @@
     <include file="changesets/20200310_lockdatasetssnapshots.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20200312_addpartitions.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20200318_lockbuckets.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20200406_allowlongernames.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20200406_allowlongernames.yaml
+++ b/src/main/resources/db/changesets/20200406_allowlongernames.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: allowlongernames
+      author: danmoran
+      changes:
+        - modifyDataType:
+            tableName: dataset_relationship
+            columnName: name
+            newDataType: text
+        - modifyDataType:
+            tableName: asset_specification
+            columnName: name
+            newDataType: text

--- a/src/test/resources/dataset-create-test.json
+++ b/src/test/resources/dataset-create-test.json
@@ -29,7 +29,7 @@
         "to":   {"table": "sample", "column": "participant_id"}
       },
       {
-        "name": "parent",
+        "name": "parent_with_a_long_pointless_suffix_to_push_the_name_length_over_the_old_limit",
         "from": {"table": "participant", "column": "id"},
         "to":   {"table": "participant", "column": "id"}
       }
@@ -56,7 +56,8 @@
           {"name": "sample", "columns": []}
         ],
         "follow": [
-          "participant_sample", "parent"
+          "participant_sample",
+          "parent_with_a_long_pointless_suffix_to_push_the_name_length_over_the_old_limit"
         ]
       }
     ]


### PR DESCRIPTION
This will allow Monster (and others) to reliably auto-generate relationships names of the form `from_<from.table>_<from.column>_to_<to.table>_<to.column>`. The current API definition frequently flags names generated that way as too long.

I removed the length restriction from asset names, too. I don't see an inherent need to restrict the characters / length, and I've been frustrated in the past by not being able to use descriptive-enough names for assets.