### PR TITLE
DR-1294: Cause Gradle task to fail if any user journeys fail.

### DIFF
--- a/datarepo-clienttests/src/main/java/common/CommandCLI.java
+++ b/datarepo-clienttests/src/main/java/common/CommandCLI.java
@@ -92,7 +92,10 @@ public class CommandCLI {
 
   public static void runTestMain(String[] args) throws Exception {
     if (args.length == 2) { // execute a test configuration or suite
-      TestRunner.executeTestConfigurationOrSuite(args[0], args[1]);
+      boolean isFailure = TestRunner.executeTestConfigurationOrSuite(args[0], args[1]);
+      if (isFailure) {
+        System.exit(1);
+      }
     } else { // if no args specified or invalid number of args specified, print help
       printHelp();
     }

--- a/datarepo-clienttests/src/main/java/runner/TestRunner.java
+++ b/datarepo-clienttests/src/main/java/runner/TestRunner.java
@@ -454,7 +454,8 @@ public class TestRunner {
     logger.info("Test run summary written to file: {}", runSummaryFile.getName());
   }
 
-  public static void executeTestConfigurationOrSuite(
+  /** Returns a boolean indicating whether the method failed or not. */
+  public static boolean executeTestConfigurationOrSuite(
       String configFileName, String outputParentDirName) throws Exception {
     logger.info("==== READING IN TEST SUITE/CONFIGURATION(S) ====");
     // read in test suite and validate it
@@ -476,6 +477,7 @@ public class TestRunner {
     }
     testSuite.validate();
 
+    boolean isFailure = false;
     for (int ctr = 0; ctr < testSuite.testConfigurations.size(); ctr++) {
       TestConfiguration testConfiguration = testSuite.testConfigurations.get(ctr);
       logger.info(
@@ -487,6 +489,17 @@ public class TestRunner {
       Exception runnerEx = null;
       try {
         runner.executeTestConfiguration();
+
+        // update the failure flag if it's not already been set
+        if (!isFailure) {
+          for (TestScriptResult.TestScriptResultSummary testScriptResultSummary :
+              runner.summary.testScriptResultSummaries) {
+            if (testScriptResultSummary.isFailure) {
+              isFailure = true;
+              break;
+            }
+          }
+        }
       } catch (Exception ex) {
         runnerEx = ex; // save exception to display after printing the results
       }
@@ -507,6 +520,8 @@ public class TestRunner {
         logger.error("Test Runner threw an exception", runnerEx);
       }
     }
+
+    return isFailure;
   }
 
   public static void collectMeasurementsForTestRun(

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/BuildSnapshotWithFiles.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/BuildSnapshotWithFiles.java
@@ -3,9 +3,6 @@ package scripts.testscripts;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
 import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.model.BulkLoadArrayRequestModel;


### PR DESCRIPTION
- Changed the TestRunner to return a boolean indicating whether any user journeys fail. I determine this boolean by looping through the test script result summaries after each test run to see if any have the isFailure flag set.
- Updated the CLI entry class to call System.exit(1) if TestRunner returns true = there was at least one failure.
- Tested that the Gradle task reports failure if a user journey throws an exception.