### PR TITLE
DR-1115: Test Suite = collection of Test Configurations

### DIFF
--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
     compile 'ch.qos.logback:logback-classic:1.2.3'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+
+    compileOnly 'com.google.code.findbugs:annotations:3.0.1'
 }
 
 group 'bio.terra'

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     compile 'com.google.apis:google-api-services-people:v1-rev277-1.23.0'
     compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.20.0'
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.0"
+
+    compile 'ch.qos.logback:logback-classic:1.2.3'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 }
 
 group 'bio.terra'

--- a/datarepo-clienttests/logback.xml
+++ b/datarepo-clienttests/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/datarepo-clienttests/src/main/java/deploymentscripts/LaunchLocalProcess.java
+++ b/datarepo-clienttests/src/main/java/deploymentscripts/LaunchLocalProcess.java
@@ -69,7 +69,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     // confirm that the local server process does NOT respond successfully to a status request
     // if it does, that means there's already a local server running that we can't control
     // so error out here
-    LOG.info(
+    LOG.debug(
         "Checking service status endpoint to confirm that there is no local server already running");
     boolean statusRequestOK;
     ApiClient apiClient = new ApiClient();
@@ -97,7 +97,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     }
 
     // launch the server locally with the gradle bootRun task
-    LOG.info("Launching the server locally with the gradle bootRun task");
+    LOG.debug("Launching the server locally with the gradle bootRun task");
     ArrayList<String> gradleCmdArgs = new ArrayList<>();
     gradleCmdArgs.add(":bootRun");
     Map<String, String> envVars = buildEnvVarsMap();
@@ -110,7 +110,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     int pollCtr = Math.floorDiv(maximumSecondsToWaitForProcess, secondsIntervalToPollForProcess);
 
     // wait for the local server process to respond successfully to a status request
-    LOG.info("Waiting for the local server process to respond successfully to a status request");
+    LOG.debug("Waiting for the local server process to respond successfully to a status request");
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(serverSpecification.uri);
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
@@ -145,14 +145,14 @@ public class LaunchLocalProcess extends DeploymentScript {
    * unauthenticated status endpoint does NOT respond successfully.
    */
   public void teardown() throws Exception {
-    LOG.info("Killing the local process");
+    LOG.debug("Killing the local process");
     boolean processKilled =
         ProcessUtils.killProcessAndWaitForTermination(
             serverProcess, maximumSecondsToWaitForProcess);
     LOG.debug("Server process killed: {}", processKilled);
 
     // confirm that the local server process does NOT respond successfully to a status request
-    LOG.info("Checking service status endpoint to confirm the local server is shut down");
+    LOG.debug("Checking service status endpoint to confirm the local server is shut down");
     boolean statusRequestOK;
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(serverSpecification.uri);

--- a/datarepo-clienttests/src/main/java/deploymentscripts/LaunchLocalProcess.java
+++ b/datarepo-clienttests/src/main/java/deploymentscripts/LaunchLocalProcess.java
@@ -19,7 +19,7 @@ import runner.config.ServerSpecification;
 import utils.ProcessUtils;
 
 public class LaunchLocalProcess extends DeploymentScript {
-  private static final Logger LOG = LoggerFactory.getLogger(LaunchLocalProcess.class);
+  private static final Logger logger = LoggerFactory.getLogger(LaunchLocalProcess.class);
 
   private String jadedatarepoFilePath;
 
@@ -49,7 +49,7 @@ public class LaunchLocalProcess extends DeploymentScript {
           "Must provide a file path for the jade-data-repo code directory in the parameters list");
     } else {
       jadedatarepoFilePath = parameters.get(0);
-      LOG.debug("jade-data-repo code directory: {}", jadedatarepoFilePath);
+      logger.debug("jade-data-repo code directory: {}", jadedatarepoFilePath);
     }
   }
 
@@ -69,7 +69,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     // confirm that the local server process does NOT respond successfully to a status request
     // if it does, that means there's already a local server running that we can't control
     // so error out here
-    LOG.debug(
+    logger.debug(
         "Checking service status endpoint to confirm that there is no local server already running");
     boolean statusRequestOK;
     ApiClient apiClient = new ApiClient();
@@ -97,7 +97,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     }
 
     // launch the server locally with the gradle bootRun task
-    LOG.debug("Launching the server locally with the gradle bootRun task");
+    logger.debug("Launching the server locally with the gradle bootRun task");
     ArrayList<String> gradleCmdArgs = new ArrayList<>();
     gradleCmdArgs.add(":bootRun");
     Map<String, String> envVars = buildEnvVarsMap();
@@ -110,7 +110,8 @@ public class LaunchLocalProcess extends DeploymentScript {
     int pollCtr = Math.floorDiv(maximumSecondsToWaitForProcess, secondsIntervalToPollForProcess);
 
     // wait for the local server process to respond successfully to a status request
-    LOG.debug("Waiting for the local server process to respond successfully to a status request");
+    logger.debug(
+        "Waiting for the local server process to respond successfully to a status request");
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(serverSpecification.uri);
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
@@ -119,12 +120,12 @@ public class LaunchLocalProcess extends DeploymentScript {
       try {
         unauthenticatedApi.serviceStatus();
         int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
-        LOG.debug("Service status: {}", httpStatus);
+        logger.debug("Service status: {}", httpStatus);
         if (HttpStatusCodes.isSuccess(httpStatus)) {
           break;
         }
       } catch (Exception ex) {
-        LOG.debug("Exception caught while checking service status", ex);
+        logger.debug("Exception caught while checking service status", ex);
       }
 
       TimeUnit.SECONDS.sleep(secondsIntervalToPollForProcess);
@@ -135,7 +136,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     List<String> cmdOutputLines = ProcessUtils.readStdout(serverProcess, 25);
     for (String cmdOutputLine : cmdOutputLines) {
       if (cmdOutputLine.contains("bio.terra.Main: The following profiles are active")) {
-        LOG.debug(cmdOutputLine);
+        logger.debug(cmdOutputLine);
       }
     }
   }
@@ -145,14 +146,14 @@ public class LaunchLocalProcess extends DeploymentScript {
    * unauthenticated status endpoint does NOT respond successfully.
    */
   public void teardown() throws Exception {
-    LOG.debug("Killing the local process");
+    logger.debug("Killing the local process");
     boolean processKilled =
         ProcessUtils.killProcessAndWaitForTermination(
             serverProcess, maximumSecondsToWaitForProcess);
-    LOG.debug("Server process killed: {}", processKilled);
+    logger.debug("Server process killed: {}", processKilled);
 
     // confirm that the local server process does NOT respond successfully to a status request
-    LOG.debug("Checking service status endpoint to confirm the local server is shut down");
+    logger.debug("Checking service status endpoint to confirm the local server is shut down");
     boolean statusRequestOK;
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(serverSpecification.uri);
@@ -167,10 +168,10 @@ public class LaunchLocalProcess extends DeploymentScript {
     }
 
     if (statusRequestOK) {
-      LOG.error(
+      logger.error(
           "Local server shutdown failed; it is still responding successfully to status requests");
     } else {
-      LOG.debug("Status request failed, as expected");
+      logger.debug("Status request failed, as expected");
     }
   }
 

--- a/datarepo-clienttests/src/main/java/deploymentscripts/ModularHelmChart.java
+++ b/datarepo-clienttests/src/main/java/deploymentscripts/ModularHelmChart.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import runner.DeploymentScript;
 import runner.config.ApplicationSpecification;
 import runner.config.ServerSpecification;
@@ -22,6 +24,8 @@ import utils.FileUtils;
 import utils.ProcessUtils;
 
 public class ModularHelmChart extends DeploymentScript {
+  private static final Logger LOG = LoggerFactory.getLogger(ModularHelmChart.class);
+
   private String helmApiFilePath;
 
   private ServerSpecification serverSpecification;
@@ -47,7 +51,7 @@ public class ModularHelmChart extends DeploymentScript {
           "Must provide a file path for the Helm API definition YAML in the parameters list");
     } else {
       helmApiFilePath = parameters.get(0);
-      System.out.println("Helm API definition YAML: " + helmApiFilePath);
+      LOG.debug("Helm API definition YAML: {}", helmApiFilePath);
     }
   }
 
@@ -85,7 +89,7 @@ public class ModularHelmChart extends DeploymentScript {
     Process helmDeleteProc = ProcessUtils.executeCommand("helm", deleteCmdArgs);
     List<String> cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(helmDeleteProc);
     for (String cmdOutputLine : cmdOutputLines) {
-      System.out.println(cmdOutputLine);
+      LOG.debug(cmdOutputLine);
     }
 
     // list the available deployments (for debugging)
@@ -97,7 +101,7 @@ public class ModularHelmChart extends DeploymentScript {
     Process helmListProc = ProcessUtils.executeCommand("helm", listCmdArgs);
     cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(helmListProc);
     for (String cmdOutputLine : cmdOutputLines) {
-      System.out.println(cmdOutputLine);
+      LOG.debug(cmdOutputLine);
     }
 
     // install/upgrade the API deployment using the modified YAML file we just generated
@@ -116,7 +120,7 @@ public class ModularHelmChart extends DeploymentScript {
     Process helmUpgradeProc = ProcessUtils.executeCommand("helm", installCmdArgs);
     cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(helmUpgradeProc);
     for (String cmdOutputLine : cmdOutputLines) {
-      System.out.println(cmdOutputLine);
+      LOG.debug(cmdOutputLine);
     }
 
     // delete the two temp YAML files created above
@@ -147,7 +151,7 @@ public class ModularHelmChart extends DeploymentScript {
     int pollCtr = Math.floorDiv(maximumSecondsToWaitForDeploy, secondsIntervalToPollForDeploy);
 
     // first wait for the datarepo-api deployment to report "deployed" by helm ls
-    System.out.println("Checking Helm status of datarepo-api deployment");
+    LOG.info("Waiting for Helm to report datarepo-api as deployed");
     boolean foundHelmStatusDeployed = false;
     while (pollCtr >= 0) {
       // list the available deployments
@@ -159,7 +163,7 @@ public class ModularHelmChart extends DeploymentScript {
       Process helmListProc = ProcessUtils.executeCommand("helm", listCmdArgs);
       List<String> cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(helmListProc);
       for (String cmdOutputLine : cmdOutputLines) {
-        System.out.println(cmdOutputLine);
+        LOG.debug(cmdOutputLine);
       }
 
       for (String cmdOutputLine : cmdOutputLines) {
@@ -180,7 +184,7 @@ public class ModularHelmChart extends DeploymentScript {
     }
 
     // then wait for the datarepo-api deployment to respond successfully to a status request
-    System.out.println("Checking service status endpoint");
+    LOG.info("Waiting for the datarepo-api to respond successfully to a status request");
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(serverSpecification.uri);
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
@@ -189,12 +193,12 @@ public class ModularHelmChart extends DeploymentScript {
       try {
         unauthenticatedApi.serviceStatus();
         int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
-        System.out.println("Service status: " + httpStatus);
+        LOG.debug("Service status: {}", httpStatus);
         if (HttpStatusCodes.isSuccess(httpStatus)) {
           break;
         }
       } catch (ApiException apiEx) {
-        System.out.println("Exception caught while checking service status: " + apiEx.getMessage());
+        LOG.debug("Exception caught while checking service status", apiEx);
       }
 
       TimeUnit.SECONDS.sleep(secondsIntervalToPollForDeploy);

--- a/datarepo-clienttests/src/main/java/deploymentscripts/ModularHelmChart.java
+++ b/datarepo-clienttests/src/main/java/deploymentscripts/ModularHelmChart.java
@@ -151,7 +151,7 @@ public class ModularHelmChart extends DeploymentScript {
     int pollCtr = Math.floorDiv(maximumSecondsToWaitForDeploy, secondsIntervalToPollForDeploy);
 
     // first wait for the datarepo-api deployment to report "deployed" by helm ls
-    LOG.info("Waiting for Helm to report datarepo-api as deployed");
+    LOG.debug("Waiting for Helm to report datarepo-api as deployed");
     boolean foundHelmStatusDeployed = false;
     while (pollCtr >= 0) {
       // list the available deployments
@@ -184,7 +184,7 @@ public class ModularHelmChart extends DeploymentScript {
     }
 
     // then wait for the datarepo-api deployment to respond successfully to a status request
-    LOG.info("Waiting for the datarepo-api to respond successfully to a status request");
+    LOG.debug("Waiting for the datarepo-api to respond successfully to a status request");
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(serverSpecification.uri);
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);

--- a/datarepo-clienttests/src/main/java/deploymentscripts/ModularHelmChart.java
+++ b/datarepo-clienttests/src/main/java/deploymentscripts/ModularHelmChart.java
@@ -24,7 +24,7 @@ import utils.FileUtils;
 import utils.ProcessUtils;
 
 public class ModularHelmChart extends DeploymentScript {
-  private static final Logger LOG = LoggerFactory.getLogger(ModularHelmChart.class);
+  private static final Logger logger = LoggerFactory.getLogger(ModularHelmChart.class);
 
   private String helmApiFilePath;
 
@@ -51,7 +51,7 @@ public class ModularHelmChart extends DeploymentScript {
           "Must provide a file path for the Helm API definition YAML in the parameters list");
     } else {
       helmApiFilePath = parameters.get(0);
-      LOG.debug("Helm API definition YAML: {}", helmApiFilePath);
+      logger.debug("Helm API definition YAML: {}", helmApiFilePath);
     }
   }
 
@@ -89,7 +89,7 @@ public class ModularHelmChart extends DeploymentScript {
     Process helmDeleteProc = ProcessUtils.executeCommand("helm", deleteCmdArgs);
     List<String> cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(helmDeleteProc);
     for (String cmdOutputLine : cmdOutputLines) {
-      LOG.debug(cmdOutputLine);
+      logger.debug(cmdOutputLine);
     }
 
     // list the available deployments (for debugging)
@@ -101,7 +101,7 @@ public class ModularHelmChart extends DeploymentScript {
     Process helmListProc = ProcessUtils.executeCommand("helm", listCmdArgs);
     cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(helmListProc);
     for (String cmdOutputLine : cmdOutputLines) {
-      LOG.debug(cmdOutputLine);
+      logger.debug(cmdOutputLine);
     }
 
     // install/upgrade the API deployment using the modified YAML file we just generated
@@ -120,7 +120,7 @@ public class ModularHelmChart extends DeploymentScript {
     Process helmUpgradeProc = ProcessUtils.executeCommand("helm", installCmdArgs);
     cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(helmUpgradeProc);
     for (String cmdOutputLine : cmdOutputLines) {
-      LOG.debug(cmdOutputLine);
+      logger.debug(cmdOutputLine);
     }
 
     // delete the two temp YAML files created above
@@ -151,7 +151,7 @@ public class ModularHelmChart extends DeploymentScript {
     int pollCtr = Math.floorDiv(maximumSecondsToWaitForDeploy, secondsIntervalToPollForDeploy);
 
     // first wait for the datarepo-api deployment to report "deployed" by helm ls
-    LOG.debug("Waiting for Helm to report datarepo-api as deployed");
+    logger.debug("Waiting for Helm to report datarepo-api as deployed");
     boolean foundHelmStatusDeployed = false;
     while (pollCtr >= 0) {
       // list the available deployments
@@ -163,7 +163,7 @@ public class ModularHelmChart extends DeploymentScript {
       Process helmListProc = ProcessUtils.executeCommand("helm", listCmdArgs);
       List<String> cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(helmListProc);
       for (String cmdOutputLine : cmdOutputLines) {
-        LOG.debug(cmdOutputLine);
+        logger.debug(cmdOutputLine);
       }
 
       for (String cmdOutputLine : cmdOutputLines) {
@@ -184,7 +184,7 @@ public class ModularHelmChart extends DeploymentScript {
     }
 
     // then wait for the datarepo-api deployment to respond successfully to a status request
-    LOG.debug("Waiting for the datarepo-api to respond successfully to a status request");
+    logger.debug("Waiting for the datarepo-api to respond successfully to a status request");
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(serverSpecification.uri);
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
@@ -193,12 +193,12 @@ public class ModularHelmChart extends DeploymentScript {
       try {
         unauthenticatedApi.serviceStatus();
         int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
-        LOG.debug("Service status: {}", httpStatus);
+        logger.debug("Service status: {}", httpStatus);
         if (HttpStatusCodes.isSuccess(httpStatus)) {
           break;
         }
       } catch (ApiException apiEx) {
-        LOG.debug("Exception caught while checking service status", apiEx);
+        logger.debug("Exception caught while checking service status", apiEx);
       }
 
       TimeUnit.SECONDS.sleep(secondsIntervalToPollForDeploy);

--- a/datarepo-clienttests/src/main/java/runner/TestRunner.java
+++ b/datarepo-clienttests/src/main/java/runner/TestRunner.java
@@ -414,15 +414,18 @@ class TestRunner {
     // read in test suite and validate it
     TestSuite testSuite;
     boolean isSuite = args[0].startsWith(TestSuite.resourceDirectory + "/");
+    boolean isSingleConfig = args[0].startsWith(TestConfiguration.resourceDirectory + "/");
     if (isSuite) {
       testSuite = TestSuite.fromJSONFile(args[0].split(TestSuite.resourceDirectory + "/")[1]);
       LOG.info("Found a test suite: {}", testSuite.name);
-    } else {
+    } else if (isSingleConfig) {
       TestConfiguration testConfiguration =
           TestConfiguration.fromJSONFile(
               args[0].split(TestConfiguration.resourceDirectory + "/")[1]);
       testSuite = TestSuite.fromSingleTestConfiguration(testConfiguration);
       LOG.info("Found a single test configuration: {}", testConfiguration.name);
+    } else {
+      throw new RuntimeException("Invalid file reference to test suite or configuration.");
     }
     testSuite.validate();
 

--- a/datarepo-clienttests/src/main/java/runner/TestScriptResult.java
+++ b/datarepo-clienttests/src/main/java/runner/TestScriptResult.java
@@ -23,11 +23,11 @@ public class TestScriptResult {
     public long maxElapsedTimeMS;
     public double meanElapsedTimeMS;
 
-    public int totalRun;
-    public int numCompleted;
-    public int numExceptionsThrown;
+    public int totalRun; // total number of user journey threads submitted to the thread pool
+    public int numCompleted; // number of user journey threads that completed
+    public int numExceptionsThrown; // number of user journey threads that threw exceptions
 
-    public boolean isFailure;
+    public boolean isFailure; // numCompleted < totalRun
 
     private TestScriptResultSummary(String testScriptDescription) {
       this.testScriptDescription = testScriptDescription;

--- a/datarepo-clienttests/src/main/java/runner/TestScriptResult.java
+++ b/datarepo-clienttests/src/main/java/runner/TestScriptResult.java
@@ -1,10 +1,10 @@
 package runner;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import runner.config.TestScriptSpecification;
 
 public class TestScriptResult {
-  public TestScriptSpecification testScriptSpecification;
   public List<UserJourneyResult> userJourneyResults;
   public TestScriptResultSummary summary;
 
@@ -13,6 +13,9 @@ public class TestScriptResult {
    * This class does not include a reference to the full TestScriptSpecification or the list of
    * UserJourneyResults.
    */
+  @SuppressFBWarnings(
+      value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+      justification = "This POJO class is used for easy serialization to JSON using Jackson.")
   public static class TestScriptResultSummary {
     public String testScriptDescription;
 
@@ -33,7 +36,6 @@ public class TestScriptResult {
 
   public TestScriptResult(
       TestScriptSpecification testScriptSpecification, List<UserJourneyResult> userJourneyResults) {
-    this.testScriptSpecification = testScriptSpecification;
     this.userJourneyResults = userJourneyResults;
 
     summary = new TestScriptResultSummary(testScriptSpecification.description);

--- a/datarepo-clienttests/src/main/java/runner/TestScriptResult.java
+++ b/datarepo-clienttests/src/main/java/runner/TestScriptResult.java
@@ -8,7 +8,11 @@ public class TestScriptResult {
   public List<UserJourneyResult> userJourneyResults;
   public TestScriptResultSummary summary;
 
-  
+  /**
+   * Summary statistics are pulled out into a separate inner class for easier summary reporting.
+   * This class does not include a reference to the full TestScriptSpecification or the list of
+   * UserJourneyResults.
+   */
   public static class TestScriptResultSummary {
     public String testScriptDescription;
 
@@ -40,6 +44,7 @@ public class TestScriptResult {
     return summary;
   }
 
+  /** Loop through the UserJourneyResults calculating reporting statistics of interest. */
   private void calculateStatistics() {
     for (int ctr = 0; ctr < userJourneyResults.size(); ctr++) {
       UserJourneyResult result = userJourneyResults.get(ctr);

--- a/datarepo-clienttests/src/main/java/runner/TestScriptResult.java
+++ b/datarepo-clienttests/src/main/java/runner/TestScriptResult.java
@@ -1,0 +1,70 @@
+package runner;
+
+import java.util.List;
+import runner.config.TestScriptSpecification;
+
+public class TestScriptResult {
+  public TestScriptSpecification testScriptSpecification;
+  public List<UserJourneyResult> userJourneyResults;
+  public TestScriptResultSummary summary;
+
+  
+  public static class TestScriptResultSummary {
+    public String testScriptDescription;
+
+    public long minElapsedTimeMS;
+    public long maxElapsedTimeMS;
+    public double meanElapsedTimeMS;
+
+    public int totalRun;
+    public int numCompleted;
+    public int numExceptionsThrown;
+
+    public boolean isFailure;
+
+    private TestScriptResultSummary(String testScriptDescription) {
+      this.testScriptDescription = testScriptDescription;
+    }
+  }
+
+  public TestScriptResult(
+      TestScriptSpecification testScriptSpecification, List<UserJourneyResult> userJourneyResults) {
+    this.testScriptSpecification = testScriptSpecification;
+    this.userJourneyResults = userJourneyResults;
+
+    summary = new TestScriptResultSummary(testScriptSpecification.description);
+    calculateStatistics();
+  }
+
+  public TestScriptResultSummary getSummary() {
+    return summary;
+  }
+
+  private void calculateStatistics() {
+    for (int ctr = 0; ctr < userJourneyResults.size(); ctr++) {
+      UserJourneyResult result = userJourneyResults.get(ctr);
+
+      // calculate the min, max, mean elapsed time
+      if (summary.minElapsedTimeMS > result.elapsedTimeNS || ctr == 0) {
+        summary.minElapsedTimeMS = result.elapsedTimeNS;
+      }
+      if (summary.maxElapsedTimeMS < result.elapsedTimeNS || ctr == 0) {
+        summary.maxElapsedTimeMS = result.elapsedTimeNS;
+      }
+      summary.meanElapsedTimeMS += result.elapsedTimeNS;
+
+      // count the number of user journeys that completed and threw exceptions
+      summary.numCompleted += (result.completed) ? 1 : 0;
+      summary.numExceptionsThrown += (result.exceptionThrown != null) ? 1 : 0;
+    }
+    summary.meanElapsedTimeMS /= userJourneyResults.size();
+    summary.totalRun = userJourneyResults.size();
+
+    summary.isFailure = summary.numCompleted < summary.totalRun;
+
+    // convert all the times from nanoseconds to milliseconds
+    summary.minElapsedTimeMS /= (1e6);
+    summary.maxElapsedTimeMS /= (1e6);
+    summary.meanElapsedTimeMS /= (1e6);
+  }
+}

--- a/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
+++ b/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
@@ -10,7 +10,7 @@ public class UserJourneyResult {
   public String threadName;
 
   public boolean completed;
-  public long elapsedTime;
+  public long elapsedTimeNS;
   public Exception exceptionThrown;
 
   public UserJourneyResult(String userJourneyDescription, String threadName) {

--- a/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
+++ b/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
@@ -1,6 +1,11 @@
 package runner;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class UserJourneyResult {
+  private static final Logger LOG = LoggerFactory.getLogger(UserJourneyResult.class);
+
   public String userJourneyDescription;
   public String threadName;
 
@@ -17,11 +22,10 @@ public class UserJourneyResult {
   }
 
   public void display() {
-    System.out.println("User Journey Result: " + userJourneyDescription);
-    System.out.println("  threadName: " + threadName);
-    System.out.println("  completed: " + completed);
-    System.out.println("  elapsedTime (sec): " + (double) elapsedTime / (1e9));
-    System.out.println(
-        "  exceptionThrown: " + (exceptionThrown == null ? "" : exceptionThrown.getMessage()));
+    LOG.info("User Journey Result: {}", userJourneyDescription);
+    LOG.info("  threadName: {}", threadName);
+    LOG.info("  completed: {}", completed);
+    LOG.info("  elapsedTime (sec): {}", elapsedTime / (1e9));
+    LOG.info("  exceptionThrown: {}", exceptionThrown == null, exceptionThrown);
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
+++ b/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
@@ -1,12 +1,13 @@
 package runner;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+@SuppressFBWarnings(
+    value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+    justification = "This POJO class is used for easy serialization to JSON using Jackson.")
 public class UserJourneyResult {
-  private static final Logger logger = LoggerFactory.getLogger(UserJourneyResult.class);
-
   public String userJourneyDescription;
+
   public String threadName;
 
   public boolean completed;

--- a/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
+++ b/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UserJourneyResult {
-  private static final Logger LOG = LoggerFactory.getLogger(UserJourneyResult.class);
+  private static final Logger logger = LoggerFactory.getLogger(UserJourneyResult.class);
 
   public String userJourneyDescription;
   public String threadName;

--- a/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
+++ b/datarepo-clienttests/src/main/java/runner/UserJourneyResult.java
@@ -20,12 +20,4 @@ public class UserJourneyResult {
     this.exceptionThrown = null;
     this.completed = false;
   }
-
-  public void display() {
-    LOG.info("User Journey Result: {}", userJourneyDescription);
-    LOG.info("  threadName: {}", threadName);
-    LOG.info("  completed: {}", completed);
-    LOG.info("  elapsedTime (sec): {}", elapsedTime / (1e9));
-    LOG.info("  exceptionThrown: {}", exceptionThrown == null, exceptionThrown);
-  }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/ApplicationSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ApplicationSpecification.java
@@ -1,6 +1,11 @@
 package runner.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ApplicationSpecification implements SpecificationInterface {
+  private static final Logger LOG = LoggerFactory.getLogger(ApplicationSpecification.class);
+
   public int maxStairwayThreads = 20;
   public int maxBulkFileLoad = 1000000;
   public int loadConcurrentFiles = 4;
@@ -30,12 +35,12 @@ public class ApplicationSpecification implements SpecificationInterface {
   }
 
   public void display() {
-    System.out.println("Application: ");
-    System.out.println("  maxStairwayThreads: " + maxStairwayThreads);
-    System.out.println("  maxBulkFileLoad: " + maxBulkFileLoad);
-    System.out.println("  loadConcurrentFiles: " + loadConcurrentFiles);
-    System.out.println("  loadConcurrentIngests: " + loadConcurrentIngests);
-    System.out.println("  loadHistoryCopyChunkSize: " + loadHistoryCopyChunkSize);
-    System.out.println("  loadHistoryWaitSeconds: " + loadHistoryWaitSeconds);
+    LOG.info("Application: ");
+    LOG.info("  maxStairwayThreads: {}", maxStairwayThreads);
+    LOG.info("  maxBulkFileLoad: {}", maxBulkFileLoad);
+    LOG.info("  loadConcurrentFiles: {}", loadConcurrentFiles);
+    LOG.info("  loadConcurrentIngests: {}", loadConcurrentIngests);
+    LOG.info("  loadHistoryCopyChunkSize: {}", loadHistoryCopyChunkSize);
+    LOG.info("  loadHistoryWaitSeconds: {}", loadHistoryWaitSeconds);
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/ApplicationSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ApplicationSpecification.java
@@ -1,11 +1,6 @@
 package runner.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class ApplicationSpecification implements SpecificationInterface {
-  private static final Logger LOG = LoggerFactory.getLogger(ApplicationSpecification.class);
-
   public int maxStairwayThreads = 20;
   public int maxBulkFileLoad = 1000000;
   public int loadConcurrentFiles = 4;

--- a/datarepo-clienttests/src/main/java/runner/config/ApplicationSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ApplicationSpecification.java
@@ -33,14 +33,4 @@ public class ApplicationSpecification implements SpecificationInterface {
           "Application property loadHistoryWaitSeconds must be >= 0");
     }
   }
-
-  public void display() {
-    LOG.info("Application: ");
-    LOG.info("  maxStairwayThreads: {}", maxStairwayThreads);
-    LOG.info("  maxBulkFileLoad: {}", maxBulkFileLoad);
-    LOG.info("  loadConcurrentFiles: {}", loadConcurrentFiles);
-    LOG.info("  loadConcurrentIngests: {}", loadConcurrentIngests);
-    LOG.info("  loadHistoryCopyChunkSize: {}", loadHistoryCopyChunkSize);
-    LOG.info("  loadHistoryWaitSeconds: {}", loadHistoryWaitSeconds);
-  }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/DeploymentScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/DeploymentScriptSpecification.java
@@ -2,9 +2,13 @@ package runner.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import runner.DeploymentScript;
 
 public class DeploymentScriptSpecification implements SpecificationInterface {
+  private static final Logger LOG = LoggerFactory.getLogger(DeploymentScriptSpecification.class);
+
   public String name = "";
   public List<String> parameters = new ArrayList<>();
 
@@ -28,10 +32,10 @@ public class DeploymentScriptSpecification implements SpecificationInterface {
   }
 
   public void display() {
-    System.out.println("Deployment Script: " + name);
-    System.out.println("  name: " + name);
+    LOG.info("Deployment Script: {}", name);
+    LOG.info("  name: {}", name);
 
     String parametersStr = (parameters == null) ? "" : String.join(",", parameters);
-    System.out.println("  parameters: " + parametersStr);
+    LOG.info("  parameters: {}", parametersStr);
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/DeploymentScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/DeploymentScriptSpecification.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import runner.DeploymentScript;
 
 public class DeploymentScriptSpecification implements SpecificationInterface {
-  private static final Logger LOG = LoggerFactory.getLogger(DeploymentScriptSpecification.class);
+  private static final Logger logger = LoggerFactory.getLogger(DeploymentScriptSpecification.class);
 
   public String name = "";
   public List<String> parameters = new ArrayList<>();

--- a/datarepo-clienttests/src/main/java/runner/config/DeploymentScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/DeploymentScriptSpecification.java
@@ -2,13 +2,9 @@ package runner.config;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import runner.DeploymentScript;
 
 public class DeploymentScriptSpecification implements SpecificationInterface {
-  private static final Logger logger = LoggerFactory.getLogger(DeploymentScriptSpecification.class);
-
   public String name = "";
   public List<String> parameters = new ArrayList<>();
 

--- a/datarepo-clienttests/src/main/java/runner/config/DeploymentScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/DeploymentScriptSpecification.java
@@ -30,12 +30,4 @@ public class DeploymentScriptSpecification implements SpecificationInterface {
       throw new IllegalArgumentException("Deployment script class not found: " + name, classEx);
     }
   }
-
-  public void display() {
-    LOG.info("Deployment Script: {}", name);
-    LOG.info("  name: {}", name);
-
-    String parametersStr = (parameters == null) ? "" : String.join(",", parameters);
-    LOG.info("  parameters: {}", parametersStr);
-  }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/KubernetesSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/KubernetesSpecification.java
@@ -1,11 +1,6 @@
 package runner.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class KubernetesSpecification implements SpecificationInterface {
-  private static final Logger logger = LoggerFactory.getLogger(KubernetesSpecification.class);
-
   public int numberOfInitialPods = 1;
 
   KubernetesSpecification() {}

--- a/datarepo-clienttests/src/main/java/runner/config/KubernetesSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/KubernetesSpecification.java
@@ -1,6 +1,11 @@
 package runner.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class KubernetesSpecification implements SpecificationInterface {
+  private static final Logger LOG = LoggerFactory.getLogger(KubernetesSpecification.class);
+
   public int numberOfInitialPods = 1;
 
   KubernetesSpecification() {}
@@ -13,7 +18,7 @@ public class KubernetesSpecification implements SpecificationInterface {
   }
 
   public void display() {
-    System.out.println("Kubernetes: ");
-    System.out.println("  numberOfInitialPods: " + numberOfInitialPods);
+    LOG.info("Kubernetes: ");
+    LOG.info("  numberOfInitialPods: {}", numberOfInitialPods);
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/KubernetesSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/KubernetesSpecification.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class KubernetesSpecification implements SpecificationInterface {
-  private static final Logger LOG = LoggerFactory.getLogger(KubernetesSpecification.class);
+  private static final Logger logger = LoggerFactory.getLogger(KubernetesSpecification.class);
 
   public int numberOfInitialPods = 1;
 

--- a/datarepo-clienttests/src/main/java/runner/config/KubernetesSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/KubernetesSpecification.java
@@ -16,9 +16,4 @@ public class KubernetesSpecification implements SpecificationInterface {
       throw new IllegalArgumentException("Number of initial Kubernetes pods must be >= 0");
     }
   }
-
-  public void display() {
-    LOG.info("Kubernetes: ");
-    LOG.info("  numberOfInitialPods: {}", numberOfInitialPods);
-  }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
@@ -37,7 +37,6 @@ public class ServerSpecification implements SpecificationInterface {
     ObjectMapper objectMapper = new ObjectMapper();
 
     // read in the server file
-    LOG.info("Parsing the server specification file as JSON");
     InputStream inputStream =
         FileUtils.getJSONFileHandle(resourceDirectory + "/" + resourceFileName);
     return objectMapper.readValue(inputStream, ServerSpecification.class);

--- a/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import utils.FileUtils;
 
 public class ServerSpecification implements SpecificationInterface {
-  private static final Logger LOG = LoggerFactory.getLogger(ServerSpecification.class);
+  private static final Logger logger = LoggerFactory.getLogger(ServerSpecification.class);
 
   public String name;
   public String description = "";

--- a/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
@@ -2,13 +2,9 @@ package runner.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import utils.FileUtils;
 
 public class ServerSpecification implements SpecificationInterface {
-  private static final Logger logger = LoggerFactory.getLogger(ServerSpecification.class);
-
   public String name;
   public String description = "";
   public String uri;

--- a/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
@@ -1,7 +1,10 @@
 package runner.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.InputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import utils.FileUtils;
 
 public class ServerSpecification implements SpecificationInterface {
   private static final Logger LOG = LoggerFactory.getLogger(ServerSpecification.class);
@@ -21,6 +24,24 @@ public class ServerSpecification implements SpecificationInterface {
   public static final String resourceDirectory = "servers";
 
   ServerSpecification() {}
+
+  /**
+   * Read an instance of this class in from a JSON-formatted file. This method expects that the file
+   * name exists in the directory specified by {@link #resourceDirectory}
+   *
+   * @param resourceFileName file name
+   * @return an instance of this class
+   */
+  public static ServerSpecification fromJSONFile(String resourceFileName) throws Exception {
+    // use Jackson to map the stream contents to a TestConfiguration object
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    // read in the server file
+    LOG.info("Parsing the server specification file as JSON");
+    InputStream inputStream =
+        FileUtils.getJSONFileHandle(resourceDirectory + "/" + resourceFileName);
+    return objectMapper.readValue(inputStream, ServerSpecification.class);
+  }
 
   /**
    * Validate the server specification read in from the JSON file. None of the properties should be
@@ -47,23 +68,6 @@ public class ServerSpecification implements SpecificationInterface {
         throw new IllegalArgumentException("Server deployment script must be defined");
       }
       deploymentScript.validate();
-    }
-  }
-
-  public void display() {
-    LOG.info("Server: {}", name);
-    LOG.info("  description: {}", description);
-    LOG.info("  uri: {}", uri);
-    LOG.info("  clusterName: {}", clusterName);
-    LOG.info("  clusterShortName: {}", clusterShortName);
-    LOG.info("  region: {}", region);
-    LOG.info("  project: {}", project);
-    LOG.info("  namespace: {}", namespace);
-    LOG.info("  skipKubernetes: {}", skipKubernetes);
-    LOG.info("  skipDeployment: {}", skipDeployment);
-
-    if (!skipDeployment) {
-      deploymentScript.display();
     }
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ServerSpecification.java
@@ -1,6 +1,11 @@
 package runner.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ServerSpecification implements SpecificationInterface {
+  private static final Logger LOG = LoggerFactory.getLogger(ServerSpecification.class);
+
   public String name;
   public String description = "";
   public String uri;
@@ -46,19 +51,18 @@ public class ServerSpecification implements SpecificationInterface {
   }
 
   public void display() {
-    System.out.println("Server: " + name);
-    System.out.println("  description: " + description);
-    System.out.println("  uri: " + uri);
-    System.out.println("  clusterName: " + clusterName);
-    System.out.println("  clusterShortName: " + clusterShortName);
-    System.out.println("  region: " + region);
-    System.out.println("  project: " + project);
-    System.out.println("  namespace: " + namespace);
-    System.out.println("  skipKubernetes: " + skipKubernetes);
-    System.out.println("  skipDeployment: " + skipDeployment);
+    LOG.info("Server: {}", name);
+    LOG.info("  description: {}", description);
+    LOG.info("  uri: {}", uri);
+    LOG.info("  clusterName: {}", clusterName);
+    LOG.info("  clusterShortName: {}", clusterShortName);
+    LOG.info("  region: {}", region);
+    LOG.info("  project: {}", project);
+    LOG.info("  namespace: {}", namespace);
+    LOG.info("  skipKubernetes: {}", skipKubernetes);
+    LOG.info("  skipDeployment: {}", skipDeployment);
 
     if (!skipDeployment) {
-      System.out.println();
       deploymentScript.display();
     }
   }

--- a/datarepo-clienttests/src/main/java/runner/config/ServiceAccountSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ServiceAccountSpecification.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import utils.FileUtils;
 
 public class ServiceAccountSpecification implements SpecificationInterface {
-  private static final Logger LOG = LoggerFactory.getLogger(ServiceAccountSpecification.class);
+  private static final Logger logger = LoggerFactory.getLogger(ServiceAccountSpecification.class);
 
   public String name;
   public String serviceAccountEmail;

--- a/datarepo-clienttests/src/main/java/runner/config/ServiceAccountSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ServiceAccountSpecification.java
@@ -1,8 +1,12 @@
 package runner.config;
 
 import java.io.File;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ServiceAccountSpecification implements SpecificationInterface {
+  private static final Logger LOG = LoggerFactory.getLogger(ServiceAccountSpecification.class);
+
   public String name;
   public String serviceAccountEmail;
   public String jsonKeyFilePath;
@@ -40,9 +44,9 @@ public class ServiceAccountSpecification implements SpecificationInterface {
   }
 
   public void display() {
-    System.out.println("Service Account: " + name);
-    System.out.println("  serviceAccountEmail: " + serviceAccountEmail);
-    System.out.println("  jsonKeyFilePath: " + jsonKeyFilePath);
-    System.out.println("  pemFilePath: " + pemFilePath);
+    LOG.info("Service Account: {}", name);
+    LOG.info("  serviceAccountEmail: {}", serviceAccountEmail);
+    LOG.info("  jsonKeyFilePath: {}", jsonKeyFilePath);
+    LOG.info("  pemFilePath: {}", pemFilePath);
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/ServiceAccountSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ServiceAccountSpecification.java
@@ -1,8 +1,11 @@
 package runner.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
+import java.io.InputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import utils.FileUtils;
 
 public class ServiceAccountSpecification implements SpecificationInterface {
   private static final Logger LOG = LoggerFactory.getLogger(ServiceAccountSpecification.class);
@@ -18,6 +21,22 @@ public class ServiceAccountSpecification implements SpecificationInterface {
   public static final String resourceDirectory = "serviceaccounts";
 
   ServiceAccountSpecification() {}
+
+  /**
+   * Read an instance of this class in from a JSON-formatted file. This method expects that the file
+   * name exists in the directory specified by {@link #resourceDirectory}
+   *
+   * @param resourceFileName file name
+   * @return an instance of this class
+   */
+  public static ServiceAccountSpecification fromJSONFile(String resourceFileName) throws Exception {
+    // use Jackson to map the stream contents to a TestConfiguration object
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    InputStream inputStream =
+        FileUtils.getJSONFileHandle(resourceDirectory + "/" + resourceFileName);
+    return objectMapper.readValue(inputStream, ServiceAccountSpecification.class);
+  }
 
   /**
    * Validate the service account specification read in from the JSON file. None of the properties
@@ -41,12 +60,5 @@ public class ServiceAccountSpecification implements SpecificationInterface {
     if (!pemFile.exists()) {
       throw new IllegalArgumentException("PEM file does not exist: " + pemFilePath);
     }
-  }
-
-  public void display() {
-    LOG.info("Service Account: {}", name);
-    LOG.info("  serviceAccountEmail: {}", serviceAccountEmail);
-    LOG.info("  jsonKeyFilePath: {}", jsonKeyFilePath);
-    LOG.info("  pemFilePath: {}", pemFilePath);
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/ServiceAccountSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/ServiceAccountSpecification.java
@@ -3,13 +3,9 @@ package runner.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.InputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import utils.FileUtils;
 
 public class ServiceAccountSpecification implements SpecificationInterface {
-  private static final Logger logger = LoggerFactory.getLogger(ServiceAccountSpecification.class);
-
   public String name;
   public String serviceAccountEmail;
   public String jsonKeyFilePath;

--- a/datarepo-clienttests/src/main/java/runner/config/SpecificationInterface.java
+++ b/datarepo-clienttests/src/main/java/runner/config/SpecificationInterface.java
@@ -2,19 +2,15 @@ package runner.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public interface SpecificationInterface {
-  static final Logger LOG = LoggerFactory.getLogger(SpecificationInterface.class);
-
   void validate();
 
-  default void display() {
+  default String display() {
     try {
       // use Jackson to map the specification object to a JSON-formatted text block
       ObjectMapper objectMapper = new ObjectMapper();
-      LOG.info(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this));
+      return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
     } catch (JsonProcessingException jpEx) {
       throw new RuntimeException(
           "Error converting SpecificationInterface object to a JSON-formatted string");

--- a/datarepo-clienttests/src/main/java/runner/config/SpecificationInterface.java
+++ b/datarepo-clienttests/src/main/java/runner/config/SpecificationInterface.java
@@ -2,8 +2,12 @@ package runner.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface SpecificationInterface {
+  Logger logger = LoggerFactory.getLogger(SpecificationInterface.class);
+
   void validate();
 
   default String display() {
@@ -12,8 +16,12 @@ public interface SpecificationInterface {
       ObjectMapper objectMapper = new ObjectMapper();
       return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
     } catch (JsonProcessingException jpEx) {
+      logger.error(
+          "Error converting SpecificationInterface object to a JSON-formatted string: {}",
+          this.toString(),
+          jpEx);
       throw new RuntimeException(
-          "Error converting SpecificationInterface object to a JSON-formatted string");
+          "Error converting SpecificationInterface object to a JSON-formatted string", jpEx);
     }
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/SpecificationInterface.java
+++ b/datarepo-clienttests/src/main/java/runner/config/SpecificationInterface.java
@@ -1,7 +1,23 @@
 package runner.config;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public interface SpecificationInterface {
+  static final Logger LOG = LoggerFactory.getLogger(SpecificationInterface.class);
+
   void validate();
 
-  void display();
+  default void display() {
+    try {
+      // use Jackson to map the specification object to a JSON-formatted text block
+      ObjectMapper objectMapper = new ObjectMapper();
+      LOG.info(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(this));
+    } catch (JsonProcessingException jpEx) {
+      throw new RuntimeException(
+          "Error converting SpecificationInterface object to a JSON-formatted string");
+    }
+  }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import utils.FileUtils;
 
 public class TestConfiguration implements SpecificationInterface {
-  private static final Logger LOG = LoggerFactory.getLogger(TestConfiguration.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestConfiguration.class);
 
   public String name;
   public String description = "";
@@ -54,11 +54,11 @@ public class TestConfiguration implements SpecificationInterface {
 
     // instantiate default kubernetes, application specification objects, if null
     if (testConfig.kubernetes == null) {
-      LOG.debug("Test Configuration: Using default Kubernetes specification");
+      logger.debug("Test Configuration: Using default Kubernetes specification");
       testConfig.kubernetes = new KubernetesSpecification();
     }
     if (testConfig.application == null) {
-      LOG.debug("Test Configuration: Using default application specification");
+      logger.debug("Test Configuration: Using default application specification");
       testConfig.application = new ApplicationSpecification();
     }
 
@@ -70,17 +70,17 @@ public class TestConfiguration implements SpecificationInterface {
    * of the objects, for example by parsing the string values in the JSON object.
    */
   public void validate() {
-    LOG.debug("Validating the server, Kubernetes and application specifications");
+    logger.debug("Validating the server, Kubernetes and application specifications");
     server.validate();
     kubernetes.validate();
     application.validate();
 
-    LOG.debug("Validating the test script specifications");
+    logger.debug("Validating the test script specifications");
     for (TestScriptSpecification testScript : testScripts) {
       testScript.validate();
     }
 
-    LOG.debug("Validating the test user specifications");
+    logger.debug("Validating the test user specifications");
     for (TestUserSpecification testUser : testUsers) {
       testUser.validate();
     }

--- a/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
@@ -27,49 +27,38 @@ public class TestConfiguration implements SpecificationInterface {
 
   TestConfiguration() {}
 
+  /**
+   * Read an instance of this class in from a JSON-formatted file. This method expects that the file
+   * name exists in the directory specified by {@link #resourceDirectory}
+   *
+   * @param resourceFileName file name
+   * @return an instance of this class
+   */
   public static TestConfiguration fromJSONFile(String resourceFileName) throws Exception {
     // use Jackson to map the stream contents to a TestConfiguration object
     ObjectMapper objectMapper = new ObjectMapper();
 
     // read in the test config file
-    LOG.info("Test Configuration: Parsing the test configuration file as JSON");
     InputStream inputStream =
         FileUtils.getJSONFileHandle(resourceDirectory + "/" + resourceFileName);
     TestConfiguration testConfig = objectMapper.readValue(inputStream, TestConfiguration.class);
 
     // read in the server file
-    LOG.info("Test Configuration: Parsing the server specification file as JSON");
-    inputStream =
-        FileUtils.getJSONFileHandle(
-            ServerSpecification.resourceDirectory + "/" + testConfig.serverSpecificationFile);
-    testConfig.server = objectMapper.readValue(inputStream, ServerSpecification.class);
+    testConfig.server = ServerSpecification.fromJSONFile(testConfig.serverSpecificationFile);
 
     // read in the test user files and the nested service account files
-    LOG.info(
-        "Test Configuration: Parsing the test user and service account specification files as JSON");
     for (String testUserFile : testConfig.testUserFiles) {
-      inputStream =
-          FileUtils.getJSONFileHandle(TestUserSpecification.resourceDirectory + "/" + testUserFile);
-      TestUserSpecification testUser =
-          objectMapper.readValue(inputStream, TestUserSpecification.class);
-
-      inputStream =
-          FileUtils.getJSONFileHandle(
-              ServiceAccountSpecification.resourceDirectory
-                  + "/"
-                  + testUser.delegatorServiceAccountFile);
-      testUser.delegatorServiceAccount =
-          objectMapper.readValue(inputStream, ServiceAccountSpecification.class);
+      TestUserSpecification testUser = TestUserSpecification.fromJSONFile(testUserFile);
       testConfig.testUsers.add(testUser);
     }
 
     // instantiate default kubernetes, application specification objects, if null
     if (testConfig.kubernetes == null) {
-      LOG.info("Test Configuration: Using default Kubernetes specification");
+      LOG.debug("Test Configuration: Using default Kubernetes specification");
       testConfig.kubernetes = new KubernetesSpecification();
     }
     if (testConfig.application == null) {
-      LOG.info("Test Configuration: Using default application specification");
+      LOG.debug("Test Configuration: Using default application specification");
       testConfig.application = new ApplicationSpecification();
     }
 
@@ -81,39 +70,19 @@ public class TestConfiguration implements SpecificationInterface {
    * of the objects, for example by parsing the string values in the JSON object.
    */
   public void validate() {
-    LOG.info(
-        "Test Configuration: Validating the server, Kubernetes and application specifications");
+    LOG.debug("Validating the server, Kubernetes and application specifications");
     server.validate();
     kubernetes.validate();
     application.validate();
 
-    LOG.info("Test Configuration: Validating the test script specifications");
+    LOG.debug("Validating the test script specifications");
     for (TestScriptSpecification testScript : testScripts) {
       testScript.validate();
     }
 
-    LOG.info("Test Configuration: Validating the test user specifications");
+    LOG.debug("Validating the test user specifications");
     for (TestUserSpecification testUser : testUsers) {
       testUser.validate();
-    }
-  }
-
-  public void display() {
-    LOG.info("Test configuration: {}", name);
-    LOG.info("  Description: {}", description);
-
-    server.display();
-    kubernetes.display();
-    application.display();
-
-    LOG.info("  Billing account: {}", billingAccount);
-
-    for (TestScriptSpecification testScript : testScripts) {
-      testScript.display();
-    }
-
-    for (TestUserSpecification testUser : testUsers) {
-      testUser.display();
     }
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import utils.FileUtils;
 
 public class TestConfiguration implements SpecificationInterface {
+  private static final Logger LOG = LoggerFactory.getLogger(TestConfiguration.class);
+
   public String name;
   public String description = "";
   public String serverSpecificationFile;
@@ -28,17 +32,21 @@ public class TestConfiguration implements SpecificationInterface {
     ObjectMapper objectMapper = new ObjectMapper();
 
     // read in the test config file
+    LOG.info("Test Configuration: Parsing the test configuration file as JSON");
     InputStream inputStream =
         FileUtils.getJSONFileHandle(resourceDirectory + "/" + resourceFileName);
     TestConfiguration testConfig = objectMapper.readValue(inputStream, TestConfiguration.class);
 
     // read in the server file
+    LOG.info("Test Configuration: Parsing the server specification file as JSON");
     inputStream =
         FileUtils.getJSONFileHandle(
             ServerSpecification.resourceDirectory + "/" + testConfig.serverSpecificationFile);
     testConfig.server = objectMapper.readValue(inputStream, ServerSpecification.class);
 
     // read in the test user files and the nested service account files
+    LOG.info(
+        "Test Configuration: Parsing the test user and service account specification files as JSON");
     for (String testUserFile : testConfig.testUserFiles) {
       inputStream =
           FileUtils.getJSONFileHandle(TestUserSpecification.resourceDirectory + "/" + testUserFile);
@@ -57,9 +65,11 @@ public class TestConfiguration implements SpecificationInterface {
 
     // instantiate default kubernetes, application specification objects, if null
     if (testConfig.kubernetes == null) {
+      LOG.info("Test Configuration: Using default Kubernetes specification");
       testConfig.kubernetes = new KubernetesSpecification();
     }
     if (testConfig.application == null) {
+      LOG.info("Test Configuration: Using default application specification");
       testConfig.application = new ApplicationSpecification();
     }
 
@@ -71,45 +81,39 @@ public class TestConfiguration implements SpecificationInterface {
    * of the objects, for example by parsing the string values in the JSON object.
    */
   public void validate() {
+    LOG.info(
+        "Test Configuration: Validating the server, Kubernetes and application specifications");
     server.validate();
     kubernetes.validate();
     application.validate();
 
+    LOG.info("Test Configuration: Validating the test script specifications");
     for (TestScriptSpecification testScript : testScripts) {
       testScript.validate();
     }
 
+    LOG.info("Test Configuration: Validating the test user specifications");
     for (TestUserSpecification testUser : testUsers) {
       testUser.validate();
     }
   }
 
   public void display() {
-    System.out.println("Test configuration: " + name);
-    System.out.println("  Description: " + description);
+    LOG.info("Test configuration: {}", name);
+    LOG.info("  Description: {}", description);
 
-    System.out.println();
     server.display();
-
-    System.out.println();
     kubernetes.display();
-
-    System.out.println();
     application.display();
 
-    System.out.println();
-    System.out.println("  Billing account: " + billingAccount);
+    LOG.info("  Billing account: {}", billingAccount);
 
     for (TestScriptSpecification testScript : testScripts) {
-      System.out.println();
       testScript.display();
     }
 
     for (TestUserSpecification testUser : testUsers) {
-      System.out.println();
       testUser.display();
     }
-
-    System.out.println();
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
@@ -47,15 +47,4 @@ public class TestScriptSpecification implements SpecificationInterface {
       throw new IllegalArgumentException("Test script class not found: " + name, classEx);
     }
   }
-
-  public void display() {
-    LOG.info("Test Script: " + name);
-    LOG.info("  totalNumberToRun: {}", totalNumberToRun);
-    LOG.info("  numberToRunInParallel: {}", numberToRunInParallel);
-    LOG.info("  expectedTimeForEach: {}", expectedTimeForEach);
-    LOG.info("  expectedTimeForEachUnit: {}", expectedTimeForEachUnitObj);
-
-    String parametersStr = (parameters == null) ? "" : String.join(",", parameters);
-    LOG.info("  parameters: {}", parametersStr);
-  }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
@@ -18,6 +18,7 @@ public class TestScriptSpecification implements SpecificationInterface {
 
   public Class<? extends TestScript> scriptClass;
   public TimeUnit expectedTimeForEachUnitObj;
+  public String description;
 
   public static final String scriptsPackage = "testscripts";
 
@@ -45,6 +46,12 @@ public class TestScriptSpecification implements SpecificationInterface {
       scriptClass = (Class<? extends TestScript>) scriptClassGeneric;
     } catch (ClassNotFoundException | ClassCastException classEx) {
       throw new IllegalArgumentException("Test script class not found: " + name, classEx);
+    }
+
+    // generate a separate description property that also includes any test script parameters
+    description = name;
+    if (parameters != null) {
+      description += ": " + String.join(",", parameters);
     }
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import runner.TestScript;
 
 public class TestScriptSpecification implements SpecificationInterface {
-  private static final Logger LOG = LoggerFactory.getLogger(TestScriptSpecification.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestScriptSpecification.class);
 
   public String name;
   public int totalNumberToRun;

--- a/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
@@ -2,13 +2,9 @@ package runner.config;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import runner.TestScript;
 
 public class TestScriptSpecification implements SpecificationInterface {
-  private static final Logger logger = LoggerFactory.getLogger(TestScriptSpecification.class);
-
   public String name;
   public int totalNumberToRun;
   public int numberToRunInParallel;

--- a/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
@@ -2,9 +2,13 @@ package runner.config;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import runner.TestScript;
 
 public class TestScriptSpecification implements SpecificationInterface {
+  private static final Logger LOG = LoggerFactory.getLogger(TestScriptSpecification.class);
+
   public String name;
   public int totalNumberToRun;
   public int numberToRunInParallel;
@@ -45,13 +49,13 @@ public class TestScriptSpecification implements SpecificationInterface {
   }
 
   public void display() {
-    System.out.println("Test Script: " + name);
-    System.out.println("  totalNumberToRun: " + totalNumberToRun);
-    System.out.println("  numberToRunInParallel: " + numberToRunInParallel);
-    System.out.println("  expectedTimeForEach: " + expectedTimeForEach);
-    System.out.println("  expectedTimeForEachUnit: " + expectedTimeForEachUnitObj);
+    LOG.info("Test Script: " + name);
+    LOG.info("  totalNumberToRun: {}", totalNumberToRun);
+    LOG.info("  numberToRunInParallel: {}", numberToRunInParallel);
+    LOG.info("  expectedTimeForEach: {}", expectedTimeForEach);
+    LOG.info("  expectedTimeForEachUnit: {}", expectedTimeForEachUnitObj);
 
     String parametersStr = (parameters == null) ? "" : String.join(",", parameters);
-    System.out.println("  parameters: " + parametersStr);
+    LOG.info("  parameters: {}", parametersStr);
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/TestSuite.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestSuite.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import utils.FileUtils;
 
 public class TestSuite implements SpecificationInterface {
-  private static final Logger LOG = LoggerFactory.getLogger(TestSuite.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestSuite.class);
 
   public String name;
   public String description = "";
@@ -36,7 +36,7 @@ public class TestSuite implements SpecificationInterface {
     ObjectMapper objectMapper = new ObjectMapper();
 
     // read in the test suite file
-    LOG.info("Parsing the test suite file as JSON");
+    logger.info("Parsing the test suite file as JSON");
     InputStream inputStream =
         FileUtils.getJSONFileHandle(resourceDirectory + "/" + resourceFileName);
     TestSuite testSuite = objectMapper.readValue(inputStream, TestSuite.class);
@@ -46,7 +46,7 @@ public class TestSuite implements SpecificationInterface {
 
     // read in the test config files
     for (String testConfigurationFile : testSuite.testConfigurationFiles) {
-      LOG.info("Parsing the test configuration file as JSON");
+      logger.info("Parsing the test configuration file as JSON");
       TestConfiguration testConfig = TestConfiguration.fromJSONFile(testConfigurationFile);
 
       // override the server specification defined in each test configuration with the one defined
@@ -76,7 +76,7 @@ public class TestSuite implements SpecificationInterface {
    * of the objects, for example by parsing the string values in the JSON object.
    */
   public void validate() {
-    LOG.info("Validating the test configurations");
+    logger.info("Validating the test configurations");
     for (TestConfiguration testConfig : testConfigurations) {
       testConfig.validate();
     }

--- a/datarepo-clienttests/src/main/java/runner/config/TestSuite.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestSuite.java
@@ -1,0 +1,87 @@
+package runner.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import utils.FileUtils;
+
+public class TestSuite implements SpecificationInterface {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSuite.class);
+
+  public String name;
+  public String description = "";
+  public String serverSpecificationFile;
+  public List<String> testConfigurationFiles;
+
+  ServerSpecification server;
+  public List<TestConfiguration> testConfigurations = new ArrayList<>();
+
+  public static final String resourceDirectory = "suites";
+
+  TestSuite() {}
+
+  /**
+   * Read an instance of this class in from a JSON-formatted file. This method expects that the file
+   * name exists in the directory specified by {@link #resourceDirectory}
+   *
+   * @param resourceFileName file name
+   * @return an instance of this class
+   */
+  public static TestSuite fromJSONFile(String resourceFileName) throws Exception {
+    // use Jackson to map the stream contents to a TestConfiguration object
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    // read in the test suite file
+    LOG.info("Test Suite: Parsing the test suite file as JSON");
+    InputStream inputStream =
+        FileUtils.getJSONFileHandle(resourceDirectory + "/" + resourceFileName);
+    TestSuite testSuite = objectMapper.readValue(inputStream, TestSuite.class);
+
+    // read in the server file
+    testSuite.server = ServerSpecification.fromJSONFile(testSuite.serverSpecificationFile);
+
+    // read in the test config files
+    for (String testConfigurationFile : testSuite.testConfigurationFiles) {
+      LOG.info("Test Suite: Parsing the test configuration file as JSON");
+      TestConfiguration testConfig = TestConfiguration.fromJSONFile(testConfigurationFile);
+
+      // override the server specification defined in each test configuration with the one defined
+      // for the test suite
+      testConfig.serverSpecificationFile = testSuite.serverSpecificationFile;
+      testConfig.server = testSuite.server;
+
+      testSuite.testConfigurations.add(testConfig);
+    }
+
+    return testSuite;
+  }
+
+  public static TestSuite fromSingleTestConfiguration(TestConfiguration testConfiguration)
+      throws Exception {
+    TestSuite testSuite = new TestSuite();
+    testSuite.name = "GENERATED_SingleTestSuite";
+    testSuite.description = "Single Test Configuration: " + testConfiguration.description;
+    testSuite.serverSpecificationFile = testConfiguration.serverSpecificationFile;
+    testSuite.server = testConfiguration.server;
+    testSuite.testConfigurations.add(testConfiguration);
+    return testSuite;
+  }
+
+  /**
+   * Validate the object read in from the JSON file. This method also fills in additional properties
+   * of the objects, for example by parsing the string values in the JSON object.
+   */
+  public void validate() {
+    LOG.info(
+        "Test Suite: Validating the server specification that overrides the one for each test configuration");
+    server.validate();
+
+    LOG.info("Test Suite: Validating the test configurations");
+    for (TestConfiguration testConfig : testConfigurations) {
+      testConfig.validate();
+    }
+  }
+}

--- a/datarepo-clienttests/src/main/java/runner/config/TestSuite.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestSuite.java
@@ -35,7 +35,7 @@ public class TestSuite implements SpecificationInterface {
     ObjectMapper objectMapper = new ObjectMapper();
 
     // read in the test suite file
-    LOG.info("Test Suite: Parsing the test suite file as JSON");
+    LOG.info("Parsing the test suite file as JSON");
     InputStream inputStream =
         FileUtils.getJSONFileHandle(resourceDirectory + "/" + resourceFileName);
     TestSuite testSuite = objectMapper.readValue(inputStream, TestSuite.class);
@@ -45,7 +45,7 @@ public class TestSuite implements SpecificationInterface {
 
     // read in the test config files
     for (String testConfigurationFile : testSuite.testConfigurationFiles) {
-      LOG.info("Test Suite: Parsing the test configuration file as JSON");
+      LOG.info("Parsing the test configuration file as JSON");
       TestConfiguration testConfig = TestConfiguration.fromJSONFile(testConfigurationFile);
 
       // override the server specification defined in each test configuration with the one defined
@@ -75,11 +75,7 @@ public class TestSuite implements SpecificationInterface {
    * of the objects, for example by parsing the string values in the JSON object.
    */
   public void validate() {
-    LOG.info(
-        "Test Suite: Validating the server specification that overrides the one for each test configuration");
-    server.validate();
-
-    LOG.info("Test Suite: Validating the test configurations");
+    LOG.info("Validating the test configurations");
     for (TestConfiguration testConfig : testConfigurations) {
       testConfig.validate();
     }

--- a/datarepo-clienttests/src/main/java/runner/config/TestSuite.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestSuite.java
@@ -13,7 +13,8 @@ public class TestSuite implements SpecificationInterface {
 
   public String name;
   public String description = "";
-  public String serverSpecificationFile;
+  public String
+      serverSpecificationFile; // overrides the server specification for all test configurations
   public List<String> testConfigurationFiles;
 
   ServerSpecification server;

--- a/datarepo-clienttests/src/main/java/runner/config/TestUserSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestUserSpecification.java
@@ -2,13 +2,9 @@ package runner.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import utils.FileUtils;
 
 public class TestUserSpecification implements SpecificationInterface {
-  private static final Logger logger = LoggerFactory.getLogger(TestUserSpecification.class);
-
   public String name;
   public String userEmail;
   public String delegatorServiceAccountFile;

--- a/datarepo-clienttests/src/main/java/runner/config/TestUserSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestUserSpecification.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import utils.FileUtils;
 
 public class TestUserSpecification implements SpecificationInterface {
-  private static final Logger LOG = LoggerFactory.getLogger(TestUserSpecification.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestUserSpecification.class);
 
   public String name;
   public String userEmail;

--- a/datarepo-clienttests/src/main/java/runner/config/TestUserSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestUserSpecification.java
@@ -1,6 +1,11 @@
 package runner.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class TestUserSpecification implements SpecificationInterface {
+  private static final Logger LOG = LoggerFactory.getLogger(TestUserSpecification.class);
+
   public String name;
   public String userEmail;
   public String delegatorServiceAccountFile;
@@ -26,11 +31,10 @@ public class TestUserSpecification implements SpecificationInterface {
   }
 
   public void display() {
-    System.out.println("Test User: " + name);
-    System.out.println("  userEmail: " + userEmail);
-    System.out.println("  delegatorServiceAccountFile: " + delegatorServiceAccountFile);
+    LOG.info("Test User: {}", name);
+    LOG.info("  userEmail: {}", userEmail);
+    LOG.info("  delegatorServiceAccountFile: {}", delegatorServiceAccountFile);
 
-    System.out.println();
     delegatorServiceAccount.display();
   }
 }

--- a/datarepo-clienttests/src/main/java/runner/config/TestUserSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestUserSpecification.java
@@ -1,7 +1,10 @@
 package runner.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.InputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import utils.FileUtils;
 
 public class TestUserSpecification implements SpecificationInterface {
   private static final Logger LOG = LoggerFactory.getLogger(TestUserSpecification.class);
@@ -17,6 +20,28 @@ public class TestUserSpecification implements SpecificationInterface {
   TestUserSpecification() {}
 
   /**
+   * Read an instance of this class in from a JSON-formatted file. This method expects that the file
+   * name exists in the directory specified by {@link #resourceDirectory}
+   *
+   * @param resourceFileName file name
+   * @return an instance of this class
+   */
+  public static TestUserSpecification fromJSONFile(String resourceFileName) throws Exception {
+    // use Jackson to map the stream contents to a TestConfiguration object
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    InputStream inputStream =
+        FileUtils.getJSONFileHandle(resourceDirectory + "/" + resourceFileName);
+    TestUserSpecification testUser =
+        objectMapper.readValue(inputStream, TestUserSpecification.class);
+
+    testUser.delegatorServiceAccount =
+        ServiceAccountSpecification.fromJSONFile(testUser.delegatorServiceAccountFile);
+
+    return testUser;
+  }
+
+  /**
    * Validate the test user specification read in from the JSON file. None of the properties should
    * be null.
    */
@@ -28,13 +53,5 @@ public class TestUserSpecification implements SpecificationInterface {
     }
 
     delegatorServiceAccount.validate();
-  }
-
-  public void display() {
-    LOG.info("Test User: {}", name);
-    LOG.info("  userEmail: {}", userEmail);
-    LOG.info("  delegatorServiceAccountFile: {}", delegatorServiceAccountFile);
-
-    delegatorServiceAccount.display();
   }
 }

--- a/datarepo-clienttests/src/main/java/testscripts/EnumerateProfiles.java
+++ b/datarepo-clienttests/src/main/java/testscripts/EnumerateProfiles.java
@@ -3,8 +3,12 @@ package testscripts;
 import bio.terra.datarepo.api.ResourcesApi;
 import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.model.EnumerateBillingProfileModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class EnumerateProfiles extends runner.TestScript {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EnumerateProfiles.class);
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public EnumerateProfiles() {
@@ -16,6 +20,9 @@ public class EnumerateProfiles extends runner.TestScript {
     EnumerateBillingProfileModel profiles = resourcesApi.enumerateProfiles(0, 10);
 
     int httpStatus = resourcesApi.getApiClient().getStatusCode();
-    System.out.println("Enumerate profiles: HTTP" + httpStatus + ", TOTAL" + profiles.getTotal());
+    LOG.info(
+        "Enumerate profiles: HTTP status {}, number of profiles found = {}",
+        httpStatus,
+        profiles.getTotal());
   }
 }

--- a/datarepo-clienttests/src/main/java/testscripts/EnumerateProfiles.java
+++ b/datarepo-clienttests/src/main/java/testscripts/EnumerateProfiles.java
@@ -20,7 +20,7 @@ public class EnumerateProfiles extends runner.TestScript {
     EnumerateBillingProfileModel profiles = resourcesApi.enumerateProfiles(0, 10);
 
     int httpStatus = resourcesApi.getApiClient().getStatusCode();
-    LOG.info(
+    LOG.debug(
         "Enumerate profiles: HTTP status {}, number of profiles found = {}",
         httpStatus,
         profiles.getTotal());

--- a/datarepo-clienttests/src/main/java/testscripts/EnumerateProfiles.java
+++ b/datarepo-clienttests/src/main/java/testscripts/EnumerateProfiles.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 
 public class EnumerateProfiles extends runner.TestScript {
 
-  private static final Logger LOG = LoggerFactory.getLogger(EnumerateProfiles.class);
+  private static final Logger logger = LoggerFactory.getLogger(EnumerateProfiles.class);
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public EnumerateProfiles() {
@@ -20,7 +20,7 @@ public class EnumerateProfiles extends runner.TestScript {
     EnumerateBillingProfileModel profiles = resourcesApi.enumerateProfiles(0, 10);
 
     int httpStatus = resourcesApi.getApiClient().getStatusCode();
-    LOG.debug(
+    logger.debug(
         "Enumerate profiles: HTTP status {}, number of profiles found = {}",
         httpStatus,
         profiles.getTotal());

--- a/datarepo-clienttests/src/main/java/testscripts/IngestFile.java
+++ b/datarepo-clienttests/src/main/java/testscripts/IngestFile.java
@@ -20,7 +20,7 @@ import utils.DataRepoUtils;
 import utils.FileUtils;
 
 public class IngestFile extends runner.TestScript {
-  private static final Logger LOG = LoggerFactory.getLogger(IngestFile.class);
+  private static final Logger logger = LoggerFactory.getLogger(IngestFile.class);
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public IngestFile() {
@@ -42,7 +42,7 @@ public class IngestFile extends runner.TestScript {
       } catch (URISyntaxException synEx) {
         throw new RuntimeException("Error parsing source file URI: " + parameters.get(0), synEx);
       }
-    LOG.debug("Source file URI: {}", sourceFileURI);
+    logger.debug("Source file URI: {}", sourceFileURI);
   }
 
   public void setup(Map<String, ApiClient> apiClients) throws Exception {
@@ -58,7 +58,7 @@ public class IngestFile extends runner.TestScript {
     // create a new profile
     billingProfileModel =
         DataRepoUtils.createProfile(resourcesApi, billingAccount, "profile-simple", true);
-    LOG.info("Successfully created profile: {}", billingProfileModel.getProfileName());
+    logger.info("Successfully created profile: {}", billingProfileModel.getProfileName());
 
     // make the create dataset request and wait for the job to finish
     JobModel createDatasetJobResponse =
@@ -69,7 +69,7 @@ public class IngestFile extends runner.TestScript {
     datasetSummaryModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, createDatasetJobResponse, DatasetSummaryModel.class);
-    LOG.info("Successfully created dataset: {}", datasetSummaryModel.getName());
+    logger.info("Successfully created dataset: {}", datasetSummaryModel.getName());
   }
 
   public void userJourney(ApiClient apiClient) throws Exception {
@@ -89,7 +89,7 @@ public class IngestFile extends runner.TestScript {
     ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
     FileModel fileModel =
         DataRepoUtils.expectJobSuccess(repositoryApi, ingestFileJobResponse, FileModel.class);
-    LOG.debug(
+    logger.debug(
         "Successfully ingested file: path = {}, id = {}, size = {}",
         fileModel.getPath(),
         fileModel.getFileId(),
@@ -108,10 +108,10 @@ public class IngestFile extends runner.TestScript {
         DataRepoUtils.waitForJobToFinish(repositoryApi, deleteDatasetJobResponse);
     DataRepoUtils.expectJobSuccess(
         repositoryApi, deleteDatasetJobResponse, DeleteResponseModel.class);
-    LOG.info("Successfully deleted dataset: {}", datasetSummaryModel.getName());
+    logger.info("Successfully deleted dataset: {}", datasetSummaryModel.getName());
 
     // delete the profile
     resourcesApi.deleteProfile(billingProfileModel.getId());
-    LOG.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
+    logger.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
   }
 }

--- a/datarepo-clienttests/src/main/java/testscripts/IngestFile.java
+++ b/datarepo-clienttests/src/main/java/testscripts/IngestFile.java
@@ -89,7 +89,7 @@ public class IngestFile extends runner.TestScript {
     ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
     FileModel fileModel =
         DataRepoUtils.expectJobSuccess(repositoryApi, ingestFileJobResponse, FileModel.class);
-    LOG.info(
+    LOG.debug(
         "Successfully ingested file: path = {}, id = {}, size = {}",
         fileModel.getPath(),
         fileModel.getFileId(),

--- a/datarepo-clienttests/src/main/java/testscripts/IngestFile.java
+++ b/datarepo-clienttests/src/main/java/testscripts/IngestFile.java
@@ -14,10 +14,13 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import utils.DataRepoUtils;
 import utils.FileUtils;
 
 public class IngestFile extends runner.TestScript {
+  private static final Logger LOG = LoggerFactory.getLogger(IngestFile.class);
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public IngestFile() {
@@ -39,7 +42,7 @@ public class IngestFile extends runner.TestScript {
       } catch (URISyntaxException synEx) {
         throw new RuntimeException("Error parsing source file URI: " + parameters.get(0), synEx);
       }
-    System.out.println("source file URI: " + sourceFileURI);
+    LOG.debug("Source file URI: {}", sourceFileURI);
   }
 
   public void setup(Map<String, ApiClient> apiClients) throws Exception {
@@ -55,8 +58,7 @@ public class IngestFile extends runner.TestScript {
     // create a new profile
     billingProfileModel =
         DataRepoUtils.createProfile(resourcesApi, billingAccount, "profile-simple", true);
-
-    System.out.println("successfully created profile: " + billingProfileModel.getProfileName());
+    LOG.info("Successfully created profile: {}", billingProfileModel.getProfileName());
 
     // make the create dataset request and wait for the job to finish
     JobModel createDatasetJobResponse =
@@ -67,8 +69,7 @@ public class IngestFile extends runner.TestScript {
     datasetSummaryModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, createDatasetJobResponse, DatasetSummaryModel.class);
-
-    System.out.println("successfully created dataset: " + datasetSummaryModel.getName());
+    LOG.info("Successfully created dataset: {}", datasetSummaryModel.getName());
   }
 
   public void userJourney(ApiClient apiClient) throws Exception {
@@ -88,14 +89,11 @@ public class IngestFile extends runner.TestScript {
     ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
     FileModel fileModel =
         DataRepoUtils.expectJobSuccess(repositoryApi, ingestFileJobResponse, FileModel.class);
-
-    System.out.println(
-        "successfully ingested file: "
-            + fileModel.getPath()
-            + ", id: "
-            + fileModel.getFileId()
-            + ", size: "
-            + fileModel.getSize());
+    LOG.info(
+        "Successfully ingested file: path = {}, id = {}, size = {}",
+        fileModel.getPath(),
+        fileModel.getFileId(),
+        fileModel.getSize());
   }
 
   public void cleanup(Map<String, ApiClient> apiClients) throws Exception {
@@ -110,12 +108,10 @@ public class IngestFile extends runner.TestScript {
         DataRepoUtils.waitForJobToFinish(repositoryApi, deleteDatasetJobResponse);
     DataRepoUtils.expectJobSuccess(
         repositoryApi, deleteDatasetJobResponse, DeleteResponseModel.class);
-
-    System.out.println("successfully deleted dataset: " + datasetSummaryModel.getName());
+    LOG.info("Successfully deleted dataset: {}", datasetSummaryModel.getName());
 
     // delete the profile
     resourcesApi.deleteProfile(billingProfileModel.getId());
-
-    System.out.println("successfully deleted profile: " + billingProfileModel.getProfileName());
+    LOG.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
   }
 }

--- a/datarepo-clienttests/src/main/java/testscripts/KubeConfig.java
+++ b/datarepo-clienttests/src/main/java/testscripts/KubeConfig.java
@@ -14,7 +14,7 @@ import utils.FileUtils;
 import utils.KubernetesClientUtils;
 
 public class KubeConfig extends runner.TestScript {
-  private static final Logger LOG = LoggerFactory.getLogger(KubeConfig.class);
+  private static final Logger logger = LoggerFactory.getLogger(KubeConfig.class);
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public KubeConfig() {
@@ -48,7 +48,7 @@ public class KubeConfig extends runner.TestScript {
     // create a new profile
     billingProfileModel =
         DataRepoUtils.createProfile(resourcesApi, billingAccount, "profile-simple", true);
-    LOG.info("Successfully created profile: {}", billingProfileModel.getProfileName());
+    logger.info("Successfully created profile: {}", billingProfileModel.getProfileName());
 
     // make the create dataset request and wait for the job to finish
     JobModel createDatasetJobResponse =
@@ -59,7 +59,7 @@ public class KubeConfig extends runner.TestScript {
     datasetSummaryModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, createDatasetJobResponse, DatasetSummaryModel.class);
-    LOG.info("Successfully created dataset: {}", datasetSummaryModel.getName());
+    logger.info("Successfully created dataset: {}", datasetSummaryModel.getName());
   }
 
   // The purpose of this test is to have a long-running workload that completes successfully
@@ -80,7 +80,7 @@ public class KubeConfig extends runner.TestScript {
         DataRepoUtils.pollForRunningJob(repositoryApi, bulkLoadArrayJobResponse, 30);
 
     if (bulkLoadArrayJobResponse.getJobStatus().equals(JobModel.JobStatusEnum.RUNNING)) {
-      LOG.debug("Scaling pods down to 1");
+      logger.debug("Scaling pods down to 1");
       KubernetesClientUtils.changeReplicaSetSizeAndWait(1);
 
       // allow job to run on scaled down pods for interval
@@ -89,7 +89,7 @@ public class KubeConfig extends runner.TestScript {
 
       // if job still running, scale back up
       if (bulkLoadArrayJobResponse.getJobStatus().equals(JobModel.JobStatusEnum.RUNNING)) {
-        LOG.debug("Scaling pods back up to 4");
+        logger.debug("Scaling pods back up to 4");
         KubernetesClientUtils.changeReplicaSetSizeAndWait(4);
       }
     }
@@ -112,7 +112,7 @@ public class KubeConfig extends runner.TestScript {
             .loadTag(loadTag)
             .maxFailedFileLoads(filesToLoad); // do not stop if there is a failure.
 
-    LOG.debug(
+    logger.debug(
         "longFileLoadTest loading {} files into dataset id {}",
         filesToLoad,
         datasetSummaryModel.getId());
@@ -144,10 +144,10 @@ public class KubeConfig extends runner.TestScript {
             repositoryApi, bulkLoadArrayJobResponse, BulkLoadArrayResultModel.class);
 
     BulkLoadResultModel loadSummary = result.getLoadSummary();
-    LOG.debug("Total files    : {}", loadSummary.getTotalFiles());
-    LOG.debug("Succeeded files: {}", loadSummary.getSucceededFiles());
-    LOG.debug("Failed files   : {}", loadSummary.getFailedFiles());
-    LOG.debug("Not Tried files: {}", loadSummary.getNotTriedFiles());
+    logger.debug("Total files    : {}", loadSummary.getTotalFiles());
+    logger.debug("Succeeded files: {}", loadSummary.getSucceededFiles());
+    logger.debug("Failed files   : {}", loadSummary.getFailedFiles());
+    logger.debug("Not Tried files: {}", loadSummary.getNotTriedFiles());
   }
 
   public void cleanup(Map<String, ApiClient> apiClients) throws Exception {
@@ -162,10 +162,10 @@ public class KubeConfig extends runner.TestScript {
         DataRepoUtils.waitForJobToFinish(repositoryApi, deleteDatasetJobResponse);
     DataRepoUtils.expectJobSuccess(
         repositoryApi, deleteDatasetJobResponse, DeleteResponseModel.class);
-    LOG.info("Successfully deleted dataset: {}", datasetSummaryModel.getName());
+    logger.info("Successfully deleted dataset: {}", datasetSummaryModel.getName());
 
     // delete the profile
     resourcesApi.deleteProfile(billingProfileModel.getId());
-    LOG.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
+    logger.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
   }
 }

--- a/datarepo-clienttests/src/main/java/testscripts/RetrieveDataset.java
+++ b/datarepo-clienttests/src/main/java/testscripts/RetrieveDataset.java
@@ -57,7 +57,7 @@ public class RetrieveDataset extends runner.TestScript {
   public void userJourney(ApiClient apiClient) throws Exception {
     RepositoryApi repositoryApi = new RepositoryApi(apiClient);
     DatasetModel datasetModel = repositoryApi.retrieveDataset(datasetSummaryModel.getId());
-    LOG.info(
+    LOG.debug(
         "Successfully retrieved dataset: name = {}, data project = {}",
         datasetModel.getName(),
         datasetModel.getDataProject());

--- a/datarepo-clienttests/src/main/java/testscripts/RetrieveDataset.java
+++ b/datarepo-clienttests/src/main/java/testscripts/RetrieveDataset.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import utils.DataRepoUtils;
 
 public class RetrieveDataset extends runner.TestScript {
-  private static final Logger LOG = LoggerFactory.getLogger(RetrieveDataset.class);
+  private static final Logger logger = LoggerFactory.getLogger(RetrieveDataset.class);
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public RetrieveDataset() {
@@ -40,7 +40,7 @@ public class RetrieveDataset extends runner.TestScript {
     // create a new profile
     billingProfileModel =
         DataRepoUtils.createProfile(resourcesApi, billingAccount, "profile-simple", true);
-    LOG.info("Successfully created profile: {}", billingProfileModel.getProfileName());
+    logger.info("Successfully created profile: {}", billingProfileModel.getProfileName());
 
     // make the create dataset request and wait for the job to finish
     JobModel createDatasetJobResponse =
@@ -51,13 +51,13 @@ public class RetrieveDataset extends runner.TestScript {
     datasetSummaryModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, createDatasetJobResponse, DatasetSummaryModel.class);
-    LOG.info("Successfully created dataset: {}", datasetSummaryModel.getName());
+    logger.info("Successfully created dataset: {}", datasetSummaryModel.getName());
   }
 
   public void userJourney(ApiClient apiClient) throws Exception {
     RepositoryApi repositoryApi = new RepositoryApi(apiClient);
     DatasetModel datasetModel = repositoryApi.retrieveDataset(datasetSummaryModel.getId());
-    LOG.debug(
+    logger.debug(
         "Successfully retrieved dataset: name = {}, data project = {}",
         datasetModel.getName(),
         datasetModel.getDataProject());
@@ -75,10 +75,10 @@ public class RetrieveDataset extends runner.TestScript {
         DataRepoUtils.waitForJobToFinish(repositoryApi, deleteDatasetJobResponse);
     DataRepoUtils.expectJobSuccess(
         repositoryApi, deleteDatasetJobResponse, DeleteResponseModel.class);
-    LOG.info("Successfully deleted dataset: {}", datasetSummaryModel.getName());
+    logger.info("Successfully deleted dataset: {}", datasetSummaryModel.getName());
 
     // delete the profile
     resourcesApi.deleteProfile(billingProfileModel.getId());
-    LOG.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
+    logger.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
   }
 }

--- a/datarepo-clienttests/src/main/java/testscripts/RetrieveDataset.java
+++ b/datarepo-clienttests/src/main/java/testscripts/RetrieveDataset.java
@@ -11,9 +11,12 @@ import bio.terra.datarepo.model.JobModel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import utils.DataRepoUtils;
 
 public class RetrieveDataset extends runner.TestScript {
+  private static final Logger LOG = LoggerFactory.getLogger(RetrieveDataset.class);
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public RetrieveDataset() {
@@ -37,8 +40,7 @@ public class RetrieveDataset extends runner.TestScript {
     // create a new profile
     billingProfileModel =
         DataRepoUtils.createProfile(resourcesApi, billingAccount, "profile-simple", true);
-
-    System.out.println("successfully created profile: " + billingProfileModel.getProfileName());
+    LOG.info("Successfully created profile: {}", billingProfileModel.getProfileName());
 
     // make the create dataset request and wait for the job to finish
     JobModel createDatasetJobResponse =
@@ -49,19 +51,16 @@ public class RetrieveDataset extends runner.TestScript {
     datasetSummaryModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, createDatasetJobResponse, DatasetSummaryModel.class);
-
-    System.out.println("successfully created dataset: " + datasetSummaryModel.getName());
+    LOG.info("Successfully created dataset: {}", datasetSummaryModel.getName());
   }
 
   public void userJourney(ApiClient apiClient) throws Exception {
     RepositoryApi repositoryApi = new RepositoryApi(apiClient);
     DatasetModel datasetModel = repositoryApi.retrieveDataset(datasetSummaryModel.getId());
-
-    System.out.println(
-        "successfully retrieved dataset: "
-            + datasetModel.getName()
-            + ", data project: "
-            + datasetModel.getDataProject());
+    LOG.info(
+        "Successfully retrieved dataset: name = {}, data project = {}",
+        datasetModel.getName(),
+        datasetModel.getDataProject());
   }
 
   public void cleanup(Map<String, ApiClient> apiClients) throws Exception {
@@ -76,12 +75,10 @@ public class RetrieveDataset extends runner.TestScript {
         DataRepoUtils.waitForJobToFinish(repositoryApi, deleteDatasetJobResponse);
     DataRepoUtils.expectJobSuccess(
         repositoryApi, deleteDatasetJobResponse, DeleteResponseModel.class);
-
-    System.out.println("successfully deleted dataset: " + datasetSummaryModel.getName());
+    LOG.info("Successfully deleted dataset: {}", datasetSummaryModel.getName());
 
     // delete the profile
     resourcesApi.deleteProfile(billingProfileModel.getId());
-
-    System.out.println("successfully deleted profile: " + billingProfileModel.getProfileName());
+    LOG.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
   }
 }

--- a/datarepo-clienttests/src/main/java/testscripts/ServiceStatus.java
+++ b/datarepo-clienttests/src/main/java/testscripts/ServiceStatus.java
@@ -19,6 +19,6 @@ public class ServiceStatus extends runner.TestScript {
     unauthenticatedApi.serviceStatus();
 
     int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
-    LOG.info("Service status: {}", httpStatus);
+    LOG.debug("Service status: {}", httpStatus);
   }
 }

--- a/datarepo-clienttests/src/main/java/testscripts/ServiceStatus.java
+++ b/datarepo-clienttests/src/main/java/testscripts/ServiceStatus.java
@@ -3,8 +3,11 @@ package testscripts;
 import bio.terra.datarepo.api.UnauthenticatedApi;
 import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.client.ApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ServiceStatus extends runner.TestScript {
+  private static final Logger LOG = LoggerFactory.getLogger(ServiceStatus.class);
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public ServiceStatus() {
@@ -16,6 +19,6 @@ public class ServiceStatus extends runner.TestScript {
     unauthenticatedApi.serviceStatus();
 
     int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
-    System.out.println("Service status: " + httpStatus);
+    LOG.info("Service status: {}", httpStatus);
   }
 }

--- a/datarepo-clienttests/src/main/java/testscripts/ServiceStatus.java
+++ b/datarepo-clienttests/src/main/java/testscripts/ServiceStatus.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ServiceStatus extends runner.TestScript {
-  private static final Logger LOG = LoggerFactory.getLogger(ServiceStatus.class);
+  private static final Logger logger = LoggerFactory.getLogger(ServiceStatus.class);
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public ServiceStatus() {
@@ -19,6 +19,6 @@ public class ServiceStatus extends runner.TestScript {
     unauthenticatedApi.serviceStatus();
 
     int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
-    LOG.debug("Service status: {}", httpStatus);
+    logger.debug("Service status: {}", httpStatus);
   }
 }

--- a/datarepo-clienttests/src/main/java/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/DataRepoUtils.java
@@ -10,8 +10,12 @@ import bio.terra.datarepo.model.JobModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class DataRepoUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DataRepoUtils.class);
 
   private DataRepoUtils() {}
 
@@ -31,6 +35,7 @@ public final class DataRepoUtils {
    */
   public static JobModel waitForJobToFinish(RepositoryApi repositoryApi, JobModel job)
       throws Exception {
+    LOG.debug("Waiting for Data Repo job to finish");
     int pollCtr = Math.floorDiv(maximumSecondsToWaitForJob, secondsIntervalToPollJob);
     job = repositoryApi.retrieveJob(job.getId());
 
@@ -59,6 +64,7 @@ public final class DataRepoUtils {
    */
   public static <T> T getJobResult(RepositoryApi repositoryApi, JobModel job, Class<T> resultClass)
       throws Exception {
+    LOG.debug("Fetching Data Repo job result");
     Object jobResult = repositoryApi.retrieveJobResult(job.getId());
 
     ObjectMapper objectMapper = new ObjectMapper();
@@ -107,6 +113,7 @@ public final class DataRepoUtils {
       String apipayloadFilename,
       boolean randomizeName)
       throws Exception {
+    LOG.debug("Creating a dataset");
     // use Jackson to map the stream contents to a DatasetRequestModel object
     ObjectMapper objectMapper = new ObjectMapper();
     InputStream datasetRequestFile =
@@ -137,6 +144,7 @@ public final class DataRepoUtils {
   public static BillingProfileModel createProfile(
       ResourcesApi resourcesApi, String billingAccount, String profileName, boolean randomizeName)
       throws Exception {
+    LOG.debug("Creating a billing profile");
 
     if (randomizeName) {
       profileName = FileUtils.randomizeName(profileName);

--- a/datarepo-clienttests/src/main/java/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/DataRepoUtils.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 public final class DataRepoUtils {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DataRepoUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(DataRepoUtils.class);
 
   private DataRepoUtils() {}
 
@@ -35,7 +35,7 @@ public final class DataRepoUtils {
    */
   public static JobModel waitForJobToFinish(RepositoryApi repositoryApi, JobModel job)
       throws Exception {
-    LOG.debug("Waiting for Data Repo job to finish");
+    logger.debug("Waiting for Data Repo job to finish");
     job = pollForRunningJob(repositoryApi, job, maximumSecondsToWaitForJob);
 
     if (job.getJobStatus().equals(JobModel.JobStatusEnum.RUNNING)) {
@@ -60,7 +60,7 @@ public final class DataRepoUtils {
     int tryCount = 1;
 
     while (job.getJobStatus().equals(JobModel.JobStatusEnum.RUNNING) && pollCtr >= 0) {
-      LOG.debug("Sleeping. try #" + tryCount + " For Job: " + job.getDescription());
+      logger.debug("Sleeping. try #" + tryCount + " For Job: " + job.getDescription());
       TimeUnit.SECONDS.sleep(secondsIntervalToPollJob);
       job = repositoryApi.retrieveJob(job.getId());
       tryCount++;
@@ -81,7 +81,7 @@ public final class DataRepoUtils {
    */
   public static <T> T getJobResult(RepositoryApi repositoryApi, JobModel job, Class<T> resultClass)
       throws Exception {
-    LOG.debug("Fetching Data Repo job result");
+    logger.debug("Fetching Data Repo job result");
     Object jobResult = repositoryApi.retrieveJobResult(job.getId());
 
     ObjectMapper objectMapper = new ObjectMapper();
@@ -130,7 +130,7 @@ public final class DataRepoUtils {
       String apipayloadFilename,
       boolean randomizeName)
       throws Exception {
-    LOG.debug("Creating a dataset");
+    logger.debug("Creating a dataset");
     // use Jackson to map the stream contents to a DatasetRequestModel object
     ObjectMapper objectMapper = new ObjectMapper();
     InputStream datasetRequestFile =
@@ -161,7 +161,7 @@ public final class DataRepoUtils {
   public static BillingProfileModel createProfile(
       ResourcesApi resourcesApi, String billingAccount, String profileName, boolean randomizeName)
       throws Exception {
-    LOG.debug("Creating a billing profile");
+    logger.debug("Creating a billing profile");
 
     if (randomizeName) {
       profileName = FileUtils.randomizeName(profileName);

--- a/datarepo-clienttests/src/main/java/utils/KubernetesClientUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/KubernetesClientUtils.java
@@ -24,10 +24,13 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import runner.config.ServerSpecification;
 
 // TODO: add try/catch for refresh token around all utils methods
 public final class KubernetesClientUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(KubernetesClientUtils.class);
 
   private static int maximumSecondsToWaitForReplicaSetSizeChange = 500;
   private static int secondsIntervalToPollReplicaSetSizeChange = 5;
@@ -64,6 +67,8 @@ public final class KubernetesClientUtils {
    */
   public static void buildKubernetesClientObject(ServerSpecification server) throws Exception {
     // call the fetchGKECredentials script that uses gcloud to generate the kubeconfig file
+    LOG.debug(
+        "Calling the fetchGKECredentials script that uses gcloud to generate the kubeconfig file");
     List<String> scriptArgs = new ArrayList<>();
     scriptArgs.add("tools/fetchGKECredentials.sh");
     scriptArgs.add(server.clusterShortName);
@@ -72,7 +77,7 @@ public final class KubernetesClientUtils {
     Process fetchCredentialsProc = ProcessUtils.executeCommand("sh", scriptArgs);
     List<String> cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(fetchCredentialsProc);
     for (String cmdOutputLine : cmdOutputLines) {
-      System.out.println(cmdOutputLine);
+      LOG.debug(cmdOutputLine);
     }
 
     // path to kubeconfig file, that was just created/updated by gcloud get-credentials above
@@ -84,6 +89,7 @@ public final class KubernetesClientUtils {
     KubeConfig kubeConfig = KubeConfig.loadKubeConfig(filereader);
 
     // get a refreshed SA access token and its expiration time
+    LOG.debug("Getting a refreshed service account access token and its expiration time");
     GoogleCredentials applicationDefaultCredentials =
         AuthenticationUtils.getApplicationDefaultCredential();
     AccessToken accessToken = AuthenticationUtils.getAccessToken(applicationDefaultCredentials);
@@ -133,6 +139,7 @@ public final class KubernetesClientUtils {
     kubeConfig.setContext(server.clusterName);
 
     // build the client object from the config
+    LOG.debug("Building the client objects from the config");
     ApiClient client = ClientBuilder.kubeconfig(kubeConfig).build();
 
     // set the global default client to the one created above because the CoreV1Api and AppsV1Api

--- a/datarepo-clienttests/src/main/java/utils/KubernetesClientUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/KubernetesClientUtils.java
@@ -30,7 +30,7 @@ import runner.config.ServerSpecification;
 
 // TODO: add try/catch for refresh token around all utils methods
 public final class KubernetesClientUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(KubernetesClientUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(KubernetesClientUtils.class);
 
   private static int maximumSecondsToWaitForReplicaSetSizeChange = 500;
   private static int secondsIntervalToPollReplicaSetSizeChange = 5;
@@ -69,7 +69,7 @@ public final class KubernetesClientUtils {
    */
   public static void buildKubernetesClientObject(ServerSpecification server) throws Exception {
     // call the fetchGKECredentials script that uses gcloud to generate the kubeconfig file
-    LOG.debug(
+    logger.debug(
         "Calling the fetchGKECredentials script that uses gcloud to generate the kubeconfig file");
     List<String> scriptArgs = new ArrayList<>();
     scriptArgs.add("tools/fetchGKECredentials.sh");
@@ -79,7 +79,7 @@ public final class KubernetesClientUtils {
     Process fetchCredentialsProc = ProcessUtils.executeCommand("sh", scriptArgs);
     List<String> cmdOutputLines = ProcessUtils.waitForTerminateAndReadStdout(fetchCredentialsProc);
     for (String cmdOutputLine : cmdOutputLines) {
-      LOG.debug(cmdOutputLine);
+      logger.debug(cmdOutputLine);
     }
 
     namespace = server.namespace;
@@ -93,7 +93,7 @@ public final class KubernetesClientUtils {
     KubeConfig kubeConfig = KubeConfig.loadKubeConfig(filereader);
 
     // get a refreshed SA access token and its expiration time
-    LOG.debug("Getting a refreshed service account access token and its expiration time");
+    logger.debug("Getting a refreshed service account access token and its expiration time");
     GoogleCredentials applicationDefaultCredentials =
         AuthenticationUtils.getApplicationDefaultCredential();
     AccessToken accessToken = AuthenticationUtils.getAccessToken(applicationDefaultCredentials);
@@ -143,7 +143,7 @@ public final class KubernetesClientUtils {
     kubeConfig.setContext(server.clusterName);
 
     // build the client object from the config
-    LOG.debug("Building the client objects from the config");
+    logger.debug("Building the client objects from the config");
     ApiClient client = ClientBuilder.kubeconfig(kubeConfig).build();
 
     // set the global default client to the one created above because the CoreV1Api and AppsV1Api
@@ -297,16 +297,16 @@ public final class KubernetesClientUtils {
     if (apiDeployment == null) {
       throw new RuntimeException("API deployment not found.");
     }
-    LOG.debug(
+    logger.debug(
         "Pod count before scaling kubernetes pods: {}", KubernetesClientUtils.listPods().size());
     apiDeployment = KubernetesClientUtils.changeReplicaSetSize(apiDeployment, podCount);
     KubernetesClientUtils.waitForReplicaSetSizeChange(apiDeployment, podCount);
 
     // print out the current pods
     List<V1Pod> pods = KubernetesClientUtils.listPods();
-    LOG.debug("Pod count after scaling kubernetes pods: {}", pods.size());
+    logger.debug("Pod count after scaling kubernetes pods: {}", pods.size());
     for (V1Pod pod : pods) {
-      LOG.debug("  pod: {}", pod.getMetadata().getName());
+      logger.debug("  pod: {}", pod.getMetadata().getName());
     }
   }
 }

--- a/datarepo-clienttests/src/main/java/utils/ProcessUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/ProcessUtils.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class ProcessUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(ProcessUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(ProcessUtils.class);
 
   private ProcessUtils() {}
 
@@ -44,7 +44,7 @@ public final class ProcessUtils {
       throws IOException {
     // build the full command string
     cmdArgs.add(0, cmd);
-    LOG.debug("Executing command: {}", String.join(" ", cmdArgs));
+    logger.debug("Executing command: {}", String.join(" ", cmdArgs));
 
     // build and run process from the specified working directory
     ProcessBuilder procBuilder = new ProcessBuilder(cmdArgs);

--- a/datarepo-clienttests/src/main/java/utils/ProcessUtils.java
+++ b/datarepo-clienttests/src/main/java/utils/ProcessUtils.java
@@ -9,8 +9,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ProcessUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessUtils.class);
 
   private ProcessUtils() {}
 
@@ -41,7 +44,7 @@ public final class ProcessUtils {
       throws IOException {
     // build the full command string
     cmdArgs.add(0, cmd);
-    System.out.println("Executing command: " + String.join(" ", cmdArgs));
+    LOG.debug("Executing command: {}", String.join(" ", cmdArgs));
 
     // build and run process from the specified working directory
     ProcessBuilder procBuilder = new ProcessBuilder(cmdArgs);

--- a/datarepo-clienttests/src/main/resources/logback.xml
+++ b/datarepo-clienttests/src/main/resources/logback.xml
@@ -1,10 +1,10 @@
-<configuration>
+<configuration scan="true" scanPeriod="1 second">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="debug">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/datarepo-clienttests/src/main/resources/suites/BasicSmoke.json
+++ b/datarepo-clienttests/src/main/resources/suites/BasicSmoke.json
@@ -1,0 +1,6 @@
+{
+  "name": "BasicSmoke",
+  "description": "Two smoke tests. One requires authentication and one does not. Only queries, no data creation.",
+  "serverSpecificationFile": "mmdev.json",
+  "testConfigurationFiles": ["BasicAuthenticated.json", "BasicUnauthenticated.json"]
+}

--- a/datarepo-clienttests/src/main/resources/suites/BasicSmoke.json
+++ b/datarepo-clienttests/src/main/resources/suites/BasicSmoke.json
@@ -1,6 +1,6 @@
 {
   "name": "BasicSmoke",
   "description": "Two smoke tests. One requires authentication and one does not. Only queries, no data creation.",
-  "serverSpecificationFile": "mmdev.json",
+  "serverSpecificationFile": "localhost.json",
   "testConfigurationFiles": ["BasicAuthenticated.json", "BasicUnauthenticated.json"]
 }


### PR DESCRIPTION
- Added concept of Test Suite = collection of Test Configurations. First example is BasicSmoke.json, which runs BasicUnauthenticated.json (hitting status endpoint several times) and BasicAuthenticated.json (hitting enumerate profiles endpoint several times).
- Added a Test Script Result class = collection of User Journey Results (one from each user journey thread) + associated statistics (e.g. min/max/mean elapsed time, number of threads completed).

- Replaced stdout.println with SLF4J logger. Most of the printlns are now at the debug log level. The info level is the default and much less chatty. The log level is set in the src/main/resources/logback.xml file 
- Changed the specification objects' display methods to use Jackson to print JSON instead of plain text.
- Moved the JSON file -> specification POJO object code into each specification class rather than having it all centralized in the Test Configuration class.
- Updated README.