### PR TITLE
Datarepo helm chart version update: 0.1.28

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -3,8 +3,7 @@ on:
   schedule:
     - cron: '30 2 * * *' # run at 2:30 AM UTC
 env:
-  chartVersion: 0.1.19
-
+  chartVersion: 0.1.28
 jobs:
   alpha_promotion:
     strategy:


### PR DESCRIPTION
Update versions in **0.1.28**.
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/broadinstitute/datarepo-helm/actions/runs/399325278).*