### PR TITLE
DR-1080: Use data project from snapshot for integration tests.

### DIFF
--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -62,7 +62,7 @@ public class DrsTest extends UsersBase {
     @Test
     public void drsHackyTest() throws Exception {
         // Get a DRS ID from the dataset
-        BigQuery bigQueryReader = BigQueryFixtures.getBigQuery(testConfiguration.getGoogleProjectId(), readerToken);
+        BigQuery bigQueryReader = BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), readerToken);
         String drsObjectId = BigQueryFixtures.queryForDrsId(bigQueryReader,
             snapshotModel,
             "file",

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -105,7 +105,7 @@ public class EncodeFixture {
         // TODO: Add dataProject to SnapshotSummaryModel?
         SnapshotModel snapshotModel = dataRepoFixtures.getSnapshot(custodian, snapshotSummary.getId());
         String readerToken = authService.getDirectAccessAuthToken(reader.getEmail());
-        BigQuery bigQueryReader = BigQueryFixtures.getBigQuery(testConfiguration.getGoogleProjectId(), readerToken);
+        BigQuery bigQueryReader = BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), readerToken);
         BigQueryFixtures.hasAccess(bigQueryReader, snapshotModel.getDataProject(), snapshotModel.getName());
 
         return snapshotSummary;

--- a/src/test/java/bio/terra/service/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/iam/AccessTest.java
@@ -229,7 +229,7 @@ public class AccessTest extends UsersBase {
         //
         // We make a BigQuery context for the reader in the test project. The reader doesn't have access
         // to run queries in the dataset project.
-        BigQuery bigQueryReader = BigQueryFixtures.getBigQuery(testConfiguration.getGoogleProjectId(), readerToken);
+        BigQuery bigQueryReader = BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), readerToken);
         BigQueryFixtures.hasAccess(bigQueryReader, snapshotModel.getDataProject(), snapshotModel.getName());
 
         // Step 5. Read and validate the DRS URI from the file ref column in the 'file' table.


### PR DESCRIPTION
Changed 3 places in the integration tests where we were using the test configuration data project id to get the BQ object, to use the snapshot data project instead.