### PR TITLE
DR-1596 Attempt to use pre-existing billing profile to test runner smoke tests

### DIFF
--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -61,6 +61,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/${workingDir}
           echo "Building Data Repo client library"
           export TEST_RUNNER_SERVER_SPECIFICATION_FILE="staging.json"
+          export TEST_RUNNER_BILLING_PROFILE_NAME="stest1"
           ENABLE_SUBPROJECT_TASKS=1 ./gradlew :datarepo-client:clean :datarepo-client:assemble
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-clienttests
           export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -21,8 +21,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Checkout tag for DataBiosphere/jade-data-repo"
+        if: github.ref == 'refs/heads/develop'
         run: |
           git checkout ${{ steps.apiprevioustag.outputs.tag }}
+          echo "Current branch is ${{ github.ref }}"
       - name: "Import Vault staging secrets"
         uses: hashicorp/vault-action@v2.1.0
         with:

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -53,9 +53,11 @@ public class RetrieveSnapshot extends SimpleDataset {
     if (StringUtils.isBlank(profileNameRaw)) {
       profileName = Optional.empty();
       deleteProfile = true;
+      logger.info("No profile name specified.  Will create a new billing profile");
     } else {
       profileName = Optional.ofNullable(profileNameRaw);
       deleteProfile = false;
+      logger.info("Will attempt to use a billing profile named {}", profileName.get());
     }
 
     // pick the a user that is a Data Repo steward to be the dataset creator

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -33,7 +33,7 @@ public class RetrieveSnapshot extends SimpleDataset {
 
   // Specify the name of a profile to use for the test with the TEST_RUNNER_BILLING_PROFILE_NAME
   // env variable.
-  private static final String profileNameRaw = System.getenv("TEST_RUNNER_BILLING_PROFILE_NAME");
+  private static final String PROFILE_NAME_RAW = System.getenv("TEST_RUNNER_BILLING_PROFILE_NAME");
 
   /** Public constructor so that this class can be instantiated via reflection. */
   public RetrieveSnapshot() {
@@ -45,12 +45,12 @@ public class RetrieveSnapshot extends SimpleDataset {
 
   public void setup(List<TestUserSpecification> testUsers) throws Exception {
     Optional<String> profileName;
-    if (StringUtils.isBlank(profileNameRaw)) {
+    if (StringUtils.isBlank(PROFILE_NAME_RAW)) {
       profileName = Optional.empty();
       deleteProfile = true;
       logger.info("No profile name specified.  Will create a new billing profile");
     } else {
-      profileName = Optional.ofNullable(profileNameRaw);
+      profileName = Optional.ofNullable(PROFILE_NAME_RAW);
       deleteProfile = false;
       logger.info("Will attempt to use a billing profile named {}", profileName.get());
     }

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -17,6 +17,11 @@ import bio.terra.datarepo.model.SnapshotSummaryModel;
 import com.google.cloud.storage.BlobId;
 import common.utils.FileUtils;
 import common.utils.StorageUtils;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -25,12 +30,6 @@ import runner.config.TestUserSpecification;
 import scripts.testscripts.baseclasses.SimpleDataset;
 import scripts.utils.DataRepoUtils;
 import scripts.utils.SAMUtils;
-
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 public class RetrieveSnapshot extends SimpleDataset {
   private static final Logger logger = LoggerFactory.getLogger(RetrieveSnapshot.class);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
@@ -20,13 +20,9 @@ public class SimpleDataset extends runner.TestScript {
   protected TestUserSpecification datasetCreator;
   protected BillingProfileModel billingProfileModel;
   protected DatasetSummaryModel datasetSummaryModel;
+  protected boolean deleteProfile;
 
   public void setup(List<TestUserSpecification> testUsers) throws Exception {
-    setup(testUsers, null);
-  }
-
-  public void setup(List<TestUserSpecification> testUsers, BillingProfileModel billingProfile)
-      throws Exception {
     // pick the a user that is a Data Repo steward to be the dataset creator
     datasetCreator = SAMUtils.findTestUserThatIsDataRepoSteward(testUsers, server);
     if (datasetCreator == null) {
@@ -40,13 +36,12 @@ public class SimpleDataset extends runner.TestScript {
     RepositoryApi repositoryApi = new RepositoryApi(datasetCreatorClient);
 
     // create a new profile
-    if (billingProfile == null) {
+    if (billingProfileModel == null) {
       billingProfileModel =
           DataRepoUtils.createProfile(
               resourcesApi, repositoryApi, billingAccount, "profile-simple", true);
       logger.info("Successfully created profile: {}", billingProfileModel.getProfileName());
     } else {
-      billingProfileModel = billingProfile;
       logger.info("Using existing profile: {}", billingProfileModel.getProfileName());
     }
 
@@ -63,11 +58,6 @@ public class SimpleDataset extends runner.TestScript {
   }
 
   public void cleanup(List<TestUserSpecification> testUsers) throws Exception {
-    cleanup(testUsers, true);
-  }
-
-  public void cleanup(List<TestUserSpecification> testUsers, boolean deleteProfile)
-      throws Exception {
     // get the ApiClient for the dataset creator
     ApiClient datasetCreatorClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
     ResourcesApi resourcesApi = new ResourcesApi(datasetCreatorClient);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
@@ -7,13 +7,12 @@ import bio.terra.datarepo.model.BillingProfileModel;
 import bio.terra.datarepo.model.DatasetSummaryModel;
 import bio.terra.datarepo.model.DeleteResponseModel;
 import bio.terra.datarepo.model.JobModel;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import runner.config.TestUserSpecification;
 import scripts.utils.DataRepoUtils;
 import scripts.utils.SAMUtils;
-
-import java.util.List;
 
 public class SimpleDataset extends runner.TestScript {
   private static final Logger logger = LoggerFactory.getLogger(SimpleDataset.class);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
@@ -20,7 +20,7 @@ public class SimpleDataset extends runner.TestScript {
   protected TestUserSpecification datasetCreator;
   protected BillingProfileModel billingProfileModel;
   protected DatasetSummaryModel datasetSummaryModel;
-  protected boolean deleteProfile;
+  protected boolean deleteProfile = true;
 
   public void setup(List<TestUserSpecification> testUsers) throws Exception {
     // pick the a user that is a Data Repo steward to be the dataset creator


### PR DESCRIPTION
This attempt uses an environment variable named `TEST_RUNNER_BILLING_PROFILE_NAME` to specify the name of a billing profile to look up and use.  I couldn't figure out how to do this with parameters that could be easily overwritten.  If nothing is specified, the current behavior is followed.

This updates the staging smoke test action. We may want a similar one for alpha