### PR TITLE
DR-1466 Make default logging Stackdriver JSON based

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ To have the code hot reload, enable automatic builds in intellij, go to:
 `Preferences -> Build, Execution, Deployment -> Compiler`
 and select `Build project automatically`
 
+Note: when running locally, it may be useful to not log in JSON but as traditional log message.  This can be enabled by
+setting the environment variable:
+`TDR_LOG_APPENDER=Console-Standard`
+(the default is "Console-Stackdriver")
+
 The swagger page is:
 https://local.broadinstitue.org:8080
 

--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,8 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-web:2.2.6.RELEASE"
 
     compile 'org.springframework:spring-jdbc:5.1.9.RELEASE'
+    compile 'org.springframework.cloud:spring-cloud-gcp-starter-logging:1.2.5.RELEASE'
+    compile "org.springframework.cloud:spring-cloud-starter-sleuth:2.2.5.RELEASE"
     compile 'org.broadinstitute.dsde.workbench:sam-client_2.12:0.1-343dfff-SNAP'
     compile 'org.antlr:ST4:4.3'                          // String templating
     compile group: 'io.kubernetes', name: 'client-java', version: '8.0.2'

--- a/src/main/java/bio/terra/app/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/app/controller/GlobalExceptionHandler.java
@@ -120,10 +120,11 @@ public class GlobalExceptionHandler {
     }
 
     private ErrorModel buildErrorModel(Throwable ex, List<String> errorDetail) {
-        logger.error("Global exception handler: catch stack", ex);
+        StringBuilder combinedCauseString = new StringBuilder();
         for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
-            logger.error("   cause: " + cause.toString());
+            combinedCauseString.append("cause: " + cause.toString() + ", ");
         }
+        logger.error("Global exception handler: " + combinedCauseString.toString(), ex);
         return new ErrorModel().message(ex.getMessage()).errorDetail(errorDetail);
     }
 }

--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -1,3 +1,5 @@
+import org.springframework.cloud.gcp.logging.StackdriverJsonLayout
+
 // LogBack Configuration File
 // This file controls how, where, and what gets logged.
 // For more information see: https://logback.qos.ch/manual/groovy.html
@@ -8,9 +10,18 @@ scan("30 seconds")
 def LOG_PATH = "logs"
 
 // Appender that sends to the console
-appender("Console-Appender", ConsoleAppender) {
+appender("Console-Standard", ConsoleAppender) {
     encoder(PatternLayoutEncoder) {
         pattern = "%date %-5level [%thread] %logger{36}: %message%n"
+    }
+}
+
+appender("Console-Stackdriver", ConsoleAppender) {
+    encoder(LayoutWrappingEncoder) {
+        layout(StackdriverJsonLayout) {
+            includeTraceId = true
+            includeSpanId = true
+        }
     }
 }
 
@@ -29,4 +40,4 @@ logger("bio.terra.service.tabulardata.google.BigQueryProject", DEBUG);
 */
 
 // root sets the default logging level and appenders
-root(INFO, ["Console-Appender"])
+root(INFO, [System.getenv().getOrDefault("TDR_LOG_APPENDER", "Console-Stackdriver")])


### PR DESCRIPTION
There is still the ability to run the api service using standard console logging by setting the environment variable:
`TDR_LOG_APPENDER=Console-Standard`

But by default this will log with JSON and include:
- Severity in its own field
- Multiline messages consolidated
- Span and Trace IDs are also logged

The tail of my logs uses this format if folks want to see what this looks like:
https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22broad-jade-dev%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22dev-master%22%0Aresource.labels.namespace_name%3D%22nm%22%0Alabels.k8s-pod%2Fcomponent%3D%22nm-jade-datarepo-api%22;timeRange=2020-10-30T19:10:31.984Z%2F2020-10-30T21:05:17.400Z?folder=true&pageState=(%22savedViews%22:(%22i%22:%220f82fd0573b94b22a7ac9cd216a7dbc5%22,%22c%22:%5B%5D,%22n%22:%5B%22nm%22%5D))&organizationId=true&project=broad-jade-dev


And play with https://jade-nm.datarepo-dev.broadinstitute.org/ to see what the logs end up looking like