### PR TITLE
DR-1369 Fix exception handling for firestore batches

### DIFF
--- a/src/main/java/bio/terra/app/configuration/JdbcConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/JdbcConfiguration.java
@@ -99,6 +99,10 @@ public class JdbcConfiguration {
         props.setProperty("password", getPassword());
         props.setProperty("maxTotal", String.valueOf(poolMaxTotal));
         props.setProperty("maxIdle", String.valueOf(poolMaxIdle));
+        // TODO: these two settings are for trying to debug our connection hang issue.
+        //  They should be removed after that is figured out. Further, we plan to
+        //  replace dbcp2 with a different connection pooler, at which point they will
+        //  be obsolete.
         props.setProperty("logExpiredConnections", "true");
         props.setProperty("logAbandoned", "true");
 

--- a/src/main/java/bio/terra/app/configuration/JdbcConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/JdbcConfiguration.java
@@ -99,6 +99,8 @@ public class JdbcConfiguration {
         props.setProperty("password", getPassword());
         props.setProperty("maxTotal", String.valueOf(poolMaxTotal));
         props.setProperty("maxIdle", String.valueOf(poolMaxIdle));
+        props.setProperty("logExpiredConnections", "true");
+        props.setProperty("logAbandoned", "true");
 
         ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(getUri(), props);
 


### PR DESCRIPTION
I also added logging properties that may or may not do anything to get dbcp2 to tell us what is going on.
