### PR TITLE
DR-1305 Fix reader permissions for snapshot files and snapshot BQ dataset

### DIFF
--- a/src/main/java/bio/terra/common/PrimaryDataAccess.java
+++ b/src/main/java/bio/terra/common/PrimaryDataAccess.java
@@ -1,14 +1,19 @@
 package bio.terra.common;
 
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.snapshot.RowIdMatch;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotSource;
-import bio.terra.service.snapshot.RowIdMatch;
-import bio.terra.service.dataset.Dataset;
 
-import java.util.Collection;
 import java.util.List;
 
 /**
+ * TODO: removed this interface. What we have determined in our implementation experience is that
+ *  it really doesn't work to have an interface for this level. The details of what needs to be
+ *  in the flights are sensitive to the underlying implementation, so the real place where we
+ *  need to choose the back end is within the flights and not at this interface level. We have
+ *  gone around this interface as much as we have gone through it. We should remove it!
+ *
  * In the long term, we want to make the primary data store be pluggable, supporting different implementations.
  * This interface documents what that pluggable interface might look like. Of course, we never know until we
  * build another one.
@@ -80,17 +85,6 @@ public interface PrimaryDataAccess {
      * @return true if the snapshot was deleted; false if it was not found; throw on other errors
      */
     boolean deleteSnapshot(Snapshot snapshot) throws InterruptedException;
-
-
-    /**
-     * Add the google group for the snapshot readers to the BQ snapshot
-     *
-     * @param snapshot snapshot metadata
-     * @param readersEmail email address for readers group (as returned by SAM)
-     */
-    void addReaderGroupToSnapshot(Snapshot snapshot, String readersEmail) throws InterruptedException;
-
-    void grantReadAccessToDataset(Dataset dataset, Collection<String> policyGroupEmails) throws InterruptedException;
 
     /**
      * Checks to see if a dataset exists

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzPrimaryDataStep.java
@@ -18,6 +18,8 @@ import com.google.cloud.bigquery.BigQueryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -51,7 +53,13 @@ public class CreateDatasetAuthzPrimaryDataStep implements Step {
                     new BigQueryError("invalid", "fake", "IAM setPolicy fake failure"));
             }
 
-            bigQueryPdao.grantReadAccessToDataset(dataset, policyEmails.values());
+            // Build the list of the policy emails that should have read access to the big query dataset
+            List<String> emails = new ArrayList<>();
+            emails.add(policyEmails.get(IamRole.STEWARD));
+            emails.add(policyEmails.get(IamRole.CUSTODIAN));
+            emails.add(policyEmails.get(IamRole.INGESTER));
+            bigQueryPdao.grantReadAccessToDataset(dataset, emails);
+
         } catch (BigQueryException ex) {
             if (FlightUtils.isBigQueryIamPropagationError(ex)) {
                 return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzFileAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzFileAclStep.java
@@ -53,7 +53,6 @@ public class SnapshotAuthzFileAclStep implements Step {
         Snapshot snapshot = snapshotService.retrieve(snapshotId);
 
         Map<IamRole, String> policies = workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, Map.class);
-        String readersPolicyEmail = policies.get(IamRole.READER);
 
         // TODO: when we support multiple datasets, we can generate more than one copy of this
         //  step: one for each dataset. That is because each dataset keeps its file dependencies
@@ -69,7 +68,7 @@ public class SnapshotAuthzFileAclStep implements Step {
                 throw new StorageException(400, "Fake IAM failure", "badRequest", null);
             }
 
-            gcsPdao.setAclOnFiles(dataset, fileIds, readersPolicyEmail);
+            gcsPdao.setAclOnFiles(dataset, fileIds, policies);
         } catch (StorageException ex) {
             // Now, how to figure out if the failure is due to IAM propagation delay. We know it will
             // be a 400 - bad request and the docs indicate the reason will be "badRequest". So for now
@@ -91,7 +90,6 @@ public class SnapshotAuthzFileAclStep implements Step {
         Snapshot snapshot = snapshotService.retrieve(snapshotId);
 
         Map<IamRole, String> policies = workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, Map.class);
-        String readersPolicyEmail = policies.get(IamRole.READER);
 
         // TODO: when we support multiple datasets, we can generate more than one copy of this
         //  step: one for each dataset. That is because each dataset keeps its file dependencies
@@ -103,7 +101,7 @@ public class SnapshotAuthzFileAclStep implements Step {
 
         List<String> fileIds = fireStoreDao.getDatasetSnapshotFileIds(dataset, snapshotId.toString());
         try {
-            gcsPdao.removeAclOnFiles(dataset, fileIds, readersPolicyEmail);
+            gcsPdao.removeAclOnFiles(dataset, fileIds, policies);
         } catch (StorageException ex) {
             // We don't let the exception stop us from continuing to remove the rest of the snapshot parts.
             // TODO: change this to whatever our alert-a-human log message is.

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -119,10 +119,12 @@ public class ConnectedOperations {
     public void stubOutSamCalls(IamProviderInterface samService) throws Exception {
         Map<IamRole, String> snapshotPolicies = new HashMap<>();
         snapshotPolicies.put(IamRole.CUSTODIAN, "hi@hi.com");
+        snapshotPolicies.put(IamRole.STEWARD, "hi@hi.com");
         snapshotPolicies.put(IamRole.READER,  "hi@hi.com");
         Map<IamRole, String> datasetPolicies = new HashMap<>();
         datasetPolicies.put(IamRole.CUSTODIAN, "hi@hi.com");
         datasetPolicies.put(IamRole.STEWARD,  "hi@hi.com");
+        datasetPolicies.put(IamRole.INGESTER,  "hi@hi.com");
 
         when(samService.createSnapshotResource(any(), any(), any())).thenReturn(snapshotPolicies);
         when(samService.isAuthorized(any(), any(), any(), any())).thenReturn(Boolean.TRUE);


### PR DESCRIPTION
For all snapshot primary data - both files and BQ dataset - we were only giving the Reader role read access. The Custodian and Steward roles are supposed to have read_data action, but were not included.

In the process, I made several cleanups:
 1. Refactored helper methods in SamIam to put more work in the helpers and less in the callers.
 2. Specifically listed out the permissions to set for the dataset BQ dataset case; it was just passing through whatever came out of SamIam. That is correct for now, but might be wrong if we added something in SamIam and didn't realize we needed to change BqPdao.
 3. Changed the BQ Pdao call to set permissions so it has the same format for both snapshots and datasets.
