### PR TITLE
DR-1522 Increase retries to 4 for Firestore retries

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/EnumerateProfiles.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/EnumerateProfiles.java
@@ -18,14 +18,19 @@ public class EnumerateProfiles extends runner.TestScript {
   }
 
   public void userJourney(TestUserSpecification testUser) throws Exception {
-    ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
-    ResourcesApi resourcesApi = new ResourcesApi(apiClient);
-    EnumerateBillingProfileModel profiles = resourcesApi.enumerateProfiles(0, 10);
+    try {
+      ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
+      ResourcesApi resourcesApi = new ResourcesApi(apiClient);
+      EnumerateBillingProfileModel profiles = resourcesApi.enumerateProfiles(0, 10);
 
-    int httpStatus = resourcesApi.getApiClient().getStatusCode();
-    logger.debug(
-        "Enumerate profiles: HTTP status {}, number of profiles found = {}",
-        httpStatus,
-        profiles.getTotal());
+      int httpStatus = resourcesApi.getApiClient().getStatusCode();
+      logger.debug(
+          "Enumerate profiles: HTTP status {}, number of profiles found = {}",
+          httpStatus,
+          profiles.getTotal());
+    } catch (Exception e) {
+      logger.info("User journey failed: ", e);
+      throw e;
+    }
   }
 }

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/EnumerateProfiles.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/EnumerateProfiles.java
@@ -3,6 +3,7 @@ package scripts.testscripts;
 import bio.terra.datarepo.api.ResourcesApi;
 import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.model.EnumerateBillingProfileModel;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import runner.config.TestUserSpecification;
@@ -19,6 +20,7 @@ public class EnumerateProfiles extends runner.TestScript {
 
   public void userJourney(TestUserSpecification testUser) throws Exception {
     try {
+      TimeUnit.SECONDS.sleep(60);
       ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
       ResourcesApi resourcesApi = new ResourcesApi(apiClient);
       EnumerateBillingProfileModel profiles = resourcesApi.enumerateProfiles(0, 10);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
@@ -21,7 +21,7 @@ public class RetrieveDataset extends SimpleDataset {
     ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
     RepositoryApi repositoryApi = new RepositoryApi(apiClient);
     DatasetModel datasetModel = repositoryApi.retrieveDataset(datasetSummaryModel.getId());
-    logger.debug(
+    logger.info(
         "Successfully retrieved dataset: name = {}, data project = {}",
         datasetModel.getName(),
         datasetModel.getDataProject());

--- a/datarepo-clienttests/src/main/resources/configs/basicexamples/BasicAuthenticated.json
+++ b/datarepo-clienttests/src/main/resources/configs/basicexamples/BasicAuthenticated.json
@@ -10,7 +10,7 @@
       "name": "EnumerateProfiles",
       "numberOfUserJourneyThreadsToRun": 5,
       "userJourneyThreadPoolSize": 2,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 40,
       "expectedTimeForEachUnit": "SECONDS"
     }
   ],

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -151,7 +151,7 @@ public class FireStoreUtils {
         return Long.toHexString(crc.getValue());
     }
 
-    private static final int NO_PROGRESS_MAX = 2;
+    private static final int NO_PROGRESS_MAX = 4;
     private static final int SLEEP_MILLISECONDS = 1000;
 
     /**

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -129,6 +129,7 @@ public class DataRepoFixtures {
 
         DataRepoResponse<DatasetSummaryModel> response = dataRepoClient.waitForResponseLog(
             user, jobResponse, DatasetSummaryModel.class);
+        logger.info("Response was: {}", response);
         assertThat("dataset create is successful", response.getStatusCode(), equalTo(HttpStatus.CREATED));
         assertTrue("dataset create response is present", response.getResponseObject().isPresent());
         return response.getResponseObject().get();

--- a/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
@@ -46,8 +46,8 @@ public class BatchOperationTest {
     @Test(expected = FileSystemExecutionException.class)
     public void batchFailureTest() throws Exception {
         // make sure batch operation works with some retries
-        // 15 retries should fail entirely twice through and give up
-        FakeApiFuture.initialize(15);
+        // 25 retries should fail entirely four times through and give up
+        FakeApiFuture.initialize(25);
         List<String> inputs = makeInputs(5);
         fireStoreUtils.batchOperation(inputs, input -> new FakeApiFuture());
     }


### PR DESCRIPTION
Right now we retry 3 times on firestore failures.  Retry 5 times