### PR TITLE
DR-1363 Move billing account ID to test config

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
@@ -14,7 +14,6 @@ public class GoogleResourceConfiguration {
     private String applicationName;
     private long projectCreateTimeoutSeconds;
     private String projectId;
-    private String coreBillingAccount;
     private String parentResourceType;
     private String parentResourceId;
     private String singleDataProjectId;
@@ -41,14 +40,6 @@ public class GoogleResourceConfiguration {
 
     public void setProjectId(String projectId) {
         this.projectId = projectId;
-    }
-
-    public String getCoreBillingAccount() {
-        return coreBillingAccount;
-    }
-
-    public void setCoreBillingAccount(String coreBillingAccount) {
-        this.coreBillingAccount = coreBillingAccount;
     }
 
     public String getParentResourceType() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,7 +59,6 @@ sam.operationTimeoutSeconds=300
 google.projectid=${GOOGLE_CLOUD_PROJECT}
 google.applicationName=jade-data-repo
 google.projectCreateTimeoutSeconds=600
-google.coreBillingAccount=00708C-45D19D-27AAFA
 google.parentResourceType=folder
 google.parentResourceId=270278425081
 google.singleDataProjectId=${GOOGLE_CLOUD_DATA_PROJECT}

--- a/src/test/java/bio/terra/app/configuration/ConnectedTestConfiguration.java
+++ b/src/test/java/bio/terra/app/configuration/ConnectedTestConfiguration.java
@@ -11,6 +11,7 @@ public class ConnectedTestConfiguration {
 
     private String ingestbucket;
     private String ingestRequesterPaysBucket;
+    private String googleBillingAccountId;
 
     public String getIngestbucket() {
         return ingestbucket;
@@ -26,5 +27,13 @@ public class ConnectedTestConfiguration {
 
     public void setIngestRequesterPaysBucket(String ingestRequesterPaysBucket) {
         this.ingestRequesterPaysBucket = ingestRequesterPaysBucket;
+    }
+
+    public String getGoogleBillingAccountId() {
+        return googleBillingAccountId;
+    }
+
+    public void setGoogleBillingAccountId(String googleBillingAccountId) {
+        this.googleBillingAccountId = googleBillingAccountId;
     }
 }

--- a/src/test/java/bio/terra/app/controller/ProfileTest.java
+++ b/src/test/java/bio/terra/app/controller/ProfileTest.java
@@ -1,14 +1,13 @@
 package bio.terra.app.controller;
 
-import bio.terra.common.category.Unit;
 import bio.terra.common.TestUtils;
+import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.model.ErrorModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -20,8 +19,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.equalTo;
@@ -53,13 +50,7 @@ public class ProfileTest {
 
     @Before
     public void setup() throws Exception {
-        billingProfileRequest = requestModel("billing-profile.json");
-    }
-
-    private BillingProfileRequestModel requestModel(String jsonResourceFileName) throws IOException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String datasetJsonStr = IOUtils.toString(classLoader.getResourceAsStream(jsonResourceFileName));
-        return objectMapper.readerFor(BillingProfileRequestModel.class).readValue(datasetJsonStr);
+        billingProfileRequest = jsonLoader.loadObject("billing-profile.json", BillingProfileRequestModel.class);
     }
 
     @Test

--- a/src/test/java/bio/terra/common/configuration/TestConfiguration.java
+++ b/src/test/java/bio/terra/common/configuration/TestConfiguration.java
@@ -17,6 +17,7 @@ public class TestConfiguration {
     private String ingestbucket;
     private List<User> users = new ArrayList<>();
     private String googleProjectId;
+    private String googleBillingAccountId;
 
     public static class User {
         private String role;
@@ -103,5 +104,13 @@ public class TestConfiguration {
 
     public void setGoogleProjectId(String googleProjectId) {
         this.googleProjectId = googleProjectId;
+    }
+
+    public String getGoogleBillingAccountId() {
+        return googleBillingAccountId;
+    }
+
+    public void setGoogleBillingAccountId(String googleBillingAccountId) {
+        this.googleBillingAccountId = googleBillingAccountId;
     }
 }

--- a/src/test/java/bio/terra/common/fixtures/JsonLoader.java
+++ b/src/test/java/bio/terra/common/fixtures/JsonLoader.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 @Component
 public class JsonLoader {
@@ -18,12 +19,14 @@ public class JsonLoader {
         this.objectMapper = objectMapper;
     }
 
-    public String loadJson(String resourcePath) throws IOException {
-        return IOUtils.toString(classLoader.getResourceAsStream(resourcePath));
+    public String loadJson(final String resourcePath) throws IOException {
+        try (InputStream stream = classLoader.getResourceAsStream(resourcePath)) {
+            return IOUtils.toString(stream);
+        }
     }
 
-    public <T> T loadObject(String resourcePath, Class<T> resourceClass) throws IOException {
-        String json = loadJson(resourcePath);
+    public <T> T loadObject(final String resourcePath, final Class<T> resourceClass) throws IOException {
+        final String json = loadJson(resourcePath);
         return objectMapper.readerFor(resourceClass).readValue(json);
     }
 

--- a/src/test/java/bio/terra/common/fixtures/ProfileFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/ProfileFixtures.java
@@ -28,7 +28,7 @@ public final class ProfileFixtures {
         return String.join("-", groups).toUpperCase();
     }
 
-    public static BillingProfile billingProfileForAccount(String accountId) {
+    public static BillingProfile billingProfileForAccount(final String accountId) {
         return new BillingProfile()
             .biller("direct")
             .name("test profile")
@@ -39,11 +39,14 @@ public final class ProfileFixtures {
         return billingProfileForAccount(randomBillingAccountId());
     }
 
-    public static BillingProfileRequestModel randomBillingProfileRequest() {
-        BillingProfile profile = randomBillingProfile();
+    public static BillingProfileRequestModel billingProfileRequest(final BillingProfile profile) {
         return new BillingProfileRequestModel()
             .biller(profile.getBiller())
             .profileName(profile.getName())
             .billingAccountId(profile.getBillingAccountId());
+    }
+
+    public static BillingProfileRequestModel randomBillingProfileRequest() {
+        return billingProfileRequest(randomBillingProfile());
     }
 }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -65,7 +65,8 @@ public class DataRepoFixtures {
 
     // Create a Billing Profile model: expect successful creation
     public BillingProfileModel createBillingProfile(TestConfiguration.User user) throws Exception {
-        BillingProfileRequestModel billingProfileRequestModel = ProfileFixtures.randomBillingProfileRequest();
+        BillingProfileRequestModel billingProfileRequestModel = ProfileFixtures.billingProfileRequest(
+            ProfileFixtures.billingProfileForAccount(testConfig.getGoogleBillingAccountId()));
         String json = TestUtils.mapToJson(billingProfileRequestModel);
         DataRepoResponse<BillingProfileModel> postResponse = dataRepoClient.post(
             user,

--- a/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
@@ -98,7 +98,7 @@ public class DatasetConnectedTest {
         connectedOperations.stubOutSamCalls(samService);
         configService.reset();
         billingProfile =
-            connectedOperations.createProfileForAccount(googleResourceConfiguration.getCoreBillingAccount());
+            connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
         // create a dataset and check that it succeeds
         String resourcePath = "snapshot-test-dataset.json";
         datasetRequest =

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
@@ -119,7 +119,7 @@ public class EncodeFileTest {
     public void setup() throws Exception {
         // Setup mock sam service
         connectedOperations.stubOutSamCalls(samService);
-        String coreBillingAccountId = googleResourceConfiguration.getCoreBillingAccount();
+        String coreBillingAccountId = testConfig.getGoogleBillingAccountId();
         profileModel = connectedOperations.createProfileForAccount(coreBillingAccountId);
         loadTag = "encodeLoadTag" + UUID.randomUUID();
         datasetSummary = connectedOperations.createDataset(profileModel, "encodefiletest-dataset.json");

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FileLoadTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FileLoadTest.java
@@ -90,7 +90,7 @@ public class FileLoadTest {
         connectedOperations.stubOutSamCalls(samService);
 
         // Retrieve billing info
-        coreBillingAccountId = googleResourceConfiguration.getCoreBillingAccount();
+        coreBillingAccountId = testConfig.getGoogleBillingAccountId();
         profileModel = connectedOperations.createProfileForAccount(coreBillingAccountId);
         datasetSummary = connectedOperations.createDataset(profileModel, "snapshot-test-dataset.json");
     }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FileOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FileOperationTest.java
@@ -126,7 +126,7 @@ public class FileOperationTest {
         validFileCounter = 0;
 
         // Retrieve billing info
-        coreBillingAccountId = googleResourceConfiguration.getCoreBillingAccount();
+        coreBillingAccountId = testConfig.getGoogleBillingAccountId();
         profileModel = connectedOperations.createProfileForAccount(coreBillingAccountId);
 
         datasetSummary = connectedOperations.createDataset(profileModel, "snapshot-test-dataset.json");

--- a/src/test/java/bio/terra/service/resourcemanagement/BucketResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/BucketResourceTest.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement;
 
+import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.model.BillingProfileModel;
@@ -62,6 +63,7 @@ public class BucketResourceTest {
     @Autowired private GoogleResourceDao resourceDao;
     @Autowired private DataLocationService dataLocationService;
     @Autowired private ProfileService profileService;
+    @Autowired private ConnectedTestConfiguration testConfig;
     @MockBean private IamProviderInterface samService;
 
     private BillingProfileModel profile;
@@ -75,7 +77,7 @@ public class BucketResourceTest {
         allowReuseExistingBuckets = resourceService.getAllowReuseExistingBuckets();
         logger.info("app property allowReuseExistingBuckets = " + resourceService.getAllowReuseExistingBuckets());
 
-        profile = connectedOperations.createProfileForAccount(resourceConfiguration.getCoreBillingAccount());
+        profile = connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
         connectedOperations.stubOutSamCalls(samService);
         storage = StorageOptions.getDefaultInstance().getService();
         bucketNames = new ArrayList<>();

--- a/src/test/java/bio/terra/service/resourcemanagement/OneProjectPerProfileIdSelectorTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/OneProjectPerProfileIdSelectorTest.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement;
 
+import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.ProfileFixtures;
@@ -61,6 +62,9 @@ public class OneProjectPerProfileIdSelectorTest {
     @Autowired
     private ConfigurationService configService;
 
+    @Autowired
+    private ConnectedTestConfiguration testConfig;
+
     @MockBean
     private IamProviderInterface iamService;
 
@@ -76,7 +80,7 @@ public class OneProjectPerProfileIdSelectorTest {
     }
     @Test
     public void shouldGetCorrectIdForDataset() throws Exception {
-        String coreBillingAccountId = resourceConfiguration.getCoreBillingAccount();
+        String coreBillingAccountId = testConfig.getGoogleBillingAccountId();
         String profileName = ProfileFixtures.randomHex(16);
         BillingProfileRequestModel billingProfileRequestModel = ProfileFixtures.randomBillingProfileRequest()
             .billingAccountId(coreBillingAccountId)
@@ -94,7 +98,7 @@ public class OneProjectPerProfileIdSelectorTest {
 
     @Test
     public void shouldGetCorrectIdForDatasetWithSpecialChars() throws Exception {
-        String coreBillingAccountId = resourceConfiguration.getCoreBillingAccount();
+        String coreBillingAccountId = testConfig.getGoogleBillingAccountId();
         String namePrefix = "chars  ";
         String hexDigits = ProfileFixtures.randomHex(8);
         String profileName = namePrefix + hexDigits;
@@ -114,7 +118,7 @@ public class OneProjectPerProfileIdSelectorTest {
 
     @Test
     public void shouldGetCorrectIdForSnapshot() throws Exception {
-        String coreBillingAccountId = resourceConfiguration.getCoreBillingAccount();
+        String coreBillingAccountId = testConfig.getGoogleBillingAccountId();
         String profileName = ProfileFixtures.randomHex(16);
         BillingProfileRequestModel billingProfileRequestModel = ProfileFixtures.randomBillingProfileRequest()
             .billingAccountId(coreBillingAccountId)

--- a/src/test/java/bio/terra/service/resourcemanagement/ResourceServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ResourceServiceTest.java
@@ -1,6 +1,7 @@
 package bio.terra.service.resourcemanagement;
 
 
+import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.model.BillingProfileModel;
@@ -41,12 +42,13 @@ public class ResourceServiceTest {
     @Autowired private GoogleResourceConfiguration resourceConfiguration;
     @Autowired private GoogleResourceService resourceService;
     @Autowired private ConnectedOperations connectedOperations;
+    @Autowired private ConnectedTestConfiguration testConfig;
 
     private BillingProfileModel profile;
 
     @Before
     public void setup() throws Exception {
-        profile = connectedOperations.createProfileForAccount(resourceConfiguration.getCoreBillingAccount());
+        profile = connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
     }
 
     @After

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -126,7 +126,7 @@ public class SnapshotConnectedTest {
         connectedOperations.stubOutSamCalls(samService);
         configService.reset();
         billingProfile =
-            connectedOperations.createProfileForAccount(googleResourceConfiguration.getCoreBillingAccount());
+            connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
         datasetSummary = createTestDataset("snapshot-test-dataset.json");
         loadCsvData(datasetSummary.getId(), "thetable", "snapshot-test-dataset-data.csv");
     }

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -99,7 +99,7 @@ public class BigQueryPdaoTest {
         // Setup mock sam service
         connectedOperations.stubOutSamCalls(samService);
 
-        String coreBillingAccount = googleResourceConfiguration.getCoreBillingAccount();
+        String coreBillingAccount = testConfig.getGoogleBillingAccountId();
         profileModel = connectedOperations.createProfileForAccount(coreBillingAccount);
     }
 

--- a/src/test/resources/application-connectedtest.properties
+++ b/src/test/resources/application-connectedtest.properties
@@ -1,6 +1,7 @@
 # ct for connected test
 ct.ingestBucket=jade-testdata
 ct.ingestRequesterPaysBucket=jade_testbucket_requester_pays
+ct.googleBillingAccountId=00708C-45D19D-27AAFA
 
 # Variables usually defined in environment-specific helm definitions
 # Must define here for connected tests since they do not run against an external env

--- a/src/test/resources/application-integrationtest.properties
+++ b/src/test/resources/application-integrationtest.properties
@@ -4,6 +4,7 @@ it.jadePemFileName=${GOOGLE_SA_CERT}
 it.jadeEmail=jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com
 it.ingestbucket=jade-testdata
 it.googleProjectId=broad-jade-integration
+it.googleBillingAccountId=00708C-45D19D-27AAFA
 
 #users
 


### PR DESCRIPTION
Currently, we generate random billing IDs in our tests but we also sometimes pull the billing ID in tests from `google.coreBillingAccount` which lives in application.properties.  Given that this appears to be strictly for testing, the property shouldn't live in this file.  This PR:
- Moves the config into the connected and integration test configs and properties files
- Updates the tests to use the correct config methods
- Removes the conf from `GoogleResourceConfiguration`

Also, does a drive by in the testing code to close `InputStream`'s when reading resource files in our tests.  Happy to move that to a separate PR if we feel it's worthwhile.

I split the config bits into 2 commits to isolate the mechanical bits in order to make it easier to review