### PR TITLE
DR-617 Fix use of a non-STRING column as an asset root

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -286,12 +286,12 @@ public class BigQueryPdao implements PrimaryDataAccess {
         return bigQueryProject.deleteDataset(prefixName(dataset.getName()));
     }
 
+    // NOTE: The CAST here should be valid for all column types but ARRAYs.
+    // We validate that asset root columns are non-arrays as part of dataset creation.
+    // https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules
     private static final String mapValuesToRowsTemplate =
         "SELECT T." + PDAO_ROW_ID_COLUMN + ", V.input_value FROM (" +
             "SELECT input_value FROM UNNEST([<inputVals:{v|'<v>'}; separator=\",\">]) AS input_value) AS V " +
-            // NOTE: The CAST here should be valid for all column types but ARRAYs.
-            // We validate that asset root columns are non-arrays as part of dataset creation.
-            // https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules
             "LEFT JOIN `<project>.<dataset>.<table>` AS T ON V.input_value = CAST(T.<column> AS STRING)";
 
     // compute the row ids from the input ids and validate all inputs have matches

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -290,8 +290,7 @@ public class BigQueryPdao implements PrimaryDataAccess {
         "SELECT T." + PDAO_ROW_ID_COLUMN + ", V.input_value FROM (" +
             "SELECT input_value FROM UNNEST([<inputVals:{v|'<v>'}; separator=\",\">]) AS input_value) AS V " +
             // NOTE: The CAST here should be valid for all column types but ARRAYs.
-            // It's unlikely an array would be used as an asset root, so that should be OK?
-            // But it'd be good to validate if so.
+            // We validate that asset root columns are non-arrays as part of dataset creation.
             // https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules
             "LEFT JOIN `<project>.<dataset>.<table>` AS T ON V.input_value = CAST(T.<column> AS STRING)";
 

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -289,7 +289,11 @@ public class BigQueryPdao implements PrimaryDataAccess {
     private static final String mapValuesToRowsTemplate =
         "SELECT T." + PDAO_ROW_ID_COLUMN + ", V.input_value FROM (" +
             "SELECT input_value FROM UNNEST([<inputVals:{v|'<v>'}; separator=\",\">]) AS input_value) AS V " +
-            "LEFT JOIN `<project>.<dataset>.<table>` AS T ON V.input_value = T.<column>";
+            // NOTE: The CAST here should be valid for all column types but ARRAYs.
+            // It's unlikely an array would be used as an asset root, so that should be OK?
+            // But it'd be good to validate if so.
+            // https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules
+            "LEFT JOIN `<project>.<dataset>.<table>` AS T ON V.input_value = CAST(T.<column> AS STRING)";
 
     // compute the row ids from the input ids and validate all inputs have matches
 

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -294,6 +294,72 @@ public class BigQueryPdaoTest {
         }
     }
 
+    @Test
+    public void nonStringAssetRootTest() throws Exception {
+        Dataset dataset = readDataset("ingest-test-dataset.json");
+
+        // Stage tabular data for ingest.
+        String targetPath = "scratch/file" + UUID.randomUUID().toString() + "/";
+
+        String bucket = testConfig.getIngestbucket();
+
+        BlobInfo participantBlob = BlobInfo
+            .newBuilder(bucket, targetPath + "ingest-test-participant.json")
+            .build();
+        BlobInfo sampleBlob = BlobInfo
+            .newBuilder(bucket, targetPath + "ingest-test-sample.json")
+            .build();
+        BlobInfo fileBlob = BlobInfo
+            .newBuilder(bucket, targetPath + "ingest-test-file.json")
+            .build();
+
+        try {
+            bigQueryPdao.createDataset(dataset);
+
+            storage.create(participantBlob, readFile("ingest-test-participant.json"));
+            storage.create(sampleBlob, readFile("ingest-test-sample.json"));
+            storage.create(fileBlob, readFile("ingest-test-file.json"));
+
+            // Ingest staged data into the new dataset.
+            IngestRequestModel ingestRequest = new IngestRequestModel()
+                .format(IngestRequestModel.FormatEnum.JSON);
+
+            String datasetId = dataset.getId().toString();
+            connectedOperations.ingestTableSuccess(datasetId,
+                ingestRequest.table("participant").path(gsPath(participantBlob)));
+            connectedOperations.ingestTableSuccess(datasetId,
+                ingestRequest.table("sample").path(gsPath(sampleBlob)));
+            connectedOperations.ingestTableSuccess(datasetId,
+                ingestRequest.table("file").path(gsPath(fileBlob)));
+
+            // Create a snapshot!
+            DatasetSummaryModel datasetSummaryModel =
+                DatasetJsonConversion.datasetSummaryModelFromDatasetSummary(dataset.getDatasetSummary());
+            SnapshotSummaryModel snapshotSummary =
+                connectedOperations.createSnapshot(datasetSummaryModel,
+                    "ingest-test-snapshot-by-date.json", "");
+            SnapshotModel snapshot = connectedOperations.getSnapshot(snapshotSummary.getId());
+
+            BigQueryProject bigQueryProject = TestUtils.bigQueryProjectForDatasetName(
+                datasetDao, dataLocationService, dataset.getName());
+            Assert.assertThat(snapshot.getTables().size(), is(equalTo(3)));
+            List<String> participantIds = queryForIds(snapshot.getName(), "participant", bigQueryProject);
+            List<String> sampleIds = queryForIds(snapshot.getName(), "sample", bigQueryProject);
+            List<String> fileIds = queryForIds(snapshot.getName(), "file", bigQueryProject);
+
+            Assert.assertThat(participantIds, containsInAnyOrder(
+                "participant_1", "participant_2", "participant_3", "participant_4", "participant_5"));
+            Assert.assertThat(sampleIds, containsInAnyOrder("sample1", "sample2", "sample5"));
+            Assert.assertThat(fileIds, is(equalTo(Collections.singletonList("file1"))));
+        } finally {
+            storage.delete(participantBlob.getBlobId(), sampleBlob.getBlobId(), fileBlob.getBlobId());
+            bigQueryPdao.deleteDataset(dataset);
+            // Need to manually clean up the DAO because `readDataset` bypasses the
+            // `connectedOperations` object, so we can't rely on its auto-teardown logic.
+            datasetDao.delete(dataset.getId());
+        }
+    }
+
     /* BigQuery Legacy SQL supports querying a "meta-table" about partitions
      * for any partitioned table.
      *

--- a/src/test/resources/ingest-test-dataset.json
+++ b/src/test/resources/ingest-test-dataset.json
@@ -75,6 +75,23 @@
           "participant_children",
           "participant_files"
         ]
+      },
+      {
+        "name":   "sample_by_collection_date",
+        "rootTable": "sample",
+        "rootColumn": "date_collected",
+        "tables": [
+          {"name": "sample", "columns": []},
+          {"name": "participant", "columns": []},
+          {"name": "file", "columns": []}
+        ],
+        "follow": [
+          "sample_derived_from",
+          "participant_samples",
+          "sample_participants",
+          "participant_children",
+          "participant_files"
+        ]
       }
     ]
   }

--- a/src/test/resources/ingest-test-sample.json
+++ b/src/test/resources/ingest-test-sample.json
@@ -1,7 +1,7 @@
 {"id":"sample1","participant_ids":["participant_1"],"date_collected":"2019-02-27","derived_from":null}
-{"id":"sample2","participant_ids":["participant_2"],"date_collected":"2019-02-27","derived_from":null}
-{"id":"sample3","participant_ids":["participant_3"],"date_collected":"2019-02-27","derived_from":null}
-{"id":"sample4","participant_ids":["participant_3"],"date_collected":"2019-02-27","derived_from":null}
-{"id":"sample5","participant_ids":["participant_2","participant_5"],"date_collected":"2019-02-27","derived_from":null}
-{"id":"sample6","participant_ids":[],"date_collected":"2019-02-27","derived_from":"sample5"}
-{"id":"sample7","participant_ids":[],"date_collected":"2019-02-27","derived_from":"sample2"}
+{"id":"sample2","participant_ids":["participant_2"],"date_collected":"2020-02-29","derived_from":null}
+{"id":"sample3","participant_ids":["participant_3"],"date_collected":"2019-02-28","derived_from":null}
+{"id":"sample4","participant_ids":["participant_3"],"date_collected":"2019-03-01","derived_from":null}
+{"id":"sample5","participant_ids":["participant_2","participant_5"],"date_collected":"2019-03-02","derived_from":null}
+{"id":"sample6","participant_ids":[],"date_collected":"2019-02-10","derived_from":"sample5"}
+{"id":"sample7","participant_ids":[],"date_collected":"2019-02-12","derived_from":"sample2"}

--- a/src/test/resources/ingest-test-snapshot-by-date.json
+++ b/src/test/resources/ingest-test-snapshot-by-date.json
@@ -1,0 +1,17 @@
+{
+  "name":"demo",
+  "description":"desc",
+  "contents":[
+    {
+      "datasetName": "IngestTest",
+      "mode": "byAsset",
+      "assetSpec": {
+        "assetName": "sample_by_collection_date",
+        "rootValues": [
+          "2019-02-27",
+          "2020-02-29"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Without this change, trying to use a non-STRING results in a SQL error on `V.input_value = T.<column>` because of mismatched types.