### PR TITLE
DR-1522 Include table in loop for de-duplicating columns

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
@@ -89,32 +89,33 @@ public class CreateSnapshotFireStoreDataStep implements Step {
                             refIds.size());
                     }
                 }
-
-                if (numFilesSeen != uniqueRefIds.size()) {
-                    logger.info("some files are repeated. {} unique values across {} total file references",
-                        uniqueRefIds.size(), numFilesSeen);
-                }
-                List<String> uniqueRefIdsAsList = new ArrayList<>(uniqueRefIds);
-                Dataset dataset = datasetService.retrieve(snapshotSource.getDataset().getId());
-
-                String addFilesTimer = performanceLogger.timerStart();
-                fileDao.addFilesToSnapshot(dataset, snapshot, uniqueRefIdsAsList);
-                performanceLogger.timerEndAndLog(
-                    addFilesTimer,
-                    context.getFlightId(),
-                    this.getClass().getName(),
-                    "fileDao.addFilesToSnapshot",
-                    uniqueRefIds.size());
-
-                String addDependenciesTimer = performanceLogger.timerStart();
-                dependencyDao.storeSnapshotFileDependencies(dataset, snapshot.getId().toString(), uniqueRefIdsAsList);
-                performanceLogger.timerEndAndLog(
-                    addDependenciesTimer,
-                    context.getFlightId(),
-                    this.getClass().getName(),
-                    "dependencyDao.storeSnapshotFileDependencies",
-                    uniqueRefIds.size());
             }
+
+            if (numFilesSeen != uniqueRefIds.size()) {
+                logger.info("some files are repeated. {} unique values across {} total file references",
+                    uniqueRefIds.size(), numFilesSeen);
+            }
+
+            List<String> uniqueRefIdsAsList = new ArrayList<>(uniqueRefIds);
+            Dataset dataset = datasetService.retrieve(snapshotSource.getDataset().getId());
+
+            String addFilesTimer = performanceLogger.timerStart();
+            fileDao.addFilesToSnapshot(dataset, snapshot, uniqueRefIdsAsList);
+            performanceLogger.timerEndAndLog(
+                addFilesTimer,
+                context.getFlightId(),
+                this.getClass().getName(),
+                "fileDao.addFilesToSnapshot",
+                uniqueRefIds.size());
+
+            String addDependenciesTimer = performanceLogger.timerStart();
+            dependencyDao.storeSnapshotFileDependencies(dataset, snapshot.getId().toString(), uniqueRefIdsAsList);
+            performanceLogger.timerEndAndLog(
+                addDependenciesTimer,
+                context.getFlightId(),
+                this.getClass().getName(),
+                "dependencyDao.storeSnapshotFileDependencies",
+                uniqueRefIds.size());
         }
 
         return StepResult.getStepResultSuccess();


### PR DESCRIPTION
I had put but the aggregate column in the inner (column) loop so fileIds being repeated across tables were still showing up.  This PR moves the bit that writes to firestore out of the inner loop so it only happens at the end