### PR TITLE
DR-1571 Enable micrometer library to expose /actuator/prometheus endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,7 @@ dependencies {
     }
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus:latest.release'
 
     // Forcing this due to vulnerability issues
     compile ('com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1') {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -72,3 +72,4 @@ google.singleDataProjectId=${GOOGLE_CLOUD_DATA_PROJECT}
 google.allowReuseExistingBuckets=false
 google.allowReuseExistingProjects=false
 management.health.probes.enabled=true
+management.endpoints.web.exposure.include=*


### PR DESCRIPTION
There's a related PR https://github.com/broadinstitute/datarepo-helm-definitions/pull/268 to scrape this endpoint in dev prometheus to allow more advanced metrics