### PR TITLE
Datarepo helm chart version update: 0.1.34

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: '30 2 * * *' # run at 2:30 AM UTC
 env:
-  chartVersion: 0.1.33
+  chartVersion: 0.1.34
 jobs:
   alpha_promotion:
     strategy:


### PR DESCRIPTION
Update versions in **0.1.34**.
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/broadinstitute/datarepo-helm/actions/runs/497492979).*