### PR TITLE
DR-1048: Refactor locking connected tests. Add config reset to connected teardown.

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           actions_subcommand: 'helmdeploy'
           helm_secret_chart_version: '0.0.4'
-          helm_datarepo_chart_version: '0.1.7'
+          helm_datarepo_chart_version: '0.1.9'
       - name: "Run Integration test via Gradle"
         uses: broadinstitute/datarepo-actions@0.6.0
         with:

--- a/skaffold.yaml.template
+++ b/skaffold.yaml.template
@@ -25,8 +25,8 @@ deploy:
       valuesFiles:
       - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/TEMPSecrets.yaml
     - name: TEMP-jade
-      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-0.1.7/datarepo-0.1.7.tgz
-      version: 0.1.7
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-0.1.9/datarepo-0.1.9.tgz
+      version: 0.1.9
       namespace: TEMP
       remote: true
       values:

--- a/src/main/java/bio/terra/service/configuration/ConfigurationService.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigurationService.java
@@ -227,7 +227,7 @@ public class ConfigurationService {
             ConfigFaultCountedModel.RateStyleEnum.FIXED);
         addFaultSimple(FILE_DELETE_LOCK_CONFLICT_CONTINUE_FAULT);
 
-        // File delete lock faults. These are used by DatasetConnectedTest > testSharedLockFileDelete
+        // Table ingest lock faults. These are used by DatasetConnectedTest > testSharedLockTableIngest
         addFaultCounted(TABLE_INGEST_LOCK_CONFLICT_STOP_FAULT, 0, 2, 100,
             ConfigFaultCountedModel.RateStyleEnum.FIXED);
         addFaultSimple(TABLE_INGEST_LOCK_CONFLICT_CONTINUE_FAULT);

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -228,6 +228,11 @@ public class DatasetDao {
         return datasetId;
     }
 
+    /**
+     * This method is intended for TESTING ONLY. It returns the internal state of the exclusive lock on a dataset.
+     * @param id the dataset id
+     * @return the flight id that holds the exclusive lock. null if no exclusive lock is taken out.
+     */
     protected String getExclusiveLock(UUID id) {
         try {
             String sql = "SELECT flightid FROM dataset WHERE id = :id";
@@ -238,6 +243,11 @@ public class DatasetDao {
         }
     }
 
+    /**
+     * This method is intended for TESTING ONLY. It returns the internal state of the shared locks on a dataset.
+     * @param id the dataset id
+     * @return the array of flight ids that hold shared locks. empty if no shared locks are taken out.
+     */
     protected String[] getSharedLocks(UUID id) {
         try {
             String sql = "SELECT sharedlock FROM dataset WHERE id = :id";

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -31,12 +31,12 @@ public class DatasetIngestFlight extends Flight {
         UUID datasetId = UUID.fromString(inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class));
 
         addStep(new LockDatasetStep(datasetDao, datasetId, true));
-        addStep(new IngestSetupStep(datasetService));
+        addStep(new IngestSetupStep(datasetService, configService));
         addStep(new IngestLoadTableStep(datasetService, bigQueryPdao));
         addStep(new IngestRowIdsStep(datasetService, bigQueryPdao));
         addStep(new IngestValidateRefsStep(datasetService, bigQueryPdao, fileDao));
         addStep(new IngestInsertIntoDatasetTableStep(datasetService, bigQueryPdao));
-        addStep(new IngestCleanupStep(datasetService, bigQueryPdao, configService));
+        addStep(new IngestCleanupStep(datasetService, bigQueryPdao));
         addStep(new UnlockDatasetStep(datasetDao, datasetId, true));
     }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCleanupStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCleanupStep.java
@@ -1,7 +1,5 @@
 package bio.terra.service.dataset.flight.ingest;
 
-import bio.terra.service.configuration.ConfigEnum;
-import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.service.dataset.DatasetService;
@@ -11,33 +9,19 @@ import bio.terra.stairway.StepResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
-
 public class IngestCleanupStep implements Step {
     private Logger logger = LoggerFactory.getLogger("bio.terra.service.dataset.flight.ingest");
 
     private final DatasetService datasetService;
     private final BigQueryPdao bigQueryPdao;
-    private final ConfigurationService configService;
 
-    public IngestCleanupStep(DatasetService datasetService, BigQueryPdao bigQueryPdao,
-                             ConfigurationService configService) {
+    public IngestCleanupStep(DatasetService datasetService, BigQueryPdao bigQueryPdao) {
         this.datasetService = datasetService;
         this.bigQueryPdao = bigQueryPdao;
-        this.configService = configService;
     }
 
     @Override
-    public StepResult doStep(FlightContext context) throws InterruptedException {
-        if (configService.testInsertFault(ConfigEnum.TABLE_INGEST_LOCK_CONFLICT_STOP_FAULT)) {
-            logger.info("TABLE_INGEST_LOCK_CONFLICT_STOP_FAULT");
-            while (!configService.testInsertFault(ConfigEnum.TABLE_INGEST_LOCK_CONFLICT_CONTINUE_FAULT)) {
-                logger.info("Sleeping for CONTINUE FAULT");
-                TimeUnit.SECONDS.sleep(5);
-            }
-            logger.info("TABLE_INGEST_LOCK_CONFLICT_CONTINUE_FAULT");
-        }
-
+    public StepResult doStep(FlightContext context) {
         // We do not want to fail the insert because we fail to cleanup the staging table.
         // We log the failure and move on.
         String stagingTableName = "<unknown>";

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -55,7 +55,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -481,7 +480,7 @@ public class ConnectedOperations {
 
     public void resetConfiguration() throws Exception {
         String url = "/api/repository/v1/configs/reset";
-        MvcResult result = mvc.perform(put(url)
+        mvc.perform(put(url)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent()) // HTTP status 204
             .andReturn();

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FileLoadTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FileLoadTest.java
@@ -135,6 +135,11 @@ public class FileLoadTest {
         logger.info("correct failed files    = " + summary.getFailedFiles());
         logger.info("correct notTried files  = " + summary.getNotTriedFiles());
 
+        // delete the dataset within this test, instead of in teardown
+        // so that the LOAD_SKIP_FILE_LOAD fault is still enabled and we don't try to delete a file
+        // that was never actually copied to GCS
+        connectedOperations.deleteTestDataset(datasetSummary.getId());
+
         assertThat(summary.getSucceededFiles(), equalTo(filesToLoad));
     }
 


### PR DESCRIPTION
- Refactored the connected tests that use hangs to test locking. Now all asserts are done after the hang is disabled, to reduce the chance of a failure before the hang is disabled.
- Added a call to the configuration reset endpoint in connectedoperations.teardown so that faults don't leak out of tests, at least when teardown is called in a Junit After method, as it often is.
- Moved the hang used to test parallel table ingests to the setup step rather than the cleanup step, so the flight gets to the hang faster.
- Added a delete dataset call to the fileLoadTest to make sure the fault to skip file loads is still enabled during delete and we don't try to delete a file that was never copied to GCS.

* I decided against forcibly cleaning up the locks, for example by adding a method to the dataset/snapshot daos that would wipe the exclusive and shared lock columns. I think the problem is that we had hung flights that persisted after tests because the hang was never being disabled after an assertion failure. The flights weren't leaving locks laying around, they were just never finishing. Rather than forcibly removing the lock, I modified the tests to let all the flights complete before any test assertions.

** This change is intended to fix the connected tests that fail with a 500 on dataset delete in teardown with a message of "Failed to lock the dataset".