### PR TITLE
DR-994 Exclude exclusively locked from lookups: datasets, dataset files, snapshots.

### DIFF
--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -155,7 +155,7 @@ public class RepositoryApiController implements RepositoryApi {
     @Override
     public ResponseEntity<DatasetModel> retrieveDataset(@PathVariable("id") String id) {
         iamService.verifyAuthorization(getAuthenticatedInfo(), IamResourceType.DATASET, id, IamAction.READ_DATASET);
-        return new ResponseEntity<>(datasetService.retrieveModel(UUID.fromString(id)), HttpStatus.OK);
+        return new ResponseEntity<>(datasetService.retrieveAvailableDatasetModel(UUID.fromString(id)), HttpStatus.OK);
     }
 
     @Override

--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -368,7 +368,7 @@ public class RepositoryApiController implements RepositoryApi {
     @Override
     public ResponseEntity<SnapshotModel> retrieveSnapshot(@PathVariable("id") String id) {
         iamService.verifyAuthorization(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id, IamAction.READ_DATA);
-        SnapshotModel snapshotModel = snapshotService.retrieveModel(UUID.fromString(id));
+        SnapshotModel snapshotModel = snapshotService.retrieveAvailableSnapshotModel(UUID.fromString(id));
         return new ResponseEntity<>(snapshotModel, HttpStatus.OK);
     }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -292,7 +292,7 @@ public class DatasetDao {
     }
 
     /**
-     * This is a convenience wrapper that returns all datasets that are NOT exclusively locked.
+     * This is a convenience wrapper that returns a dataset only if it is NOT exclusively locked.
      * This method is intended for user-facing API calls (e.g. from RepositoryApiController).
      * @param id the dataset id
      * @return the DatasetSummary object
@@ -323,7 +323,7 @@ public class DatasetDao {
     }
 
     /**
-     * This is a convenience wrapper that returns all datasets, regardless of whether they are exclusively locked.
+     * This is a convenience wrapper that returns a dataset, regardless of whether it is exclusively locked.
      * Most places in the API code that are retrieving a dataset will call this method.
      * @param id the dataset id
      * @return the DatasetSummary object
@@ -365,8 +365,18 @@ public class DatasetDao {
         }
     }
 
-    // does not return sub-objects with datasets
-    // excludes datasets that are exclusively locked
+    /**
+     * Fetch a list of all the available datasets.
+     * This method returns summary objects, which do not include sub-objects associated with datasets (e.g. tables).
+     * Note that this method will only return datasets that are NOT exclusively locked.
+     * @param offset skip this many datasets from the beginning of the list (intended for "scrolling" behavior)
+     * @param limit only return this many datasets in the list
+     * @param sort field for order by clause. possible values are: name, description, created_date
+     * @param direction asc or desc
+     * @param filter string to match (SQL ILIKE) in dataset name or description
+     * @param accessibleDatasetIds list of dataset ids that caller has access to (fetched from IAM service)
+     * @return a list of dataset summary objects
+     */
     public MetadataEnumeration<DatasetSummary> enumerate(
         int offset,
         int limit,

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -229,9 +229,11 @@ public class DatasetDao {
     }
 
     /**
-     * This method is intended for TESTING ONLY. It returns the internal state of the exclusive lock on a dataset.
-     * @param id the dataset id
-     * @return the flight id that holds the exclusive lock. null if no exclusive lock is taken out.
+     * TESTING ONLY. This method returns the internal state of the exclusive lock on a dataset.
+     * It is protected because it's for use in tests only.
+     * Currently, we don't expose the lock state of a dataset outside of the DAO for other API code to consume.
+     * @param id
+     * @return the flightid that holds an exclusive lock. null if none.
      */
     protected String getExclusiveLock(UUID id) {
         try {
@@ -244,7 +246,9 @@ public class DatasetDao {
     }
 
     /**
-     * This method is intended for TESTING ONLY. It returns the internal state of the shared locks on a dataset.
+     * TESTING ONLY. This method returns the internal state of the shared locks on a dataset.
+     * It is protected because it's for use in tests only.
+     * Currently, we don't expose the lock state of a dataset outside of the DAO for other API code to consume.
      * @param id the dataset id
      * @return the array of flight ids that hold shared locks. empty if no shared locks are taken out.
      */

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -232,7 +232,7 @@ public class DatasetDao {
      * TESTING ONLY. This method returns the internal state of the exclusive lock on a dataset.
      * It is protected because it's for use in tests only.
      * Currently, we don't expose the lock state of a dataset outside of the DAO for other API code to consume.
-     * @param id
+     * @param id the dataset id
      * @return the flightid that holds an exclusive lock. null if none.
      */
     protected String getExclusiveLock(UUID id) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -60,6 +60,14 @@ public class DatasetService {
         return datasetDao.retrieve(id);
     }
 
+    /** Fetch existing Dataset object that is NOT exclusively locked.
+     * @param id in UUID format
+     * @return a Dataset object
+     */
+    public Dataset retrieveAvailable(UUID id) {
+        return datasetDao.retrieveAvailable(id);
+    }
+
     /** Fetch existing Dataset object using the name.
      * @param name
      * @return a Dataset object
@@ -71,11 +79,15 @@ public class DatasetService {
 
     /** Convenience wrapper around fetching an existing Dataset object and converting it to a Model object.
      * Unlike the Dataset object, the Model object includes a reference to the associated cloud project.
+     *
+     * Note that this method will only return a dataset if it is NOT exclusively locked.
+     * It is intended for user-facing calls (e.g. from RepositoryApiController), not internal calls that may require
+     * an exclusively locked dataset to be returned (e.g. dataset deletion).
      * @param id in UUID formant
      * @return a DatasetModel = API output-friendly representation of the Dataset
      */
-    public DatasetModel retrieveModel(UUID id) {
-        Dataset dataset = retrieve(id);
+    public DatasetModel retrieveAvailableDatasetModel(UUID id) {
+        Dataset dataset = retrieveAvailable(id);
         return retrieveModel(dataset);
     }
 

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -147,13 +147,23 @@ public class FileService {
         return fileModelFromFSItem(fsItem);
     }
 
+    /**
+     * Note that this method will only return a file if the encompassing dataset is NOT exclusively locked.
+     * It is intended for user-facing calls (e.g. from RepositoryApiController), not internal calls that may require
+     * an exclusively locked dataset to be returned (e.g. file deletion).
+     */
     FSItem lookupFSItem(String datasetId, String fileId, int depth) {
-        Dataset dataset = datasetService.retrieve(UUID.fromString(datasetId));
+        Dataset dataset = datasetService.retrieveAvailable(UUID.fromString(datasetId));
         return fileDao.retrieveById(dataset, fileId, depth, true);
     }
 
+    /**
+     * Note that this method will only return a file if the encompassing dataset is NOT exclusively locked.
+     * It is intended for user-facing calls (e.g. from RepositoryApiController), not internal calls that may require
+     * an exclusively locked dataset to be returned (e.g. file deletion).
+     */
     FSItem lookupFSItemByPath(String datasetId, String path, int depth) {
-        Dataset dataset = datasetService.retrieve(UUID.fromString(datasetId));
+        Dataset dataset = datasetService.retrieveAvailable(UUID.fromString(datasetId));
         return fileDao.retrieveByPath(dataset, path, depth, true);
     }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -152,7 +152,7 @@ public class SnapshotDao {
         return snapshotId;
     }
 
-    protected String getExclusiveLock(UUID id) {
+    protected String getExclusiveLockState(UUID id) {
         try {
             String sql = "SELECT flightid FROM snapshot WHERE id = :id";
             MapSqlParameterSource params = new MapSqlParameterSource().addValue("id", id);

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -152,6 +152,12 @@ public class SnapshotDao {
         return snapshotId;
     }
 
+    /**
+     * This method is protected because it's for use in tests only.
+     * Currently, we don't expose the lock state of a snapshot outside of the DAO for other API code to consume.
+     * @param id
+     * @return the flightid that holds an exclusive lock. null if none.
+     */
     protected String getExclusiveLockState(UUID id) {
         try {
             String sql = "SELECT flightid FROM snapshot WHERE id = :id";
@@ -196,7 +202,17 @@ public class SnapshotDao {
     }
 
     /**
-     * This is a convenience wrapper that returns all snapshots, regardless of whether they are exclusively locked.
+     * This is a convenience wrapper that returns a snapshot only if it is NOT exclusively locked.
+     * This method is intended for user-facing API calls (e.g. from RepositoryApiController).
+     * @param snapshotId the snapshot id
+     * @return the Snapshot object
+     */
+    public Snapshot retrieveAvailableSnapshot(UUID snapshotId) {
+        return retrieveSnapshot(snapshotId, true);
+    }
+
+    /**
+     * This is a convenience wrapper that returns a snapshot, regardless of whether it is exclusively locked.
      * Most places in the API code that are retrieving a snapshot will call this method.
      * @param snapshotId the snapshot id
      * @return the Snapshot object
@@ -208,7 +224,8 @@ public class SnapshotDao {
     /**
      * Retrieves a Snapshot object from the snapshot id.
      * @param snapshotId the snapshot id
-     * @param onlyRetrieveAvailable true to exclude snapshots that are exclusively locked, false to include all snapshots
+     * @param onlyRetrieveAvailable true to exclude snapshots that are exclusively locked,
+     *                              false to include all snapshots
      * @return the Snapshot object
      */
     public Snapshot retrieveSnapshot(UUID snapshotId, boolean onlyRetrieveAvailable) {
@@ -306,19 +323,30 @@ public class SnapshotDao {
         return snapshotSources;
     }
 
-    // excludes snapshots that are exclusively locked
+    /**
+     * Fetch a list of all the available snapshots.
+     * This method returns summary objects, which do not include sub-objects associated with snapshots (e.g. tables).
+     * Note that this method will only return snapshots that are NOT exclusively locked.
+     * @param offset skip this many snapshots from the beginning of the list (intended for "scrolling" behavior)
+     * @param limit only return this many snapshots in the list
+     * @param sort field for order by clause. possible values are: name, description, created_date
+     * @param direction asc or desc
+     * @param filter string to match (SQL ILIKE) in snapshots name or description
+     * @param accessibleSnapshotIds list of snapshots ids that caller has access to (fetched from IAM service)
+     * @return a list of dataset summary objects
+     */
     public MetadataEnumeration<SnapshotSummary> retrieveSnapshots(
         int offset,
         int limit,
         String sort,
         String direction,
         String filter,
-        List<UUID> accessibleDatasetIds) {
+        List<UUID> accessibleSnapshotIds) {
         logger.debug("retrieve snapshots offset: " + offset + " limit: " + limit + " sort: " + sort +
             " direction: " + direction + " filter:" + filter);
         MapSqlParameterSource params = new MapSqlParameterSource();
         List<String> whereClauses = new ArrayList<>();
-        DaoUtils.addAuthzIdsClause(accessibleDatasetIds, params, whereClauses);
+        DaoUtils.addAuthzIdsClause(accessibleSnapshotIds, params, whereClauses);
         whereClauses.add(" flightid IS NULL"); // exclude snapshots that are exclusively locked
 
         // add the filter to the clause to get the actual items

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -154,11 +154,15 @@ public class SnapshotService {
 
     /** Convenience wrapper around fetching an existing Snapshot object and converting it to a Model object.
      * Unlike the Snapshot object, the Model object includes a reference to the associated cloud project.
+     *
+     * Note that this method will only return a snapshot if it is NOT exclusively locked.
+     * It is intended for user-facing calls (e.g. from RepositoryApiController), not internal calls that may require
+     * an exclusively locked snapshot to be returned (e.g. snapshot deletion).
      * @param id in UUID formant
      * @return a SnapshotModel = API output-friendly representation of the Snapshot
      */
-    public SnapshotModel retrieveModel(UUID id) {
-        Snapshot snapshot = retrieve(id);
+    public SnapshotModel retrieveAvailableSnapshotModel(UUID id) {
+        Snapshot snapshot = retrieveAvailable(id);
         SnapshotDataProject dataProject = dataLocationService.getProjectOrThrow(snapshot);
         return populateSnapshotModelFromSnapshot(snapshot).dataProject(dataProject.getGoogleProjectId());
     }
@@ -169,6 +173,14 @@ public class SnapshotService {
      */
     public Snapshot retrieve(UUID id) {
         return snapshotDao.retrieveSnapshot(id);
+    }
+
+    /** Fetch existing Snapshot object that is NOT exclusively locked.
+     * @param id in UUID format
+     * @return a Snapshot object
+     */
+    public Snapshot retrieveAvailable(UUID id) {
+        return snapshotDao.retrieveSnapshot(id, true);
     }
 
     /** Fetch existing Snapshot object using the name.

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -180,7 +180,7 @@ public class SnapshotService {
      * @return a Snapshot object
      */
     public Snapshot retrieveAvailable(UUID id) {
-        return snapshotDao.retrieveSnapshot(id, true);
+        return snapshotDao.retrieveAvailableSnapshot(id);
     }
 
     /** Fetch existing Snapshot object using the name.

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -9,7 +9,6 @@ public class SnapshotSummary {
     private String description;
     private Instant createdDate;
     private UUID profileId;
-    private String flightId;
 
     public UUID getId() {
         return id;
@@ -55,14 +54,4 @@ public class SnapshotSummary {
         this.profileId = profileId;
         return this;
     }
-
-    public String getFlightId() {
-        return flightId;
-    }
-
-    public SnapshotSummary flightId(String flightId) {
-        this.flightId = flightId;
-        return this;
-    }
-
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPrimaryDataQueryStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPrimaryDataQueryStep.java
@@ -66,7 +66,7 @@ public class CreateSnapshotPrimaryDataQueryStep implements Step {
         String datasetName = datasetNames.get(0);
 
         Dataset dataset = datasetService.retrieveByName(datasetName);
-        DatasetModel datasetModel = datasetService.retrieveModel(dataset.getId());
+        DatasetModel datasetModel = datasetService.retrieveModel(dataset);
 
         // get asset out of dataset
         Optional<AssetSpecification> assetSpecOp = dataset.getAssetSpecificationByName(snapshotAssetName);

--- a/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
@@ -15,6 +15,7 @@ import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.DeleteResponseModel;
+import bio.terra.model.EnumerateDatasetModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.FileModel;
@@ -748,6 +749,161 @@ public class DatasetConnectedTest {
         connectedOperations.getDatasetExpectError(summaryModel.getId(), HttpStatus.NOT_FOUND);
     }
 
+    @Test
+    public void testExcludeLockedFromDatasetLookups() throws Exception {
+        // create a dataset and check that it succeeds
+        String resourcePath = "snapshot-test-dataset.json";
+        DatasetRequestModel datasetRequest =
+            jsonLoader.loadObject(resourcePath, DatasetRequestModel.class);
+        datasetRequest
+            .name(Names.randomizeName(datasetRequest.getName()))
+            .defaultProfileId(billingProfile.getId());
+        DatasetSummaryModel summaryModel = connectedOperations.createDataset(datasetRequest);
+
+        // check that the dataset metadata row is unlocked
+        UUID datasetId = UUID.fromString(summaryModel.getId());
+        String exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+        assertNull("dataset row is not exclusively locked", exclusiveLock);
+        String[] sharedLocks = datasetDao.getSharedLocks(datasetId);
+        assertEquals("dataset row has no shared lock", 0, sharedLocks.length);
+
+        // retrieve the dataset and check that it finds it
+        DatasetModel datasetModel = connectedOperations.getDataset(summaryModel.getId());
+        assertEquals("Lookup unlocked dataset succeeds", summaryModel.getName(), datasetModel.getName());
+
+        // enumerate datasets and check that this dataset is included in the set
+        EnumerateDatasetModel enumerateDatasetModel = connectedOperations.enumerateDatasets(summaryModel.getName());
+        List<DatasetSummaryModel> enumeratedDatasets = enumerateDatasetModel.getItems();
+        boolean foundDatasetWithMatchingId = false;
+        for (DatasetSummaryModel enumeratedDataset : enumeratedDatasets) {
+            if (enumeratedDataset.getId().equals(summaryModel.getId())) {
+                foundDatasetWithMatchingId = true;
+                break;
+            }
+        }
+        assertTrue("Unlocked included in enumeration", foundDatasetWithMatchingId);
+
+        // enable wait in DeleteDatasetPrimaryDataStep
+        configService.setFault(ConfigEnum.DATASET_DELETE_LOCK_CONFLICT_STOP_FAULT.name(), true);
+
+        // kick off a request to delete the dataset. this should hang before unlocking the dataset object.
+        MvcResult deleteResult = mvc.perform(delete("/api/repository/v1/datasets/" + summaryModel.getId())).andReturn();
+
+        // check that the dataset metadata row has an exclusive lock
+        exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+        assertNotNull("dataset row is exclusively locked", exclusiveLock);
+        sharedLocks = datasetDao.getSharedLocks(datasetId);
+        assertEquals("dataset row has no shared lock", 0, sharedLocks.length);
+
+        // retrieve the dataset and check that it returns not found
+        connectedOperations.getDatasetExpectError(summaryModel.getId(), HttpStatus.NOT_FOUND);
+
+        // enumerate datasets and check that this dataset is not included in the set
+        enumerateDatasetModel = connectedOperations.enumerateDatasets(summaryModel.getName());
+        enumeratedDatasets = enumerateDatasetModel.getItems();
+        foundDatasetWithMatchingId = false;
+        for (DatasetSummaryModel enumeratedDataset : enumeratedDatasets) {
+            if (enumeratedDataset.getId().equals(summaryModel.getId())) {
+                foundDatasetWithMatchingId = true;
+                break;
+            }
+        }
+        assertFalse("Exclusively locked not included in enumeration", foundDatasetWithMatchingId);
+
+        // disable wait in DeleteDatasetPrimaryDataStep
+        configService.setFault(ConfigEnum.DATASET_DELETE_LOCK_CONFLICT_CONTINUE_FAULT.name(), true);
+
+        // check the response from the delete request
+        MockHttpServletResponse deleteResponse = connectedOperations.validateJobModelAndWait(deleteResult);
+        DeleteResponseModel deleteResponseModel =
+            connectedOperations.handleSuccessCase(deleteResponse, DeleteResponseModel.class);
+        assertEquals("Dataset delete returned successfully",
+            DeleteResponseModel.ObjectStateEnum.DELETED, deleteResponseModel.getObjectState());
+
+        // try to fetch the dataset again and confirm nothing is returned
+        connectedOperations.getDatasetExpectError(summaryModel.getId(), HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    public void testExcludeLockedFromFileLookups() throws Exception {
+        // create a dataset and check that it succeeds
+        String resourcePath = "snapshot-test-dataset.json";
+        DatasetRequestModel datasetRequest =
+            jsonLoader.loadObject(resourcePath, DatasetRequestModel.class);
+        datasetRequest
+            .name(Names.randomizeName(datasetRequest.getName()))
+            .defaultProfileId(billingProfile.getId());
+        DatasetSummaryModel summaryModel = connectedOperations.createDataset(datasetRequest);
+
+        // check that the dataset metadata row is unlocked
+        UUID datasetId = UUID.fromString(summaryModel.getId());
+        String exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+        assertNull("dataset row is not exclusively locked", exclusiveLock);
+        String[] sharedLocks = datasetDao.getSharedLocks(datasetId);
+        assertEquals("dataset row has no shared lock", 0, sharedLocks.length);
+
+        // ingest a file
+        URI sourceUri = new URI("gs", "jade-testdata", "/fileloadprofiletest/1KBfile.txt",
+            null, null);
+        String targetPath1 = "/mm/" + Names.randomizeName("testdir") + "/testExcludeLockedFromFileLookups.txt";
+        FileLoadModel fileLoadModel = new FileLoadModel()
+            .sourcePath(sourceUri.toString())
+            .description("testExcludeLockedFromFileLookups")
+            .mimeType("text/plain")
+            .targetPath(targetPath1)
+            .profileId(billingProfile.getId());
+        FileModel fileModel = connectedOperations.ingestFileSuccess(summaryModel.getId(), fileLoadModel);
+
+        // lookup the file by id and check that it's found
+        FileModel fileModelFromIdLookup =
+            connectedOperations.lookupFileSuccess(summaryModel.getId(), fileModel.getFileId());
+        assertEquals("File found by id lookup",
+            fileModel.getDescription(), fileModelFromIdLookup.getDescription());
+
+        // lookup the file by path and check that it's found
+        FileModel fileModelFromPathLookup =
+            connectedOperations.lookupFileByPathSuccess(summaryModel.getId(), fileModel.getPath(), -1);
+        assertEquals("File found by path lookup", fileModel.getDescription(), fileModelFromPathLookup.getDescription());
+
+        // enable wait in DeleteDatasetPrimaryDataStep
+        configService.setFault(ConfigEnum.DATASET_DELETE_LOCK_CONFLICT_STOP_FAULT.name(), true);
+
+        // kick off a request to delete the dataset. this should hang before unlocking the dataset object.
+        MvcResult deleteResult = mvc.perform(delete("/api/repository/v1/datasets/" + summaryModel.getId())).andReturn();
+
+        // check that the dataset metadata row has an exclusive lock
+        exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+        assertNotNull("dataset row is exclusively locked", exclusiveLock);
+        sharedLocks = datasetDao.getSharedLocks(datasetId);
+        assertEquals("dataset row has no shared lock", 0, sharedLocks.length);
+
+        // lookup the file by id and check that it's NOT found
+        MockHttpServletResponse response =
+            connectedOperations.lookupFileRaw(summaryModel.getId(), fileModel.getFileId());
+        assertEquals("File NOT found by id lookup", HttpStatus.NOT_FOUND, HttpStatus.valueOf(response.getStatus()));
+
+        // lookup the file by path and check that it's NOT found
+        response =
+            connectedOperations.lookupFileByPathRaw(summaryModel.getId(), fileModel.getPath(), -1);
+        assertEquals("File NOT found by path lookup", HttpStatus.NOT_FOUND, HttpStatus.valueOf(response.getStatus()));
+
+        // disable wait in DeleteDatasetPrimaryDataStep
+        configService.setFault(ConfigEnum.DATASET_DELETE_LOCK_CONFLICT_CONTINUE_FAULT.name(), true);
+
+        // check the response from the delete request
+        MockHttpServletResponse deleteResponse = connectedOperations.validateJobModelAndWait(deleteResult);
+        DeleteResponseModel deleteResponseModel =
+            connectedOperations.handleSuccessCase(deleteResponse, DeleteResponseModel.class);
+        assertEquals("Dataset delete returned successfully",
+            DeleteResponseModel.ObjectStateEnum.DELETED, deleteResponseModel.getObjectState());
+
+        // remove the file from the connectedoperation bookkeeping list
+        connectedOperations.removeFile(summaryModel.getId(), fileModel.getFileId());
+
+        // try to fetch the dataset again and confirm nothing is returned
+        connectedOperations.getDatasetExpectError(summaryModel.getId(), HttpStatus.NOT_FOUND);
+    }
+
     private List<String> getRowIdsFromBQTable(String datasetName, String tableName) throws Exception {
         String rowIdColumn = PdaoConstant.PDAO_ROW_ID_COLUMN;
         TableResult bqQueryResult = TestUtils.selectFromBigQueryDataset(bigQueryPdao, datasetDao, dataLocationService,
@@ -791,5 +947,4 @@ public class DatasetConnectedTest {
 
         return softDeleteRequest;
     }
-
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -357,5 +357,5 @@ public class DatasetIntegrationTest extends UsersBase {
 
         // there should be (7 - 5) = 2 rows "visible" in the sample table
         assertTableCount(bigQuery, dataset, "sample", 2L);
-    }DatasetConnectedTest.java
+    }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -357,5 +357,5 @@ public class DatasetIntegrationTest extends UsersBase {
 
         // there should be (7 - 5) = 2 rows "visible" in the sample table
         assertTableCount(bigQuery, dataset, "sample", 2L);
-    }
+    }DatasetConnectedTest.java
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -12,7 +12,10 @@ import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.DeleteResponseModel;
 import bio.terra.model.EnumerateSnapshotModel;
 import bio.terra.model.ErrorModel;
+import bio.terra.model.FileLoadModel;
+import bio.terra.model.FileModel;
 import bio.terra.model.IngestRequestModel;
+import bio.terra.model.IngestResponseModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SnapshotRequestModel;
@@ -56,10 +59,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.stringtemplate.v4.ST;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static bio.terra.common.PdaoConstant.PDAO_PREFIX;
@@ -472,9 +477,88 @@ public class SnapshotConnectedTest {
 
     @Test
     public void testExcludeLockedFromSnapshotFileLookups() throws Exception {
-        // TODO: see similar test in datasetconnectedtest class
-        // note: need to use a dataset that includes filerefs, so that files get included in the snapshot
-        // I don't think the dataset used in the above test includes filerefs. check encode test maybe?
+        // create a dataset
+        DatasetSummaryModel datasetSummary = createTestDataset("simple-with-filerefs-dataset.json");
+
+        // ingest a file
+        URI sourceUri = new URI("gs", "jade-testdata", "/fileloadprofiletest/1KBfile.txt",
+            null, null);
+        String targetFilePath =
+            "/mm/" + Names.randomizeName("testdir") + "/testExcludeLockedFromSnapshotFileLookups.txt";
+        FileLoadModel fileLoadModel = new FileLoadModel()
+            .sourcePath(sourceUri.toString())
+            .description("testExcludeLockedFromSnapshotFileLookups")
+            .mimeType("text/plain")
+            .targetPath(targetFilePath)
+            .profileId(billingProfile.getId());
+        FileModel fileModel = connectedOperations.ingestFileSuccess(datasetSummary.getId(), fileLoadModel);
+
+        // generate a JSON file with the fileref
+        String jsonLine = "{\"name\":\"name1\", \"file\":\"" + fileModel.getFileId() + "\"}\n";
+
+        // load a JSON file that contains the table rows to load into the test bucket
+        String jsonFileName = "snapshot-test-dataset-data-without-rowids.json";
+        String dirInCloud = "scratch/testExcludeLockedFromSnapshotFileLookups/" + UUID.randomUUID().toString();
+        BlobInfo ingestTableBlob = BlobInfo
+            .newBuilder(testConfig.getIngestbucket(), dirInCloud + "/" + jsonFileName)
+            .build();
+        Storage storage = StorageOptions.getDefaultInstance().getService();
+        storage.create(ingestTableBlob, jsonLine.getBytes());
+
+        // make sure the JSON file gets cleaned up on test teardown
+        connectedOperations.addScratchFile(dirInCloud + "/" + jsonFileName);
+
+        // ingest the tabular data from the JSON file we just generated
+        String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + dirInCloud + "/" + jsonFileName;
+        IngestRequestModel ingestRequest1 = new IngestRequestModel()
+            .format(IngestRequestModel.FormatEnum.JSON)
+            .table("tableA")
+            .path(gsPath);
+        connectedOperations.ingestTableSuccess(datasetSummary.getId(), ingestRequest1);
+
+        // create a snapshot
+//        SnapshotSummaryModel snapshotSummary = connectedOperations.createSnapshot(datasetSummary,
+//            "snapshot-test-snapshot.json", "_d2_");
+
+        // I think this is where you'll need the DRS service.
+
+        // TODO: lookup the snapshot file by id and path, make sure it's returned
+
+        // TODO: lookup the snapshot file by path and check that it's found
+
+        // enable wait in DeleteSnapshotPrimaryDataStep
+//        configService.setFault(ConfigEnum.SNAPSHOT_DELETE_LOCK_CONFLICT_STOP_FAULT.name(), true);
+
+        // kick off a request to delete the snapshot. this should hang before unlocking the snapshot object.
+//        MvcResult deleteResult = mvc.perform(delete("/api/repository/v1/snapshots/" + snapshotSummary.getId())).andReturn();
+//        TimeUnit.SECONDS.sleep(5); // give the flight time to launch
+
+        // check that the snapshot metadata row has an exclusive lock
+//        exclusiveLock = snapshotDao.getExclusiveLock(UUID.fromString(snapshotSummary.getId()));
+//        assertNotNull("snapshot row is exclusively locked", exclusiveLock);
+
+        // TODO: lookup the snapshot file by id and check that it's NOT found
+
+        // TODO: lookup the snapshot file by path and check that it's NOT found
+
+        // disable wait in DeleteSnapshotPrimaryDataStep
+//        configService.setFault(ConfigEnum.SNAPSHOT_DELETE_LOCK_CONFLICT_CONTINUE_FAULT.name(), true);
+
+        // check the response from the snapshot delete request
+//        MockHttpServletResponse deleteResponse = connectedOperations.validateJobModelAndWait(deleteResult);
+//        DeleteResponseModel deleteResponseModel =
+//            connectedOperations.handleSuccessCase(deleteResponse, DeleteResponseModel.class);
+//        assertEquals("Snapshot delete returned successfully",
+//            DeleteResponseModel.ObjectStateEnum.DELETED, deleteResponseModel.getObjectState());
+
+        // delete the dataset and check that it succeeds
+        connectedOperations.deleteTestDataset(datasetSummary.getId());
+
+        // remove the file from the connectedoperation bookkeeping list
+        connectedOperations.removeFile(datasetSummary.getId(), fileModel.getFileId());
+
+        // try to fetch the dataset again and confirm nothing is returned
+        connectedOperations.getDatasetExpectError(datasetSummary.getId(), HttpStatus.NOT_FOUND);
     }
 
     private DatasetSummaryModel setupMinimalDataset() throws Exception {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -7,15 +7,11 @@ import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.Names;
 import bio.terra.model.BillingProfileModel;
-import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.DeleteResponseModel;
 import bio.terra.model.EnumerateSnapshotModel;
 import bio.terra.model.ErrorModel;
-import bio.terra.model.FileLoadModel;
-import bio.terra.model.FileModel;
 import bio.terra.model.IngestRequestModel;
-import bio.terra.model.IngestResponseModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SnapshotRequestModel;
@@ -59,12 +55,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.stringtemplate.v4.ST;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static bio.terra.common.PdaoConstant.PDAO_PREFIX;
@@ -473,92 +467,6 @@ public class SnapshotConnectedTest {
 
         // try to fetch the snapshot again and confirm nothing is returned
         connectedOperations.getSnapshotExpectError(snapshotSummary.getId(), HttpStatus.NOT_FOUND);
-    }
-
-    @Test
-    public void testExcludeLockedFromSnapshotFileLookups() throws Exception {
-        // create a dataset
-        DatasetSummaryModel datasetSummary = createTestDataset("simple-with-filerefs-dataset.json");
-
-        // ingest a file
-        URI sourceUri = new URI("gs", "jade-testdata", "/fileloadprofiletest/1KBfile.txt",
-            null, null);
-        String targetFilePath =
-            "/mm/" + Names.randomizeName("testdir") + "/testExcludeLockedFromSnapshotFileLookups.txt";
-        FileLoadModel fileLoadModel = new FileLoadModel()
-            .sourcePath(sourceUri.toString())
-            .description("testExcludeLockedFromSnapshotFileLookups")
-            .mimeType("text/plain")
-            .targetPath(targetFilePath)
-            .profileId(billingProfile.getId());
-        FileModel fileModel = connectedOperations.ingestFileSuccess(datasetSummary.getId(), fileLoadModel);
-
-        // generate a JSON file with the fileref
-        String jsonLine = "{\"name\":\"name1\", \"file\":\"" + fileModel.getFileId() + "\"}\n";
-
-        // load a JSON file that contains the table rows to load into the test bucket
-        String jsonFileName = "snapshot-test-dataset-data-without-rowids.json";
-        String dirInCloud = "scratch/testExcludeLockedFromSnapshotFileLookups/" + UUID.randomUUID().toString();
-        BlobInfo ingestTableBlob = BlobInfo
-            .newBuilder(testConfig.getIngestbucket(), dirInCloud + "/" + jsonFileName)
-            .build();
-        Storage storage = StorageOptions.getDefaultInstance().getService();
-        storage.create(ingestTableBlob, jsonLine.getBytes());
-
-        // make sure the JSON file gets cleaned up on test teardown
-        connectedOperations.addScratchFile(dirInCloud + "/" + jsonFileName);
-
-        // ingest the tabular data from the JSON file we just generated
-        String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + dirInCloud + "/" + jsonFileName;
-        IngestRequestModel ingestRequest1 = new IngestRequestModel()
-            .format(IngestRequestModel.FormatEnum.JSON)
-            .table("tableA")
-            .path(gsPath);
-        connectedOperations.ingestTableSuccess(datasetSummary.getId(), ingestRequest1);
-
-        // create a snapshot
-//        SnapshotSummaryModel snapshotSummary = connectedOperations.createSnapshot(datasetSummary,
-//            "snapshot-test-snapshot.json", "_d2_");
-
-        // I think this is where you'll need the DRS service.
-
-        // TODO: lookup the snapshot file by id and path, make sure it's returned
-
-        // TODO: lookup the snapshot file by path and check that it's found
-
-        // enable wait in DeleteSnapshotPrimaryDataStep
-//        configService.setFault(ConfigEnum.SNAPSHOT_DELETE_LOCK_CONFLICT_STOP_FAULT.name(), true);
-
-        // kick off a request to delete the snapshot. this should hang before unlocking the snapshot object.
-//        MvcResult deleteResult = mvc.perform(delete("/api/repository/v1/snapshots/" + snapshotSummary.getId())).andReturn();
-//        TimeUnit.SECONDS.sleep(5); // give the flight time to launch
-
-        // check that the snapshot metadata row has an exclusive lock
-//        exclusiveLock = snapshotDao.getExclusiveLock(UUID.fromString(snapshotSummary.getId()));
-//        assertNotNull("snapshot row is exclusively locked", exclusiveLock);
-
-        // TODO: lookup the snapshot file by id and check that it's NOT found
-
-        // TODO: lookup the snapshot file by path and check that it's NOT found
-
-        // disable wait in DeleteSnapshotPrimaryDataStep
-//        configService.setFault(ConfigEnum.SNAPSHOT_DELETE_LOCK_CONFLICT_CONTINUE_FAULT.name(), true);
-
-        // check the response from the snapshot delete request
-//        MockHttpServletResponse deleteResponse = connectedOperations.validateJobModelAndWait(deleteResult);
-//        DeleteResponseModel deleteResponseModel =
-//            connectedOperations.handleSuccessCase(deleteResponse, DeleteResponseModel.class);
-//        assertEquals("Snapshot delete returned successfully",
-//            DeleteResponseModel.ObjectStateEnum.DELETED, deleteResponseModel.getObjectState());
-
-        // delete the dataset and check that it succeeds
-        connectedOperations.deleteTestDataset(datasetSummary.getId());
-
-        // remove the file from the connectedoperation bookkeeping list
-        connectedOperations.removeFile(datasetSummary.getId(), fileModel.getFileId());
-
-        // try to fetch the dataset again and confirm nothing is returned
-        connectedOperations.getDatasetExpectError(datasetSummary.getId(), HttpStatus.NOT_FOUND);
     }
 
     private DatasetSummaryModel setupMinimalDataset() throws Exception {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -339,7 +339,7 @@ public class SnapshotConnectedTest {
         assertNotNull("fetched snapshot successfully after creation", snapshotModel);
 
         // check that the snapshot metadata row is unlocked
-        String exclusiveLock = snapshotDao.getExclusiveLock(UUID.fromString(snapshotModel.getId()));
+        String exclusiveLock = snapshotDao.getExclusiveLockState(UUID.fromString(snapshotModel.getId()));
         assertNull("snapshot row is unlocked", exclusiveLock);
 
         // try to create the same snapshot again and check that it fails
@@ -409,7 +409,7 @@ public class SnapshotConnectedTest {
             "snapshot-test-snapshot.json", "_d2_");
 
         // check that the snapshot metadata row is unlocked
-        String exclusiveLock = snapshotDao.getExclusiveLock(UUID.fromString(snapshotSummary.getId()));
+        String exclusiveLock = snapshotDao.getExclusiveLockState(UUID.fromString(snapshotSummary.getId()));
         assertNull("snapshot row is unlocked", exclusiveLock);
 
         // retrieve the snapshot and check that it finds it
@@ -436,7 +436,7 @@ public class SnapshotConnectedTest {
         MvcResult deleteResult = mvc.perform(delete("/api/repository/v1/snapshots/" + snapshotSummary.getId())).andReturn();
 
         // check that the snapshot metadata row has an exclusive lock
-        exclusiveLock = snapshotDao.getExclusiveLock(UUID.fromString(snapshotSummary.getId()));
+        exclusiveLock = snapshotDao.getExclusiveLockState(UUID.fromString(snapshotSummary.getId()));
         assertNotNull("snapshot row is exclusively locked", exclusiveLock);
 
         // retrieve the snapshot and check that it returns not found

--- a/src/test/resources/simple-with-filerefs-dataset.json
+++ b/src/test/resources/simple-with-filerefs-dataset.json
@@ -1,0 +1,26 @@
+{
+  "name":        "SimpleWithFilerefs",
+  "description": "This is a sample dataset definition with filerefs",
+  "defaultProfileId": "deadbeef-face-cafe-bead-0ddba11deed5",
+  "schema":      {
+    "tables":        [
+      {
+        "name":    "tableA",
+        "columns": [
+          {"name": "name", "datatype": "string"},
+          {"name": "file", "datatype": "fileref"}
+        ]
+      }
+    ],
+    "assets":        [
+      {
+        "name":   "simpleasset",
+        "rootTable": "tableA",
+        "rootColumn": "name",
+        "tables": [
+          {"name": "tableA", "columns": []}
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Exclude datasets, dataset files, and snapshots from external lookups if the dataset/snapshot is exclusively locked.
- This is intended to not return datasets/snapshots that are in the process of being created or deleted.
- The affected endpoints are: enumerateDatasets, retrieveDataset, lookupFileById, lookupFileByPath, enumerateSnapshots, retrieveSnapshot.
- Removed the exclusive lock property from the SnapshotSummary object and replaced it with a protected method in the DAO class. The intent is to expose the internal lock state of a snapshot to tests only, not the API code. This is now consistent the way we test dataset locks.

** This PR should be merged after soft deletes have been changed to use shared locks, otherwise soft deletes will also cause datasets and files to not be returned by lookups.