### PR TITLE
DR-1161: Add scopes to AuthUtils methods.

### DIFF
--- a/datarepo-clienttests/src/main/java/runner/TestRunner.java
+++ b/datarepo-clienttests/src/main/java/runner/TestRunner.java
@@ -15,7 +15,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,12 +67,10 @@ class TestRunner {
     }
 
     // get an instance of the API client per test user
-    List<String> userScopes = Arrays.asList("openid", "email", "profile");
     for (TestUserSpecification testUser : config.testUsers) {
       ApiClient apiClient = new ApiClient();
       apiClient.setBasePath(config.server.uri);
-      GoogleCredentials userCredential =
-          AuthenticationUtils.getDelegatedUserCredential(testUser, userScopes);
+      GoogleCredentials userCredential = AuthenticationUtils.getDelegatedUserCredential(testUser);
       AccessToken userAccessToken = AuthenticationUtils.getAccessToken(userCredential);
       apiClient.setAccessToken(userAccessToken.getTokenValue());
 

--- a/datarepo-clienttests/src/main/java/utils/AuthenticationUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/AuthenticationUtils.java
@@ -6,6 +6,9 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -15,7 +18,7 @@ import runner.config.TestUserSpecification;
 public final class AuthenticationUtils {
 
   private static volatile GoogleCredentials applicationDefaultCredential;
-  private static volatile ServiceAccountCredentials serviceAccountCredential;
+  private static volatile GoogleCredentials serviceAccountCredential;
   private static Map<String, GoogleCredentials> delegatedUserCredentials =
       new ConcurrentHashMap<>();
 
@@ -24,43 +27,65 @@ public final class AuthenticationUtils {
 
   private AuthenticationUtils() {}
 
+  // the list of scopes we request from end users when they log in. this should always match exactly
+  // what the UI requests, so our tests represent actual user behavior
+  private static final List<String> userLoginScopes = Arrays.asList("openid", "email", "profile");
+
+  // the list of "extra" scopes we request for the test users, so that we can access BigQuery and
+  // Cloud Storage directly (e.g. to query the snapshot table, write a file to a scratch bucket)
+  private static final List<String> directAccessScopes =
+      Arrays.asList(
+          "https://www.googleapis.com/auth/bigquery",
+          "https://www.googleapis.com/auth/devstorage.full_control");
+
   public static GoogleCredentials getDelegatedUserCredential(
-      TestUserSpecification testUserSpecification, List<String> scopes) throws IOException {
+      TestUserSpecification testUserSpecification) throws IOException {
     GoogleCredentials delegatedUserCredential =
         delegatedUserCredentials.get(testUserSpecification.userEmail);
-    if (delegatedUserCredential == null) {
-      ServiceAccountCredentials serviceAccountCredential =
-          getServiceAccountCredential(testUserSpecification.delegatorServiceAccount);
-      delegatedUserCredential =
-          serviceAccountCredential
-              .createScoped(scopes)
-              .createDelegated(testUserSpecification.userEmail);
-      delegatedUserCredentials.put(testUserSpecification.userEmail, delegatedUserCredential);
+    if (delegatedUserCredential != null) {
+      return delegatedUserCredential;
     }
+
+    List<String> scopes = new ArrayList<>();
+    scopes.addAll(userLoginScopes);
+    scopes.addAll(directAccessScopes);
+
+    GoogleCredentials serviceAccountCredential =
+        getServiceAccountCredential(testUserSpecification.delegatorServiceAccount);
+    delegatedUserCredential =
+        serviceAccountCredential
+            .createScoped(scopes)
+            .createDelegated(testUserSpecification.userEmail);
+    delegatedUserCredentials.put(testUserSpecification.userEmail, delegatedUserCredential);
     return delegatedUserCredential;
   }
 
-  public static ServiceAccountCredentials getServiceAccountCredential(
+  public static GoogleCredentials getServiceAccountCredential(
       ServiceAccountSpecification serviceAccount) throws IOException {
-    if (serviceAccountCredential == null) {
-      synchronized (lockServiceAccountCredential) {
-        File jsonKey = serviceAccount.jsonKeyFile;
-        serviceAccountCredential =
-            ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey));
-      }
+    if (serviceAccountCredential != null) {
+      return serviceAccountCredential;
+    }
+
+    synchronized (lockServiceAccountCredential) {
+      File jsonKey = serviceAccount.jsonKeyFile;
+      serviceAccountCredential =
+          ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey))
+              .createScoped(
+                  Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
     }
     return serviceAccountCredential;
   }
 
   public static GoogleCredentials getApplicationDefaultCredential() throws IOException {
-    if (applicationDefaultCredential == null) {
-      synchronized (lockApplicationDefaultCredential) {
-        applicationDefaultCredential = GoogleCredentials.getApplicationDefault();
-        // if (applicationDefaultCredential.createScopedRequired()) { // when is this true?
-        //   applicationDefaultCredential = applicationDefaultCredential.createScoped(
-        //     Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-        // }
-      }
+    if (applicationDefaultCredential != null) {
+      return applicationDefaultCredential;
+    }
+
+    synchronized (lockApplicationDefaultCredential) {
+      applicationDefaultCredential =
+          GoogleCredentials.getApplicationDefault()
+              .createScoped(
+                  Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
     }
     return applicationDefaultCredential;
   }

--- a/datarepo-clienttests/src/main/java/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/DataRepoUtils.java
@@ -9,6 +9,7 @@ import bio.terra.datarepo.model.ErrorModel;
 import bio.terra.datarepo.model.JobModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
 
 public final class DataRepoUtils {
 
@@ -34,7 +35,7 @@ public final class DataRepoUtils {
     job = repositoryApi.retrieveJob(job.getId());
 
     while (job.getJobStatus().equals(JobModel.JobStatusEnum.RUNNING) && pollCtr >= 0) {
-      Thread.sleep(secondsIntervalToPollJob * 1000);
+      TimeUnit.SECONDS.sleep(secondsIntervalToPollJob);
       job = repositoryApi.retrieveJob(job.getId());
       pollCtr--;
     }

--- a/datarepo-clienttests/src/main/java/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/DataRepoUtils.java
@@ -34,7 +34,7 @@ public final class DataRepoUtils {
     job = repositoryApi.retrieveJob(job.getId());
 
     while (job.getJobStatus().equals(JobModel.JobStatusEnum.RUNNING) && pollCtr >= 0) {
-      Thread.sleep(secondsIntervalToPollJob);
+      Thread.sleep(secondsIntervalToPollJob * 1000);
       job = repositoryApi.retrieveJob(job.getId());
       pollCtr--;
     }

--- a/datarepo-clienttests/src/main/java/utils/KubernetesClientUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/KubernetesClientUtils.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import runner.config.ServerSpecification;
 
 // TODO: add try/catch for refresh token around all utils methods
@@ -241,7 +242,7 @@ public final class KubernetesClientUtils {
             .count();
 
     while (numPods != numberOfReplicas && pollCtr >= 0) {
-      Thread.sleep(secondsIntervalToPollReplicaSetSizeChange * 1000);
+      TimeUnit.SECONDS.sleep(secondsIntervalToPollReplicaSetSizeChange);
       numPods =
           listPods(namespace).stream()
               .filter(

--- a/datarepo-clienttests/src/main/resources/servers/shdev.json
+++ b/datarepo-clienttests/src/main/resources/servers/shdev.json
@@ -1,0 +1,11 @@
+{
+  "name": "shdev",
+  "description": "Developer namespace (sh) in Jade dev cluster.",
+  "uri": "https://jade-sh.datarepo-dev.broadinstitute.org",
+  "clusterName": "gke_broad-jade-dev_us-central1_dev-master",
+  "clusterShortName": "dev-master",
+  "region": "us-central1",
+  "project": "broad-jade-dev",
+  "namespace": "sh",
+  "helmApiDeploymentFilePath": "datarepo-helm-definitions/dev/sh/shDeployment.YAML"
+}


### PR DESCRIPTION
- Always add the same scopes (openid, profile, email) to the test user credentials as when a user logs in via the UI. Also added BQ and Cloud Storage scopes for directly accessing cloud resources.
- Always add the auth/cloud-platform scope for the SA and application default credentials.

- Fixed a bad sec -> millisec conversion for waiting on a Data Repo job to complete.
- Added a new server specification for sh namespace in dev cluster.