### PR TITLE
DR-1462 - Remove gcs.allowReuseExistingBucket variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ skaffold run
 1. Locally, application properties are controlled by the values in the various application.properties files.
     - `application.properties` contains the base/default values. A new property should be added here first.
     ```
-    datarepo.gcs.allowReuseExistingBuckets=false
+    google.allowReuseExistingBuckets=false
     ```
     - You can override the default value for connected and integration tests by adding a line to
     `application-connectedtest.properties` and `application-integrationtest.properties`.
     ```
-    datarepo.gcs.allowReuseExistingBuckets=true
+    google.allowReuseExistingBuckets=true
     ```
 2. Now that we use Helm, the properties also need to be added to the
 [base Data Repo charts](https://github.com/broadinstitute/datarepo-helm).
@@ -160,15 +160,15 @@ skaffold run
     - Add a new property under the `env` section. The formatting below might be messed up, and the yaml is very picky
     about spaces. So, copy/paste from another variable in the section instead of here.
     ```
-            {{- if .Values.env.datarepoGcsAllowreuseexistingbuckets }}
-            - name: DATAREPO_GCS_ALLOWREUSEEXISTINGBUCKETS
-              value: {{ .Values.env.datarepoGcsAllowreuseexistingbuckets | quote }}
+            {{- if .Values.env.googleAllowreuseexistingbuckets }}
+            - name: GOOGLE_ALLOWREUSEEXISTINGBUCKETS
+              value: {{ .Values.env.googleAllowreuseexistingbuckets | quote }}
             {{- end }}
     ```
     - Find the the [values.yaml](https://github.com/broadinstitute/datarepo-helm/blob/master/charts/datarepo-api/values.yaml) file.
     - Add a new line under the `env` section.
     ```
-      datarepoGcsAllowreuseexistingbuckets:
+      googleAllowreuseexistingbuckets:
     ```
     - Release a new version of the chart. Talk to DevOps to do this.
 3. To override properties for specific environments (e.g. integration), modify the
@@ -177,7 +177,7 @@ skaffold run
     for the specific environment.
     - Add a new line under the `env` section.
     ```
-    datarepoGcsAllowreuseexistingbuckets: true
+    googleAllowreuseexistingbuckets: true
     ```
    - It's a good idea to test out changes on your developer-namespace before making a PR.
    - Changes to integration, temp, or developer-namespace environments are good with regular PR approval (1 thumb for this repository).

--- a/datarepo-clienttests/src/main/java/scripts/deploymentscripts/LaunchLocalProcess.java
+++ b/datarepo-clienttests/src/main/java/scripts/deploymentscripts/LaunchLocalProcess.java
@@ -192,7 +192,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     // always set the following testing-related environment variables
     envVars.put("DB_STAIRWAY_FORCECLEAN", "true");
     envVars.put("DB_MIGRATE_DROPALLONSTART", "true");
-    envVars.put("DATAREPO_GCS_ALLOWREUSEEXISTINGBUCKETS", "true");
+    envVars.put("GOOGLE_ALLOWREUSEEXISTINGBUCKETS", "true");
 
     // set the following environment variables from the application specification object
     envVars.put(

--- a/datarepo-clienttests/src/main/java/scripts/deploymentscripts/LaunchLocalProcess.java
+++ b/datarepo-clienttests/src/main/java/scripts/deploymentscripts/LaunchLocalProcess.java
@@ -193,6 +193,7 @@ public class LaunchLocalProcess extends DeploymentScript {
     envVars.put("DB_STAIRWAY_FORCECLEAN", "true");
     envVars.put("DB_MIGRATE_DROPALLONSTART", "true");
     envVars.put("GOOGLE_ALLOWREUSEEXISTINGBUCKETS", "true");
+    envVars.put("GOOGLE_ALLOWREUSEEXISTINGPROJECTS", "true");
 
     // set the following environment variables from the application specification object
     envVars.put(

--- a/datarepo-clienttests/src/main/java/scripts/deploymentscripts/ModularHelmChart.java
+++ b/datarepo-clienttests/src/main/java/scripts/deploymentscripts/ModularHelmChart.java
@@ -249,7 +249,6 @@ public class ModularHelmChart extends DeploymentScript {
     // always set the following testing-related environment variables
     envSubTree.put("DB_STAIRWAY_FORCECLEAN", "true");
     envSubTree.put("DB_MIGRATE_DROPALLONSTART", "true");
-    envSubTree.put("DATAREPO_GCS_ALLOWREUSEEXISTINGBUCKETS", "true");
     envSubTree.put("GOOGLE_ALLOWREUSEEXISTINGBUCKETS", "true");
     envSubTree.put("GOOGLE_ALLOWREUSEEXISTINGPROJECTS", "true");
 

--- a/src/main/java/bio/terra/service/configuration/ConfigurationService.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigurationService.java
@@ -228,14 +228,7 @@ public class ConfigurationService {
         addParameter(FIRESTORE_QUERY_BATCH_SIZE, appConfiguration.getFirestoreQueryBatchSize());
         addParameter(AUTH_CACHE_SIZE, appConfiguration.getAuthCacheSize());
         addParameter(AUTH_CACHE_TIMEOUT_SECONDS, appConfiguration.getAuthCacheTimeoutSeconds());
-
-        // TODO: Temporarily there are two places where allowReuseExistingBuckets is set. The old one is
-        //  in the GcsConfiguration. The new one is in GoogleResourceConfiguration, which has related
-        //  settings. For now, we make the initial setting of the parameter the logical or of the two settings.
-        //  Once all of the helm charts are updated, we can remove the GcsConfiguration version.
-        addParameter(ALLOW_REUSE_EXISTING_BUCKETS,
-            (gcsConfiguration.getAllowReuseExistingBuckets() ||
-                googleResourceConfiguration.getAllowReuseExistingBuckets()));
+        addParameter(ALLOW_REUSE_EXISTING_BUCKETS, googleResourceConfiguration.getAllowReuseExistingBuckets());
 
         // -- Faults --
         addFaultSimple(CREATE_ASSET_FAULT);

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsConfiguration.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsConfiguration.java
@@ -16,7 +16,6 @@ public class GcsConfiguration {
     private String region;
     private int connectTimeoutSeconds;
     private int readTimeoutSeconds;
-    private boolean allowReuseExistingBuckets;
 
     public String getBucket() {
         return bucket;
@@ -48,14 +47,5 @@ public class GcsConfiguration {
 
     public void setReadTimeoutSeconds(int readTimeoutSeconds) {
         this.readTimeoutSeconds = readTimeoutSeconds;
-    }
-
-    public boolean getAllowReuseExistingBuckets() {
-        return allowReuseExistingBuckets;
-    }
-
-    public GcsConfiguration setAllowReuseExistingBuckets(boolean allowReuseExistingBuckets) {
-        this.allowReuseExistingBuckets = allowReuseExistingBuckets;
-        return this;
     }
 }

--- a/src/main/resources/application-dd.properties
+++ b/src/main/resources/application-dd.properties
@@ -1,4 +1,3 @@
-datarepo.gcs.allowReuseExistingBuckets=true
 google.projectid=broad-jade-dd
 google.singleDataProjectId=broad-jade-dd-data
 google.allowReuseExistingBuckets=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,7 +54,6 @@ datarepo.gcs.bucket=broad-jade-dev-data
 datarepo.gcs.region=us-central1
 datarepo.gcs.connectTimeoutSeconds=20
 datarepo.gcs.readTimeoutSeconds=40
-datarepo.gcs.allowReuseExistingBuckets=false
 datarepo.bq.rateLimitRetries=3
 datarepo.bq.rateLimitRetryWaitMs=500
 datarepo.numPerformanceThreads=50


### PR DESCRIPTION
With DR-1458, we switched from using datarepo.gcs.allowReuseExisitingBuckets to google.allowReuseExisitingBuckets. However, both we were left in the code as we transitioned our helm definitions. So, these changes simply clean up the old variables that are no longer used now that we've transitioned to using the new variable. 