### PR TITLE
DR-549: Database status check

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -515,4 +515,20 @@ public class DatasetDao {
                 .createdDate(rs.getTimestamp("created_date").toInstant());
         }
     }
+
+    /**
+     * Probe to see if can access database
+     */
+    public boolean statusCheck() {
+        String sql = "Select count(1)";
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        try {
+            jdbcTemplate.queryForObject(sql, params, Integer.class);
+            return true;
+        } catch (Exception ex) {
+            logger.error("Database status check failed: " + ex.getMessage());
+            return false;
+        }
+
+    }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -520,7 +520,7 @@ public class DatasetDao {
      * Probe to see if can access database
      */
     public boolean statusCheck() {
-        String sql = "Select count(1)";
+        String sql = "SELECT count(1)";
         MapSqlParameterSource params = new MapSqlParameterSource();
         try {
             jdbcTemplate.queryForObject(sql, params, Integer.class);


### PR DESCRIPTION
These changes add a simple database call to our unauthenticated /status endpoint. If it can successfully query the database, then we can infer that the database is up and able to receive requests. If it fails, we log an error and return HttpStatus.SERVICE_UNAVAILABLE. 

Testing Strategy:
- Tested on dev deployment:
(1) Deployed to my dev container and included log to show that the status check was returning true.
(2) Deleted the sh-jade-gcloud-sqlproxy pod
(3) Checked that the logs in the api pod reflected the status of the sql pod:
<img width="1436" alt="Screen Shot 2020-10-13 at 10 04 13 AM" src="https://user-images.githubusercontent.com/13254229/95874889-6398ef80-0d3f-11eb-9269-944236a2a019.png">
