### PR TITLE
DR-1384 More Firestore retries

### DIFF
--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreBatchQueryIterator.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreBatchQueryIterator.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public class FireStoreBatchQueryIterator {
     private static final Logger logger = LoggerFactory.getLogger(FireStoreBatchQueryIterator.class);
@@ -85,6 +86,8 @@ public class FireStoreBatchQueryIterator {
                     throw new FileSystemExecutionException("get batch execution exception", ex);
                 }
             }
+
+            TimeUnit.MILLISECONDS.sleep(SLEEP_MILLISECONDS);
         }
         throw new FileSystemExecutionException("get batch failed - no more retries");
     }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreBatchQueryIterator.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreBatchQueryIterator.java
@@ -3,10 +3,12 @@ package bio.terra.service.filedata.google.firestore;
 
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.rpc.AbortedException;
+import com.google.api.gax.rpc.DeadlineExceededException;
+import com.google.api.gax.rpc.UnavailableException;
 import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
-import com.google.cloud.firestore.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,30 +18,31 @@ import java.util.concurrent.ExecutionException;
 public class FireStoreBatchQueryIterator {
     private static final Logger logger = LoggerFactory.getLogger(FireStoreBatchQueryIterator.class);
 
+    private static final int RETRIES = 3;
+    private static final int SLEEP_MILLISECONDS = 1000;
+
+
     private final Query baseQuery;
     private final int batchSize;
-    private final Transaction transaction;
     private List<QueryDocumentSnapshot> currentList;
     private int count;
 
     /**
      * Construct and iterator over a query with a specific batch size.
+     *
      * @param baseQuery the base query
      * @param batchSize the size of batches to request
      */
-    public FireStoreBatchQueryIterator(Query baseQuery, int batchSize, Transaction transaction) {
+    public FireStoreBatchQueryIterator(Query baseQuery, int batchSize) {
         this.baseQuery = baseQuery;
         this.batchSize = batchSize;
-        this.transaction = transaction;
         this.currentList = null;
         this.count = 0;
     }
 
-    public FireStoreBatchQueryIterator(Query baseQuery, int batchSize) {
-        this(baseQuery, batchSize, null);
-    }
     /**
      * Get the next batch of documents
+     *
      * @return a list of documents, or no if the iteration is complete
      * @throws InterruptedException on pod shut down
      */
@@ -58,25 +61,32 @@ public class FireStoreBatchQueryIterator {
             query = baseQuery.startAfter(lastDoc).limit(batchSize);
         }
 
-        // Get the next batch; use the transaction if we have it
+        // Get the next batch
         logger.info("Retrieving batch {} with batch size of {}", count, batchSize);
         count++;
-        ApiFuture<QuerySnapshot> querySnapshot;
-        if (transaction == null) {
-            querySnapshot = query.get();
-        } else {
-            querySnapshot = transaction.get(query);
-        }
 
-        try {
-            currentList = querySnapshot.get().getDocuments();
-        } catch (ExecutionException ex) {
-            throw new FileSystemExecutionException("has reference - execution exception", ex);
+        for (int i = 0; i < RETRIES; i++) {
+            ApiFuture<QuerySnapshot> querySnapshot = query.get();
+
+            try {
+                currentList = querySnapshot.get().getDocuments();
+                if (currentList.size() == 0) {
+                    // Nothing to return so we at the end of the iteration
+                    return null;
+                }
+                return currentList;
+            } catch (DeadlineExceededException |
+                UnavailableException |
+                AbortedException |
+                ExecutionException ex) {
+                if (FireStoreUtils.shouldRetry(ex)) {
+                    logger.warn("Retry-able error in firestore future get - message: " + ex.getMessage());
+                } else {
+                    throw new FileSystemExecutionException("get batch execution exception", ex);
+                }
+            }
         }
-        if (currentList.size() == 0) {
-            // Nothing to return so we at the end of the iteration
-            return null;
-        }
-        return currentList;
+        throw new FileSystemExecutionException("get batch failed - no more retries");
     }
+
 }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -183,7 +183,7 @@ public class FireStoreUtils {
                 break;
             }
 
-            // tried to collect a response for every request we generated
+            // try to collect a response for every request we generated
             int completeCount = 0;
             for (int i = 0; i < inputSize; i++) {
                 ApiFuture<T> future = futures.get(i);
@@ -195,12 +195,15 @@ public class FireStoreUtils {
                         UnavailableException |
                         AbortedException |
                         ExecutionException ex) {
-                        if (!shouldRetry(ex, inputs.get(i))) {
+                        if (shouldRetry(ex)) {
+                            logger.warn("Retry-able error in firestore future get - input: " +
+                                inputs.get(i) + " message: " + ex.getMessage());
+                        } else
                             throw new FileSystemExecutionException("batch operation failed", ex);
-                        }
                     }
                 }
             }
+
             // If we completed our requests we are done
             if (completeCount == requestCount) {
                 break;
@@ -219,18 +222,17 @@ public class FireStoreUtils {
         return outputs;
     }
 
-    private <V> boolean shouldRetry(Throwable throwable, V input) {
+    static boolean shouldRetry(Throwable throwable) {
         if (throwable == null) {
             return false; // Did not find a retry-able exception
         }
         if (throwable instanceof DeadlineExceededException ||
             throwable instanceof UnavailableException ||
             throwable instanceof AbortedException) {
-            logger.warn("Retry-able error in firestore future get - input: " +
-                input + " message: " + throwable.getMessage());
+
             return true;
         }
-        return shouldRetry(throwable.getCause(), input);
+        return shouldRetry(throwable.getCause());
     }
 
 }


### PR DESCRIPTION
I removed the transaction around directory enumerate. It is not needed and ends up holding a transaction over hundreds of thousands of requests.

Added a common method in FireStoreUtils for deciding retry-able.

Updated the FireStoreBatchQueryIterator to have a retry loop and sleep so it can redo queries on contention.