### PR TITLE
DR-1338 Use the last element of the source file path to name file in GCS

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -244,7 +244,7 @@ public class DrsService {
         return Collections.singletonList(hdr);
     }
 
-    private String getLastNameFromPath(String path) {
+    public static String getLastNameFromPath(String path) {
         String[] pathParts = StringUtils.split(path, '/');
         return pathParts[pathParts.length - 1];
     }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
@@ -16,6 +16,8 @@ import bio.terra.stairway.StepResult;
 
 import java.time.Instant;
 
+import static bio.terra.service.filedata.DrsService.getLastNameFromPath;
+
 public class IngestFilePrimaryDataStep implements Step {
     private final ConfigurationService configService;
     private final GcsPdao gcsPdao;
@@ -59,10 +61,13 @@ public class IngestFilePrimaryDataStep implements Step {
 
     @Override
     public StepResult undoStep(FlightContext context) {
+        FlightMap inputParameters = context.getInputParameters();
+        FileLoadModel fileLoadModel = inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
         FlightMap workingMap = context.getWorkingMap();
         String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
         GoogleBucketResource bucketResource = IngestUtils.getBucketInfo(context);
-        gcsPdao.deleteFileById(dataset, fileId, bucketResource);
+        String fileName = getLastNameFromPath(fileLoadModel.getSourcePath());
+        gcsPdao.deleteFileById(dataset, fileId, fileName, bucketResource);
 
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_SNAPSHOT_BATCH_SIZE;
+import static bio.terra.service.filedata.DrsService.getLastNameFromPath;
 
 @Component
 public class GcsPdao {
@@ -75,8 +76,10 @@ public class GcsPdao {
             String targetProjectId = bucketResource.projectIdForBucket();
             Blob sourceBlob = getBlobFromGsPath(storage, fileLoadModel.getSourcePath(), targetProjectId);
 
-            // Our path is /<dataset-id>/<file-id>
-            String targetPath = dataset.getId().toString() + "/" + fileId;
+            // Read the leaf node of the source file to use as a way to sname the file we store
+            String sourceFileName = getLastNameFromPath(sourceBlob.getName());
+            // Our path is /<dataset-id>/<file-id>/<source-file-name>
+            String targetPath = dataset.getId().toString() + "/" + fileId + "/" + sourceFileName;
 
             // The documentation is vague whether or not it is important to copy by chunk. One set of
             // examples does it and another doesn't.
@@ -171,6 +174,7 @@ public class GcsPdao {
         if (blob != null) {
             return blob.delete();
         }
+        logger.warn("{} was not found and so deletion was skipped", bucketPath);
         return false;
     }
 

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -145,8 +145,9 @@ public class GcsPdao {
 
     public boolean deleteFileById(Dataset dataset,
                                   String fileId,
+                                  String fileName,
                                   GoogleBucketResource bucketResource) {
-        String bucketPath = dataset.getId().toString() + "/" + fileId;
+        String bucketPath = dataset.getId().toString() + "/" + fileId + "/" + fileName;
         return deleteWorker(bucketResource, bucketPath);
     }
 

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -31,7 +31,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Optional;
 
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
@@ -122,8 +121,8 @@ public class DrsTest extends UsersBase {
                     StringUtils.equals(checksum.getType(), "crc32c"));
         }
 
-        Optional.ofNullable(drsObject.getAccessMethods()).ifPresent(m -> {
-            for (DRSAccessMethod method: m) {
+        if (drsObject.getAccessMethods() != null) {
+            for (DRSAccessMethod method: drsObject.getAccessMethods()) {
                 if (method.getType() == DRSAccessMethod.TypeEnum.GS) {
                     assertThat(
                         "Has proper file name (gs)",
@@ -146,7 +145,7 @@ public class DrsTest extends UsersBase {
                     );
                 }
             }
-        });
+        }
     }
 
     private String getDirectoryPath(String path) {


### PR DESCRIPTION
This changes the storage in GCS from:
`gs://<bucket>/<datasetId>/<fileId>`
to
`gs://<bucket>/<datasetId>/<fileId>/<sourceFileName>`

Existing DRS files remain unchanged so change is backwards compatible

Note: this didn't require and method signature changes to the GcsPdao since things like delete statements just delete the containing directory (e.g. `gs://<bucket>/<datasetId>/<fileId>`), so the behavior remains the same