### PR TITLE
DR-1549: Update datarepo-actions to 0.35.0

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -48,7 +48,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -78,22 +78,22 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -102,26 +102,26 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: 0.19.7
           helm_oidc_proxy_chart_version: 0.0.15
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'waitfordeployment'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.34.0
+        uses: broadinstitute/datarepo-actions@0.35.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'


### PR DESCRIPTION
Only display errors and warnings (required to show build scan). The build scan will still have all the data, including `INFO`.

See the PR for 0.35.0 here: https://github.com/broadinstitute/datarepo-actions/pull/41