### PR TITLE
Replace travis link with github link for build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [jade-data-repository](https://jade-terra.datarepo-prod.broadinstitute.org/) &middot; [![GitHub license](https://img.shields.io/github/license/DataBiosphere/jade-data-repo)](https://github.com/DataBiosphere/jade-data-repo/blob/develop/LICENSE.md) [![TravisCI](https://travis-ci.org/DataBiosphere/jade-data-repo.svg?branch=develop)](https://travis-ci.org/DataBiosphere/jade-data-repo)
+# [jade-data-repository](https://jade-terra.datarepo-prod.broadinstitute.org/) &middot; [![GitHub license](https://img.shields.io/github/license/DataBiosphere/jade-data-repo)](https://github.com/DataBiosphere/jade-data-repo/blob/develop/LICENSE.md) [![Integration test and Connected tests](https://github.com/DataBiosphere/jade-data-repo/workflows/Integration%20test%20and%20Connected%20tests/badge.svg?branch=develop)](https://github.com/DataBiosphere/jade-data-repo/actions?query=workflow%3A%22Integration+test+and+Connected+tests%22+branch%3Adevelop)
 
 The [Terra](https://terra.bio/) Data Repository built by the Jade team as part of the
 [Data Biosphere](https://medium.com/@benedictpaten/a-data-biosphere-for-biomedical-research-d212bbfae95d).


### PR DESCRIPTION
I noticed that the jade repo README has a build badge that points to travis (which hasn’t built jade in 10 months). It’s easy to update it to use a github build badge, but I wasn’t sure what builds to show. It’s easy to add multiple badges if that makes sense. This adds Integration and Connected for `develop`. Should I add others too?