### PR TITLE
DR-1593 - part 2 - fix 3- add git pull to dev image update

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -67,6 +67,7 @@ jobs:
           helm_env_prefix: dev
       - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
         run: |
+          git pull
           git checkout ${{ steps.bumperstep.outputs.tag }}
       - name: 'Release Candidate Container Build: Checkout DataBiosphere/jade-data-repo-ui repo'
         uses: actions/checkout@v2


### PR DESCRIPTION
Follow on to https://github.com/DataBiosphere/jade-data-repo/pull/796
Successful run that includes this change here: https://github.com/DataBiosphere/jade-data-repo/actions/runs/537604980
