### PR TITLE
DR-1584 Wire in new permissions into TDR

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/BillingProfileOwnerHandoffTest.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/BillingProfileOwnerHandoffTest.java
@@ -40,13 +40,11 @@ public class BillingProfileOwnerHandoffTest extends BillingProfileUsers {
     try {
       profile = ownerUser1Api.createProfile(billingAccount, "profile_permission_test", true);
       String profileId = profile.getId();
-      // Remove stewards from the owner list. Otherwise, voldemort has access by default :(
-      ownerUser1Api.deleteProfilePolicyMember(profileId, "owner", stewardsEmail);
 
       ownerUser1Api.addProfilePolicyMember(profileId, "owner", userUser.userEmail);
-      userUserApi.deleteProfilePolicyMember(profileId, "owner", ownerUser1.userEmail);
+      userUserApi.deleteProfilePolicyMember(profileId, "owner", ownerUser2.userEmail);
       // Make sure removed owner can perform none of the operations
-      testOperations(ownerUser1Api, RoleState.NONE, profileId);
+      testOperations(ownerUser2Api, RoleState.NONE, profileId);
 
       userUserApi.addProfilePolicyMember(profileId, "owner", ownerUser2.userEmail);
       testOperations(ownerUser2Api, RoleState.OWNER, profileId);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/BillingProfileRoleAccessTest.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/BillingProfileRoleAccessTest.java
@@ -1,6 +1,10 @@
 package scripts.testscripts;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import bio.terra.datarepo.model.BillingProfileModel;
+import bio.terra.datarepo.model.DeleteResponseModel;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +74,9 @@ public class BillingProfileRoleAccessTest extends BillingProfileUsers {
       throw e;
     } finally {
       if (profile != null) {
-        ownerUser1Api.deleteProfile(profile.getId());
+        assertThat(
+            ownerUser1Api.deleteProfile(profile.getId()).getObjectState(),
+            equalTo(DeleteResponseModel.ObjectStateEnum.DELETED));
       }
     }
   }

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
@@ -144,13 +144,12 @@ public class CreateSnapshot extends SimpleDataset {
       DataRepoUtils.expectJobSuccess(
           repositoryApi, deleteSnapshotJobResponse, DeleteResponseModel.class);
       logger.info("Successfully deleted snapshot: {}", snapshotModel.getName());
-
-      super.cleanup(testUsers);
-      // delete the profile and dataset
-
-      // delete the scratch files used for ingesting tabular data and soft delete rows
-      StorageUtils.deleteFiles(
-          StorageUtils.getClientForServiceAccount(server.testRunnerServiceAccount), scratchFiles);
     }
+    super.cleanup(testUsers);
+    // delete the profile and dataset
+
+    // delete the scratch files used for ingesting tabular data and soft delete rows
+    StorageUtils.deleteFiles(
+        StorageUtils.getClientForServiceAccount(server.testRunnerServiceAccount), scratchFiles);
   }
 }

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/BillingProfileUsers.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/BillingProfileUsers.java
@@ -108,7 +108,6 @@ public class BillingProfileUsers extends runner.TestScript {
       retrievePolicySuccess = false;
     }
     logger.info("Role {} retrievePolicies {}", role, retrievePolicySuccess);
-
     switch (role) {
       case NONE:
         // all operations should fail

--- a/datarepo-clienttests/src/main/resources/configs/functional/BillingProfileAccess.json
+++ b/datarepo-clienttests/src/main/resources/configs/functional/BillingProfileAccess.json
@@ -17,5 +17,5 @@
       "expectedTimeForEachUnit": "HOURS"
     }
   ],
-  "testUserFiles": ["dumbledore.json", "voldemort.json", "mcgonagall.json"]
+  "testUserFiles": ["dumbledore.json", "harry.json", "mcgonagall.json"]
 }

--- a/datarepo-clienttests/src/main/resources/configs/functional/BillingProfileInUse.json
+++ b/datarepo-clienttests/src/main/resources/configs/functional/BillingProfileInUse.json
@@ -17,5 +17,5 @@
       "expectedTimeForEachUnit": "HOURS"
     }
   ],
-  "testUserFiles": ["dumbledore.json", "voldemort.json", "mcgonagall.json"]
+  "testUserFiles": ["dumbledore.json", "harry.json", "mcgonagall.json"]
 }

--- a/datarepo-clienttests/src/main/resources/configs/functional/BillingProfileOwnerHandoff.json
+++ b/datarepo-clienttests/src/main/resources/configs/functional/BillingProfileOwnerHandoff.json
@@ -17,5 +17,5 @@
       "expectedTimeForEachUnit": "HOURS"
     }
   ],
-  "testUserFiles": ["dumbledore.json", "voldemort.json", "mcgonagall.json"]
+  "testUserFiles": ["dumbledore.json", "harry.json", "mcgonagall.json"]
 }

--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -200,7 +200,7 @@ public class RepositoryApiController implements RepositoryApi {
     public ResponseEntity<JobModel> addDatasetAssetSpecifications(@PathVariable("id") String id,
                                                   @Valid @RequestBody AssetModel asset) {
         AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-        iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id, IamAction.EDIT_DATASET);
+        iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id, IamAction.MANAGE_SCHEMA);
         String jobId = datasetService.addDatasetAssetSpecifications(id, asset, userReq);
         return jobToResponse(jobService.retrieveJob(jobId, userReq));
     }
@@ -209,7 +209,7 @@ public class RepositoryApiController implements RepositoryApi {
     public ResponseEntity<JobModel> removeDatasetAssetSpecifications(@PathVariable("id") String id,
                                                                      @PathVariable("assetId") String assetId) {
         AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-        iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id, IamAction.EDIT_DATASET);
+        iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id, IamAction.MANAGE_SCHEMA);
         String jobId = datasetService.removeDatasetAssetSpecifications(id, assetId, userReq);
         return jobToResponse(jobService.retrieveJob(jobId, userReq));
     }
@@ -219,7 +219,7 @@ public class RepositoryApiController implements RepositoryApi {
     public ResponseEntity<JobModel> deleteFile(@PathVariable("id") String id,
                                                @PathVariable("fileid") String fileid) {
         AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-        iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id, IamAction.UPDATE_DATA);
+        iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id, IamAction.SOFT_DELETE);
         String jobId = fileService.deleteFile(id, fileid, userReq);
         // we can retrieve the job we just created
         return jobToResponse(jobService.retrieveJob(jobId, userReq));
@@ -328,7 +328,7 @@ public class RepositoryApiController implements RepositoryApi {
                 userReq,
                 IamResourceType.DATASET,
                 sourceId.toString(),
-                IamAction.CREATE_DATASNAPSHOT))
+                IamAction.LINK_SNAPSHOT))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -23,6 +23,7 @@ import bio.terra.service.snapshot.exception.AssetNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -104,7 +105,7 @@ public class DatasetService {
     public EnumerateDatasetModel enumerate(
         int offset, int limit, String sort, String direction, String filter, List<UUID> resources) {
         if (resources.isEmpty()) {
-            return new EnumerateDatasetModel().total(0);
+            return new EnumerateDatasetModel().total(0).items(Collections.emptyList());
         }
         MetadataEnumeration<DatasetSummary> datasetEnum = datasetDao.enumerate(
             offset, limit, sort, direction, filter, resources);

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzPrimaryDataStep.java
@@ -57,7 +57,7 @@ public class CreateDatasetAuthzPrimaryDataStep implements Step {
             List<String> emails = new ArrayList<>();
             emails.add(policyEmails.get(IamRole.STEWARD));
             emails.add(policyEmails.get(IamRole.CUSTODIAN));
-            emails.add(policyEmails.get(IamRole.INGESTER));
+            emails.add(policyEmails.get(IamRole.SNAPSHOT_CREATOR));
             bigQueryPdao.grantReadAccessToDataset(dataset, emails);
 
         } catch (BigQueryException ex) {

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -1,16 +1,12 @@
 package bio.terra.service.dataset.flight.create;
 
-import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.flight.UnlockDatasetStep;
 import bio.terra.service.iam.AuthenticatedUserRequest;
-import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamProviderInterface;
-import bio.terra.service.iam.IamResourceType;
-import bio.terra.service.iam.flight.VerifyAuthorizationStep;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.service.profile.flight.AuthorizeBillingProfileUseStep;
@@ -35,15 +31,8 @@ public class DatasetCreateFlight extends Flight {
         ResourceService resourceService = (ResourceService) appContext.getBean("resourceService");
         BigQueryPdao bigQueryPdao = (BigQueryPdao) appContext.getBean("bigQueryPdao");
         IamProviderInterface iamClient = (IamProviderInterface) appContext.getBean("iamProvider");
-        ApplicationConfiguration appConfig = (ApplicationConfiguration) appContext.getBean("applicationConfiguration");
         ConfigurationService configService = (ConfigurationService) appContext.getBean("configurationService");
         ProfileService profileService = (ProfileService) appContext.getBean("profileService");
-
-        addStep(new VerifyAuthorizationStep(
-            iamClient,
-            IamResourceType.DATAREPO,
-            appConfig.getResourceId(),
-            IamAction.CREATE_DATASET));
 
         DatasetRequestModel datasetRequest =
             inputParameters.get(JobMapKeys.REQUEST.getKeyName(), DatasetRequestModel.class);

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
@@ -45,7 +45,7 @@ public class DatasetDataDeleteFlight extends Flight {
             iamClient,
             IamResourceType.DATASET,
             datasetId,
-            IamAction.UPDATE_DATA));
+            IamAction.SOFT_DELETE));
 
         // need to lock, need dataset name and flight id
         addStep(new LockDatasetStep(datasetDao, UUID.fromString(datasetId), true),

--- a/src/main/java/bio/terra/service/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/iam/IamAction.java
@@ -14,7 +14,6 @@ public enum IamAction {
     READ_POLICIES,
     ALTER_POLICIES,
     // datarepo
-    CREATE_DATASET,
     LIST_JOBS,
     DELETE_JOBS,
     CONFIGURE,

--- a/src/main/java/bio/terra/service/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/iam/IamAction.java
@@ -18,13 +18,15 @@ public enum IamAction {
     DELETE_JOBS,
     CONFIGURE,
     // dataset
-    EDIT_DATASET,
+    MANAGE_SCHEMA,
     READ_DATASET,
     INGEST_DATA,
-    UPDATE_DATA,
-    // snapshots
-    CREATE_DATASNAPSHOT,
-    EDIT_DATASNAPSHOT,
+    SOFT_DELETE,
+    HARD_DELETE,
+    LINK_SNAPSHOT,
+    UNLINK_SNAPSHOT,
+    // snapshots,
+    UPDATE_SNAPSHOT,
     READ_DATA,
     DISCOVER_DATA,
     // billing profiles

--- a/src/main/java/bio/terra/service/iam/IamRole.java
+++ b/src/main/java/bio/terra/service/iam/IamRole.java
@@ -8,11 +8,11 @@ public enum IamRole {
     ADMIN,
     STEWARD,
     CUSTODIAN,
-    INGESTER,
     READER,
     DISCOVERER,
     OWNER,
-    USER;
+    USER,
+    SNAPSHOT_CREATOR;
 
     @Override
     @JsonValue

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -188,14 +188,17 @@ public class SamIam implements IamProviderInterface {
         CreateResourceCorrectRequest req = new CreateResourceCorrectRequest();
         req.setResourceId(datasetId.toString());
         req.addPoliciesItem(
+            IamRole.ADMIN.toString(),
+            createAccessPolicyOne(IamRole.ADMIN, samConfig.getAdminsGroupEmail()));
+        req.addPoliciesItem(
             IamRole.STEWARD.toString(),
-            createAccessPolicyOne(IamRole.STEWARD, samConfig.getStewardsGroupEmail()));
+            createAccessPolicyOne(IamRole.STEWARD, userReq.getEmail()));
         req.addPoliciesItem(
             IamRole.CUSTODIAN.toString(),
             createAccessPolicyOne(IamRole.CUSTODIAN, userReq.getEmail()));
         req.addPoliciesItem(
-            IamRole.INGESTER.toString(),
-            createAccessPolicy(IamRole.INGESTER, null));
+            IamRole.SNAPSHOT_CREATOR.toString(),
+            createAccessPolicy(IamRole.SNAPSHOT_CREATOR, null));
 
         ResourcesApi samResourceApi = samResourcesApi(userReq.getRequiredToken());
         logger.debug(req.toString());
@@ -205,8 +208,9 @@ public class SamIam implements IamProviderInterface {
 
         // we'll want all of these roles to have read access to the underlying data,
         // so we sync and return the emails for the policies that get created by SAM
+        // Note: ADMIN explicitly does NOT require this since it does not require read access to the data
         Map<IamRole, String> policies = new HashMap<>();
-        for (IamRole role : Arrays.asList(IamRole.STEWARD, IamRole.CUSTODIAN, IamRole.INGESTER)) {
+        for (IamRole role : Arrays.asList(IamRole.STEWARD, IamRole.CUSTODIAN, IamRole.SNAPSHOT_CREATOR)) {
             String policy = syncOnePolicy(userReq, IamResourceType.DATASET, datasetId, role);
             policies.put(role, policy);
         }
@@ -230,11 +234,11 @@ public class SamIam implements IamProviderInterface {
         CreateResourceCorrectRequest req = new CreateResourceCorrectRequest();
         req.setResourceId(snapshotId.toString());
         req.addPoliciesItem(
-            IamRole.STEWARD.toString(),
-            createAccessPolicyOne(IamRole.STEWARD, samConfig.getStewardsGroupEmail()));
+            IamRole.ADMIN.toString(),
+            createAccessPolicyOne(IamRole.ADMIN, samConfig.getAdminsGroupEmail()));
         req.addPoliciesItem(
-            IamRole.CUSTODIAN.toString(),
-            createAccessPolicyOne(IamRole.CUSTODIAN, userReq.getEmail()));
+            IamRole.STEWARD.toString(),
+            createAccessPolicyOne(IamRole.STEWARD, userReq.getEmail()));
         req.addPoliciesItem(
             IamRole.READER.toString(),
             createAccessPolicy(IamRole.READER, readersList));
@@ -252,8 +256,6 @@ public class SamIam implements IamProviderInterface {
         Map<IamRole, String> policies = new HashMap<>();
         String policy = syncOnePolicy(userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.READER);
         policies.put(IamRole.READER, policy);
-        policy = syncOnePolicy(userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.CUSTODIAN);
-        policies.put(IamRole.CUSTODIAN, policy);
         policy = syncOnePolicy(userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.STEWARD);
         policies.put(IamRole.STEWARD, policy);
         return policies;
@@ -280,16 +282,14 @@ public class SamIam implements IamProviderInterface {
     }
 
     private Void createProfileResourceInner(AuthenticatedUserRequest userReq, String profileId) throws ApiException {
-        // TODO: For now we continue to give stewards access to all profiles. That is consistent with
-        //  the current behavior. When we do the migration to the new permission model we should remove
-        //  this and replace it with the admin group or similar. See DR-663
-        List<String> ownerList = Arrays.asList(userReq.getEmail(), samConfig.getStewardsGroupEmail());
-
         CreateResourceCorrectRequest req = new CreateResourceCorrectRequest();
         req.setResourceId(profileId);
         req.addPoliciesItem(
+            IamRole.ADMIN.toString(),
+            createAccessPolicyOne(IamRole.ADMIN, samConfig.getAdminsGroupEmail()));
+        req.addPoliciesItem(
             IamRole.OWNER.toString(),
-            createAccessPolicy(IamRole.OWNER, ownerList));
+            createAccessPolicyOne(IamRole.OWNER, userReq.getEmail()));
         req.addPoliciesItem(
             IamRole.USER.toString(),
             createAccessPolicy(IamRole.USER, null));

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -131,7 +131,7 @@ public class ProfileService {
                                                           AuthenticatedUserRequest user) {
         List<UUID> resources = iamService.listAuthorizedResources(user, IamResourceType.SPEND_PROFILE);
         if (resources.isEmpty()) {
-            return new EnumerateBillingProfileModel().items(Collections.emptyList()).total(0);
+            return new EnumerateBillingProfileModel().total(0).items(Collections.emptyList());
         }
         return profileDao.enumerateBillingProfiles(offset, limit, resources);
     }

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -130,7 +131,7 @@ public class ProfileService {
                                                           AuthenticatedUserRequest user) {
         List<UUID> resources = iamService.listAuthorizedResources(user, IamResourceType.SPEND_PROFILE);
         if (resources.isEmpty()) {
-            return new EnumerateBillingProfileModel().total(0);
+            return new EnumerateBillingProfileModel().items(Collections.emptyList()).total(0);
         }
         return profileDao.enumerateBillingProfiles(offset, limit, resources);
     }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -129,7 +129,7 @@ public class SnapshotService {
         List<UUID> datasetIds,
         List<UUID> resources) {
         if (resources.isEmpty()) {
-            return new EnumerateSnapshotModel().total(0);
+            return new EnumerateSnapshotModel().total(0).items(Collections.emptyList());
         }
         MetadataEnumeration<SnapshotSummary> enumeration = snapshotDao.retrieveSnapshots(offset, limit, sort, direction,
             filter, datasetIds, resources);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -34,11 +34,11 @@ public class SnapshotAuthzBqJobUserStep implements Step {
 
         Snapshot snapshot = snapshotService.retrieveByName(snapshotName);
 
-        // Allow the custodian to make queries in this project.
+        // Allow the reader to make queries in this project.
         // The underlying service provides retries so we do not need to retry this operation
         resourceService.grantPoliciesBqJobUser(
             snapshot.getProjectResource().getGoogleProjectId(),
-            Collections.singletonList(policyMap.get(IamRole.CUSTODIAN)));
+            Collections.singletonList(policyMap.get(IamRole.READER)));
 
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -49,7 +49,6 @@ public class SnapshotAuthzTabularAclStep implements Step {
         // Build the list of the policy emails that should have read access to the big query dataset
         List<String> emails = new ArrayList<>();
         emails.add(policies.get(IamRole.STEWARD));
-        emails.add(policies.get(IamRole.CUSTODIAN));
         emails.add(policies.get(IamRole.READER));
 
         try {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -446,8 +446,8 @@ paths:
           schema:
             type: string
             enum:
-              - reader
-              - discoverer
+              - owner
+              - user
         - name: memberEmail
           in: path
           description: The email of the user to remove

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -869,6 +869,7 @@ paths:
           schema:
             type: string
             enum:
+              - steward
               - reader
               - discoverer
       requestBody:
@@ -924,6 +925,7 @@ paths:
           schema:
             type: string
             enum:
+              - steward
               - reader
               - discoverer
         - name: memberEmail
@@ -1217,7 +1219,7 @@ paths:
             enum:
               - steward
               - custodian
-              - ingester
+              - snapshot_creator
       requestBody:
         description: Dataset to change the policy of
         content:
@@ -1273,7 +1275,7 @@ paths:
             enum:
               - steward
               - custodian
-              - ingester
+              - snapshot_creator
         - name: memberEmail
           in: path
           description: The email of the user to remove
@@ -3961,6 +3963,7 @@ components:
       schema:
         type: string
         enum:
+          - steward
           - reader
           - discoverer
     DatasetPolicyName:
@@ -3973,7 +3976,7 @@ components:
         enum:
           - steward
           - custodian
-          - ingester
+          - snapshot_creator
     ProfilePolicyName:
       name: policyName
       in: path

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -114,13 +114,12 @@ public class ConnectedOperations {
 
     public void stubOutSamCalls(IamProviderInterface samService) throws Exception {
         Map<IamRole, String> snapshotPolicies = new HashMap<>();
-        snapshotPolicies.put(IamRole.CUSTODIAN, "hi@hi.com");
         snapshotPolicies.put(IamRole.STEWARD, "hi@hi.com");
         snapshotPolicies.put(IamRole.READER,  "hi@hi.com");
         Map<IamRole, String> datasetPolicies = new HashMap<>();
         datasetPolicies.put(IamRole.CUSTODIAN, "hi@hi.com");
         datasetPolicies.put(IamRole.STEWARD,  "hi@hi.com");
-        datasetPolicies.put(IamRole.INGESTER,  "hi@hi.com");
+        datasetPolicies.put(IamRole.SNAPSHOT_CREATOR,  "hi@hi.com");
 
         when(samService.createSnapshotResource(any(), any(), any())).thenReturn(snapshotPolicies);
         when(samService.isAuthorized(any(), any(), any(), any())).thenReturn(Boolean.TRUE);

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -260,13 +260,8 @@ public class FileTest extends UsersBase {
             job.getStatusCode(),
             equalTo(HttpStatus.UNAUTHORIZED));
 
-        job = dataRepoFixtures.deleteFileLaunch(custodian(), datasetId, fileId);
-        assertThat("Custodian is not authorized to delete file",
-            job.getStatusCode(),
-            equalTo(HttpStatus.UNAUTHORIZED));
-
         // validates success
-        dataRepoFixtures.deleteFile(steward(), datasetId, fileId);
+        dataRepoFixtures.deleteFile(custodian(), datasetId, fileId);
     }
 
     @Test

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -48,6 +48,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -101,7 +102,7 @@ public class FileTest extends UsersBase {
     @After
     public void tearDown() throws Exception {
         if (snapshotId != null) {
-            dataRepoFixtures.deleteSnapshot(steward(), snapshotId);
+            dataRepoFixtures.deleteSnapshot(custodian(), snapshotId);
         }
         if (datasetId != null) {
             fileIds.forEach(f -> {
@@ -308,12 +309,14 @@ public class FileTest extends UsersBase {
 
         // Use DRS API to lookup the file by DRS ID
         String drsObjectId = String.format("v1_%s_%s", snapshotId, fileId);
-        DRSObject drsObject = dataRepoFixtures.drsGetObject(steward(), drsObjectId);
+        // Should fail due to insufficient permissions
+        assertThatThrownBy(() -> dataRepoFixtures.drsGetObject(steward(), drsObjectId));
+        DRSObject drsObject = dataRepoFixtures.drsGetObject(custodian(), drsObjectId);
 
         logger.info("Drs Object: {}", drsObject);
 
         TestUtils.validateDrsAccessMethods(drsObject.getAccessMethods(),
-            authService.getDirectAccessAuthToken(steward().getEmail()));
+            authService.getDirectAccessAuthToken(custodian().getEmail()));
     }
 
 }

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -147,8 +147,7 @@ public class DrsTest extends UsersBase {
         validateBQJobUserRolePresent(Arrays.asList(
             datasetIamRoles.get(IamRole.STEWARD),
             datasetIamRoles.get(IamRole.CUSTODIAN),
-            datasetIamRoles.get(IamRole.INGESTER),
-            snapshotIamRoles.get(IamRole.CUSTODIAN)
+            datasetIamRoles.get(IamRole.SNAPSHOT_CREATOR)
         ));
 
         // We don't have a DRS URI for a directory, so we back into it by computing the parent path
@@ -180,7 +179,7 @@ public class DrsTest extends UsersBase {
         validateBQJobUserRolePresent(Arrays.asList(
             datasetIamRoles.get(IamRole.STEWARD),
             datasetIamRoles.get(IamRole.CUSTODIAN),
-            datasetIamRoles.get(IamRole.INGESTER)
+            datasetIamRoles.get(IamRole.SNAPSHOT_CREATOR)
         ));
 
         // Delete dataset and make sure that project level ACLs are reset
@@ -190,7 +189,7 @@ public class DrsTest extends UsersBase {
         validateBQJobUserRoleNotPresent(Arrays.asList(
             datasetIamRoles.get(IamRole.STEWARD),
             datasetIamRoles.get(IamRole.CUSTODIAN),
-            datasetIamRoles.get(IamRole.INGESTER)
+            datasetIamRoles.get(IamRole.SNAPSHOT_CREATOR)
         ));
     }
 
@@ -283,8 +282,6 @@ public class DrsTest extends UsersBase {
      */
     private void validateContainsAcls(List<Acl> acls) {
         final Collection<String> entities = CollectionUtils.collect(acls, a -> a.getEntity().toString());
-        assertThat("Has custodian ACLs", entities, hasItem(String.format("group-%s",
-            snapshotIamRoles.get(IamRole.CUSTODIAN))));
         assertThat("Has steward ACLs", entities, hasItem(String.format("group-%s",
             snapshotIamRoles.get(IamRole.STEWARD))));
         assertThat("Has reader ACLs", entities, hasItem(String.format("group-%s",
@@ -298,8 +295,6 @@ public class DrsTest extends UsersBase {
         final Collection<String> entities = CollectionUtils.collect(acls, a -> a.getEntity().toString());
         assertThat("Doesn't have custodian ACLs", entities, not(hasItem(String.format("group-%s",
             snapshotIamRoles.get(IamRole.CUSTODIAN)))));
-        assertThat("Doesn't have steward ACLs", entities, not(hasItem(String.format("group-%s",
-            snapshotIamRoles.get(IamRole.STEWARD)))));
         assertThat("Doesn't have reader ACLs", entities, not(hasItem(String.format("group-%s",
             snapshotIamRoles.get(IamRole.READER)))));
     }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -125,6 +125,12 @@ public class EncodeFixture {
         SnapshotSummaryModel snapshotSummary = dataRepoFixtures.createSnapshot(
             custodian, datasetSummary.getName(), profileId, "encodefiletest-snapshot.json");
 
+        dataRepoFixtures.addSnapshotPolicyMember(
+            custodian,
+            snapshotSummary.getId(),
+            IamRole.STEWARD,
+            steward.getEmail());
+
         // TODO: Fix use of IamProviderInterface - see DR-494
         dataRepoFixtures.addSnapshotPolicyMember(
             custodian,

--- a/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
@@ -133,7 +133,6 @@ public class SnapshotTest extends UsersBase {
                 datasetSummaryModel.getName(),
                 profileId,
                 "ingest-test-snapshot.json");
-        createdSnapshotIds.add(snapshotSummary.getId());
 
         DataRepoResponse<JobModel> deleteSnapResp =
             dataRepoFixtures.deleteSnapshotLaunch(reader(), snapshotSummary.getId());
@@ -179,6 +178,9 @@ public class SnapshotTest extends UsersBase {
         assertThat("Dataset filters to dataSnapshots",
             enumSnapByBadDatasetId.getTotal(),
             equalTo(0));
+
+        // Delete snapshot as custodian for this test since teardown uses steward
+        dataRepoFixtures.deleteSnapshot(custodian(), snapshotSummary.getId());
     }
 
     @Test


### PR DESCRIPTION
This PR has a lot of files but not that many lines have changed.  This pr:
- No longer requires that user need the create_dataset action to perform the respective actions.  This means that users no longer need to be a part of the stewards group to create a dataset
- No longer adds the steward group to dataset and snapshot resources.  Instead, adds the user creating the resource and the admins group
- No longer adds custodians to snapshots or ingesters to datasets
- ...Does add snapshot_creators to datasets and makes it so that those users can read data
- Update openapi spec to reflect new roles
- Updates the action names as described in the design doc
- A lot of this PR is test refactoring since some of the test test assumptions are no longer accurate (e.g. dataset custodians are now allowed to delete files).

This did include a couple of drive-by fixes that were causing issues in UI/client tests or were actual bugs:
- When we fetch datasets and snapshots and profiles, we no longer return a `null` for items but rather a list
- Fix the enum for delete policy members on spend profiles (looks like it was copy/pasta from the snapshot delete policy members)