### PR TITLE
DR 1010: DRY up snapshot creation w helper methods

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -235,8 +235,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         Snapshot snapshot,
         String projectId,
         BigQuery bigQuery,
-        BigQueryProject bigQueryProject
-        ) {
+        BigQueryProject bigQueryProject) {
         // create the views
         List<String> bqTableNames = createViews(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery);
 
@@ -906,7 +905,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 throw new MismatchedValueException("Query results did not match dataset root row ids");
             }
 
-            // TODO should this be pulled up to the top of the methohd and added to the snapshotCreatBQDataset helper method
+            // TODO should this be pulled up to the top of queryForRowIds() / added to snapshotCreatBQDataset() helper
             bigQueryProject.createTable(snapshotName, PDAO_ROW_ID_TABLE, rowIdTableSchema());
 
             // populate root row ids. Must happen before the relationship walk.

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -219,7 +219,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         return rowIdMatch;
     }
 
-    public void snapshotCreatBQDataset(BigQueryProject bigQueryProject, Snapshot snapshot) {
+    public void snapshotCreateBQDataset(BigQueryProject bigQueryProject, Snapshot snapshot) {
         String snapshotName = snapshot.getName();
         // Idempotency: delete possibly partial create.
         if (bigQueryProject.datasetExists(snapshotName)) {
@@ -264,7 +264,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         BigQuery bigQuery = bigQueryProject.getBigQuery();
 
         // create snapshot BQ dataset
-        snapshotCreatBQDataset(bigQueryProject, snapshot);
+        snapshotCreateBQDataset(bigQueryProject, snapshot);
 
         // create the row id table
         bigQueryProject.createTable(snapshotName, PDAO_ROW_ID_TABLE, rowIdTableSchema());
@@ -324,7 +324,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         SnapshotRequestRowIdModel rowIdModel = contentsModel.getRowIdSpec();
 
         // create snapshot BQ dataset
-        snapshotCreatBQDataset(bigQueryProject, snapshot);
+        snapshotCreateBQDataset(bigQueryProject, snapshot);
 
         // create the row id table
         bigQueryProject.createTable(snapshotName, PDAO_ROW_ID_TABLE, rowIdTableSchema());
@@ -863,7 +863,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         try {
 
             // create snapshot BQ dataset
-            snapshotCreatBQDataset(bigQueryProject, snapshot);
+            snapshotCreateBQDataset(bigQueryProject, snapshot);
 
             // now create a temp table with all the selected row ids based on the query in it
             bigQueryProject.createTable(snapshotName, PDAO_TEMP_TABLE, tempTableSchema());
@@ -905,7 +905,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 throw new MismatchedValueException("Query results did not match dataset root row ids");
             }
 
-            // TODO should this be pulled up to the top of queryForRowIds() / added to snapshotCreatBQDataset() helper
+            // TODO should this be pulled up to the top of queryForRowIds() / added to snapshotCreateBQDataset() helper
             bigQueryProject.createTable(snapshotName, PDAO_ROW_ID_TABLE, rowIdTableSchema());
 
             // populate root row ids. Must happen before the relationship walk.

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -219,6 +219,32 @@ public class BigQueryPdao implements PrimaryDataAccess {
         return rowIdMatch;
     }
 
+    public void snapshotCreatBQDataset(BigQueryProject bigQueryProject, Snapshot snapshot) {
+        String snapshotName = snapshot.getName();
+        // Idempotency: delete possibly partial create.
+        if (bigQueryProject.datasetExists(snapshotName)) {
+            bigQueryProject.deleteDataset(snapshotName);
+        }
+        // create snapshot BQ dataset
+        bigQueryProject.createDataset(snapshotName, snapshot.getDescription());
+    }
+
+    public void snapshotViewCreation(
+        String datasetBqDatasetName,
+        String snapshotName,
+        Snapshot snapshot,
+        String projectId,
+        BigQuery bigQuery,
+        BigQueryProject bigQueryProject
+        ) {
+        // create the views
+        List<String> bqTableNames = createViews(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery);
+
+        // set authorization on views
+        List<Acl> acls = convertToViewAcls(projectId, snapshotName, bqTableNames);
+        bigQueryProject.addDatasetAcls(datasetBqDatasetName, acls);
+    }
+
     private static final String loadRootRowIdsTemplate =
         "INSERT INTO `<project>.<snapshot>." + PDAO_ROW_ID_TABLE + "` " +
             "(" + PDAO_TABLE_ID_COLUMN + "," + PDAO_ROW_ID_COLUMN + ") " +
@@ -238,11 +264,8 @@ public class BigQueryPdao implements PrimaryDataAccess {
         String snapshotName = snapshot.getName();
         BigQuery bigQuery = bigQueryProject.getBigQuery();
 
-        // Idempotency: delete possibly partial create.
-        if (bigQueryProject.datasetExists(snapshotName)) {
-            bigQueryProject.deleteDataset(snapshotName);
-        }
-        bigQueryProject.createDataset(snapshotName, snapshot.getDescription());
+        // create snapshot BQ dataset
+        snapshotCreatBQDataset(bigQueryProject, snapshot);
 
         // create the row id table
         bigQueryProject.createTable(snapshotName, PDAO_ROW_ID_TABLE, rowIdTableSchema());
@@ -288,12 +311,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         List<WalkRelationship> walkRelationships = WalkRelationship.ofAssetSpecification(asset);
         walkRelationships(datasetBqDatasetName, snapshotName, walkRelationships, rootTableId, projectId, bigQuery);
 
-        // create the views
-        List<String> bqTableNames = createViews(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery);
-
-        // set authorization on views
-        List<Acl> acls = convertToViewAcls(projectId, snapshotName, bqTableNames);
-        bigQueryProject.addDatasetAcls(datasetBqDatasetName, acls);
+        snapshotViewCreation(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery, bigQueryProject);
     }
 
     public void createSnapshotWithProvidedIds(
@@ -306,11 +324,8 @@ public class BigQueryPdao implements PrimaryDataAccess {
         BigQuery bigQuery = bigQueryProject.getBigQuery();
         SnapshotRequestRowIdModel rowIdModel = contentsModel.getRowIdSpec();
 
-        // Idempotency: delete possibly partial create.
-        if (bigQueryProject.datasetExists(snapshotName)) {
-            bigQueryProject.deleteDataset(snapshotName);
-        }
-        bigQueryProject.createDataset(snapshotName, snapshot.getDescription());
+        // create snapshot BQ dataset
+        snapshotCreatBQDataset(bigQueryProject, snapshot);
 
         // create the row id table
         bigQueryProject.createTable(snapshotName, PDAO_ROW_ID_TABLE, rowIdTableSchema());
@@ -355,12 +370,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             }
         }
 
-        // create the views
-        List<String> bqTableNames = createViews(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery);
-
-        // set authorization on views
-        List<Acl> acls = convertToViewAcls(projectId, snapshotName, bqTableNames);
-        bigQueryProject.addDatasetAcls(datasetBqDatasetName, acls);
+        snapshotViewCreation(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery, bigQueryProject);
     }
 
     @Override
@@ -852,14 +862,13 @@ public class BigQueryPdao implements PrimaryDataAccess {
 
         // create snapshot bq dataset
         try {
-            // Idempotency: delete possibly partial create
-            if (bigQueryProject.datasetExists(snapshotName)) {
-                bigQueryProject.deleteDataset(snapshotName);
-            }
 
-            bigQueryProject.createDataset(snapshotName, snapshot.getDescription());
+            // create snapshot BQ dataset
+            snapshotCreatBQDataset(bigQueryProject, snapshot);
+
             // now create a temp table with all the selected row ids based on the query in it
             bigQueryProject.createTable(snapshotName, PDAO_TEMP_TABLE, tempTableSchema());
+
             QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(sqlQuery)
                 .setDestinationTable(TableId.of(snapshotName, PDAO_TEMP_TABLE))
                 .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
@@ -897,6 +906,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
                 throw new MismatchedValueException("Query results did not match dataset root row ids");
             }
 
+            // TODO should this be pulled up to the top of the methohd and added to the snapshotCreatBQDataset helper method
             bigQueryProject.createTable(snapshotName, PDAO_ROW_ID_TABLE, rowIdTableSchema());
 
             // populate root row ids. Must happen before the relationship walk.
@@ -921,12 +931,10 @@ public class BigQueryPdao implements PrimaryDataAccess {
             List<WalkRelationship> walkRelationships = WalkRelationship.ofAssetSpecification(assetSpecification);
             walkRelationships(datasetBqDatasetName, snapshotName, walkRelationships, rootTableId, projectId, bigQuery);
 
-            // create the views
-            List<String> bqTableNames = createViews(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery);
+            // populate root row ids. Must happen before the relationship walk.
+            // NOTE: when we have multiple sources, we can put this into a loop
+            snapshotViewCreation(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery, bigQueryProject);
 
-            // set authorization on views
-            List<Acl> acls = convertToViewAcls(projectId, snapshotName, bqTableNames);
-            bigQueryProject.addDatasetAcls(datasetBqDatasetName, acls);
         } catch (PdaoException ex) {
             // TODO What if the select list doesn't match the temp table schema?
             // TODO what if the query is invalid? Seems like there might be more to catch here.


### PR DESCRIPTION
Minimal drying up of the snapshot creation workflow.
Additional tech debt still needs to be addressed, but this is specifically in preparation for the addition of live view snapshots


unclear about whether this should also include:

        // create the row id table
        bigQueryProject.createTable(snapshotName, PDAO_ROW_ID_TABLE, rowIdTableSchema());