### PR TITLE
DR-1373: Re-enable snapshotByQueryHappyPathTest in Alpha

### DIFF
--- a/.github/workflows/alpha-integration-tests.yaml
+++ b/.github/workflows/alpha-integration-tests.yaml
@@ -74,13 +74,6 @@ jobs:
         pg_isready -h ${PGHOST} -p 5432
         psql -U postgres -f ./db/create-data-repo-db
 
-        # disable snapshotByQueryHappyPathTest
-        FILE="./src/test/java/bio/terra/service/snapshot/SnapshotTest.java"
-        NR=$(awk "/snapshotByQueryHappyPathTest/{print NR-1}" ${FILE})
-        sed -i \
-          -e "s/^import org.junit.Test;/import org.junit.Ignore;\nimport org.junit.Test;/" \
-          -e "${NR}s/@Test/@Ignore\n    @Test/" ${FILE}
-
         # run integration tests
         ./gradlew assemble
         ./gradlew testIntegration --scan


### PR DESCRIPTION
Now that https://github.com/DataBiosphere/jade-data-repo/pull/636 is in, remove hacky code that disabled this test.