### PR TITLE
DR-1461 Dataset Bucket Link unit tests

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
@@ -53,6 +53,9 @@ public class DatasetBucketDao {
     private static final String sqlExistsLink =
         "SELECT COUNT(*) FROM dataset_bucket" + whereClause;
 
+    private static final String sqlGetSuccessfulIngestCount =
+        "SELECT successful_ingests FROM dataset_bucket" + whereClause;
+
     private static final String sqlDeleteLink =
         "DELETE FROM dataset_bucket" + whereClause;
 
@@ -95,6 +98,18 @@ public class DatasetBucketDao {
             throw new CorruptMetadataException("Impossible null value from count");
         }
         return (count == 1);
+    }
+
+    // Used for testing
+    public int datasetBucketSuccessfulIngestCount(UUID datasetId, UUID bucketResourceId) {
+        MapSqlParameterSource params = new MapSqlParameterSource()
+            .addValue("dataset_id", datasetId)
+            .addValue("bucket_resource_id", bucketResourceId);
+        Integer count = jdbcTemplate.queryForObject(sqlGetSuccessfulIngestCount, params, Integer.class);
+        if (count == null) {
+            throw new CorruptMetadataException("Impossible null value from count");
+        }
+        return count;
     }
 
     private void incrementDatasetBucketLink(UUID datasetId, UUID bucketResourceId) {

--- a/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
@@ -85,7 +85,8 @@ public class DatasetBucketDao {
         datasetBucketLinkUpdate(sqlDecrementCount, datasetId, bucketResourceId);
     }
 
-    private boolean datasetBucketLinkExists(UUID datasetId, UUID bucketResourceId) {
+    // public for testing purposes
+    public boolean datasetBucketLinkExists(UUID datasetId, UUID bucketResourceId) {
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("dataset_id", datasetId)
             .addValue("bucket_resource_id", bucketResourceId);

--- a/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
@@ -88,8 +88,7 @@ public class DatasetBucketDao {
         datasetBucketLinkUpdate(sqlDecrementCount, datasetId, bucketResourceId);
     }
 
-    // public for testing purposes
-    public boolean datasetBucketLinkExists(UUID datasetId, UUID bucketResourceId) {
+    boolean datasetBucketLinkExists(UUID datasetId, UUID bucketResourceId) {
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("dataset_id", datasetId)
             .addValue("bucket_resource_id", bucketResourceId);
@@ -100,8 +99,8 @@ public class DatasetBucketDao {
         return (count == 1);
     }
 
-    // Used for testing
-    public int datasetBucketSuccessfulIngestCount(UUID datasetId, UUID bucketResourceId) {
+    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+    int datasetBucketSuccessfulIngestCount(UUID datasetId, UUID bucketResourceId) {
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("dataset_id", datasetId)
             .addValue("bucket_resource_id", bucketResourceId);

--- a/src/test/java/bio/terra/common/fixtures/ProfileFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/ProfileFixtures.java
@@ -3,6 +3,7 @@ package bio.terra.common.fixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -10,6 +11,7 @@ import java.util.UUID;
 
 public final class ProfileFixtures {
     private ProfileFixtures() {}
+    private static SecureRandom randomGenerator = new SecureRandom();
 
     public static String randomHex(int n) {
         Random r = new Random();
@@ -33,7 +35,7 @@ public final class ProfileFixtures {
         return new BillingProfileModel()
             .id(UUID.randomUUID().toString())
             .billingAccountId(accountId)
-            .profileName("test profile")
+            .profileName(randomizeName("test-profile"))
             .biller("direct")
             .description("test profile description");
     }
@@ -54,4 +56,10 @@ public final class ProfileFixtures {
     public static BillingProfileRequestModel randomBillingProfileRequest() {
         return billingProfileRequest(randomBillingProfile());
     }
+
+    public static String randomizeName(String baseName) {
+        long suffix = randomGenerator.nextLong();
+        return baseName + Long.toUnsignedString(suffix);
+    }
+
 }

--- a/src/test/java/bio/terra/common/fixtures/ResourceFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/ResourceFixtures.java
@@ -2,6 +2,7 @@ package bio.terra.common.fixtures;
 
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,11 +24,7 @@ public final class ResourceFixtures {
     public static String shuffleString(String input) {
         List<String> newProjectNum = Arrays.asList(input.split(""));
         Collections.shuffle(newProjectNum);
-        String shuffled = "";
-        for (String let : newProjectNum) {
-            shuffled = shuffled.concat(let);
-        }
-        return shuffled;
+        return StringUtils.join(newProjectNum, "");
     }
 
 }

--- a/src/test/java/bio/terra/common/fixtures/ResourceFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/ResourceFixtures.java
@@ -3,7 +3,7 @@ package bio.terra.common.fixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 
-import java.util.UUID;
+import java.util.*;
 
 public final class ResourceFixtures {
     private ResourceFixtures() {}
@@ -16,5 +16,25 @@ public final class ResourceFixtures {
             .googleProjectNumber("123456")
             .profileId(UUID.fromString(billingProfile.getId()));
     }
+
+    public static GoogleProjectResource randomProjectResourceAndName(BillingProfileModel billingProfile) {
+
+        return new GoogleProjectResource()
+            .googleProjectId(ProfileFixtures.randomizeName("fake-test-project-id"))
+            .googleProjectNumber(shuffleString("123456"))
+            .profileId(UUID.fromString(billingProfile.getId()));
+    }
+
+    public static String shuffleString(String input) {
+        List<String> newProjectNum = Arrays.asList(input.split(""));
+        Collections.shuffle(newProjectNum);
+        String shuffled = "";
+        for (String let : newProjectNum) {
+            shuffled += let;
+        }
+        return shuffled;
+    }
+
+
 
 }

--- a/src/test/java/bio/terra/common/fixtures/ResourceFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/ResourceFixtures.java
@@ -3,7 +3,10 @@ package bio.terra.common.fixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 public final class ResourceFixtures {
     private ResourceFixtures() {}
@@ -11,14 +14,6 @@ public final class ResourceFixtures {
     // Build the a random project resource given the billing profile in support of
     // DAO-only unit tests. This is ready to be used as a request to the GoogleResourceDao
     public static GoogleProjectResource randomProjectResource(BillingProfileModel billingProfile) {
-        return new GoogleProjectResource()
-            .googleProjectId("fake-test-project-id")
-            .googleProjectNumber("123456")
-            .profileId(UUID.fromString(billingProfile.getId()));
-    }
-
-    public static GoogleProjectResource randomProjectResourceAndName(BillingProfileModel billingProfile) {
-
         return new GoogleProjectResource()
             .googleProjectId(ProfileFixtures.randomizeName("fake-test-project-id"))
             .googleProjectNumber(shuffleString("123456"))
@@ -30,11 +25,9 @@ public final class ResourceFixtures {
         Collections.shuffle(newProjectNum);
         String shuffled = "";
         for (String let : newProjectNum) {
-            shuffled += let;
+            shuffled = shuffled.concat(let);
         }
         return shuffled;
     }
-
-
 
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
@@ -1,0 +1,246 @@
+package bio.terra.service.dataset;
+
+import bio.terra.common.Column;
+import bio.terra.common.MetadataEnumeration;
+import bio.terra.common.Table;
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.common.fixtures.ProfileFixtures;
+import bio.terra.common.fixtures.ResourceFixtures;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.BillingProfileRequestModel;
+import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.dataset.exception.DatasetLockException;
+import bio.terra.service.dataset.exception.DatasetNotFoundException;
+import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class DatasetBucketDaoTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatasetBucketDaoTest.class);
+
+    @Autowired
+    private JsonLoader jsonLoader;
+
+    @Autowired
+    private DatasetDao datasetDao;
+
+    @Autowired
+    private DatasetBucketDao datasetBucketDao;
+
+    @Autowired
+    private ProfileDao profileDao;
+
+    @Autowired
+    private GoogleResourceDao resourceDao;
+
+    @Autowired
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ResourceService resourceService;
+
+    private BillingProfileModel billingProfile;
+    private GoogleBucketResource bucketForFile;
+    private UUID projectId;
+    private Dataset dataset;
+
+    private UUID datasetId;
+    private UUID bucketResourceId;
+
+    private UUID createDataset(DatasetRequestModel datasetRequest, String newName) throws Exception {
+        datasetRequest.name(newName).defaultProfileId(billingProfile.getId());
+        dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
+        dataset.projectResourceId(projectId);
+        String createFlightId = UUID.randomUUID().toString();
+        UUID datasetId = UUID.randomUUID();
+        dataset.id(datasetId);
+        datasetDao.createAndLock(dataset, createFlightId);
+        datasetDao.unlockExclusive(dataset.getId(), createFlightId);
+        return datasetId;
+    }
+
+    private UUID createBucket() throws InterruptedException {
+        String ingestFileFlightId = UUID.randomUUID().toString();
+        bucketForFile =
+            resourceService.getOrCreateBucketForFile(
+                dataset.getName(),
+                billingProfile,
+                ingestFileFlightId);
+        return bucketForFile.getResourceId();
+    }
+
+    private UUID createDataset(String datasetFile) throws Exception  {
+        DatasetRequestModel datasetRequest = jsonLoader.loadObject(datasetFile, DatasetRequestModel.class);
+        return createDataset(datasetRequest, datasetRequest.getName() + UUID.randomUUID().toString());
+    }
+
+    @Before
+    public void setup() {
+        logger.info("-------------------Setup----------------------");
+        BillingProfileRequestModel profileRequest = ProfileFixtures.randomBillingProfileRequest();
+        billingProfile = profileDao.createBillingProfile(profileRequest, "hi@hi.hi");
+
+        GoogleProjectResource projectResource = ResourceFixtures.randomProjectResource(billingProfile);
+        projectId = resourceDao.createProject(projectResource);
+        logger.info("-------------------Test----------------------");
+    }
+
+    @After
+    public void teardown() {
+        logger.info("-------------------Cleanup----------------------");
+        datasetBucketDao.deleteDatasetBucketLink(datasetId, bucketResourceId);
+        datasetDao.delete(datasetId);
+        resourceDao.deleteProject(projectId);
+        profileDao.deleteBillingProfileById(UUID.fromString(billingProfile.getId()));
+    }
+
+
+    @Test
+    public void TestDatasetBucketLink() throws Exception {
+        datasetId = createDataset("dataset-minimal.json");
+        bucketResourceId = createBucket();
+
+        //initial check - link should not yet exist
+        boolean linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertFalse("Link should not yet exist.", linkExists);
+
+        // create link
+        datasetBucketDao.createDatasetBucketLink(datasetId, bucketResourceId);
+        linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertTrue("Link should now exist.", linkExists);
+
+        // delete link
+        datasetBucketDao.deleteDatasetBucketLink(datasetId, bucketResourceId);
+        linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertFalse("Link should no longer exists.", linkExists);
+    }
+
+    @Test
+    public void TestMultipleLinks() throws Exception {
+        datasetId = createDataset("dataset-minimal.json");
+        bucketResourceId = createBucket();
+
+        //initial check - link should not yet exist
+        boolean linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertFalse("Link should not yet exist.", linkExists);
+
+        // create link
+        datasetBucketDao.createDatasetBucketLink(datasetId, bucketResourceId);
+        linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertTrue("Link should now exist.", linkExists);
+
+        // create link
+        datasetBucketDao.createDatasetBucketLink(datasetId, bucketResourceId);
+        linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertTrue("Link should now exist.", linkExists);
+
+        // create link
+        datasetBucketDao.createDatasetBucketLink(datasetId, bucketResourceId);
+        linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertTrue("Link should now exist.", linkExists);
+
+        // delete link
+        datasetBucketDao.deleteDatasetBucketLink(datasetId, bucketResourceId);
+        linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertFalse("Link should no longer exists.", linkExists);
+    }
+
+    // TODO: Fix code to allow this test to pass or change test to match expected behavior
+    @Ignore
+    @Test
+    public void TestDecrementLink() throws Exception {
+        datasetId = createDataset("dataset-minimal.json");
+        bucketResourceId = createBucket();
+
+        //initial check - link should not yet exist
+        boolean linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertFalse("Link should not yet exist.", linkExists);
+
+        // create link
+        datasetBucketDao.createDatasetBucketLink(datasetId, bucketResourceId);
+        linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertTrue("Link should now exist.", linkExists);
+
+        // decrement the link
+        // Is this the expected behavior?
+        // Since we're returning COUNT(*) in the exists check, even a successful_ingests=0 will return 1
+        datasetBucketDao.decrementDatasetBucketLink(datasetId, bucketResourceId);
+        linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, bucketResourceId);
+        assertFalse("After decrementing bucket link, Link should no longer exist.", linkExists);
+    }
+
+    // Test key restraints - There must be entries in the dataset table and bucket_resource table
+    // in order to create a link in the dataset_bucket table
+    @Test(expected = Exception.class)
+    public void DatasetMustExistToLink() throws Exception {
+
+        // create dataset to pass to bucket create
+        datasetId = createDataset("dataset-minimal.json");
+        bucketResourceId = createBucket();
+
+        // fake datasetId
+        UUID randomDatasetId = UUID.randomUUID();
+
+        //initial check - link should not yet exist
+        boolean linkExists = datasetBucketDao.datasetBucketLinkExists(randomDatasetId, bucketResourceId);
+        assertFalse("Link should not yet exist.", linkExists);
+
+        // this should fail -> no requires real dataset and bucket to link
+        datasetBucketDao.createDatasetBucketLink(randomDatasetId, bucketResourceId);
+    }
+
+    @Test(expected = Exception.class)
+    public void BucketMustExistToLink() throws Exception {
+
+        // create dataset
+        datasetId = createDataset("dataset-minimal.json");
+
+        // fake datasetId
+        UUID randomBucketResourceId= UUID.randomUUID();
+
+        //initial check - link should not yet exist
+        boolean linkExists = datasetBucketDao.datasetBucketLinkExists(datasetId, randomBucketResourceId);
+        assertFalse("Link should not yet exist.", linkExists);
+
+        // this should fail -> no requires real dataset and bucket to link
+        datasetBucketDao.createDatasetBucketLink(datasetId, randomBucketResourceId);
+    }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/DatasetBucketLinkTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/DatasetBucketLinkTest.java
@@ -8,13 +8,10 @@ import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.service.dataset.Dataset;
-import bio.terra.service.dataset.DatasetBucketDao;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.dataset.DatasetUtils;
 import bio.terra.service.profile.ProfileDao;
-import bio.terra.service.resourcemanagement.google.GoogleBucketService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
-import bio.terra.service.resourcemanagement.google.GoogleProjectService;
 import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
 import org.junit.After;
 import org.junit.Before;
@@ -24,7 +21,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
@@ -53,25 +49,10 @@ public class DatasetBucketLinkTest {
     private DatasetDao datasetDao;
 
     @Autowired
-    private DatasetBucketDao datasetBucketDao;
-
-    @Autowired
     private ProfileDao profileDao;
 
     @Autowired
     private GoogleResourceDao resourceDao;
-
-    @Autowired
-    private NamedParameterJdbcTemplate jdbcTemplate;
-
-    @Autowired
-    private ResourceService resourceService;
-
-    @Autowired
-    private GoogleProjectService googleProjectService;
-
-    @Autowired
-    private GoogleBucketService googleBucketService;
 
     @Autowired
     private OneProjectPerProfileIdSelector oneProjectPerProfileIdSelector;
@@ -105,20 +86,6 @@ public class DatasetBucketLinkTest {
         projectResource2.id(projectId2);
         projects.add(projectResource2);
 
-    }
-
-    private Dataset createDataset(BillingProfileModel billingProfile, UUID projectId) throws IOException {
-        Dataset dataset;
-        DatasetRequestModel datasetRequest1 = jsonLoader.loadObject("dataset-minimal.json", DatasetRequestModel.class);
-        datasetRequest1.name(datasetRequest1.getName() + UUID.randomUUID().toString())
-            .defaultProfileId(billingProfile.getId());
-        dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest1);
-        dataset.projectResourceId(projectId);
-        String createFlightId1 = UUID.randomUUID().toString();
-        dataset.id(UUID.randomUUID());
-        datasetDao.createAndLock(dataset, createFlightId1);
-        datasetDao.unlockExclusive(dataset.getId(), createFlightId1);
-        return dataset;
     }
 
     @After
@@ -163,5 +130,19 @@ public class DatasetBucketLinkTest {
         logger.info("Bucket 1: {}; Bucket 2: {}", bucketName1, bucketName2);
 
         assertEquals("Buckets should be named the same", bucketName1, bucketName2);
+    }
+
+    private Dataset createDataset(BillingProfileModel billingProfile, UUID projectId) throws IOException {
+        Dataset dataset;
+        DatasetRequestModel datasetRequest1 = jsonLoader.loadObject("dataset-minimal.json", DatasetRequestModel.class);
+        datasetRequest1.name(datasetRequest1.getName() + UUID.randomUUID().toString())
+            .defaultProfileId(billingProfile.getId());
+        dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest1);
+        dataset.projectResourceId(projectId);
+        String createFlightId1 = UUID.randomUUID().toString();
+        dataset.id(UUID.randomUUID());
+        datasetDao.createAndLock(dataset, createFlightId1);
+        datasetDao.unlockExclusive(dataset.getId(), createFlightId1);
+        return dataset;
     }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/DatasetBucketLinkTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/DatasetBucketLinkTest.java
@@ -1,0 +1,209 @@
+package bio.terra.service.resourcemanagement;
+
+import bio.terra.common.Column;
+import bio.terra.common.MetadataEnumeration;
+import bio.terra.common.Table;
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.common.fixtures.ProfileFixtures;
+import bio.terra.common.fixtures.ResourceFixtures;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.BillingProfileRequestModel;
+import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetBucketDao;
+import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.dataset.DatasetUtils;
+import bio.terra.service.dataset.exception.DatasetLockException;
+import bio.terra.service.dataset.exception.DatasetNotFoundException;
+import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.resourcemanagement.OneProjectPerProfileIdSelector;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.google.*;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class DatasetBucketLinkTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatasetBucketLinkTest.class);
+
+    @Autowired
+    private JsonLoader jsonLoader;
+
+    @Autowired
+    private DatasetDao datasetDao;
+
+    @Autowired
+    private DatasetBucketDao datasetBucketDao;
+
+    @Autowired
+    private ProfileDao profileDao;
+
+    @Autowired
+    private GoogleResourceDao resourceDao;
+
+    @Autowired
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ResourceService resourceService;
+
+    @Autowired
+    private GoogleProjectService googleProjectService;
+
+    @Autowired
+    private GoogleBucketService googleBucketService;
+
+    @Autowired
+    private OneProjectPerProfileIdSelector oneProjectPerProfileIdSelector;
+
+    private BillingProfileModel billingProfile1;
+    private GoogleBucketResource bucket1;
+    private UUID projectId1;
+    private Dataset dataset1;
+
+    private BillingProfileModel billingProfile2;
+    private GoogleBucketResource bucket2;
+    private UUID projectId2;
+    private Dataset dataset2;
+
+
+    @Before
+    public void setup() throws IOException, InterruptedException {
+        logger.info("-------------------Setup----------------------");
+        // Two billing profiles
+        BillingProfileRequestModel profileRequest1 = ProfileFixtures.randomBillingProfileRequest();
+        billingProfile1 = profileDao.createBillingProfile(profileRequest1, "hi@hi.hi");
+
+        BillingProfileRequestModel profileRequest2 = ProfileFixtures.randomBillingProfileRequest();
+        billingProfile2 = profileDao.createBillingProfile(profileRequest2, "hi@hi.hi");
+
+        // two google project resources
+        GoogleProjectResource projectResource1 = ResourceFixtures.randomProjectResourceAndName(billingProfile1);
+        projectId1 = resourceDao.createProject(projectResource1);
+
+        GoogleProjectResource projectResource2 = ResourceFixtures.randomProjectResourceAndName(billingProfile2);
+        projectId2 = resourceDao.createProject(projectResource2);
+
+        // Create dataset 1
+        DatasetRequestModel datasetRequest1 = jsonLoader.loadObject("dataset-minimal.json", DatasetRequestModel.class);
+        datasetRequest1.name(datasetRequest1.getName() + UUID.randomUUID().toString())
+            .defaultProfileId(billingProfile1.getId());
+        dataset1 = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest1);
+        dataset1.projectResourceId(projectId1);
+        String createFlightId = UUID.randomUUID().toString();
+        dataset1.id(UUID.randomUUID());
+        datasetDao.createAndLock(dataset1, createFlightId);
+        datasetDao.unlockExclusive(dataset1.getId(), createFlightId);
+
+        // Create dataset 2
+        DatasetRequestModel datasetRequest2 = jsonLoader.loadObject("dataset-minimal.json", DatasetRequestModel.class);
+        datasetRequest2.name(datasetRequest2.getName() + UUID.randomUUID().toString())
+            .defaultProfileId(billingProfile2.getId());
+        dataset2 = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest2);
+        dataset2.projectResourceId(projectId2);
+        String createFlightId2 = UUID.randomUUID().toString();
+        dataset2.id(UUID.randomUUID());
+        datasetDao.createAndLock(dataset2, createFlightId2);
+        datasetDao.unlockExclusive(dataset2.getId(), createFlightId2);
+
+        // create bucket 1
+        String flightId = UUID.randomUUID().toString();
+        // Every bucket needs to live in a project, so we get or create a project first
+        // Q: Should the bucket projects be different from project that we created dataset with?
+        /*GoogleProjectResource bucketProjectResource1 = googleProjectService.getOrCreateProject(
+            oneProjectPerProfileIdSelector.projectIdForFile(dataset1.getName(), billingProfile1),
+            billingProfile1,
+            null);*/
+
+        bucket1 = googleBucketService.getOrCreateBucket(
+            oneProjectPerProfileIdSelector.bucketForFile(dataset1.getName(), billingProfile1),
+            projectResource1,
+            flightId);
+
+        // create bucket 2
+        String flightId2 = UUID.randomUUID().toString();
+        /*GoogleProjectResource bucketProjectResource2 = googleProjectService.getOrCreateProject(
+            oneProjectPerProfileIdSelector.projectIdForFile(dataset2.getName(), billingProfile2),
+            billingProfile2,
+            null);*/
+
+        bucket2 = googleBucketService.getOrCreateBucket(
+            oneProjectPerProfileIdSelector.bucketForFile(dataset2.getName(), billingProfile2),
+            projectResource2,
+            flightId2);
+        logger.info("-------------------Test----------------------");
+    }
+
+    @After
+    public void teardown() {
+        logger.info("-------------------Cleanup----------------------");
+        datasetBucketDao.deleteDatasetBucketLink(dataset1.getId(), bucket1.getResourceId());
+        datasetBucketDao.deleteDatasetBucketLink(dataset2.getId(), bucket2.getResourceId());
+        datasetDao.delete(dataset1.getId());
+        datasetDao.delete(dataset2.getId());
+        resourceDao.deleteProject(projectId1);
+        resourceDao.deleteProject(projectId2);
+        profileDao.deleteBillingProfileById(UUID.fromString(billingProfile1.getId()));
+        profileDao.deleteBillingProfileById(UUID.fromString(billingProfile2.getId()));
+    }
+
+    @Test
+    public void TestDatasetBucketBillingProfileMapping() throws Exception {
+
+        assertNotEquals("Buckets should be named differently", bucket1.getName(), bucket2.getName());
+
+        //initial check - link should not yet exist
+        boolean linkExists = datasetBucketDao.datasetBucketLinkExists(dataset1.getId(), bucket1.getResourceId());
+        assertFalse("Link should not yet exist.", linkExists);
+
+        linkExists = datasetBucketDao.datasetBucketLinkExists(dataset2.getId(), bucket2.getResourceId());
+        assertFalse("Link should not yet exist.", linkExists);
+
+        // create link
+        datasetBucketDao.createDatasetBucketLink(dataset1.getId(), bucket1.getResourceId());
+        linkExists = datasetBucketDao.datasetBucketLinkExists(dataset1.getId(), bucket1.getResourceId());
+        assertTrue("Link should now exist.", linkExists);
+
+        // create link
+        datasetBucketDao.createDatasetBucketLink(dataset2.getId(), bucket2.getResourceId());
+        linkExists = datasetBucketDao.datasetBucketLinkExists(dataset2.getId(), bucket2.getResourceId());
+        assertTrue("Link should now exist.", linkExists);
+
+
+    }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/DatasetBucketLinkTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/DatasetBucketLinkTest.java
@@ -1,8 +1,5 @@
 package bio.terra.service.resourcemanagement;
 
-import bio.terra.common.Column;
-import bio.terra.common.MetadataEnumeration;
-import bio.terra.common.Table;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.ProfileFixtures;
@@ -14,41 +11,29 @@ import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetBucketDao;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.dataset.DatasetUtils;
-import bio.terra.service.dataset.exception.DatasetLockException;
-import bio.terra.service.dataset.exception.DatasetNotFoundException;
 import bio.terra.service.profile.ProfileDao;
-import bio.terra.service.resourcemanagement.OneProjectPerProfileIdSelector;
-import bio.terra.service.resourcemanagement.ResourceService;
-import bio.terra.service.resourcemanagement.google.*;
-import org.hamcrest.Matchers;
+import bio.terra.service.resourcemanagement.google.GoogleBucketService;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.resourcemanagement.google.GoogleProjectService;
+import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,119 +76,92 @@ public class DatasetBucketLinkTest {
     @Autowired
     private OneProjectPerProfileIdSelector oneProjectPerProfileIdSelector;
 
-    private BillingProfileModel billingProfile1;
-    private GoogleBucketResource bucket1;
-    private UUID projectId1;
-    private Dataset dataset1;
-
-    private BillingProfileModel billingProfile2;
-    private GoogleBucketResource bucket2;
-    private UUID projectId2;
-    private Dataset dataset2;
-
+    private List<BillingProfileModel> billingProfiles;
+    private List<GoogleProjectResource> projects;
+    private List<Dataset> datasets;
 
     @Before
     public void setup() throws IOException, InterruptedException {
-        logger.info("-------------------Setup----------------------");
+        // Initialize lists
+        billingProfiles = new ArrayList<>();
+        projects = new ArrayList<>();
+        datasets = new ArrayList<>();
+
         // Two billing profiles
         BillingProfileRequestModel profileRequest1 = ProfileFixtures.randomBillingProfileRequest();
-        billingProfile1 = profileDao.createBillingProfile(profileRequest1, "hi@hi.hi");
+        billingProfiles.add(profileDao.createBillingProfile(profileRequest1, "testUser"));
 
         BillingProfileRequestModel profileRequest2 = ProfileFixtures.randomBillingProfileRequest();
-        billingProfile2 = profileDao.createBillingProfile(profileRequest2, "hi@hi.hi");
+        billingProfiles.add(profileDao.createBillingProfile(profileRequest2, "testUser"));
 
         // two google project resources
-        GoogleProjectResource projectResource1 = ResourceFixtures.randomProjectResourceAndName(billingProfile1);
-        projectId1 = resourceDao.createProject(projectResource1);
+        GoogleProjectResource projectResource1 = ResourceFixtures.randomProjectResource(billingProfiles.get(0));
+        UUID projectId = resourceDao.createProject(projectResource1);
+        projectResource1.id(projectId);
+        projects.add(projectResource1);
 
-        GoogleProjectResource projectResource2 = ResourceFixtures.randomProjectResourceAndName(billingProfile2);
-        projectId2 = resourceDao.createProject(projectResource2);
+        GoogleProjectResource projectResource2 = ResourceFixtures.randomProjectResource(billingProfiles.get(1));
+        UUID projectId2 = resourceDao.createProject(projectResource2);
+        projectResource2.id(projectId2);
+        projects.add(projectResource2);
 
-        // Create dataset 1
+    }
+
+    private Dataset createDataset(BillingProfileModel billingProfile, UUID projectId) throws IOException {
+        Dataset dataset;
         DatasetRequestModel datasetRequest1 = jsonLoader.loadObject("dataset-minimal.json", DatasetRequestModel.class);
         datasetRequest1.name(datasetRequest1.getName() + UUID.randomUUID().toString())
-            .defaultProfileId(billingProfile1.getId());
-        dataset1 = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest1);
-        dataset1.projectResourceId(projectId1);
-        String createFlightId = UUID.randomUUID().toString();
-        dataset1.id(UUID.randomUUID());
-        datasetDao.createAndLock(dataset1, createFlightId);
-        datasetDao.unlockExclusive(dataset1.getId(), createFlightId);
-
-        // Create dataset 2
-        DatasetRequestModel datasetRequest2 = jsonLoader.loadObject("dataset-minimal.json", DatasetRequestModel.class);
-        datasetRequest2.name(datasetRequest2.getName() + UUID.randomUUID().toString())
-            .defaultProfileId(billingProfile2.getId());
-        dataset2 = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest2);
-        dataset2.projectResourceId(projectId2);
-        String createFlightId2 = UUID.randomUUID().toString();
-        dataset2.id(UUID.randomUUID());
-        datasetDao.createAndLock(dataset2, createFlightId2);
-        datasetDao.unlockExclusive(dataset2.getId(), createFlightId2);
-
-        // create bucket 1
-        String flightId = UUID.randomUUID().toString();
-        // Every bucket needs to live in a project, so we get or create a project first
-        // Q: Should the bucket projects be different from project that we created dataset with?
-        /*GoogleProjectResource bucketProjectResource1 = googleProjectService.getOrCreateProject(
-            oneProjectPerProfileIdSelector.projectIdForFile(dataset1.getName(), billingProfile1),
-            billingProfile1,
-            null);*/
-
-        bucket1 = googleBucketService.getOrCreateBucket(
-            oneProjectPerProfileIdSelector.bucketForFile(dataset1.getName(), billingProfile1),
-            projectResource1,
-            flightId);
-
-        // create bucket 2
-        String flightId2 = UUID.randomUUID().toString();
-        /*GoogleProjectResource bucketProjectResource2 = googleProjectService.getOrCreateProject(
-            oneProjectPerProfileIdSelector.projectIdForFile(dataset2.getName(), billingProfile2),
-            billingProfile2,
-            null);*/
-
-        bucket2 = googleBucketService.getOrCreateBucket(
-            oneProjectPerProfileIdSelector.bucketForFile(dataset2.getName(), billingProfile2),
-            projectResource2,
-            flightId2);
-        logger.info("-------------------Test----------------------");
+            .defaultProfileId(billingProfile.getId());
+        dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest1);
+        dataset.projectResourceId(projectId);
+        String createFlightId1 = UUID.randomUUID().toString();
+        dataset.id(UUID.randomUUID());
+        datasetDao.createAndLock(dataset, createFlightId1);
+        datasetDao.unlockExclusive(dataset.getId(), createFlightId1);
+        return dataset;
     }
 
     @After
     public void teardown() {
-        logger.info("-------------------Cleanup----------------------");
-        datasetBucketDao.deleteDatasetBucketLink(dataset1.getId(), bucket1.getResourceId());
-        datasetBucketDao.deleteDatasetBucketLink(dataset2.getId(), bucket2.getResourceId());
-        datasetDao.delete(dataset1.getId());
-        datasetDao.delete(dataset2.getId());
-        resourceDao.deleteProject(projectId1);
-        resourceDao.deleteProject(projectId2);
-        profileDao.deleteBillingProfileById(UUID.fromString(billingProfile1.getId()));
-        profileDao.deleteBillingProfileById(UUID.fromString(billingProfile2.getId()));
+        for (Dataset dataset : datasets) {
+            datasetDao.delete(dataset.getId());
+        }
+        for (GoogleProjectResource project : projects) {
+            resourceDao.deleteProject(project.getId());
+        }
+        for (BillingProfileModel billingProfile : billingProfiles) {
+            profileDao.deleteBillingProfileById(UUID.fromString(billingProfile.getId()));
+        }
     }
 
     @Test
-    public void TestDatasetBucketBillingProfileMapping() throws Exception {
+    public void twoDatasetsTwoBillingProfilesTwoBuckets() throws Exception {
+        //Two dataset, two billing profiles
+        datasets.add(createDataset(billingProfiles.get(0), projects.get(0).getId()));
+        datasets.add(createDataset(billingProfiles.get(1), projects.get(1).getId()));
 
-        assertNotEquals("Buckets should be named differently", bucket1.getName(), bucket2.getName());
+        String bucketName1 = oneProjectPerProfileIdSelector.bucketForFile(
+            datasets.get(0).getName(), billingProfiles.get(0));
+        String bucketName2 = oneProjectPerProfileIdSelector.bucketForFile(
+            datasets.get(1).getName(), billingProfiles.get(1));
+        logger.info("Bucket 1: {}; Bucket 2: {}", bucketName1, bucketName2);
 
-        //initial check - link should not yet exist
-        boolean linkExists = datasetBucketDao.datasetBucketLinkExists(dataset1.getId(), bucket1.getResourceId());
-        assertFalse("Link should not yet exist.", linkExists);
+        assertNotEquals("Buckets should be named differently", bucketName1, bucketName2);
+    }
 
-        linkExists = datasetBucketDao.datasetBucketLinkExists(dataset2.getId(), bucket2.getResourceId());
-        assertFalse("Link should not yet exist.", linkExists);
+    @Test
+    public void twoDatasetsOneBillingProfileOneBucket() throws Exception {
 
-        // create link
-        datasetBucketDao.createDatasetBucketLink(dataset1.getId(), bucket1.getResourceId());
-        linkExists = datasetBucketDao.datasetBucketLinkExists(dataset1.getId(), bucket1.getResourceId());
-        assertTrue("Link should now exist.", linkExists);
+        //Two dataset, one billing profile
+        datasets.add(createDataset(billingProfiles.get(0), projects.get(0).getId()));
+        datasets.add(createDataset(billingProfiles.get(0), projects.get(0).getId()));
 
-        // create link
-        datasetBucketDao.createDatasetBucketLink(dataset2.getId(), bucket2.getResourceId());
-        linkExists = datasetBucketDao.datasetBucketLinkExists(dataset2.getId(), bucket2.getResourceId());
-        assertTrue("Link should now exist.", linkExists);
+        String bucketName1 = oneProjectPerProfileIdSelector.bucketForFile(
+            datasets.get(0).getName(), billingProfiles.get(0));
+        String bucketName2 = oneProjectPerProfileIdSelector.bucketForFile(
+            datasets.get(1).getName(), billingProfiles.get(0));
+        logger.info("Bucket 1: {}; Bucket 2: {}", bucketName1, bucketName2);
 
-
+        assertEquals("Buckets should be named the same", bucketName1, bucketName2);
     }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceUtils.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceUtils.java
@@ -1,0 +1,22 @@
+package bio.terra.service.resourcemanagement.google;
+
+import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.model.ConfigParameterModel;
+import bio.terra.model.ConfigModel;
+import bio.terra.model.ConfigGroupModel;
+
+public class BucketResourceUtils {
+    boolean getAllowReuseExistingBuckets(ConfigurationService configService) {
+        return configService.getParameterValue(ConfigEnum.ALLOW_REUSE_EXISTING_BUCKETS);
+    }
+
+    public void setAllowReuseExistingBuckets(ConfigurationService configService, boolean allow) {
+        ConfigModel model = configService.getConfig(ConfigEnum.ALLOW_REUSE_EXISTING_BUCKETS.name());
+        model.setParameter(new ConfigParameterModel().value(String.valueOf(allow)));
+        ConfigGroupModel configGroupModel = new ConfigGroupModel()
+            .label("BucketResourceTest")
+            .addGroupItem(model);
+        configService.setConfig(configGroupModel);
+    }
+}


### PR DESCRIPTION
### Two Tests
1. DatasetBucketDaoTest - Unit tests for DatasetBucketDao. Tests include:
- Creating and deleting links between a dataset and bucket
- Successful_ingest counter
- Check if link exists between a dataset and bucket

2. DatasetBucketLinkTest: These tests check two cases when using the oneProjectPerProfileIdSelector:
(1) Two datasets created with two billing profiles should point to two different buckets
(2) Two datasets created with the same billing profile should point to the same bucket

### Additional Changes
- More randomization: To avoid duplication while creating multiple projects and billing profiles during a single test run, I added randomization to the ids and names of these artifacts when creating them for the tests. 
- "datasetBucketSuccessfulIngestCount()" method: This was added to allow for more precise testing. By design, the datasetBucketLinkExists() method returns true even when successful_ingest = 0. In order to test the decrementDatasetBucketLink, the count method was added. 
- Pulled "setAllowReuseExistingBuckets" method into shared util to be shared between BucketResourceTest and DatasetBucketDaoTest