### PR TITLE
DR-856: Ensure that file ingest tolerates extra keys

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -18,7 +18,6 @@ import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.RetryRuleRandomBackoff;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.ApplicationContext;
 
 /*
@@ -41,7 +40,6 @@ public class FileIngestBulkFlight extends Flight {
         ApplicationContext appContext = (ApplicationContext) applicationContext;
         IamProviderInterface iamClient = (IamProviderInterface) appContext.getBean("iamProvider");
         LoadService loadService = (LoadService)appContext.getBean("loadService");
-        ObjectMapper objectMapper = (ObjectMapper)appContext.getBean("objectMapper");
         ApplicationConfiguration appConfig = (ApplicationConfiguration)appContext.getBean("applicationConfiguration");
         DataLocationService locationService = (DataLocationService)appContext.getBean("dataLocationService");
         BigQueryPdao bigQueryPdao = (BigQueryPdao)appContext.getBean("bigQueryPdao");
@@ -104,7 +102,6 @@ public class FileIngestBulkFlight extends Flight {
         } else {
             addStep(new IngestPopulateFileStateFromFileStep(
                 loadService,
-                objectMapper,
                 appConfig.getMaxBadLoadFileLineErrorsReported(),
                 appConfig.getLoadFilePopulateBatchSize()));
         }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileStep.java
@@ -11,6 +11,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
@@ -24,22 +25,23 @@ import java.util.UUID;
 // Populate the files to be loaded from the incoming array
 public class IngestPopulateFileStateFromFileStep implements Step {
     private final LoadService loadService;
-    private final ObjectMapper objectMapper;
     private final int maxBadLines;
     private final int batchSize;
 
     public IngestPopulateFileStateFromFileStep(LoadService loadService,
-                                               ObjectMapper objectMapper,
                                                int maxBadLines,
                                                int batchSize) {
         this.loadService = loadService;
-        this.objectMapper = objectMapper;
         this.maxBadLines = maxBadLines;
         this.batchSize = batchSize;
     }
 
     @Override
     public StepResult doStep(FlightContext context) {
+        // Ensure that file ingestion works with extra key-value pairs
+        ObjectMapper objectMapper = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
         FlightMap inputParameters = context.getInputParameters();
         BulkLoadRequestModel loadRequest =
             inputParameters.get(JobMapKeys.REQUEST.getKeyName(), BulkLoadRequestModel.class);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileStep.java
@@ -13,6 +13,8 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
@@ -40,6 +42,8 @@ public class IngestPopulateFileStateFromFileStep implements Step {
     public StepResult doStep(FlightContext context) {
         // Ensure that file ingestion works with extra key-value pairs
         ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new Jdk8Module())
+            .registerModule(new JavaTimeModule())
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
         FlightMap inputParameters = context.getInputParameters();


### PR DESCRIPTION
- Move the `ObjectMapper` into the ingest file step
- Disable the `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` property on the `ObjectMapper`
- Add a test to inject extra key-value pairs into file lines