### PR TITLE
DR-1367 Build client from top level directory

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -87,7 +87,7 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.9'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@mm-build-client-from-top-level-directory
+        uses: broadinstitute/datarepo-actions@0.27.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -87,7 +87,7 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.9'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@0.26.0
+        uses: broadinstitute/datarepo-actions@mm-build-client-from-top-level-directory
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}
           echo "Building Data Repo client library"
-          ENABLE_SUBPROJECT_TASKS=1 ./gradlew clean assemble
+          ENABLE_SUBPROJECT_TASKS=1 ./gradlew :datarepo-client:clean :datarepo-client:assemble
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
           export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
           echo "Running TestRunner suite"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -8,11 +8,8 @@ env:
   GOOGLE_ZONE: us-central1
   K8_CLUSTER: jade-master-us-central1
 on:
-#  schedule:
-#    - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
-  pull_request:
-    branches:
-      - develop
+  schedule:
+    - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
 jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
@@ -73,7 +70,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
           export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
           echo "Running TestRunner suite"
-          ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults"
+          ./gradlew runTest --args="suites/NightlyPerfWorkflow.json tmp/TestRunnerResults"
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Clean whitelisted Runner IP"
         if: always()

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}
           echo "Building Data Repo client library"
-          ./gradlew clean assemble
+          ENABLE_SUBPROJECT_TASKS=1 ./gradlew clean assemble
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
           export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
           echo "Running TestRunner suite"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -64,9 +64,9 @@ jobs:
           done
       - name: "Build and run Test Runner"
         run: |
-          cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-client
+          cd ${GITHUB_WORKSPACE}/${workingDir}
           echo "Building Data Repo client library"
-          ../gradlew clean assemble
+          ./gradlew clean assemble
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
           export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
           echo "Running TestRunner suite"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -8,8 +8,11 @@ env:
   GOOGLE_ZONE: us-central1
   K8_CLUSTER: jade-master-us-central1
 on:
-  schedule:
-    - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
+#  schedule:
+#    - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
+  pull_request:
+    branches:
+      - develop
 jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
@@ -70,7 +73,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
           export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
           echo "Running TestRunner suite"
-          ./gradlew runTest --args="suites/NightlyPerfWorkflow.json tmp/TestRunnerResults"
+          ./gradlew runTest --args="suites/PRSmokeTests.json tmp/TestRunnerResults"
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Clean whitelisted Runner IP"
         if: always()

--- a/datarepo-clienttests/src/main/java/scripts/deploymentscripts/LaunchLocalProcess.java
+++ b/datarepo-clienttests/src/main/java/scripts/deploymentscripts/LaunchLocalProcess.java
@@ -77,8 +77,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
     // call the unauthenticated status endpoint
     try {
-      unauthenticatedApi.serviceStatus();
-      int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
+      int httpStatus = unauthenticatedApi.serviceStatusWithHttpInfo().getStatusCode();
       statusRequestOK = HttpStatusCodes.isSuccess(httpStatus);
     } catch (Exception ex) {
       statusRequestOK = false;
@@ -118,8 +117,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     while (pollCtr >= 0) {
       // call the unauthenticated status endpoint
       try {
-        unauthenticatedApi.serviceStatus();
-        int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
+        int httpStatus = unauthenticatedApi.serviceStatusWithHttpInfo().getStatusCode();
         logger.debug("Service status: {}", httpStatus);
         if (HttpStatusCodes.isSuccess(httpStatus)) {
           break;
@@ -160,8 +158,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
     // call the unauthenticated status endpoint
     try {
-      unauthenticatedApi.serviceStatus();
-      int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
+      int httpStatus = unauthenticatedApi.serviceStatusWithHttpInfo().getStatusCode();
       statusRequestOK = HttpStatusCodes.isSuccess(httpStatus);
     } catch (Exception ex) {
       statusRequestOK = false;

--- a/datarepo-clienttests/src/main/java/scripts/deploymentscripts/ModularHelmChart.java
+++ b/datarepo-clienttests/src/main/java/scripts/deploymentscripts/ModularHelmChart.java
@@ -191,8 +191,7 @@ public class ModularHelmChart extends DeploymentScript {
     while (pollCtr >= 0) {
       // call the unauthenticated status endpoint
       try {
-        unauthenticatedApi.serviceStatus();
-        int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
+        int httpStatus = unauthenticatedApi.serviceStatusWithHttpInfo().getStatusCode();
         logger.debug("Service status: {}", httpStatus);
         if (HttpStatusCodes.isSuccess(httpStatus)) {
           break;

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/EnumerateProfiles.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/EnumerateProfiles.java
@@ -2,6 +2,7 @@ package scripts.testscripts;
 
 import bio.terra.datarepo.api.ResourcesApi;
 import bio.terra.datarepo.client.ApiClient;
+import bio.terra.datarepo.client.ApiResponse;
 import bio.terra.datarepo.model.EnumerateBillingProfileModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,9 +21,11 @@ public class EnumerateProfiles extends runner.TestScript {
   public void userJourney(TestUserSpecification testUser) throws Exception {
     ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
     ResourcesApi resourcesApi = new ResourcesApi(apiClient);
-    EnumerateBillingProfileModel profiles = resourcesApi.enumerateProfiles(0, 10);
+    ApiResponse<EnumerateBillingProfileModel> response =
+        resourcesApi.enumerateProfilesWithHttpInfo(0, 10);
+    EnumerateBillingProfileModel profiles = response.getData();
 
-    int httpStatus = resourcesApi.getApiClient().getStatusCode();
+    int httpStatus = response.getStatusCode();
     logger.debug(
         "Enumerate profiles: HTTP status {}, number of profiles found = {}",
         httpStatus,

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/ServiceStatus.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/ServiceStatus.java
@@ -18,9 +18,8 @@ public class ServiceStatus extends runner.TestScript {
   public void userJourney(TestUserSpecification testUser) throws Exception {
     ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
-    unauthenticatedApi.serviceStatus();
 
-    int httpStatus = unauthenticatedApi.getApiClient().getStatusCode();
+    int httpStatus = unauthenticatedApi.serviceStatusWithHttpInfo().getStatusCode();
     logger.debug("Service status: {}", httpStatus);
   }
 }


### PR DESCRIPTION
Note: There is a related [PR](https://github.com/broadinstitute/datarepo-actions/pull/34) in the datarepo-actions repository that needs to be merged in coordination with this.

When we changed to building the client library from the top-level directory instead of from the datarepo-client sub-directory, some API methods changed. This caused compile errors in the Test Runner tests that called these methods. This did not cause failures in the GH actions that ran Test Runner suites because they built the client locally instead of pulling from Maven (this is necessary because the code under test is not always merged yet).

These 2 PRs change the Test Runner to work with the updated client library, as built from the top-level directory. They also update the on-PR and perf-nightly GH actions to build the client locally from the top-level directory, so that the generated JAR file will always match what is pushed to Maven on merge.