### PR TITLE
DR-1092 Added transaction to load state queries; specify loadDriverWaitSeconds

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -160,7 +160,7 @@ public class IngestDriverStep implements Step {
 
     private void checkForOrphans(FlightContext context, UUID loadId)
         throws DatabaseOperationException, InterruptedException {
-        // Check for launch orphans - these are loads in the RUNNING state that are in the load_files table
+        // Check for launch orphans - these are loads in the RUNNING state in the load_files table
         // in the database, but not known to Stairway. We revert them to NOT_TRIED before starting the
         // load loop.
         List<LoadFile> runningLoads = loadService.findRunningLoads(loadId);
@@ -168,6 +168,7 @@ public class IngestDriverStep implements Step {
             try {
                 context.getStairway().getFlightState(load.getFlightId());
             } catch (FlightNotFoundException ex) {
+                logger.debug("Resetting orphan file load from running to not tried: " + load.getLoadId());
                 loadService.setLoadFileNotTried(load.getLoadId(), load.getTargetPath());
             }
         }
@@ -246,7 +247,7 @@ public class IngestDriverStep implements Step {
 
         for (int i = 0; i < launchCount; i++) {
             LoadFile loadFile = loadFiles.get(i);
-            String flightId = stairway.createFlightId().toString();
+            String flightId = stairway.createFlightId();
 
             FileLoadModel fileLoadModel = new FileLoadModel()
                 .sourcePath(loadFile.getSourcePath())

--- a/src/main/java/bio/terra/service/load/LoadDao.java
+++ b/src/main/java/bio/terra/service/load/LoadDao.java
@@ -195,6 +195,7 @@ public class LoadDao {
         return queryByState(loadId, state, limit);
     }
 
+    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
     public LoadCandidates findCandidates(UUID loadId, int candidatesToFind) {
         final String countFailedSql = "SELECT count(*) AS failed FROM load_file" +
             " WHERE load_id = :load_id AND state = :state";
@@ -252,6 +253,7 @@ public class LoadDao {
                     }
                     switch (state) {
                         case RUNNING:
+                            logger.info("Unexpected running loads: " + rs.getInt("statecount"));
                             throw new CorruptMetadataException("No loads should be running!");
 
                         case FAILED:

--- a/src/main/resources/application-dd.properties
+++ b/src/main/resources/application-dd.properties
@@ -1,5 +1,6 @@
 datarepo.gcs.allowReuseExistingBuckets=true
 google.projectid=broad-jade-dd
+google.singleDataProjectId=broad-jade-dd-data
 userEmail=dd.datarepo@gmail.com
 db.migrate.dropAllOnStart=true
 db.migrate.updateAllOnStart=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,7 @@ datarepo.maxBulkFileLoadArray=100
 datarepo.maxBulkFileLoad=1000000
 datarepo.loadConcurrentFiles=4
 datarepo.loadConcurrentIngests=2
+datarepo.loadDriverWaitSeconds=10
 datarepo.maxBadLoadFileLineErrorsReported=5
 datarepo.loadFilePopulateBatchSize=50
 datarepo.shutdownTimeoutSeconds=30

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -98,7 +98,8 @@ public class FileTest extends UsersBase {
 
         String loadTag = Names.randomizeName("longtest");
 
-        BulkLoadArrayRequestModel arrayLoad = new BulkLoadArrayRequestModel()
+        BulkLoadArrayRequestModel
+            arrayLoad = new BulkLoadArrayRequestModel()
             .profileId(profileId)
             .loadTag(loadTag)
             .maxFailedFileLoads(filesToLoad); // do not stop if there is a failure.


### PR DESCRIPTION
i have not been able to reproduce the original failure that i saw. i did close a timing problem where the lord state wherries were not in one transaction. so that could account for what i saw. 

i also found that the loadDriverWaitSeconds was not set. that led to the driver step running in a tight blue waiting for the last file loads to complete.