### PR TITLE
DR-1550 Cache the results of the status endpoint

### DIFF
--- a/src/main/java/bio/terra/app/configuration/CacheConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/CacheConfiguration.java
@@ -33,7 +33,7 @@ public class CacheConfiguration implements CachingConfigurer {
     public static final String STATUS_PROP = "STATUS";
 
     public enum CacheProperties {
-        STATUS(30L, TimeUnit.SECONDS, null);
+        STATUS(5L, TimeUnit.SECONDS, null);
 
         private final long duration;
         private final TimeUnit unit;

--- a/src/main/java/bio/terra/app/configuration/CacheConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/CacheConfiguration.java
@@ -39,7 +39,7 @@ public class CacheConfiguration implements CachingConfigurer {
         private final TimeUnit unit;
         private final Optional<Long> maxSize;
 
-        CacheProperties(Long duration, TimeUnit unit, Long maxSize) {
+        CacheProperties(final long duration, final TimeUnit unit, final Long maxSize) {
             this.duration = duration;
             this.unit = unit;
             this.maxSize = Optional.ofNullable(maxSize);

--- a/src/main/java/bio/terra/app/configuration/CacheConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/CacheConfiguration.java
@@ -1,0 +1,83 @@
+package bio.terra.app.configuration;
+
+import com.google.common.cache.CacheBuilder;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.cache.interceptor.CacheResolver;
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.cache.interceptor.SimpleCacheErrorHandler;
+import org.springframework.cache.interceptor.SimpleCacheResolver;
+import org.springframework.cache.interceptor.SimpleKeyGenerator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configures a cache to be used by Spring.  It likely makes sense to use a cache per endpoint.
+ */
+@EnableCaching
+@Configuration
+public class CacheConfiguration implements CachingConfigurer {
+
+    public static final String SPRING_CACHE_MANAGER = "springCacheManager";
+
+    // Use these strings to reference CacheProperties
+    public static final String STATUS_PROP = "STATUS";
+
+    public enum CacheProperties {
+        STATUS(30L, TimeUnit.SECONDS, null);
+
+        private final long duration;
+        private final TimeUnit unit;
+        private final Optional<Long> maxSize;
+
+        CacheProperties(Long duration, TimeUnit unit, Long maxSize) {
+            this.duration = duration;
+            this.unit = unit;
+            this.maxSize = Optional.ofNullable(maxSize);
+        }
+    };
+
+    @Bean(name = SPRING_CACHE_MANAGER)
+    @Override
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager() {
+
+            @Override
+            @NonNull
+            protected Cache createConcurrentMapCache(@NonNull final String name) {
+                final CacheProperties config = CacheProperties.valueOf(name);
+                final CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder()
+                    .expireAfterWrite(config.duration, config.unit);
+
+                config.maxSize.ifPresent(builder::maximumSize);
+
+                return new ConcurrentMapCache(name, builder.build().asMap(), false);
+            }
+        };
+    }
+
+    @Override
+    public CacheResolver cacheResolver() {
+        return new SimpleCacheResolver();
+    }
+
+    @Override
+    public KeyGenerator keyGenerator() {
+        return new SimpleKeyGenerator();
+    }
+
+    @Override
+    public CacheErrorHandler errorHandler() {
+        return new SimpleCacheErrorHandler();
+    }
+
+}

--- a/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
+++ b/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
@@ -1,5 +1,6 @@
 package bio.terra.app.controller;
 
+import bio.terra.app.configuration.CacheConfiguration;
 import bio.terra.app.configuration.OauthConfiguration;
 import bio.terra.controller.UnauthenticatedApi;
 import bio.terra.model.RepositoryConfigurationModel;
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -77,6 +79,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
     }
 
     @Override
+    @Cacheable(value = { CacheConfiguration.STATUS_PROP }, cacheManager = CacheConfiguration.SPRING_CACHE_MANAGER)
     public ResponseEntity<RepositoryStatusModel> serviceStatus() {
         RepositoryStatusModel repoStatus = statusService.getStatus();
         HttpStatus httpStatus = repoStatus.isOk() ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE;

--- a/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
+++ b/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
@@ -135,9 +135,8 @@ public class GoogleBillingService {
         ProjectBillingInfo content = ProjectBillingInfo.newBuilder()
             .setBillingAccountName("billingAccounts/" + billingAccountId)
             .build();
-        try {
-            ProjectBillingInfo billingResponse = cloudBillingClient()
-                .updateProjectBillingInfo("projects/" + projectId, content);
+        try (CloudBillingClient client = cloudBillingClient()) {
+            ProjectBillingInfo billingResponse = client.updateProjectBillingInfo("projects/" + projectId, content);
             return billingResponse.getBillingEnabled();
         } catch (ApiException e) {
             String message = String.format("Could not assign billing account '%s' to project: %s", billingAccountId,

--- a/src/test/java/bio/terra/app/controller/StatusTest.java
+++ b/src/test/java/bio/terra/app/controller/StatusTest.java
@@ -41,7 +41,7 @@ public class StatusTest {
     private CacheManager cacheManager;
 
     @Before
-    public void setUp() throws Exception {
+    public void setup() throws Exception {
         clearCache();
     }
 

--- a/src/test/java/bio/terra/app/controller/StatusTest.java
+++ b/src/test/java/bio/terra/app/controller/StatusTest.java
@@ -1,22 +1,26 @@
 package bio.terra.app.controller;
 
 import bio.terra.common.category.Unit;
-import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.configuration.ConfigurationService;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.mock.web.MockHttpServletResponse;
-import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
 
+import static bio.terra.app.configuration.CacheConfiguration.SPRING_CACHE_MANAGER;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -32,6 +36,14 @@ public class StatusTest {
     private MockMvc mvc;
     @Autowired
     private ConfigurationService configurationService;
+    @Autowired
+    @Qualifier(SPRING_CACHE_MANAGER)
+    private CacheManager cacheManager;
+
+    @Before
+    public void setUp() throws Exception {
+        clearCache();
+    }
 
     @Test
     public void testStatus() throws Exception {
@@ -42,6 +54,7 @@ public class StatusTest {
     public void testStatusDown() throws Exception {
         configurationService.setFault(ConfigEnum.LIVENESS_FAULT.name(), true);
         this.mvc.perform(get("/status")).andExpect(status().is5xxServerError());
+        clearCache();
         configurationService.setFault(ConfigEnum.LIVENESS_FAULT.name(), false);
         this.mvc.perform(get("/status")).andExpect(status().isOk());
     }
@@ -52,6 +65,7 @@ public class StatusTest {
         MvcResult result = this.mvc.perform(get("/status"))
             .andExpect(status().is5xxServerError())
             .andReturn();
+        clearCache();
         MockHttpServletResponse downResponse = result.getResponse();
         String responseBody = downResponse.getContentAsString();
         assertThat("/Status response should indicate that postgres is down, and therefore the whole system is down.",
@@ -63,10 +77,14 @@ public class StatusTest {
         MvcResult upResult = this.mvc.perform(get("/status"))
             .andExpect(status().isOk())
             .andReturn();
+        clearCache();
         MockHttpServletResponse upResponse = upResult.getResponse();
         String upResponseBody = upResponse.getContentAsString();
         assertThat("/Status response should indicate that the whole system is up",
             upResponseBody, startsWith("{\"ok\":true"));
     }
 
+    private void clearCache() {
+        cacheManager.getCacheNames().forEach(c -> cacheManager.getCache(c).clear());
+    }
 }

--- a/src/test/java/bio/terra/common/FutureUtilsTest.java
+++ b/src/test/java/bio/terra/common/FutureUtilsTest.java
@@ -40,7 +40,7 @@ public class FutureUtilsTest {
     private ThreadPoolExecutor executorService;
 
     @Before
-    public void setUp() throws Exception {
+    public void setup() throws Exception {
         executorService = new ThreadPoolExecutor(
             3,
             3,


### PR DESCRIPTION
We currently hit this endpoint about 3-4 times a second and it happens to potentially be a fairly expensive api to call since it hits postgres and SAM.  This adds a Guava cache in front of the endpoint (with some Spring annotations to make it a little easier to configure).  For the status endpoint, this keeps the result 30 seconds which should be plenty accurate for our use case, I would think.

Note, I know the statics are a little weird but I liked having the constants in there.  I couldn't find a better way to predefine the enum with configs while allowing to reference them in the `@Cacheable` method annotation

I also did a drive-by change to fix a billing client that we weren't closing