### PR TITLE
DR-754 - part 1: Update concurrent file parameter during ingest

### DIFF
--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -93,10 +93,6 @@ public class FileService {
             .addParameter(LoadMapKeys.IS_ARRAY, false)
             .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
             .addParameter(LoadMapKeys.LOAD_TAG, loadTag)
-            .addParameter(LoadMapKeys.CONCURRENT_INGESTS,
-                configService.getParameterValue(ConfigEnum.LOAD_CONCURRENT_INGESTS))
-            .addParameter(LoadMapKeys.CONCURRENT_FILES,
-                configService.getParameterValue(ConfigEnum.LOAD_CONCURRENT_FILES))
             .addParameter(LoadMapKeys.DRIVER_WAIT_SECONDS,
                 configService.getParameterValue(ConfigEnum.LOAD_DRIVER_WAIT_SECONDS))
             .addParameter(LoadMapKeys.LOAD_HISTORY_COPY_CHUNK_SIZE,
@@ -123,10 +119,6 @@ public class FileService {
             .addParameter(LoadMapKeys.IS_ARRAY, true)
             .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
             .addParameter(LoadMapKeys.LOAD_TAG, loadTag)
-            .addParameter(LoadMapKeys.CONCURRENT_INGESTS,
-                configService.getParameterValue(ConfigEnum.LOAD_CONCURRENT_INGESTS))
-            .addParameter(LoadMapKeys.CONCURRENT_FILES,
-                configService.getParameterValue(ConfigEnum.LOAD_CONCURRENT_FILES))
             .addParameter(LoadMapKeys.DRIVER_WAIT_SECONDS,
                 configService.getParameterValue(ConfigEnum.LOAD_DRIVER_WAIT_SECONDS))
             .addParameter(LoadMapKeys.LOAD_HISTORY_COPY_CHUNK_SIZE,

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -3,6 +3,7 @@ package bio.terra.service.filedata.flight.ingest;
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamProviderInterface;
@@ -46,11 +47,11 @@ public class FileIngestBulkFlight extends Flight {
         DataLocationService locationService = (DataLocationService)appContext.getBean("dataLocationService");
         BigQueryPdao bigQueryPdao = (BigQueryPdao)appContext.getBean("bigQueryPdao");
         DatasetService datasetService = (DatasetService) appContext.getBean("datasetService");
+        ConfigurationService configurationService = (ConfigurationService) appContext.getBean("configurationService");
 
         // Common input parameters
         String datasetId = inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class);
         String loadTag = inputParameters.get(LoadMapKeys.LOAD_TAG, String.class);
-        int concurrentFiles = inputParameters.get(LoadMapKeys.CONCURRENT_FILES, Integer.class);
         int driverWaitSeconds = inputParameters.get(LoadMapKeys.DRIVER_WAIT_SECONDS, Integer.class);
         int fileChunkSize = inputParameters.get(LoadMapKeys.LOAD_HISTORY_COPY_CHUNK_SIZE, Integer.class);
         boolean isArray = inputParameters.get(LoadMapKeys.IS_ARRAY, Boolean.class);
@@ -111,9 +112,9 @@ public class FileIngestBulkFlight extends Flight {
         addStep(new IngestFilePrimaryDataLocationStep(locationService, profileId), createBucketRetry);
         addStep(new IngestDriverStep(
             loadService,
+            configurationService,
             datasetId,
             loadTag,
-            concurrentFiles,
             maxFailedFileLoads,
             driverWaitSeconds,
             profileId));

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -1,6 +1,8 @@
 package bio.terra.service.filedata.flight.ingest;
 
 import bio.terra.model.FileLoadModel;
+import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.FSFileInfo;
 import bio.terra.service.filedata.exception.FileSystemCorruptException;
 import bio.terra.service.filedata.flight.FileMapKeys;
@@ -42,24 +44,24 @@ public class IngestDriverStep implements Step {
     private final Logger logger = LoggerFactory.getLogger(IngestDriverStep.class);
 
     private final LoadService loadService;
+    private final ConfigurationService configurationService;
     private final String datasetId;
     private final String loadTag;
-    private final int concurrentFiles;
     private final int maxFailedFileLoads;
     private final int driverWaitSeconds;
     private final String profileId;
 
     public IngestDriverStep(LoadService loadService,
+                            ConfigurationService configurationService,
                             String datasetId,
                             String loadTag,
-                            int concurrentFiles,
                             int maxFailedFileLoads,
                             int driverWaitSeconds,
                             String profileId) {
         this.loadService = loadService;
+        this.configurationService = configurationService;
         this.datasetId = datasetId;
         this.loadTag = loadTag;
-        this.concurrentFiles = concurrentFiles;
         this.maxFailedFileLoads = maxFailedFileLoads;
         this.driverWaitSeconds = driverWaitSeconds;
         this.profileId = profileId;
@@ -81,6 +83,7 @@ public class IngestDriverStep implements Step {
 
             // Load Loop
             while (true) {
+                int concurrentFiles = configurationService.getParameterValue(ConfigEnum.LOAD_CONCURRENT_FILES);
                 // Get the state of active and failed loads
                 LoadCandidates candidates = getLoadCandidates(context, loadId, concurrentFiles);
 

--- a/src/main/java/bio/terra/service/kubernetes/KubeService.java
+++ b/src/main/java/bio/terra/service/kubernetes/KubeService.java
@@ -94,6 +94,8 @@ public class KubeService {
      * Launch the pod listener thread.
      */
     public void startPodListener() {
+        // TODO Remove before merging!! 
+        logger.info("inKubernetes value: {}", inKubernetes);
         if (inKubernetes) {
             podListener = new KubePodListener(jobShutdownState, namespace, podName);
             podListenerThread = new Thread(podListener);

--- a/src/main/java/bio/terra/service/kubernetes/KubeService.java
+++ b/src/main/java/bio/terra/service/kubernetes/KubeService.java
@@ -94,8 +94,6 @@ public class KubeService {
      * Launch the pod listener thread.
      */
     public void startPodListener() {
-        // TODO Remove before merging!! 
-        logger.info("inKubernetes value: {}", inKubernetes);
         if (inKubernetes) {
             podListener = new KubePodListener(jobShutdownState, namespace, podName);
             podListenerThread = new Thread(podListener);

--- a/src/main/java/bio/terra/service/load/flight/LoadMapKeys.java
+++ b/src/main/java/bio/terra/service/load/flight/LoadMapKeys.java
@@ -6,8 +6,6 @@ public final class LoadMapKeys {
     }
     public static final String LOAD_TAG = "loadTag";
     public static final String LOAD_ID = "loadId";
-    public static final String CONCURRENT_INGESTS = "concurrentIngests";
-    public static final String CONCURRENT_FILES = "concurrentFiles";
     public static final String DRIVER_WAIT_SECONDS = "driverWaitSeconds";
     public static final String IS_ARRAY = "isArray";
     public static final String LOAD_HISTORY_COPY_CHUNK_SIZE = "loadHistoryCopyChunkSize";


### PR DESCRIPTION
This is the first step towards implementing parameters that scale with the number of pods. 

Before these changes, the max number of concurrent file loads allowed was set at the beginning of a file load. Now, the parameter is updated during the flight to allow scaling of the number of concurrent files to be loaded in proportion with the number of Kubernete pods. 

So, this change boils down to:
1. Moving the fetch parameter statement from the start of the flight to within the file ingest flight, so that it can be updated.
2. Remove the intermediary parameters in the LoadMapKeys that are no longer used (CONCURRENT_FILES & CONCURRENT_INGESTS).  The original parameters have not been altered and are still defined in the ConfigEnum (LOAD_CONCURRENT_INGESTS & LOAD_CONCURRENT_FILES). 