### PR TITLE
DR-1464: Fix gradle build in test runner project.

### DIFF
--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -92,6 +92,10 @@ test {
     }
 }
 
+application {
+    mainClassName = 'common.commands.PrintHelp'
+}
+
 task(runTest, dependsOn: 'classes', type: JavaExec) {
     main = "common.commands.RunTest"
     classpath = sourceSets.main.runtimeClasspath


### PR DESCRIPTION
- Previously, `./gradlew build` run from within the datarepo-clienttests generated an error every time.

- This command was not being used before, but it's useful to check that scripts compile without actually running them.

- This PR fixes the build command by defining a main class name, as required by the application plugin. I tested that this does compile script classes, even if they are not referenced anywhere.
