### PR TITLE
DR-1504 Add validation for the projectId of the google project to create

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -471,7 +471,7 @@ public class GoogleProjectService {
         Preconditions.checkNotNull(projectId, "Project Id must not be null");
 
         Preconditions.checkArgument(
-            projectId.matches("^[a-z][a-z0-9-]{5,29}(?<!-)$"),
+            projectId.matches("^[a-z][a-z0-9-]{4,28}[a-z0-9]$"),
             String.format("The project ID \"%s\" must be a unique string of 6 to 30 lowercase letters, digits, " +
                 "or hyphens. It must start with a letter, and cannot have a trailing hyphen. You cannot change a " +
                 "project ID once it has been created. You cannot re-use a project ID that is in use, or one that " +

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -166,8 +166,7 @@ public class GoogleProjectService {
         Map<String, List<String>> roleIdentityMapping)
         throws InterruptedException {
 
-        // Ensure that the project Id is valid
-        validateProjectId(requestedProjectId);
+        ensureValidProjectId(requestedProjectId);
 
         // projects created by service accounts must live under a parent resource (either a folder or an
         // organization)
@@ -200,16 +199,6 @@ public class GoogleProjectService {
         } catch (IOException | GeneralSecurityException e) {
             throw new GoogleResourceException("Could not create project", e);
         }
-    }
-
-    @VisibleForTesting
-    static void validateProjectId(final String projectId) {
-        Preconditions.checkArgument(
-            projectId.matches("[a-z][a-z0-9-]{5,29}(?<!-)$"),
-            String.format("The project ID \"%s\" must be a unique string of 6 to 30 lowercase letters, digits, " +
-                "or hyphens. It must start with a letter, and cannot have a trailing hyphen. You cannot change a " +
-                "project ID once it has been created. You cannot re-use a project ID that is in use, or one that " +
-                "has been used for a deleted project.", projectId));
     }
 
     // Common project initialization for new projects, in the case where we are reusing
@@ -475,5 +464,17 @@ public class GoogleProjectService {
             operation = request.execute();
         }
         return operation;
+    }
+
+    @VisibleForTesting
+    static void ensureValidProjectId(final String projectId) {
+        Preconditions.checkNotNull(projectId, "Project Id must not be null");
+
+        Preconditions.checkArgument(
+            projectId.matches("^[a-z][a-z0-9-]{5,29}(?<!-)$"),
+            String.format("The project ID \"%s\" must be a unique string of 6 to 30 lowercase letters, digits, " +
+                "or hyphens. It must start with a letter, and cannot have a trailing hyphen. You cannot change a " +
+                "project ID once it has been created. You cannot re-use a project ID that is in use, or one that " +
+                "has been used for a deleted project.", projectId));
     }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -23,8 +23,10 @@ import com.google.api.services.cloudresourcemanager.model.SetIamPolicyRequest;
 import com.google.api.services.cloudresourcemanager.model.Status;
 import com.google.api.services.serviceusage.v1.ServiceUsage;
 import com.google.api.services.serviceusage.v1.model.BatchEnableServicesRequest;
-import com.google.api.services.serviceusage.v1.model.ListServicesResponse;
 import com.google.api.services.serviceusage.v1.model.GoogleApiServiceusageV1Service;
+import com.google.api.services.serviceusage.v1.model.ListServicesResponse;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
@@ -164,6 +166,9 @@ public class GoogleProjectService {
         Map<String, List<String>> roleIdentityMapping)
         throws InterruptedException {
 
+        // Ensure that the project Id is valid
+        validateProjectId(requestedProjectId);
+
         // projects created by service accounts must live under a parent resource (either a folder or an
         // organization)
         ResourceId parentResource =
@@ -195,6 +200,16 @@ public class GoogleProjectService {
         } catch (IOException | GeneralSecurityException e) {
             throw new GoogleResourceException("Could not create project", e);
         }
+    }
+
+    @VisibleForTesting
+    static void validateProjectId(final String projectId) {
+        Preconditions.checkArgument(
+            projectId.matches("[a-z][a-z0-9-]{5,29}(?<!-)$"),
+            String.format("The project ID \"%s\" must be a unique string of 6 to 30 lowercase letters, digits, " +
+                "or hyphens. It must start with a letter, and cannot have a trailing hyphen. You cannot change a " +
+                "project ID once it has been created. You cannot re-use a project ID that is in use, or one that " +
+                "has been used for a deleted project.", projectId));
     }
 
     // Common project initialization for new projects, in the case where we are reusing

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceTest.java
@@ -1,0 +1,55 @@
+package bio.terra.service.resourcemanagement.google;
+
+import bio.terra.common.category.Unit;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(SpringRunner.class)
+@Category(Unit.class)
+public class GoogleProjectServiceTest {
+
+    @Test
+    public void testVerifyProjectId() {
+        // Should pass
+        GoogleProjectService.validateProjectId("abc1234-567");
+        // All below should fail
+
+        assertThatThrownBy(
+            () -> GoogleProjectService.validateProjectId("abc1234_567"),
+            "Can only contain letters, numbers, and hyphens")
+                .hasMessage(
+                    "The project ID \"abc1234_567\" must be a unique string of 6 to 30 lowercase letters, digits, " +
+                    "or hyphens. It must start with a letter, and cannot have a trailing hyphen. You cannot change a " +
+                    "project ID once it has been created. You cannot re-use a project ID that is in use, or one that " +
+                    "has been used for a deleted project.");
+
+        assertThatThrownBy(
+            () -> GoogleProjectService.validateProjectId("aBc1234-567"),
+            "Can't have uppercase letters");
+
+        assertThatThrownBy(
+            () -> GoogleProjectService.validateProjectId("1bc1234-567"),
+            "Can't start with anything but a letter");
+        assertThatThrownBy(
+            () -> GoogleProjectService.validateProjectId("-bc1234-567"),
+            "Can't start with anything but a letter");
+
+        assertThatThrownBy(
+            () -> GoogleProjectService.validateProjectId("abc12"),
+            "Can't contain fewer than 6 characters");
+        GoogleProjectService.validateProjectId("abc123");
+
+        assertThatThrownBy(
+            () -> GoogleProjectService.validateProjectId("a012345678901234567890123456789"),
+            "Can't contain more than 30 characters");
+        GoogleProjectService.validateProjectId("a01234567890123456789012345678");
+
+        assertThatThrownBy(
+            () -> GoogleProjectService.validateProjectId("abc1234-567-"),
+            "Can't end with a hyphen");
+    }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceTest.java
@@ -15,11 +15,16 @@ public class GoogleProjectServiceTest {
     @Test
     public void testVerifyProjectId() {
         // Should pass
-        GoogleProjectService.validateProjectId("abc1234-567");
+        GoogleProjectService.ensureValidProjectId("abc1234-567");
         // All below should fail
 
         assertThatThrownBy(
-            () -> GoogleProjectService.validateProjectId("abc1234_567"),
+            () -> GoogleProjectService.ensureValidProjectId(null),
+            "Can't be null")
+                .hasMessage("Project Id must not be null");
+
+        assertThatThrownBy(
+            () -> GoogleProjectService.ensureValidProjectId("abc1234_567"),
             "Can only contain letters, numbers, and hyphens")
                 .hasMessage(
                     "The project ID \"abc1234_567\" must be a unique string of 6 to 30 lowercase letters, digits, " +
@@ -28,28 +33,30 @@ public class GoogleProjectServiceTest {
                     "has been used for a deleted project.");
 
         assertThatThrownBy(
-            () -> GoogleProjectService.validateProjectId("aBc1234-567"),
+            () -> GoogleProjectService.ensureValidProjectId("aBc1234-567"),
             "Can't have uppercase letters");
 
         assertThatThrownBy(
-            () -> GoogleProjectService.validateProjectId("1bc1234-567"),
+            () -> GoogleProjectService.ensureValidProjectId("1bc1234-567"),
             "Can't start with anything but a letter");
         assertThatThrownBy(
-            () -> GoogleProjectService.validateProjectId("-bc1234-567"),
+            () -> GoogleProjectService.ensureValidProjectId("-bc1234-567"),
             "Can't start with anything but a letter");
 
         assertThatThrownBy(
-            () -> GoogleProjectService.validateProjectId("abc12"),
+            () -> GoogleProjectService.ensureValidProjectId("abc12"),
             "Can't contain fewer than 6 characters");
-        GoogleProjectService.validateProjectId("abc123");
+        // Check that 6 characters is OK
+        GoogleProjectService.ensureValidProjectId("abc123");
 
         assertThatThrownBy(
-            () -> GoogleProjectService.validateProjectId("a012345678901234567890123456789"),
+            () -> GoogleProjectService.ensureValidProjectId("a012345678901234567890123456789"),
             "Can't contain more than 30 characters");
-        GoogleProjectService.validateProjectId("a01234567890123456789012345678");
+        // Check that 30 characters is OK
+        GoogleProjectService.ensureValidProjectId("a01234567890123456789012345678");
 
         assertThatThrownBy(
-            () -> GoogleProjectService.validateProjectId("abc1234-567-"),
+            () -> GoogleProjectService.ensureValidProjectId("abc1234-567-"),
             "Can't end with a hyphen");
     }
 }


### PR DESCRIPTION
This makes it a little more obvious why we might not have been able to create a google project.  This validates the project name before even trying to create the project in google.