### PR TITLE
DR-1147 part 1: Added TestConfiguration.isFunctional and TestScript.manipulatesKubernetes flags.

### DIFF
--- a/datarepo-clienttests/src/main/java/runner/TestRunner.java
+++ b/datarepo-clienttests/src/main/java/runner/TestRunner.java
@@ -55,10 +55,11 @@ class TestRunner {
       executeTestConfigurationNoGuaranteedCleanup();
     } catch (Exception originalEx) {
       // cleanup deployment (i.e. run teardown method)
-      logger.info(
-          "Deployment: Calling {}.teardown() after failure", deploymentScript.getClass().getName());
       try {
         if (!config.server.skipDeployment) {
+          logger.info(
+              "Deployment: Calling {}.teardown() after failure",
+              deploymentScript.getClass().getName());
           deploymentScript.teardown();
         }
       } catch (Exception deploymentTeardownEx) {
@@ -139,28 +140,19 @@ class TestRunner {
       apiClientsForUsers.put(testUser.name, apiClient);
     }
 
-    // get an instance of each test script class
+    // setup the instance of each test script class
     logger.info(
         "Test Scripts: Fetching instance of each class, setting billing account and parameters");
     for (TestScriptSpecification testScriptSpecification : config.testScripts) {
-      try {
-        TestScript testScriptInstance = testScriptSpecification.scriptClass.newInstance();
+      TestScript testScriptInstance = testScriptSpecification.scriptClassInstance;
 
-        // set the billing account for the test script to use
-        testScriptInstance.setBillingAccount(config.billingAccount);
+      // set the billing account for the test script to use
+      testScriptInstance.setBillingAccount(config.billingAccount);
 
-        // set any parameters specified by the configuration
-        testScriptInstance.setParameters(testScriptSpecification.parameters);
+      // set any parameters specified by the configuration
+      testScriptInstance.setParameters(testScriptSpecification.parameters);
 
-        scripts.add(testScriptInstance);
-      } catch (IllegalAccessException | InstantiationException niEx) {
-        logger.error(
-            "Test Scripts: Error calling constructor of TestScript class: {}",
-            testScriptSpecification.name,
-            niEx);
-        throw new IllegalArgumentException(
-            "Error calling constructor of TestScript class: " + testScriptSpecification.name, niEx);
-      }
+      scripts.add(testScriptInstance);
     }
 
     // call the setup method of each test script

--- a/datarepo-clienttests/src/main/java/runner/TestScript.java
+++ b/datarepo-clienttests/src/main/java/runner/TestScript.java
@@ -10,6 +10,7 @@ public abstract class TestScript {
   public TestScript() {}
 
   protected String billingAccount;
+  protected boolean manipulatesKubernetes = false;
 
   /**
    * Setter for the billing account property of this class. This property will be set by the Test
@@ -19,6 +20,17 @@ public abstract class TestScript {
    */
   public void setBillingAccount(String billingAccount) {
     this.billingAccount = billingAccount;
+  }
+
+  /**
+   * Getter for the manipulates Kubernetes property of this class. This property may be overridden by
+   * Test Script classes that manipulate Kubernetes as part of the setup, cleanup, or userJourney
+   * methods. The default value of this property is false (i.e. Kubernetes is not manipulated).
+   *
+   * @return true if Kubernetes is required, false otherwise
+   */
+  public boolean manipulatesKubernetes() {
+    return manipulatesKubernetes;
   }
 
   /**

--- a/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
@@ -15,6 +15,7 @@ public class TestConfiguration implements SpecificationInterface {
   public String description = "";
   public String serverSpecificationFile;
   public String billingAccount;
+  public boolean isFunctional = false;
   public List<String> testUserFiles;
 
   public ServerSpecification server;
@@ -78,6 +79,22 @@ public class TestConfiguration implements SpecificationInterface {
     logger.debug("Validating the test script specifications");
     for (TestScriptSpecification testScript : testScripts) {
       testScript.validate();
+      if (isFunctional) {
+        if (testScript.totalNumberToRun > 1) {
+          throw new IllegalArgumentException(
+              "For a functional test script, the total number to run should be 1.");
+        }
+        if (testScript.numberToRunInParallel > 1) {
+          throw new IllegalArgumentException(
+              "For a functional test script, the number to run in parallel should be 1.");
+        }
+      }
+      if (server.skipKubernetes && testScript.scriptClassInstance.manipulatesKubernetes()) {
+        throw new IllegalArgumentException(
+            "The Test Script class "
+                + name
+                + " manipulates Kubernetes, but the server specification has disabled Kubernetes manipulations (see server.skipKubernetes flag).");
+      }
     }
 
     logger.debug("Validating the test user specifications");

--- a/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
@@ -6,13 +6,13 @@ import runner.TestScript;
 
 public class TestScriptSpecification implements SpecificationInterface {
   public String name;
-  public int totalNumberToRun;
-  public int numberToRunInParallel;
+  public int totalNumberToRun = 1;
+  public int numberToRunInParallel = 1;
   public long expectedTimeForEach;
   public String expectedTimeForEachUnit;
   public List<String> parameters;
 
-  public Class<? extends TestScript> scriptClass;
+  public TestScript scriptClassInstance;
   public TimeUnit expectedTimeForEachUnitObj;
   public String description;
 
@@ -39,9 +39,13 @@ public class TestScriptSpecification implements SpecificationInterface {
 
     try {
       Class<?> scriptClassGeneric = Class.forName(scriptsPackage + "." + name);
-      scriptClass = (Class<? extends TestScript>) scriptClassGeneric;
+      Class<? extends TestScript> scriptClass = (Class<? extends TestScript>) scriptClassGeneric;
+      scriptClassInstance = scriptClass.newInstance();
     } catch (ClassNotFoundException | ClassCastException classEx) {
       throw new IllegalArgumentException("Test script class not found: " + name, classEx);
+    } catch (IllegalAccessException | InstantiationException niEx) {
+      throw new IllegalArgumentException(
+          "Error calling constructor of TestScript class: " + name, niEx);
     }
 
     // generate a separate description property that also includes any test script parameters

--- a/datarepo-clienttests/src/main/java/testscripts/ScalePodsToZero.java
+++ b/datarepo-clienttests/src/main/java/testscripts/ScalePodsToZero.java
@@ -19,6 +19,7 @@ public class ScalePodsToZero extends runner.TestScript {
   /** Public constructor so that this class can be instantiated via reflection. */
   public ScalePodsToZero() {
     super();
+    manipulatesKubernetes = true; // this test script manipulates Kubernetes
   }
 
   private int filesToLoad;

--- a/datarepo-clienttests/src/main/java/testscripts/ScalePodsUpDown.java
+++ b/datarepo-clienttests/src/main/java/testscripts/ScalePodsUpDown.java
@@ -17,6 +17,7 @@ public class ScalePodsUpDown extends runner.TestScript {
   /** Public constructor so that this class can be instantiated via reflection. */
   public ScalePodsUpDown() {
     super();
+      manipulatesKubernetes = true; // this test script manipulates Kubernetes
   }
 
   private int filesToLoad;

--- a/datarepo-clienttests/src/main/resources/configs/ScalePodsToZero.json
+++ b/datarepo-clienttests/src/main/resources/configs/ScalePodsToZero.json
@@ -1,0 +1,20 @@
+{
+  "name": "ScalePods",
+  "description": "One user ingests many files into one dataset while we scale the Kubernetes pods down to 0 and up to 3.",
+  "serverSpecificationFile": "localhost.json",
+  "billingAccount": "00708C-45D19D-27AAFA",
+  "isFunctional": true,
+  "kubernetes": {
+    "numberOfInitialPods" : 3
+  },
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ScalePodsToZero",
+      "parameters": [29],
+      "expectedTimeForEach": 300,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": ["dumbledore.json"]
+}

--- a/datarepo-clienttests/src/main/resources/configs/ScalePodsUpDown.json
+++ b/datarepo-clienttests/src/main/resources/configs/ScalePodsUpDown.json
@@ -1,8 +1,9 @@
 {
   "name": "ScalePods",
-  "description": "One user ingests many files into one dataset while we manipulate the kubernetes pods",
+  "description": "One user ingests many files into one dataset while we scale the Kubernetes pods down to 1 and up to 4.",
   "serverSpecificationFile": "localhost.json",
   "billingAccount": "00708C-45D19D-27AAFA",
+  "isFunctional": true,
   "kubernetes": {
     "numberOfInitialPods" : 3
   },
@@ -11,15 +12,6 @@
     {
       "name": "ScalePodsUpDown",
       "parameters": [29],
-      "totalNumberToRun": 1,
-      "numberToRunInParallel": 1,
-      "expectedTimeForEach": 300,
-      "expectedTimeForEachUnit": "SECONDS"
-    }, {
-      "name": "ScalePodsToZero",
-      "parameters": [29],
-      "totalNumberToRun": 1,
-      "numberToRunInParallel": 1,
       "expectedTimeForEach": 300,
       "expectedTimeForEachUnit": "SECONDS"
     }


### PR DESCRIPTION
- Added an isFunctional flag to the TestConfiguration class. This forces both the number of user journey threads to run and the number to run in parallel to 1. Default values: isFunctional = false, number threads to run = 1, number to run in parallel = 1.
- Added a manipulatesKubernetes property to the TestScript base class. This is to help validation. If there is a test script that manipulates Kubernetes (e.g. the bulk load scaling tests), then setting this flag will throw an error during validation if you try to run it against a server that doesn't allow Kubernetes manipulations (e.g. localhost). Previously, running these tests against localhost would throw less readable errors when trying to access the Kubernetes client objects.
- Separated out the two bulk load tests into two separate test configurations, rather than running in parallel within a single test configuration.
