### PR TITLE
DR-1147 part 2: Fix broken testConfig.display from part 1.

### DIFF
--- a/datarepo-clienttests/src/main/java/runner/TestRunner.java
+++ b/datarepo-clienttests/src/main/java/runner/TestRunner.java
@@ -144,7 +144,7 @@ class TestRunner {
     logger.info(
         "Test Scripts: Fetching instance of each class, setting billing account and parameters");
     for (TestScriptSpecification testScriptSpecification : config.testScripts) {
-      TestScript testScriptInstance = testScriptSpecification.scriptClassInstance;
+      TestScript testScriptInstance = testScriptSpecification.scriptClassInstance();
 
       // set the billing account for the test script to use
       testScriptInstance.setBillingAccount(config.billingAccount);

--- a/datarepo-clienttests/src/main/java/runner/TestScript.java
+++ b/datarepo-clienttests/src/main/java/runner/TestScript.java
@@ -23,8 +23,8 @@ public abstract class TestScript {
   }
 
   /**
-   * Getter for the manipulates Kubernetes property of this class. This property may be overridden by
-   * Test Script classes that manipulate Kubernetes as part of the setup, cleanup, or userJourney
+   * Getter for the manipulates Kubernetes property of this class. This property may be overridden
+   * by Test Script classes that manipulate Kubernetes as part of the setup, cleanup, or userJourney
    * methods. The default value of this property is false (i.e. Kubernetes is not manipulated).
    *
    * @return true if Kubernetes is required, false otherwise

--- a/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestConfiguration.java
@@ -89,7 +89,7 @@ public class TestConfiguration implements SpecificationInterface {
               "For a functional test script, the number to run in parallel should be 1.");
         }
       }
-      if (server.skipKubernetes && testScript.scriptClassInstance.manipulatesKubernetes()) {
+      if (server.skipKubernetes && testScript.scriptClassInstance().manipulatesKubernetes()) {
         throw new IllegalArgumentException(
             "The Test Script class "
                 + name

--- a/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
+++ b/datarepo-clienttests/src/main/java/runner/config/TestScriptSpecification.java
@@ -12,13 +12,17 @@ public class TestScriptSpecification implements SpecificationInterface {
   public String expectedTimeForEachUnit;
   public List<String> parameters;
 
-  public TestScript scriptClassInstance;
+  private TestScript scriptClassInstance;
   public TimeUnit expectedTimeForEachUnitObj;
   public String description;
 
   public static final String scriptsPackage = "testscripts";
 
   TestScriptSpecification() {}
+
+  public TestScript scriptClassInstance() {
+    return scriptClassInstance;
+  }
 
   /**
    * Validate the test script specification read in from the JSON file. The time unit string is

--- a/datarepo-clienttests/src/main/java/testscripts/ScalePodsUpDown.java
+++ b/datarepo-clienttests/src/main/java/testscripts/ScalePodsUpDown.java
@@ -17,7 +17,7 @@ public class ScalePodsUpDown extends runner.TestScript {
   /** Public constructor so that this class can be instantiated via reflection. */
   public ScalePodsUpDown() {
     super();
-      manipulatesKubernetes = true; // this test script manipulates Kubernetes
+    manipulatesKubernetes = true; // this test script manipulates Kubernetes
   }
 
   private int filesToLoad;


### PR DESCRIPTION
When I separated out my code for DR-1147 part 1 from the remaining code changes, I didn't include a renamed getter method. This broke Jackson's deserialization when writing the test configuration out to logger.info.