### PR TITLE
DR-1356-follow up: Nightly Perf test run: Use automerge action and increase spin-up wait time to 5 minutes

### DIFF
--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -145,7 +145,7 @@ jobs:
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           RETRY_COUNT=0
           until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_VERSION }}" ]]; do
-            if [[ ${RETRY_COUNT} > 20 ]]; then
+            if [[ ${RETRY_COUNT} -gt 20 ]]; then
               echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_VERSION }}"
               exit 1
             fi

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -145,7 +145,7 @@ jobs:
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           RETRY_COUNT=0
           until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_VERSION }}" ]]; do
-            if [[ ${RETRY_COUNT} > 5 ]]; then
+            if [[ ${RETRY_COUNT} > 20 ]]; then
               echo "Failed to match perf $PERF_VERSION to dev version ${{ steps.read_property.outputs.LATEST_VERSION }}"
               exit 1
             fi

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -125,6 +125,7 @@ jobs:
           if git rev-parse --verify origin/version-update-${{ steps.read_property.outputs.LATEST_VERSION }}; then
             git merge origin/version-update-${{ steps.read_property.outputs.LATEST_VERSION }}
             git push
+            git pull
             git push origin --delete version-update-${{ steps.read_property.outputs.LATEST_VERSION }}
           else
             echo "Branch version-update-${{ steps.read_property.outputs.LATEST_VERSION }} not found."

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -115,20 +115,7 @@ jobs:
           body: |
             Update versions in perf env to reflect image tag ${{ steps.read_property.outputs.LATEST_VERSION }}.
             *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
-          labels: "broadbot,datarepo,automerge"
-      - name: "Merge datarepo-helm-definition pull request"
-        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions
-          git checkout master
-          git config pull.rebase false
-          if git rev-parse --verify origin/version-update-${{ steps.read_property.outputs.LATEST_VERSION }}; then
-            git merge origin/version-update-${{ steps.read_property.outputs.LATEST_VERSION }}
-            git push
-          else
-            echo "Branch version-update-${{ steps.read_property.outputs.LATEST_VERSION }} not found."
-          fi
-          cd ${GITHUB_WORKSPACE}/${workingDir}
+          labels: "datarepo,automerge,version-update"
       - name: "Install Helmfile"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/setup-helmfile@v0.5.0 #Forked from mamezou-tech/setup-helmfile

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -125,8 +125,6 @@ jobs:
           if git rev-parse --verify origin/version-update-${{ steps.read_property.outputs.LATEST_VERSION }}; then
             git merge origin/version-update-${{ steps.read_property.outputs.LATEST_VERSION }}
             git push
-            git pull
-            git push origin --delete version-update-${{ steps.read_property.outputs.LATEST_VERSION }}
           else
             echo "Branch version-update-${{ steps.read_property.outputs.LATEST_VERSION }} not found."
           fi


### PR DESCRIPTION
The datarepo-helm-definitions repo now has an "automerge" action that is triggered with the label "automerge." 

While testing, I ran into an issue where the new image took 3 minutes to spin up. I've up the wait time to 5 minutes. 