### PR TITLE
DR-1376: Apply semantic versioning in GCR on dev merge

### DIFF
--- a/.github/workflows/alpha-nightly.yaml
+++ b/.github/workflows/alpha-nightly.yaml
@@ -5,6 +5,7 @@ env:
   # This must be defined for the bash redirection
   GOOGLE_SA_CERT: 'jade-dev-account.pem'
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
 jobs:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -60,7 +60,7 @@ jobs:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: 'integration-4,integration-5'
       - name: Trigger action to tag containers with semantic version
-        uses: benc-uk/workflow-dispatch@v1
+        uses: broadinstitute/workflow-dispatch@v1
         with:
           workflow: Alpha Nightly
           token: ${{ secrets.WORKFLOW_DISPATCH }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -59,6 +59,11 @@ jobs:
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: 'integration-4,integration-5'
+      - name: Tag containers with semantic version
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Alpha Nightly
+          token: ${{ secrets.WORKFLOW_DISPATCH }}
       - name: Slack job status
         if: always()
         uses: broadinstitute/action-slack@v2

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: 'integration-4,integration-5'
-      - name: Tag containers with semantic version
+      - name: Trigger action to tag containers with semantic version
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Alpha Nightly


### PR DESCRIPTION
Currently, we update the semantic version of the repository and the repository tag on every dev merge. However, the containers that are pushed into GCR do not have the associated semantic version (they have a git hash). This means that if there were many dev updates in a day then only a single container per night is appropriately tagged with a semantic version in GCR, and there are "gaps" between versions which causes issues. This updates the actions so that the semantic versioning in the repo is in sync with the semantic versioning in GCR.