### PR TITLE
DR-1522 Make sure files don't get written to Firestore many times

### DIFF
--- a/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
+++ b/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
@@ -81,8 +81,8 @@ public class GoogleBillingService {
             .setResource(resource.toString())
             .addAllPermissions(permissions)
             .build();
-        try {
-            TestIamPermissionsResponse response = cloudBillingClient().testIamPermissions(permissionsRequest);
+        try (CloudBillingClient client = cloudBillingClient()) {
+            TestIamPermissionsResponse response = client.testIamPermissions(permissionsRequest);
             List<String> actualPermissions = response.getPermissionsList();
             return actualPermissions != null && actualPermissions.equals(permissions);
         } catch (ApiException e) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
@@ -19,8 +19,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 public class CreateSnapshotFireStoreDataStep implements Step {
     private static final Logger logger = LoggerFactory.getLogger(CreateSnapshotFireStoreDataStep.class);
@@ -53,17 +55,18 @@ public class CreateSnapshotFireStoreDataStep implements Step {
     public StepResult doStep(FlightContext context) throws InterruptedException {
         // We need a complete snapshot; use the snapshotService to get one.
         Snapshot snapshot = snapshotService.retrieveByName(snapshotReq.getName());
-
         // Build the snapshot file system and record the file dependencies
         // The algorithm is:
         // Loop through sources, loop through map tables, loop through map columns
         // if from column is FILEREF or DIRREF, ask pdao to get the ids from that
         // column that are in the snapshot; do the filestore processing
         //
-        // NOTE: This is brute force doing a column at a time. Depending on how much memory and
-        // swap we want to use, we could extract all row ids in one go. Doing it column-by-column
-        // bounds the intermediate size in a way.
+        // NOTE: This is brute force doing a column at a time. We extract all fileIds that need to be processed to
+        // ensure that we don't reprocess the same file repeatedly since this can have sever performance impacts
+        // TODO: We may want to find a more memory efficient way to track this
         for (SnapshotSource snapshotSource : snapshot.getSnapshotSources()) {
+            Set<String> uniqueRefIds = new HashSet<>();
+            int numFilesSeen = 0;
             for (SnapshotMapTable mapTable : snapshotSource.getSnapshotMapTables()) {
                 for (SnapshotMapColumn mapColumn : mapTable.getSnapshotMapColumns()) {
                     String fromDatatype = mapColumn.getFromColumn().getType();
@@ -76,39 +79,41 @@ public class CreateSnapshotFireStoreDataStep implements Step {
                             mapTable.getFromTable().getName(),
                             mapTable.getFromTable().getId().toString(),
                             mapColumn.getFromColumn());
-                        List<String> uniqueRefIds = refIds.stream().distinct().collect(Collectors.toList());
-                        if (refIds.size() != uniqueRefIds.size()) {
-                            logger.info("some files are repeated. {} unique values across {} total file references",
-                                uniqueRefIds.size(), refIds.size());
-                        }
+                        numFilesSeen += refIds.size();
+                        uniqueRefIds.addAll(refIds);
                         performanceLogger.timerEndAndLog(
                             bigQueryTimer,
                             context.getFlightId(),
                             this.getClass().getName(),
                             "bigQueryPdao.getSnapshotRefIds",
                             refIds.size());
-
-                        Dataset dataset = datasetService.retrieve(snapshotSource.getDataset().getId());
-
-                        String addFilesTimer = performanceLogger.timerStart();
-                        fileDao.addFilesToSnapshot(dataset, snapshot, refIds);
-                        performanceLogger.timerEndAndLog(
-                            addFilesTimer,
-                            context.getFlightId(),
-                            this.getClass().getName(),
-                            "fileDao.addFilesToSnapshot",
-                            refIds.size());
-
-                        String addDependenciesTimer = performanceLogger.timerStart();
-                        dependencyDao.storeSnapshotFileDependencies(dataset, snapshot.getId().toString(), uniqueRefIds);
-                        performanceLogger.timerEndAndLog(
-                            addDependenciesTimer,
-                            context.getFlightId(),
-                            this.getClass().getName(),
-                            "dependencyDao.storeSnapshotFileDependencies",
-                            refIds.size());
                     }
                 }
+
+                if (numFilesSeen != uniqueRefIds.size()) {
+                    logger.info("some files are repeated. {} unique values across {} total file references",
+                        uniqueRefIds.size(), numFilesSeen);
+                }
+                List<String> uniqueRefIdsAsList = new ArrayList<>(uniqueRefIds);
+                Dataset dataset = datasetService.retrieve(snapshotSource.getDataset().getId());
+
+                String addFilesTimer = performanceLogger.timerStart();
+                fileDao.addFilesToSnapshot(dataset, snapshot, uniqueRefIdsAsList);
+                performanceLogger.timerEndAndLog(
+                    addFilesTimer,
+                    context.getFlightId(),
+                    this.getClass().getName(),
+                    "fileDao.addFilesToSnapshot",
+                    uniqueRefIds.size());
+
+                String addDependenciesTimer = performanceLogger.timerStart();
+                dependencyDao.storeSnapshotFileDependencies(dataset, snapshot.getId().toString(), uniqueRefIdsAsList);
+                performanceLogger.timerEndAndLog(
+                    addDependenciesTimer,
+                    context.getFlightId(),
+                    this.getClass().getName(),
+                    "dependencyDao.storeSnapshotFileDependencies",
+                    uniqueRefIds.size());
             }
         }
 


### PR DESCRIPTION
...if they are referenced in several columns.  Note: this puts some memory pressure on the VM but at our current scales, we should be ok.  We'll need to revisit the approach here

Note: this also does a drive by fix to ensure that we properly close the billing client