### PR TITLE
Datarepo helm integraton chart version update

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -97,10 +97,10 @@ jobs:
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
-          helm_datarepo_api_chart_version: '0.0.23'
-          helm_datarepo_ui_chart_version: '0.0.12'
-          helm_gcloud_sqlproxy_chart_version: '0.19.7'
-          helm_oidc_proxy_chart_version: '0.0.14'
+          helm_datarepo_api_chart_version: 0.0.23
+          helm_datarepo_ui_chart_version: 0.0.12
+          helm_gcloud_sqlproxy_chart_version: 0.19.7
+          helm_oidc_proxy_chart_version: 0.0.15
       - name: "Wait for deployment to come back online"
         uses: broadinstitute/datarepo-actions@0.34.0
         with:


### PR DESCRIPTION
gcloud-sqlproxy-version: 0.19.7
datarpeo-api-version: 0.0.23
datarpeo-ui-version: 0.0.12
oidc-proxy-version: 0.0.15
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/broadinstitute/datarepo-helm/actions/runs/408681400).*