### PR TITLE
DR-1558 Remove duplicate dependencies; version lock

### DIFF
--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -33,19 +33,15 @@ dependencies {
 
     }
 
+    // TODO: the comment below seems wrong, since we are version locking these.
     // Swagger deps, versions controlled by dependencyManagement in root project
     implementation group: "io.swagger", name: "swagger-annotations", version: "${swagger}"
-    implementation group: "org.glassfish.jersey.core", name: "jersey-client"
-    implementation group: "org.glassfish.jersey.media", name: "jersey-media-json-jackson"
-    implementation group: "org.glassfish.jersey.media", name: "jersey-media-multipart"
-    implementation group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jsr310"
-    implementation group: "io.swagger.core.v3", name: "swagger-annotations"
+    implementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: "${jersey}"
+    implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: "${jersey}"
+    implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: "${jersey}"
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: "${jackson}"
+    implementation group: "io.swagger.core.v3", name: "swagger-annotations", version: "${swaggerAnnotations}"
     swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"
-
-    compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: "${jersey}"
-    compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: "${jersey}"
-    compile group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: "${jersey}"
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: "${jackson}"
 }
 
 // OpenAPI/Swagger Client Generation


### PR DESCRIPTION
There are duplicate library inclusions in the client gradle build. One is version locked and the other isn't. When I built against this with jadecli, I got an error for swagger-annotations 2.1.5. That is because the un-locked include got 2.1.6, so 2.1.5 was not build into the client. This removes the duplicates and version locks the libraries.