### PR TITLE
DR-1160: Add isEnabled method to PerformanceLogger(ON/OFF) classes.

### DIFF
--- a/src/main/java/bio/terra/app/logging/PerformanceLogger.java
+++ b/src/main/java/bio/terra/app/logging/PerformanceLogger.java
@@ -9,9 +9,9 @@ import java.time.Duration;
 public interface PerformanceLogger {
 
     /**
-     * True if performance logging is enabled, false otherwise.
+     * Returns true if performance logging is enabled, false otherwise.
      */
-    boolean isPerformanceLoggingEnabled = false;
+    boolean isEnabled();
 
     /**
      * Log a timestamp for an event, specified with a job id, class and operation names.

--- a/src/main/java/bio/terra/app/logging/PerformanceLoggerOFF.java
+++ b/src/main/java/bio/terra/app/logging/PerformanceLoggerOFF.java
@@ -1,7 +1,5 @@
 package bio.terra.app.logging;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -16,11 +14,7 @@ import java.time.Duration;
 @Component
 public class PerformanceLoggerOFF implements PerformanceLogger {
 
-    private static Logger logger = LoggerFactory.getLogger(PerformanceLoggerOFF.class);
-
-    public PerformanceLoggerOFF() {
-        logger.info("Performance logging OFF");
-    }
+    public PerformanceLoggerOFF() { }
 
     public boolean isEnabled() {
         return false;

--- a/src/main/java/bio/terra/app/logging/PerformanceLoggerOFF.java
+++ b/src/main/java/bio/terra/app/logging/PerformanceLoggerOFF.java
@@ -2,12 +2,9 @@ package bio.terra.app.logging;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-
-@Component
 
 /**
  * This class implements DISABLED performance logging. It is used when the "perftest" profile is NOT active.
@@ -16,15 +13,17 @@ import java.time.Duration;
  * methods in a production environment, but it is low because there is no actual work being done here. It's just
  * the overhead of calling a Java method and returning.
  */
+@Component
 public class PerformanceLoggerOFF implements PerformanceLogger {
-
-    public static final boolean isPerformanceLoggingEnabled = false;
 
     private static Logger logger = LoggerFactory.getLogger(PerformanceLoggerOFF.class);
 
-    @Autowired
     public PerformanceLoggerOFF() {
         logger.info("Performance logging OFF");
+    }
+
+    public boolean isEnabled() {
+        return false;
     }
 
     public void log(String jobId, String className, String operationName,

--- a/src/main/java/bio/terra/app/logging/PerformanceLoggerON.java
+++ b/src/main/java/bio/terra/app/logging/PerformanceLoggerON.java
@@ -53,7 +53,6 @@ public class PerformanceLoggerON implements PerformanceLogger {
 
     public PerformanceLoggerON() {
         this.objectMapper = new ObjectMapper();
-        logger.info("Performance logging ON");
     }
 
     public boolean isEnabled() {

--- a/src/main/java/bio/terra/app/logging/PerformanceLoggerON.java
+++ b/src/main/java/bio/terra/app/logging/PerformanceLoggerON.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -15,10 +14,6 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
-
-@Primary
-@Profile({"perftest"})
-@Component
 
 /**
  * This class implements ENABLED performance logging. It is used when the "perftest" profile is active.
@@ -34,9 +29,10 @@ import java.util.Map;
  *  New types of information that seem broadly useful should use the first option and those that will probably only
  *  be used in a small number of places should use the second option.
  */
+@Component
+@Profile("perftest")
+@Primary
 public class PerformanceLoggerON implements PerformanceLogger {
-
-    public static final boolean isPerformanceLoggingEnabled = true;
 
     private ObjectMapper objectMapper;
 
@@ -55,10 +51,13 @@ public class PerformanceLoggerON implements PerformanceLogger {
 
     private static final ThreadLocal<Long> logCounter = ThreadLocal.withInitial(() -> Long.valueOf(0));
 
-    @Autowired
-    public PerformanceLoggerON(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+    public PerformanceLoggerON() {
+        this.objectMapper = new ObjectMapper();
         logger.info("Performance logging ON");
+    }
+
+    public boolean isEnabled() {
+        return true;
     }
 
     public void log(String jobId, String className, String operationName,

--- a/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
+++ b/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
@@ -21,6 +21,7 @@ public class StairwayLoggingHooks implements StairwayHook {
 
     public StairwayLoggingHooks(PerformanceLogger performanceLogger) {
         this.performanceLogger = performanceLogger;
+        logger.info("Performance logging " + (performanceLogger.isEnabled() ? "ON" : "OFF"));
     }
 
     @Override


### PR DESCRIPTION
- Replaced the static boolean isPerformanceLoggingEnabled in the interface class with an isEnabled method. Implementations of the interface did not override the boolean.
- Also removed the Autowired annotation from the PerformanceLogger(ON/OFF) constructors.
