### PR TITLE
DR-1169 Remove length limit on snapshot relationship names in DB.

### DIFF
--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -29,4 +29,5 @@
     <include file="changesets/20200525_snapshottablerowcounts.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20200529_datasetuniqueasset.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20200712_snapshotrelationships.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20200717_allowlongsnapshotrelnames.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20200717_allowlongsnapshotrelnames.yaml
+++ b/src/main/resources/db/changesets/20200717_allowlongsnapshotrelnames.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: allowlongsnapshotrelnames
+      author: danmoran
+      changes:
+        - modifyDataType:
+            tableName: snapshot_relationship
+            columnName: name
+            newDataType: text

--- a/src/test/resources/snapshot-test-dataset.json
+++ b/src/test/resources/snapshot-test-dataset.json
@@ -18,7 +18,7 @@
     ],
     "relationships": [
       {
-        "name": "therelationship",
+        "name": "the_relationship_with_a_very_very_very_very_very_very_very_very_very_very_very_very_very_long_name",
         "from": {"table": "thetable", "column": "thecolumn"},
         "to":   {"table": "anothertable", "column": "anothercolumn"}
       }
@@ -32,7 +32,7 @@
           {"name": "thetable", "columns": []},
           {"name": "anothertable", "columns": []}
         ],
-        "follow": ["therelationship"]
+        "follow": ["the_relationship_with_a_very_very_very_very_very_very_very_very_very_very_very_very_very_long_name"]
       }
     ]
   }


### PR DESCRIPTION
This is the same migration logic that was applied to dataset-relationship / asset names in #441 