### PR TITLE
DR-1321 Common firestore batcher with retries; use of and unit test for that

### DIFF
--- a/src/main/java/bio/terra/service/filedata/google/firestore/ApiFutureGenerator.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/ApiFutureGenerator.java
@@ -1,0 +1,8 @@
+package bio.terra.service.filedata.google.firestore;
+
+import com.google.api.core.ApiFuture;
+
+@FunctionalInterface
+public interface ApiFutureGenerator<T, V> {
+    ApiFuture<T> accept(V input) throws InterruptedException;
+}

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -4,6 +4,8 @@ import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.rpc.AbortedException;
+import com.google.api.gax.rpc.DeadlineExceededException;
+import com.google.api.gax.rpc.UnavailableException;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreException;
@@ -17,8 +19,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class FireStoreUtils {
@@ -147,6 +151,70 @@ public class FireStoreUtils {
         PureJavaCrc32C crc = new PureJavaCrc32C();
         crc.update(inputBytes, 0, inputBytes.length);
         return Long.toHexString(crc.getValue());
+    }
+
+    private static final int NO_PROGRESS_MAX = 2;
+    private static final int SLEEP_MILLISECONDS = 1000;
+
+    <T, V> List<T> batchOperation(List<V> inputs, ApiFutureGenerator<T, V> generator) throws InterruptedException {
+        int inputSize = inputs.size();
+        // We drive the retry processing by which outputs have not been filled in,
+        // so we initialize the outputs to be all null -> not filled in.
+        List<T> outputs = new ArrayList<>(inputSize);
+        for (int i = 0; i < inputSize; i++) {
+            outputs.add(null);
+        }
+
+        int noProgressCount = 0;
+        while (true) {
+            List<ApiFuture<T>> futures = new ArrayList<>(inputSize);
+
+            // generate a request for every not completed output
+            int requestCount = 0;
+            for (int i = 0; i < inputSize; i++) {
+                if (outputs.get(i) != null) {
+                    futures.add(null);
+                } else {
+                    futures.add(generator.accept(inputs.get(i)));
+                    requestCount++;
+                }
+            }
+            if (requestCount == 0) {
+                break;
+            }
+
+            // tried to collect a response for every request we generated
+            int completeCount = 0;
+            for (int i = 0; i < inputSize; i++) {
+                ApiFuture<T> future = futures.get(i);
+                if (future != null) {
+                    try {
+                        outputs.set(i, future.get());
+                        completeCount++;
+                    } catch (DeadlineExceededException | UnavailableException ex) {
+                        logger.warn("Retry-able error in firestore future get - input: " +
+                            inputs.get(i) + " message: " + ex.getMessage());
+                    } catch (ExecutionException ex) {
+                        throw new FileSystemExecutionException("batch operation failed", ex);
+                    }
+                }
+            }
+            // If we completed our requests we are done
+            if (completeCount == requestCount) {
+                break;
+            }
+
+            if (completeCount == 0) {
+                noProgressCount++;
+                if (noProgressCount > NO_PROGRESS_MAX) {
+                    throw new FileSystemExecutionException("batch operation failed. " +
+                        NO_PROGRESS_MAX + " tries with no progress.");
+                }
+            }
+            TimeUnit.MILLISECONDS.sleep(SLEEP_MILLISECONDS);
+        }
+
+        return outputs;
     }
 
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
@@ -1,0 +1,63 @@
+package bio.terra.service.filedata.google.firestore;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.filedata.exception.FileSystemExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+@Category(Unit.class)
+public class BatchOperationTest {
+    private FireStoreUtils fireStoreUtils;
+
+    @Before
+    public void setup() {
+        fireStoreUtils = new FireStoreUtils();
+    }
+
+    @Test
+    public void batchSuccessTest() throws Exception {
+        // Make sure batch operation works without any retries
+        FakeApiFuture.initialize(0); // never throw
+
+        List<String> inputs = makeInputs(10);
+        List<String> outputs = fireStoreUtils.batchOperation(inputs, input -> new FakeApiFuture());
+        assertThat("correct output size", outputs.size(), equalTo(inputs.size()));
+    }
+
+    @Test
+    public void batchRetrySuccessTest() throws Exception {
+        // make sure batch operation works with some retries
+        // 15 retries should fail entirely on the first loop, half on the second loop,
+        // and succeed on the third loop.
+        FakeApiFuture.initialize(15);
+
+        List<String> inputs = makeInputs(10);
+        List<String> outputs = fireStoreUtils.batchOperation(inputs, input -> new FakeApiFuture());
+        assertThat("correct output size", outputs.size(), equalTo(inputs.size()));
+    }
+
+    @Test(expected = FileSystemExecutionException.class)
+    public void batchFailureTest() throws Exception {
+        // make sure batch operation works with some retries
+        // 15 retries should fail entirely twice through and give up
+        FakeApiFuture.initialize(15);
+        List<String> inputs = makeInputs(5);
+        fireStoreUtils.batchOperation(inputs, input -> new FakeApiFuture());
+    }
+
+
+    private List<String> makeInputs(int count) {
+        List<String> inputs = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            inputs.add("in" + i);
+        }
+        return inputs;
+    }
+}

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FakeApiFuture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FakeApiFuture.java
@@ -1,0 +1,66 @@
+package bio.terra.service.filedata.google.firestore;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.DeadlineExceededException;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static io.grpc.Status.Code.DEADLINE_EXCEEDED;
+
+// Fake future class testing fire store batchOperation.
+// This is not thread safe!
+public class FakeApiFuture implements ApiFuture<String> {
+
+    private static int testThrowCount;
+    private static int currentCount;
+
+    public static void initialize(int throwCount) {
+        testThrowCount = throwCount;
+        currentCount = 0;
+    }
+
+    public static boolean shouldThrow() {
+        currentCount++;
+        return (currentCount <= testThrowCount);
+    }
+
+    @Override
+    public void addListener(Runnable listener, Executor executor) {
+
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return false;
+    }
+
+    @Override
+    public String get() throws InterruptedException, ExecutionException, DeadlineExceededException {
+        if (FakeApiFuture.shouldThrow()) {
+            throw new DeadlineExceededException("test",
+                new IllegalArgumentException("test"),
+                GrpcStatusCode.of(DEADLINE_EXCEEDED),
+                false);
+        }
+        return "abc";
+    }
+
+    @Override
+    public String get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return null;
+    }
+}


### PR DESCRIPTION
In brief, this provides retries for the firestore errors we have been seeing when doing batch operations. This should make the batch operations more robust and might allow us to increase the batch sizes to some extent.

The previous batching pattern was pretty simple, so refactoring didn't seem worth it. However, adding retries to the batching is more complex, so I refactored the core batcher into a templated utility method and a templated function interface.

I added a separate unit test to exercise the batchOperation code to make sure it was working as expected.