### PR TITLE
DR-1523 billing upgrade

### DIFF
--- a/src/main/java/bio/terra/service/iam/exception/IamConflictException.java
+++ b/src/main/java/bio/terra/service/iam/exception/IamConflictException.java
@@ -1,0 +1,13 @@
+package bio.terra.service.iam.exception;
+
+import bio.terra.common.exception.ConflictException;
+
+public class IamConflictException extends ConflictException {
+    public IamConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public IamConflictException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -11,6 +11,7 @@ import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamRole;
 import bio.terra.service.iam.exception.IamBadRequestException;
+import bio.terra.service.iam.exception.IamConflictException;
 import bio.terra.service.iam.exception.IamInternalServerErrorException;
 import bio.terra.service.iam.exception.IamNotFoundException;
 import bio.terra.service.iam.exception.IamUnauthorizedException;
@@ -519,6 +520,9 @@ public class SamIam implements IamProviderInterface {
             }
             case HttpStatusCodes.STATUS_CODE_NOT_FOUND: {
                 return new IamNotFoundException(samEx);
+            }
+            case HttpStatusCodes.STATUS_CODE_CONFLICT: {
+                return new IamConflictException(samEx);
             }
             case HttpStatusCodes.STATUS_CODE_SERVER_ERROR: {
                 return new IamInternalServerErrorException(samEx);

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -274,7 +274,7 @@ public class SamIam implements IamProviderInterface {
     private Void createProfileResourceInner(AuthenticatedUserRequest userReq, String profileId) throws ApiException {
         // TODO: For now we continue to give stewards access to all profiles. That is consistent with
         //  the current behavior. When we do the migration to the new permission model we should remove
-        //  this and replace it with the admin group or similar.
+        //  this and replace it with the admin group or similar. See DR-663
         List<String> ownerList = Arrays.asList(userReq.getEmail(), samConfig.getStewardsGroupEmail());
 
         CreateResourceCorrectRequest req = new CreateResourceCorrectRequest();
@@ -511,6 +511,10 @@ public class SamIam implements IamProviderInterface {
                 return new IamBadRequestException(samEx);
             }
             case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED: {
+                return new IamUnauthorizedException(samEx);
+            }
+            case HttpStatusCodes.STATUS_CODE_FORBIDDEN: {
+                // TODO: This is the wrong exception. See https://broadworkbench.atlassian.net/browse/DR-1482
                 return new IamUnauthorizedException(samEx);
             }
             case HttpStatusCodes.STATUS_CODE_NOT_FOUND: {

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -272,11 +272,16 @@ public class SamIam implements IamProviderInterface {
     }
 
     private Void createProfileResourceInner(AuthenticatedUserRequest userReq, String profileId) throws ApiException {
+        // TODO: For now we continue to give stewards access to all profiles. That is consistent with
+        //  the current behavior. When we do the migration to the new permission model we should remove
+        //  this and replace it with the admin group or similar.
+        List<String> ownerList = Arrays.asList(userReq.getEmail(), samConfig.getStewardsGroupEmail());
+
         CreateResourceCorrectRequest req = new CreateResourceCorrectRequest();
         req.setResourceId(profileId);
         req.addPoliciesItem(
             IamRole.OWNER.toString(),
-            createAccessPolicyOne(IamRole.OWNER, userReq.getEmail()));
+            createAccessPolicy(IamRole.OWNER, ownerList));
         req.addPoliciesItem(
             IamRole.USER.toString(),
             createAccessPolicy(IamRole.USER, null));

--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -41,6 +41,8 @@ public class ProfileDao {
         + " FROM billing_profile"
         + " WHERE id in (:idlist)";
 
+    private static final String sqlListOld = "SELECT " + sqlSelectList
+        + " FROM billing_profile";
 
     @Autowired
     public ProfileDao(NamedParameterJdbcTemplate jdbcTemplate) {
@@ -110,6 +112,16 @@ public class ProfileDao {
         int rowsAffected = jdbcTemplate.update("DELETE FROM billing_profile WHERE id = :id",
             new MapSqlParameterSource().addValue("id", id));
         return rowsAffected > 0;
+    }
+
+    /**
+     * This method is made for use by upgrade, where we need to find all of the old billing profiles
+     * without regard to visibility.
+     * @return list of billing profile models
+     */
+    @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
+    public List<BillingProfileModel> getOldBillingProfiles() {
+        return jdbcTemplate.query(sqlListOld, new BillingProfileMapper());
     }
 
     private static class BillingProfileMapper implements RowMapper<BillingProfileModel> {

--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -41,7 +41,7 @@ public class ProfileDao {
         + " FROM billing_profile"
         + " WHERE id in (:idlist)";
 
-    private static final String sqlListOld = "SELECT " + sqlSelectList
+    private static final String sqlListAll = "SELECT " + sqlSelectList
         + " FROM billing_profile";
 
     @Autowired
@@ -121,7 +121,7 @@ public class ProfileDao {
      */
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
     public List<BillingProfileModel> getOldBillingProfiles() {
-        return jdbcTemplate.query(sqlListOld, new BillingProfileMapper());
+        return jdbcTemplate.query(sqlListAll, new BillingProfileMapper());
     }
 
     private static class BillingProfileMapper implements RowMapper<BillingProfileModel> {

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -42,6 +42,7 @@ public class ProfileService {
     private final GoogleBillingService billingService;
     private final SamConfiguration samConfig;
 
+
     @Autowired
     public ProfileService(ProfileDao profileDao,
                           IamService iamService,
@@ -86,7 +87,7 @@ public class ProfileService {
      *     that is, no snapshots, dataset, or buckets referencing the profile</le>
      * </ul>
      *
-     * @param id   the unique id of the bill profile
+     * @param id the unique id of the bill profile
      * @param user the user attempting the delete
      * @return jobId of the submitted stairway job
      */
@@ -104,8 +105,8 @@ public class ProfileService {
      * Enumerate the profiles that are visible to the requesting user
      *
      * @param offset start of the range of profiles to return for this request
-     * @param limit  maximum number of profiles to return in this request
-     * @param user   user on whose behalf we are making this request
+     * @param limit maximum number of profiles to return in this request
+     * @param user user on whose behalf we are making this request
      * @return enumeration profile containing the list and total
      */
     public EnumerateBillingProfileModel enumerateProfiles(Integer offset,
@@ -121,7 +122,7 @@ public class ProfileService {
     /**
      * Lookup a billing profile by the profile id with auth check. Supports the REST API
      *
-     * @param id   the unique idea of this billing profile
+     * @param id the unique idea of this billing profile
      * @param user authenticated user
      * @return On success, the billing profile model
      * @throws ProfileNotFoundException when the profile is not found
@@ -158,7 +159,7 @@ public class ProfileService {
      * having "create link" permission on the billing account.
      *
      * @param profileId the profile id to attempt to authorize
-     * @param user      the user attempting associate some object with the profile
+     * @param user the user attempting associate some object with the profile
      * @return the profile model associated with the profile id
      */
     public BillingProfileModel authorizeLinking(UUID profileId, AuthenticatedUserRequest user) {
@@ -231,10 +232,19 @@ public class ProfileService {
     // This code generates sam resources for any billing profile it does not have one. It sets the
     // stewards group as the owner of the billing profile.
     //
-    // We assume this is being run as a Steward and that the Steward has access to any billing
+    // In the current state, no billing profiles have sam resources, so the resources list will be empty.
+    // When we upgrade a billing profile, we give stewards owner role. Since we run this
+    // as a steward, we will be able to see any profiles we have already converted.
+    //
+    // The hole here is if someone gets in and creates a billing profile with a resource before
+    // we run the upgrade. We would not retrieve that one here. However, Sam would not let us create
+    // the resource in the step below. We would log an error, but otherwise, things would work.
+
     public UpgradeResponseModel upgradeProfileResources(UpgradeModel request, AuthenticatedUserRequest user) {
+
         Instant startTime = Instant.now();
         List<BillingProfileModel> profiles = profileDao.getOldBillingProfiles();
+
         List<UUID> resources = iamService.listAuthorizedResources(user, IamResourceType.SPEND_PROFILE);
         Set<String> profileResourceSet;
         if (resources == null) {

--- a/src/main/java/bio/terra/service/upgrade/UpgradeService.java
+++ b/src/main/java/bio/terra/service/upgrade/UpgradeService.java
@@ -1,0 +1,56 @@
+package bio.terra.service.upgrade;
+
+import bio.terra.common.exception.NotImplementedException;
+import bio.terra.model.UpgradeModel;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.job.JobService;
+import bio.terra.service.upgrade.exception.InvalidCustomNameException;
+import bio.terra.service.upgrade.flight.UpgradeProfileFlight;
+import bio.terra.stairway.Flight;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpgradeService {
+
+    private enum CustomFlight {
+        BILLING_PROFILE_PERMISSION(UpgradeProfileFlight.class);
+
+        private final Class<? extends Flight> flightClass;
+
+        CustomFlight(Class<? extends Flight> flightClass) {
+            this.flightClass = flightClass;
+        }
+
+        public Class<? extends Flight> getFlightClass() {
+            return flightClass;
+        }
+    }
+
+    private final JobService jobService;
+
+    @Autowired
+    public UpgradeService(JobService jobService) {
+        this.jobService = jobService;
+    }
+
+    public String upgrade(UpgradeModel request, AuthenticatedUserRequest user) {
+        if (request.getUpgradeType() != UpgradeModel.UpgradeTypeEnum.CUSTOM) {
+            throw new NotImplementedException("Upgrade type is not implemented: " + request.getUpgradeType().name());
+        }
+
+        CustomFlight customFlight;
+        try {
+            customFlight = CustomFlight.valueOf(request.getCustomName());
+        } catch (NullPointerException ex) {
+            throw new InvalidCustomNameException("Custom name is required for custom upgrade type");
+        } catch (IllegalArgumentException ex) {
+            throw new InvalidCustomNameException("Invalid custom name provided to upgrade: "
+                + request.getCustomName());
+        }
+
+        return jobService
+            .newJob(request.getCustomName(), customFlight.getFlightClass(), request, user)
+            .submit();
+    }
+}

--- a/src/main/java/bio/terra/service/upgrade/UpgradeService.java
+++ b/src/main/java/bio/terra/service/upgrade/UpgradeService.java
@@ -25,10 +25,6 @@ public class UpgradeService {
         CustomFlight(Class<? extends Flight> flightClass) {
             this.flightClass = flightClass;
         }
-
-        public Class<? extends Flight> getFlightClass() {
-            return flightClass;
-        }
     }
 
     private final JobService jobService;
@@ -57,7 +53,7 @@ public class UpgradeService {
         // Note: in order to allow for an extensible endpoint, we do not require that customName is filled in.
         // That means it could be null here. We could do a separate null check, but the valueOf also does the
         // check and throws the NPE.
-        CustomFlight customFlight;
+        final CustomFlight customFlight;
         try {
             customFlight = CustomFlight.valueOf(request.getCustomName());
         } catch (NullPointerException ex) {
@@ -68,7 +64,7 @@ public class UpgradeService {
         }
 
         return jobService
-            .newJob(request.getCustomName(), customFlight.getFlightClass(), request, user)
+            .newJob(request.getCustomName(), customFlight.flightClass, request, user)
             .submit();
     }
 }

--- a/src/main/java/bio/terra/service/upgrade/exception/InvalidCustomNameException.java
+++ b/src/main/java/bio/terra/service/upgrade/exception/InvalidCustomNameException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.upgrade.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+public class InvalidCustomNameException extends BadRequestException {
+    public InvalidCustomNameException(String message) {
+        super(message);
+    }
+
+    public InvalidCustomNameException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidCustomNameException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/upgrade/flight/UpgradeProfileFlight.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/UpgradeProfileFlight.java
@@ -1,0 +1,27 @@
+package bio.terra.service.upgrade.flight;
+
+import bio.terra.model.UpgradeModel;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.ProfileService;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import org.springframework.context.ApplicationContext;
+
+public class UpgradeProfileFlight extends Flight {
+
+    public UpgradeProfileFlight(FlightMap inputParameters, Object applicationContext) {
+        super(inputParameters, applicationContext);
+
+        ApplicationContext appContext = (ApplicationContext) applicationContext;
+        ProfileService profileService = (ProfileService) appContext.getBean("profileService");
+
+        UpgradeModel request =
+            inputParameters.get(JobMapKeys.REQUEST.getKeyName(), UpgradeModel.class);
+        AuthenticatedUserRequest user = inputParameters.get(
+            JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+
+        addStep(new UpgradeProfileResourcesStep(profileService, request, user));
+    }
+
+}

--- a/src/main/java/bio/terra/service/upgrade/flight/UpgradeProfileResourcesStep.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/UpgradeProfileResourcesStep.java
@@ -1,0 +1,36 @@
+package bio.terra.service.upgrade.flight;
+
+import bio.terra.model.UpgradeModel;
+import bio.terra.model.UpgradeResponseModel;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.ProfileService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+public class UpgradeProfileResourcesStep implements Step {
+    private final ProfileService profileService;
+    private final UpgradeModel request;
+    private final AuthenticatedUserRequest user;
+
+    public UpgradeProfileResourcesStep(ProfileService profileService,
+                                       UpgradeModel request,
+                                       AuthenticatedUserRequest user) {
+        this.profileService = profileService;
+        this.request = request;
+        this.user = user;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext context) throws InterruptedException {
+        UpgradeResponseModel response = profileService.upgradeProfileResources(request, user);
+        context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), response);
+        return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) throws InterruptedException {
+        return StepResult.getStepResultSuccess();
+    }
+}

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2126,6 +2126,62 @@ paths:
         204:
           description: configuration reset
           content: {}
+
+  /api/repository/v1/upgrade:
+    post:
+      tags:
+        - repository
+      description: >-
+        Extensible endpoint for triggering upgrade tasks in the data repository.
+        The asynchronous result is UpgradeResponseModel
+      operationId: upgrade
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpgradeModel'
+        required: true
+      responses:
+        200:
+          description: Redirect for upgrade complete
+          headers:
+            location:
+              description: url for the job result
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobModel'
+        202:
+          description: Job status of upgrade job & url for polling in the response
+            header
+          headers:
+            location:
+              description: url for the job polling
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobModel'
+        400:
+          description: Bad request - invalid upgrade request, badly formed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: No permission to upgrade
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+      x-codegen-request-body-name: upgrade
+
+##############################################################################
+## DRS STANDARD ENDPOINTS
+##############################################################################
   /ga4gh/drs/v1/service-info:
     get:
       tags:
@@ -3438,6 +3494,48 @@ components:
           description: whether to enable (default) or disable the fault
           default: true
       description: Control whether a fault is enabled
+
+    UpgradeModel:
+      required:
+        - upgradeName
+        - upgradeType
+      type: object
+      properties:
+        upgradeName:
+          type: string
+          description: Unique name for the upgrade
+        upgradeType:
+          type: string
+          description: Enumeration to allow different kinds upgrades
+          enum:
+            - custom
+        customName:
+          type: string
+          description: >-
+            Name of custom upgrade to launch. Only used when upgradeType is custom.
+        customArgs:
+          description: >-
+            Array of string arguments to the custom upgrade. Only used when upgradeType is custom.
+          type: array
+          items:
+            type: string
+
+    UpgradeResponseModel:
+      type: object
+      properties:
+        upgradeName:
+          type: string
+          description: Unique name for the upgrade
+        startTime:
+          type: string
+          description: Timestamp the upgrade was started
+        endTime:
+          type: string
+          description: Timestamp the upgrade completed
+
+    ##############################################################################
+    ## DRS STANDARD MODELS
+    ##############################################################################
     DRSChecksum:
       required:
         - checksum

--- a/src/main/resources/application-dd.properties
+++ b/src/main/resources/application-dd.properties
@@ -4,6 +4,6 @@ google.singleDataProjectId=broad-jade-dd-data
 google.allowReuseExistingBuckets=true
 google.allowReuseExistingProjects=true
 userEmail=dd.datarepo@gmail.com
-db.migrate.dropAllOnStart=true
+db.migrate.dropAllOnStart=false
 db.migrate.updateAllOnStart=true
 datarepo.maxBulkFileLoadArray=5000

--- a/tools/billingProfileUpgradeScripts/test_step0_setup.sh
+++ b/tools/billingProfileUpgradeScripts/test_step0_setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# NOTE: this is meant to be source'd not executed. The functions and env vars are needed by later scripts
+# You must have your gcloud configured to the correct account.
+#
+export AUTH_TOKEN=$(gcloud auth print-access-token)
+export DRAPI="https://jade-dd.datarepo-dev.broadinstitute.org"
+
+# -- functions --
+
+function waitForComplete() {
+    JOBID=$1
+
+    POLL_STATUS_CODE=$(poll ${JOBID})
+    while [ "$POLL_STATUS_CODE" != "200" ]; do
+        sleep 5
+        POLL_STATUS_CODE=$(poll ${JOBID})
+    done
+
+     RESULT=$(curl -H 'Content-Type: application/json' -H 'Accept: application/json' \
+                  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+                  ${DRAPI}/api/repository/v1/jobs/${JOBID}/result)
+    echo $RESULT
+}
+
+function poll() {
+    JOBID=$1
+    POLL_RESPONSE=$(curl -H 'Content-Type: application/json' -H 'Accept: application/json' \
+                             -H "Authorization: Bearer ${AUTH_TOKEN}" \
+                             -s -o /dev/null -w "%{http_code}" \
+                             ${DRAPI}/api/repository/v1/jobs/${JOBID})
+    echo "${POLL_RESPONSE}"
+}
+

--- a/tools/billingProfileUpgradeScripts/test_step1_before_deploy.sh
+++ b/tools/billingProfileUpgradeScripts/test_step1_before_deploy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Do this script before the upgrade release is installed
+# NOTE: this is meant to be source'd not executed - as output it sets PROFILE_ID env var
+
+# -- main --
+
+ : ${DRAPI:?}
+ : ${AUTH_TOKEN:?}
+
+# Create the canary billing account. It will not have a Sam resource
+export PROFILE_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+echo "ProfileId=$PROFILE_ID"
+BILLING_ACCOUNT_ID="00708C-45D19D-27AAFA"
+
+PROFILE_BODY=$(cat <<EOF
+{"id":"${PROFILE_ID}",
+ "billingAccountId":"${BILLING_ACCOUNT_ID}",
+ "profileName":"canaryProfile",
+ "biller":"direct",
+ "description":"canary profile"
+}
+EOF
+)
+
+PROFILE_JOB=$(echo $PROFILE_BODY | curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" -d @- \
+  ${DRAPI}/api/resources/v1/profiles)
+echo "PROFILE_JOB=$PROFILE_JOB"
+JOBID=$(echo $PROFILE_JOB | jq -r ".id")
+echo "JOBID=$JOBID"
+
+RESULT=$(waitForComplete ${JOBID})
+echo "RESULT=$RESULT"
+PROFILENAME=$(echo $RESULT | jq -r ".profileName")
+echo "Created billing profile ${profilename}"

--- a/tools/billingProfileUpgradeScripts/test_step2and4_validate.sh
+++ b/tools/billingProfileUpgradeScripts/test_step2and4_validate.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Do this script after the upgrade release is installed, but before the upgrade is executed to make sure
+# existing billing profiles can be used. It makes a dataset and deletes it.
+# Do this script again after the upgrade is executed to make sure the billing profiles can still be used.
+# NOTE: this is meant to be source'd not executed
+
+# -- main --
+
+ : ${DRAPI:?}
+ : ${AUTH_TOKEN:?}
+ : ${PROFILE_ID:?}
+
+echo "PROFILE_ID=$PROFILE_ID"
+echo "DRAPI=$DRAPI"
+
+DATASET_BODY=$(cat <<EOF
+{
+  "name":        "canaryDataset",
+  "description": "canary dataset",
+  "defaultProfileId": "${PROFILE_ID}",
+  "schema":      {
+    "tables":        [
+      {
+        "name":    "participant",
+        "columns": [
+          {"name": "id", "datatype": "string"},
+          {"name": "age", "datatype": "integer"}
+        ]
+      },
+      {
+        "name":    "sample",
+        "columns": [
+          {"name": "id", "datatype": "string"},
+          {"name": "participant_id", "datatype": "string"},
+          {"name": "date_collected", "datatype": "date"}
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "name": "participant_sample",
+        "from": {"table": "participant", "column": "id"},
+        "to":   {"table": "sample", "column": "participant_id"}
+      }
+    ],
+    "assets":        [
+      {
+        "name":   "sample",
+        "rootTable": "sample",
+        "rootColumn": "id",
+        "tables": [
+          {"name": "sample", "columns": []},
+          {"name": "participant", "columns": []}
+        ],
+        "follow": ["participant_sample"]
+      }
+    ]
+  }
+}
+}
+EOF
+)
+
+CREATE_JOB=$(echo $DATASET_BODY | curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" -d @- \
+  ${DRAPI}/api/repository/v1/datasets)
+echo "CREATE_JOB=$CREATE_JOB"
+JOBID=$(echo $CREATE_JOB | jq -r ".id")
+echo "JOBID=$JOBID"
+
+RESULT=$(waitForComplete ${JOBID})
+echo "RESULT=$RESULT"
+DATASET_ID=$(echo $RESULT | jq -r ".id")
+echo "Created dataset id ${DATASET_ID}"
+
+DELETE_JOB=$(curl -X DELETE -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  ${DRAPI}/api/repository/v1/datasets/${DATASET_ID})
+echo "DELETE_JOB=$DELETE_JOB"
+JOBID=$(echo $DELETE_JOB | jq -r ".id")
+echo "JOBID=$JOBID"
+
+RESULT=$(waitForComplete ${JOBID})
+echo "RESULT=$RESULT"
+

--- a/tools/billingProfileUpgradeScripts/test_step3_upgrade.sh
+++ b/tools/billingProfileUpgradeScripts/test_step3_upgrade.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Invoke the upgrade endpoint
+# NOTE: this is meant to be source'd not executed
+
+# -- main --
+
+ : ${DRAPI:?}
+ : ${AUTH_TOKEN:?}
+ : ${PROFILE_ID:?}
+
+echo "PROFILE_ID=$PROFILE_ID"
+echo "DRAPI=$DRAPI"
+
+UPGRADE_BODY=$(cat <<EOF
+{
+  "customArgs": [],
+  "customName": "BILLING_PROFILE_PERMISSION",
+  "upgradeName": "dd upgrade",
+  "upgradeType": "custom"
+}
+EOF
+)
+
+UPGRADE_JOB=$(echo $UPGRADE_BODY | curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" -d @- \
+  ${DRAPI}/api/repository/v1/upgrade)
+echo "UPGRADE_JOB=$UPGRADE_JOB"
+JOBID=$(echo $UPGRADE_JOB | jq -r ".id")
+echo "JOBID=$JOBID"
+
+RESULT=$(waitForComplete ${JOBID})
+echo "RESULT=$RESULT"
+

--- a/tools/billingProfileUpgradeScripts/test_step5_addmember.sh
+++ b/tools/billingProfileUpgradeScripts/test_step5_addmember.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Try to add a member to the policy
+# NOTE: this is meant to be source'd not executed
+
+# -- main --
+
+ : ${DRAPI:?}
+ : ${AUTH_TOKEN:?}
+ : ${PROFILE_ID:?}
+
+echo "PROFILE_ID=$PROFILE_ID"
+echo "DRAPI=$DRAPI"
+
+ADD_BODY=$(cat <<EOF
+{
+  "email": "mcgonagall.curator@test.firecloud.org"
+}
+EOF
+)
+
+ADD_RESPONSE=$(echo ${ADD_BODY} | curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' \
+                    -H "Authorization: Bearer ${AUTH_TOKEN}" -d @- \
+                    ${DRAPI}/api/resources/v1/profiles/${PROFILE_ID}/policies/user/members)
+echo "ADD_RESPONSE=$ADD_RESPONSE"

--- a/tools/billingProfileUpgradeScripts/test_step6_delete_profile.sh
+++ b/tools/billingProfileUpgradeScripts/test_step6_delete_profile.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Try to delete the profile
+# NOTE: this is meant to be source'd not executed
+
+# -- main --
+
+ : ${DRAPI:?}
+ : ${AUTH_TOKEN:?}
+ : ${PROFILE_ID:?}
+
+echo "PROFILE_ID=$PROFILE_ID"
+echo "DRAPI=$DRAPI"
+
+PROFILE_JOB=$(curl -X DELETE -H 'Content-Type: application/json' -H 'Accept: application/json' \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  ${DRAPI}/api/resources/v1/profiles/${PROFILE_ID})
+echo "PROFILE_JOB=$PROFILE_JOB"
+JOBID=$(echo $PROFILE_JOB | jq -r ".id")
+echo "JOBID=$JOBID"
+
+RESULT=$(waitForComplete ${JOBID})
+echo "RESULT=$RESULT"
+echo "Deleted billing profile ${PROFILE_ID}"


### PR DESCRIPTION
This branch includes the upgrade code to add sam resources to billing profiles that do not have them. It will also include the code that creates sam resources on billing profile creation, and deletes sam resources and projects on billing profile deletion. It will not contain code to do authorization against billing profiles.

We can deploy this on the running dev deployment. Then we can manually trigger the upgrade code. No downtime will be needed.

Specific features:
- Create profile will work and will create a profile with a Sam resource
- Delete profile should work. It does not perform and authorization check. It tolerates Sam resource not found when trying to cleanup a resource. Ordinarily, that would be treated as not privileged, but during this interim time, we log a warning and continue. It will delete unused projects. That will not apply in dev, but will apply in fake prod.
- Add profile policy member should work - it also tolerates Sam resource not found and returns success.
- Enumerate billing profile will complete successfully, but always returns an empty list of profiles.
- Delete profile policy member is not yet implemented
- Get profile by id works. Everyone can see all profile information (as it is today)
