### PR TITLE
DR-1364 Pass server and billing account to disruptive script.

### DIFF
--- a/datarepo-clienttests/src/main/java/runner/DisruptiveScript.java
+++ b/datarepo-clienttests/src/main/java/runner/DisruptiveScript.java
@@ -1,14 +1,44 @@
 package runner;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
+import runner.config.ServerSpecification;
 import runner.config.TestUserSpecification;
 
+@SuppressFBWarnings(
+    value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+    justification =
+        "There are no disruptive scripts that currently need a billing account, but a disruptive script should have all the information that a test script has.")
 public abstract class DisruptiveScript {
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public DisruptiveScript() {}
 
+  protected String billingAccount;
+  protected ServerSpecification server;
   protected boolean manipulatesKubernetes = false;
+
+  /**
+   * Setter for the billing account property of this class. This property will be set by the Test
+   * Runner based on the current Test Configuration, and can be accessed by the Disruptive Script
+   * methods.
+   *
+   * @param billingAccount Google billing account id
+   */
+  public void setBillingAccount(String billingAccount) {
+    this.billingAccount = billingAccount;
+  }
+
+  /**
+   * Setter for the server specification property of this class. This property will be set by the
+   * Test Runner based on the current Test Configuration, and can be accessed by the Disruptive
+   * Script methods.
+   *
+   * @param server the specification of the server(s) this test runs against
+   */
+  public void setServer(ServerSpecification server) {
+    this.server = server;
+  }
 
   /**
    * Getter for the manipulates Kubernetes property of this class. This property may be overridden

--- a/datarepo-clienttests/src/main/java/runner/TestRunner.java
+++ b/datarepo-clienttests/src/main/java/runner/TestRunner.java
@@ -186,7 +186,9 @@ public class TestRunner {
           new DisruptiveThread(disruptiveScriptInstance, config.testUsers);
       disruptionThreadPool.execute(disruptiveThread);
       logger.debug("Successfully submitted disruptive thread.");
-      TimeUnit.SECONDS.sleep(1);
+      TimeUnit.SECONDS.sleep(
+          1); // give the disruptive script thread some time to start before kicking off the user
+      // journeys.
     }
 
     // set the start time for the user journey portion this test run

--- a/datarepo-clienttests/src/main/java/runner/TestRunner.java
+++ b/datarepo-clienttests/src/main/java/runner/TestRunner.java
@@ -173,15 +173,20 @@ public class TestRunner {
     // Disruptive Thread: fetch script specification if config is defined
     if (config.disruptiveScript != null) {
       logger.debug("Creating thread pool for disruptive script.");
-      DisruptiveScript disruptiveScript = config.disruptiveScript.disruptiveScriptClassInstance();
-      disruptiveScript.setParameters(config.disruptiveScript.parameters);
+      DisruptiveScript disruptiveScriptInstance =
+          config.disruptiveScript.disruptiveScriptClassInstance();
+      disruptiveScriptInstance.setBillingAccount(config.billingAccount);
+      disruptiveScriptInstance.setServer(config.server);
+      disruptiveScriptInstance.setParameters(config.disruptiveScript.parameters);
 
       // create a thread pool for running its disrupt method
       disruptionThreadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(1);
 
-      DisruptiveThread disruptiveThread = new DisruptiveThread(disruptiveScript, config.testUsers);
+      DisruptiveThread disruptiveThread =
+          new DisruptiveThread(disruptiveScriptInstance, config.testUsers);
       disruptionThreadPool.execute(disruptiveThread);
       logger.debug("Successfully submitted disruptive thread.");
+      TimeUnit.SECONDS.sleep(1);
     }
 
     // set the start time for the user journey portion this test run
@@ -246,7 +251,7 @@ public class TestRunner {
 
     // shutdown the disrupt thread pool
     if (disruptionThreadPool != null) {
-      logger.debug("Force shut down of the disruption thread pool");
+      logger.debug("Tell the disruption thread pool to shutdown");
       disruptionThreadPool.shutdownNow();
       if (!disruptionThreadPool.awaitTermination(secondsToWaitForPoolShutdown, TimeUnit.SECONDS)) {
         logger.error("Disruption Script: Thread pool for disruption script failed to terminate");
@@ -380,7 +385,6 @@ public class TestRunner {
   private static class DisruptiveThread implements Runnable {
     DisruptiveScript disruptiveScript;
     List<TestUserSpecification> testUsers;
-    int waitBeforeStartingDisrupt = 15;
 
     public DisruptiveThread(
         DisruptiveScript disruptiveScript, List<TestUserSpecification> testUsers) {
@@ -390,8 +394,6 @@ public class TestRunner {
 
     public void run() {
       try {
-        // give task time to get started before disruption
-        TimeUnit.SECONDS.sleep(waitBeforeStartingDisrupt);
         disruptiveScript.disrupt(testUsers);
       } catch (Exception ex) {
         logger.info("Disruptive thread threw exception: {}", ex.getMessage());

--- a/datarepo-clienttests/src/main/java/scripts/disruptivescripts/DeleteInitialPods.java
+++ b/datarepo-clienttests/src/main/java/scripts/disruptivescripts/DeleteInitialPods.java
@@ -4,20 +4,26 @@ import common.utils.KubernetesClientUtils;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import runner.DisruptiveScript;
 import runner.config.TestUserSpecification;
 
 public class DeleteInitialPods extends DisruptiveScript {
+  private static final Logger logger = LoggerFactory.getLogger(DeleteInitialPods.class);
+
   public DeleteInitialPods() {
     super();
     manipulatesKubernetes = true;
   }
 
-  private static final Logger logger = LoggerFactory.getLogger(DeleteInitialPods.class);
+  protected static final int secondsToWaitBeforeStartingDisrupt = 15;
 
   public void disrupt(List<TestUserSpecification> testUsers) throws Exception {
+    // give user journey threads time to get started before disruption
+    TimeUnit.SECONDS.sleep(secondsToWaitBeforeStartingDisrupt);
+
     logger.info(
         "Starting disruption - all initially created api pods will be deleted, one by one.");
 

--- a/datarepo-clienttests/src/main/java/scripts/disruptivescripts/EnableFaults.java
+++ b/datarepo-clienttests/src/main/java/scripts/disruptivescripts/EnableFaults.java
@@ -1,0 +1,46 @@
+package scripts.disruptivescripts;
+
+import bio.terra.datarepo.api.RepositoryApi;
+import bio.terra.datarepo.client.ApiClient;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import runner.DisruptiveScript;
+import runner.config.TestUserSpecification;
+import scripts.utils.DataRepoUtils;
+
+public class EnableFaults extends DisruptiveScript {
+  private static final Logger logger = LoggerFactory.getLogger(EnableFaults.class);
+
+  public EnableFaults() {
+    super();
+  }
+
+  protected List<String> faultNames;
+
+  public void setParameters(List<String> parameters) {
+    if (parameters == null || parameters.size() == 0) {
+      throw new IllegalArgumentException(
+          "At least one parameter is required: name of the fault(s) to enable (e.g. SAM_TIMEOUT_FAULT, CREATE_ASSET_FAULT)");
+    }
+    faultNames = parameters;
+  }
+
+  public void disrupt(List<TestUserSpecification> testUsers) throws Exception {
+    logger.info("Starting disruptive script: Resetting config, enabling faults.");
+
+    // just pick the first test user
+    ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUsers.get(0), server);
+    RepositoryApi repositoryApi = new RepositoryApi(apiClient);
+
+    // reset the config
+    repositoryApi.resetConfig();
+    logger.info("Config reset");
+
+    // enable the faults
+    for (String faultName : faultNames) {
+      repositoryApi.setFault(faultName, true);
+      logger.info("Fault enabled: {}", faultName);
+    }
+  }
+}

--- a/datarepo-clienttests/src/main/java/scripts/disruptivescripts/RandomPodDelete.java
+++ b/datarepo-clienttests/src/main/java/scripts/disruptivescripts/RandomPodDelete.java
@@ -9,15 +9,16 @@ import runner.DisruptiveScript;
 import runner.config.TestUserSpecification;
 
 public class RandomPodDelete extends DisruptiveScript {
+  private static final Logger logger = LoggerFactory.getLogger(RandomPodDelete.class);
+
   public RandomPodDelete() {
     super();
     manipulatesKubernetes = true;
   }
 
-  private static final Logger logger = LoggerFactory.getLogger(RandomPodDelete.class);
-
   private int repeatCount = 1;
   private int secondsBetweenRepeat = 30;
+  protected static final int secondsToWaitBeforeStartingDisrupt = 15;
 
   public void setParameters(List<String> parameters) {
 
@@ -39,6 +40,9 @@ public class RandomPodDelete extends DisruptiveScript {
   }
 
   public void disrupt(List<TestUserSpecification> testUsers) throws Exception {
+    // give user journey threads time to get started before disruption
+    TimeUnit.SECONDS.sleep(secondsToWaitBeforeStartingDisrupt);
+
     logger.info(
         "Starting disruption - A single random pod will be deleted {} times at {} second intervals.",
         repeatCount,

--- a/datarepo-clienttests/src/main/resources/configs/functional/BasicAuthenticatedWithSAMTimeout.json
+++ b/datarepo-clienttests/src/main/resources/configs/functional/BasicAuthenticatedWithSAMTimeout.json
@@ -1,0 +1,22 @@
+{
+  "name": "BasicAuthenticatedWithSAMTimeout",
+  "description": "Two users fetch the available profiles repeatedly, concurrently. SAM timeout fault enabled.",
+  "serverSpecificationFile": "perf.json",
+  "billingAccount": "00708C-45D19D-27AAFA",
+  "kubernetes": {},
+  "application": {},
+  "disruptiveScript": {
+    "name": "EnableFaults",
+    "parameters": ["SAM_TIMEOUT_FAULT", "CREATE_ASSET_FAULT"]
+  },
+  "testScripts": [
+    {
+      "name": "EnumerateProfiles",
+      "totalNumberToRun": 50,
+      "numberToRunInParallel": 2,
+      "expectedTimeForEach": 5,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": ["dumbledore.json", "hermione.json"]
+}


### PR DESCRIPTION
- Passed the server and billing account to disruptive script. This now matches what the Test Runner passes to test scripts. Importantly, this allows the disruptive scripts to make calls with the API client.
- Added an example disruptive script that resets the config and enables a list of faults. Included a config that uses this disruptive script.
- Changed the brief wait between kicking off the disruptive script thread and kicking off the user journey threads from 15 seconds to 1 second. Moved the longer wait into the Kubernetes-specific disruptive scripts that really wanted this longer wait time.