### PR TITLE
DR-1593 - Part 1: Bump github action version and datarepo version

### DIFF
--- a/.github/workflows/alpha-nightly.yaml
+++ b/.github/workflows/alpha-nightly.yaml
@@ -35,7 +35,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Create alpha release images'
-        uses: broadinstitute/datarepo-actions@0.26.0
+        uses: broadinstitute/datarepo-actions@0.36.0
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.HELM_REPO_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Bump the tag to a new version"
-        uses: broadinstitute/datarepo-actions@0.26.0
+        uses: broadinstitute/datarepo-actions@0.36.0
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -54,13 +54,13 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions@0.26.0
+        uses: broadinstitute/datarepo-actions@0.36.0
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check and edit Helm definition for dev"
-        uses: broadinstitute/datarepo-actions@0.26.0
+        uses: broadinstitute/datarepo-actions@0.36.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ plugins {
 
 allprojects {
     group 'bio.terra'
-    version '1.0.202-SNAPSHOT'
+    version '1.1.0-SNAPSHOT'
 
     ext {
         resourceDir = "${rootDir}/src/main/resources/api"


### PR DESCRIPTION
- [X] https://github.com/broadinstitute/datarepo-actions/pull/42 needs to be merged first - Merged!
- [X] As a part of testing, the version of datarepo was bumped in some places but not everywhere. Need to bump to 1.1.0 so it will be 1.2.0 when merged. 
      * https://github.com/DataBiosphere/jade-data-repo/releases/tag/1.1.0
      * https://github.com/broadinstitute/datarepo-helm-definitions/pull/325