### PR TITLE
DR-1946 Instrument MDC Logging for Flight/Flight Step Logging

### DIFF
--- a/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
+++ b/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
@@ -9,6 +9,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 public class StairwayLoggingHooks implements StairwayHook {
   private static final String FlightLogFormat =
@@ -16,59 +17,94 @@ public class StairwayLoggingHooks implements StairwayHook {
   private static final String StepLogFormat =
       "Operation: {}, flightClass: {}, flightId: {}, stepClass: {}, "
           + "stepIndex: {}, direction: {}, timestamp: {}";
-  private static final Logger logger = LoggerFactory.getLogger(StairwayHook.class);
+  /**
+   * Id of the flight
+   */
+  private static final String FLIGHT_ID_KEY = "flightId";
+  /**
+   * Class of the flight
+   */
+  private static final String FLIGHT_CLASS_KEY = "flightClass";
+  /**
+   * Class of the flight step
+   */
+  private static final String FLIGHT_STEP_CLASS_KEY = "flightStepClass";
+  /**
+   * Direction of the step (START, DO, UNDO or SWITCH)
+   */
+  private static final String FLIGHT_STEP_DIRECTION_KEY = "flightStepDirection";
+  /**
+   * The step's execution order
+   */
+  private static final String FLIGHT_STEP_NUMBER_KEY = "flightStepNumber";
+  /**
+   * The type of operation primarily being logged (startFlight, startStep, endStep or endFlight)
+   */
+  private static final String FLIGHT_OPERATION_KEY = "flightStepOperation";
 
-  private PerformanceLogger performanceLogger;
+
+  private static final String FLIGHT_OPERATION_START = "startFlight";
+  private static final String FLIGHT_OPERATION_END = "endFlight";
+  private static final String FLIGHT_STEP_OPERATION_START = "startStep";
+  private static final String FLIGHT_STEP_OPERATION_END = "endStep";
+
+    private static final Logger logger = LoggerFactory.getLogger(StairwayHook.class);
+
+  private final PerformanceLogger performanceLogger;
 
   public StairwayLoggingHooks(PerformanceLogger performanceLogger) {
     this.performanceLogger = performanceLogger;
-    logger.info("Performance logging " + (performanceLogger.isEnabled() ? "ON" : "OFF"));
+    logger.info("Performance logging {}", performanceLogger.isEnabled() ? "ON" : "OFF");
   }
 
   @Override
   public HookAction startFlight(FlightContext context) {
-    logger.info(
-        FlightLogFormat,
-        "startFlight",
+    MDC.put(FLIGHT_ID_KEY, context.getFlightId());
+        MDC.put(FLIGHT_CLASS_KEY, context.getFlightClassName());
+        MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_OPERATION_START);
+        logger.info(FlightLogFormat, FLIGHT_OPERATION_START,
         context.getFlightClassName(),
         context.getFlightId(),
         Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
-    performanceLogger.log(context.getFlightId(), context.getFlightClassName(), "startFlight");
+    performanceLogger.log(context.getFlightId(), context.getFlightClassName(), FLIGHT_OPERATION_START);
     return HookAction.CONTINUE;
   }
 
   @Override
   public HookAction startStep(FlightContext context) {
-    logger.info(
-        StepLogFormat,
-        "startStep",
+    MDC.put(FLIGHT_ID_KEY, context.getFlightId());
+        MDC.put(FLIGHT_CLASS_KEY, context.getFlightClassName());
+        MDC.put(FLIGHT_STEP_CLASS_KEY, context.getStepClassName());
+        MDC.put(FLIGHT_STEP_DIRECTION_KEY, context.getDirection().toString());
+        MDC.put(FLIGHT_STEP_NUMBER_KEY, Integer.toString(context.getStepIndex()));
+        MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_STEP_OPERATION_START);
+        logger.info(StepLogFormat, FLIGHT_STEP_OPERATION_START,
         context.getFlightClassName(),
         context.getFlightId(),
         context.getStepClassName(),
         context.getStepIndex(),
         context.getDirection().name(),
         Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
-    performanceLogger.timerStart("stairwayStep" + context.getFlightId());
+    performanceLogger.timerStart(getStepTimerName(context.getFlightId()));
     return HookAction.CONTINUE;
   }
 
   @Override
   public HookAction endFlight(FlightContext context) {
-    logger.info(
-        FlightLogFormat,
-        "endFlight",
+    MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_OPERATION_END);
+        logger.info(FlightLogFormat, FLIGHT_OPERATION_END,
         context.getFlightClassName(),
         context.getFlightId(),
         Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
-    performanceLogger.log(context.getFlightId(), context.getFlightClassName(), "endFlight");
+    performanceLogger.log(context.getFlightId(), context.getFlightClassName(), FLIGHT_OPERATION_END);
+        clearMdcKeys();
     return HookAction.CONTINUE;
   }
 
   @Override
   public HookAction endStep(FlightContext context) {
-    logger.info(
-        StepLogFormat,
-        "endStep",
+    MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_STEP_OPERATION_END);
+        logger.info(StepLogFormat, FLIGHT_STEP_OPERATION_END,
         context.getFlightClassName(),
         context.getFlightId(),
         context.getStepClassName(),
@@ -76,11 +112,25 @@ public class StairwayLoggingHooks implements StairwayHook {
         context.getDirection().name(),
         Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
     performanceLogger.timerEndAndLog(
-        "stairwayStep" + context.getFlightId(),
+        getStepTimerName(context.getFlightId()),
         context.getFlightId(),
         context.getFlightClassName(),
-        "endStep",
+        FLIGHT_STEP_OPERATION_END,
         context.getStepIndex());
-    return HookAction.CONTINUE;
-  }
+    clearMdcKeys();
+        return HookAction.CONTINUE;
+    }
+
+    private void clearMdcKeys() {
+        MDC.remove(FLIGHT_ID_KEY);
+        MDC.remove(FLIGHT_CLASS_KEY);
+        MDC.remove(FLIGHT_STEP_CLASS_KEY);
+        MDC.remove(FLIGHT_STEP_DIRECTION_KEY);
+        MDC.remove(FLIGHT_STEP_NUMBER_KEY);
+        MDC.remove(FLIGHT_OPERATION_KEY);
+    }
+
+    private String getStepTimerName(final String flightId) {
+        return String.format("stairwayStep%s", flightId);
+    }
 }


### PR DESCRIPTION
This is an example of what instrumenting MDC logging might look like for flight and steps.  I've described this in: https://docs.google.com/document/d/1KoVtBc8SogqQB2QjIu07AAwZY9VJK8I9nNUsoNn_8cg

This tracks:
`flightId` - Id of the flight 
`flightClass` - Class of the flight
`flightStepClass` - Class of the flight step
`flightStepDirection` - Direction of the step (`START`, `DO`, `UNDO` or `SWITCH`)
`flightStepNumber` - The step's execution order
`flightStepOperation` - The type of operation primarily being logged (`startFlight`, `startStep`, `endStep` or `endFlight`)

Running this ends up giving you log messages that look like:
```
{
  "flightStepDirection": "DO",
  "flightId": "jdYpmEeTRBe3I9-OW1YYFg",
  "flightClass": "bio.terra.service.snapshot.flight.create.SnapshotCreateFlight",
  "flightStepOperation": "startStep",
  "flightStepNumber": "8",
  "flightStepClass": "bio.terra.service.snapshot.flight.create.CreateSnapshotFireStoreComputeStep",
  "timestampSeconds": 1607534900,
  "timestampNanos": 415000000,
  "severity": "INFO",
  "thread": "pool-7-thread-15",
  "logger": "bio.terra.service.filedata.google.firestore.FireStoreBatchQueryIterator",
  "message": "Retrieving batch 0 with batch size of 500",
  "context": "default"
}
```