### PR TITLE
DR-934 Change how we wait for load jobs

### DIFF
--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -61,6 +61,7 @@ public class JobService {
         this.stairwayJdbcConfiguration = stairwayJdbcConfiguration;
         this.migrateConfiguration = migrateConfiguration;
 
+        logger.info("Creating Stairway thread pool. maxStairwayThreads: " + appConfig.getMaxStairwayThreads());
         ExecutorService executorService = Executors.newFixedThreadPool(appConfig.getMaxStairwayThreads());
         ExceptionSerializer serializer = new StairwayExceptionSerializer(objectMapper);
         stairway = new Stairway(executorService, applicationContext, serializer);

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -63,6 +63,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static bio.terra.common.PdaoConstant.PDAO_EXTERNAL_TABLE_PREFIX;
@@ -446,15 +447,29 @@ public class BigQueryPdao implements PrimaryDataAccess {
         LoadJobConfiguration configuration = loadBuilder.build();
 
         Job loadJob = bigQuery.create(JobInfo.of(configuration));
-        try {
-            loadJob = loadJob.waitFor();
-            if (loadJob.getStatus() == null) {
-                throw new PdaoException("Unexpected return from BigQuery job - no getStatus()");
+        Instant loadJobMaxTime = Instant.now().plusSeconds(TimeUnit.MINUTES.toSeconds(20L));
+        while (!loadJob.isDone()) {
+            logger.info("Waiting for staging table load job " + loadJob.getJobId().getJob() + " to complete");
+            // TODO: when DR-897 is in, let this just throw InterruptedException
+            try {
+                TimeUnit.SECONDS.sleep(5L);
+            } catch (InterruptedException e) {
+                throw new IngestInterruptedException("Load job interrupted");
             }
-        } catch (InterruptedException ex) {
-            // Someone is shutting down the application
-            Thread.currentThread().interrupt();
-            throw new IngestInterruptedException("Ingest was interrupted");
+
+            if (loadJobMaxTime.isBefore(Instant.now())) {
+                loadJob.cancel();
+                throw new PdaoException("Staging table load failed to complete within timeout - canceled");
+            }
+        }
+        loadJob = loadJob.reload();
+
+        BigQueryError loadJobError = loadJob.getStatus().getError();
+        if (loadJobError == null) {
+            logger.info("Staging table load job " + loadJob.getJobId().getJob() + " succeeded");
+        } else {
+            logger.info("Staging table load job " + loadJob.getJobId().getJob() + " failed: " + loadJobError);
+            throw new PdaoException("Unexpected return from BigQuery job - no getStatus()");
         }
 
         if (loadJob.getStatus().getError() != null) {

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -469,11 +469,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             logger.info("Staging table load job " + loadJob.getJobId().getJob() + " succeeded");
         } else {
             logger.info("Staging table load job " + loadJob.getJobId().getJob() + " failed: " + loadJobError);
-            throw new PdaoException("Unexpected return from BigQuery job - no getStatus()");
-        }
-
-        if (loadJob.getStatus().getError() != null) {
-            if ("notFound".equals(loadJob.getStatus().getError().getReason())) {
+            if ("notFound".equals(loadJobError.getReason())) {
                 throw new IngestFileNotFoundException("Ingest source file not found: " + ingestRequest.getPath());
             }
 


### PR DESCRIPTION
I changed how we wait for load jobs so that we poll the isDone rather than sit in a sleep forever. If the load takes more than 20 minutes, we give up.

I also added logging of the number of stairway threads on startup. It looks like dev is running with 2, but the application.properties says 20 and I can't find anything that overrides that.
