### PR TITLE
DR-1239, DR-1240 fixes for requester pays bucket

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
@@ -29,19 +29,6 @@ public class IngestFilePrimaryDataStep implements Step {
         this.dataset = dataset;
     }
 
-    private GoogleBucketResource getBufferInfo(FlightContext context) {
-        // The bucket has been selected for this file. In the single file load case, the info
-        // is stored in the working map. In the bulk load case, the info is stored in the input
-        // parameters.
-        // TODO: simplify this when we remove single file load
-        GoogleBucketResource bucketResource =
-            context.getInputParameters().get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
-        if (bucketResource == null) {
-            bucketResource = context.getWorkingMap().get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
-        }
-        return bucketResource;
-    }
-
     @Override
     public StepResult doStep(FlightContext context) {
         FlightMap inputParameters = context.getInputParameters();
@@ -51,7 +38,7 @@ public class IngestFilePrimaryDataStep implements Step {
         String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
         Boolean loadComplete = workingMap.get(FileMapKeys.LOAD_COMPLETED, Boolean.class);
         if (loadComplete == null || !loadComplete) {
-            GoogleBucketResource bucketResource = getBufferInfo(context);
+            GoogleBucketResource bucketResource = IngestUtils.getBucketInfo(context);
             FSFileInfo fsFileInfo;
             if (configService.testInsertFault(ConfigEnum.LOAD_SKIP_FILE_LOAD)) {
                 fsFileInfo = new FSFileInfo()
@@ -74,7 +61,7 @@ public class IngestFilePrimaryDataStep implements Step {
     public StepResult undoStep(FlightContext context) {
         FlightMap workingMap = context.getWorkingMap();
         String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
-        GoogleBucketResource bucketResource = getBufferInfo(context);
+        GoogleBucketResource bucketResource = IngestUtils.getBucketInfo(context);
         gcsPdao.deleteFileById(dataset, fileId, bucketResource);
 
         return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestUtils.java
@@ -1,0 +1,26 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.stairway.FlightContext;
+
+public final class IngestUtils {
+    private IngestUtils() {
+
+    }
+
+    public static GoogleBucketResource getBucketInfo(FlightContext context) {
+        // The bucket has been selected for this file. In the single file load case, the info
+        // is stored in the working map. In the bulk load case, the info is stored in the input
+        // parameters.
+        // TODO: simplify this when we remove single file load
+        // TODO: This is a cut and paste from IngestFilePrimaryDataStep. Both can be removed
+        //  when we get rid of single file load
+        GoogleBucketResource bucketResource =
+            context.getInputParameters().get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+        if (bucketResource == null) {
+            bucketResource = context.getWorkingMap().get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+        }
+        return bucketResource;
+    }
+}

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsBufferedReader.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsBufferedReader.java
@@ -10,9 +10,9 @@ import java.nio.charset.StandardCharsets;
  * Given a gs path and a storage object, return a buffered reader for the blob
  */
 public class GcsBufferedReader extends BufferedReader {
-    public GcsBufferedReader(Storage storage, String gspath) {
+    public GcsBufferedReader(Storage storage, String projectId, String gspath) {
         super(Channels.newReader(
-            GcsPdao.getBlobFromGsPath(storage, gspath).reader(),
+            GcsPdao.getBlobFromGsPath(storage, gspath, projectId).reader(),
             StandardCharsets.UTF_8.name()));
     }
 }

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -54,14 +54,8 @@ public class GcsPdao {
     }
 
     public Storage storageForBucket(GoogleBucketResource bucketResource) {
-        GcsProject gcsProject = gcsProjectFactory.get(projectIdForBucket(bucketResource));
-        return gcsProject.getStorage();
+        return gcsProjectFactory.getStorage(bucketResource.projectIdForBucket());
     }
-
-    public String projectIdForBucket(GoogleBucketResource bucketResource) {
-        return bucketResource.getProjectResource().getGoogleProjectId();
-    }
-
     public FSFileInfo copyFile(Dataset dataset,
                                FileLoadModel fileLoadModel,
                                String fileId,
@@ -69,7 +63,7 @@ public class GcsPdao {
 
         try {
             Storage storage = storageForBucket(bucketResource);
-            String targetProjectId = projectIdForBucket(bucketResource);
+            String targetProjectId = bucketResource.projectIdForBucket();
             Blob sourceBlob = getBlobFromGsPath(storage, fileLoadModel.getSourcePath(), targetProjectId);
 
             // Our path is /<dataset-id>/<file-id>

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -53,12 +53,12 @@ public class GcsPdao {
         this.applicationContext = applicationContext;
     }
 
-    private Storage storageForBucket(GoogleBucketResource bucketResource) {
+    public Storage storageForBucket(GoogleBucketResource bucketResource) {
         GcsProject gcsProject = gcsProjectFactory.get(projectIdForBucket(bucketResource));
         return gcsProject.getStorage();
     }
 
-    private String projectIdForBucket(GoogleBucketResource bucketResource) {
+    public String projectIdForBucket(GoogleBucketResource bucketResource) {
         return bucketResource.getProjectResource().getGoogleProjectId();
     }
 
@@ -175,8 +175,6 @@ public class GcsPdao {
         ACL_OP_CREATE,
         ACL_OP_DELETE
     }
-
-    ;
 
     public void setAclOnFiles(Dataset dataset, List<String> fileIds, String readersPolicyEmail) {
         fileAclOp(AclOp.ACL_OP_CREATE, dataset, fileIds, readersPolicyEmail);

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsProjectFactory.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsProjectFactory.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata.google.gcs;
 
+import com.google.cloud.storage.Storage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -22,5 +23,9 @@ public class GcsProjectFactory {
                 gcsConfiguration.getConnectTimeoutSeconds(),
                 gcsConfiguration.getReadTimeoutSeconds()));
         return gcsProjectCache.get(projectId);
+    }
+
+    public Storage getStorage(String projectId) {
+        return get(projectId).getStorage();
     }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketResource.java
@@ -1,5 +1,7 @@
 package bio.terra.service.resourcemanagement.google;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.UUID;
 
 public class GoogleBucketResource {
@@ -73,5 +75,10 @@ public class GoogleBucketResource {
     public GoogleBucketResource region(String region) {
         this.region = region;
         return this;
+    }
+
+    @JsonIgnore
+    public String projectIdForBucket() {
+        return getProjectResource().getGoogleProjectId();
     }
 }

--- a/src/main/resources/application-connectedtest.properties
+++ b/src/main/resources/application-connectedtest.properties
@@ -1,5 +1,6 @@
 # ct for connected test
 ct.ingestBucket=jade-testdata
+ct.ingestRequesterPaysBucket=jade_testbucket_requester_pays
 datarepo.gcs.allowReuseExistingBuckets=true
 db.migrate.dropAllOnStart=true
 datarepo.loadHistoryWaitSeconds=2

--- a/src/test/java/bio/terra/app/configuration/ConnectedTestConfiguration.java
+++ b/src/test/java/bio/terra/app/configuration/ConnectedTestConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 public class ConnectedTestConfiguration {
 
     private String ingestbucket;
+    private String ingestRequesterPaysBucket;
 
     public String getIngestbucket() {
         return ingestbucket;
@@ -17,5 +18,13 @@ public class ConnectedTestConfiguration {
 
     public void setIngestbucket(String ingestbucket) {
         this.ingestbucket = ingestbucket;
+    }
+
+    public String getIngestRequesterPaysBucket() {
+        return ingestRequesterPaysBucket;
+    }
+
+    public void setIngestRequesterPaysBucket(String ingestRequesterPaysBucket) {
+        this.ingestRequesterPaysBucket = ingestRequesterPaysBucket;
     }
 }

--- a/src/test/java/bio/terra/common/category/OnDemand.java
+++ b/src/test/java/bio/terra/common/category/OnDemand.java
@@ -1,0 +1,7 @@
+package bio.terra.common.category;
+
+/**
+ * On demand test category. Tests in this category are not run automatically
+ */
+public interface OnDemand {
+}

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
@@ -113,7 +113,7 @@ public class EncodeFileTest {
     private Storage storage;
     private String targetProjectId;
     private String loadTag;
-    DatasetSummaryModel datasetSummary;
+    private DatasetSummaryModel datasetSummary;
 
     @Before
     public void setup() throws Exception {

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
@@ -17,6 +17,7 @@ import bio.terra.model.IngestRequestModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.filedata.DrsId;
 import bio.terra.service.filedata.DrsIdService;
+import bio.terra.service.filedata.google.gcs.GcsProjectFactory;
 import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
@@ -82,15 +83,26 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 public class EncodeFileTest {
     private static final Logger logger = LoggerFactory.getLogger(EncodeFileTest.class);
 
-    @Autowired private MockMvc mvc;
-    @Autowired private ObjectMapper objectMapper;
-    @Autowired private ConnectedTestConfiguration testConfig;
-    @Autowired private DataLocationService dataLocationService;
-    @Autowired private SnapshotDao snapshotDao;
-    @Autowired private GoogleResourceConfiguration googleResourceConfiguration;
-    @Autowired private ConnectedOperations connectedOperations;
-    @Autowired private DrsIdService drsIdService;
-    @Autowired private FireStoreUtils fireStoreUtils;
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private ConnectedTestConfiguration testConfig;
+    @Autowired
+    private DataLocationService dataLocationService;
+    @Autowired
+    private SnapshotDao snapshotDao;
+    @Autowired
+    private GoogleResourceConfiguration googleResourceConfiguration;
+    @Autowired
+    private GcsProjectFactory gcsProjectFactory;
+    @Autowired
+    private ConnectedOperations connectedOperations;
+    @Autowired
+    private DrsIdService drsIdService;
+    @Autowired
+    private FireStoreUtils fireStoreUtils;
 
     private static final String ID_GARBAGE = "GARBAGE";
 
@@ -98,8 +110,10 @@ public class EncodeFileTest {
     private IamProviderInterface samService;
 
     private BillingProfileModel profileModel;
-    private Storage storage = StorageOptions.getDefaultInstance().getService();
+    private Storage storage;
+    private String targetProjectId;
     private String loadTag;
+    DatasetSummaryModel datasetSummary;
 
     @Before
     public void setup() throws Exception {
@@ -108,6 +122,13 @@ public class EncodeFileTest {
         String coreBillingAccountId = googleResourceConfiguration.getCoreBillingAccount();
         profileModel = connectedOperations.createProfileForAccount(coreBillingAccountId);
         loadTag = "encodeLoadTag" + UUID.randomUUID();
+        datasetSummary = connectedOperations.createDataset(profileModel, "encodefiletest-dataset.json");
+        targetProjectId = googleResourceConfiguration.getSingleDataProjectId(); // we rely on using single project
+        // Build a storage object for the data project of the dataset.
+        StorageOptions storageOptions = StorageOptions.newBuilder()
+            .setProjectId(targetProjectId)
+            .build();
+        storage = storageOptions.getService();
         logger.info("--------begin test---------");
     }
 
@@ -117,17 +138,23 @@ public class EncodeFileTest {
         connectedOperations.teardown();
     }
 
-    // NOTES ABOUT THIS TEST: this test requires create access to the jade-testdata bucket in order to
+    // NOTES ABOUT THESE TESTS: these tests require create access to the jade-testdata bucket in order to
     // re-write the json source data replacing the gs paths with the Jade object id.
     @Test
     public void encodeFileTest() throws Exception {
-        DatasetSummaryModel datasetSummary = connectedOperations.createDataset(profileModel,
-            "encodefiletest-dataset.json");
+        encodeTest(testConfig.getIngestbucket());
+    }
 
+    @Test
+    public void encodeFileRequesterPaysTest() throws Exception {
+        encodeTest(testConfig.getIngestRequesterPaysBucket());
+    }
+
+    private void encodeTest(String bucketName) throws Exception {
         // Load all of the files into the dataset
-        String targetPath = loadFiles(datasetSummary.getId(), false, false);
+        String targetPath = loadFiles(datasetSummary.getId(), false, false, bucketName);
 
-        String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + targetPath;
+        String gsPath = "gs://" + bucketName + "/" + targetPath;
         IngestRequestModel ingestRequest = new IngestRequestModel()
             .format(IngestRequestModel.FormatEnum.JSON)
             .table("file")
@@ -136,15 +163,16 @@ public class EncodeFileTest {
         connectedOperations.ingestTableSuccess(datasetSummary.getId(), ingestRequest);
 
         // Delete the scratch blob
-        Blob scratchBlob = storage.get(BlobId.of(testConfig.getIngestbucket(), targetPath));
+        Blob scratchBlob = storage.get(BlobId.of(bucketName, targetPath),
+            Storage.BlobGetOption.userProject(targetProjectId));
         if (scratchBlob != null) {
-            scratchBlob.delete();
+            scratchBlob.delete(Blob.BlobSourceOption.userProject(targetProjectId));
         }
 
         // Load donor success
         ingestRequest
             .table("donor")
-            .path("gs://" + testConfig.getIngestbucket() + "/encodetest/donor.json");
+            .path("gs://" + bucketName + "/encodetest/donor.json");
 
         connectedOperations.ingestTableSuccess(datasetSummary.getId(), ingestRequest);
 
@@ -196,6 +224,7 @@ public class EncodeFileTest {
     //                                                                                 /ENCFF823AJQ.bam.bai
 
     private static int MAX_DIRECTORY_DEPTH = 6;
+
     private Map<String, List<String>> makeDirectoryMap(String datasetPath) {
         Map<String, List<String>> dirmap = new HashMap<>();
         dirmap.put(datasetPath,
@@ -279,10 +308,9 @@ public class EncodeFileTest {
 
     @Test
     public void encodeFileBadFileId() throws Exception {
-        DatasetSummaryModel datasetSummary = connectedOperations.createDataset(profileModel,
-            "encodefiletest-dataset.json");
-        String targetPath = loadFiles(datasetSummary.getId(), true, false);
-        String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + targetPath;
+        String bucketName = testConfig.getIngestbucket();
+        String targetPath = loadFiles(datasetSummary.getId(), true, false, bucketName);
+        String gsPath = "gs://" + bucketName + "/" + targetPath;
 
         IngestRequestModel ingestRequest = new IngestRequestModel()
             .format(IngestRequestModel.FormatEnum.JSON)
@@ -315,10 +343,9 @@ public class EncodeFileTest {
 
     @Test
     public void encodeFileBadRowTest() throws Exception {
-        DatasetSummaryModel datasetSummary = connectedOperations.createDataset(profileModel,
-            "encodefiletest-dataset.json");
-        String targetPath = loadFiles(datasetSummary.getId(), false, true);
-        String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + targetPath;
+        String bucketName = testConfig.getIngestbucket();
+        String targetPath = loadFiles(datasetSummary.getId(), false, true, bucketName);
+        String gsPath = "gs://" + bucketName + "/" + targetPath;
 
         IngestRequestModel ingestRequest = new IngestRequestModel()
             .format(IngestRequestModel.FormatEnum.JSON)
@@ -355,13 +382,16 @@ public class EncodeFileTest {
                 "JSON parsing error in row starting at position 0: Parser terminated before end of string"));
 
         // Delete the scratch blob
-        Blob scratchBlob = storage.get(BlobId.of(testConfig.getIngestbucket(), targetPath));
+        Blob scratchBlob = storage.get(BlobId.of(bucketName, targetPath));
         if (scratchBlob != null) {
             scratchBlob.delete();
         }
     }
 
-    private String loadFiles(String datasetId, boolean insertBadId, boolean insertBadRow) throws Exception {
+    private String loadFiles(String datasetId,
+                             boolean insertBadId,
+                             boolean insertBadRow,
+                             String bucketName) throws Exception {
         // Open the source data from the bucket
         // Open target data in bucket
         // Read one line at a time - unpack into pojo
@@ -372,15 +402,17 @@ public class EncodeFileTest {
         // For a bigger test use encodetest/file.json (1000+ files)
         // For normal testing encodetest/file_small.json (10 files)
         Blob sourceBlob = storage.get(
-            BlobId.of(testConfig.getIngestbucket(), "encodetest/file_small.json"));
+            BlobId.of(bucketName, "encodetest/file_small.json"),
+            Storage.BlobGetOption.userProject(targetProjectId));
         assertNotNull("source blob not null", sourceBlob);
 
         BlobInfo targetBlobInfo = BlobInfo
-            .newBuilder(BlobId.of(testConfig.getIngestbucket(), targetPath))
+            .newBuilder(BlobId.of(bucketName, targetPath))
             .build();
 
-        try (WriteChannel writer = storage.writer(targetBlobInfo);
-             BufferedReader reader = new BufferedReader(Channels.newReader(sourceBlob.reader(), "UTF-8"))) {
+        try (WriteChannel writer = storage.writer(targetBlobInfo, Storage.BlobWriteOption.userProject(targetProjectId));
+             BufferedReader reader = new BufferedReader(Channels.newReader(
+                 sourceBlob.reader(Blob.BlobSourceOption.userProject(targetProjectId)), "UTF-8"))) {
 
             boolean badIdInserted = false;
             boolean badRowInserted = false;

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -30,6 +30,7 @@ public class GcsPdaoTest {
     @Autowired private ConnectedTestConfiguration testConfig;
 
     private Storage storage = StorageOptions.getDefaultInstance().getService();
+    private String projectId = StorageOptions.getDefaultProjectId();
 
     @Test
     public void testGetBlobSimple() {
@@ -37,7 +38,10 @@ public class GcsPdaoTest {
 
         try {
             storage.create(BlobInfo.newBuilder(testBlob).build());
-            Blob blob = GcsPdao.getBlobFromGsPath(storage, "gs://" + testBlob.getBucket() + "/" + testBlob.getName());
+            Blob blob = GcsPdao.getBlobFromGsPath(
+                storage,
+                "gs://" + testBlob.getBucket() + "/" + testBlob.getName(),
+                projectId);
             Assert.assertNotNull(blob);
 
             BlobId actualId = blob.getBlobId();
@@ -55,7 +59,10 @@ public class GcsPdaoTest {
 
         try {
             storage.create(BlobInfo.newBuilder(testBlob).build());
-            Blob blob = GcsPdao.getBlobFromGsPath(storage, "gs://" + testBlob.getBucket() + "/" + testBlob.getName());
+            Blob blob = GcsPdao.getBlobFromGsPath(
+                storage,
+                "gs://" + testBlob.getBucket() + "/" + testBlob.getName(),
+                projectId);
             Assert.assertNotNull(blob);
 
             BlobId actualId = blob.getBlobId();
@@ -68,12 +75,18 @@ public class GcsPdaoTest {
 
     @Test(expected = PdaoInvalidUriException.class)
     public void testGetBlobNonGs() {
-        GcsPdao.getBlobFromGsPath(storage, "s3://my-aws-bucket/my-cool-path");
+        GcsPdao.getBlobFromGsPath(
+            storage,
+            "s3://my-aws-bucket/my-cool-path",
+            projectId);
     }
 
     @Test(expected = PdaoInvalidUriException.class)
     public void testGetBlobBucketNameTooShort() {
-        GcsPdao.getBlobFromGsPath(storage, "gs://ab/some-path");
+        GcsPdao.getBlobFromGsPath(
+            storage,
+            "gs://ab/some-path",
+            projectId);
     }
 
     @Test(expected = PdaoInvalidUriException.class)
@@ -83,7 +96,10 @@ public class GcsPdaoTest {
             if (i != 0) bucket.append(".");
             bucket.append("component");
         }
-        GcsPdao.getBlobFromGsPath(storage, "gs://" + bucket.toString() + "/some-path");
+        GcsPdao.getBlobFromGsPath(
+            storage,
+            "gs://" + bucket.toString() + "/some-path",
+            projectId);
     }
 
     @Test(expected = PdaoInvalidUriException.class)
@@ -92,21 +108,24 @@ public class GcsPdaoTest {
         for (int i = 0; i < 64; i++) {
             bucket.append("a");
         }
-        GcsPdao.getBlobFromGsPath(storage, "gs://" + bucket.toString() + "/some-path");
+        GcsPdao.getBlobFromGsPath(
+            storage,
+            "gs://" + bucket.toString() + "/some-path",
+            projectId);
     }
 
     @Test(expected = PdaoInvalidUriException.class)
     public void testGetBlobBucketInvalidCharacters() {
-        GcsPdao.getBlobFromGsPath(storage, "gs://AFSDAFADSFADSFASF@@@@/foo");
+        GcsPdao.getBlobFromGsPath(storage, "gs://AFSDAFADSFADSFASF@@@@/foo", projectId);
     }
 
     @Test(expected = PdaoInvalidUriException.class)
     public void testGetBlobNoObjectName() {
-        GcsPdao.getBlobFromGsPath(storage, "gs://bucket");
+        GcsPdao.getBlobFromGsPath(storage, "gs://bucket", projectId);
     }
 
     @Test(expected = PdaoSourceFileNotFoundException.class)
     public void testGetBlobNonexistent() {
-        GcsPdao.getBlobFromGsPath(storage, "gs://" + testConfig.getIngestbucket() + "/file-doesnt-exist");
+        GcsPdao.getBlobFromGsPath(storage, "gs://" + testConfig.getIngestbucket() + "/file-doesnt-exist", projectId);
     }
 }

--- a/src/test/java/bio/terra/service/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/iam/AccessTest.java
@@ -3,7 +3,7 @@ package bio.terra.service.iam;
 import bio.terra.common.PdaoConstant;
 import bio.terra.common.TestUtils;
 import bio.terra.common.auth.AuthService;
-import bio.terra.common.category.Integration;
+import bio.terra.common.category.OnDemand;
 import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.integration.BigQueryFixtures;
 import bio.terra.integration.DataRepoFixtures;
@@ -65,7 +65,7 @@ import static org.junit.Assert.fail;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "integrationtest"})
-@Category(Integration.class)
+@Category(OnDemand.class)
 @SuppressFBWarnings(
     value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
     justification = "Spurious RCN check; related to Java 11")


### PR DESCRIPTION
Provide target project id for requester pays; fix undo in primary data step
Add a requester pays bucket and reuse a test to use it.

Note that i had to grant the k8s SA service account Service Usage Admin permission on the projects that are going to pay for the requester pays bucket. So if you see 403 errors when running connected tests in your personal environments, you may have to add that permission to the service account under which you are running DRmanager

I also created an on demand category for tests, and i put AccessTest into it. Just got fed up with that failure over and over again!

