### PR TITLE
DR-369 Enable Firestore when creating a data project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,7 @@ dependencies {
     compile 'com.google.cloud:google-cloud-billing:1.1.6'
     compile 'com.google.cloud:google-cloud-resourcemanager:0.118.2-alpha'
     compile 'com.google.apis:google-api-services-serviceusage:v1-rev20201021-1.30.10'
+    compile 'com.google.apis:google-api-services-appengine:v1-rev20201201-1.31.0'
     compile 'com.google.cloud:google-cloud-bigquery:1.108.1'
     compile 'com.google.cloud:google-cloud-storage:1.108.0'
     compile 'com.google.cloud:google-cloud-firestore:1.22.0'
@@ -174,6 +175,8 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.28'                 // Logging facade
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation group: "javax.validation", name: "validation-api"
+    // Fix to this version
+    compile 'com.google.http-client:google-http-client:1.38.0'
 
     implementation group: "io.swagger.core.v3", name: "swagger-annotations"
     swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"

--- a/build.gradle
+++ b/build.gradle
@@ -408,8 +408,19 @@ task testUnit(type: Test) {
     outputs.upToDateWhen { false }
 }
 
+task testOnDemand(type: Test) {
+    useJUnit {
+        includeCategories 'bio.terra.common.category.OnDemand'
+    }
+    testLogging {
+        events = ["passed", "failed", "skipped", "started", "standard_out"]
+    }
+    outputs.upToDateWhen { false }
+}
+
 task testAll(type: Test) {
     useJUnit {
+        // Note: explicitly not including OnDemand tests
         includeCategories 'bio.terra.common.category.Connected', 'bio.terra.common.category.Unit'
     }
     outputs.upToDateWhen { false }

--- a/src/main/java/bio/terra/service/resourcemanagement/exception/AppengineException.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/exception/AppengineException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.resourcemanagement.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class AppengineException extends InternalServerErrorException {
+    public AppengineException(String message) {
+        super(message);
+    }
+
+    public AppengineException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AppengineException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -488,7 +488,7 @@ public class GoogleProjectService {
         String appId,
         long timeoutSeconds) throws IOException, InterruptedException {
         long start = System.currentTimeMillis();
-        final long pollInterval = 10 * 1000; // 10 seconds
+        final long pollInterval = TimeUnit.SECONDS.toMillis(10);
         // Get
         final String opName = operation.getName();
         // The format returns is apps/{appId}/operations/{useful id} so we need to extract it
@@ -507,7 +507,7 @@ public class GoogleProjectService {
             }
             Thread.sleep(pollInterval);
             long elapsed = System.currentTimeMillis() - start;
-            if (elapsed >= timeoutSeconds * 1000) {
+            if (elapsed >= TimeUnit.SECONDS.toMillis(timeoutSeconds)) {
                 throw new AppengineException("Timed out waiting for operation to complete");
             }
             logger.info("checking operation: {}", opId);
@@ -532,7 +532,7 @@ public class GoogleProjectService {
         CloudResourceManager resourceManager, Operation operation, long timeoutSeconds)
         throws IOException, InterruptedException {
         long start = System.currentTimeMillis();
-        final long pollInterval = 10 * 1000; // 10 seconds
+        final long pollInterval = TimeUnit.SECONDS.toMillis(10);
         String opId = operation.getName();
 
         while (operation != null && (operation.getDone() == null || !operation.getDone())) {
@@ -543,7 +543,7 @@ public class GoogleProjectService {
             }
             Thread.sleep(pollInterval);
             long elapsed = System.currentTimeMillis() - start;
-            if (elapsed >= timeoutSeconds * 1000) {
+            if (elapsed >= TimeUnit.SECONDS.toMillis(timeoutSeconds)) {
                 throw new GoogleResourceException("Timed out waiting for operation to complete");
             }
             logger.info("checking operation: {}", opId);
@@ -575,7 +575,7 @@ public class GoogleProjectService {
         throws IOException, InterruptedException {
 
         long start = System.currentTimeMillis();
-        final long pollInterval = 5 * 1000; // 5 seconds
+        final long pollInterval = TimeUnit.SECONDS.toMillis(5);
         String opId = operation.getName();
 
         while (operation != null && (operation.getDone() == null || !operation.getDone())) {
@@ -586,7 +586,7 @@ public class GoogleProjectService {
             }
             Thread.sleep(pollInterval);
             long elapsed = System.currentTimeMillis() - start;
-            if (elapsed >= timeoutSeconds * 1000) {
+            if (elapsed >= TimeUnit.SECONDS.toMillis(timeoutSeconds)) {
                 throw new GoogleResourceException("Timed out waiting for operation to complete");
             }
             ServiceUsage.Operations.Get request = serviceUsage.operations().get(opId);

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -69,7 +69,6 @@ public class GoogleProjectService {
     /**
      * This is where the Firestore database will be created.
      */
-    private static final String DEFAULT_FS_LOCATION_ID = "us-central";
     private static final String FIRESTORE_DB_TYPE = "CLOUD_FIRESTORE";
 
     private final GoogleBillingService billingService;
@@ -314,7 +313,13 @@ public class GoogleProjectService {
                 blockUntilServiceOperationComplete(serviceUsage, batchEnable.execute(), timeout);
             }
 
-            enableFirestore(appengine(), projectResource.getGoogleProjectId(), DEFAULT_FS_LOCATION_ID, timeout);
+            enableFirestore(
+                appengine(),
+                projectResource.getGoogleProjectId(),
+                resourceConfiguration.getDefaultFirestoreLocation(),
+                timeout
+            );
+
         } catch (IOException | GeneralSecurityException e) {
             // In development we are reusing projects. The TDR service account may not have permission to
             // properly enable the services on a developer's project. In those cases, we do not want to

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
@@ -17,6 +17,7 @@ public class GoogleResourceConfiguration {
     private String parentResourceType;
     private String parentResourceId;
     private String singleDataProjectId;
+    private String defaultFirestoreLocation;
     private boolean allowReuseExistingProjects;
     private boolean allowReuseExistingBuckets;
 
@@ -82,6 +83,14 @@ public class GoogleResourceConfiguration {
 
     public void setAllowReuseExistingBuckets(boolean allowReuseExistingBuckets) {
         this.allowReuseExistingBuckets = allowReuseExistingBuckets;
+    }
+
+    public String getDefaultFirestoreLocation() {
+        return defaultFirestoreLocation;
+    }
+
+    public void setDefaultFirestoreLocation(String defaultFirestoreLocation) {
+        this.defaultFirestoreLocation = defaultFirestoreLocation;
     }
 
     // TODO: Is this used?

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -72,5 +72,6 @@ google.parentResourceId=270278425081
 google.singleDataProjectId=${GOOGLE_CLOUD_DATA_PROJECT}
 google.allowReuseExistingBuckets=false
 google.allowReuseExistingProjects=false
+google.defaultFirestoreLocation=us-central
 management.health.probes.enabled=true
 management.endpoints.web.exposure.include=*

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceOnDemandTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceOnDemandTest.java
@@ -1,0 +1,29 @@
+package bio.terra.service.resourcemanagement.google;
+
+import bio.terra.common.category.OnDemand;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@AutoConfigureMockMvc
+@SpringBootTest
+@Category(OnDemand.class)
+public class GoogleProjectServiceOnDemandTest {
+
+    @Autowired
+    private GoogleProjectService projectService;
+
+    @Test
+    public void testInitFirestore() throws InterruptedException {
+        // Test the explicit activation of a Firestore DB in an empty project
+        // Note, runner needs to populate in a project id and number before running
+        projectService.enableServices(new GoogleProjectResource()
+            .googleProjectId("")
+            .googleProjectNumber(""));
+    }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceTest.java
@@ -1,16 +1,25 @@
 package bio.terra.service.resourcemanagement.google;
 
 import bio.terra.common.category.Unit;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RunWith(SpringRunner.class)
+@AutoConfigureMockMvc
+@SpringBootTest
 @Category(Unit.class)
 public class GoogleProjectServiceTest {
+
+    @Autowired
+    private GoogleProjectService projectService;
 
     @Test
     public void testVerifyProjectId() {
@@ -58,5 +67,14 @@ public class GoogleProjectServiceTest {
         assertThatThrownBy(
             () -> GoogleProjectService.ensureValidProjectId("abc1234-567-"),
             "Can't end with a hyphen");
+    }
+
+
+    @Test
+    @Ignore("Un-ignore to test the explicit activation of a Firestore DB in an empty project")
+    public void testInitFirestore() throws InterruptedException {
+        projectService.enableServices(new GoogleProjectResource()
+            .googleProjectId("")
+            .googleProjectNumber(""));
     }
 }


### PR DESCRIPTION
Turns out there there's an admin client that *mostly* works.  Had to do some workarounds by:
- Explicitly setting the project we want to target in the request headers
- Parsing the operation Id since the API doesn't return a well formatted ID