### PR TITLE
DR-974 Update the shared lock changeset fix null values

### DIFF
--- a/src/main/resources/db/changesets/20200420_datasetsharedlock.yaml
+++ b/src/main/resources/db/changesets/20200420_datasetsharedlock.yaml
@@ -10,5 +10,10 @@ databaseChangeLog:
                   name: sharedlock
                   type: text[]
                   defaultValue: {}
-                  constraints:
-                    nullable: false
+        - sql:
+            comment: populate the sharedlock column with empty array
+            sql: UPDATE dataset SET sharedlock = '{}'
+        - addNotNullConstraint:
+            tableName: dataset
+            columnName: sharedlock
+


### PR DESCRIPTION
The sharedlock changeset applied a not null constraint on the new sharedlock column.
That failed in dev where existing columns had nulls in them.

This PR updates the changeset to apply the change in three steps:
1. add the new column
2. update all existing instances of the column to have an empty array in them
3. add the not null constraint to the column

I tested this by checking out a pre-merge version of dev without that changeset. Then I created a dataset in it. So I had an older version of the schema.

I set my local flags to not dropAll and ran this change set. It took me a few tries to get the liquibase right, but this worked for me...