### PR TITLE
DR-1496: bump vault-action version

### DIFF
--- a/.github/workflows/alpha-integration-tests.yaml
+++ b/.github/workflows/alpha-integration-tests.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: "Checkout code"
       uses: actions/checkout@v2
     - name: "Import Vault alpha secrets"
-      uses: hashicorp/vault-action@v2.0.1
+      uses: hashicorp/vault-action@v2.1.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle
@@ -56,7 +56,7 @@ jobs:
         echo ${OK_BINDINGS} | jq '.' > policy.json
         gcloud projects set-iam-policy ${GOOGLE_CLOUD_DATA_PROJECT} policy.json
     - name: "Import Vault dev secrets"
-      uses: hashicorp/vault-action@v2.0.1
+      uses: hashicorp/vault-action@v2.1.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           git checkout ${{ steps.apiprevioustag.outputs.tag }}
       - name: "Import Vault staging secrets"
-        uses: hashicorp/vault-action@v2.0.1
+        uses: hashicorp/vault-action@v2.1.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -40,7 +40,7 @@ jobs:
 
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.0.1
+        uses: hashicorp/vault-action@v2.1.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           ref: ${{ steps.read_property.outputs.LATEST_VERSION }}
       - name: "Import Vault perf secrets"
-        uses: hashicorp/vault-action@v2.0.1
+        uses: hashicorp/vault-action@v2.1.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -45,7 +45,7 @@ jobs:
 
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.0.1
+        uses: hashicorp/vault-action@v2.1.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle


### PR DESCRIPTION
Bump vault-action version as GitHub has disabled `set-env` functionality.