### PR TITLE
DR-1504 Add logging when creating a google project

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -152,6 +152,7 @@ public class GoogleProjectService {
                 .setName(requestedProjectId)
                 .setProjectId(requestedProjectId)
                 .setParent(parentResource);
+        logger.info("creating project with request: {}", requestBody);
         try {
             // kick off a project create request and poll until it is done
             CloudResourceManager resourceManager = cloudResourceManager();


### PR DESCRIPTION
Logs the request body before TDR attempts to ask Google to create a project