### PR TITLE
DR-1587 Add admin group config to TDR

### DIFF
--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -89,8 +89,6 @@ public class RepositoryApiController implements RepositoryApi {
     private final ConfigurationService configurationService;
     private final AssetModelValidator assetModelValidator;
     private final UpgradeService upgradeService;
-
-    // needed for local testing w/o proxy
     private final ApplicationConfiguration appConfig;
 
     @Autowired
@@ -505,6 +503,11 @@ public class RepositoryApiController implements RepositoryApi {
 
     @Override
     public ResponseEntity<ConfigListModel> getConfigList() {
+        iamService.verifyAuthorization(
+            getAuthenticatedInfo(),
+            IamResourceType.DATAREPO,
+            appConfig.getResourceId(),
+            IamAction.CONFIGURE);
         ConfigListModel configModelList = configurationService.getConfigList();
         return new ResponseEntity<>(configModelList, HttpStatus.OK);
     }

--- a/src/main/java/bio/terra/service/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/iam/IamAction.java
@@ -17,6 +17,7 @@ public enum IamAction {
     CREATE_DATASET,
     LIST_JOBS,
     DELETE_JOBS,
+    CONFIGURE,
     // dataset
     EDIT_DATASET,
     READ_DATASET,

--- a/src/main/java/bio/terra/service/iam/sam/SamConfiguration.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 public class SamConfiguration {
     private String basePath;
     private String stewardsGroupEmail;
+    private String adminsGroupEmail;
     private int retryInitialWaitSeconds;
     private int retryMaximumWaitSeconds;
     private int operationTimeoutSeconds;
@@ -28,6 +29,14 @@ public class SamConfiguration {
 
     public void setStewardsGroupEmail(String stewardsGroupEmail) {
         this.stewardsGroupEmail = stewardsGroupEmail;
+    }
+
+    public String getAdminsGroupEmail() {
+        return adminsGroupEmail;
+    }
+
+    public void setAdminsGroupEmail(String adminsGroupEmail) {
+        this.adminsGroupEmail = adminsGroupEmail;
     }
 
     // SAM Retry notes:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,6 +61,7 @@ datarepo.numPerformanceThreads=50
 datarepo.maxPerformanceThreadQueueSize=1000
 sam.basePath=https://sam.dsde-dev.broadinstitute.org
 sam.stewardsGroupEmail=JadeStewards-dev@dev.test.firecloud.org
+sam.adminsGroupEmail=DataRepoAdmins@dev.test.firecloud.org
 sam.retryInitialWaitSeconds=10
 sam.retryMaximumWaitSeconds=30
 sam.operationTimeoutSeconds=300

--- a/src/test/java/bio/terra/app/controller/RepositoryApiControllerAccessTest.java
+++ b/src/test/java/bio/terra/app/controller/RepositoryApiControllerAccessTest.java
@@ -1,0 +1,46 @@
+package bio.terra.app.controller;
+
+import bio.terra.common.category.Integration;
+import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.UsersBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This is meant to be a very lightweight integration test to make sure that SAM actions are used as expected.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "integrationtest"})
+@Category(Integration.class)
+public class RepositoryApiControllerAccessTest extends UsersBase {
+
+    @Autowired
+    private DataRepoFixtures dataRepoFixtures;
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @Test
+    public void testGetConfigList() throws Exception {
+        // Assume this call is successful
+        dataRepoFixtures.getConfigList(steward());
+
+        // This call should be unsuccessful
+        assertThat(dataRepoFixtures.getConfigListRaw(reader()).getStatusCode())
+            .isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+}


### PR DESCRIPTION
This is a pretty small PR that:
- adds the admin group config property
- to sanity check, makes sure that admin users (e.g. voldemort and dumbledore) can hit the list configs endpoint.  There's a followon ticket to add a similar authz check to the other config endpoints but I wanted to add this here to make sure things were wired correctly.
-  added a super light integration test to make sure that the authz works as expected for the config endpoints

Followon PRs coming soon to:
- assign the admin group when creating snapshots and datasets and spend profiles
- protect the rest of the config endpoints
- adding the environment specific groups to the various environment configs