### PR TITLE
DR-1003 snapshot row counts

### DIFF
--- a/src/main/java/bio/terra/common/Table.java
+++ b/src/main/java/bio/terra/common/Table.java
@@ -9,6 +9,7 @@ public interface Table {
     UUID getId();
     String getName();
     List<Column> getColumns();
+    Long getRowCount();
 
     default Optional<Column> getColumnById(UUID id) {
         for (Column tryColumn : getColumns()) {

--- a/src/main/java/bio/terra/service/dataset/BigQueryPartitionConfigV1.java
+++ b/src/main/java/bio/terra/service/dataset/BigQueryPartitionConfigV1.java
@@ -14,12 +14,12 @@ public final class BigQueryPartitionConfigV1 {
     // we want or need to change the settings we collect about BQ
     // partitioning in the future, we'll still be able to distinguish
     // the "old" style of config stored in the DB.
-    @JsonProperty private final long version;
-    @JsonProperty private final Mode mode;
-    @JsonProperty private final String columnName;
-    @JsonProperty private final Long intMin;
-    @JsonProperty private final Long intMax;
-    @JsonProperty private final Long intInterval;
+    @JsonProperty private long version;
+    @JsonProperty private Mode mode;
+    @JsonProperty private String columnName;
+    @JsonProperty private Long intMin;
+    @JsonProperty private Long intMax;
+    @JsonProperty private Long intInterval;
 
     private BigQueryPartitionConfigV1(Mode mode, String columnName, Long intMin, Long intMax, Long intInterval) {
         this.version = 1;
@@ -29,6 +29,8 @@ public final class BigQueryPartitionConfigV1 {
         this.intMax = intMax;
         this.intInterval = intInterval;
     }
+
+    public BigQueryPartitionConfigV1() {}
 
     String getColumnName() {
         return this.columnName;

--- a/src/main/java/bio/terra/service/dataset/DatasetTable.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTable.java
@@ -24,6 +24,7 @@ public class DatasetTable implements Table {
     private List<Column> columns = Collections.emptyList();
     private List<Column> primaryKey = Collections.emptyList();
     private BigQueryPartitionConfigV1 bqPartitionConfig;
+    private Long rowCount;
 
     public UUID getId() {
         return id;
@@ -85,6 +86,16 @@ public class DatasetTable implements Table {
 
     public DatasetTable bigQueryPartitionConfig(BigQueryPartitionConfigV1 config) {
         this.bqPartitionConfig = config;
+        return this;
+    }
+
+    @Override
+    public Long getRowCount() {
+        return rowCount;
+    }
+
+    public DatasetTable setRowCount(Long rowCount) {
+        this.rowCount = rowCount;
         return this;
     }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -420,11 +420,11 @@ public class SnapshotService {
                 .profileId(snapshot.getProfileId().toString())
                 .source(snapshot.getSnapshotSources()
                         .stream()
-                        .map(source -> makeSourceModelFromSource(source))
+                        .map(this::makeSourceModelFromSource)
                         .collect(Collectors.toList()))
                 .tables(snapshot.getTables()
                         .stream()
-                        .map(table -> makeTableModelFromTable(table))
+                        .map(this::makeTableModelFromTable)
                         .collect(Collectors.toList()));
     }
 
@@ -451,11 +451,13 @@ public class SnapshotService {
 
     // TODO: share these methods with dataset table in some common place
     private TableModel makeTableModelFromTable(Table table) {
+        Long rowCount = table.getRowCount();
         return new TableModel()
                 .name(table.getName())
+                .rowCount(rowCount != null ? rowCount.intValue() : null)
                 .columns(table.getColumns()
                         .stream()
-                        .map(column -> makeColumnModelFromColumn(column))
+                        .map(this::makeColumnModelFromColumn)
                         .collect(Collectors.toList()));
     }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTable.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTable.java
@@ -11,6 +11,7 @@ public class SnapshotTable implements Table {
     private UUID id;
     private String name;
     private List<Column> columns = Collections.emptyList();
+    private Long rowCount;
 
     public UUID getId() {
         return id;
@@ -36,6 +37,16 @@ public class SnapshotTable implements Table {
 
     public SnapshotTable columns(List<Column> columns) {
         this.columns = columns;
+        return this;
+    }
+
+    @Override
+    public Long getRowCount() {
+        return rowCount;
+    }
+
+    public SnapshotTable rowCount(long rowCount) {
+        this.rowCount = rowCount;
         return this;
     }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
@@ -19,7 +19,7 @@ public class SnapshotTableDao {
         "(name, parent_id) VALUES (:name, :parent_id)";
     private static final String sqlInsertColumn = "INSERT INTO snapshot_column " +
         "(table_id, name, type, array_of) VALUES (:table_id, :name, :type, :array_of)";
-    private static final String sqlSelectTable = "SELECT id, name FROM snapshot_table " +
+    private static final String sqlSelectTable = "SELECT id, name, row_count FROM snapshot_table " +
         "WHERE parent_id = :parent_id";
     private static final String sqlSelectColumn = "SELECT id, name, type, array_of FROM snapshot_column " +
         "WHERE table_id = :table_id";
@@ -64,7 +64,8 @@ public class SnapshotTableDao {
         return jdbcTemplate.query(sqlSelectTable, params, (rs, rowNum) -> {
             SnapshotTable table = new SnapshotTable()
                 .id(rs.getObject("id", UUID.class))
-                .name(rs.getString("name"));
+                .name(rs.getString("name"))
+                .rowCount(rs.getLong("row_count"));
             List<Column> columns = retrieveColumns(table);
             return table.columns(columns);
         });

--- a/src/main/java/bio/terra/service/snapshot/exception/MissingRowCountsException.java
+++ b/src/main/java/bio/terra/service/snapshot/exception/MissingRowCountsException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.snapshot.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class MissingRowCountsException extends InternalServerErrorException {
+    public MissingRowCountsException(String message) {
+        super(message);
+    }
+
+    public MissingRowCountsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MissingRowCountsException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStep.java
@@ -1,0 +1,41 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotDao;
+import bio.terra.service.tabulardata.google.BigQueryPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+
+import java.util.Map;
+
+public class CountSnapshotTableRowsStep implements Step {
+
+    private final BigQueryPdao bigQueryPdao;
+    private final SnapshotDao snapshotDao;
+    private final SnapshotRequestModel snapshotReq;
+
+    public CountSnapshotTableRowsStep(BigQueryPdao bigQueryPdao,
+                                      SnapshotDao snapshotDao,
+                                      SnapshotRequestModel snapshotReq) {
+        this.bigQueryPdao = bigQueryPdao;
+        this.snapshotDao = snapshotDao;
+        this.snapshotReq = snapshotReq;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext flightContext) throws InterruptedException, RetryException {
+        Snapshot snapshot = snapshotDao.retrieveSnapshotByName(snapshotReq.getName());
+        Map<String, Long> tableRowCounts = bigQueryPdao.getSnapshotTableRowCounts(snapshot);
+        snapshotDao.updateSnapshotTableRowCounts(snapshot, tableRowCounts);
+        return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+        // nothing to do here
+        return StepResult.getStepResultSuccess();
+    }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -69,6 +69,7 @@ public class SnapshotCreateFlight extends Flight {
             default:
                 throw new InvalidSnapshotException("Snapshot does not have required mode information");
         }
+        addStep(new CountSnapshotTableRowsStep(bigQueryPdao, snapshotDao, snapshotReq));
         addStep(new CreateSnapshotFireStoreDataStep(
             bigQueryPdao, snapshotService, dependencyDao, datasetService, snapshotReq, fileDao));
         addStep(new CreateSnapshotFireStoreComputeStep(snapshotService, snapshotReq, fileDao));

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -1519,6 +1519,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         }
     }
 
+    // we select from the live view here so that the row counts take into account rows that have been hard deleted
     private static final String rowCountTemplate = "SELECT COUNT(<rowId>) FROM `<project>.<dataset>.<table>`";
 
     public Map<String, Long> getSnapshotTableRowCounts(Snapshot snapshot) throws InterruptedException {

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1961,6 +1961,8 @@ definitions:
         $ref: '#/definitions/DatePartitionOptionsModel'
       intPartitionOptions:
         $ref: '#/definitions/IntPartitionOptionsModel'
+      rowCount:
+        type: integer
 
   DatePartitionOptionsModel:
     description: Describes how a date partition should be configured.

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -26,4 +26,5 @@
     <include file="changesets/20200406_allowlongernames.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20200404_addChecksum.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20200420_datasetsharedlock.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20200525_snapshottablerowcounts.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20200525_snapshottablerowcounts.yaml
+++ b/src/main/resources/db/changesets/20200525_snapshottablerowcounts.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: snapshottablerowcounts
+      author: jh
+      changes:
+        - addColumn:
+            tableName: snapshot_table
+            columns:
+              - column:
+                  name: row_count
+                  type: integer

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -12,6 +12,7 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.service.dataset.DatasetUtils;
 import bio.terra.service.resourcemanagement.ProfileDao;
+import bio.terra.service.snapshot.exception.MissingRowCountsException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -86,6 +88,12 @@ public class SnapshotDaoTest {
         snapshotDao.delete(snapshotId);
         datasetDao.delete(datasetId);
         profileDao.deleteBillingProfileById(profileId);
+    }
+
+    @Test(expected = MissingRowCountsException.class)
+    public void testMissingRowCounts() throws Exception {
+        Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
+        snapshotDao.updateSnapshotTableRowCounts(snapshot, Collections.emptyMap());
     }
 
     @Test


### PR DESCRIPTION
Adds a new step to calculate row counts per snapshot table. This step will need to be reused whenever snapshot row data changes, e.g. when data is hard deleted. Since hard deletes aren't currently implemented there is only one time to use this: snapshot creation.

The workspace manager team needs this for integration.