### PR TITLE
DR-1385 Remove additional profile ids

### DIFF
--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -139,15 +139,6 @@ public class Dataset implements FSContainerInterface {
         return this;
     }
 
-    public List<UUID> getAdditionalProfileIds() {
-        return datasetSummary.getAdditionalProfileIds();
-    }
-
-    public Dataset additionalProfileIds(List<UUID> additionalProfileIds) {
-        datasetSummary.additionalProfileIds(additionalProfileIds);
-        return this;
-    }
-
     public Instant getCreatedDate() {
         return datasetSummary.getCreatedDate();
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -1,8 +1,8 @@
 package bio.terra.service.dataset;
 
-import bio.terra.app.configuration.DataRepoJdbcConfiguration;
 import bio.terra.common.DaoKeyHolder;
 import bio.terra.common.DaoUtils;
+import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.exception.RetryQueryException;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
@@ -10,12 +10,15 @@ import bio.terra.service.dataset.exception.DatasetLockException;
 import bio.terra.service.dataset.exception.DatasetNotFoundException;
 import bio.terra.service.dataset.exception.InvalidDatasetException;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
-import bio.terra.common.MetadataEnumeration;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.*;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -26,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.sql.Array;
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -39,40 +41,39 @@ import static bio.terra.common.DaoUtils.retryQuery;
 public class DatasetDao {
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
-    private final Connection connection;
     private final DatasetTableDao tableDao;
     private final DatasetRelationshipDao relationshipDao;
     private final AssetDao assetDao;
+    private final ConfigurationService configurationService;
 
-    private static Logger logger = LoggerFactory.getLogger(DatasetDao.class);
-
-    @Autowired
-    private ConfigurationService configurationService;
+    private static final Logger logger = LoggerFactory.getLogger(DatasetDao.class);
 
     @Autowired
-    public DatasetDao(DataRepoJdbcConfiguration jdbcConfiguration,
-                    DatasetTableDao tableDao,
-                    DatasetRelationshipDao relationshipDao,
-                    AssetDao assetDao) throws SQLException {
-        jdbcTemplate = new NamedParameterJdbcTemplate(jdbcConfiguration.getDataSource());
-        connection = jdbcConfiguration.getDataSource().getConnection();
+    public DatasetDao(NamedParameterJdbcTemplate jdbcTemplate,
+                      DatasetTableDao tableDao,
+                      DatasetRelationshipDao relationshipDao,
+                      AssetDao assetDao,
+                      ConfigurationService configurationService) throws SQLException {
+        this.jdbcTemplate = jdbcTemplate;
         this.tableDao = tableDao;
         this.relationshipDao = relationshipDao;
         this.assetDao = assetDao;
+        this.configurationService = configurationService;
     }
 
     /**
      * Take an exclusive lock on the dataset object before doing something with it (e.g. delete).
      * This method returns successfully when this flight has an exclusive lock on the dataset object, and
      * throws an exception in all other cases. So, multiple locks can succeed with no errors. Logic flow of the method:
-     *     1. Update the dataset record to give this flight the lock.
-     *     2. Throw an exception if no records were updated.
+     * 1. Update the dataset record to give this flight the lock.
+     * 2. Throw an exception if no records were updated.
+     *
      * @param datasetId id of the dataset to lock, this is a unique column
-     * @param flightId flight id that wants to lock the dataset
-     * @throws DatasetLockException if the dataset is locked by another flight, either a shared or exclusive lock
+     * @param flightId  flight id that wants to lock the dataset
+     * @throws DatasetLockException     if the dataset is locked by another flight, either a shared or exclusive lock
      * @throws DatasetNotFoundException if the dataset does not exist
      */
-    @Transactional(propagation =  Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
     public void lockExclusive(UUID datasetId, String flightId) {
         if (flightId == null) {
             throw new DatasetLockException("Locking flight id cannot be null");
@@ -98,11 +99,12 @@ public class DatasetDao {
      * exception in this case. So, multiple unlocks can succeed with no errors. The method does return a boolean
      * indicating whether any rows were updated or not. So, callers can decide to throw an error if the unlock
      * was a no-op.
+     *
      * @param datasetId id of the dataset to unlock, this is a unique column
-     * @param flightId flight id that wants to unlock the dataset
+     * @param flightId  flight id that wants to unlock the dataset
      * @return true if a dataset exclusive lock was released, false otherwise
      */
-    @Transactional(propagation =  Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
     public boolean unlockExclusive(UUID datasetId, String flightId) {
         logger.debug("Lock Operation: Unlocking exclusive lock for datasetId: {}, flightId: {}", datasetId, flightId);
         // update the dataset entry to remove the flightid IF it is currently set to this flightid
@@ -120,17 +122,16 @@ public class DatasetDao {
         return unlockSucceeded;
     }
 
-
-
     /**
      * Take a shared lock on the dataset object before doing something with it (e.g. file ingest, file delete).
      * This method returns successfully when this flight has a shared lock on the dataset object, and
      * throws an exception in all other cases. So, multiple locks can succeed with no errors. Logic flow of the method:
-     *     1. Update the dataset record to give this flight a shared lock.
-     *     2. Throw an exception if no records were updated.
+     * 1. Update the dataset record to give this flight a shared lock.
+     * 2. Throw an exception if no records were updated.
+     *
      * @param datasetId id of the dataset to lock, this is a unique column
-     * @param flightId flight id that wants to lock the dataset
-     * @throws DatasetLockException if another flight has an exclusive lock on the dataset
+     * @param flightId  flight id that wants to lock the dataset
+     * @throws DatasetLockException     if another flight has an exclusive lock on the dataset
      * @throws DatasetNotFoundException if the dataset does not exist
      */
     @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
@@ -150,13 +151,12 @@ public class DatasetDao {
             // the ARRAY_AGG function will return null if passed zero rows, but that will never be the case here
             // because we are appending a new element, so there will always be at least one row
             "(SELECT ARRAY_AGG(DISTINCT arrayelt) " +
-                "FROM UNNEST(ARRAY_APPEND(sharedlock, :flightid::text)) arrayelt) " +
+            "FROM UNNEST(ARRAY_APPEND(sharedlock, :flightid::text)) arrayelt) " +
 
             "WHERE id = :datasetid AND flightid IS NULL";
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("datasetid", datasetId)
             .addValue("flightid", flightId);
-
 
 
         int numRowsUpdated = performLockQuery(sql, params, LockType.LockShared, datasetId);
@@ -171,11 +171,12 @@ public class DatasetDao {
      * an exception in this case. So, multiple unlocks can succeed with no errors. The method does return a boolean
      * indicating whether any rows were updated or not. So, callers can decide to throw an error if the unlock was
      * a no-op.
+     *
      * @param datasetId id of the dataset to unlock, this is a unique column
-     * @param flightId flight id that wants to unlock the dataset
+     * @param flightId  flight id that wants to unlock the dataset
      * @return true if a dataset shared lock was released, false otherwise
      */
-    @Transactional(propagation =  Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
     public boolean unlockShared(UUID datasetId, String flightId) {
         logger.debug("Lock Operation: Unlocking shared lock for datasetId: {}, flightId: {}", datasetId, flightId);
         // update the dataset entry to remove the flightid from the sharedlock list IF it is currently included there
@@ -200,8 +201,9 @@ public class DatasetDao {
         UnlockExclusive,
         UnlockShared
     }
+
     private int performLockQuery(String sql, MapSqlParameterSource params,
-                            LockType lockType, UUID datasetId) {
+                                 LockType lockType, UUID datasetId) {
         int numRowsUpdated = 0;
         DataAccessException faultToInsert = getFaultToInsert(lockType);
         try {
@@ -273,6 +275,7 @@ public class DatasetDao {
     /**
      * Create a new dataset object and lock it. An exception is thrown if the dataset already exists.
      * The correct order to call the DatasetDao methods when creating a dataset is: createAndLock, unlock.
+     *
      * @param dataset the dataset object to create
      * @return the id of the new dataset
      * @throws SQLException
@@ -283,15 +286,14 @@ public class DatasetDao {
     public UUID createAndLock(Dataset dataset, String flightId) throws IOException, SQLException {
         logger.debug("Lock Operation: createAndLock datasetId: {} for flightId: {}", dataset.getId(), flightId);
         String sql = "INSERT INTO dataset " +
-            "(name, default_profile_id, flightid, description, additional_profile_ids, sharedlock) " +
-            "VALUES (:name, :default_profile_id, :flightid, :description, :additional_profile_ids, ARRAY[]::TEXT[]) ";
-        Array additionalProfileIds = DaoUtils.createSqlUUIDArray(connection, dataset.getAdditionalProfileIds());
+            "(name, default_profile_id, flightid, description, sharedlock) " +
+            "VALUES (:name, :default_profile_id, :flightid, :description, ARRAY[]::TEXT[]) ";
+
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("name", dataset.getName())
             .addValue("default_profile_id", dataset.getDefaultProfileId())
             .addValue("flightid", flightId)
-            .addValue("description", dataset.getDescription())
-            .addValue("additional_profile_ids", additionalProfileIds);
+            .addValue("description", dataset.getDescription());
         DaoKeyHolder keyHolder = new DaoKeyHolder();
         try {
             jdbcTemplate.update(sql, params, keyHolder);
@@ -315,6 +317,7 @@ public class DatasetDao {
      * TESTING ONLY. This method returns the internal state of the exclusive lock on a dataset.
      * It is protected because it's for use in tests only.
      * Currently, we don't expose the lock state of a dataset outside of the DAO for other API code to consume.
+     *
      * @param id the dataset id
      * @return the flightid that holds an exclusive lock. null if none.
      */
@@ -332,6 +335,7 @@ public class DatasetDao {
      * TESTING ONLY. This method returns the internal state of the shared locks on a dataset.
      * It is protected because it's for use in tests only.
      * Currently, we don't expose the lock state of a dataset outside of the DAO for other API code to consume.
+     *
      * @param id the dataset id
      * @return the array of flight ids that hold shared locks. empty if no shared locks are taken out.
      */
@@ -343,7 +347,7 @@ public class DatasetDao {
             if (arr == null) {
                 throw new CorruptMetadataException("Dataset shared locks array column should not be null. id " + id);
             }
-            return (String[])arr.getArray();
+            return (String[]) arr.getArray();
         } catch (EmptyResultDataAccessException | SQLException ex) {
             throw new DatasetNotFoundException("Dataset not found for id " + id);
         }
@@ -352,7 +356,7 @@ public class DatasetDao {
     @Transactional
     public boolean delete(UUID id) {
         int rowsAffected = jdbcTemplate.update("DELETE FROM dataset WHERE id = :id",
-                new MapSqlParameterSource().addValue("id", id));
+            new MapSqlParameterSource().addValue("id", id));
         return rowsAffected > 0;
     }
 
@@ -377,6 +381,7 @@ public class DatasetDao {
     /**
      * This is a convenience wrapper that returns a dataset only if it is NOT exclusively locked.
      * This method is intended for user-facing API calls (e.g. from RepositoryApiController).
+     *
      * @param id the dataset id
      * @return the DatasetSummary object
      */
@@ -408,6 +413,7 @@ public class DatasetDao {
     /**
      * This is a convenience wrapper that returns a dataset, regardless of whether it is exclusively locked.
      * Most places in the API code that are retrieving a dataset will call this method.
+     *
      * @param id the dataset id
      * @return the DatasetSummary object
      */
@@ -417,14 +423,15 @@ public class DatasetDao {
 
     /**
      * Retrieves a DatasetSummary object from the dataset id.
-     * @param id the dataset id
+     *
+     * @param id                    the dataset id
      * @param onlyRetrieveAvailable true to exclude datasets that are exclusively locked, false to include all datasets
      * @return the DatasetSummary object
      */
     public DatasetSummary retrieveSummaryById(UUID id, boolean onlyRetrieveAvailable) {
         try {
             String sql = "SELECT " +
-                "id, name, description, default_profile_id, additional_profile_ids, created_date " +
+                "id, name, description, default_profile_id, created_date " +
                 "FROM dataset WHERE id = :id";
             if (onlyRetrieveAvailable) { // exclude datasets that are exclusively locked
                 sql += " AND flightid IS NULL";
@@ -439,7 +446,7 @@ public class DatasetDao {
     public DatasetSummary retrieveSummaryByName(String name) {
         try {
             String sql = "SELECT " +
-                "id, name, description, default_profile_id, additional_profile_ids, created_date " +
+                "id, name, description, default_profile_id, created_date " +
                 "FROM dataset WHERE name = :name";
             MapSqlParameterSource params = new MapSqlParameterSource().addValue("name", name);
             return jdbcTemplate.queryForObject(sql, params, new DatasetSummaryMapper());
@@ -452,11 +459,13 @@ public class DatasetDao {
      * Fetch a list of all the available datasets.
      * This method returns summary objects, which do not include sub-objects associated with datasets (e.g. tables).
      * Note that this method will only return datasets that are NOT exclusively locked.
-     * @param offset skip this many datasets from the beginning of the list (intended for "scrolling" behavior)
-     * @param limit only return this many datasets in the list
-     * @param sort field for order by clause. possible values are: name, description, created_date
-     * @param direction asc or desc
-     * @param filter string to match (SQL ILIKE) in dataset name or description
+     *
+     * @param offset               skip this many datasets from the beginning of the list
+     *                             (intended for "scrolling" behavior)
+     * @param limit                only return this many datasets in the list
+     * @param sort                 field for order by clause. possible values are: name, description, created_date
+     * @param direction            asc or desc
+     * @param filter               string to match (SQL ILIKE) in dataset name or description
      * @param accessibleDatasetIds list of dataset ids that caller has access to (fetched from IAM service)
      * @return a list of dataset summary objects
      */
@@ -485,7 +494,7 @@ public class DatasetDao {
             whereSql = " WHERE " + StringUtils.join(whereClauses, " AND ");
         }
         String sql = "SELECT " +
-            "id, name, description, default_profile_id, additional_profile_ids, created_date " +
+            "id, name, description, default_profile_id, created_date " +
             "FROM dataset " + whereSql +
             DaoUtils.orderByClause(sort, direction) + " OFFSET :offset LIMIT :limit";
         params.addValue("offset", offset).addValue("limit", limit);
@@ -499,12 +508,11 @@ public class DatasetDao {
     private static class DatasetSummaryMapper implements RowMapper<DatasetSummary> {
         public DatasetSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new DatasetSummary()
-                    .id(rs.getObject("id", UUID.class))
-                    .name(rs.getString("name"))
-                    .description(rs.getString("description"))
-                    .defaultProfileId(rs.getObject("default_profile_id", UUID.class))
-                    .additionalProfileIds(DaoUtils.getUUIDList(rs, "additional_profile_ids"))
-                    .createdDate(rs.getTimestamp("created_date").toInstant());
+                .id(rs.getObject("id", UUID.class))
+                .name(rs.getString("name"))
+                .description(rs.getString("description"))
+                .defaultProfileId(rs.getObject("default_profile_id", UUID.class))
+                .createdDate(rs.getTimestamp("created_date").toInstant());
         }
     }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -25,7 +25,6 @@ public final class DatasetJsonConversion {
         Map<String, Relationship> relationshipsMap = new HashMap<>();
         List<AssetSpecification> assetSpecifications = new ArrayList<>();
         UUID defaultProfileId = UUID.fromString(datasetRequest.getDefaultProfileId());
-        List<UUID> additionalProfileIds = stringsToUUIDs(datasetRequest.getAdditionalProfileIds());
         DatasetSpecificationModel datasetSpecification = datasetRequest.getSchema();
         datasetSpecification.getTables().forEach(tableModel ->
                 tablesMap.put(tableModel.getName(), tableModelToTable(tableModel)));
@@ -45,8 +44,7 @@ public final class DatasetJsonConversion {
         return new Dataset(new DatasetSummary()
                 .name(datasetRequest.getName())
                 .description(datasetRequest.getDescription())
-                .defaultProfileId(defaultProfileId)
-                .additionalProfileIds(additionalProfileIds))
+                .defaultProfileId(defaultProfileId))
                 .tables(new ArrayList<>(tablesMap.values()))
                 .relationships(new ArrayList<>(relationshipsMap.values()))
                 .assetSpecifications(assetSpecifications);
@@ -58,8 +56,8 @@ public final class DatasetJsonConversion {
                 .name(dataset.getName())
                 .description(dataset.getDescription())
                 .createdDate(dataset.getCreatedDate().toString())
-                .defaultProfileId(dataset.getDefaultProfileId().toString())
-                .additionalProfileIds(uuidsToStrings(dataset.getAdditionalProfileIds()));
+                .defaultProfileId(dataset.getDefaultProfileId().toString());
+
     }
 
     public static DatasetModel populateDatasetModelFromDataset(Dataset dataset) {
@@ -68,7 +66,6 @@ public final class DatasetJsonConversion {
                 .name(dataset.getName())
                 .description(dataset.getDescription())
                 .defaultProfileId(dataset.getDefaultProfileId().toString())
-                .additionalProfileIds(uuidsToStrings(dataset.getAdditionalProfileIds()))
                 .createdDate(dataset.getCreatedDate().toString())
                 .schema(datasetSpecificationModelFromDatasetSchema(dataset));
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -1,7 +1,6 @@
 package bio.terra.service.dataset;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
 public class DatasetSummary {
@@ -9,7 +8,6 @@ public class DatasetSummary {
     private String name;
     private String description;
     private UUID defaultProfileId;
-    private List<UUID> additionalProfileIds;
     private Instant createdDate;
 
     public UUID getId() {
@@ -45,15 +43,6 @@ public class DatasetSummary {
 
     public DatasetSummary defaultProfileId(UUID defaultProfileId) {
         this.defaultProfileId = defaultProfileId;
-        return this;
-    }
-
-    public List<UUID> getAdditionalProfileIds() {
-        return additionalProfileIds;
-    }
-
-    public DatasetSummary additionalProfileIds(List<UUID> additionalProfileIds) {
-        this.additionalProfileIds = additionalProfileIds;
         return this;
     }
 

--- a/src/main/resources/data-repository-openapi.yaml
+++ b/src/main/resources/data-repository-openapi.yaml
@@ -1833,11 +1833,6 @@ definitions:
       dataProject:
         type: string
         description: Project id of the project where tabular data in BigQuery lives
-      additionalProfileIds:
-        type: array
-        description: Additional profile ids to be used for this dataset
-        items:
-          $ref: '#/definitions/UniqueIdProperty'
       defaultSnapshotId:
         type: string
         description: Id of the auto-generated default passthru snapshot
@@ -1862,11 +1857,6 @@ definitions:
       defaultProfileId:
         $ref: '#/definitions/UniqueIdProperty'
         description: This is the ID of the profile used for core dataset resources
-      additionalProfileIds:
-        type: array
-        description: Additional profile IDs to be used for this dataset
-        items:
-          $ref: '#/definitions/UniqueIdProperty'
       createdDate:
         type: string
         description: Date the dataset was created
@@ -1888,11 +1878,6 @@ definitions:
       defaultProfileId:
         $ref: '#/definitions/UniqueIdProperty'
         description: This is the ID of the profile used for core dataset resources
-      additionalProfileIds:
-        type: array
-        description: Additional profile IDs to be used for this dataset
-        items:
-          $ref: '#/definitions/UniqueIdProperty'
       schema:
         $ref: '#/definitions/DatasetSpecificationModel'
 
@@ -1908,7 +1893,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/DatasetSummaryModel'
-
 
   ## Schema Definitions ##
 

--- a/src/main/resources/db/changesets/20201002_removeadditionalprofileids.yaml
+++ b/src/main/resources/db/changesets/20201002_removeadditionalprofileids.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: removeadditionalprofileid
+      author: dd
+      changes:
+        - dropColumn:
+            tableName: dataset
+            columns:
+              - column:
+                  name: additional_project_id
+                  type: ${uuid_type}[]
+


### PR DESCRIPTION
The purpose of this field is unclear. It is only stored on dataset creation, never updated, simply returned on dataset retrieve. The datatype was an array of UUID, which meant that you had to get ahold of a connection object in order to process the array. That broke the encapsulation of transaction management usage.

I feel quite certain that it is not on our path to supporting multiple storage locations for dataset data, so i have removed it entirely. I queried the dev deployment and did not find any use of this field.

I have done this as a not upward compatible change to the REST API. If there objections to that, i can restore the API and simply ignore input and returned all for output.