### PR TITLE
DR-1445: Update Skaffold template to work with modular helm charts

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -92,10 +92,10 @@ jobs:
         with:
           actions_subcommand: 'helmdeploy'
           helm_secret_chart_version: '0.0.4'
-          helm_datarepo_api_chart_version: '0.0.19'
-          helm_datarepo_ui_chart_version: '0.0.9'
+          helm_datarepo_api_chart_version: '0.0.22'
+          helm_datarepo_ui_chart_version: '0.0.12'
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
-          helm_oidc_proxy_chart_version: '0.0.9'
+          helm_oidc_proxy_chart_version: '0.0.13'
       - name: "Run Test Runner smoke tests via Gradle"
         uses: broadinstitute/datarepo-actions@0.28.0
         with:

--- a/docs/jade-getting-started.md
+++ b/docs/jade-getting-started.md
@@ -109,8 +109,11 @@ helm repo update
 continuous development of Kubernetes resources. Newer versions are incompatible
 with our development environments, so version 1.3.1 is installed instead.
 
+Download file:
+https://raw.githubusercontent.com/Homebrew/homebrew-core/5db9ede616f5d681fa9873b150416d6795e0e0e9/Formula/skaffold.rb
+
 ```
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/5db9ede616f5d681fa9873b150416d6795e0e0e9/Formula/skaffold.rb
+brew install ~/YOUR/LOCAL/PATH/skaffold.rb
 brew pin skaffold
 ```
 

--- a/docs/jade-getting-started.md
+++ b/docs/jade-getting-started.md
@@ -109,11 +109,9 @@ helm repo update
 continuous development of Kubernetes resources. Newer versions are incompatible
 with our development environments, so version 1.3.1 is installed instead.
 
-Download file:
-https://raw.githubusercontent.com/Homebrew/homebrew-core/5db9ede616f5d681fa9873b150416d6795e0e0e9/Formula/skaffold.rb
-
 ```
-brew install ~/YOUR/LOCAL/PATH/skaffold.rb
+curl https://raw.githubusercontent.com/Homebrew/homebrew-core/5db9ede616f5d681fa9873b150416d6795e0e0e9/Formula/skaffold.rb --output skaffold.rb
+brew install skaffold.rb
 brew pin skaffold
 ```
 

--- a/skaffold.yaml.template
+++ b/skaffold.yaml.template
@@ -17,19 +17,45 @@ deploy:
         - --install
         - --debug
     releases:
-    - name: TEMP-secrets
-      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/create-secret-manager-secret-0.0.6/create-secret-manager-secret-0.0.6.tgz
-      version: 0.0.6
-      namespace: TEMP
-      remote: true
-      valuesFiles:
-      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/TEMPSecrets.yaml
-    - name: TEMP-jade
-      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-0.1.10/datarepo-0.1.10.tgz
-      version: 0.1.10
+      # create secrets
+      - name: TEMP-jade-create-secret-manager-secret
+        chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/create-secret-manager-secret-0.0.6/create-secret-manager-secret-0.0.6.tgz
+        version: 0.0.6
+        namespace: TEMP
+        remote: true
+        valuesFiles:
+          - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/create-secret-manager-secret.yaml
+      # gcp sqlproxy
+      - name: TEMP-jade-gcloud-sqlproxy
+        chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/gcloud-sqlproxy-0.19.7/gcloud-sqlproxy-0.19.7.tgz
+        version: 0.19.7
+        namespace: TEMP
+        remote: true
+        valuesFiles:
+          - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/gcloud-sqlproxy.yaml
+      # datarepo-api
+    - name: TEMP-jade-datarepo-api
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-api-0.0.22/datarepo-api-0.0.22.tgz
+      version: 0.0.22
       namespace: TEMP
       remote: true
       values:
-        datarepo-api.imageName: gcr.io/broad-jade-dev/jade-data-repo
+        imageName: gcr.io/broad-jade-dev/jade-data-repo
       valuesFiles:
-      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/TEMPDeployment.yaml
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/datarepo-api.yaml
+      # datarepo-ui
+      - name: TEMP-jade-datarepo-ui
+        chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-ui-0.0.12/datarepo-ui-0.0.12.tgz
+        version: 0.0.12
+        namespace: TEMP
+        remote: true
+        valuesFiles:
+          - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/datarepo-ui.yaml
+      # oidc-proxy
+      - name: TEMP-jade-oidc-proxy
+        chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/oidc-proxy-0.0.13/oidc-proxy-0.0.13.tgz
+        version: 0.0.13
+        namespace: TEMP
+        remote: true
+        valuesFiles:
+          - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/oidc-proxy.yaml

--- a/skaffold.yaml.template
+++ b/skaffold.yaml.template
@@ -17,23 +17,23 @@ deploy:
         - --install
         - --debug
     releases:
-      # create secrets
-      - name: TEMP-jade-create-secret-manager-secret
-        chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/create-secret-manager-secret-0.0.6/create-secret-manager-secret-0.0.6.tgz
-        version: 0.0.6
-        namespace: TEMP
-        remote: true
-        valuesFiles:
-          - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/create-secret-manager-secret.yaml
-      # gcp sqlproxy
-      - name: TEMP-jade-gcloud-sqlproxy
-        chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/gcloud-sqlproxy-0.19.7/gcloud-sqlproxy-0.19.7.tgz
-        version: 0.19.7
-        namespace: TEMP
-        remote: true
-        valuesFiles:
-          - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/gcloud-sqlproxy.yaml
-      # datarepo-api
+    # create secrets
+    - name: TEMP-jade-create-secret-manager-secret
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/create-secret-manager-secret-0.0.6/create-secret-manager-secret-0.0.6.tgz
+      version: 0.0.6
+      namespace: TEMP
+      remote: true
+      valuesFiles:
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/create-secret-manager-secret.yaml
+    # gcp sqlproxy
+    - name: TEMP-jade-gcloud-sqlproxy
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/gcloud-sqlproxy-0.19.7/gcloud-sqlproxy-0.19.7.tgz
+      version: 0.19.7
+      namespace: TEMP
+      remote: true
+      valuesFiles:
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/gcloud-sqlproxy.yaml
+    # datarepo-api
     - name: TEMP-jade-datarepo-api
       chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-api-0.0.22/datarepo-api-0.0.22.tgz
       version: 0.0.22
@@ -43,19 +43,19 @@ deploy:
         imageName: gcr.io/broad-jade-dev/jade-data-repo
       valuesFiles:
       - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/datarepo-api.yaml
-      # datarepo-ui
-      - name: TEMP-jade-datarepo-ui
-        chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-ui-0.0.12/datarepo-ui-0.0.12.tgz
-        version: 0.0.12
-        namespace: TEMP
-        remote: true
-        valuesFiles:
-          - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/datarepo-ui.yaml
-      # oidc-proxy
-      - name: TEMP-jade-oidc-proxy
-        chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/oidc-proxy-0.0.13/oidc-proxy-0.0.13.tgz
-        version: 0.0.13
-        namespace: TEMP
-        remote: true
-        valuesFiles:
-          - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/oidc-proxy.yaml
+    # datarepo-ui
+    - name: TEMP-jade-datarepo-ui
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-ui-0.0.12/datarepo-ui-0.0.12.tgz
+      version: 0.0.12
+      namespace: TEMP
+      remote: true
+      valuesFiles:
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/datarepo-ui.yaml
+    # oidc-proxy
+    - name: TEMP-jade-oidc-proxy
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/oidc-proxy-0.0.13/oidc-proxy-0.0.13.tgz
+      version: 0.0.13
+      namespace: TEMP
+      remote: true
+      valuesFiles:
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/TEMP/oidc-proxy.yaml


### PR DESCRIPTION
Included Changes:
- Updating chart versions
- Moving to modular chart model

Test strategy: I was able to successfully deploy using `skaffold run` using the skaffold.yaml generated by this template. 