### PR TITLE
DR-1394 - Point nightly perf test run to semantic version; Re-enable Slack Notifications

### DIFF
--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -147,7 +147,7 @@ jobs:
             PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
             ((RETRY_COUNT=RETRY_COUNT+1))
           done;
-          echo "Perf successfully running on new version: ${PERF_VERSION%-*}""
+          echo "Perf successfully running on new version: ${PERF_VERSION%-*}"
       - name: "Build and run Test Runner"
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -139,10 +139,10 @@ jobs:
           RETRY_COUNT=0
           until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
             if [[ ${RETRY_COUNT} > 5 ]]; then
-              echo "Failed to match perf ${PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
               exit 1
             fi
-            echo "Retry #${RETRY_COUNT}: Waiting for ${PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
             sleep 10
             PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
             ((RETRY_COUNT=RETRY_COUNT+1))

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -190,7 +190,7 @@ jobs:
             --enable-master-authorized-networks \
             --master-authorized-networks ${RESTORE_IPS}
       - name: "Notify Jade Slack"
-        if:  ${{ github.event_name != 'workflow_dispatch' && always() }}
+        if:  always()
         uses: broadinstitute/action-slack@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -201,14 +201,14 @@ jobs:
           channel: "#jade-alerts"
           username: "Data Repo tests"
           text: "Perf tests"
-      #- name: "Notify QA Slack"
-      #  if: ${{ github.event_name != 'workflow_dispatch' && always() }}
-      #  uses: broadinstitute/action-slack@v2
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #  with:
-      #    status: ${{ job.status }}
-      #    channel: "#dsde-qa"
-      #    username: "Data Repo tests"
-      #    text: "Perf tests"
+      - name: "Notify QA Slack"
+        if: ${{ github.event_name != 'workflow_dispatch' && always() }}
+        uses: broadinstitute/action-slack@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          channel: "#dsde-qa"
+          username: "Data Repo tests"
+          text: "Perf tests"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,19 +14,15 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: "Fetch latest semantic version from data-repo dev"
-        id: "read_property"
-        run: |
-          CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
-          echo "Current Version: $CURRENT_VERSION"
-          echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION" 
-          LATEST_VERSION=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
-          echo "Latest Version: $LATEST_VERSION"
-          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
-      - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
+      - name: 'Get latest semantic version from data-repo dev'
+        id: apilatesttag
+        uses: "broadinstitute/github-action-get-previous-tag@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"  
+      - name: "Checkout jade-data-repo ${{ steps.apilatesttag.outputs.tag }} branch"
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.read_property.outputs.LATEST_SEMVER }}
+          ref: ${{ steps.apilatesttag.outputs.tag }}
       - name: "Import Vault perf secrets"
         uses: hashicorp/vault-action@v2.0.1
         with:
@@ -89,68 +85,77 @@ jobs:
               fi
             fi
           done
+      - name: "Check if perf env is already on latest semantic version from data-repo dev"
+        id: "read_property"
+        run: |
+          CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
+          echo "Current Version: $CURRENT_VERSION"
+          echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION" 
+          echo "Latest Version: ${{ steps.apilatesttag.outputs.tag }}"
+          echo "::set-output name=UPDATE::${{ steps.apilatesttag.outputs.tag != steps.read_property.outputs.CURRENT_SEMVER }}" 
+          echo "Need to update perf version? ${{ steps.read_property.outputs.UPDATE }}"
       - name: 'Checkout datarepo-helm-definitions repo'
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: docker://mikefarah/yq:latest
         with:
-          args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_SEMVER }}
+          args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.apilatesttag.outputs.tag }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: broadinstitute/create-pull-request@v3 # forked from peter-evans/create-pull-request
         with:
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
-          commit-message: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+          commit-message: "Perf Datarepo version update: ${{ steps.apilatesttag.outputs.tag }}"
           committer: datarepo-bot <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_SEMVER }}"
-          branch: "version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}"
+          title: "Perf Datarepo version update: ${{ steps.apilatesttag.outputs.tag }}"
+          branch: "version-update-${{ steps.apilatesttag.outputs.tag }}"
           body: |
-            Update versions in perf env to reflect image tag ${{ steps.read_property.outputs.LATEST_SEMVER }}.
+            Update versions in perf env to reflect image tag ${{ steps.apilatesttag.outputs.tag }}.
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge"
       - name: "Merge datarepo-helm-definition pull request"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
           git checkout master
           git config pull.rebase false
-          if git rev-parse --verify origin/version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}; then
-            git merge origin/version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}
+          if git rev-parse --verify origin/version-update-${{ steps.apilatesttag.outputs.tag }}; then
+            git merge origin/version-update-${{ steps.apilatesttag.outputs.tag }}
             git push
-            git push origin --delete version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}
+            git push origin --delete version-update-${{ steps.apilatesttag.outputs.tag }}
           else
-            echo "Branch version-update-${{ steps.read_property.outputs.LATEST_SEMVER }} not found."
+            echo "Branch version-update-${{ steps.apilatesttag.outputs.tag }} not found."
           fi
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Install Helmfile"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to apply image tag update to Perf yaml"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         run: |
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
           RETRY_COUNT=0
-          until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
+          until [[ "$PERF_VERSION" == "${{ steps.apilatesttag.outputs.tag }}" ]]; do
             if [[ ${RETRY_COUNT} > 5 ]]; then
-              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.apilatesttag.outputs.tag }}"
               exit 1
             fi
-            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.apilatesttag.outputs.tag }}"
             sleep 15
             PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
             ((RETRY_COUNT=RETRY_COUNT+1))

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -187,7 +187,7 @@ jobs:
       
             #- name: "Notify Jade Slack"
       - name: "Test conditional2"
-        if:  ${{ github.event_name != "workflow_dispatch"}} && always()
+        if:  ${{ github.event_name != 'workflow_dispatch' }} && always()
         run: echo ${{ github.event_name }}
       #  if: always()
       #  uses: broadinstitute/action-slack@v2

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Test conditional"
-        if:  ${{ github.event_name != 'workflow_dispatch' }} || always()
+        if:  ${{ github.event_name != 'workflow_dispatch' && always() }}
         run: echo ${{ github.event_name }}
       - name: "Fetch latest image git hash from data-repo dev"
         id: "read_property"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -22,7 +22,9 @@ jobs:
           echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION" 
           LATEST_VERSION=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
           echo "Latest Version: $LATEST_VERSION"
-          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
+          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"
+          echo "::set-output name=UPDATE::${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}" 
+          echo "Need to update perf version? ${{ steps.read_property.outputs.UPDATE }}"
       - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
         uses: actions/checkout@v2
         with:
@@ -90,19 +92,19 @@ jobs:
             fi
           done
       - name: 'Checkout datarepo-helm-definitions repo'
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: docker://mikefarah/yq:latest
         with:
           args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_SEMVER }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: broadinstitute/create-pull-request@v3 # forked from peter-evans/create-pull-request
         with:
           token: ${{ secrets.HELM_REPO_TOKEN }}
@@ -117,7 +119,7 @@ jobs:
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge"
       - name: "Merge datarepo-helm-definition pull request"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
           git checkout master
@@ -131,17 +133,17 @@ jobs:
           fi
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Install Helmfile"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to apply image tag update to Perf yaml"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.UPDATE }}
         run: |
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
           RETRY_COUNT=0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Test conditional"
-        if:  ${{ github.event_name != "workflow_dispatch"}} && always()
+        if:  ${{ github.event_name != 'workflow_dispatch' }} && always()
         run: echo ${{ github.event_name }}
       - name: "Fetch latest image git hash from data-repo dev"
         id: "read_property"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,15 +14,19 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Get latest semantic version from data-repo dev'
-        id: apilatesttag
-        uses: "broadinstitute/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"  
-      - name: "Checkout jade-data-repo ${{ steps.apilatesttag.outputs.tag }} branch"
+      - name: "Fetch latest semantic version from data-repo dev"
+        id: "read_property"
+        run: |
+          CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
+          echo "Current Version: $CURRENT_VERSION"
+          echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION" 
+          LATEST_VERSION=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
+          echo "Latest Version: $LATEST_VERSION"
+          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
+      - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.apilatesttag.outputs.tag }}
+          ref: ${{ steps.read_property.outputs.LATEST_SEMVER }}
       - name: "Import Vault perf secrets"
         uses: hashicorp/vault-action@v2.0.1
         with:
@@ -85,77 +89,68 @@ jobs:
               fi
             fi
           done
-      - name: "Check if perf env is already on latest semantic version from data-repo dev"
-        id: "read_property"
-        run: |
-          CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
-          echo "Current Version: $CURRENT_VERSION"
-          echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION" 
-          echo "Latest Version: ${{ steps.apilatesttag.outputs.tag }}"
-          echo "::set-output name=UPDATE::${{ steps.apilatesttag.outputs.tag != steps.read_property.outputs.CURRENT_SEMVER }}" 
-          echo "Need to update perf version? ${{ steps.read_property.outputs.UPDATE }}"
       - name: 'Checkout datarepo-helm-definitions repo'
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: docker://mikefarah/yq:latest
         with:
-          args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.apilatesttag.outputs.tag }}
+          args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_SEMVER }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/create-pull-request@v3 # forked from peter-evans/create-pull-request
         with:
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
-          commit-message: "Perf Datarepo version update: ${{ steps.apilatesttag.outputs.tag }}"
+          commit-message: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_SEMVER }}"
           committer: datarepo-bot <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: "Perf Datarepo version update: ${{ steps.apilatesttag.outputs.tag }}"
-          branch: "version-update-${{ steps.apilatesttag.outputs.tag }}"
+          title: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+          branch: "version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}"
           body: |
-            Update versions in perf env to reflect image tag ${{ steps.apilatesttag.outputs.tag }}.
+            Update versions in perf env to reflect image tag ${{ steps.read_property.outputs.LATEST_SEMVER }}.
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge"
       - name: "Merge datarepo-helm-definition pull request"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
           git checkout master
           git config pull.rebase false
-          if git rev-parse --verify origin/version-update-${{ steps.apilatesttag.outputs.tag }}; then
-            git merge origin/version-update-${{ steps.apilatesttag.outputs.tag }}
+          if git rev-parse --verify origin/version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}; then
+            git merge origin/version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}
             git push
-            git push origin --delete version-update-${{ steps.apilatesttag.outputs.tag }}
+            git push origin --delete version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}
           else
-            echo "Branch version-update-${{ steps.apilatesttag.outputs.tag }} not found."
+            echo "Branch version-update-${{ steps.read_property.outputs.LATEST_SEMVER }} not found."
           fi
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Install Helmfile"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to apply image tag update to Perf yaml"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
           RETRY_COUNT=0
-          until [[ "$PERF_VERSION" == "${{ steps.apilatesttag.outputs.tag }}" ]]; do
+          until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
             if [[ ${RETRY_COUNT} > 5 ]]; then
-              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.apilatesttag.outputs.tag }}"
+              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
               exit 1
             fi
-            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.apilatesttag.outputs.tag }}"
+            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
             sleep 15
             PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
             ((RETRY_COUNT=RETRY_COUNT+1))

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,10 +14,6 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout jade-data-repo develop branch"
-        uses: actions/checkout@v2
-        with:
-          ref: develop
       - name: 'Get latest semantic version from data-repo dev'
         id: apilatesttag
         uses: "broadinstitute/github-action-get-previous-tag@master"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -17,11 +17,11 @@ jobs:
       - name: "Fetch latest image git hash from data-repo dev"
         id: "read_property"
         run: |
-          CURRENT_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
-          echo "Current Version: ${CURRENT_VERSION%-*}" 
-          LATEST_VERSION=$(curl -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
-          echo "Latest Version: ${LATEST_VERSION%-*}"
-          echo "::set-output name=LATEST_SEMVER::${LATEST_VERSION%-*}"  
+          CURRENT_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
+          echo "Current Version: $CURRENT_VERSION" 
+          LATEST_VERSION=$(curl -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
+          echo "Latest Version: $LATEST_VERSION"
+          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
       - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
         uses: actions/checkout@v2
         with:
@@ -135,19 +135,19 @@ jobs:
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
         run: |
-          PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
+          PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
           RETRY_COUNT=0
-          until [[ "${PERF_VERSION%-*}" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
+          until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
             if [[ ${RETRY_COUNT} > 5 ]]; then
-              echo "Failed to match perf ${PERF_VERSION%-*} to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+              echo "Failed to match perf ${PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
               exit 1
             fi
-            echo "Retry #${RETRY_COUNT}: Waiting for ${PERF_VERSION%-*} to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+            echo "Retry #${RETRY_COUNT}: Waiting for ${PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
             sleep 10
-            PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
+            PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
             ((RETRY_COUNT=RETRY_COUNT+1))
           done;
-          echo "Perf successfully running on new version: ${PERF_VERSION%-*}"
+          echo "Perf successfully running on new version: $PERF_VERSION"
       - name: "Build and run Test Runner"
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -22,11 +22,11 @@ jobs:
           echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION" 
           LATEST_VERSION=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           echo "Latest Version: $LATEST_VERSION"
-          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
-      - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
+          echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"  
+      - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_VERSION }} branch"
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.read_property.outputs.LATEST_SEMVER }}
+          ref: ${{ steps.read_property.outputs.LATEST_VERSION }}
       - name: "Import Vault perf secrets"
         uses: hashicorp/vault-action@v2.0.1
         with:
@@ -90,67 +90,67 @@ jobs:
             fi
           done
       - name: 'Checkout datarepo-helm-definitions repo'
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: docker://mikefarah/yq:latest
         with:
-          args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_SEMVER }}
+          args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_VERSION }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/create-pull-request@v3 # forked from peter-evans/create-pull-request
         with:
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
-          commit-message: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+          commit-message: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_VERSION }}"
           committer: datarepo-bot <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_SEMVER }}"
-          branch: "version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}"
+          title: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_VERSION }}"
+          branch: "version-update-${{ steps.read_property.outputs.LATEST_VERSION }}"
           body: |
-            Update versions in perf env to reflect image tag ${{ steps.read_property.outputs.LATEST_SEMVER }}.
+            Update versions in perf env to reflect image tag ${{ steps.read_property.outputs.LATEST_VERSION }}.
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge"
       - name: "Merge datarepo-helm-definition pull request"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
           git checkout master
           git config pull.rebase false
-          if git rev-parse --verify origin/version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}; then
-            git merge origin/version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}
+          if git rev-parse --verify origin/version-update-${{ steps.read_property.outputs.LATEST_VERSION }}; then
+            git merge origin/version-update-${{ steps.read_property.outputs.LATEST_VERSION }}
             git push
-            git push origin --delete version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}
+            git push origin --delete version-update-${{ steps.read_property.outputs.LATEST_VERSION }}
           else
-            echo "Branch version-update-${{ steps.read_property.outputs.LATEST_SEMVER }} not found."
+            echo "Branch version-update-${{ steps.read_property.outputs.LATEST_VERSION }} not found."
           fi
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Install Helmfile"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to apply image tag update to Perf yaml"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
-        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           RETRY_COUNT=0
-          until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
+          until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_VERSION }}" ]]; do
             if [[ ${RETRY_COUNT} > 5 ]]; then
-              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_VERSION }}"
               exit 1
             fi
-            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_VERSION }}"
             sleep 15
             PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
             ((RETRY_COUNT=RETRY_COUNT+1))

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,10 +14,21 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout jade-data-repo develop branch"
+      - name: "Fetch latest image git hash from data-repo dev"
+        id: "read_property"
+        run: |
+          CURRENT_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
+          echo "Current Version: $CURRENT_VERSION" 
+          LATEST_VERSION=$(curl -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
+          echo "Latest Version: $LATEST_VERSION"
+          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"
+          UPDATE=$([[ "$CURRENT_VERSION" != "$LATEST_VERSION" ]])
+          echo $UPDATE
+          echo "::set-output name=UPDATE::$UPDATE"
+      - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
         uses: actions/checkout@v2
         with:
-          ref: develop
+          ref: ${{ steps.read_property.outputs.LATEST_SEMVER }}
       - name: "Import Vault perf secrets"
         uses: hashicorp/vault-action@v2.0.1
         with:
@@ -80,70 +91,70 @@ jobs:
               fi
             fi
           done
-      - name: "Fetch latest image git hash from data-repo dev"
-        id: "read_property"
-        run: |
-          echo "Current Version: " $(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.gitHash')
-          LATEST_VERSION=$(curl -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.gitHash')
-          echo "Latest Version: $LATEST_VERSION"
-          echo "::set-output name=LATEST_GITHASH::$LATEST_VERSION"
       - name: 'Checkout datarepo-helm-definitions repo'
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
-      - name: "Update perf image tag with gitHash"
+      - name: "Update perf image tag with semVer"
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: docker://mikefarah/yq:latest
         with:
-          args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_GITHASH }}
+          args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_SEMVER }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: broadinstitute/create-pull-request@v3 # forked from peter-evans/create-pull-request
         with:
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
-          commit-message: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_GITHASH }}"
+          commit-message: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_SEMVER }}"
           committer: datarepo-bot <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_GITHASH }}"
-          branch: "version-update-${{ steps.read_property.outputs.LATEST_GITHASH }}"
+          title: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+          branch: "version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}"
           body: |
-            Update versions in perf env to reflect image tag ${{ steps.read_property.outputs.LATEST_GITHASH }}.
+            Update versions in perf env to reflect image tag ${{ steps.read_property.outputs.LATEST_SEMVER }}.
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge"
       - name: "Merge datarepo-helm-definition pull request"
+        if: ${{ steps.read_property.outputs.UPDATE }}
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
           git checkout master
           git config pull.rebase false
-          if git rev-parse --verify origin/version-update-${{ steps.read_property.outputs.LATEST_GITHASH }}; then
-            git merge origin/version-update-${{ steps.read_property.outputs.LATEST_GITHASH }}
+          if git rev-parse --verify origin/version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}; then
+            git merge origin/version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}
             git push
-            git push origin --delete version-update-${{ steps.read_property.outputs.LATEST_GITHASH }}
+            git push origin --delete version-update-${{ steps.read_property.outputs.LATEST_SEMVER }}
           else
-            echo "Branch version-update-${{ steps.read_property.outputs.LATEST_GITHASH }} not found."
+            echo "Branch version-update-${{ steps.read_property.outputs.LATEST_SEMVER }} not found."
           fi
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Install Helmfile"
+        if: ${{ steps.read_property.outputs.UPDATE }}
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to apply image tag update to Perf yaml"
+        if: ${{ steps.read_property.outputs.UPDATE }}
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
+        if: ${{ steps.read_property.outputs.UPDATE }}
         run: |
-          PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.gitHash')
+          PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
           RETRY_COUNT=0
-          until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_GITHASH }}" ]]; do
+          until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
             if [[ ${RETRY_COUNT} > 5 ]]; then
-              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_GITHASH }}"
+              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
               exit 1
             fi
-            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_GITHASH }}"
+            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
             sleep 10
-            PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.gitHash')
+            PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
             ((RETRY_COUNT=RETRY_COUNT+1))
           done;
           echo "Perf successfully running on new version: $PERF_VERSION"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,6 +14,10 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
+      - name: "Checkout jade-data-repo develop branch"
+        uses: actions/checkout@v2
+        with:
+          ref: develop
       - name: 'Get latest semantic version from data-repo dev'
         id: apilatesttag
         uses: "broadinstitute/github-action-get-previous-tag@master"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -181,25 +181,27 @@ jobs:
           gcloud container clusters update ${K8_CLUSTER} \
             --enable-master-authorized-networks \
             --master-authorized-networks ${RESTORE_IPS}
-      - name: "Notify Jade Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#jade-alerts"
-          username: "Data Repo tests"
-          text: "Perf tests"
-      - name: "Notify QA Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#dsde-qa"
-          username: "Data Repo tests"
-          text: "Perf tests"
+      - name: "Test conditional"
+        run: echo ${{ github.event_name }}
+            #- name: "Notify Jade Slack"
+      #  if: always()
+      #  uses: broadinstitute/action-slack@v2
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #  with:
+      #    status: ${{ job.status }}
+      #    channel: "#jade-alerts"
+      #    username: "Data Repo tests"
+      #    text: "Perf tests"
+      #- name: "Notify QA Slack"
+      #  if: always()
+      #  uses: broadinstitute/action-slack@v2
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #  with:
+      #    status: ${{ job.status }}
+      #    channel: "#dsde-qa"
+      #    username: "Data Repo tests"
+      #    text: "Perf tests"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,15 +14,15 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: "Checkout jade-data-repo develop branch"
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
-      - name: 'Get Previous tag'
+          ref: develop
+      - name: 'Get latest semantic version from data-repo dev'
         id: apilatesttag
         uses: "broadinstitute/github-action-get-previous-tag@master"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"  
       - name: "Checkout jade-data-repo ${{ steps.apilatesttag.outputs.tag }} branch"
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,7 +14,7 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: "Fetch latest sematic version from data-repo dev"
+      - name: "Fetch latest semantic version from data-repo dev"
         id: "read_property"
         run: |
           CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -137,17 +137,17 @@ jobs:
         run: |
           PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
           RETRY_COUNT=0
-          until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
+          until [[ "${PERF_VERSION%-*}" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
             if [[ ${RETRY_COUNT} > 5 ]]; then
-              echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+              echo "Failed to match perf ${PERF_VERSION%-*} to dev version ${{ steps.read_property.outputs.LATEST_SEMVER }}"
               exit 1
             fi
-            echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
+            echo "Retry #${RETRY_COUNT}: Waiting for ${PERF_VERSION%-*} to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
             sleep 10
             PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
             ((RETRY_COUNT=RETRY_COUNT+1))
           done;
-          echo "Perf successfully running on new version: $PERF_VERSION"
+          echo "Perf successfully running on new version: ${PERF_VERSION%-*}""
       - name: "Build and run Test Runner"
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,14 +14,12 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: "Test conditional"
-        if:  ${{ github.event_name != 'workflow_dispatch' && always() }}
-        run: echo ${{ github.event_name }}
       - name: "Fetch latest image git hash from data-repo dev"
         id: "read_property"
         run: |
           CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
-          echo "Current Version: $CURRENT_VERSION" 
+          echo "Current Version: $CURRENT_VERSION"
+          echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION" 
           LATEST_VERSION=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
           echo "Latest Version: $LATEST_VERSION"
           echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
@@ -92,16 +90,19 @@ jobs:
             fi
           done
       - name: 'Checkout datarepo-helm-definitions repo'
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: docker://mikefarah/yq:latest
         with:
           args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_SEMVER }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/create-pull-request@v3 # forked from peter-evans/create-pull-request
         with:
           token: ${{ secrets.HELM_REPO_TOKEN }}
@@ -116,6 +117,7 @@ jobs:
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge"
       - name: "Merge datarepo-helm-definition pull request"
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
           git checkout master
@@ -129,14 +131,17 @@ jobs:
           fi
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Install Helmfile"
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to apply image tag update to Perf yaml"
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
           RETRY_COUNT=0
@@ -185,22 +190,19 @@ jobs:
             --enable-master-authorized-networks \
             --master-authorized-networks ${RESTORE_IPS}
       
-            #- name: "Notify Jade Slack"
-      - name: "Test conditional2"
-        if:  ${{ github.event_name != 'workflow_dispatch' }} && always()
-        run: echo ${{ github.event_name }}
-      #  if: always()
-      #  uses: broadinstitute/action-slack@v2
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #  with:
-      #    status: ${{ job.status }}
-      #    channel: "#jade-alerts"
-      #    username: "Data Repo tests"
-      #    text: "Perf tests"
+      - name: "Notify Jade Slack"
+        if:  ${{ github.event_name != 'workflow_dispatch' && always() }}
+        uses: broadinstitute/action-slack@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          channel: "#jade-alerts"
+          username: "Data Repo tests"
+          text: "Perf tests"
       #- name: "Notify QA Slack"
-      #  if: always()
+      #  if: ${{ github.event_name != 'workflow_dispatch' && always() }}
       #  uses: broadinstitute/action-slack@v2
       #  env:
       #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -22,9 +22,11 @@ jobs:
           LATEST_VERSION=$(curl -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
           echo "Latest Version: $LATEST_VERSION"
           echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"
-          UPDATE=$([[ "$CURRENT_VERSION" != "$LATEST_VERSION" ]])
-          echo $UPDATE
-          echo "::set-output name=UPDATE::$UPDATE"
+          TO_UPDATE=0
+          if [[ "$CURRENT_VERSION" != "$LATEST_VERSION" ]]
+            TO_UPDATE=1
+          fi
+          echo "::set-output name=UPDATE::$TO_UPDATE"    
       - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
         uses: actions/checkout@v2
         with:
@@ -92,19 +94,19 @@ jobs:
             fi
           done
       - name: 'Checkout datarepo-helm-definitions repo'
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         uses: docker://mikefarah/yq:latest
         with:
           args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_SEMVER }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         uses: broadinstitute/create-pull-request@v3 # forked from peter-evans/create-pull-request
         with:
           token: ${{ secrets.HELM_REPO_TOKEN }}
@@ -119,7 +121,7 @@ jobs:
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge"
       - name: "Merge datarepo-helm-definition pull request"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
           git checkout master
@@ -133,17 +135,17 @@ jobs:
           fi
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Install Helmfile"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to apply image tag update to Perf yaml"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         run: |
           PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
           RETRY_COUNT=0
@@ -191,17 +193,17 @@ jobs:
           gcloud container clusters update ${K8_CLUSTER} \
             --enable-master-authorized-networks \
             --master-authorized-networks ${RESTORE_IPS}
-      - name: "Notify Jade Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#jade-alerts"
-          username: "Data Repo tests"
-          text: "Perf tests"
+      #- name: "Notify Jade Slack"
+      #  if: always()
+      #  uses: broadinstitute/action-slack@v2
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       #   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+       # with:
+       #   status: ${{ job.status }}
+       #   channel: "#jade-alerts"
+       #   username: "Data Repo tests"
+       #   text: "Perf tests"
       #- name: "Notify QA Slack"
       #  if: always()
       #  uses: broadinstitute/action-slack@v2

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -22,9 +22,7 @@ jobs:
           echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION" 
           LATEST_VERSION=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
           echo "Latest Version: $LATEST_VERSION"
-          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"
-          echo "::set-output name=UPDATE::${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}" 
-          echo "Need to update perf version? ${{ steps.read_property.outputs.UPDATE }}"
+          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
       - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
         uses: actions/checkout@v2
         with:
@@ -92,19 +90,19 @@ jobs:
             fi
           done
       - name: 'Checkout datarepo-helm-definitions repo'
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: docker://mikefarah/yq:latest
         with:
           args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_SEMVER }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/create-pull-request@v3 # forked from peter-evans/create-pull-request
         with:
           token: ${{ secrets.HELM_REPO_TOKEN }}
@@ -119,7 +117,7 @@ jobs:
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge"
       - name: "Merge datarepo-helm-definition pull request"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
           git checkout master
@@ -133,17 +131,17 @@ jobs:
           fi
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Install Helmfile"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to apply image tag update to Perf yaml"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
-        if: ${{ steps.read_property.outputs.UPDATE }}
+        if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
           RETRY_COUNT=0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -190,7 +190,7 @@ jobs:
             --enable-master-authorized-networks \
             --master-authorized-networks ${RESTORE_IPS}
       - name: "Notify Jade Slack"
-        if:  always()
+        if: always()
         uses: broadinstitute/action-slack@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -17,10 +17,10 @@ jobs:
       - name: "Fetch latest semantic version from data-repo dev"
         id: "read_property"
         run: |
-          CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
+          CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           echo "Current Version: $CURRENT_VERSION"
           echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION" 
-          LATEST_VERSION=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
+          LATEST_VERSION=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           echo "Latest Version: $LATEST_VERSION"
           echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
       - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
@@ -143,7 +143,7 @@ jobs:
       - name: "Wait for Perf Cluster to come back up with correct version"
         if: ${{ steps.read_property.outputs.LATEST_SEMVER != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
-          PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
+          PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           RETRY_COUNT=0
           until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_SEMVER }}" ]]; do
             if [[ ${RETRY_COUNT} > 5 ]]; then
@@ -152,7 +152,7 @@ jobs:
             fi
             echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_SEMVER }}"
             sleep 15
-            PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
+            PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
             ((RETRY_COUNT=RETRY_COUNT+1))
           done;
           echo "Perf successfully running on new version: $PERF_VERSION"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -21,12 +21,7 @@ jobs:
           echo "Current Version: $CURRENT_VERSION" 
           LATEST_VERSION=$(curl -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
           echo "Latest Version: $LATEST_VERSION"
-          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"
-          TO_UPDATE=0
-          if [[ "$CURRENT_VERSION" != "$LATEST_VERSION" ]]
-            TO_UPDATE=1
-          fi
-          echo "::set-output name=UPDATE::$TO_UPDATE"    
+          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
       - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
         uses: actions/checkout@v2
         with:
@@ -94,19 +89,16 @@ jobs:
             fi
           done
       - name: 'Checkout datarepo-helm-definitions repo'
-        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
-        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         uses: docker://mikefarah/yq:latest
         with:
           args: yq w -i datarepo-helm-definitions/perf/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_SEMVER }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"
-        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         uses: broadinstitute/create-pull-request@v3 # forked from peter-evans/create-pull-request
         with:
           token: ${{ secrets.HELM_REPO_TOKEN }}
@@ -121,7 +113,6 @@ jobs:
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge"
       - name: "Merge datarepo-helm-definition pull request"
-        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
           git checkout master
@@ -135,17 +126,14 @@ jobs:
           fi
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Install Helmfile"
-        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to apply image tag update to Perf yaml"
-        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
-        if: ${{ steps.read_property.outputs.UPDATE }} == 1
         run: |
           PERF_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
           RETRY_COUNT=0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,6 +14,8 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
+      - name: "Test conditional"
+        run: echo ${{ github.event_name }}
       - name: "Fetch latest image git hash from data-repo dev"
         id: "read_property"
         run: |
@@ -181,8 +183,7 @@ jobs:
           gcloud container clusters update ${K8_CLUSTER} \
             --enable-master-authorized-networks \
             --master-authorized-networks ${RESTORE_IPS}
-      - name: "Test conditional"
-        run: echo ${{ github.event_name }}
+      
             #- name: "Notify Jade Slack"
       #  if: always()
       #  uses: broadinstitute/action-slack@v2

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -181,25 +181,25 @@ jobs:
           gcloud container clusters update ${K8_CLUSTER} \
             --enable-master-authorized-networks \
             --master-authorized-networks ${RESTORE_IPS}
-      #- name: "Notify Jade Slack"
-      #  if: always()
-      #  uses: broadinstitute/action-slack@v2
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-       #   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-       # with:
-       #   status: ${{ job.status }}
-       #   channel: "#jade-alerts"
-       #   username: "Data Repo tests"
-       #   text: "Perf tests"
-      #- name: "Notify QA Slack"
-      #  if: always()
-      #  uses: broadinstitute/action-slack@v2
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #  with:
-      #    status: ${{ job.status }}
-      #    channel: "#dsde-qa"
-      #    username: "Data Repo tests"
-       #   text: "Perf tests"
+      - name: "Notify Jade Slack"
+        if: always()
+        uses: broadinstitute/action-slack@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          channel: "#jade-alerts"
+          username: "Data Repo tests"
+          text: "Perf tests"
+      - name: "Notify QA Slack"
+        if: always()
+        uses: broadinstitute/action-slack@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          channel: "#dsde-qa"
+          username: "Data Repo tests"
+          text: "Perf tests"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Test conditional"
-        if:  ${{ github.event_name != 'workflow_dispatch' }} && always()
+        if:  ${{ github.event_name != 'workflow_dispatch' }} || always()
         run: echo ${{ github.event_name }}
       - name: "Fetch latest image git hash from data-repo dev"
         id: "read_property"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -18,10 +18,10 @@ jobs:
         id: "read_property"
         run: |
           CURRENT_VERSION=$(curl -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
-          echo "Current Version: $CURRENT_VERSION" 
+          echo "Current Version: ${CURRENT_VERSION%-*}" 
           LATEST_VERSION=$(curl -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer')
-          echo "Latest Version: $LATEST_VERSION"
-          echo "::set-output name=LATEST_SEMVER::$LATEST_VERSION"  
+          echo "Latest Version: ${LATEST_VERSION%-*}"
+          echo "::set-output name=LATEST_SEMVER::${LATEST_VERSION%-*}"  
       - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_SEMVER }} branch"
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,15 +14,15 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout jade-data-repo develop branch"
+      - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: develop
-      - name: 'Get latest semantic version from data-repo dev'
+          fetch-depth: 0
+      - name: 'Get Previous tag'
         id: apilatesttag
         uses: "broadinstitute/github-action-get-previous-tag@master"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"  
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: "Checkout jade-data-repo ${{ steps.apilatesttag.outputs.tag }} branch"
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -14,7 +14,7 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: "Fetch latest image git hash from data-repo dev"
+      - name: "Fetch latest sematic version from data-repo dev"
         id: "read_property"
         run: |
           CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer' | sed 's/-SNAPSHOT//')
@@ -189,7 +189,6 @@ jobs:
           gcloud container clusters update ${K8_CLUSTER} \
             --enable-master-authorized-networks \
             --master-authorized-networks ${RESTORE_IPS}
-      
       - name: "Notify Jade Slack"
         if:  ${{ github.event_name != 'workflow_dispatch' && always() }}
         uses: broadinstitute/action-slack@v2

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Test conditional"
+        if:  ${{ github.event_name != "workflow_dispatch"}} && always()
         run: echo ${{ github.event_name }}
       - name: "Fetch latest image git hash from data-repo dev"
         id: "read_property"
@@ -185,6 +186,9 @@ jobs:
             --master-authorized-networks ${RESTORE_IPS}
       
             #- name: "Notify Jade Slack"
+      - name: "Test conditional2"
+        if:  ${{ github.event_name != "workflow_dispatch"}} && always()
+        run: echo ${{ github.event_name }}
       #  if: always()
       #  uses: broadinstitute/action-slack@v2
       #  env:


### PR DESCRIPTION
These changes include a few clean-up items:
- Instead of using the githash for the container image, we're now pointing to the semantic version
- Re-enable slack notifications *only* for the scheduled runs (not manually dispatched runs)
- If perf is already pointing to the latest version of the data-repo, skip versioning steps