### PR TITLE
DR-1508 Old billing profile upgrade

### DIFF
--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -41,6 +41,8 @@ public class ProfileDao {
         + " FROM billing_profile"
         + " WHERE id in (:idlist)";
 
+    private static final String sqlListOld = "SELECT " + sqlSelectList
+        + " FROM billing_profile";
 
     @Autowired
     public ProfileDao(NamedParameterJdbcTemplate jdbcTemplate) {
@@ -110,6 +112,16 @@ public class ProfileDao {
         int rowsAffected = jdbcTemplate.update("DELETE FROM billing_profile WHERE id = :id",
             new MapSqlParameterSource().addValue("id", id));
         return rowsAffected > 0;
+    }
+
+    /**
+     * This method is made for use by upgrade, where we need to find all of the old billing profiles
+     * without regard to visibility.
+     * @return list of billing profile models
+     */
+    @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
+    public List<BillingProfileModel> getOldBillingProfiles() {
+        return jdbcTemplate.query(sqlListOld, new BillingProfileMapper());
     }
 
     private static class BillingProfileMapper implements RowMapper<BillingProfileModel> {

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -42,6 +42,7 @@ public class ProfileService {
     private final GoogleBillingService billingService;
     private final SamConfiguration samConfig;
 
+
     @Autowired
     public ProfileService(ProfileDao profileDao,
                           IamService iamService,
@@ -86,7 +87,7 @@ public class ProfileService {
      *     that is, no snapshots, dataset, or buckets referencing the profile</le>
      * </ul>
      *
-     * @param id   the unique id of the bill profile
+     * @param id the unique id of the bill profile
      * @param user the user attempting the delete
      * @return jobId of the submitted stairway job
      */
@@ -104,8 +105,8 @@ public class ProfileService {
      * Enumerate the profiles that are visible to the requesting user
      *
      * @param offset start of the range of profiles to return for this request
-     * @param limit  maximum number of profiles to return in this request
-     * @param user   user on whose behalf we are making this request
+     * @param limit maximum number of profiles to return in this request
+     * @param user user on whose behalf we are making this request
      * @return enumeration profile containing the list and total
      */
     public EnumerateBillingProfileModel enumerateProfiles(Integer offset,
@@ -121,7 +122,7 @@ public class ProfileService {
     /**
      * Lookup a billing profile by the profile id with auth check. Supports the REST API
      *
-     * @param id   the unique idea of this billing profile
+     * @param id the unique idea of this billing profile
      * @param user authenticated user
      * @return On success, the billing profile model
      * @throws ProfileNotFoundException when the profile is not found
@@ -158,7 +159,7 @@ public class ProfileService {
      * having "create link" permission on the billing account.
      *
      * @param profileId the profile id to attempt to authorize
-     * @param user      the user attempting associate some object with the profile
+     * @param user the user attempting associate some object with the profile
      * @return the profile model associated with the profile id
      */
     public BillingProfileModel authorizeLinking(UUID profileId, AuthenticatedUserRequest user) {
@@ -231,10 +232,19 @@ public class ProfileService {
     // This code generates sam resources for any billing profile it does not have one. It sets the
     // stewards group as the owner of the billing profile.
     //
-    // We assume this is being run as a Steward and that the Steward has access to any billing
+    // In the current state, no billing profiles have sam resources, so the resources list will be empty.
+    // When we upgrade a billing profile, we give stewards owner role. Since we run this
+    // as a steward, we will be able to see any profiles we have already converted.
+    //
+    // The hole here is if someone gets in and creates a billing profile with a resource before
+    // we run the upgrade. We would not retrieve that one here. However, Sam would not let us create
+    // the resource in the step below. We would log an error, but otherwise, things would work.
+
     public UpgradeResponseModel upgradeProfileResources(UpgradeModel request, AuthenticatedUserRequest user) {
+
         Instant startTime = Instant.now();
         List<BillingProfileModel> profiles = profileDao.getOldBillingProfiles();
+
         List<UUID> resources = iamService.listAuthorizedResources(user, IamResourceType.SPEND_PROFILE);
         Set<String> profileResourceSet;
         if (resources == null) {

--- a/src/main/java/bio/terra/service/upgrade/UpgradeService.java
+++ b/src/main/java/bio/terra/service/upgrade/UpgradeService.java
@@ -1,0 +1,56 @@
+package bio.terra.service.upgrade;
+
+import bio.terra.common.exception.NotImplementedException;
+import bio.terra.model.UpgradeModel;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.job.JobService;
+import bio.terra.service.upgrade.exception.InvalidCustomNameException;
+import bio.terra.service.upgrade.flight.UpgradeProfileFlight;
+import bio.terra.stairway.Flight;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpgradeService {
+
+    private enum CustomFlight {
+        BILLING_PROFILE_PERMISSION(UpgradeProfileFlight.class);
+
+        private final Class<? extends Flight> flightClass;
+
+        CustomFlight(Class<? extends Flight> flightClass) {
+            this.flightClass = flightClass;
+        }
+
+        public Class<? extends Flight> getFlightClass() {
+            return flightClass;
+        }
+    }
+
+    private final JobService jobService;
+
+    @Autowired
+    public UpgradeService(JobService jobService) {
+        this.jobService = jobService;
+    }
+
+    public String upgrade(UpgradeModel request, AuthenticatedUserRequest user) {
+        if (request.getUpgradeType() != UpgradeModel.UpgradeTypeEnum.CUSTOM) {
+            throw new NotImplementedException("Upgrade type is not implemented: " + request.getUpgradeType().name());
+        }
+
+        CustomFlight customFlight;
+        try {
+            customFlight = CustomFlight.valueOf(request.getCustomName());
+        } catch (NullPointerException ex) {
+            throw new InvalidCustomNameException("Custom name is required for custom upgrade type");
+        } catch (IllegalArgumentException ex) {
+            throw new InvalidCustomNameException("Invalid custom name provided to upgrade: "
+                + request.getCustomName());
+        }
+
+        return jobService
+            .newJob(request.getCustomName(), customFlight.getFlightClass(), request, user)
+            .submit();
+    }
+}

--- a/src/main/java/bio/terra/service/upgrade/exception/InvalidCustomNameException.java
+++ b/src/main/java/bio/terra/service/upgrade/exception/InvalidCustomNameException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.upgrade.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+public class InvalidCustomNameException extends BadRequestException {
+    public InvalidCustomNameException(String message) {
+        super(message);
+    }
+
+    public InvalidCustomNameException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidCustomNameException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/upgrade/flight/UpgradeProfileFlight.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/UpgradeProfileFlight.java
@@ -1,0 +1,27 @@
+package bio.terra.service.upgrade.flight;
+
+import bio.terra.model.UpgradeModel;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.ProfileService;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import org.springframework.context.ApplicationContext;
+
+public class UpgradeProfileFlight extends Flight {
+
+    public UpgradeProfileFlight(FlightMap inputParameters, Object applicationContext) {
+        super(inputParameters, applicationContext);
+
+        ApplicationContext appContext = (ApplicationContext) applicationContext;
+        ProfileService profileService = (ProfileService) appContext.getBean("profileService");
+
+        UpgradeModel request =
+            inputParameters.get(JobMapKeys.REQUEST.getKeyName(), UpgradeModel.class);
+        AuthenticatedUserRequest user = inputParameters.get(
+            JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+
+        addStep(new UpgradeProfileResourcesStep(profileService, request, user));
+    }
+
+}

--- a/src/main/java/bio/terra/service/upgrade/flight/UpgradeProfileResourcesStep.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/UpgradeProfileResourcesStep.java
@@ -1,0 +1,36 @@
+package bio.terra.service.upgrade.flight;
+
+import bio.terra.model.UpgradeModel;
+import bio.terra.model.UpgradeResponseModel;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.ProfileService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+public class UpgradeProfileResourcesStep implements Step {
+    private final ProfileService profileService;
+    private final UpgradeModel request;
+    private final AuthenticatedUserRequest user;
+
+    public UpgradeProfileResourcesStep(ProfileService profileService,
+                                       UpgradeModel request,
+                                       AuthenticatedUserRequest user) {
+        this.profileService = profileService;
+        this.request = request;
+        this.user = user;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext context) throws InterruptedException {
+        UpgradeResponseModel response = profileService.upgradeProfileResources(request, user);
+        context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), response);
+        return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) throws InterruptedException {
+        return StepResult.getStepResultSuccess();
+    }
+}

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2126,6 +2126,62 @@ paths:
         204:
           description: configuration reset
           content: {}
+
+  /api/repository/v1/upgrade:
+    post:
+      tags:
+        - repository
+      description: >-
+        Extensible endpoint for triggering upgrade tasks in the data repository.
+        The asynchronous result is UpgradeResponseModel
+      operationId: upgrade
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpgradeModel'
+        required: true
+      responses:
+        200:
+          description: Redirect for upgrade complete
+          headers:
+            location:
+              description: url for the job result
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobModel'
+        202:
+          description: Job status of upgrade job & url for polling in the response
+            header
+          headers:
+            location:
+              description: url for the job polling
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobModel'
+        400:
+          description: Bad request - invalid upgrade request, badly formed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: No permission to upgrade
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+      x-codegen-request-body-name: upgrade
+
+##############################################################################
+## DRS STANDARD ENDPOINTS
+##############################################################################
   /ga4gh/drs/v1/service-info:
     get:
       tags:
@@ -3438,6 +3494,48 @@ components:
           description: whether to enable (default) or disable the fault
           default: true
       description: Control whether a fault is enabled
+
+    UpgradeModel:
+      required:
+        - upgradeName
+        - upgradeType
+      type: object
+      properties:
+        upgradeName:
+          type: string
+          description: Unique name for the upgrade
+        upgradeType:
+          type: string
+          description: Enumeration to allow different kinds upgrades
+          enum:
+            - custom
+        customName:
+          type: string
+          description: >-
+            Name of custom upgrade to launch. Only used when upgradeType is custom.
+        customArgs:
+          description: >-
+            Array of string arguments to the custom upgrade. Only used when upgradeType is custom.
+          type: array
+          items:
+            type: string
+
+    UpgradeResponseModel:
+      type: object
+      properties:
+        upgradeName:
+          type: string
+          description: Unique name for the upgrade
+        startTime:
+          type: string
+          description: Timestamp the upgrade was started
+        endTime:
+          type: string
+          description: Timestamp the upgrade completed
+
+    ##############################################################################
+    ## DRS STANDARD MODELS
+    ##############################################################################
     DRSChecksum:
       required:
         - checksum

--- a/src/main/resources/application-dd.properties
+++ b/src/main/resources/application-dd.properties
@@ -4,6 +4,6 @@ google.singleDataProjectId=broad-jade-dd-data
 google.allowReuseExistingBuckets=true
 google.allowReuseExistingProjects=true
 userEmail=dd.datarepo@gmail.com
-db.migrate.dropAllOnStart=true
+db.migrate.dropAllOnStart=false
 db.migrate.updateAllOnStart=true
 datarepo.maxBulkFileLoadArray=5000


### PR DESCRIPTION
Plumb in upgrade end point. Implement billing profile upgrade flight.

The root problem is that the new billing profile code expects there to be sam resources for all billing profiles. However, there are existing profiles that do not have sam resources associated with them. The fixed proposed here is to implement a subset of the design from [Upgrade Processing](https://docs.google.com/document/d/1u4TrZjmw1PdHG4plb90ZRCa0-j5z8RdLnF223CUIByA/edit#).

Specifically, it adds the `custom` upgrade form that launches a flight to perform an upgrade. The flight has a single step that finds all existing billing profiles and creates Sam resources for them. It grants owner role to the steward's group, because that reflects the current permissions. Also there is no way for us to know who the true owner of the billing profiles should be.

The idea is that we would rule out this upgrade and ask people not to create anything new while we invoked the upgrade via the swagger UI page. In my tests the upgrade is very fast.