### PR TITLE
DR-1377 Fixes to Postgres connection management

### DIFF
--- a/src/main/java/bio/terra/app/configuration/JdbcConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/JdbcConfiguration.java
@@ -98,21 +98,13 @@ public class JdbcConfiguration {
         final Properties props = new Properties();
         props.setProperty("user", getUsername());
         props.setProperty("password", getPassword());
-        props.setProperty("maxTotal", String.valueOf(poolMaxTotal));
-        props.setProperty("maxIdle", String.valueOf(poolMaxIdle));
-        // TODO: these two settings are for trying to debug our connection hang issue.
-        //  They should be removed after that is figured out. Further, we plan to
-        //  replace dbcp2 with a different connection pooler, at which point they will
-        //  be obsolete.
-        props.setProperty("logExpiredConnections", "true");
-        props.setProperty("logAbandoned", "true");
 
         final ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(getUri(), props);
 
         final PoolableConnectionFactory poolableConnectionFactory =
                 new PoolableConnectionFactory(connectionFactory, null);
 
-        final GenericObjectPoolConfig<PoolableConnection> config = new GenericObjectPoolConfig();
+        final GenericObjectPoolConfig<PoolableConnection> config = new GenericObjectPoolConfig<>();
         config.setMaxTotal(poolMaxTotal);
         config.setMaxIdle(poolMaxIdle);
         final ObjectPool<PoolableConnection> connectionPool =

--- a/src/main/java/bio/terra/app/configuration/JdbcConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/JdbcConfiguration.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 import java.util.Properties;
 
@@ -94,7 +95,7 @@ public class JdbcConfiguration {
     }
 
     private void configureDataSource() {
-        Properties props = new Properties();
+        final Properties props = new Properties();
         props.setProperty("user", getUsername());
         props.setProperty("password", getPassword());
         props.setProperty("maxTotal", String.valueOf(poolMaxTotal));
@@ -106,13 +107,16 @@ public class JdbcConfiguration {
         props.setProperty("logExpiredConnections", "true");
         props.setProperty("logAbandoned", "true");
 
-        ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(getUri(), props);
+        final ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(getUri(), props);
 
-        PoolableConnectionFactory poolableConnectionFactory =
+        final PoolableConnectionFactory poolableConnectionFactory =
                 new PoolableConnectionFactory(connectionFactory, null);
 
-        ObjectPool<PoolableConnection> connectionPool =
-                new GenericObjectPool<>(poolableConnectionFactory);
+        final GenericObjectPoolConfig<PoolableConnection> config = new GenericObjectPoolConfig();
+        config.setMaxTotal(poolMaxTotal);
+        config.setMaxIdle(poolMaxIdle);
+        final ObjectPool<PoolableConnection> connectionPool =
+                new GenericObjectPool<>(poolableConnectionFactory, config);
 
         poolableConnectionFactory.setPool(connectionPool);
 


### PR DESCRIPTION
A couple of things in this PR:
- It doesn't look like dbcp2 was actually getting our maxIdle and maxConnections settings so I'm explicitly setting those properties when we initialize the connection pool
- Looks like we were asking (and hanging on to) a couple of connections when instantiating DAO classes.  We should only keep the connection pool as the member variable and ask for a connection as needed
- Make sure to close a `Stream` that we weren't closing