### PR TITLE
DR-1365 Move fault enable into PUT body for HTTP compliance

### DIFF
--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -8,6 +8,7 @@ import bio.terra.controller.RepositoryApi;
 import bio.terra.model.AssetModel;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.model.ConfigEnableModel;
 import bio.terra.model.ConfigGroupModel;
 import bio.terra.model.ConfigListModel;
 import bio.terra.model.ConfigModel;
@@ -526,9 +527,8 @@ public class RepositoryApiController implements RepositoryApi {
 
     @Override
     public ResponseEntity<Void> setFault(@PathVariable("name") String name,
-                                         @Valid @RequestParam(value = "enable", required = false, defaultValue = "true")
-                                             Boolean enable) {
-        configurationService.setFault(name, enable);
+                                         @Valid @RequestBody ConfigEnableModel configEnable) {
+        configurationService.setFault(name, configEnable.isEnabled());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1460,11 +1460,11 @@ paths:
           required: true
           in: path
           type: string
-        - in: query
-          name: enable
+        - in: body
+          name: configEnable
           type: boolean
-          default: true
-          description: whether to enable (default) or disable the fault
+          schema:
+            $ref: '#/definitions/ConfigEnableModel'
       responses:
         204:
           description: fault was en/dis-abled successfully - no content
@@ -2873,6 +2873,7 @@ definitions:
   #      logging:
   #        $ref: '#/definitions/ConfigLoggingModel'
 
+
   ConfigFaultModel:
     description: Fault control parameters
     properties:
@@ -2964,8 +2965,15 @@ definitions:
         items:
           $ref: '#/definitions/ConfigModel'
 
+  ConfigEnableModel:
+    description: Control whether a fault is enabled
+    properties:
+      enabled:
+        type: boolean
+        default: true
+        description: whether to enable (default) or disable the fault
 
-##########################################################################################
+  ##########################################################################################
 # DRS DEFINITIONS
 ##########################################################################################
   DRSChecksum:

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -10,6 +10,7 @@ import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadArrayResultModel;
+import bio.terra.model.ConfigEnableModel;
 import bio.terra.model.ConfigGroupModel;
 import bio.terra.model.ConfigListModel;
 import bio.terra.model.ConfigModel;
@@ -598,9 +599,11 @@ public class DataRepoFixtures {
     public DataRepoResponse<ConfigModel> setFault(TestConfiguration.User user,
                                                   String configName,
                                                   boolean enable) throws Exception {
+        ConfigEnableModel configEnableModel = new ConfigEnableModel().enabled(enable);
+        String json = TestUtils.mapToJson(configEnableModel);
         return dataRepoClient.put(user,
-            "/api/repository/v1/configs/" + configName + "?enable=" + enable,
-            null,
+            "/api/repository/v1/configs/" + configName,
+            json,
             null); // TODO should this validation on returned value?
     }
 


### PR DESCRIPTION
It turns out that when you use put you are supposed to provide a body. The jersey client complains about this. We had never used this through the jade client. Clearly no one else had either, i am making this not backward compatible change.

