### PR TITLE
DR 1071 duplicate auth views blocking snapshot recreation

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -1274,7 +1274,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         }).collect(Collectors.toList());
     }
 
-    private void deleteViews(
+    private void deleteViewsandAcls(
         String datasetBqDatasetName,
         Snapshot snapshot,
         String projectId) throws InterruptedException {

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -637,7 +637,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         String datasetBqDatasetName = prefixName(datasetName);
 
         deleteViewAcls(datasetBqDatasetName, snapshot, projectId);
-        return bigQueryProjectForSnapshot(snapshot).deleteDataset(snapshot.getName());
+        return bigQueryProject.deleteDataset(snapshot.getName());
     }
 
     private List<Acl> convertToViewAcls(String projectId, String datasetName, List<String> tableNames) {

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -636,8 +636,8 @@ public class BigQueryPdao implements PrimaryDataAccess {
         String datasetName = snapshot.getSnapshotSources().get(0).getDataset().getName();
         String datasetBqDatasetName = prefixName(datasetName);
 
-        deleteViewAcls(datasetBqDatasetName, snapshot, projectId);
-        return bigQueryProject.deleteDataset(snapshot.getName());
+        deleteViewsandAcls(datasetBqDatasetName, snapshot, projectId);
+        return bigQueryProjectForSnapshot(snapshot).deleteDataset(snapshot.getName());
     }
 
     private List<Acl> convertToViewAcls(String projectId, String datasetName, List<String> tableNames) {

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -360,15 +360,15 @@ public class BigQueryPdao implements PrimaryDataAccess {
 
     public void snapshotViewCreation(
         String datasetBqDatasetName,
-        String snapshotName,
         Snapshot snapshot,
         String projectId,
         BigQuery bigQuery,
         BigQueryProject bigQueryProject) {
         // create the views
-        List<String> bqTableNames = createViews(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery);
+        List<String> bqTableNames = createViews(datasetBqDatasetName, snapshot, projectId, bigQuery);
 
         // set authorization on views
+        String snapshotName = snapshot.getName();
         List<Acl> acls = convertToViewAcls(projectId, snapshotName, bqTableNames);
         bigQueryProject.addDatasetAcls(datasetBqDatasetName, acls);
     }
@@ -439,7 +439,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         List<WalkRelationship> walkRelationships = WalkRelationship.ofAssetSpecification(asset);
         walkRelationships(datasetBqDatasetName, snapshotName, walkRelationships, rootTableId, projectId, bigQuery);
 
-        snapshotViewCreation(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery, bigQueryProject);
+        snapshotViewCreation(datasetBqDatasetName, snapshot, projectId, bigQuery, bigQueryProject);
     }
 
     private static final String insertAllLiveViewDataTemplate =
@@ -526,7 +526,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             throw new PdaoException("This snapshot is empty");
         }
 
-        snapshotViewCreation(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery, bigQueryProject);
+        snapshotViewCreation(datasetBqDatasetName, snapshot, projectId, bigQuery, bigQueryProject);
     }
 
 
@@ -586,7 +586,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             }
         }
 
-        snapshotViewCreation(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery, bigQueryProject);
+        snapshotViewCreation(datasetBqDatasetName, snapshot, projectId, bigQuery, bigQueryProject);
     }
 
     @Override
@@ -1124,7 +1124,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
 
             // populate root row ids. Must happen before the relationship walk.
             // NOTE: when we have multiple sources, we can put this into a loop
-            snapshotViewCreation(datasetBqDatasetName, snapshotName, snapshot, projectId, bigQuery, bigQueryProject);
+            snapshotViewCreation(datasetBqDatasetName, snapshot, projectId, bigQuery, bigQueryProject);
 
         } catch (PdaoException ex) {
             // TODO What if the select list doesn't match the temp table schema?
@@ -1232,7 +1232,6 @@ public class BigQueryPdao implements PrimaryDataAccess {
 
     private List<String> createViews( // TODO this creates the views, but what deletes them?
         String datasetBqDatasetName,
-        String snapshotName,
         Snapshot snapshot,
         String projectId,
         BigQuery bigQuery) {
@@ -1240,6 +1239,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             // Build the FROM clause from the source
             // NOTE: we can put this in a loop when we do multiple sources
             SnapshotSource source = snapshot.getSnapshotSources().get(0);
+            String snapshotName = snapshot.getName();
 
             // Find the table map for the table. If there is none, we skip it.
             // NOTE: for now, we know that there will be one, because we generate it directly.

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -1308,7 +1308,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         bigQueryProject.removeDatasetAcls(datasetBqDatasetName, acls);
     }
 
-    private void deleteViews(
+    private void deleteViewsandAcls(
         String datasetBqDatasetName,
         Snapshot snapshot,
         String projectId) throws InterruptedException {

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -1236,7 +1236,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             "S." + PDAO_ROW_ID_COLUMN + " = R." + PDAO_ROW_ID_COLUMN + " AND " +
             "R." + PDAO_TABLE_ID_COLUMN + " = '<tableId>')";
 
-    private List<String> createViews( // TODO this creates the views, but what deletes them?
+    private List<String> createViews(
         String datasetBqDatasetName,
         Snapshot snapshot,
         String projectId,

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -630,7 +630,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     @Override
-    public boolean deleteSnapshot(Snapshot snapshot) throws InterruptedException {
+    public boolean deleteSnapshot(Snapshot snapshot) throws InterruptedException { // TODO is this what should delete the views?
         return bigQueryProjectForSnapshot(snapshot).deleteDataset(snapshot.getName());
     }
 
@@ -1230,7 +1230,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
             "S." + PDAO_ROW_ID_COLUMN + " = R." + PDAO_ROW_ID_COLUMN + " AND " +
             "R." + PDAO_TABLE_ID_COLUMN + " = '<tableId>')";
 
-    private List<String> createViews(
+    private List<String> createViews( // TODO this creates the views, but what deletes them?
         String datasetBqDatasetName,
         String snapshotName,
         Snapshot snapshot,
@@ -1272,6 +1272,29 @@ public class BigQueryPdao implements PrimaryDataAccess {
 
             return tableName;
         }).collect(Collectors.toList());
+    }
+
+    private void deleteViews(
+        String snapshotName,
+        Snapshot snapshot) throws InterruptedException {
+        BigQueryProject bigQueryProject = bigQueryProjectForSnapshot(snapshot);
+        snapshot.getTables().forEach(table -> {
+            // Build the FROM clause from the source
+            // NOTE: we can put this in a loop when we do multiple sources
+            SnapshotSource source = snapshot.getSnapshotSources().get(0);
+
+            // Find the table map for the table. If there is none, we skip it.
+            // NOTE: for now, we know that there will be one, because we generate it directly.
+            // In the future when we have more than one, we can just return.
+            SnapshotMapTable mapTable = lookupMapTable(table, source);
+            if (mapTable == null) {
+                throw new PdaoException("No matching map table for snapshot table " + table.getName());
+            }
+            // delete the view
+            String tableName = table.getName();
+            logger.info("Deleting view " + snapshotName + "." + tableName);
+            bigQueryProject.deleteTable(snapshotName, tableName);
+        });
     }
 
     private String sourceSelectSql(String snapshotId, Column targetColumn, SnapshotMapTable mapTable) {

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -636,7 +636,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         String datasetName = snapshot.getSnapshotSources().get(0).getDataset().getName();
         String datasetBqDatasetName = prefixName(datasetName);
 
-        deleteViewsandAcls(datasetBqDatasetName, snapshot, projectId);
+        deleteViewAcls(datasetBqDatasetName, snapshot, projectId);
         return bigQueryProjectForSnapshot(snapshot).deleteDataset(snapshot.getName());
     }
 
@@ -1280,7 +1280,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         }).collect(Collectors.toList());
     }
 
-    private void deleteViewsandAcls(
+    private void deleteViewAcls(
         String datasetBqDatasetName,
         Snapshot snapshot,
         String projectId) throws InterruptedException {
@@ -1301,13 +1301,9 @@ public class BigQueryPdao implements PrimaryDataAccess {
             return table.getName();
         }).collect(Collectors.toList());
 
-        // delete the views
+        // delete the view Acls
         String snapshotName = snapshot.getName();
-        viewsToDelete.forEach(tableName -> {
-            logger.info("Deleting view " + snapshotName + "." + tableName);
-            bigQueryProject.deleteTable(snapshotName, tableName);
-        });
-
+        viewsToDelete.forEach(tableName -> logger.info("Deleting ACLs for view " + snapshotName + "." + tableName));
         List<Acl> acls = convertToViewAcls(projectId, snapshotName, viewsToDelete);
         bigQueryProject.removeDatasetAcls(datasetBqDatasetName, acls);
     }

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -633,10 +633,14 @@ public class BigQueryPdao implements PrimaryDataAccess {
     public boolean deleteSnapshot(Snapshot snapshot) throws InterruptedException {
         BigQueryProject bigQueryProject = bigQueryProjectForSnapshot(snapshot);
         String projectId = bigQueryProject.getProjectId();
-        String datasetName = snapshot.getSnapshotSources().get(0).getDataset().getName();
-        String datasetBqDatasetName = prefixName(datasetName);
-
-        deleteViewAcls(datasetBqDatasetName, snapshot, projectId);
+        List<SnapshotSource> sources = snapshot.getSnapshotSources();
+        if (sources.size() > 0) {
+            String datasetName = sources.get(0).getDataset().getName();
+            String datasetBqDatasetName = prefixName(datasetName);
+            deleteViewAcls(datasetBqDatasetName, snapshot, projectId);
+        } else {
+            logger.warn("Snapshot is missing sources: " + snapshot.getName());
+        }
         return bigQueryProject.deleteDataset(snapshot.getName());
     }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -630,7 +630,13 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     @Override
-    public boolean deleteSnapshot(Snapshot snapshot) throws InterruptedException { // TODO is this what should delete the views?
+    public boolean deleteSnapshot(Snapshot snapshot) throws InterruptedException {
+        BigQueryProject bigQueryProject = bigQueryProjectForSnapshot(snapshot);
+        String projectId = bigQueryProject.getProjectId();
+        String datasetName = snapshot.getSnapshotSources().get(0).getDataset().getName();
+        String datasetBqDatasetName = prefixName(datasetName);
+
+        deleteViewsandAcls(datasetBqDatasetName, snapshot, projectId);
         return bigQueryProjectForSnapshot(snapshot).deleteDataset(snapshot.getName());
     }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -1309,10 +1309,11 @@ public class BigQueryPdao implements PrimaryDataAccess {
     }
 
     private void deleteViews(
-        String snapshotName,
-        Snapshot snapshot) throws InterruptedException {
+        String datasetBqDatasetName,
+        Snapshot snapshot,
+        String projectId) throws InterruptedException {
         BigQueryProject bigQueryProject = bigQueryProjectForSnapshot(snapshot);
-        snapshot.getTables().forEach(table -> {
+        List<String> viewsToDelete = snapshot.getTables().stream().map(table -> {
             // Build the FROM clause from the source
             // NOTE: we can put this in a loop when we do multiple sources
             SnapshotSource source = snapshot.getSnapshotSources().get(0);
@@ -1324,11 +1325,19 @@ public class BigQueryPdao implements PrimaryDataAccess {
             if (mapTable == null) {
                 throw new PdaoException("No matching map table for snapshot table " + table.getName());
             }
-            // delete the view
-            String tableName = table.getName();
+            // get the list of table names
+            return table.getName();
+        }).collect(Collectors.toList());
+
+        // delete the views
+        String snapshotName = snapshot.getName();
+        viewsToDelete.forEach(tableName -> {
             logger.info("Deleting view " + snapshotName + "." + tableName);
             bigQueryProject.deleteTable(snapshotName, tableName);
         });
+
+        List<Acl> acls = convertToViewAcls(projectId, snapshotName, viewsToDelete);
+        bigQueryProject.removeDatasetAcls(datasetBqDatasetName, acls);
     }
 
     private String sourceSelectSql(String snapshotId, Column targetColumn, SnapshotMapTable mapTable) {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -345,10 +345,9 @@ public class SnapshotConnectedTest {
         connectedOperations.getSnapshotExpectError(snapshotModel.getId(), HttpStatus.NOT_FOUND);
 
         // now after deleting the snapshot, make sure you can create it again and the delete worked!
-        SnapshotRequestModel snapshotRequestNext = makeSnapshotTestRequest(datasetSummary, "snapshot-test-snapshot.json");
-        snapshotRequestNext.setName(snapshotModel.getName());
-        response = performCreateSnapshot(snapshotRequestNext, null);
-        SnapshotSummaryModel summaryModelSequel = validateSnapshotCreated(snapshotRequestNext, response);
+        snapshotRequest.setName(snapshotModel.getName());
+        response = performCreateSnapshot(snapshotRequest, null);
+        SnapshotSummaryModel summaryModelSequel = validateSnapshotCreated(snapshotRequest, response);
 
         // then delete it a final time for cleanup
         connectedOperations.deleteTestSnapshot(summaryModelSequel.getId());

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -322,6 +322,40 @@ public class SnapshotConnectedTest {
     }
 
     @Test
+    public void testDeleteRecreateSnapshot() throws Exception {
+        // create a dataset and load some tabular data
+        DatasetSummaryModel datasetSummary = createTestDataset("snapshot-test-dataset.json");
+        loadCsvData(datasetSummary.getId(), "thetable", "snapshot-test-dataset-data.csv");
+
+        // create a snapshot
+        SnapshotRequestModel snapshotRequest = makeSnapshotTestRequest(datasetSummary, "snapshot-test-snapshot.json");
+        MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
+        SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
+
+        // fetch the snapshot and confirm the metadata matches the request
+        SnapshotModel snapshotModel = getTestSnapshot(summaryModel.getId(), snapshotRequest, datasetSummary);
+        assertNotNull("fetched snapshot successfully after creation", snapshotModel);
+
+        // check that the snapshot metadata row is unlocked
+        String exclusiveLock = snapshotDao.getExclusiveLockState(UUID.fromString(snapshotModel.getId()));
+        assertNull("snapshot row is unlocked", exclusiveLock);
+
+        // delete and confirm deleted
+        connectedOperations.deleteTestSnapshot(snapshotModel.getId());
+        connectedOperations.getSnapshotExpectError(snapshotModel.getId(), HttpStatus.NOT_FOUND);
+
+        // now after deleting the snapshot, make sure you can create it again and the delete worked!
+        SnapshotRequestModel snapshotRequestNext = makeSnapshotTestRequest(datasetSummary, "snapshot-test-snapshot.json");
+        snapshotRequestNext.setName(snapshotModel.getName());
+        response = performCreateSnapshot(snapshotRequestNext, null);
+        SnapshotSummaryModel summaryModelSequel = validateSnapshotCreated(snapshotRequestNext, response);
+
+        // then delete it a final time for cleanup
+        connectedOperations.deleteTestSnapshot(summaryModelSequel.getId());
+        connectedOperations.getSnapshotExpectError(summaryModelSequel.getId(), HttpStatus.NOT_FOUND);
+    }
+
+    @Test
     public void testOverlappingDeletes() throws Exception {
         // create a snapshot
         SnapshotSummaryModel summaryModel = connectedOperations.createSnapshot(datasetSummary,

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -345,9 +345,10 @@ public class SnapshotConnectedTest {
         connectedOperations.getSnapshotExpectError(snapshotModel.getId(), HttpStatus.NOT_FOUND);
 
         // now after deleting the snapshot, make sure you can create it again and the delete worked!
-        snapshotRequest.setName(snapshotModel.getName());
-        response = performCreateSnapshot(snapshotRequest, null);
-        SnapshotSummaryModel summaryModelSequel = validateSnapshotCreated(snapshotRequest, response);
+        SnapshotRequestModel snapshotRequestNext = makeSnapshotTestRequest(datasetSummary, "snapshot-test-snapshot.json");
+        snapshotRequestNext.setName(snapshotModel.getName());
+        response = performCreateSnapshot(snapshotRequestNext, null);
+        SnapshotSummaryModel summaryModelSequel = validateSnapshotCreated(snapshotRequestNext, response);
 
         // then delete it a final time for cleanup
         connectedOperations.deleteTestSnapshot(summaryModelSequel.getId());

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -294,6 +294,7 @@ public class BigQueryPdaoTest {
     @Test
     public void nonStringAssetRootTest() throws Exception {
         Dataset dataset = readDataset("ingest-test-dataset.json");
+        connectedOperations.addDataset(dataset.getId().toString());
 
         // Stage tabular data for ingest.
         String targetPath = "scratch/file" + UUID.randomUUID().toString() + "/";
@@ -350,10 +351,6 @@ public class BigQueryPdaoTest {
             Assert.assertThat(fileIds, is(equalTo(Collections.singletonList("file1"))));
         } finally {
             storage.delete(participantBlob.getBlobId(), sampleBlob.getBlobId(), fileBlob.getBlobId());
-            bigQueryPdao.deleteDataset(dataset);
-            // Need to manually clean up the DAO because `readDataset` bypasses the
-            // `connectedOperations` object, so we can't rely on its auto-teardown logic.
-            datasetDao.delete(dataset.getId());
         }
     }
 
@@ -476,6 +473,7 @@ public class BigQueryPdaoTest {
     @Test
     public void testGetFullViews() throws Exception {
         Dataset dataset = readDataset("ingest-test-dataset.json");
+        connectedOperations.addDataset(dataset.getId().toString());
 
         // Stage tabular data for ingest.
         String targetPath = "scratch/file" + UUID.randomUUID().toString() + "/";
@@ -532,10 +530,6 @@ public class BigQueryPdaoTest {
             Assert.assertThat(fileIds, is(equalTo(Collections.singletonList("file1"))));
         } finally {
             storage.delete(participantBlob.getBlobId(), sampleBlob.getBlobId(), fileBlob.getBlobId());
-            bigQueryPdao.deleteDataset(dataset);
-            // Need to manually clean up the DAO because `readDataset` bypasses the
-            // `connectedOperations` object, so we can't rely on its auto-teardown logic.
-            datasetDao.delete(dataset.getId());
         }
     }
 

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -181,6 +181,7 @@ public class BigQueryPdaoTest {
     @Test
     public void datasetTest() throws Exception {
         Dataset dataset = readDataset("ingest-test-dataset.json");
+        connectedOperations.addDataset(dataset.getId().toString());
 
         // Stage tabular data for ingest.
         String targetPath = "scratch/file" + UUID.randomUUID().toString() + "/";
@@ -287,10 +288,6 @@ public class BigQueryPdaoTest {
         } finally {
             storage.delete(participantBlob.getBlobId(), sampleBlob.getBlobId(),
                 fileBlob.getBlobId(), missingPkBlob.getBlobId(), nullPkBlob.getBlobId());
-            bigQueryPdao.deleteDataset(dataset);
-            // Need to manually clean up the DAO because `readDataset` bypasses the
-            // `connectedOperations` object, so we can't rely on its auto-teardown logic.
-            datasetDao.delete(dataset.getId());
         }
     }
 


### PR DESCRIPTION
If a snapshot was created, then deleted, then created again, there was an error.
This was because acls on the views were not getting cleaned up.

<img width="1505" alt="Screen Shot 2020-06-16 at 8 13 49 PM" src="https://user-images.githubusercontent.com/6863459/84842345-db197500-b012-11ea-8687-45a5c9b74722.png">
