### PR TITLE
DR-1153: Bump GitHub Action to 0.14

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.13.0
+        uses: broadinstitute/datarepo-actions@0.14.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -57,22 +57,22 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@0.13.0
+        uses: broadinstitute/datarepo-actions@0.14.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@0.13.0
+        uses: broadinstitute/datarepo-actions@0.14.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@0.13.0
+        uses: broadinstitute/datarepo-actions@0.14.0
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@0.13.0
+        uses: broadinstitute/datarepo-actions@0.14.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_secret_chart_version: '0.0.4'
@@ -81,18 +81,18 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.9'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.13.0
+        uses: broadinstitute/datarepo-actions@0.14.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.13.0
+        uses: broadinstitute/datarepo-actions@0.14.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.13.0
+        uses: broadinstitute/datarepo-actions@0.14.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -21,7 +21,6 @@ import bio.terra.service.dataset.DatasetUtils;
 import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
-import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.tabulardata.exception.BadExternalFileException;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.JobInfo;


### PR DESCRIPTION
Bump version to ensure that GitHub Action fails immediately when error occurs. See https://github.com/broadinstitute/datarepo-actions/pull/18

Also fixes checkstyles for BigQueryPdaoTest.java