### PR TITLE
DR-1063 Fix handling of GCS paths containing '#'

### DIFF
--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -188,9 +188,12 @@ public class GcsPdao {
         String sourceBucket = StringUtils.substringBefore(noGsUri, "/");
         String sourcePath = StringUtils.substringAfter(noGsUri, "/");
 
-        // GCS bucket names must be at least 3 characters long (which would put the slash at index 3).
+        // GCS bucket names must be at least 3 characters long.
         if (sourceBucket.length() < 3) {
             throw new PdaoInvalidUriException("Bucket name too short in gs path: '" + gspath + "'");
+        }
+        if (sourcePath.isEmpty()) {
+            throw new PdaoInvalidUriException("Missing object name in gs path: '" + gspath + "'");
         }
 
         Blob sourceBlob = storage.get(BlobId.of(sourceBucket, sourcePath));

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -120,13 +120,13 @@ public class FileTest extends UsersBase {
         String filePath = "/foo/bar";
 
         DataRepoResponse<JobModel> launchResp = dataRepoFixtures.ingestFileLaunch(
-            custodian(), datasetId, profileId, gsPath + "/files/File%20Design%20Notes.pdf", filePath);
+            custodian(), datasetId, profileId, gsPath + "/files/File Design Notes.pdf", filePath);
         assertThat("Custodian is not authorized to ingest a file",
             launchResp.getStatusCode(),
             equalTo(HttpStatus.UNAUTHORIZED));
 
         FileModel fileModel = dataRepoFixtures.ingestFile(
-            steward(), datasetId, profileId, gsPath + "/files/File%20Design%20Notes.pdf", filePath);
+            steward(), datasetId, profileId, gsPath + "/files/File Design Notes.pdf", filePath);
         String fileId = fileModel.getFileId();
 
         String json = String.format("{\"file_id\":\"foo\",\"file_ref\":\"%s\"}", fileId);

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FileOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FileOperationTest.java
@@ -57,7 +57,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.*;
 
 import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_TABLE;
@@ -204,16 +203,12 @@ public class FileOperationTest {
 
         // Error: Non-existent source file
         String badfile = "/I am not a file";
-        URI uribadfile = new URI("gs",
-            testConfig.getIngestbucket(),
-            badfile,
-            null,
-            null);
+        String uribadfile = "gs://" + testConfig.getIngestbucket() + "/" + badfile;
         String badPath = "/dd/files/" + Names.randomizeName("dir") + badfile;
 
         fileLoadModel = new FileLoadModel()
             .profileId(profileModel.getId())
-            .sourcePath(uribadfile.toString())
+            .sourcePath(uribadfile)
             .description(testDescription)
             .mimeType(testMimeType)
             .targetPath(badPath);
@@ -658,17 +653,13 @@ public class FileOperationTest {
         return String.format("/dd/files/foo/ValidFileName%d.pdf", validFileCounter);
     }
 
-    private FileLoadModel makeFileLoad(String profileId) throws Exception {
+    private FileLoadModel makeFileLoad(String profileId) {
         String targetDir = Names.randomizeName("dir");
-        URI uri = new URI("gs",
-            testConfig.getIngestbucket(),
-            "/files/" + testPdfFile,
-            null,
-            null);
+        String uri = "gs://" + testConfig.getIngestbucket() + "/files/" + testPdfFile;
         String targetPath = "/dd/files/" + targetDir + "/" + testPdfFile;
 
         return new FileLoadModel()
-            .sourcePath(uri.toString())
+            .sourcePath(uri)
             .description(testDescription)
             .mimeType(testMimeType)
             .targetPath(targetPath)

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -1,0 +1,46 @@
+package bio.terra.service.filedata.google.gcs;
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.category.Connected;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.UUID;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Category(Connected.class)
+public class GcsPdaoTest {
+    @Autowired private ConnectedTestConfiguration testConfig;
+
+    private Storage storage = StorageOptions.getDefaultInstance().getService();
+
+    @Test
+    public void testGetBlobWithHash() {
+        BlobId testBlob =
+            BlobId.of(testConfig.getIngestbucket(), UUID.randomUUID() + "#" + UUID.randomUUID());
+
+        try {
+            storage.create(BlobInfo.newBuilder(testBlob).build());
+            Blob blob = GcsPdao.getBlobFromGsPath(storage, "gs://" + testBlob.getBucket() + "/" + testBlob.getName());
+            Assert.assertNotNull(blob);
+            Assert.assertEquals(blob.getBlobId(), testBlob);
+        } finally {
+            storage.delete(testBlob);
+        }
+    }
+}

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -77,6 +77,30 @@ public class GcsPdaoTest {
     }
 
     @Test(expected = PdaoInvalidUriException.class)
+    public void testGetBlobBucketNameTooLong() {
+        StringBuilder bucket = new StringBuilder();
+        for (int i = 0; i < 222; i++) {
+            if (i != 0) bucket.append(".");
+            bucket.append("component");
+        }
+        GcsPdao.getBlobFromGsPath(storage, "gs://" + bucket.toString() + "/some-path");
+    }
+
+    @Test(expected = PdaoInvalidUriException.class)
+    public void testGetBlobBucketNameComponentTooLong() {
+        StringBuilder bucket = new StringBuilder();
+        for (int i = 0; i < 64; i++) {
+            bucket.append("a");
+        }
+        GcsPdao.getBlobFromGsPath(storage, "gs://" + bucket.toString() + "/some-path");
+    }
+
+    @Test(expected = PdaoInvalidUriException.class)
+    public void testGetBlobBucketInvalidCharacters() {
+        GcsPdao.getBlobFromGsPath(storage, "gs://AFSDAFADSFADSFASF@@@@/foo");
+    }
+
+    @Test(expected = PdaoInvalidUriException.class)
     public void testGetBlobNoObjectName() {
         GcsPdao.getBlobFromGsPath(storage, "gs://bucket");
     }

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -76,6 +76,11 @@ public class GcsPdaoTest {
         GcsPdao.getBlobFromGsPath(storage, "gs://ab/some-path");
     }
 
+    @Test(expected = PdaoInvalidUriException.class)
+    public void testGetBlobNoObjectName() {
+        GcsPdao.getBlobFromGsPath(storage, "gs://bucket");
+    }
+
     @Test(expected = PdaoSourceFileNotFoundException.class)
     public void testGetBlobNonexistent() {
         GcsPdao.getBlobFromGsPath(storage, "gs://" + testConfig.getIngestbucket() + "/file-doesnt-exist");

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -38,7 +38,10 @@ public class GcsPdaoTest {
             storage.create(BlobInfo.newBuilder(testBlob).build());
             Blob blob = GcsPdao.getBlobFromGsPath(storage, "gs://" + testBlob.getBucket() + "/" + testBlob.getName());
             Assert.assertNotNull(blob);
-            Assert.assertEquals(blob.getBlobId(), testBlob);
+
+            BlobId actualId = blob.getBlobId();
+            Assert.assertEquals(testBlob.getBucket(), actualId.getBucket());
+            Assert.assertEquals(testBlob.getName(), actualId.getName());
         } finally {
             storage.delete(testBlob);
         }

--- a/src/test/java/bio/terra/service/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/iam/AccessTest.java
@@ -181,7 +181,7 @@ public class AccessTest extends UsersBase {
             steward(),
             datasetSummaryModel.getId(),
             profileId,
-            gsPath + "/files/File%20Design%20Notes.pdf",
+            gsPath + "/files/File Design Notes.pdf",
             "/foo/bar");
 
         // Step 2. Ingest one row into the study 'file' table with a reference to that ingested file


### PR DESCRIPTION
For example, the HCA's v1 data store contains files named like:
```
042b4e00-82f4-47a5-9e82-408cd082fe26_2019-05-16T032622.030624Z_21935_6#96_2.fastq.gz
```
The existing URI parsing was chopping off everything after the `#`