### PR TITLE
Bump github action version 

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -44,7 +44,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
+        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -74,22 +74,22 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
+        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
+        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
+        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
+        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -98,22 +98,22 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.13'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
+        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
+        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
+        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
+        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -5,7 +5,7 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
   # This must be defined for the bash redirection
   GOOGLE_SA_CERT: 'jade-dev-account.pem'
-  GITHUB_ACTION_VERSION: 0.30.0
+  GITHUB_ACTION_REPO: 'broadinstitute/datarepo-actions@0.30.0'
 on:
   pull_request:
     branches:
@@ -42,11 +42,11 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: "Test env variable"
-        run: echo ${{ env.GITHUB_ACTION_VERSION }}
+        run: echo ${{ env.GITHUB_ACTION_REPO }}
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: ${{ env.GITHUB_ACTION_REPO }}
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -82,16 +82,16 @@ jobs:
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: ${{ env.GITHUB_ACTION_REPO }}
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: ${{ env.GITHUB_ACTION_REPO }}
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: ${{ env.GITHUB_ACTION_REPO }}
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -100,22 +100,22 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.13'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: ${{ env.GITHUB_ACTION_REPO }}
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: ${{ env.GITHUB_ACTION_REPO }}
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: ${{ env.GITHUB_ACTION_REPO }}
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: ${{ env.GITHUB_ACTION_REPO }}
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -5,7 +5,6 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
   # This must be defined for the bash redirection
   GOOGLE_SA_CERT: 'jade-dev-account.pem'
-  GITHUB_ACTION_REPO: 'broadinstitute/datarepo-actions@0.30.0'
 on:
   pull_request:
     branches:
@@ -41,12 +40,10 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - name: "Test env variable"
-        run: echo ${{ env.GITHUB_ACTION_REPO }}
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: ${{ env.GITHUB_ACTION_REPO }}
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -82,16 +79,16 @@ jobs:
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: ${{ env.GITHUB_ACTION_REPO }}
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: ${{ env.GITHUB_ACTION_REPO }}
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: ${{ env.GITHUB_ACTION_REPO }}
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -100,22 +97,22 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.13'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: ${{ env.GITHUB_ACTION_REPO }}
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: ${{ env.GITHUB_ACTION_REPO }}
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: ${{ env.GITHUB_ACTION_REPO }}
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: ${{ env.GITHUB_ACTION_REPO }}
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -44,7 +44,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -74,22 +74,22 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -98,22 +98,22 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.13'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
+        uses: broadinstitute/datarepo-actions@$GITHUB_ACTION_VERSION
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -41,10 +41,12 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
+      - name: "Test env variable"
+        run: echo ${{ env.GITHUB_ACTION_VERSION }}
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -80,16 +82,16 @@ jobs:
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -98,22 +100,22 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.13'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -73,7 +73,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@${GITHUB_ACTION_VERSION}
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.29.0
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -73,22 +73,22 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@0.29.0
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@0.29.0
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@0.29.0
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@0.29.0
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -97,22 +97,22 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.13'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@0.29.0
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.29.0
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.29.0
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.29.0
+        uses: broadinstitute/datarepo-actions@0.30.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -5,6 +5,7 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
   # This must be defined for the bash redirection
   GOOGLE_SA_CERT: 'jade-dev-account.pem'
+  GITHUB_ACTION_VERSION: 0.30.0
 on:
   pull_request:
     branches:
@@ -43,7 +44,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.30.0
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -73,22 +74,22 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@0.30.0
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@0.30.0
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@0.30.0
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@0.30.0
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -97,22 +98,22 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: '0.19.7'
           helm_oidc_proxy_chart_version: '0.0.13'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@0.30.0
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.30.0
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.30.0
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.30.0
+        uses: broadinstitute/datarepo-actions@${{ env.GITHUB_ACTION_VERSION }}
         with:
           actions_subcommand: 'gcp_whitelist_clean'


### PR DESCRIPTION
More details in github action PR. https://github.com/broadinstitute/datarepo-actions/pull/36

This fixes an issue where the test runner smoke tests were failing b/c they were using an out of date client jar to run spotbugsMain. 