### PR TITLE
DR-1307 Add retry on retrieve file metadata

### DIFF
--- a/src/main/java/bio/terra/service/configuration/ConfigEnum.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigEnum.java
@@ -63,6 +63,8 @@ public enum ConfigEnum {
     SNAPSHOT_GRANT_ACCESS_FAULT,
     SNAPSHOT_GRANT_FILE_ACCESS_FAULT,
 
+    FIRESTORE_RETRIEVE_FAULT,
+
     // Faults to test the fault system
     UNIT_TEST_SIMPLE_FAULT,
     UNIT_TEST_COUNTED_FAULT;

--- a/src/main/java/bio/terra/service/configuration/ConfigurationService.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigurationService.java
@@ -34,6 +34,7 @@ import static bio.terra.service.configuration.ConfigEnum.FILE_INGEST_LOCK_RETRY_
 import static bio.terra.service.configuration.ConfigEnum.FILE_INGEST_UNLOCK_FATAL_FAULT;
 import static bio.terra.service.configuration.ConfigEnum.FILE_INGEST_UNLOCK_RETRY_FAULT;
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_QUERY_BATCH_SIZE;
+import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_RETRIEVE_FAULT;
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_VALIDATE_BATCH_SIZE;
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_SNAPSHOT_BATCH_SIZE;
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_SNAPSHOT_CACHE_SIZE;
@@ -266,6 +267,8 @@ public class ConfigurationService {
         addFaultCounted(DATASET_GRANT_ACCESS_FAULT, 0, 3, 100, ConfigFaultCountedModel.RateStyleEnum.FIXED);
         addFaultCounted(SNAPSHOT_GRANT_ACCESS_FAULT, 0, 3, 100, ConfigFaultCountedModel.RateStyleEnum.FIXED);
         addFaultCounted(SNAPSHOT_GRANT_FILE_ACCESS_FAULT, 0, 3, 100, ConfigFaultCountedModel.RateStyleEnum.FIXED);
+
+        addFaultCounted(FIRESTORE_RETRIEVE_FAULT, 0, 11, 100, ConfigFaultCountedModel.RateStyleEnum.FIXED);
     }
 
 }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
@@ -302,7 +302,7 @@ public class FireStoreDirectoryDao {
             ApiFuture<DocumentSnapshot> docSnapFuture = xn.get(docRef);
             return docSnapFuture.get();
         } catch (AbortedException | ExecutionException ex) {
-            throw handleExecutionException("lookupByEntryPath", ex);
+            throw fireStoreUtils.handleExecutionException(ex, "lookupByEntryPath");
         }
     }
 
@@ -339,7 +339,7 @@ public class FireStoreDirectoryDao {
             return documents.get(0);
 
         } catch (AbortedException | ExecutionException ex) {
-            throw handleExecutionException("lookupByFileId", ex);
+            throw fireStoreUtils.handleExecutionException(ex, "lookupByFileId");
         }
     }
 
@@ -606,7 +606,7 @@ public class FireStoreDirectoryDao {
             ApiFuture<WriteResult> writeFuture = newRef.set(entry);
             writeFuture.get();
         } catch (AbortedException | ExecutionException ex) {
-            throw handleExecutionException("updateDirectoryEntry", ex);
+            throw fireStoreUtils.handleExecutionException(ex, "updateDirectoryEntry");
         }
     }
 
@@ -622,15 +622,8 @@ public class FireStoreDirectoryDao {
             ApiFuture<DocumentSnapshot> docSnapFuture = docRef.get();
             return docSnapFuture.get();
         } catch (AbortedException | ExecutionException ex) {
-            throw handleExecutionException("lookupByPathNoXn", ex);
+            throw fireStoreUtils.handleExecutionException(ex, "lookupByPathNoXn");
         }
     }
 
-    private RuntimeException handleExecutionException(String info, Exception ex) {
-        Throwable cause = ex.getCause();
-        if ((ex instanceof AbortedException) || (cause instanceof AbortedException)) {
-            return new FileSystemAbortTransactionException(info + " - abort exception", ex);
-        }
-        return new FileSystemExecutionException(info + " - execution exception", ex);
-    }
 }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
@@ -1,14 +1,20 @@
 package bio.terra.service.filedata.google.firestore;
 
+import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.exception.FileSystemCorruptException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.AbortedException;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.Transaction;
+import io.grpc.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +23,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * FireStoreFileDao provides CRUD operations on the file collection in Firestore.
@@ -33,10 +40,12 @@ class FireStoreFileDao {
     private final Logger logger = LoggerFactory.getLogger(FireStoreFileDao.class);
 
     private final FireStoreUtils fireStoreUtils;
+    private final ConfigurationService configurationService;
 
     @Autowired
-    FireStoreFileDao(FireStoreUtils fireStoreUtils) {
+    FireStoreFileDao(FireStoreUtils fireStoreUtils, ConfigurationService configurationService) {
         this.fireStoreUtils = fireStoreUtils;
+        this.configurationService = configurationService;
     }
 
     void createFileMetadata(Firestore firestore, String datasetId, FireStoreFile newFile) throws InterruptedException {
@@ -64,20 +73,49 @@ class FireStoreFileDao {
         return fireStoreUtils.transactionGet("deleteFileMetadata", transaction);
     }
 
+    private static final int MAX_RETRIES = 10;
+    private static final int RETRY_MILLISECONDS = 500;
+
     // Returns null on not found
+    // We needed to add local retrying to this code path, because it is used in
+    // computeDirectory inside of the create snapshot code. We do potentially thousands
+    // of these calls inside that step, so retrying at the step level will not work;
+    // it would just redo the thousands of calls. Therefore, we retry here. (DR-1307
     FireStoreFile retrieveFileMetadata(Firestore firestore, String datasetId, String fileId)
         throws InterruptedException {
 
-        String collectionId = makeCollectionId(datasetId);
-        ApiFuture<FireStoreFile> transaction = firestore.runTransaction(xn -> {
-            DocumentSnapshot docSnap = lookupByFileId(firestore, collectionId, fileId, xn);
-            if (docSnap == null || !docSnap.exists()) {
-                return null;
-            }
-            return docSnap.toObject(FireStoreFile.class);
-        });
+        int retry = 0;
+        while (true) {
+            try {
+                String collectionId = makeCollectionId(datasetId);
+                ApiFuture<FireStoreFile> transaction = firestore.runTransaction(xn -> {
+                    DocumentSnapshot docSnap = lookupByFileId(firestore, collectionId, fileId, xn);
+                    if (docSnap == null || !docSnap.exists()) {
+                        return null;
+                    }
+                    return docSnap.toObject(FireStoreFile.class);
+                });
 
-        return fireStoreUtils.transactionGet("retrieveFileMetadata", transaction);
+                // Fault insertion to test retry
+                if (configurationService.testInsertFault(ConfigEnum.FIRESTORE_RETRIEVE_FAULT)) {
+                    throw new AbortedException(
+                        new FileSystemAbortTransactionException("fault insertion"),
+                        GrpcStatusCode.of(Status.Code.ABORTED),
+                        true);
+                }
+
+                return fireStoreUtils.transactionGet("retrieveFileMetadata", transaction);
+            } catch (AbortedException ex) {
+                if (retry < MAX_RETRIES) {
+                    // perform retry
+                    retry++;
+                    logger.info("Retry retrieveFileMetadata {} of {}", retry, MAX_RETRIES);
+                    TimeUnit.MILLISECONDS.sleep(RETRY_MILLISECONDS);
+                } else {
+                    throw new FileSystemExecutionException("Retries exhausted", ex);
+                }
+            }
+        }
     }
 
     List<FireStoreFile> batchRetrieveFileMetadata(

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
@@ -80,7 +80,7 @@ class FireStoreFileDao {
     // We needed to add local retrying to this code path, because it is used in
     // computeDirectory inside of the create snapshot code. We do potentially thousands
     // of these calls inside that step, so retrying at the step level will not work;
-    // it would just redo the thousands of calls. Therefore, we retry here. (DR-1307
+    // it would just redo the thousands of calls. Therefore, we retry here. (DR-1307)
     FireStoreFile retrieveFileMetadata(Firestore firestore, String datasetId, String fileId)
         throws InterruptedException {
 

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -33,7 +33,7 @@ public class FireStoreUtils {
         }
     }
 
-    RuntimeException handleExecutionException(ExecutionException ex, String op) {
+    RuntimeException handleExecutionException(Throwable ex, String op) {
         // The ExecutionException wraps the underlying exception caught in the FireStore Future, so we need
         // to examine the properties of the cause to understand what to do.
         // Possible outcomes:
@@ -42,7 +42,7 @@ public class FireStoreUtils {
         // - RuntimeExceptions to expose other unexpected exceptions
         // - FileSystemExecutionException to wrap non-Runtime (oddball) exceptions
 
-        Throwable throwable = ex.getCause();
+        Throwable throwable = ex;
         while (throwable instanceof ExecutionException) {
             throwable = throwable.getCause();
         }


### PR DESCRIPTION
Added a retry loop around the firestore transaction that reads a file object. In this case, we cannot use stairway retry. we are doing a recursive descent computing directory level sizes and hashes. The HCA data has thousands of files in a single directory and a stairway retry would simply redo those thousand file lookups. 

I added a faults to exercise the retry loop and two connected test cases to test the success and failure of the retry.

In working on this i noticed that the common exception handler in FireStoreUtils that decides whether a firestore exception is retry-able or not was not being used in FireStoreDirectoryDao, so i fixed that.
