### PR TITLE
DT-1322 Log SAM IAM errors in the logs

### DIFF
--- a/src/main/java/bio/terra/common/exception/DataRepoException.java
+++ b/src/main/java/bio/terra/common/exception/DataRepoException.java
@@ -1,7 +1,7 @@
 package bio.terra.common.exception;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * DataRepoException is the base exception for the other data repository exceptions.
@@ -18,17 +18,17 @@ public abstract class DataRepoException extends RuntimeException {
 
     public DataRepoException(String message) {
         super(message);
-        this.errorDetails = null;
+        this.errorDetails = Collections.emptyList();
     }
 
     public DataRepoException(String message, Throwable cause) {
         super(message, cause);
-        this.errorDetails = null;
+        this.errorDetails = Collections.emptyList();
     }
 
     public DataRepoException(Throwable cause) {
         super(cause);
-        this.errorDetails = null;
+        this.errorDetails = Collections.emptyList();
     }
 
     public DataRepoException(String message, List<String> errorDetails) {
@@ -47,10 +47,11 @@ public abstract class DataRepoException extends RuntimeException {
 
     @Override
     public String toString() {
-        if (errorDetails == null) {
-            return super.toString();
-        }
-        String details = errorDetails.stream().collect(Collectors.joining("; "));
-        return super.toString() + " Details: " + details;
+        return String.format("%s%s",
+            super.toString(),
+            !errorDetails.isEmpty()
+                ? String.format(" Details: %s", String.join("; ", errorDetails))
+                : ""
+        );
     }
 }

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -412,11 +412,14 @@ public class SamIam implements IamProviderInterface {
     /**
      * Converts a SAM-specific ApiException to a DataRepo-specific common exception, based on the HTTP status code.
      */
-    public static DataRepoException convertSAMExToDataRepoEx(ApiException samEx) {
+    public static DataRepoException convertSAMExToDataRepoEx(final ApiException samEx) {
         // TODO: add mapping based on HTTP status code
         // SAM uses com.google.api.client.http.HttpStatusCodes
         // DataRepo uses org.springframework.http.HttpStatus
 
+        logger.warn("SAM client exception code: {}", samEx.getCode());
+        logger.warn("SAM client exception message: {}", samEx.getMessage());
+        logger.warn("SAM client exception details: {}", samEx.getResponseBody());
         switch (samEx.getCode()) {
             case HttpStatusCodes.STATUS_CODE_BAD_REQUEST: {
                 return new IamBadRequestException(samEx);

--- a/src/main/java/bio/terra/service/iam/sam/SamRetry.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamRetry.java
@@ -1,6 +1,7 @@
 package bio.terra.service.iam.sam;
 
 
+import bio.terra.common.exception.DataRepoException;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.iam.exception.IamInternalServerErrorException;
@@ -43,7 +44,7 @@ class SamRetry {
                 return function.apply();
 
             } catch (ApiException ex) {
-                RuntimeException rex = SamIam.convertSAMExToDataRepoEx((ApiException) ex);
+                DataRepoException rex = SamIam.convertSAMExToDataRepoEx(ex);
                 if (!(rex instanceof IamInternalServerErrorException)) {
                     throw rex;
                 }

--- a/src/test/java/bio/terra/common/exception/DataRepoExceptionTest.java
+++ b/src/test/java/bio/terra/common/exception/DataRepoExceptionTest.java
@@ -1,0 +1,41 @@
+package bio.terra.common.exception;
+
+import bio.terra.common.category.Unit;
+import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(Unit.class)
+public class DataRepoExceptionTest extends TestCase {
+
+    public void testToStringWithMessages() {
+        final DataRepoException exception = new TestDataRepoException("BOOM", Arrays.asList("foo", "bar"));
+        assertThat(exception.toString()).isEqualTo(
+            "bio.terra.common.exception.DataRepoExceptionTest$TestDataRepoException: BOOM Details: foo; bar"
+        );
+    }
+
+    public void testToStringWithNoMessages() {
+        final DataRepoException exception = new TestDataRepoException("BOOM");
+        assertThat(exception.toString()).isEqualTo(
+            "bio.terra.common.exception.DataRepoExceptionTest$TestDataRepoException: BOOM"
+        );
+    }
+
+    /**
+     * Test extension of abstract class to test printing of messages
+     */
+    private static class TestDataRepoException extends DataRepoException {
+        TestDataRepoException(String message) {
+            super(message);
+        }
+
+        TestDataRepoException(String message, List<String> errorDetails) {
+            super(message, errorDetails);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds some constructors to our IAM exceptions that let you specify the SAM message bodies into the errorDetails lists. These get printed in logs but don't get returned.

Also did a couple of drive-by fixes:

Made sure to close the stream when printing a DataRepoException's errorDetails
Remove an unnecessary cast
This is a preview and I need to figure out what is going on with my local git...not sure why my user looks wrong. As a result, I had to do a PR from a fork instead of from the main repo

Note: this is a re-push of PR #617 that isn't off of my fork