### PR TITLE
Update alpha-nightly.yaml with envs

### DIFF
--- a/.github/workflows/alpha-nightly.yaml
+++ b/.github/workflows/alpha-nightly.yaml
@@ -1,8 +1,12 @@
 name: Alpha Nightly
+env:
+  # This must be defined for the bash redirection
+  GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
+  # This must be defined for the bash redirection
+  GOOGLE_SA_CERT: 'jade-dev-account.pem'
 on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
-
 jobs:
   update_image:
     strategy:


### PR DESCRIPTION
Adding `GOOGLE_APPLICATION_CREDENTIALS` is necessary since the action was bumped to 0.25.0