### PR TITLE
DR-1397 Batch the deletion of files for big speed up of dataset deletion

### DIFF
--- a/src/main/java/bio/terra/common/FlightUtils.java
+++ b/src/main/java/bio/terra/common/FlightUtils.java
@@ -4,6 +4,8 @@ import bio.terra.model.ErrorModel;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.RetryRuleExponentialBackoff;
+import bio.terra.stairway.RetryRuleRandomBackoff;
 import com.google.cloud.bigquery.BigQueryException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -59,5 +61,13 @@ public final class FlightUtils {
             return true;
         }
         return false;
+    }
+
+    public static RetryRuleRandomBackoff getDefaultRandomBackoffRetryRule(final int maxConcurrency) {
+        return new RetryRuleRandomBackoff(500, maxConcurrency, 5);
+    }
+
+    public static RetryRuleExponentialBackoff getDefaultExponentialBackoffRetryRule() {
+        return new RetryRuleExponentialBackoff(2, 30, 600);
     }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -17,7 +17,7 @@ import bio.terra.service.resourcemanagement.google.GoogleResourceService;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.RetryRuleExponentialBackoff;
+import bio.terra.stairway.RetryRule;
 import org.springframework.context.ApplicationContext;
 
 import static bio.terra.common.FlightUtils.getDefaultExponentialBackoffRetryRule;
@@ -59,7 +59,7 @@ public class DatasetCreateFlight extends Flight {
 
         // Google says that ACL change propagation happens in a few seconds, but can take 5-7 minutes. The max
         // operation timeout is generous.
-        RetryRuleExponentialBackoff pdaoAclRetryRule = getDefaultExponentialBackoffRetryRule();
+        RetryRule pdaoAclRetryRule = getDefaultExponentialBackoffRetryRule();
         addStep(new CreateDatasetAuthzPrimaryDataStep(bigQueryPdao, datasetService, configService), pdaoAclRetryRule);
 
         // The underlying service provides retries so we do not need to retry for BQ Job User step at this time

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -20,6 +20,8 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.RetryRuleExponentialBackoff;
 import org.springframework.context.ApplicationContext;
 
+import static bio.terra.common.FlightUtils.getDefaultExponentialBackoffRetryRule;
+
 public class DatasetCreateFlight extends Flight {
 
     public DatasetCreateFlight(FlightMap inputParameters, Object applicationContext) {
@@ -57,8 +59,7 @@ public class DatasetCreateFlight extends Flight {
 
         // Google says that ACL change propagation happens in a few seconds, but can take 5-7 minutes. The max
         // operation timeout is generous.
-        RetryRuleExponentialBackoff pdaoAclRetryRule =
-            new RetryRuleExponentialBackoff(2, 30, 600);
+        RetryRuleExponentialBackoff pdaoAclRetryRule = getDefaultExponentialBackoffRetryRule();
         addStep(new CreateDatasetAuthzPrimaryDataStep(bigQueryPdao, datasetService, configService), pdaoAclRetryRule);
 
         // The underlying service provides retries so we do not need to retry for BQ Job User step at this time

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
@@ -19,6 +19,8 @@ import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
 
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
 public class DatasetDataDeleteFlight extends Flight {
 
     public DatasetDataDeleteFlight(FlightMap inputParameters, Object applicationContext) {
@@ -37,8 +39,7 @@ public class DatasetDataDeleteFlight extends Flight {
         // get data from inputs that steps need
         String datasetId = inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class);
 
-        RetryRuleRandomBackoff lockDatasetRetry =
-            new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
+        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         addStep(new VerifyAuthorizationStep(
             iamClient,

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
@@ -14,7 +14,7 @@ import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.RetryRuleRandomBackoff;
+import bio.terra.stairway.RetryRule;
 import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
@@ -39,7 +39,7 @@ public class DatasetDataDeleteFlight extends Flight {
         // get data from inputs that steps need
         String datasetId = inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class);
 
-        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRule lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         addStep(new VerifyAuthorizationStep(
             iamClient,

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
@@ -21,6 +21,8 @@ import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
 
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
 public class DatasetDeleteFlight extends Flight {
 
 
@@ -47,8 +49,7 @@ public class DatasetDeleteFlight extends Flight {
             JobMapKeys.DATASET_ID.getKeyName(), String.class));
         AuthenticatedUserRequest userReq = inputParameters.get(
             JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
-        RetryRuleRandomBackoff lockDatasetRetry =
-            new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
+        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         addStep(new LockDatasetStep(datasetDao, datasetId, false, true),
             lockDatasetRetry);

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
@@ -16,8 +16,7 @@ import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.RetryRuleExponentialBackoff;
-import bio.terra.stairway.RetryRuleRandomBackoff;
+import bio.terra.stairway.RetryRule;
 import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
@@ -51,8 +50,8 @@ public class DatasetDeleteFlight extends Flight {
             JobMapKeys.DATASET_ID.getKeyName(), String.class));
         AuthenticatedUserRequest userReq = inputParameters.get(
             JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
-        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
-        RetryRuleExponentialBackoff primaryDataDeleteRetry = getDefaultExponentialBackoffRetryRule();
+        RetryRule lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRule primaryDataDeleteRetry = getDefaultExponentialBackoffRetryRule();
 
         addStep(new LockDatasetStep(datasetDao, datasetId, false, true),
             lockDatasetRetry);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -16,6 +16,8 @@ import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
 
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
 public class DatasetIngestFlight extends Flight {
 
     public DatasetIngestFlight(FlightMap inputParameters, Object applicationContext) {
@@ -34,8 +36,7 @@ public class DatasetIngestFlight extends Flight {
         // get data from inputs that steps need
         UUID datasetId = UUID.fromString(inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class));
 
-        RetryRuleRandomBackoff lockDatasetRetry =
-            new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
+        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         addStep(new LockDatasetStep(datasetDao, datasetId, true), lockDatasetRetry);
         addStep(new IngestSetupStep(datasetService, configService));

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -11,7 +11,7 @@ import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.RetryRuleRandomBackoff;
+import bio.terra.stairway.RetryRule;
 import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
@@ -36,7 +36,7 @@ public class DatasetIngestFlight extends Flight {
         // get data from inputs that steps need
         UUID datasetId = UUID.fromString(inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class));
 
-        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRule lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         addStep(new LockDatasetStep(datasetDao, datasetId, true), lockDatasetRetry);
         addStep(new IngestSetupStep(datasetService, configService));

--- a/src/main/java/bio/terra/service/filedata/flight/delete/FileDeleteFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/FileDeleteFlight.java
@@ -19,6 +19,8 @@ import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
 
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
 public class FileDeleteFlight extends Flight {
 
     public FileDeleteFlight(FlightMap inputParameters, Object applicationContext) {
@@ -44,10 +46,8 @@ public class FileDeleteFlight extends Flight {
         //  We should NOT put code like that in the flight constructor.
         Dataset dataset = datasetService.retrieve(UUID.fromString(datasetId));
 
-        RetryRuleRandomBackoff fileSystemRetry =
-            new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
-        RetryRuleRandomBackoff lockDatasetRetry =
-            new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
+        RetryRuleRandomBackoff fileSystemRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         // The flight plan:
         // 0. Take out a shared lock on the dataset. This is to make sure the dataset isn't deleted while this

--- a/src/main/java/bio/terra/service/filedata/flight/delete/FileDeleteFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/FileDeleteFlight.java
@@ -14,7 +14,7 @@ import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.RetryRuleRandomBackoff;
+import bio.terra.stairway.RetryRule;
 import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
@@ -46,8 +46,8 @@ public class FileDeleteFlight extends Flight {
         //  We should NOT put code like that in the flight constructor.
         Dataset dataset = datasetService.retrieve(UUID.fromString(datasetId));
 
-        RetryRuleRandomBackoff fileSystemRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
-        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRule fileSystemRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRule lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         // The flight plan:
         // 0. Take out a shared lock on the dataset. This is to make sure the dataset isn't deleted while this

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -24,6 +24,8 @@ import bio.terra.stairway.RetryRuleExponentialBackoff;
 import bio.terra.stairway.RetryRuleRandomBackoff;
 import org.springframework.context.ApplicationContext;
 
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
 /*
  * Required input parameters:
  * - DATASET_ID dataset we are loading into
@@ -79,8 +81,7 @@ public class FileIngestBulkFlight extends Flight {
             profileId = loadRequest.getProfileId();
         }
 
-        RetryRuleRandomBackoff createBucketRetry =
-            new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
+        RetryRuleRandomBackoff createBucketRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         RetryRuleExponentialBackoff driverRetry = new RetryRuleExponentialBackoff(5, 20, 600);
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -20,8 +20,8 @@ import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.RetryRuleExponentialBackoff;
-import bio.terra.stairway.RetryRuleRandomBackoff;
 import org.springframework.context.ApplicationContext;
 
 import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
@@ -81,9 +81,8 @@ public class FileIngestBulkFlight extends Flight {
             profileId = loadRequest.getProfileId();
         }
 
-        RetryRuleRandomBackoff createBucketRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
-
-        RetryRuleExponentialBackoff driverRetry = new RetryRuleExponentialBackoff(5, 20, 600);
+        RetryRule createBucketRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRule driverRetry = new RetryRuleExponentialBackoff(5, 20, 600);
 
         // The flight plan:
         // 0. Verify authorization to do the ingest

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -24,6 +24,8 @@ import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
 
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
 // The FileIngestFlight is specific to firestore. Another cloud or file system implementation
 // might be quite different and would need a different flight.
 // TODO: Refactor flights when we do the cloud refactor work.
@@ -51,13 +53,10 @@ public class FileIngestFlight extends Flight {
         FileLoadModel fileLoadModel = inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
         String profileId = fileLoadModel.getProfileId();
 
-        RetryRuleRandomBackoff lockDatasetRetry =
-            new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
+        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
-        RetryRuleRandomBackoff fileSystemRetry =
-            new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
-        RetryRuleRandomBackoff createBucketRetry =
-            new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
+        RetryRuleRandomBackoff fileSystemRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRuleRandomBackoff createBucketRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         // The flight plan:
         // 0. Take out a shared lock on the dataset. This is to make sure the dataset isn't deleted while this

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -19,7 +19,7 @@ import bio.terra.service.load.flight.LoadUnlockStep;
 import bio.terra.service.resourcemanagement.DataLocationService;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.RetryRuleRandomBackoff;
+import bio.terra.stairway.RetryRule;
 import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
@@ -53,10 +53,10 @@ public class FileIngestFlight extends Flight {
         FileLoadModel fileLoadModel = inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
         String profileId = fileLoadModel.getProfileId();
 
-        RetryRuleRandomBackoff lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRule lockDatasetRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
-        RetryRuleRandomBackoff fileSystemRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
-        RetryRuleRandomBackoff createBucketRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRule fileSystemRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+        RetryRule createBucketRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         // The flight plan:
         // 0. Take out a shared lock on the dataset. This is to make sure the dataset isn't deleted while this

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestWorkerFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestWorkerFlight.java
@@ -16,6 +16,8 @@ import org.springframework.context.ApplicationContext;
 
 import java.util.UUID;
 
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
 /*
  * The flight is launched from the IngestDriverStep within one of the bulk load flights.
  * It performs a single file ingest into a dataset.
@@ -43,7 +45,7 @@ public class FileIngestWorkerFlight extends Flight {
         UUID datasetId = UUID.fromString(inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class));
         Dataset dataset = datasetService.retrieve(datasetId);
 
-        RetryRuleRandomBackoff fileSystemRetry = new RetryRuleRandomBackoff(500, appConfig.getMaxStairwayThreads(), 5);
+        RetryRuleRandomBackoff fileSystemRetry = getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
         // The flight plan:
         // 1. Generate the new file id and store it in the working map. We need to allocate the file id before any

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
@@ -6,23 +6,26 @@ import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.exception.FileSystemCorruptException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.rpc.AbortedException;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.DocumentReference;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.Transaction;
+import com.google.cloud.firestore.WriteResult;
 import io.grpc.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -41,11 +44,15 @@ class FireStoreFileDao {
 
     private final FireStoreUtils fireStoreUtils;
     private final ConfigurationService configurationService;
+    private final ExecutorService executor;
 
     @Autowired
-    FireStoreFileDao(FireStoreUtils fireStoreUtils, ConfigurationService configurationService) {
+    FireStoreFileDao(FireStoreUtils fireStoreUtils,
+                     ConfigurationService configurationService,
+                     @Qualifier("performanceThreadpool") ExecutorService executor) {
         this.fireStoreUtils = fireStoreUtils;
         this.configurationService = configurationService;
+        this.executor = executor;
     }
 
     void createFileMetadata(Firestore firestore, String datasetId, FireStoreFile newFile) throws InterruptedException {
@@ -177,18 +184,18 @@ class FireStoreFileDao {
             collectionId,
             DELETE_BATCH_SIZE,
             document -> {
-                FireStoreFile fireStoreFile = document.toObject(FireStoreFile.class);
-                func.accept(fireStoreFile);
-                doDelete(document);
+                SettableApiFuture<WriteResult> future = SettableApiFuture.create();
+                executor.execute(() -> {
+                    try {
+                        FireStoreFile fireStoreFile = document.toObject(FireStoreFile.class);
+                        func.accept(fireStoreFile);
+                        future.set(document.getReference().delete().get());
+                    } catch (final Exception e) {
+                        future.setException(e);
+                    }
+                });
+                return future;
             });
-    }
-
-    private void doDelete(QueryDocumentSnapshot document) throws InterruptedException {
-        try {
-            document.getReference().delete().get();
-        } catch (ExecutionException ex) {
-            throw fireStoreUtils.handleExecutionException(ex, "doDelete");
-        }
     }
 
     private String makeCollectionId(String datasetId) {

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -130,7 +130,9 @@ public class FireStoreUtils {
                 ApiFuture<QuerySnapshot> future = datasetCollection.limit(batchSize).get();
                 documents = future.get().getDocuments();
                 batchCount++;
-                logger.info("Visiting batch " + batchCount + " of ~" + batchSize + " documents");
+                if (!documents.isEmpty()) {
+                    logger.info("Visiting batch " + batchCount + " of ~" + batchSize + " documents");
+                }
                 batchOperation(documents, generator);
             } while (documents.size() > 0);
         } catch (ExecutionException ex) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -22,6 +22,8 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.RetryRuleExponentialBackoff;
 import org.springframework.context.ApplicationContext;
 
+import static bio.terra.common.FlightUtils.getDefaultExponentialBackoffRetryRule;
+
 public class SnapshotCreateFlight extends Flight {
 
     public SnapshotCreateFlight(FlightMap inputParameters, Object applicationContext) {
@@ -94,8 +96,7 @@ public class SnapshotCreateFlight extends Flight {
 
         // Google says that ACL change propagation happens in a few seconds, but can take 5-7 minutes. The max
         // operation timeout is generous.
-        RetryRuleExponentialBackoff pdaoAclRetryRule =
-            new RetryRuleExponentialBackoff(2, 30, 600);
+        RetryRuleExponentialBackoff pdaoAclRetryRule = getDefaultExponentialBackoffRetryRule();
 
         // Apply the IAM readers to the BQ dataset
         addStep(new SnapshotAuthzTabularAclStep(bigQueryPdao, snapshotService, configService), pdaoAclRetryRule);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -19,7 +19,7 @@ import bio.terra.service.snapshot.flight.UnlockSnapshotStep;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.RetryRuleExponentialBackoff;
+import bio.terra.stairway.RetryRule;
 import org.springframework.context.ApplicationContext;
 
 import static bio.terra.common.FlightUtils.getDefaultExponentialBackoffRetryRule;
@@ -96,7 +96,7 @@ public class SnapshotCreateFlight extends Flight {
 
         // Google says that ACL change propagation happens in a few seconds, but can take 5-7 minutes. The max
         // operation timeout is generous.
-        RetryRuleExponentialBackoff pdaoAclRetryRule = getDefaultExponentialBackoffRetryRule();
+        RetryRule pdaoAclRetryRule = getDefaultExponentialBackoffRetryRule();
 
         // Apply the IAM readers to the BQ dataset
         addStep(new SnapshotAuthzTabularAclStep(bigQueryPdao, snapshotService, configService), pdaoAclRetryRule);


### PR DESCRIPTION
This makes use of a combination of FireStoreUtils.batchOperation (I had to update scanCollectionObjects to take in an ApiFutureGenerator so it now uses the batchOperation method under the covers) and deleting the files from the GCS bucket in parallel by wrapping the GCS delete and the firestore delete in an ApiFuture and passing that into the batching function.

Running the CreateSnapshot TestRunner test with 10K files, delete dataset went from 49 minutes down to 2 minutes.  After this change, that test now should take under 20 minutes