### PR TITLE
add a new bq helper method to use the default user

### DIFF
--- a/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
+++ b/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
@@ -39,6 +39,18 @@ public final class BigQueryUtils {
     return bigQuery;
   }
 
+  public static BigQuery getClientForServiceAccount(String googleProjectId) throws IOException {
+    GoogleCredentials userDefaultCredential = AuthenticationUtils.getApplicationDefaultCredential();
+    BigQuery bigQuery =
+        BigQueryOptions.newBuilder()
+            .setProjectId(googleProjectId)
+            .setCredentials(userDefaultCredential)
+            .build()
+            .getService();
+
+    return bigQuery;
+  }
+
   /**
    * Execute a query with the given BigQuery client object.
    *

--- a/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
+++ b/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
@@ -41,6 +41,7 @@ public final class BigQueryUtils {
 
   public static BigQuery getClientForServiceAccount(String googleProjectId) throws IOException {
     GoogleCredentials userDefaultCredential = AuthenticationUtils.getApplicationDefaultCredential();
+    logger.debug("Fetching credentials and building BigQuery client object for default user");
     BigQuery bigQuery =
         BigQueryOptions.newBuilder()
             .setProjectId(googleProjectId)

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
@@ -133,7 +133,7 @@ public class DRSLookup extends SimpleDataset {
             1L);
 
     BigQuery bigQueryClient =
-        BigQueryUtils.getClientForTestUser(datasetCreator, snapshotModel.getDataProject());
+        BigQueryUtils.getClientForServiceAccount(snapshotModel.getDataProject());
     TableResult result = BigQueryUtils.queryBigQuery(bigQueryClient, queryForFileRefs);
     ArrayList<String> fileRefs = new ArrayList<>();
     result.iterateAll().forEach(r -> fileRefs.add(r.get("VCF_File_Ref").getStringValue()));


### PR DESCRIPTION
The creator of the snapshot needs to be the same user as the query-er of the snapshot for this test setup
