### PR TITLE
DR-1559: Force migrations to run before perf test run to clean up

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -28,15 +28,15 @@ jobs:
           path: terra-helmfile
           persist-credentials: false
       - name: "Find and replace Datarepo version in versions.yaml"
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i terra-helmfile/versions.yaml releases.datarepo.appVersion ${{ steps.apiprevioustag.outputs.tag }}
       - name: "Find and replace Datarepo chartVersion version in versions.yaml"
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i terra-helmfile/versions.yaml releases.datarepo.chartVersion ${{ env.chartVersion }}
       - name: "Read terra-helmfile daterepo fields in versions.yaml"
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq r terra-helmfile/versions.yaml releases.datarepo
       - name: Create pull request

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -23,27 +23,27 @@ jobs:
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "integration-1 find and replace"
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-1/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "integration-2 find and replace"
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-2/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "integration-3 find and replace"
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-3/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "integration-4 find and replace"
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-4/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "integration-5 find and replace"
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-5/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "integration-6 find and replace"
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: Create pull request

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -99,7 +99,7 @@ jobs:
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
-        uses: docker://mikefarah/yq:latest
+        uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i datarepo-helm-definitions/perf/datarepo/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_VERSION }}
       - name: "Create datarepo-helm-definition pull request with updated perf image tag"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -125,6 +125,10 @@ jobs:
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
+          echo "Killing perf api pod to force db migration (can be removed after DR-1544 is complete)"
+          helm delete -n perf perf-jade-datarepo-api
+          sleep 15
+          echo "Apply helm updates, including updated data-repo version"
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -134,7 +134,7 @@ jobs:
       - name: "Wait for Perf Cluster to come back up with correct version"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
-          PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
+          PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -R '. | try fromjson catch {"semVer":"failedToContact"}' | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           RETRY_COUNT=0
           until [[ "$PERF_VERSION" == "${{ steps.read_property.outputs.LATEST_VERSION }}" ]]; do
             if [[ ${RETRY_COUNT} -gt 20 ]]; then
@@ -143,7 +143,7 @@ jobs:
             fi
             echo "Retry #${RETRY_COUNT}: Waiting for $PERF_VERSION to equal ${{ steps.read_property.outputs.LATEST_VERSION }}"
             sleep 15
-            PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
+            PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -R '. | try fromjson catch {"semVer":"failedToContact"}' | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
             ((RETRY_COUNT=RETRY_COUNT+1))
           done;
           echo "Perf successfully running on new version: $PERF_VERSION"

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -38,7 +38,7 @@ dependencies {
         swaggerAnnotations = "2.1.5"
         jersey = "2.30.1"
 
-        datarepoClient = "1.0.182-SNAPSHOT"
+        datarepoClient = "1.0.185-SNAPSHOT"
         samClient = "0.1-9435410-SNAP"
     }
 


### PR DESCRIPTION
This includes a few small bug fixes. 
- Perf tests are failing since we've started enforcing the one profile per project relationship. By running a helm delete on the api pod, we will force migrations to run with "drop all on start" enabled. This will give us a clean slate on each nightly test run. 
- Now that we're totally killing the api pod, the jq command that checks to see if perf has been updated was not robust enough. It couldn't handle non-json results returned from the check (which would be expected if the pod is down), so my changes add a "try/catch" for the jq call that allows for a more resilient check on the pods. It is NOT pretty, but after struggling with it for a couple of hours, I'm calling it good enough! 
- yq, which we use in 3 of our workflows, introduced breaking changes in v4. Since we're using the 'latest' docker container, this automatically meant our actions started failing. I bumped it back from 'latest' to the old version '3.3.4.' Ticket created to actually handle the breaking changes: https://broadworkbench.atlassian.net/browse/DR-1561
- In order for the local client test build to pass, the version needed to be updated to 1.0.185.

Example test runner nightly run that successfully migrated: https://github.com/DataBiosphere/jade-data-repo/runs/1591778718?check_suite_focus=true