### PR TITLE
DR-1612: Integration Tests: Fix Ingest Test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -398,7 +398,6 @@ task testIntegration(type: Test) {
         maxRetries = 3
         maxFailures = 15
     }
-    failFast = true
     outputs.upToDateWhen { false }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -394,6 +394,10 @@ task testIntegration(type: Test) {
     testLogging {
         events = ["passed", "failed", "skipped", "started", "standard_out"]
     }
+    retry {
+        maxRetries = 3
+        maxFailures = 15
+    }
     failFast = true
     outputs.upToDateWhen { false }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -394,10 +394,7 @@ task testIntegration(type: Test) {
     testLogging {
         events = ["passed", "failed", "skipped", "started", "standard_out"]
     }
-    retry {
-        maxRetries = 3
-        maxFailures = 15
-    }
+    failFast = true
     outputs.upToDateWhen { false }
 }
 

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -201,12 +201,6 @@ public class FileTest extends UsersBase {
         String gsPath = "gs://" + testConfiguration.getIngestbucket();
         String filePath = "/foo/bar";
 
-        DataRepoResponse<JobModel> launchResp = dataRepoFixtures.ingestFileLaunch(
-            custodian(), datasetId, profileId, gsPath + "/files/File Design Notes.pdf", filePath);
-        assertThat("Custodian is not authorized to ingest a file",
-            launchResp.getStatusCode(),
-            equalTo(HttpStatus.UNAUTHORIZED));
-
         FileModel fileModel = dataRepoFixtures.ingestFile(
             steward(), datasetId, profileId, gsPath + "/files/File Design Notes.pdf", filePath);
         String fileId = fileModel.getFileId();

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -133,7 +133,9 @@ public class IngestTest extends UsersBase {
         createdSnapshotIds.add(snapshotSummary.getId());
     }
 
+    // TODO: Revisit this test when permissions work is done!
     @Test
+    @Ignore
     public void ingestUnauthorizedTest() throws Exception {
         IngestRequestModel request = dataRepoFixtures.buildSimpleIngest(
             "participant", "ingest-test/ingest-test-participant.json");

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -133,17 +133,15 @@ public class IngestTest extends UsersBase {
         createdSnapshotIds.add(snapshotSummary.getId());
     }
 
-    // TODO: Revisit this test when permissions work is done!
     @Test
-    @Ignore
-    public void ingestUnauthorizedTest() throws Exception {
+    public void ingestAuthorizationTest() throws Exception {
         IngestRequestModel request = dataRepoFixtures.buildSimpleIngest(
             "participant", "ingest-test/ingest-test-participant.json");
         DataRepoResponse<JobModel> ingestCustResp = dataRepoFixtures.ingestJsonDataLaunch(
             custodian(), datasetId, request);
         assertThat("Custodian is not authorized to ingest data",
             ingestCustResp.getStatusCode(),
-            equalTo(HttpStatus.UNAUTHORIZED));
+            equalTo(HttpStatus.ACCEPTED));
         DataRepoResponse<JobModel> ingestReadResp = dataRepoFixtures.ingestJsonDataLaunch(
                 reader(), datasetId, request);
         assertThat("Reader is not authorized to ingest data",

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -137,16 +138,15 @@ public class IngestTest extends UsersBase {
     public void ingestAuthorizationTest() throws Exception {
         IngestRequestModel request = dataRepoFixtures.buildSimpleIngest(
             "participant", "ingest-test/ingest-test-participant.json");
-        DataRepoResponse<JobModel> ingestCustResp = dataRepoFixtures.ingestJsonDataLaunch(
+        IngestResponseModel ingestCustodianResp = dataRepoFixtures.ingestJsonData(
             custodian(), datasetId, request);
-        assertThat("Custodian is not authorized to ingest data",
-            ingestCustResp.getStatusCode(),
-            equalTo(HttpStatus.ACCEPTED));
+        assertThat("Custodian was able to ingest", ingestCustodianResp.getRowCount(), greaterThan(0L));
         DataRepoResponse<JobModel> ingestReadResp = dataRepoFixtures.ingestJsonDataLaunch(
-                reader(), datasetId, request);
+            reader(), datasetId, request);
         assertThat("Reader is not authorized to ingest data",
             ingestReadResp.getStatusCode(),
             equalTo(HttpStatus.UNAUTHORIZED));
+
     }
 
     @Test


### PR DESCRIPTION
### Fail Fast
With the billing profile changes, once one test fails, the rest fail with "reuse of billing profile" error. I propose a two layered response:
1. Quick patch - Let's switch tests to "fail fast". There's no need to keep running tests after one has failed and it just makes looking at the error logs confusing. Our tests are stable enough right now that we expect them to all pass before merging.
2. Long term fix [DR-1615]: if "DROP ALL ON START" is set, clean up billing profile on "setup" of test run. This way, we know we're starting with a blank slate. 

### Fix Ingest Permissions  Test
ingestUnauthorizedTest(): There have been recent changes to our SAM permissions model. Custodians can now ingest, but readers still cannot. I have adjusted the test. 

[DR-1615]: https://broadworkbench.atlassian.net/browse/DR-1615