### PR TITLE
DR-1326: Move versioning into jade-data-repo parent directory

### DIFF
--- a/.github/workflows/alpha-nightly.yaml
+++ b/.github/workflows/alpha-nightly.yaml
@@ -30,7 +30,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Create alpha release images'
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -38,8 +38,7 @@ jobs:
       - name: "Publish to Artifactory"
         uses: broadinstitute/gradle-command-action@v1
         with:
-          build-root-directory: datarepo-client
-          arguments: artifactoryPublish
+          arguments: :datarepo-client:artifactoryPublish
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Bump the tag to a new version"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -44,18 +44,18 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check and edit Helm definition for dev"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
       - name: "Check and edit Helm definition for integration"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: 'integration-4,integration-5'

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -32,7 +32,7 @@ jobs:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
-          version_file_path: datarepo-client/build.gradle
+          version_file_path: build.gradle
           version_variable_name: version
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Publish to Artifactory"

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: "Publish to Artifactory"
         uses: broadinstitute/gradle-command-action@v1
         with:
-          arguments: :datarepo-client:artifactoryPublish
+          arguments: ':datarepo-client:artifactoryPublish'
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -42,6 +42,7 @@ jobs:
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
         uses: broadinstitute/datarepo-actions@0.24.0
         with:

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -63,22 +63,22 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3, integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_secret_chart_version: '0.0.4'
@@ -87,22 +87,22 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.9'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.24.0
+        uses: broadinstitute/datarepo-actions@0.25.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ allprojects {
     version '1.0.84-SNAPSHOT'
 }
 
+// skip subproject tasks when building jade-data-repo
 subprojects.each { s ->
     s.tasks.all { task -> task.enabled = false }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,11 @@ allprojects {
     version '1.0.89-SNAPSHOT'
 }
 
-// skip subproject tasks when building jade-data-repo
+// skip subproject tasks by default when building jade-data-repo
 subprojects.each { s ->
-    s.tasks.all { task -> task.enabled = false }
+    s.tasks.all {
+        task -> task.enabled = (System.getenv("ENABLE_SUBPROJECT_TASKS") != null)
+    }
 }
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,12 @@ plugins {
   id 'antlr'
 }
 
+allprojects {
+    group 'bio.terra'
+    version '1.0.84-SNAPSHOT'
+}
+sourceCompatibility = 1.8
+
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
@@ -97,11 +103,6 @@ jacocoTestCoverageVerification {
     }
 }
 check.dependsOn jacocoTestCoverageVerification
-
-
-group 'bio.terra'
-version '0.1'
-sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
 
 allprojects {
     group 'bio.terra'
-    version '1.0.84-SNAPSHOT'
+    version '1.0.89-SNAPSHOT'
 }
 
 // skip subproject tasks when building jade-data-repo

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ allprojects {
     group 'bio.terra'
     version '1.0.84-SNAPSHOT'
 }
+
+subprojects.each { s ->
+    s.tasks.all { task -> task.enabled = false }
+}
+
 sourceCompatibility = 1.8
 
 apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
 
 allprojects {
     group 'bio.terra'
-    version '1.0.89-SNAPSHOT'
+    version '1.0.94-SNAPSHOT'
 }
 
 // skip subproject tasks by default when building jade-data-repo

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
 
 allprojects {
     group 'bio.terra'
-    version '1.0.94-SNAPSHOT'
+    version '1.0.95-SNAPSHOT'
 }
 
 // skip subproject tasks by default when building jade-data-repo

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -20,8 +20,6 @@ plugins {
     id 'com.jfrog.artifactory' version '4.13.0'
 }
 
-group 'bio.terra'
-version '1.0.95-SNAPSHOT'
 sourceCompatibility = 1.8
 
 // TODO: there may be a better way to supply these values than envvars.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'jade-data-repo'
-
+include 'datarepo-client'


### PR DESCRIPTION
- Move the versioning from the `datarepo-client` to `jade-data-repo` and apply it to all projects and subprojects.
- Correctly set the `datarepo-client` as a subproject
- Update the gradle action that does artifactoryPublish to use the subproject