### PR TITLE
DR-1113: Run tests with local client jar

### DIFF
--- a/datarepo-clienttests/README.md
+++ b/datarepo-clienttests/README.md
@@ -76,8 +76,38 @@ Find a test configuration to execute. Each configuration is a JSON file in the r
 
 Call the Gradle run task and pass it the name of the test configuration or suite to execute.
 
-`./gradlew :run --args="configs/BasicUnauthenticated.json"`
-`./gradlew :run --args="suites/BasicSmoke.json"`
+`./gradlew run --args="configs/BasicUnauthenticated.json"`
+
+`./gradlew run --args="suites/BasicSmoke.json"`
+
+#### Run against a local server
+There is a localhost.json server specification file in the resources/server directory. This file contains a filepath to
+the top-level directory of the jade-data-repo Git repository. Executing a test against this configuration, with the path
+modified for your own machine, will start a local Data Repo server by executing the Gradle bootRun task from that
+directory.
+
+This is useful for debugging or testing local server code changes.
+
+#### Use a local Data Repo client JAR file
+The version of the Data Repo client JAR file is specified in the build.gradle file in this sub-project. This JAR file is
+fetched from the Broad Institute Maven repository. You can override this to use a local version of the Data Repo client
+JAR file by specifying a Gradle project property, either with a command line argument 
+
+`./gradlew -Pdatarepoclientjar=/Users/marikomedlock/Workspaces/jade-data-repo/datarepo-client/build/libs/datarepo-client-1.0.39-SNAPSHOT.jar run --args="configs/BasicUnauthenticated.json`
+
+or an environment variable.
+
+`export ORG_GRADLE_PROJECT_datarepoclientjar../datarepo-client/build/libs/datarepo-client-1.0.39-SNAPSHOT.jar`
+`./gradlew run --args="configs/BasicUnauthenticated.json`
+
+This is useful for debugging or testing local server code changes that affect the generated client library (e.g. new API
+endpoint). You can generate the Data Repo client library with the Gradle assemble task of the datarepo-client sub-project.
+
+`cd /Users/marikomedlock/Workspaces/jade-data-repo/datarepo-client`
+
+`../gradlew clean assemble`
+
+`ls -la ./build/libs/*jar`
 
 ## Write a new test
 #### Add a new test configuration

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id "com.google.cloud.tools.jib" version "1.6.1"
     id 'application'
+    id "com.google.cloud.tools.jib" version "1.6.1"
     id 'com.diffplug.gradle.spotless' version '3.27.2'
     id 'com.github.spotbugs' version '4.0.0'
 }
@@ -50,10 +50,7 @@ dependencies {
     compile "com.google.apis:google-api-services-people:${googlePeople}"
     compile "com.google.auth:google-auth-library-oauth2-http:${googleOauth2}"
 
-
-    // Allow using a local Data Repo Client JAR file, instead of the one from the repository
-    // e.g. ./gradlew -Pdatarepoclientjar=/Users/marikomedlock/Workspaces/jade-data-repo/datarepo-client/build/libs/datarepo-client-1.0.39-SNAPSHOT.jar run --args="configs/BasicUnauthenticated.json"
-    // e.g. ORG_GRADLE_PROJECT_datarepoclientjar=../datarepo-client/build/libs/datarepo-client-1.0.39-SNAPSHOT.jar ./gradlew run --args="configs/BasicUnauthenticated.json"
+    // Gradle project property "datarepoclientjar" overrides the fetch from Maven
     if (project.hasProperty("datarepoclientjar")) {
         implementation files(project.findProperty("datarepoclientjar"))
 
@@ -61,11 +58,6 @@ dependencies {
         compile "org.glassfish.jersey.core:jersey-client:${jersey}"
         compile "org.glassfish.jersey.media:jersey-media-json-jackson:${jersey}"
         compile "org.glassfish.jersey.media:jersey-media-multipart:${jersey}"
-
-//        compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "${jackson}"
-//        compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson}"
-//        compile group: 'io.swagger', name: 'swagger-annotations', version: "${swaggerAnnotations}"
-//        compile "org.glassfish.jersey.inject:jersey-hk2:${jersey}"
     } else {
         implementation "bio.terra:datarepo-client:${datarepoClient}"
     }

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -17,22 +17,59 @@ repositories {
 }
 
 dependencies {
-    testImplementation('org.junit.jupiter:junit-jupiter-api:5.4.2')
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.4.2')
+    ext {
+        junit = "5.4.2"
+        findbugsAnnotations = "3.0.1"
 
-    implementation 'bio.terra:datarepo-client:1.0.12-SNAPSHOT'
+        jackson = "2.10.2"
+        kubernetesClient = "8.0.2"
+        logback = "1.2.3"
+        slf4j = "1.7.25"
 
-    compile group: 'io.kubernetes', name: 'client-java', version: '8.0.2'
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-people:v1-rev277-1.23.0'
-    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.20.0'
-    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.0"
+        googleApi = "1.23.0"
+        googlePeople = "v1-rev277-1.23.0"
+        googleOauth2 = "0.20.0"
 
-    compile 'ch.qos.logback:logback-classic:1.2.3'
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+        swaggerAnnotations = "1.5.22"
+        jersey = "2.30.1"
 
-    compileOnly 'com.google.code.findbugs:annotations:3.0.1'
+        datarepoClient = "1.0.39-SNAPSHOT"
+    }
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:${junit}")
+    testRuntime("org.junit.jupiter:junit-jupiter-engine:${junit}")
+    compileOnly "com.google.code.findbugs:annotations:${findbugsAnnotations}"
+
+    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jackson}"
+    compile "io.kubernetes:client-java:${kubernetesClient}"
+    compile "ch.qos.logback:logback-classic:${logback}"
+    compile "org.slf4j:slf4j-api:${slf4j}"
+
+    compile "com.google.api-client:google-api-client:${googleApi}"
+    compile "com.google.oauth-client:google-oauth-client-jetty:${googleApi}"
+    compile "com.google.apis:google-api-services-people:${googlePeople}"
+    compile "com.google.auth:google-auth-library-oauth2-http:${googleOauth2}"
+
+
+    // Allow using a local Data Repo Client JAR file, instead of the one from the repository
+    // e.g. ./gradlew -Pdatarepoclientjar=/Users/marikomedlock/Workspaces/jade-data-repo/datarepo-client/build/libs/datarepo-client-1.0.39-SNAPSHOT.jar run --args="configs/BasicUnauthenticated.json"
+    // e.g. ORG_GRADLE_PROJECT_datarepoclientjar=../datarepo-client/build/libs/datarepo-client-1.0.39-SNAPSHOT.jar ./gradlew run --args="configs/BasicUnauthenticated.json"
+    if (project.hasProperty("datarepoclientjar")) {
+        implementation files(project.findProperty("datarepoclientjar"))
+
+        compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jackson}"
+        compile "org.glassfish.jersey.core:jersey-client:${jersey}"
+        compile "org.glassfish.jersey.media:jersey-media-json-jackson:${jersey}"
+        compile "org.glassfish.jersey.media:jersey-media-multipart:${jersey}"
+
+//        compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "${jackson}"
+//        compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: "${jackson}"
+//        compile group: 'io.swagger', name: 'swagger-annotations', version: "${swaggerAnnotations}"
+//        compile "org.glassfish.jersey.inject:jersey-hk2:${jersey}"
+    } else {
+        implementation "bio.terra:datarepo-client:${datarepoClient}"
+    }
+
 }
 
 group 'bio.terra'

--- a/datarepo-clienttests/src/main/java/runner/TestRunner.java
+++ b/datarepo-clienttests/src/main/java/runner/TestRunner.java
@@ -386,8 +386,8 @@ class TestRunner {
 
   static void printHelp() {
     logger.info("Specify test configuration file as first argument.");
-    logger.info("  e.g. ./gradlew :run --args=\"configs/BasicUnauthenticated.json\"");
-    logger.info("  e.g. ./gradlew :run --args=\"suites/BasicSmoke.json\"");
+    logger.info("  e.g. ./gradlew run --args=\"configs/BasicUnauthenticated.json\"");
+    logger.info("  e.g. ./gradlew run --args=\"suites/BasicSmoke.json\"");
 
     // print out the available test configurations found in the resources directory
     logger.info("The following test configuration files were found:");


### PR DESCRIPTION
- Added a Gradle project property "datarepoclientjar". When defined, it specifies the path to a local copy of the Data Repo client JAR file. When it is not defined, which is the default, Gradle will continue to pull from the Broad Institute Maven repository.
- Separated version numbers from library names in the build.gradle file for the datarepo-clienttests sub-project.
- Updated README with instructions to test against local server and client library code.