### PR TITLE
DR 321 Snapshot duplicate name bugfix

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -285,14 +286,16 @@ public class DatasetDao {
     public UUID createAndLock(Dataset dataset, String flightId) throws IOException, SQLException {
         logger.debug("Lock Operation: createAndLock datasetId: {} for flightId: {}", dataset.getId(), flightId);
         // TODO why did this method think it already had a dataset id? ^
+        Timestamp created_date = new Timestamp(dataset.getCreatedDate().toEpochMilli());
         String sql = "INSERT INTO dataset " +
-            "(name, default_profile_id, id, flightid, description, sharedlock) " +
-            "VALUES (:name, :default_profile_id, :id, :flightid, :description, ARRAY[]::TEXT[]) ";
+            "(name, default_profile_id, id, created_date, flightid, description, sharedlock) " +
+            "VALUES (:name, :default_profile_id, :id, :created_date, :flightid, :description, ARRAY[]::TEXT[]) ";
 
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("name", dataset.getName())
             .addValue("default_profile_id", dataset.getDefaultProfileId())
             .addValue("id", dataset.getId())
+            .addValue("created_date", created_date)
             .addValue("flightid", flightId)
             .addValue("description", dataset.getDescription());
         try {

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -300,7 +300,9 @@ public class DatasetDao {
         try {
             jdbcTemplate.update(sql, params);
         } catch (DuplicateKeyException dkEx) {
-            throw new InvalidDatasetException("Dataset name already exists: " + dataset.getName(), dkEx);
+            throw new InvalidDatasetException(
+                "Dataset name or id already exists: " + dataset.getName() + ", " + dataset.getId(), dkEx);
+
         }
 
         tableDao.createTables(dataset.getId(), dataset.getTables());

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -285,7 +285,6 @@ public class DatasetDao {
     @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
     public UUID createAndLock(Dataset dataset, String flightId) throws IOException, SQLException {
         logger.debug("Lock Operation: createAndLock datasetId: {} for flightId: {}", dataset.getId(), flightId);
-        // TODO why did this method think it already had a dataset id? ^
         Timestamp created_date = new Timestamp(dataset.getCreatedDate().toEpochMilli());
         String sql = "INSERT INTO dataset " +
             "(name, default_profile_id, id, created_date, flightid, description, sharedlock) " +

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetIdStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetIdStep.java
@@ -1,42 +1,26 @@
 package bio.terra.service.dataset.flight.create;
 
-import bio.terra.model.DatasetRequestModel;
-import bio.terra.service.dataset.exception.InvalidDatasetException;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import bio.terra.stairway.StepStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
 
 public class CreateDatasetIdStep implements Step {
 
-    private DatasetRequestModel datasetRequest;
-
-    private static Logger logger = LoggerFactory.getLogger(CreateDatasetIdStep.class);
-
-    public CreateDatasetIdStep(DatasetRequestModel datasetRequest) {
-        this.datasetRequest = datasetRequest;
-    }
+    public CreateDatasetIdStep() {}
 
     @Override
     public StepResult doStep(FlightContext context) {
         // creates the dataset id and puts it in the working map
 
-        try {
-            FlightMap workingMap = context.getWorkingMap();
-            UUID datasetId = UUID.randomUUID();
-            workingMap.put(DatasetWorkingMapKeys.DATASET_ID, datasetId);
-            return StepResult.getStepResultSuccess();
-        } catch (Exception ex) {
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL,
-                new InvalidDatasetException("Cannot create dataset: " + datasetRequest.getName(), ex));
-        }
+        FlightMap workingMap = context.getWorkingMap();
+        UUID datasetId = UUID.randomUUID();
+        workingMap.put(DatasetWorkingMapKeys.DATASET_ID, datasetId);
+        return StepResult.getStepResultSuccess();
     }
 
     @Override

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetIdStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetIdStep.java
@@ -1,0 +1,50 @@
+package bio.terra.service.dataset.flight.create;
+
+import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.dataset.exception.InvalidDatasetException;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+
+public class CreateDatasetIdStep implements Step {
+
+    private DatasetRequestModel datasetRequest;
+
+    private static Logger logger = LoggerFactory.getLogger(CreateDatasetIdStep.class);
+
+    public CreateDatasetIdStep(DatasetRequestModel datasetRequest) {
+        this.datasetRequest = datasetRequest;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext context) {
+        // creates the dataset id and puts it in the working map
+
+        try {
+            FlightMap workingMap = context.getWorkingMap();
+            UUID datasetId = UUID.randomUUID();
+            workingMap.put(DatasetWorkingMapKeys.DATASET_ID, datasetId);
+            return StepResult.getStepResultSuccess();
+        } catch (InvalidDatasetException idEx) {
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, idEx);
+        } catch (Exception ex) {
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL,
+                new InvalidDatasetException("Cannot create dataset: " + datasetRequest.getName(), ex));
+        }
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) {
+        logger.debug("Dataset creation failed during id creation.");
+        return StepResult.getStepResultSuccess();
+    }
+}
+

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetIdStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetIdStep.java
@@ -33,8 +33,6 @@ public class CreateDatasetIdStep implements Step {
             UUID datasetId = UUID.randomUUID();
             workingMap.put(DatasetWorkingMapKeys.DATASET_ID, datasetId);
             return StepResult.getStepResultSuccess();
-        } catch (InvalidDatasetException idEx) {
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, idEx);
         } catch (Exception ex) {
             return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL,
                 new InvalidDatasetException("Cannot create dataset: " + datasetRequest.getName(), ex));
@@ -43,7 +41,6 @@ public class CreateDatasetIdStep implements Step {
 
     @Override
     public StepResult undoStep(FlightContext context) {
-        logger.debug("Dataset creation failed during id creation.");
         return StepResult.getStepResultSuccess();
     }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
@@ -1,13 +1,13 @@
 package bio.terra.service.dataset.flight.create;
 
-import bio.terra.service.dataset.DatasetDao;
-import bio.terra.service.dataset.exception.InvalidDatasetException;
-import bio.terra.service.dataset.DatasetUtils;
-import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
-import bio.terra.service.dataset.Dataset;
-import bio.terra.service.dataset.DatasetJsonConversion;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSummaryModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.dataset.DatasetJsonConversion;
+import bio.terra.service.dataset.DatasetUtils;
+import bio.terra.service.dataset.exception.InvalidDatasetException;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -17,7 +17,6 @@ import bio.terra.stairway.StepStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Instant;
 import java.util.UUID;
 
 
@@ -40,10 +39,7 @@ public class CreateDatasetMetadataStep implements Step {
 
             FlightMap workingMap = context.getWorkingMap();
             UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
-            Instant createdDate = Instant.now();
-            newDataset
-                .id(datasetId)
-                .createdDate(createdDate);
+            newDataset.id(datasetId);
 
             datasetDao.createAndLock(newDataset, context.getFlightId());
 

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
@@ -39,9 +39,8 @@ public class CreateDatasetMetadataStep implements Step {
             Dataset newDataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
 
             FlightMap workingMap = context.getWorkingMap();
-            UUID datasetId = UUID.randomUUID();
+            UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
             Instant createdDate = Instant.now();
-            workingMap.put(DatasetWorkingMapKeys.DATASET_ID, datasetId);
             newDataset
                 .id(datasetId)
                 .createdDate(createdDate);
@@ -65,7 +64,6 @@ public class CreateDatasetMetadataStep implements Step {
         logger.debug("Dataset creation failed. Deleting metadata.");
         FlightMap workingMap = context.getWorkingMap();
         UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
-        // TODO what if the datasetId has not yet been set when the undo happens?
         datasetDao.delete(datasetId);
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -44,6 +44,7 @@ public class DatasetCreateFlight extends Flight {
 
         DatasetRequestModel datasetRequest =
             inputParameters.get(JobMapKeys.REQUEST.getKeyName(), DatasetRequestModel.class);
+        addStep(new CreateDatasetIdStep(datasetRequest));
         addStep(new CreateDatasetMetadataStep(datasetDao, datasetRequest));
 
         // TODO: create dataset data project step

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -44,7 +44,7 @@ public class DatasetCreateFlight extends Flight {
 
         DatasetRequestModel datasetRequest =
             inputParameters.get(JobMapKeys.REQUEST.getKeyName(), DatasetRequestModel.class);
-        addStep(new CreateDatasetIdStep(datasetRequest));
+        addStep(new CreateDatasetIdStep());
         addStep(new CreateDatasetMetadataStep(datasetDao, datasetRequest));
 
         // TODO: create dataset data project step

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -125,7 +125,7 @@ public class SnapshotDao {
      * @throws InvalidSnapshotException if a row already exists with this snapshot name
      */
     @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-    public UUID createAndLock(Snapshot snapshot, String flightId, DaoKeyHolder keyHolder) {
+    public UUID createAndLock(Snapshot snapshot, String flightId) {
         logger.debug("createAndLock snapshot " + snapshot.getName());
 
         String sql = "INSERT INTO snapshot (name, description, profile_id, flightid) " +
@@ -136,7 +136,7 @@ public class SnapshotDao {
             .addValue("profile_id", snapshot.getProfileId())
             .addValue("flightid", flightId);
         try {
-            jdbcTemplate.update(sql, params, keyHolder); // TODO does this need to pass the keyholder?
+            jdbcTemplate.update(sql, params);
         } catch (DuplicateKeyException dkEx) {
             throw new InvalidSnapshotException("Snapshot name already exists: " + snapshot.getName(), dkEx);
         }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -205,6 +205,16 @@ public class SnapshotDao {
         return rowsAffected > 0;
     }
 
+    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+    public boolean deleteByNameAndFlight(String snapshotName, String flightId) {
+        String sql = "DELETE FROM snapshot WHERE name = :name AND flightid = :flightid";
+        MapSqlParameterSource params = new MapSqlParameterSource()
+            .addValue("name", snapshotName)
+            .addValue("flightid", flightId);
+        int rowsAffected = jdbcTemplate.update(sql, params);
+        return rowsAffected > 0;
+    }
+
     /**
      * This is a convenience wrapper that returns a snapshot only if it is NOT exclusively locked.
      * This method is intended for user-facing API calls (e.g. from RepositoryApiController).

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -186,20 +186,11 @@ public class SnapshotDao {
         snapshotRelationshipDao.createSnapshotRelationships(snapshotSource.getSnapshot());
     }
 
+    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
     public boolean delete(UUID id) {
         logger.debug("delete snapshot by id: " + id);
         int rowsAffected = jdbcTemplate.update("DELETE FROM snapshot WHERE id = :id",
                 new MapSqlParameterSource().addValue("id", id));
-        return rowsAffected > 0;
-    }
-
-    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-    public boolean deleteByNameAndFlight(String snapshotName, String flightId) {
-        String sql = "DELETE FROM snapshot WHERE name = :name AND flightid = :flightid";
-        MapSqlParameterSource params = new MapSqlParameterSource()
-            .addValue("name", snapshotName)
-            .addValue("flightid", flightId);
-        int rowsAffected = jdbcTemplate.update(sql, params);
         return rowsAffected > 0;
     }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -139,7 +139,8 @@ public class SnapshotDao {
         try {
             jdbcTemplate.update(sql, params);
         } catch (DuplicateKeyException dkEx) {
-            throw new InvalidSnapshotException("Snapshot name already exists: " + snapshot.getName(), dkEx);
+            throw new InvalidSnapshotException(
+                "Snapshot name or id already exists: " + snapshot.getName() + ", " + snapshot.getId(), dkEx);
         }
 
         snapshotTableDao.createTables(snapshot.getId(), snapshot.getTables());

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -125,7 +125,7 @@ public class SnapshotDao {
      * @throws InvalidSnapshotException if a row already exists with this snapshot name
      */
     @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-    public UUID createAndLock(Snapshot snapshot, String flightId) {
+    public void createAndLock(Snapshot snapshot, String flightId) {
         logger.debug("createAndLock snapshot " + snapshot.getName());
 
         String sql = "INSERT INTO snapshot (name, description, profile_id, id, flightid) " +
@@ -147,8 +147,6 @@ public class SnapshotDao {
         for (SnapshotSource snapshotSource : snapshot.getSnapshotSources()) {
             createSnapshotSource(snapshotSource);
         }
-
-        return snapshot.getId(); // TODO should this return nothing now?
     }
 
     /**

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -128,12 +128,13 @@ public class SnapshotDao {
     public UUID createAndLock(Snapshot snapshot, String flightId) {
         logger.debug("createAndLock snapshot " + snapshot.getName());
 
-        String sql = "INSERT INTO snapshot (name, description, profile_id, flightid) " +
-            "VALUES (:name, :description, :profile_id, :flightid) ";
+        String sql = "INSERT INTO snapshot (name, description, profile_id, id, flightid) " +
+            "VALUES (:name, :description, :profile_id, :id, :flightid) ";
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("name", snapshot.getName())
             .addValue("description", snapshot.getDescription())
             .addValue("profile_id", snapshot.getProfileId())
+            .addValue("id", snapshot.getId())
             .addValue("flightid", flightId);
         try {
             jdbcTemplate.update(sql, params);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
@@ -30,17 +30,14 @@ public class CreateSnapshotIdStep implements Step {
             UUID snapshotId = UUID.randomUUID();
             workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_ID, snapshotId);
             return StepResult.getStepResultSuccess();
-        } catch (InvalidSnapshotException isEx) {
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, isEx);
         } catch (Exception ex) {
             return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL,
-                new InvalidSnapshotException("Cannot create dataset: " + snapshotReq.getName(), ex));
+                new InvalidSnapshotException("Cannot create snapshot: " + snapshotReq.getName(), ex));
         }
     }
 
     @Override
     public StepResult undoStep(FlightContext context) {
-        logger.debug("Snapshot creation failed during id creation.");
         return StepResult.getStepResultSuccess();
     }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
@@ -1,0 +1,79 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.common.FlightUtils;
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.model.SnapshotSummaryModel;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotDao;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.SnapshotSummary;
+import bio.terra.service.snapshot.exception.InvalidSnapshotException;
+import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class CreateSnapshotMetadataStep implements Step {
+    private final SnapshotDao snapshotDao;
+    private final SnapshotService snapshotService;
+    private final SnapshotRequestModel snapshotReq;
+
+    private static Logger logger = LoggerFactory.getLogger(CreateSnapshotMetadataStep.class);
+
+    public CreateSnapshotMetadataStep(
+        SnapshotDao snapshotDao,
+        SnapshotService snapshotService,
+        SnapshotRequestModel snapshotReq) {
+        this.snapshotDao = snapshotDao;
+        this.snapshotService = snapshotService;
+        this.snapshotReq = snapshotReq;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext context) {
+        try {
+            Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotReq);
+
+            FlightMap workingMap = context.getWorkingMap();
+            UUID snapshotId = UUID.randomUUID();
+            Instant createdDate = Instant.now();
+            workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_ID, snapshotId);
+            snapshot
+                .id(snapshotId)
+                .createdDate(createdDate);
+
+            snapshotDao.createAndLock(snapshot, context.getFlightId());
+
+            SnapshotSummary snapshotSummary = snapshotDao.retrieveSummaryById(snapshotId);
+            SnapshotSummaryModel response = snapshotService.makeSummaryModelFromSummary(snapshotSummary);
+
+            FlightUtils.setResponse(context, response, HttpStatus.CREATED);
+            return StepResult.getStepResultSuccess();
+        } catch (InvalidSnapshotException isEx) {
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, isEx);
+        } catch (SnapshotNotFoundException ex) {
+            FlightUtils.setErrorResponse(context, ex.toString(), HttpStatus.BAD_REQUEST);
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+        }
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) {
+        logger.debug("Snapshot creation failed. Deleting metadata.");
+        FlightMap workingMap = context.getWorkingMap();
+        UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
+        // TODO what if the snapshotId has not yet been set?
+        snapshotDao.delete(snapshotId);
+        return StepResult.getStepResultSuccess();
+    }
+
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
@@ -1,14 +1,7 @@
 package bio.terra.service.snapshot.flight.create;
 
-import bio.terra.common.FlightUtils;
 import bio.terra.model.SnapshotRequestModel;
-import bio.terra.model.SnapshotSummaryModel;
-import bio.terra.service.snapshot.Snapshot;
-import bio.terra.service.snapshot.SnapshotDao;
-import bio.terra.service.snapshot.SnapshotService;
-import bio.terra.service.snapshot.SnapshotSummary;
 import bio.terra.service.snapshot.exception.InvalidSnapshotException;
-import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -17,62 +10,37 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 
-import java.time.Instant;
 import java.util.UUID;
 
-public class CreateSnapshotMetadataStep implements Step {
-    private final SnapshotDao snapshotDao;
-    private final SnapshotService snapshotService;
+public class CreateSnapshotIdStep implements Step {
     private final SnapshotRequestModel snapshotReq;
 
-    private static Logger logger = LoggerFactory.getLogger(CreateSnapshotMetadataStep.class);
+    private static Logger logger = LoggerFactory.getLogger(CreateSnapshotIdStep.class);
 
-    public CreateSnapshotMetadataStep(
-        SnapshotDao snapshotDao,
-        SnapshotService snapshotService,
+    public CreateSnapshotIdStep(
         SnapshotRequestModel snapshotReq) {
-        this.snapshotDao = snapshotDao;
-        this.snapshotService = snapshotService;
         this.snapshotReq = snapshotReq;
     }
 
     @Override
     public StepResult doStep(FlightContext context) {
         try {
-            Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotReq);
-
             FlightMap workingMap = context.getWorkingMap();
             UUID snapshotId = UUID.randomUUID();
-            Instant createdDate = Instant.now();
             workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_ID, snapshotId);
-            snapshot
-                .id(snapshotId)
-                .createdDate(createdDate);
-
-            snapshotDao.createAndLock(snapshot, context.getFlightId());
-
-            SnapshotSummary snapshotSummary = snapshotDao.retrieveSummaryById(snapshotId);
-            SnapshotSummaryModel response = snapshotService.makeSummaryModelFromSummary(snapshotSummary);
-
-            FlightUtils.setResponse(context, response, HttpStatus.CREATED);
             return StepResult.getStepResultSuccess();
         } catch (InvalidSnapshotException isEx) {
             return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, isEx);
-        } catch (SnapshotNotFoundException ex) {
-            FlightUtils.setErrorResponse(context, ex.toString(), HttpStatus.BAD_REQUEST);
-            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+        } catch (Exception ex) {
+            return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL,
+                new InvalidSnapshotException("Cannot create dataset: " + snapshotReq.getName(), ex));
         }
     }
 
     @Override
     public StepResult undoStep(FlightContext context) {
-        logger.debug("Snapshot creation failed. Deleting metadata.");
-        FlightMap workingMap = context.getWorkingMap();
-        UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-        // TODO what if the snapshotId has not yet been set?
-        snapshotDao.delete(snapshotId);
+        logger.debug("Snapshot creation failed during id creation.");
         return StepResult.getStepResultSuccess();
     }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -53,7 +53,7 @@ public class CreateSnapshotMetadataStep implements Step {
 
             snapshotDao.createAndLock(snapshot, context.getFlightId());
 
-            SnapshotSummary snapshotSummary = snapshotDao.retrieveSummaryById(snapshot.getId());
+            SnapshotSummary snapshotSummary = snapshotDao.retrieveSummaryById(snapshotId);
             SnapshotSummaryModel response = snapshotService.makeSummaryModelFromSummary(snapshotSummary);
 
             FlightUtils.setResponse(context, response, HttpStatus.CREATED);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
-import java.time.Instant;
 import java.util.UUID;
 
 public class CreateSnapshotMetadataStep implements Step {
@@ -45,10 +44,7 @@ public class CreateSnapshotMetadataStep implements Step {
 
             FlightMap workingMap = context.getWorkingMap();
             UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-            Instant createdDate = Instant.now();
-            snapshot
-                .id(snapshotId)
-                .createdDate(createdDate);
+            snapshot.id(snapshotId);
 
             snapshotDao.createAndLock(snapshot, context.getFlightId());
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -44,9 +44,8 @@ public class CreateSnapshotMetadataStep implements Step {
             Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotReq);
 
             FlightMap workingMap = context.getWorkingMap();
-            UUID snapshotId = UUID.randomUUID();
+            UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
             Instant createdDate = Instant.now();
-            workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_ID, snapshotId);
             snapshot
                 .id(snapshotId)
                 .createdDate(createdDate);
@@ -71,7 +70,6 @@ public class CreateSnapshotMetadataStep implements Step {
         logger.debug("Snapshot creation failed. Deleting metadata.");
         FlightMap workingMap = context.getWorkingMap();
         UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-        // TODO what if the snapshotId has not yet been set?
         snapshotDao.delete(snapshotId);
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -62,7 +62,7 @@ public class CreateSnapshotMetadataStep implements Step {
     @Override
     public StepResult undoStep(FlightContext context) {
         logger.debug("Snapshot creation failed. Deleting metadata.");
-        snapshotDao.deleteByName(snapshotReq.getName());
+        snapshotDao.deleteByNameAndFlight(snapshotReq.getName(), context.getFlightId());
         return StepResult.getStepResultSuccess();
     }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -48,6 +48,7 @@ public class SnapshotCreateFlight extends Flight {
         String snapshotName = snapshotReq.getName();
 
         // create the snapshot metadata object in postgres and lock it
+        // mint a snapshot id and put it in the working map
         addStep(new CreateSnapshotMetadataStep(snapshotDao, snapshotService, snapshotReq));
 
         // Make the big query dataset with views and populate row id filtering tables.

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -49,6 +49,7 @@ public class SnapshotCreateFlight extends Flight {
 
         // create the snapshot metadata object in postgres and lock it
         // mint a snapshot id and put it in the working map
+        addStep(new CreateSnapshotIdStep(snapshotReq));
         addStep(new CreateSnapshotMetadataStep(snapshotDao, snapshotService, snapshotReq));
 
         // Make the big query dataset with views and populate row id filtering tables.

--- a/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
@@ -137,7 +137,7 @@ public class DatasetConnectedTest {
         ErrorModel errorModel =
             connectedOperations.createDatasetExpectError(datasetRequest, HttpStatus.BAD_REQUEST);
         assertThat("error message includes name conflict",
-            errorModel.getMessage(), containsString("Dataset name already exists"));
+            errorModel.getMessage(), containsString("Dataset name or id already exists"));
 
         // fetch the dataset and confirm the metadata still matches the original
         DatasetModel origModel = connectedOperations.getDataset(summaryModel.getId());

--- a/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
@@ -133,10 +133,15 @@ public class DatasetConnectedTest {
         assertNull("dataset row is unlocked", exclusiveLock);
 
         // try to create the same dataset again and check that it fails
+        datasetRequest.description("Make sure nothing is getting overwritten");
         ErrorModel errorModel =
             connectedOperations.createDatasetExpectError(datasetRequest, HttpStatus.BAD_REQUEST);
         assertThat("error message includes name conflict",
             errorModel.getMessage(), containsString("Dataset name already exists"));
+
+        // fetch the dataset and confirm the metadata still matches the original
+        DatasetModel origModel = connectedOperations.getDataset(summaryModel.getId());
+        assertEquals("fetched dataset remains unchanged", datasetModel, origModel);
 
         // delete the dataset and check that it succeeds
         connectedOperations.deleteTestDatasetAndCleanup(summaryModel.getId());

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -66,10 +66,8 @@ public class DatasetDaoTest {
         Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         String createFlightId = UUID.randomUUID().toString();
         UUID datasetId = UUID.randomUUID();
-        Instant createdDate = Instant.now();
         dataset
-            .id(datasetId)
-            .createdDate(createdDate);
+            .id(datasetId);
         datasetDao.createAndLock(dataset, createFlightId);
         datasetDao.unlockExclusive(dataset.getId(), createFlightId);
         return datasetId;

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -64,7 +65,12 @@ public class DatasetDaoTest {
         datasetRequest.name(newName).defaultProfileId(billingProfile.getId().toString());
         Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         String createFlightId = UUID.randomUUID().toString();
-        UUID datasetId = datasetDao.createAndLock(dataset, createFlightId);
+        UUID datasetId = UUID.randomUUID();
+        Instant createdDate = Instant.now();
+        dataset
+            .id(datasetId)
+            .createdDate(createdDate);
+        datasetDao.createAndLock(dataset, createFlightId);
         datasetDao.unlockExclusive(dataset.getId(), createFlightId);
         return datasetId;
     }

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -26,7 +26,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -66,8 +66,7 @@ public class DatasetDaoTest {
         Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         String createFlightId = UUID.randomUUID().toString();
         UUID datasetId = UUID.randomUUID();
-        dataset
-            .id(datasetId);
+        dataset.id(datasetId);
         datasetDao.createAndLock(dataset, createFlightId);
         datasetDao.unlockExclusive(dataset.getId(), createFlightId);
         return datasetId;

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -86,10 +86,8 @@ public class DatasetServiceTest {
         Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         String createFlightId = UUID.randomUUID().toString();
         UUID datasetId = UUID.randomUUID();
-        Instant createdDate = Instant.now();
         dataset
-            .id(datasetId)
-            .createdDate(createdDate);
+            .id(datasetId);
         datasetDao.createAndLock(dataset, createFlightId);
         datasetDao.unlockExclusive(datasetId, createFlightId);
         datasetIdList.add(datasetId);

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -32,6 +32,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -84,8 +85,13 @@ public class DatasetServiceTest {
         datasetRequest.name(newName).defaultProfileId(billingProfile.getId().toString());
         Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         String createFlightId = UUID.randomUUID().toString();
-        UUID datasetId = datasetDao.createAndLock(dataset, createFlightId);
-        datasetDao.unlockExclusive(dataset.getId(), createFlightId);
+        UUID datasetId = UUID.randomUUID();
+        Instant createdDate = Instant.now();
+        dataset
+            .id(datasetId)
+            .createdDate(createdDate);
+        datasetDao.createAndLock(dataset, createFlightId);
+        datasetDao.unlockExclusive(datasetId, createFlightId);
         datasetIdList.add(datasetId);
         return datasetId;
     }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -32,7 +32,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -344,7 +344,7 @@ public class SnapshotConnectedTest {
         ErrorModel errorModel = handleCreateSnapshotFailureCase(response);
         assertThat(response.getStatus(), equalTo(HttpStatus.BAD_REQUEST.value()));
         assertThat("error message includes name conflict",
-            errorModel.getMessage(), containsString("Snapshot name already exists"));
+            errorModel.getMessage(), containsString("Snapshot name or id already exists"));
 
         // fetch the snapshot and confirm the metadata still matches the original
         SnapshotModel origModel = getTestSnapshot(summaryModel.getId(), snapshotRequest, datasetSummary);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -346,6 +346,10 @@ public class SnapshotConnectedTest {
         assertThat("error message includes name conflict",
             errorModel.getMessage(), containsString("Snapshot name already exists"));
 
+        // fetch the snapshot and confirm the metadata still matches the original
+        SnapshotModel origModel = getTestSnapshot(summaryModel.getId(), snapshotRequest, datasetSummary);
+        assertEquals("fetched snapshot remains unchanged", snapshotModel, origModel);
+
         // delete and confirm deleted
         connectedOperations.deleteTestSnapshot(snapshotModel.getId());
         connectedOperations.getSnapshotExpectError(snapshotModel.getId(), HttpStatus.NOT_FOUND);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -24,7 +24,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -106,10 +105,7 @@ public class SnapshotDaoTest {
 
         String flightId = "happyInOutTest_flightId";
         Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
-        Instant createdDate = Instant.now();
-        snapshot
-            .id(snapshotId)
-            .createdDate(createdDate);
+        snapshot.id(snapshotId);
         snapshotDao.createAndLock(snapshot, flightId);
         snapshotDao.unlock(snapshotId, flightId);
         Snapshot fromDB = snapshotDao.retrieveSnapshot(snapshotId);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -212,7 +212,7 @@ public class SnapshotDaoTest {
                 .description(UUID.randomUUID().toString() + ((i % 2 == 0) ? "==foo==" : ""));
             String flightId = "snapshotEnumerateTest_flightId";
             Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
-            UUID snapshotId = UUID.randomUUID();
+            snapshotId = UUID.randomUUID();
             snapshot.id(snapshotId);
             snapshotDao.createAndLock(snapshot, flightId);
             snapshotDao.unlock(snapshotId, flightId);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -74,10 +74,7 @@ public class SnapshotDaoTest {
         dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         String createFlightId = UUID.randomUUID().toString();
         datasetId = UUID.randomUUID();
-        Instant createdDate = Instant.now();
-        dataset
-            .id(datasetId)
-            .createdDate(createdDate);
+        dataset.id(datasetId);
         datasetDao.createAndLock(dataset, createFlightId);
         datasetDao.unlockExclusive(dataset.getId(), createFlightId);
         dataset = datasetDao.retrieve(datasetId);
@@ -220,8 +217,7 @@ public class SnapshotDaoTest {
             String flightId = "snapshotEnumerateTest_flightId";
             Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
             UUID snapshotId = UUID.randomUUID();
-            snapshot
-                .id(snapshotId);
+            snapshot.id(snapshotId);
             snapshotDao.createAndLock(snapshot, flightId);
             snapshotDao.unlock(snapshotId, flightId);
             snapshotIds.add(snapshotId);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -110,12 +110,11 @@ public class SnapshotDaoTest {
         String flightId = "happyInOutTest_flightId";
         Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
         UUID snapshotId = UUID.randomUUID();
-        Instant createdDate = Instant.now(); // TODO Does this need to be set for timezone / format etc?
-        // Load Service uses Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT);
+        Instant createdDate = Instant.now();
         snapshot
             .id(snapshotId)
             .createdDate(createdDate);
-        snapshotId = snapshotDao.createAndLock(snapshot, flightId);
+        snapshotDao.createAndLock(snapshot, flightId);
         snapshotDao.unlock(snapshotId, flightId);
         Snapshot fromDB = snapshotDao.retrieveSnapshot(snapshotId);
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -220,11 +220,8 @@ public class SnapshotDaoTest {
             String flightId = "snapshotEnumerateTest_flightId";
             Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
             UUID snapshotId = UUID.randomUUID();
-            Instant createdDate = Instant.now(); // TODO Does this need to be set for timezone / format etc?
-            // Load Service uses Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT);
             snapshot
-                .id(snapshotId)
-                .createdDate(createdDate);
+                .id(snapshotId);
             snapshotDao.createAndLock(snapshot, flightId);
             snapshotDao.unlock(snapshotId, flightId);
             snapshotIds.add(snapshotId);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -109,7 +109,6 @@ public class SnapshotDaoTest {
 
         String flightId = "happyInOutTest_flightId";
         Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
-        UUID snapshotId = UUID.randomUUID();
         Instant createdDate = Instant.now();
         snapshot
             .id(snapshotId)
@@ -319,7 +318,7 @@ public class SnapshotDaoTest {
             assertThat("correct snapshot id",
                     snapshotIds.get(index),
                     equalTo(summary.getId()));
-            assertThat("correct snapshot namee",
+            assertThat("correct snapshot name",
                     makeName(snapshotName, index),
                     equalTo(summary.getName()));
             index++;

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -1,16 +1,16 @@
 package bio.terra.service.snapshot;
 
-import bio.terra.common.Relationship;
-import bio.terra.common.category.Unit;
-import bio.terra.service.dataset.DatasetDao;
-import bio.terra.common.fixtures.JsonLoader;
-import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.common.Column;
 import bio.terra.common.MetadataEnumeration;
-import bio.terra.service.dataset.Dataset;
+import bio.terra.common.Relationship;
 import bio.terra.common.Table;
-import bio.terra.model.SnapshotRequestModel;
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.model.DatasetRequestModel;
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.dataset.DatasetUtils;
 import bio.terra.service.resourcemanagement.ProfileDao;
 import bio.terra.service.snapshot.exception.MissingRowCountsException;
@@ -73,7 +73,12 @@ public class SnapshotDaoTest {
             .defaultProfileId(profileId.toString());
         dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         String createFlightId = UUID.randomUUID().toString();
-        datasetId = datasetDao.createAndLock(dataset, createFlightId);
+        datasetId = UUID.randomUUID();
+        Instant createdDate = Instant.now();
+        dataset
+            .id(datasetId)
+            .createdDate(createdDate);
+        datasetDao.createAndLock(dataset, createFlightId);
         datasetDao.unlockExclusive(dataset.getId(), createFlightId);
         dataset = datasetDao.retrieve(datasetId);
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -103,6 +104,12 @@ public class SnapshotDaoTest {
 
         String flightId = "happyInOutTest_flightId";
         Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
+        UUID snapshotId = UUID.randomUUID();
+        Instant createdDate = Instant.now(); // TODO Does this need to be set for timezone / format etc?
+        // Load Service uses Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT);
+        snapshot
+            .id(snapshotId)
+            .createdDate(createdDate);
         snapshotId = snapshotDao.createAndLock(snapshot, flightId);
         snapshotDao.unlock(snapshotId, flightId);
         Snapshot fromDB = snapshotDao.retrieveSnapshot(snapshotId);
@@ -209,7 +216,13 @@ public class SnapshotDaoTest {
                 .description(UUID.randomUUID().toString() + ((i % 2 == 0) ? "==foo==" : ""));
             String flightId = "snapshotEnumerateTest_flightId";
             Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
-            snapshotId = snapshotDao.createAndLock(snapshot, flightId);
+            UUID snapshotId = UUID.randomUUID();
+            Instant createdDate = Instant.now(); // TODO Does this need to be set for timezone / format etc?
+            // Load Service uses Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT);
+            snapshot
+                .id(snapshotId)
+                .createdDate(createdDate);
+            snapshotDao.createAndLock(snapshot, flightId);
             snapshotDao.unlock(snapshotId, flightId);
             snapshotIds.add(snapshotId);
         }

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -53,7 +53,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.stringtemplate.v4.ST;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -126,10 +126,8 @@ public class BigQueryPdaoTest {
         Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         String createFlightId = UUID.randomUUID().toString();
         UUID datasetId = UUID.randomUUID();
-        Instant createdDate = Instant.now();
         dataset
-            .id(datasetId)
-            .createdDate(createdDate);
+            .id(datasetId);
         datasetDao.createAndLock(dataset, createFlightId);
         datasetDao.unlockExclusive(dataset.getId(), createFlightId);
         dataLocationService.getOrCreateProject(dataset);

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -53,6 +53,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.stringtemplate.v4.ST;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -124,6 +125,11 @@ public class BigQueryPdaoTest {
             .name(datasetName());
         Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
         String createFlightId = UUID.randomUUID().toString();
+        UUID datasetId = UUID.randomUUID();
+        Instant createdDate = Instant.now();
+        dataset
+            .id(datasetId)
+            .createdDate(createdDate);
         datasetDao.createAndLock(dataset, createFlightId);
         datasetDao.unlockExclusive(dataset.getId(), createFlightId);
         dataLocationService.getOrCreateProject(dataset);


### PR DESCRIPTION
When a snapshot creation is kicked off with a name that already exists as a snapshot, the new snapshot creation was failing AND the snapshot that originally had the shared name was getting deleted (the undo step was deleting by name).

This pr updates tests to make sure that the original dataset and snapshot remain untouched and fixes the undo step which deleted the original snapshot.

The main question I have is whether the creation date needs to be zoned or formatted