### PR TITLE
DR-1478 Make sure that files with non-standard characters have valid DrsObjects

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -9,6 +9,7 @@ import bio.terra.model.DRSObject;
 import bio.terra.service.filedata.exception.DrsObjectNotFoundException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import bio.terra.service.filedata.exception.InvalidDrsIdException;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamResourceType;
@@ -25,7 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -223,10 +223,12 @@ public class DrsService {
 
     private String makeHttpsFromGs(String gspath) {
         try {
-            URI gsuri = URI.create(gspath);
-            String gsBucket = gsuri.getAuthority();
-            String gsPath = StringUtils.removeStart(gsuri.getPath(), "/");
-            String encodedPath = URLEncoder.encode(gsPath, StandardCharsets.UTF_8.toString());
+            String gsBucket = GcsPdao.extractBucketFromPath(gspath);
+            String gsPath = GcsPdao.extractFilePathInBucket(gspath, gsBucket);
+            String encodedPath = URLEncoder.encode(gsPath, StandardCharsets.UTF_8.toString())
+                // Google uses %20 instead of + to encode spaces.
+                // Original + characters should already have been converted to %2B
+                .replaceAll("\\+", "%20");
             return String.format("https://www.googleapis.com/storage/v1/b/%s/o/%s?alt=media", gsBucket, encodedPath);
         } catch (UnsupportedEncodingException ex) {
             throw new InvalidDrsIdException("Failed to urlencode file path", ex);

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -226,8 +226,8 @@ public class DrsService {
             String gsBucket = GcsPdao.extractBucketFromPath(gspath);
             String gsPath = GcsPdao.extractFilePathInBucket(gspath, gsBucket);
             String encodedPath = URLEncoder.encode(gsPath, StandardCharsets.UTF_8.toString())
-                // Google uses %20 instead of + to encode spaces.
-                // Original + characters should already have been converted to %2B
+                // Google does not recognize the + characters that are produced from spaces by the URLEncoder.encode
+                // method. As a result, these must be converted to %2B.
                 .replaceAll("\\+", "%20");
             return String.format("https://www.googleapis.com/storage/v1/b/%s/o/%s?alt=media", gsBucket, encodedPath);
         } catch (UnsupportedEncodingException ex) {

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -130,7 +130,8 @@ public class DrsTest extends UsersBase {
         final DRSObject drsObjectFile = dataRepoFixtures.drsGetObject(reader(), drsObjectId);
         validateDrsObject(drsObjectFile, drsObjectId);
         assertNull("Contents of file is null", drsObjectFile.getContents());
-        TestUtils.validateDrsAccessMethods(drsObjectFile.getAccessMethods());
+        TestUtils.validateDrsAccessMethods(drsObjectFile.getAccessMethods(),
+            authService.getDirectAccessAuthToken(steward().getEmail()));
         Map<String, List<Acl>> preDeleteAcls = TestUtils.readDrsGCSAcls(drsObjectFile.getAccessMethods());
         validateContainsAcls(preDeleteAcls.values().iterator().next());
         validateBQJobUserRolePresent(Arrays.asList(

--- a/src/test/java/bio/terra/service/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/iam/AccessTest.java
@@ -268,7 +268,7 @@ public class AccessTest extends UsersBase {
 
         // Use DRS API to lookup the file by DRS ID (pulled out of the URI).
         DRSObject drsObject = dataRepoFixtures.drsGetObject(reader(), drsObjectId);
-        String gsuri = TestUtils.validateDrsAccessMethods(drsObject.getAccessMethods());
+        String gsuri = TestUtils.validateDrsAccessMethods(drsObject.getAccessMethods(), custodianToken);
 
         // Try to read the file of the gs path as reader and discoverer
         String[] strings = gsuri.split("/", 4);


### PR DESCRIPTION
Currently, before storing objects in Firestore, we were URL-encoding them.  The problem is that we were storing the file names in GCS not-url encoded.  This would make it so that the Drs object we would create for a given object was pointing to an invalid location.  E.g. a file named `file with space and #hash%percent+plus.txt` would be stored in GSS as `file with space and #hash%percent+plus.txt` but our record of it in Firestore was `file%20with%20space%20and%20%23hash%25percent%2Bplus.txt` (note this is the file I ended using in my test). As a result, the drs object we would get back would point to an invalid location.

What this PR does is to *NOT* Url encode the files (e.g. keep the current structure for storing in GCS) but then change the methods by which we extract bucket name and path from GCS urls.  I also had to vary a little bit from the standard URL encoding to use `%20` instead of `+` since this is apparently what GCS uses.

The biggest code change here is that we now actually test that we can read objects in Drs objects.  This validates that the paths are valid and that they are actually reachable with proper authentication via GS and HTTPS

Note: This does not fix existing entries meaning we'll either need to come up with a way to migrate or reingest

Note 2: I organized the commits into logical bits to make reviewing (hopefully) a little easier