### PR TITLE
DR-1550 Force the docker image to use 2g of ram (no more no less)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -330,6 +330,9 @@ jib {
     to {
         image = "gcr.io/broad-jade-dev/jade-data-repo:" + (System.env.GCR_TAG ?: getGitHash())
     }
+    container {
+        jvmFlags = ["-Xms2g", "-Xmx2g"]
+    }
 }
 // jib expects all classes to be under app/classes in the resulting image. this, combined with the extraDirectories
 // setting above will ensure that the generated classes end up in the right place when jib builds.


### PR DESCRIPTION
This will keep the memory from growing continually.

Note: matching this PR is https://github.com/broadinstitute/datarepo-helm/pull/77 which sets the amount of memory required by the pod to be this + 25% which generally what is recommended