### PR TITLE
DR-1386 Improve the performance of creating snapshots

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
@@ -1,11 +1,13 @@
 package scripts.testscripts;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.model.BulkLoadArrayRequestModel;
 import bio.terra.datarepo.model.BulkLoadArrayResultModel;
-import bio.terra.datarepo.model.BulkLoadFileModel;
-import bio.terra.datarepo.model.BulkLoadFileResultModel;
+import bio.terra.datarepo.model.BulkLoadResultModel;
 import bio.terra.datarepo.model.DeleteResponseModel;
 import bio.terra.datarepo.model.IngestRequestModel;
 import bio.terra.datarepo.model.IngestResponseModel;
@@ -15,16 +17,13 @@ import bio.terra.datarepo.model.SnapshotSummaryModel;
 import com.google.cloud.storage.BlobId;
 import common.utils.FileUtils;
 import common.utils.StorageUtils;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import runner.config.TestUserSpecification;
 import scripts.testscripts.baseclasses.SimpleDataset;
+import scripts.utils.BulkLoadUtils;
 import scripts.utils.DataRepoUtils;
 
 public class CreateSnapshot extends SimpleDataset {
@@ -43,83 +42,38 @@ public class CreateSnapshot extends SimpleDataset {
     // create the profile and dataset
     super.setup(testUsers);
 
-    // get the ApiClient for the snapshot creator, same as the dataset creator
     ApiClient datasetCreatorClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
     RepositoryApi repositoryApi = new RepositoryApi(datasetCreatorClient);
 
-    // load data into the new dataset
-    // note that there's a fileref in the dataset
-    // ingest a file -- TODO CannedTestData.getMeA1KBFile
-    URI sourceUri = new URI("gs://jade-testdata/fileloadprofiletest/1KBfile.txt");
+    // set up and start bulk load job of small local files
+    BulkLoadArrayRequestModel arrayLoad =
+        BulkLoadUtils.buildBulkLoadFileRequest100B(filesToLoad, billingProfileModel.getId());
+    JobModel bulkLoadArrayJobResponse =
+        repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), arrayLoad);
 
-    String loadTag = FileUtils.randomizeName("lookupTest");
-    BulkLoadArrayRequestModel fileLoadModelArray =
-        new BulkLoadArrayRequestModel()
-            .profileId(datasetSummaryModel.getDefaultProfileId())
-            .loadTag(loadTag)
-            .maxFailedFileLoads(0);
+    // wait for the job to complete
+    bulkLoadArrayJobResponse =
+        DataRepoUtils.waitForJobToFinish(repositoryApi, bulkLoadArrayJobResponse);
+    BulkLoadArrayResultModel result =
+        DataRepoUtils.expectJobSuccess(
+            repositoryApi, bulkLoadArrayJobResponse, BulkLoadArrayResultModel.class);
+    BulkLoadResultModel loadSummary = result.getLoadSummary();
+    assertThat(
+        "Number of successful files loaded should equal total files.",
+        loadSummary.getTotalFiles(),
+        equalTo(loadSummary.getSucceededFiles()));
 
-    List<String> fileIds = new ArrayList<>();
-    for (int i = 0; i < filesToLoad; i++) {
-      String targetPath = "/testrunner/IngestFile/" + FileUtils.randomizeName("") + ".txt";
+    // generate load for the simple dataset
+    String testConfigGetIngestbucket = "jade-testdata";
+    String fileRefName =
+        "scratch/buildSnapshotWithFiles/" + FileUtils.randomizeName("input") + ".json";
+    BlobId scratchFile =
+        BulkLoadUtils.writeScratchFileForIngestRequest(
+            server.testRunnerServiceAccount, result, testConfigGetIngestbucket, fileRefName);
+    IngestRequestModel ingestRequest = BulkLoadUtils.makeIngestRequestFromScratchFile(scratchFile);
+    scratchFiles.add(scratchFile); // make sure the scratch file gets cleaned up later
 
-      BulkLoadFileModel fileLoadModel =
-          new BulkLoadFileModel()
-              .sourcePath(sourceUri.toString())
-              .description("IngestFile")
-              .mimeType("text/plain")
-              .targetPath(targetPath);
-      fileLoadModelArray.addLoadArrayItem(fileLoadModel);
-      if (fileLoadModelArray.getLoadArray().size() % 1000 == 0 || i == filesToLoad - 1) {
-        JobModel ingestFileJobResponse =
-            repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
-        ingestFileJobResponse =
-            DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
-        BulkLoadArrayResultModel bulkLoadArrayResultModel =
-            DataRepoUtils.expectJobSuccess(
-                repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);
-
-        try (Stream<BulkLoadFileResultModel> resultStream =
-            bulkLoadArrayResultModel.getLoadFileResults().stream()) {
-          fileIds.addAll(
-              resultStream.map(BulkLoadFileResultModel::getFileId).collect(Collectors.toList()));
-        }
-        fileLoadModelArray.getLoadArray().clear();
-      }
-    }
-    String jsonLines;
-    try (Stream<String> resultStream = fileIds.stream()) {
-      // ingest the tabular data from the JSON file we just generated
-      // generate a JSON file with the fileref
-      jsonLines =
-          resultStream
-              .map(
-                  fileId ->
-                      "{\"VCF_File_Name\":\"name1\", \"Description\":\"description1\", \"VCF_File_Ref\":\""
-                          + fileId
-                          + "\"}")
-              .collect(Collectors.joining("\n"));
-    }
-    byte[] fileRefBytes = jsonLines.getBytes(StandardCharsets.UTF_8);
-    // load a JSON file that contains the table rows to load into the test bucket
-    String jsonFileName = FileUtils.randomizeName("this-better-pass") + ".json";
-    String fileRefName = "scratch/testDRSLookup/" + jsonFileName;
-
-    String scratchFileBucketName = "jade-testdata";
-    BlobId scratchFileTabularData =
-        StorageUtils.writeBytesToFile(
-            StorageUtils.getClientForServiceAccount(server.testRunnerServiceAccount),
-            scratchFileBucketName,
-            fileRefName,
-            fileRefBytes);
-    scratchFiles.add(scratchFileTabularData); // make sure the scratch file gets cleaned up later
-    String gsPath = StorageUtils.blobIdToGSPath(scratchFileTabularData);
-
-    IngestRequestModel ingestRequest =
-        new IngestRequestModel()
-            .format(IngestRequestModel.FormatEnum.JSON)
-            .table("vcf_file")
-            .path(gsPath);
+    // load the data
     JobModel ingestTabularDataJobResponse =
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
@@ -1,0 +1,199 @@
+package scripts.testscripts;
+
+import bio.terra.datarepo.api.RepositoryApi;
+import bio.terra.datarepo.client.ApiClient;
+import bio.terra.datarepo.model.BulkLoadArrayRequestModel;
+import bio.terra.datarepo.model.BulkLoadArrayResultModel;
+import bio.terra.datarepo.model.BulkLoadFileModel;
+import bio.terra.datarepo.model.BulkLoadFileResultModel;
+import bio.terra.datarepo.model.DeleteResponseModel;
+import bio.terra.datarepo.model.IngestRequestModel;
+import bio.terra.datarepo.model.IngestResponseModel;
+import bio.terra.datarepo.model.JobModel;
+import bio.terra.datarepo.model.SnapshotModel;
+import bio.terra.datarepo.model.SnapshotSummaryModel;
+import com.google.cloud.storage.BlobId;
+import common.utils.FileUtils;
+import common.utils.StorageUtils;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import runner.config.TestUserSpecification;
+import scripts.testscripts.baseclasses.SimpleDataset;
+import scripts.utils.DataRepoUtils;
+
+public class CreateSnapshot extends SimpleDataset {
+  private static final Logger logger = LoggerFactory.getLogger(CreateSnapshot.class);
+
+  /** Public constructor so that this class can be instantiated via reflection. */
+  public CreateSnapshot() {
+    super();
+  }
+
+  private SnapshotModel snapshotModel;
+
+  private static List<BlobId> scratchFiles = new ArrayList<>();
+
+  public void setup(List<TestUserSpecification> testUsers) throws Exception {
+    // create the profile and dataset
+    super.setup(testUsers);
+
+    // get the ApiClient for the snapshot creator, same as the dataset creator
+    ApiClient datasetCreatorClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
+    RepositoryApi repositoryApi = new RepositoryApi(datasetCreatorClient);
+
+    // load data into the new dataset
+    // note that there's a fileref in the dataset
+    // ingest a file -- TODO CannedTestData.getMeA1KBFile
+    URI sourceUri = new URI("gs://jade-testdata/fileloadprofiletest/1KBfile.txt");
+
+    String loadTag = FileUtils.randomizeName("lookupTest");
+    BulkLoadArrayRequestModel fileLoadModelArray =
+        new BulkLoadArrayRequestModel()
+            .profileId(datasetSummaryModel.getDefaultProfileId())
+            .loadTag(loadTag)
+            .maxFailedFileLoads(0);
+
+    List<String> fileIds = new ArrayList<>();
+    for (int i = 0; i < filesToLoad; i++) {
+      String targetPath = "/testrunner/IngestFile/" + FileUtils.randomizeName("") + ".txt";
+
+      BulkLoadFileModel fileLoadModel =
+          new BulkLoadFileModel()
+              .sourcePath(sourceUri.toString())
+              .description("IngestFile")
+              .mimeType("text/plain")
+              .targetPath(targetPath);
+      fileLoadModelArray.addLoadArrayItem(fileLoadModel);
+      if (fileLoadModelArray.getLoadArray().size() % 1000 == 0 || i == filesToLoad - 1) {
+        JobModel ingestFileJobResponse =
+            repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
+        ingestFileJobResponse =
+            DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
+        BulkLoadArrayResultModel bulkLoadArrayResultModel =
+            DataRepoUtils.expectJobSuccess(
+                repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);
+
+        try (Stream<BulkLoadFileResultModel> resultStream =
+            bulkLoadArrayResultModel.getLoadFileResults().stream()) {
+          fileIds.addAll(
+              resultStream.map(BulkLoadFileResultModel::getFileId).collect(Collectors.toList()));
+        }
+        fileLoadModelArray.getLoadArray().clear();
+      }
+    }
+    String jsonLines;
+    try (Stream<String> resultStream = fileIds.stream()) {
+      // ingest the tabular data from the JSON file we just generated
+      // generate a JSON file with the fileref
+      jsonLines =
+          resultStream
+              .map(
+                  fileId ->
+                      "{\"VCF_File_Name\":\"name1\", \"Description\":\"description1\", \"VCF_File_Ref\":\""
+                          + fileId
+                          + "\"}")
+              .collect(Collectors.joining("\n"));
+    }
+    byte[] fileRefBytes = jsonLines.getBytes(StandardCharsets.UTF_8);
+    // load a JSON file that contains the table rows to load into the test bucket
+    String jsonFileName = FileUtils.randomizeName("this-better-pass") + ".json";
+    String fileRefName = "scratch/testDRSLookup/" + jsonFileName;
+
+    String scratchFileBucketName = "jade-testdata";
+    BlobId scratchFileTabularData =
+        StorageUtils.writeBytesToFile(
+            StorageUtils.getClientForServiceAccount(server.testRunnerServiceAccount),
+            scratchFileBucketName,
+            fileRefName,
+            fileRefBytes);
+    scratchFiles.add(scratchFileTabularData); // make sure the scratch file gets cleaned up later
+    String gsPath = StorageUtils.blobIdToGSPath(scratchFileTabularData);
+
+    IngestRequestModel ingestRequest =
+        new IngestRequestModel()
+            .format(IngestRequestModel.FormatEnum.JSON)
+            .table("vcf_file")
+            .path(gsPath);
+    JobModel ingestTabularDataJobResponse =
+        repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
+
+    ingestTabularDataJobResponse =
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse);
+    IngestResponseModel ingestResponse =
+        DataRepoUtils.expectJobSuccess(
+            repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
+    logger.info("Successfully loaded data into dataset: {}", ingestResponse.getDataset());
+  }
+
+  private int filesToLoad;
+
+  public void setParameters(List<String> parameters) throws Exception {
+    if (parameters == null || parameters.size() == 0) {
+      throw new IllegalArgumentException(
+          "Must provide a number of files to load in the parameters list");
+    } else {
+      filesToLoad = Integer.parseInt(parameters.get(0));
+    }
+  }
+
+  public void userJourney(TestUserSpecification testUser) throws Exception {
+    try {
+      logger.info("Creating a snapshot");
+      // get the ApiClient for the snapshot creator, same as the dataset creator
+      ApiClient datasetCreatorClient = DataRepoUtils.getClientForTestUser(testUser, server);
+      RepositoryApi repositoryApi = new RepositoryApi(datasetCreatorClient);
+      // make the create snapshot request and wait for the job to finish
+      JobModel createSnapshotJobResponse =
+          DataRepoUtils.createSnapshot(
+              repositoryApi, datasetSummaryModel, "snapshot-simple.json", true);
+
+      logger.info("Snapshot job is done");
+      if (createSnapshotJobResponse.getJobStatus() == JobModel.JobStatusEnum.FAILED) {
+        throw new RuntimeException("Snapshot job did not finish successfully");
+      }
+      // save a reference to the snapshot summary model so we can delete it in cleanup()
+      SnapshotSummaryModel snapshotSummaryModel =
+          DataRepoUtils.expectJobSuccess(
+              repositoryApi, createSnapshotJobResponse, SnapshotSummaryModel.class);
+      logger.info("Successfully created snapshot: {}", snapshotSummaryModel.getName());
+
+      // now go and retrieve the file Id that should be stored in the snapshot
+      snapshotModel = repositoryApi.retrieveSnapshot(snapshotSummaryModel.getId());
+    } catch (Exception e) {
+      logger.error("Error in journey", e);
+      e.printStackTrace();
+      throw e;
+    }
+  }
+
+  public void cleanup(List<TestUserSpecification> testUsers) throws Exception {
+    logger.info("Tearing down");
+
+    // get the ApiClient for the dataset creator
+    ApiClient datasetCreatorClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
+    RepositoryApi repositoryApi = new RepositoryApi(datasetCreatorClient);
+
+    // make the delete request and wait for the job to finish
+    if (snapshotModel != null) {
+      JobModel deleteSnapshotJobResponse = repositoryApi.deleteSnapshot(snapshotModel.getId());
+      deleteSnapshotJobResponse =
+          DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse);
+      DataRepoUtils.expectJobSuccess(
+          repositoryApi, deleteSnapshotJobResponse, DeleteResponseModel.class);
+      logger.info("Successfully deleted snapshot: {}", snapshotModel.getName());
+
+      super.cleanup(testUsers);
+      // delete the profile and dataset
+
+      // delete the scratch files used for ingesting tabular data and soft delete rows
+      StorageUtils.deleteFiles(
+          StorageUtils.getClientForServiceAccount(server.testRunnerServiceAccount), scratchFiles);
+    }
+  }
+}

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
@@ -45,6 +45,9 @@ public class CreateSnapshot extends SimpleDataset {
     ApiClient datasetCreatorClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
     RepositoryApi repositoryApi = new RepositoryApi(datasetCreatorClient);
 
+    // Be careful testing this at larger sizes
+    DataRepoUtils.setConfigParameter(repositoryApi, "LOAD_BULK_ARRAY_FILES_MAX", filesToLoad);
+
     // set up and start bulk load job of small local files
     BulkLoadArrayRequestModel arrayLoad =
         BulkLoadUtils.buildBulkLoadFileRequest100B(filesToLoad, billingProfileModel.getId());

--- a/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
@@ -37,7 +37,8 @@ public final class DataRepoUtils {
 
   private DataRepoUtils() {}
 
-  private static int maximumSecondsToWaitForJob = 500;
+  private static int maximumSecondsToWaitForJob =
+      Long.valueOf(TimeUnit.HOURS.toSeconds(2)).intValue();
   private static int secondsIntervalToPollJob = 5;
 
   private static Map<TestUserSpecification, ApiClient> apiClientsForTestUsers = new HashMap<>();

--- a/datarepo-clienttests/src/main/resources/configs/basicexamples/CreateSnapshot.json
+++ b/datarepo-clienttests/src/main/resources/configs/basicexamples/CreateSnapshot.json
@@ -1,0 +1,21 @@
+{
+  "name": "CreateSnapshot",
+  "description": "Create a snapshot with a lot of files",
+  "serverSpecificationFile": "perf.json",
+  "billingAccount": "00708C-45D19D-27AAFA",
+  "kubernetes": {
+    "numberOfInitialPods" : 1
+  },
+  "application": {},
+  "testScripts": [
+    {
+      "name": "CreateSnapshot",
+      "parameters": [10000],
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 1,
+      "expectedTimeForEach": 2,
+      "expectedTimeForEachUnit": "HOURS"
+    }
+  ],
+  "testUserFiles": ["dumbledore.json"]
+}

--- a/datarepo-clienttests/src/main/resources/configs/functional/CreateSnapshot.json
+++ b/datarepo-clienttests/src/main/resources/configs/functional/CreateSnapshot.json
@@ -1,7 +1,7 @@
 {
   "name": "CreateSnapshot",
   "description": "Create a snapshot with a lot of files",
-  "serverSpecificationFile": "perf.json",
+  "serverSpecificationFile": "nmlocalhost.json",
   "billingAccount": "00708C-45D19D-27AAFA",
   "kubernetes": {
     "numberOfInitialPods" : 1

--- a/datarepo-clienttests/src/main/resources/servers/nmlocalhost.json
+++ b/datarepo-clienttests/src/main/resources/servers/nmlocalhost.json
@@ -1,7 +1,7 @@
 {
   "name": "localhost",
   "description": "Server running locally. Supports launching the server in a separate process. Does not support modifying Kubernetes post-deployment.",
-  "datarepoUri": "https://jade-nm.datarepo-dev.broadinstitute.org/",
+  "datarepoUri": "http://localhost:8080/",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
   "samResourceIdForDatarepo": "broad-jade-dev",
   "deploymentScript": {

--- a/datarepo-clienttests/src/main/resources/servers/nmlocalhost.json
+++ b/datarepo-clienttests/src/main/resources/servers/nmlocalhost.json
@@ -1,0 +1,14 @@
+{
+  "name": "localhost",
+  "description": "Server running locally. Supports launching the server in a separate process. Does not support modifying Kubernetes post-deployment.",
+  "datarepoUri": "https://jade-nm.datarepo-dev.broadinstitute.org/",
+  "samUri": "https://sam.dsde-dev.broadinstitute.org",
+  "samResourceIdForDatarepo": "broad-jade-dev",
+  "deploymentScript": {
+    "name": "LaunchLocalProcess",
+    "parameters": ["file:///Users/nmalfroy/src/jade-data-repo/"]
+  },
+  "testRunnerServiceAccountFile": "jade-k8-sa.json",
+  "skipDeployment": true,
+  "skipKubernetes": true
+}

--- a/datarepo-clienttests/src/main/resources/suites/NightlyPerfWorkflow.json
+++ b/datarepo-clienttests/src/main/resources/suites/NightlyPerfWorkflow.json
@@ -2,5 +2,5 @@
   "name": "NightlyPerfWorkflow",
   "description": "Performance tests to run on nightly github action",
   "serverSpecificationFile": "perf.json",
-  "testConfigurationFiles": ["basicexamples/BasicAuthenticated.json", "basicexamples/BasicUnauthenticated.json", "basicexamples/DRSLookup.json", "basicexamples/SoftDeleteDataset.json", "basicexamples/LookupDataset.json", "profiling/BuildSnapshotWithFiles1000_50.json", "profiling/BulkLoadScale200_20.json", "basicexamples/CreateSnapshot.json"]
+  "testConfigurationFiles": ["basicexamples/BasicAuthenticated.json", "basicexamples/BasicUnauthenticated.json", "basicexamples/DRSLookup.json", "basicexamples/SoftDeleteDataset.json", "basicexamples/LookupDataset.json", "profiling/BuildSnapshotWithFiles1000_50.json", "profiling/BulkLoadScale200_20.json", "functional/CreateSnapshot.json"]
 }

--- a/datarepo-clienttests/src/main/resources/suites/NightlyPerfWorkflow.json
+++ b/datarepo-clienttests/src/main/resources/suites/NightlyPerfWorkflow.json
@@ -2,5 +2,5 @@
   "name": "NightlyPerfWorkflow",
   "description": "Performance tests to run on nightly github action",
   "serverSpecificationFile": "perf.json",
-  "testConfigurationFiles": ["basicexamples/BasicAuthenticated.json", "basicexamples/BasicUnauthenticated.json", "basicexamples/DRSLookup.json", "basicexamples/SoftDeleteDataset.json", "basicexamples/LookupDataset.json", "profiling/BuildSnapshotWithFiles1000_50.json", "profiling/BulkLoadScale200_20.json"]
+  "testConfigurationFiles": ["basicexamples/BasicAuthenticated.json", "basicexamples/BasicUnauthenticated.json", "basicexamples/DRSLookup.json", "basicexamples/SoftDeleteDataset.json", "basicexamples/LookupDataset.json", "profiling/BuildSnapshotWithFiles1000_50.json", "profiling/BulkLoadScale200_20.json", "basicexamples/CreateSnapshot.json"]
 }

--- a/src/main/java/bio/terra/common/FutureUtils.java
+++ b/src/main/java/bio/terra/common/FutureUtils.java
@@ -40,7 +40,10 @@ public final class FutureUtils {
             List<T> returnList = stream
                 .map(f -> {
                     try {
-                        if (maxThreadWait.isPresent()) {
+                        // If a failure was found, all subsequent tasks should be canceled
+                        if (foundFailure.get().isPresent()) {
+                            f.cancel(true);
+                        } else if (maxThreadWait.isPresent()) {
                             return f.get(maxThreadWait.get().toMillis(), TimeUnit.MILLISECONDS);
                         } else {
                             return f.get();

--- a/src/main/java/bio/terra/common/FutureUtils.java
+++ b/src/main/java/bio/terra/common/FutureUtils.java
@@ -1,0 +1,76 @@
+package bio.terra.common;
+
+import bio.terra.app.controller.exception.ApiException;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class FutureUtils {
+
+    private FutureUtils() {
+    }
+
+    public static <T> List<T> waitFor(final List<Future<T>> futures) {
+        return waitFor(futures, Optional.empty());
+    }
+
+    /**
+     * Wait for a list of {@link Future} objects to complete and returns a list of the resolved values.
+     * If any of the threads fail, throws the first found instance of failure (non-deterministic) but waits for all
+     * futures to resolve.
+     * @param futures The {@link List} of futures to wait for
+     * @param maxThreadWait The maximum of time to wait per thread
+     * @param <T> The type that should be returned for the list of futures
+     * @return The resolved values of the futures.  There is no guarantee that the order of returned values matches the
+     * order of the passed in futures
+     */
+    public static <T> List<T> waitFor(final List<Future<T>> futures,
+                                      final Optional<Duration> maxThreadWait) {
+
+        final AtomicReference<Optional<ApiException>> foundFailure = new AtomicReference<>(Optional.empty());
+        try (Stream<Future<T>> stream = futures.stream()) {
+            List<T> returnList = stream
+                .map(f -> {
+                    try {
+                        if (maxThreadWait.isPresent()) {
+                            return f.get(maxThreadWait.get().toMillis(), TimeUnit.MILLISECONDS);
+                        } else {
+                            return f.get();
+                        }
+                    } catch (TimeoutException e) {
+                        if (!foundFailure.get().isPresent()) {
+                            foundFailure.set(Optional.of(new ApiException("Thread timed out", e)));
+                            // Cancel the thread
+                            f.cancel(true);
+                        }
+                    } catch (InterruptedException e) {
+                        if (!foundFailure.get().isPresent()) {
+                            foundFailure.set(Optional.of(new ApiException("Thread was interrupted", e)));
+                        }
+                    } catch (ExecutionException e) {
+                        if (!foundFailure.get().isPresent()) {
+                            foundFailure.set(Optional.of(new ApiException("Error executing thread", e)));
+                        }
+                    }
+                    // Returning null here but this will ultimately result in throwing an exception to results should
+                    // never be read
+                    return null;
+                })
+                .collect(Collectors.toList());
+
+            // Throw an exception if any of the tasks failed
+            foundFailure.get().ifPresent(e -> {
+                throw e;
+            });
+            return returnList;
+        }
+    }
+}

--- a/src/main/java/bio/terra/service/filedata/exception/DirectoryMetadataComputeException.java
+++ b/src/main/java/bio/terra/service/filedata/exception/DirectoryMetadataComputeException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.filedata.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class DirectoryMetadataComputeException extends InternalServerErrorException {
+    public DirectoryMetadataComputeException(String message) {
+        super(message);
+    }
+
+    public DirectoryMetadataComputeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DirectoryMetadataComputeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -1,5 +1,7 @@
 package bio.terra.service.filedata.google.firestore;
 
+import bio.terra.app.controller.exception.ApiException;
+import bio.terra.app.logging.PerformanceLogger;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetDataProject;
@@ -13,6 +15,7 @@ import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDataProject;
 import com.google.cloud.firestore.Firestore;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +26,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_SNAPSHOT_BATCH_SIZE;
 
@@ -50,18 +56,21 @@ public class FireStoreDao {
     private final FireStoreUtils fireStoreUtils;
     private final DataLocationService dataLocationService;
     private final ConfigurationService configurationService;
+    private final PerformanceLogger performanceLogger;
 
     @Autowired
     public FireStoreDao(FireStoreDirectoryDao directoryDao,
                         FireStoreFileDao fileDao,
                         FireStoreUtils fireStoreUtils,
                         DataLocationService dataLocationService,
-                        ConfigurationService configurationService) {
+                        ConfigurationService configurationService,
+                        PerformanceLogger performanceLogger) {
         this.directoryDao = directoryDao;
         this.fileDao = fileDao;
         this.fireStoreUtils = fireStoreUtils;
         this.dataLocationService = dataLocationService;
         this.configurationService = configurationService;
+        this.performanceLogger = performanceLogger;
     }
 
     public void createDirectoryEntry(Dataset dataset, FireStoreDirectoryEntry newEntry) throws InterruptedException {
@@ -98,7 +107,9 @@ public class FireStoreDao {
         DatasetDataProject dataProject = dataLocationService.getProjectOrThrow(dataset);
         Firestore firestore = FireStoreProject.get(dataProject.getGoogleProjectId()).getFirestore();
         String datasetId = dataset.getId().toString();
+        //Slow
         fileDao.deleteFilesFromDataset(firestore, datasetId, func);
+//        firestore.
         directoryDao.deleteDirectoryEntriesFromCollection(firestore, datasetId);
     }
 
@@ -165,7 +176,15 @@ public class FireStoreDao {
             // We batch the updates to firestore by collecting updated entries into this list,
             // and when we get enough, writing them out.
             List<FireStoreDirectoryEntry> updateBatch = new ArrayList<>();
+
+            String retrieveTimer = performanceLogger.timerStart();
             computeDirectory(firestore, snapshotId, topDir, updateBatch);
+            performanceLogger.timerEndAndLog(
+                retrieveTimer,
+                snapshotId, // not a flight, so no job id
+                this.getClass().getName(),
+                "fireStoreDao.computeDirectoryGetMetadata");
+
             // Write the last batch out
             directoryDao.batchStoreDirectoryEntry(firestore, snapshotId, updateBatch);
         }
@@ -408,24 +427,56 @@ public class FireStoreDao {
         String fullPath = fireStoreUtils.getFullPath(dirEntry.getPath(), dirEntry.getName());
         List<FireStoreDirectoryEntry> enumDir = directoryDao.enumerateDirectory(firestore, snapshotId, fullPath);
 
-        // Recurse to compute results from underlying directories
         List<FireStoreDirectoryEntry> enumComputed = new ArrayList<>();
-        for (FireStoreDirectoryEntry dirItem : enumDir) {
-            if (dirItem.getIsFileRef()) {
-                // Read the file metadata to get the size and checksum. We do a bit of a hack and copy
-                // the size and checksums into the in-memory dirItem. That way we only compute on the directory
-                // objects.
-                FireStoreFile file =
-                    fileDao.retrieveFileMetadata(firestore, dirItem.getDatasetId(), dirItem.getFileId());
 
-                dirItem
-                    .size(file.getSize())
-                    .checksumMd5(file.getChecksumMd5())
-                    .checksumCrc32c(file.getChecksumCrc32c());
+        // Recurse to compute results from underlying directories
+        try (Stream<FireStoreDirectoryEntry> stream = enumDir.stream()) {
+            enumComputed.addAll(stream
+                .filter(f -> !f.getIsFileRef())
+                .map(f -> {
+                    try {
+                        return computeDirectory(firestore, snapshotId, f, updateBatch);
+                    } catch (InterruptedException e) {
+                        throw new ApiException("Error computing directory metadata", e);
+                    }
+                })
+                .collect(Collectors.toList())
+            );
+        }
 
-                enumComputed.add(dirItem);
-            } else {
-                enumComputed.add(computeDirectory(firestore, snapshotId, dirItem, updateBatch));
+        // Collect metadata for file objects in the directory
+        try (Stream<FireStoreDirectoryEntry> stream = enumDir.stream()) {
+            // Group FireStoreDirectoryEntry objects by dataset Id to process one dataset at a time
+            final Map<String, List<FireStoreDirectoryEntry>> fileRefsByDatasetId = stream
+                .filter(FireStoreDirectoryEntry::getIsFileRef)
+                .collect(Collectors.groupingBy(FireStoreDirectoryEntry::getDatasetId));
+
+            for (Map.Entry<String, List<FireStoreDirectoryEntry>> entry : fileRefsByDatasetId.entrySet()) {
+                // Retrieve the file metadata from Firestore
+                final List<FireStoreFile> fireStoreFiles =
+                    fileDao.batchRetrieveFileMetadata(firestore, entry.getKey(), entry.getValue());
+
+                // Index by fileId to be able to look up
+                final Map<String, FireStoreFile> fireStoreFilesById;
+                try (Stream<FireStoreFile> fileStream = fireStoreFiles.stream()) {
+                    fireStoreFilesById = fileStream
+                        .collect(Collectors.toMap(
+                            FireStoreFile::getFileId,
+                            f -> f
+                        ));
+                }
+
+                enumComputed.addAll(
+                    CollectionUtils.collect(entry.getValue(), dirItem -> {
+                        final FireStoreFile file = fireStoreFilesById.get(dirItem.getFileId());
+                        if (file == null) {
+                            throw new ApiException("File metadata was missing");
+                        }
+                        return dirItem
+                            .size(file.getSize())
+                            .checksumMd5(file.getChecksumMd5())
+                            .checksumCrc32c(file.getChecksumCrc32c());
+                    }));
             }
         }
 

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
@@ -188,7 +188,7 @@ public class FireStoreDependencyDao {
              batch = queryIterator.getBatch()) {
 
             for (DocumentSnapshot docSnap : batch) {
-                logger.info("deleting: " + docSnap.toString());
+                logger.info("deleting: " + docSnap.getReference().getPath());
                 docSnap.getReference().delete();
             }
         }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
@@ -118,6 +118,15 @@ class FireStoreFileDao {
         }
     }
 
+    /**
+     * Retrieve metadata from a list of directory entries.
+     * @param firestore A Firestore client
+     * @param datasetId The id of the dataset that the directory entries are associated with
+     * @param directoryEntries List of objects to retried metadata for
+     * @return A list of metadata object for the specified files.  Note: the order of the list matches with the order
+     * of the input list objects
+     * @throws InterruptedException If a call to Firestore is interrupted
+     */
     List<FireStoreFile> batchRetrieveFileMetadata(
         Firestore firestore,
         String datasetId,

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -156,6 +156,16 @@ public class FireStoreUtils {
     private static final int NO_PROGRESS_MAX = 2;
     private static final int SLEEP_MILLISECONDS = 1000;
 
+    /**
+     * Perform the specified Firestore operation against a specified list of inputs in batch.
+     * @param inputs A list containing the inputs to the function to be applied in batch
+     * @param generator A generator that provides a future given an input from the inputs parameter
+     * @param <T> The class of the objects in the input list
+     * @param <V> The class of the objects that will result when the generated futures resolve
+     * @return A list of resolved futures resulting in having run the specified operation in batch. Note: the order of
+     * the list matches with the order of the input list objects
+     * @throws InterruptedException If a call to Firestore is interrupted
+     */
     <T, V> List<T> batchOperation(List<V> inputs, ApiFutureGenerator<T, V> generator) throws InterruptedException {
         int inputSize = inputs.size();
         // We drive the retry processing by which outputs have not been filled in,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,6 +55,9 @@ datarepo.gcs.readTimeoutSeconds=40
 datarepo.gcs.allowReuseExistingBuckets=false
 datarepo.bq.rateLimitRetries=3
 datarepo.bq.rateLimitRetryWaitMs=500
+datarepo.numPerformanceThreads=50
+datarepo.maxPerformanceThreadQueueSize=1000
+
 sam.basePath=https://sam.dsde-dev.broadinstitute.org
 sam.stewardsGroupEmail=JadeStewards-dev@dev.test.firecloud.org
 sam.retryInitialWaitSeconds=10

--- a/src/test/java/bio/terra/common/FutureUtilsTest.java
+++ b/src/test/java/bio/terra/common/FutureUtilsTest.java
@@ -1,0 +1,234 @@
+package bio.terra.common;
+
+import bio.terra.common.category.Unit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class FutureUtilsTest {
+    private static Logger logger = LoggerFactory.getLogger(FutureUtilsTest.class);
+
+    private ThreadPoolExecutor executorService;
+
+    @Before
+    public void setUp() throws Exception {
+        executorService = new ThreadPoolExecutor(
+            3,
+            3,
+            0,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(10)
+        );
+    }
+
+    @After
+    public void afterClass() throws Exception {
+        if (executorService != null) {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testWaitForTasks() {
+        final AtomicInteger counter = new AtomicInteger(0);
+        final Callable<Integer> action = () -> {
+            try {
+                TimeUnit.SECONDS.sleep(1);
+                return counter.getAndIncrement();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        final List<Future<Integer>> futures = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            futures.add(executorService.submit(action));
+        }
+
+        final List<Integer> resolved = FutureUtils.waitFor(futures);
+        assertThat(resolved).containsAll(IntStream.range(0, 10).boxed().collect(Collectors.toList()));
+        assertThat(executorService.getActiveCount()).isZero();
+    }
+
+    @Test
+    public void testWaitForTaskAcrossTwoBatches() {
+        // Tests two batches of actions being submitted.  The second batch should be shorter (note the sleep).  Ensure
+        // that it properly finishes before the first batch and that an exception doesn't cause the first batch to fail
+
+        // Expand the thread queue for this particular test
+        if (executorService != null) {
+            executorService.shutdown();
+        }
+        executorService = new ThreadPoolExecutor(
+            10,
+            10,
+            0,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(10)
+        );
+
+        final AtomicInteger counter1 = new AtomicInteger(0);
+        final Callable<Integer> action1 = () -> {
+            try {
+                TimeUnit.SECONDS.sleep(10);
+                return counter1.getAndIncrement();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        final AtomicInteger counter2 = new AtomicInteger(0);
+        final Callable<Integer> action2 = () -> {
+            try {
+                if (counter2.get() == 0) {
+                    throw new RuntimeException("Injected error");
+                }
+                TimeUnit.MILLISECONDS.sleep(500);
+                return counter2.getAndIncrement();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        // Submit the two batches
+        final List<Future<Integer>> batch1Futures = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            batch1Futures.add(executorService.submit(action1));
+        }
+
+        final List<Future<Integer>> batch2Futures = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            batch2Futures.add(executorService.submit(action2));
+        }
+
+        assertThatThrownBy(() -> FutureUtils.waitFor(batch2Futures));
+        // There should still be 3 services running
+        assertThat(executorService.getActiveCount()).isEqualTo(3);
+
+        final List<Integer> resolved1 = FutureUtils.waitFor(batch1Futures);
+        assertThat(resolved1).containsAll(IntStream.range(0, 3).boxed().collect(Collectors.toList()));
+        assertThat(executorService.getActiveCount()).isZero();
+    }
+
+    @Test
+    public void testWaitForTasksSomeFail() {
+        final AtomicInteger counter = new AtomicInteger(0);
+        final Callable<Integer> action = () -> {
+            try {
+                if (counter.get() > 5) {
+                    throw new RuntimeException("Injected error");
+                }
+                TimeUnit.SECONDS.sleep(1);
+                return counter.getAndIncrement();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        final List<Future<Integer>> futures = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            futures.add(executorService.submit(action));
+        }
+
+        assertThatThrownBy(() -> FutureUtils.waitFor(futures)).hasMessage("Error executing thread");
+        assertThat(executorService.getActiveCount()).isZero();
+    }
+
+    @Test
+    public void testThreadTimeoutFailure() throws InterruptedException {
+        final AtomicInteger counter = new AtomicInteger(0);
+        // Note: Logging statements left in to make understanding test runs easier
+        final Callable<Integer> action = () -> {
+            try {
+                // On the first iteration, to cause a failure
+                final int count = counter.getAndIncrement();
+                logger.info("Launching {}", count);
+                if (count == 0) {
+                    TimeUnit.SECONDS.sleep(1);
+                } else {
+                    // This should allow all other threads to complete successfully
+                    TimeUnit.MILLISECONDS.sleep(10);
+                }
+                logger.info("Done with {}", count);
+                return count;
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        final List<Future<Integer>> futures = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            futures.add(executorService.submit(action));
+        }
+
+        assertThatThrownBy(() -> FutureUtils.waitFor(futures, Optional.of(Duration.ofMillis(100))))
+            .hasMessage("Thread timed out");
+        // Note: adding a sleep since getActiveCount represents an approximation of the number of threads active.
+        // Pausing gives the thread executor a chance to learn that the thread has been canceled
+        TimeUnit.MILLISECONDS.sleep(50);
+        assertThat(executorService.getActiveCount()).isZero();
+    }
+
+    @Test
+    public void testMaxOutQueue() {
+        final AtomicInteger counter = new AtomicInteger(0);
+        final Callable<Integer> action = () -> {
+            try {
+                TimeUnit.SECONDS.sleep(1);
+                return counter.getAndIncrement();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        final List<Future<Integer>> futures = new ArrayList<>();
+        // Note: we can submit up to 3 running + 10 queue tasks
+        for (int i = 0; i < 13; i++) {
+            futures.add(executorService.submit(action));
+        }
+
+        // Can't accept new threads for now
+        assertThatThrownBy(() -> futures.add(executorService.submit(action)));
+
+        final List<Integer> resolved = FutureUtils.waitFor(futures);
+        assertThat(resolved).containsAll(IntStream.range(0, 13).boxed().collect(Collectors.toList()));
+
+        futures.clear();
+        // Now that queue is empty, we can
+        for (int i = 0; i < 10; i++) {
+            futures.add(executorService.submit(action));
+        }
+
+        final List<Integer> resolvedSecondRound = FutureUtils.waitFor(futures);
+        assertThat(resolvedSecondRound).containsAll(IntStream.range(13, 23).boxed().collect(Collectors.toList()));
+
+        assertThat(executorService.getActiveCount()).isZero();
+    }
+}


### PR DESCRIPTION
After doing a bit of digging, it looks like snapshot creation is currently slowed down by:
- Setting ACLs on files in GCS buckets
- Fetching metadata on the file objects from Firestore

This PR should make these steps significantly faster

For the first point, I added a shared thread pool (which is, by default, bound to a maximum of 50 threads with a max queue size of 1000...there may be some tuning here - this allows running two set acls flight steps at the same time on the same pod before ACL submissions start being rejected) and the ACL commands are distributed in batch across the 50 threads.  On test runs of 2K files, the ACL commands went from taking 5.5 minutes to 20 seconds.

For the second point, I updated the code that fetches file metadata to use the batch metadata fetch method.  In order to do that, I did have to rework how we organize the loop that triggers recursion by splitting the list into directory and file objects, recursing with the directory objects and using batch fetching with the file objects.  Using the same 2K file test, the numbers, the pre-batching time took 4 minutes and went down to 2 seconds with batching.

Note: the PR also includes the TestRunner test that should now be included in the nightly perf test suite