### PR TITLE
DR-1154 bulk driver bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ dependencies {
         implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
         implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.1'
     } else {
-        implementation 'bio.terra:stairway:0.0.10-SNAPSHOT'
+        implementation 'bio.terra:stairway:0.0.12-SNAPSHOT'
     }
 
     // Forcing this due to vulnerability issues

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -12,6 +12,7 @@ import bio.terra.service.load.LoadFile;
 import bio.terra.service.load.LoadService;
 import bio.terra.service.load.flight.LoadMapKeys;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.FlightState;
@@ -207,11 +208,13 @@ public class IngestDriverStep implements Step {
                 case WAITING:
                 case READY:
                 case QUEUED:
+                    logger.debug("~~running load - flight: " + flightState.getFlightId());
                     realRunningLoads.add(loadFile);
                     break;
 
                 case ERROR:
                 case FATAL: {
+                    logger.debug("~~error load - flight: " + flightState.getFlightId());
                     String error = "unknown error";
                     if (flightState.getException().isPresent()) {
                         error = flightState.getException().get().toString();
@@ -222,6 +225,7 @@ public class IngestDriverStep implements Step {
                 }
 
                 case SUCCESS: {
+                    logger.debug("~~success load - flight: " + flightState.getFlightId());
                     FlightMap resultMap = flightState.getResultMap().orElse(null);
                     if (resultMap == null) {
                         throw new FileSystemCorruptException("no result map in flight state");
@@ -231,6 +235,9 @@ public class IngestDriverStep implements Step {
                     loadService.setLoadFileSucceeded(loadId, loadFile.getTargetPath(), fileId, fileInfo);
                     break;
                 }
+
+                default:
+                    throw new CorruptMetadataException("Invalid flight state: " + flightState.getFlightStatus());
             }
         }
 
@@ -270,6 +277,7 @@ public class IngestDriverStep implements Step {
             inputParameters.put(FileMapKeys.REQUEST, fileLoadModel);
             inputParameters.put(FileMapKeys.BUCKET_INFO, bucketInfo);
 
+            logger.debug("~~set running load - flight: " + flightId);
             loadService.setLoadFileRunning(loadId, loadFile.getTargetPath(), flightId);
             // NOTE: this is the window where we have recorded a flight as RUNNING in the load_file
             // table, but it has not yet been launched. A failure in this window leaves "orphan"

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -37,9 +37,9 @@ public class DataRepoClient {
     @Autowired
     private AuthService authService;
 
-    private static Logger logger = LoggerFactory.getLogger(DataRepoClient.class);
-    private RestTemplate restTemplate;
-    private HttpHeaders headers;
+    private static final Logger logger = LoggerFactory.getLogger(DataRepoClient.class);
+    private final RestTemplate restTemplate;
+    private final HttpHeaders headers;
 
     public DataRepoClient() {
         restTemplate = new RestTemplate();
@@ -87,37 +87,66 @@ public class DataRepoClient {
     public <T> DataRepoResponse<T> waitForResponse(TestConfiguration.User user,
                                                    DataRepoResponse<JobModel> jobModelResponse,
                                                    Class<T> responseClass) throws Exception {
-        final int initialSeconds = 1;
-        final int maxSeconds = 16;
 
-        try {
-            int count = 0;
-            int sleepSeconds = initialSeconds;
-            while (jobModelResponse.getStatusCode() == HttpStatus.ACCEPTED) {
-                String location = getLocationHeader(jobModelResponse);
-                logger.info("try #{} for {}", ++count, location);
+        // if the initial response is bad gateway, then the request probably never got delivered
+        if (jobModelResponse.getStatusCode() == HttpStatus.BAD_GATEWAY) {
+            throw new IllegalStateException("unexpected job status code: " + jobModelResponse.getStatusCode());
+        }
 
-                TimeUnit.SECONDS.sleep(sleepSeconds);
-                jobModelResponse = get(user, location, JobModel.class);
+        boolean keepGoing = true;
+        String location = getLocationHeader(jobModelResponse);
+        while (keepGoing) {
+            switch (jobModelResponse.getStatusCode()) {
+                case ACCEPTED: {
+                    jobModelResponse = waitForResponseUntilNot(user, location, HttpStatus.ACCEPTED);
+                    break;
+                }
 
-                int nextSeconds = 2 * sleepSeconds;
-                sleepSeconds = (nextSeconds > maxSeconds) ? maxSeconds : nextSeconds;
+                case BAD_GATEWAY:
+                    jobModelResponse = waitForResponseUntilNot(user, location, HttpStatus.BAD_GATEWAY);
+                    break;
+
+                default:
+                    keepGoing = false;
+                    break;
             }
-        } catch (InterruptedException ex) {
-            logger.info("interrupted ex: {}", ex.getMessage());
-            ex.printStackTrace();
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("unexpected interrupt waiting for response", ex);
         }
 
         if (jobModelResponse.getStatusCode() != HttpStatus.OK) {
             throw new IllegalStateException("unexpected job status code: " + jobModelResponse.getStatusCode());
         }
 
-        String location = getLocationHeader(jobModelResponse);
-        DataRepoResponse<T> resultResponse = get(user, location, responseClass);
+        location = getLocationHeader(jobModelResponse);
+        return get(user, location, responseClass);
+    }
 
-        return resultResponse;
+    // poll for a response with a return status that is not specified status
+    private DataRepoResponse<JobModel> waitForResponseUntilNot(TestConfiguration.User user,
+                                                               String location,
+                                                               HttpStatus notStatus) throws Exception {
+        final int initialSeconds = 1;
+        final int maxSeconds = 16;
+
+        try {
+            int count = 0;
+            int sleepSeconds = initialSeconds;
+
+            while (true) {
+                logger.info("try #{} until not {} for {}", ++count, notStatus, location);
+                TimeUnit.SECONDS.sleep(sleepSeconds);
+                sleepSeconds = Math.min(2 * sleepSeconds, maxSeconds);
+
+                DataRepoResponse<JobModel> jobModelResponse = get(user, location, JobModel.class);
+                logger.info("Got response. status: " + jobModelResponse.getStatusCode()
+                    + " location: " + jobModelResponse.getLocationHeader().orElse("not present"));
+                if (jobModelResponse.getStatusCode() != notStatus) {
+                    return jobModelResponse;
+                }
+            }
+        } catch (InterruptedException ex) {
+            logger.info("interrupted ex: " + ex.getMessage(), ex);
+            throw new IllegalStateException("unexpected interrupt waiting for response", ex);
+        }
     }
 
     private String getLocationHeader(DataRepoResponse<JobModel> jobModelResponse) {
@@ -145,10 +174,10 @@ public class DataRepoClient {
     // -- Common Client Code --
 
     private <S, T> ObjectOrErrorResponse<S, T> makeRequest(String path,
-                                                      HttpMethod method,
-                                                      HttpEntity entity,
-                                                      Class<T> responseClass,
-                                                      Class<S> errorClass) throws Exception {
+                                                           HttpMethod method,
+                                                           HttpEntity entity,
+                                                           Class<T> responseClass,
+                                                           Class<S> errorClass) throws Exception {
         logger.info("api request: method={} path={}", method.toString(), path);
 
         ResponseEntity<String> response = restTemplate.exchange(
@@ -186,6 +215,5 @@ public class DataRepoClient {
         copy.set("From", user.getEmail());
         return copy;
     }
-
 
 }

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -20,6 +20,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -126,6 +129,7 @@ public class DataRepoClient {
                                                                HttpStatus notStatus) throws Exception {
         final int initialSeconds = 1;
         final int maxSeconds = 16;
+        Instant overTime = Instant.now().plus(Duration.of(1, ChronoUnit.HOURS));
 
         try {
             int count = 0;
@@ -141,6 +145,10 @@ public class DataRepoClient {
                     + " location: " + jobModelResponse.getLocationHeader().orElse("not present"));
                 if (jobModelResponse.getStatusCode() != notStatus) {
                     return jobModelResponse;
+                }
+
+                if (Instant.now().isAfter(overTime)) {
+                    throw new IllegalStateException("we have waited too long for a response");
                 }
             }
         } catch (InterruptedException ex) {


### PR DESCRIPTION
This change set has a few small changes to accommodate interface changes from stairway.
It also teaches the DataRepoClient tolerate 502 errors that come up when a pod is killed in the middle of processing a job polling request.