### PR TITLE
DR-1569: Open-api yaml fixes

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2512,6 +2512,11 @@ components:
       type: string
       description: >
         Unique identifier for a dataset, snapshot, etc.
+    ShortIdProperty:
+      pattern: ^[A-za-z0-9.\-/_]{22}
+      type: string
+      description: >
+        Unique identifier for a flights, jobs, etc.
     BillingProfileRequestModel:
       required:
         - biller
@@ -3364,8 +3369,7 @@ components:
       type: object
       properties:
         id:
-          type: string
-          description: short UUID, 22 characters
+          $ref: '#/components/schemas/ShortIdProperty'
         description:
           type: string
           description: Description of the job's flight from description flight input

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2506,6 +2506,11 @@ components:
       type: string
       description: >
         Unique identifier for a dataset, snapshot, etc.
+    ShortIdProperty:
+      pattern: ^[A-Za-z0-9\-\]{22}
+      type: string
+      description: >
+        Unique identifier for a flights, jobs, etc.
     BillingProfileRequestModel:
       required:
         - biller
@@ -3358,7 +3363,7 @@ components:
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/UniqueIdProperty'
+          $ref: '#/components/schemas/ShortIdProperty'
         description:
           type: string
           description: Description of the job's flight from description flight input

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2513,7 +2513,7 @@ components:
       description: >
         Unique identifier for a dataset, snapshot, etc.
     ShortIdProperty:
-      pattern: "[A-za-z0-9\\-/_]{22}"
+      pattern: "[A-za-z0-9\-/_]{22}"
       type: string
       description: >
         Unique identifier for a flights, jobs, etc.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2513,7 +2513,7 @@ components:
       description: >
         Unique identifier for a dataset, snapshot, etc.
     ShortIdProperty:
-      pattern: '[A-za-z0-9\-/_]{22}'
+      pattern: '[A-za-z0-9_\-]{22}'
       type: string
       description: >
         Unique identifier for a flights, jobs, etc.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2513,7 +2513,7 @@ components:
       description: >
         Unique identifier for a dataset, snapshot, etc.
     ShortIdProperty:
-      pattern: [A-za-z0-9\\-/_]{22}
+      pattern: "[A-za-z0-9\\-/_]{22}"
       type: string
       description: >
         Unique identifier for a flights, jobs, etc.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2513,7 +2513,7 @@ components:
       description: >
         Unique identifier for a dataset, snapshot, etc.
     ShortIdProperty:
-      pattern: ^[A-za-z0-9.\-/_]{22}
+      pattern: [A-za-z0-9\\-/_]{22}
       type: string
       description: >
         Unique identifier for a flights, jobs, etc.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2513,7 +2513,7 @@ components:
       description: >
         Unique identifier for a dataset, snapshot, etc.
     ShortIdProperty:
-      pattern: '[A-za-z0-9_\-]{22}'
+      pattern: '[A-za-z0-9_\\-]{22}'
       type: string
       description: >
         Unique identifier for a flights, jobs, etc.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -409,16 +409,22 @@ paths:
                 $ref: '#/components/schemas/PolicyResponse'
         400:
           description: Bad request - invalid id, badly formed, or email not found
-          schema:
-            $ref: '#/components/schemas/ErrorModel'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
         403:
           description: No permission to update policies
-          schema:
-            $ref: '#/components/schemas/ErrorModel'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
         404:
           description: Not found - profile id does not exist
-          schema:
-            $ref: '#/components/schemas/ErrorModel'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
 
   /api/resources/v1/profiles/{id}/policies/{policyName}/members/{memberEmail}:
     delete:
@@ -2506,11 +2512,6 @@ components:
       type: string
       description: >
         Unique identifier for a dataset, snapshot, etc.
-    ShortIdProperty:
-      pattern: ^[A-Za-z0-9\-\]{22}
-      type: string
-      description: >
-        Unique identifier for a flights, jobs, etc.
     BillingProfileRequestModel:
       required:
         - biller
@@ -3363,7 +3364,8 @@ components:
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/ShortIdProperty'
+          type: string
+          description: short UUID, 22 characters
         description:
           type: string
           description: Description of the job's flight from description flight input

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2513,7 +2513,7 @@ components:
       description: >
         Unique identifier for a dataset, snapshot, etc.
     ShortIdProperty:
-      pattern: '[A-za-z0-9\\-/_]{22}'
+      pattern: '[A-za-z0-9\-/_]{22}'
       type: string
       description: >
         Unique identifier for a flights, jobs, etc.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2513,7 +2513,7 @@ components:
       description: >
         Unique identifier for a dataset, snapshot, etc.
     ShortIdProperty:
-      pattern: "[A-za-z0-9\-/_]{22}"
+      pattern: '[A-za-z0-9\\-/_]{22}'
       type: string
       description: >
         Unique identifier for a flights, jobs, etc.


### PR DESCRIPTION
### Background
After working with the python client (which is built from the data-repository-openapi.yaml), we found a couple of bugs.

- JobModel's ID - the schema was set to a regular UUID, but it's actually a "ShortUUID" as defined in the Stairway repo
- POST to add policy members - Incorrect pattern for defining the 400 error model

### Testing
I created the following unit test in the stairway repo to confirm the regex for ShortUUID:
```
  @Test
  public void testRegexShortUUID() {
    for (int i = 0; i < 100000; i++) {
      String exShortUUID = ShortUUID.get();
      System.out.println(exShortUUID);
      boolean match = Pattern.matches("[A-za-z0-9_\\-]{22}", exShortUUID);
      assertTrue(match);
      System.out.println(match);
    }
  }
```