### PR TITLE
DR-1605: Update helm charts on jade-data-repo version bump

### DIFF
--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -150,19 +150,7 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
         status: ${{ job.status }}
-        fields: job,repo,message,author,took
+        fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
         channel: "#jade-alerts"
         username: "Data Repo tests"
         text: "Alpha Tests and GCR Promotion"
-    - name: "Notify QA Slack"
-      if: always()
-      uses: broadinstitute/action-slack@v3.8.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      with:
-        status: ${{ job.status }}
-        channel: "#dsde-qa"
-        username: "Data Repo tests"
-        text: "Alpha Tests and GCR Promotion"
-        fields: job,repo,message,author,took

--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -150,7 +150,19 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
         status: ${{ job.status }}
-        fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        fields: job,repo,message,author,took
         channel: "#jade-alerts"
         username: "Data Repo tests"
-        text: "Alpha Smoke tests"
+        text: "Alpha Tests and GCR Promotion"
+    - name: "Notify QA Slack"
+      if: always()
+      uses: broadinstitute/action-slack@v3.8.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        status: ${{ job.status }}
+        channel: "#dsde-qa"
+        username: "Data Repo tests"
+        text: "Alpha Tests and GCR Promotion"
+        fields: job,repo,message,author,took

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -84,7 +84,7 @@ jobs:
           secret_id: ${{ secrets.SECRET_ID }}
           alpharelease: ${{ steps.bumperstep.outputs.tag }}
           gcr_google_project: 'broad-jade-dev'
-      - name: "Update Version in helm for Integration Env"
+      - name: "Update Version in datarepo-helm and datarepo-helm-definitions"
         uses: broadinstitute/workflow-dispatch@v1
         with:
           workflow: Update integration api helm image tag

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -84,7 +84,7 @@ jobs:
           secret_id: ${{ secrets.SECRET_ID }}
           alpharelease: ${{ steps.bumperstep.outputs.tag }}
           gcr_google_project: 'broad-jade-dev'
-      - name: "Update Version in datarepo-helm and datarepo-helm-definitions"
+      - name: "Update Version for Integration Namespaces and Helm Charts"
         uses: broadinstitute/workflow-dispatch@v1
         with:
           workflow: Update integration api helm image tag

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -70,6 +70,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
+          #channel: "#jade-alerts"
           author_name: "Helm Bumper"
           only_mention_fail: smark,fb,muscles
   datarepo_helm_chart_update:
@@ -136,5 +137,6 @@ jobs:
           with:
             status: ${{ job.status }}
             fields: job,repo,message,author,took
+            #channel: "#jade-alerts"
             author_name: "Helm Bumper"
             only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -112,7 +112,7 @@ jobs:
         uses: docker://mikefarah/yq:3
         with:
           args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
-      - name: [datarepo-helm] Create pull request
+      - name: "[datarepo-helm] Create pull request"
         uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
         id: create-pr
         with:

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -1,4 +1,4 @@
-name: Update integration api helm image tag
+name: Update API Helm Image Tags
 on:
   workflow_dispatch: {}
 jobs:
@@ -69,8 +69,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          fields: job,repo,message,author,took
-          author_name: "Helm Bumper"
+          fields: job,repo,message,author,tfook
+          author_name: "[API] [datarepo-helm-definitions] Verion update for Integration namespaces"
           only_mention_fail: smark,fb,muscles
   datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
@@ -136,5 +136,5 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
-          author_name: "Helm Bumper"
+          author_name: "[API] [datarepo-helm] Verion update for Helm Charts"
           only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -3,75 +3,75 @@ on:
   workflow_dispatch: {}
 jobs:
 # new integration image updater
-  integration_helm_tag_update:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: develop
-      - name: 'Get Previous tag'
-        id: apiprevioustag
-        uses: "broadinstitute/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: 'Checkout datarepo-helm-definitions repo'
-        uses: actions/checkout@v2
-        with:
-          repository: 'broadinstitute/datarepo-helm-definitions'
-          token: ${{ secrets.HELM_REPO_TOKEN }}
-          path: datarepo-helm-definitions
-      - name: "integration-1 find and replace"
-        uses: docker://mikefarah/yq:3.3.4
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-1/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-      - name: "integration-2 find and replace"
-        uses: docker://mikefarah/yq:3.3.4
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-2/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-      - name: "integration-3 find and replace"
-        uses: docker://mikefarah/yq:3.3.4
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-3/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-      - name: "integration-4 find and replace"
-        uses: docker://mikefarah/yq:3.3.4
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-4/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-      - name: "integration-5 find and replace"
-        uses: docker://mikefarah/yq:3.3.4
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-5/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-      - name: "integration-6 find and replace"
-        uses: docker://mikefarah/yq:3.3.4
-        with:
-          args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-      - name: Create pull request
-        uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
-        id: create-pr
-        with:
-          token: ${{ secrets.TERRA_HELMFILE_TOKEN }}
-          path: datarepo-helm-definitions
-          commit-message: "Datarepo api tag version update: ${{ steps.apiprevioustag.outputs.tag }}"
-          committer: datarepo-bot <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
-          branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
-          body: |
-            Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
-            *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
-          labels: "datarepo,automerge,version-update"
-      - name: Slack job status
-        if: always()
-        uses: broadinstitute/action-slack@v3.8.0
-        with:
-          status: ${{ job.status }}
-          author_name: api_helm_bumper
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-          only_mention_fail: smark,fb,muscles
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #integration_helm_tag_update:
+  #  runs-on: ubuntu-20.04
+  #  steps:
+  #    - name: Checkout
+  #      uses: actions/checkout@v2
+  #      with:
+  #        fetch-depth: 0
+  #        ref: develop
+  #    - name: 'Get Previous tag'
+  #      id: apiprevioustag
+  #      uses: "broadinstitute/github-action-get-previous-tag@master"
+  #      env:
+  #        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  #    - name: 'Checkout datarepo-helm-definitions repo'
+  #      uses: actions/checkout@v2
+  #      with:
+  #        repository: 'broadinstitute/datarepo-helm-definitions'
+  #        token: ${{ secrets.HELM_REPO_TOKEN }}
+  #        path: datarepo-helm-definitions
+  #    - name: "integration-1 find and replace"
+  #      uses: docker://mikefarah/yq:3.3.4
+  #      with:
+  #        args: yq w -i datarepo-helm-definitions/integration/integration-1/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+  #    - name: "integration-2 find and replace"
+  #      uses: docker://mikefarah/yq:3.3.4
+  #      with:
+  #        args: yq w -i datarepo-helm-definitions/integration/integration-2/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+  #    - name: "integration-3 find and replace"
+  #      uses: docker://mikefarah/yq:3.3.4
+  #      with:
+  #        args: yq w -i datarepo-helm-definitions/integration/integration-3/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+  #    - name: "integration-4 find and replace"
+  #      uses: docker://mikefarah/yq:3.3.4
+  #      with:
+  #        args: yq w -i datarepo-helm-definitions/integration/integration-4/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+  #    - name: "integration-5 find and replace"
+  #      uses: docker://mikefarah/yq:3.3.4
+  #      with:
+  #        args: yq w -i datarepo-helm-definitions/integration/integration-5/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+  #    - name: "integration-6 find and replace"
+  #      uses: docker://mikefarah/yq:3.3.4
+  #      with:
+  #        args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+  #    - name: Create pull request
+  #      uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
+  #      id: create-pr
+  #      with:
+  #        token: ${{ secrets.TERRA_HELMFILE_TOKEN }}
+  #        path: datarepo-helm-definitions
+  #        commit-message: "Datarepo api tag version update: ${{ steps.apiprevioustag.outputs.tag }}"
+  #        committer: datarepo-bot <noreply@github.com>
+  #        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+  #        title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
+  #        branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
+  #        body: |
+  #          Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
+  #          *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
+  #        labels: "datarepo,automerge,version-update"
+  #    - name: Slack job status
+  #      if: always()
+  #      uses: broadinstitute/action-slack@v3.8.0
+  #      with:
+  #        status: ${{ job.status }}
+  #        author_name: api_helm_bumper
+  #        fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+  #        only_mention_fail: smark,fb,muscles
+  #      env:
+  #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
       steps:
@@ -128,7 +128,7 @@ jobs:
               *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
             labels: "datarepo,automerge,version-update"
         - name: Slack job status
-          if: always()
+          if: false #always()
           uses: broadinstitute/action-slack@v3.8.0
           with:
             status: ${{ job.status }}

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
-          author_name: "[API] [datarepo-helm-definitions] Verion update for Integration namespaces"
+          author_name: "[API] [datarepo-helm-definitions] Version update for Integration namespaces"
           only_mention_fail: smark,fb,muscles
   datarepo_helm_chart_update:
     runs-on: ubuntu-20.04

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -121,7 +121,7 @@ jobs:
           commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           committer: imagetagbot <robot@jade.team>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
+          title: "Datarepo datarepo-api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
           body: |
             Update datarepo-api versions in **${{ steps.apiprevioustag.outputs.tag }}**.

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -116,7 +116,7 @@ jobs:
         uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
         id: create-pr
         with:
-          token: ${{ secrets.HELM_DEF_REPO_TOKEN }}
+          token: ${{ secrets.TERRA_HELMFILE_TOKEN }}
           path: datarepo-helm
           commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           committer: imagetagbot <robot@jade.team>
@@ -124,7 +124,7 @@ jobs:
           title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
           branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
           body: |
-            Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
+            Update datarepo-api versions in **${{ steps.apiprevioustag.outputs.tag }}**.
             *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "datarepo,automerge,version-update"
       - name: "Notify Slack"

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -70,7 +70,6 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
-          #channel: "#jade-alerts"
           author_name: "Helm Bumper"
           only_mention_fail: smark,fb,muscles
   datarepo_helm_chart_update:
@@ -137,6 +136,5 @@ jobs:
           with:
             status: ${{ job.status }}
             fields: job,repo,message,author,took
-            #channel: "#jade-alerts"
             author_name: "Helm Bumper"
             only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -70,7 +70,6 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
-          #channel: "#jade-alerts"
           author_name: "Helm Bumper"
           only_mention_fail: smark,fb,muscles
     datarepo_helm_chart_update:
@@ -137,6 +136,5 @@ jobs:
           with:
             status: ${{ job.status }}
             fields: job,repo,message,author,took
-            #channel: "#jade-alerts"
             author_name: "Helm Bumper"
             only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
-          channel: "#jade-alerts"
+          #channel: "#jade-alerts"
           author_name: "Helm Bumper"
           only_mention_fail: smark,fb,muscles
     datarepo_helm_chart_update:
@@ -137,6 +137,6 @@ jobs:
           with:
             status: ${{ job.status }}
             fields: job,repo,message,author,took
-            channel: "#jade-alerts"
+            #channel: "#jade-alerts"
             author_name: "Helm Bumper"
             only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -119,7 +119,7 @@ jobs:
           token: ${{ secrets.HELM_DEF_REPO_TOKEN }}
           path: datarepo-helm
           commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
-          committer: imagetagbot <robot@jade.team>
+          committer: datarepo-bot <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
           branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -121,7 +121,7 @@ jobs:
           commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           committer: datarepo-bot <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
+          title: "Datarepo-api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
           body: |
             Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -116,7 +116,7 @@ jobs:
         uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
         id: create-pr
         with:
-          token: ${{ secrets.HELM_DEF_REPO_TOKEN }}
+          token: ${{ secrets.TERRA_HELMFILE_TOKEN }}
           path: datarepo-helm
           commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           committer: datarepo-bot <noreply@github.com>

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -72,3 +72,69 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    datarepo_helm_chart_update:
+    runs-on: ubuntu-20.04
+      steps:
+        - name: 'Checkout develop branch of jade-data-repo'
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            ref: develop
+        - name: 'Fetch latest jade-data-repo image tag'
+          id: apiprevioustag
+          uses: "broadinstitute/github-action-get-previous-tag@master"
+          env:
+            GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        - name: '[datarepo-helm] Checkout repo'
+          uses: actions/checkout@v2
+          with:
+            repository: 'broadinstitute/datarepo-helm'
+            token: ${{ secrets.HELM_REPO_TOKEN }}
+            path: datarepo-helm
+        - name: "[datarepo-helm] [value.yaml] Update image tag"
+          uses: docker://mikefarah/yq:3
+          with:
+            args: yq w -i datarepo-helm/charts/datarepo-api/values.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+        - name: "[datarepo-helm] [Chart.yaml] Update appVersion"
+          uses: docker://mikefarah/yq:3
+          with:
+            args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml appVersion ${{ steps.apiprevioustag.outputs.tag }}"
+        - name: "Fetch chart version and bump"
+          id: chartversion
+          run: |
+            version=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq r datarepo-helm/charts/datarepo-api/Chart.yaml 'version')
+            a=(`echo $version | sed 's/\./ /g'`)
+            ((a[2]++))
+            printf "increase default api version: ${a[2]}\n\n"
+            chartversion="${a[0]}.${a[1]}.${a[2]}"
+            echo "::set-output name=chartversion::$chartversion"
+        - name: "[datarepo-helm] [Chart.yaml] Update chart version"
+          uses: docker://mikefarah/yq:3
+          with:
+            args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
+        - name: [datarepo-helm] Create pull request
+          uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
+          id: create-pr
+          with:
+            token: ${{ secrets.HELM_DEF_REPO_TOKEN }}
+            path: datarepo-helm
+            commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
+            committer: imagetagbot <robot@jade.team>
+            author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+            title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
+            branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
+            body: |
+              Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
+              *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
+            labels: "datarepo,automerge,version-update"
+        - name: Slack job status
+          if: always()
+          uses: broadinstitute/action-slack@v3.8.0
+          with:
+            status: ${{ job.status }}
+            author_name: api_helm_bumper
+            fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+            only_mention_fail: smark,fb,muscles
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -72,7 +72,7 @@ jobs:
           fields: job,repo,message,author,took
           author_name: "Helm Bumper"
           only_mention_fail: smark,fb,muscles
-    datarepo_helm_chart_update:
+  datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
       steps:
         - name: 'Checkout develop branch of jade-data-repo'

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
-          channel: "#jade-alerts"
+          #channel: "#jade-alerts"
           author_name: "Helm Bumper"
           only_mention_fail: smark,fb,muscles
   datarepo_helm_chart_update:
@@ -137,6 +137,6 @@ jobs:
           with:
             status: ${{ job.status }}
             fields: job,repo,message,author,took
-            channel: "#jade-alerts"
+            #channel: "#jade-alerts"
             author_name: "Helm Bumper"
             only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -72,69 +72,69 @@ jobs:
   #      env:
   #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   #        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-    datarepo_helm_chart_update:
+  datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
-      steps:
-        - name: 'Checkout develop branch of jade-data-repo'
-          uses: actions/checkout@v2
-          with:
-            fetch-depth: 0
-            ref: develop
-        - name: 'Fetch latest jade-data-repo image tag'
-          id: apiprevioustag
-          uses: "broadinstitute/github-action-get-previous-tag@master"
-          env:
-            GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        - name: '[datarepo-helm] Checkout repo'
-          uses: actions/checkout@v2
-          with:
-            repository: 'broadinstitute/datarepo-helm'
-            token: ${{ secrets.HELM_REPO_TOKEN }}
-            path: datarepo-helm
-        - name: "[datarepo-helm] [value.yaml] Update image tag"
-          uses: docker://mikefarah/yq:3
-          with:
-            args: yq w -i datarepo-helm/charts/datarepo-api/values.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-        - name: "[datarepo-helm] [Chart.yaml] Update appVersion"
-          uses: docker://mikefarah/yq:3
-          with:
-            args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml appVersion ${{ steps.apiprevioustag.outputs.tag }}"
-        - name: "Fetch chart version and bump"
-          id: chartversion
-          run: |
-            version=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq r datarepo-helm/charts/datarepo-api/Chart.yaml 'version')
-            a=(`echo $version | sed 's/\./ /g'`)
-            ((a[2]++))
-            printf "increase default api version: ${a[2]}\n\n"
-            chartversion="${a[0]}.${a[1]}.${a[2]}"
-            echo "::set-output name=chartversion::$chartversion"
-        - name: "[datarepo-helm] [Chart.yaml] Update chart version"
-          uses: docker://mikefarah/yq:3
-          with:
-            args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
-        - name: [datarepo-helm] Create pull request
-          uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
-          id: create-pr
-          with:
-            token: ${{ secrets.HELM_DEF_REPO_TOKEN }}
-            path: datarepo-helm
-            commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
-            committer: imagetagbot <robot@jade.team>
-            author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-            title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
-            branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
-            body: |
-              Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
-              *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
-            labels: "datarepo,automerge,version-update"
-        - name: Slack job status
-          if: false #always()
-          uses: broadinstitute/action-slack@v3.8.0
-          with:
-            status: ${{ job.status }}
-            author_name: api_helm_bumper
-            fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-            only_mention_fail: smark,fb,muscles
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: 'Checkout develop branch of jade-data-repo'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: develop
+      - name: 'Fetch latest jade-data-repo image tag'
+        id: apiprevioustag
+        uses: "broadinstitute/github-action-get-previous-tag@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: '[datarepo-helm] Checkout repo'
+        uses: actions/checkout@v2
+        with:
+          repository: 'broadinstitute/datarepo-helm'
+          token: ${{ secrets.HELM_REPO_TOKEN }}
+          path: datarepo-helm
+      - name: "[datarepo-helm] [value.yaml] Update image tag"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i datarepo-helm/charts/datarepo-api/values.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: "[datarepo-helm] [Chart.yaml] Update appVersion"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml appVersion ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: "Fetch chart version and bump"
+        id: chartversion
+        run: |
+          version=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq r datarepo-helm/charts/datarepo-api/Chart.yaml 'version')
+          a=(`echo $version | sed 's/\./ /g'`)
+          ((a[2]++))
+          printf "increase default api version: ${a[2]}\n\n"
+          chartversion="${a[0]}.${a[1]}.${a[2]}"
+          echo "::set-output name=chartversion::$chartversion"
+      - name: "[datarepo-helm] [Chart.yaml] Update chart version"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
+      - name: [datarepo-helm] Create pull request
+        uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
+        id: create-pr
+        with:
+          token: ${{ secrets.HELM_DEF_REPO_TOKEN }}
+          path: datarepo-helm
+          commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
+          committer: imagetagbot <robot@jade.team>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
+          branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
+          body: |
+            Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
+            *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
+          labels: "datarepo,automerge,version-update"
+      - name: Slack job status
+        if: false #always()
+        uses: broadinstitute/action-slack@v3.8.0
+        with:
+          status: ${{ job.status }}
+          author_name: api_helm_bumper
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+          only_mention_fail: smark,fb,muscles
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
-          #channel: "#jade-alerts"
+          channel: "#jade-alerts"
           author_name: "Helm Bumper"
           only_mention_fail: smark,fb,muscles
   datarepo_helm_chart_update:
@@ -137,6 +137,6 @@ jobs:
           with:
             status: ${{ job.status }}
             fields: job,repo,message,author,took
-            #channel: "#jade-alerts"
+            channel: "#jade-alerts"
             author_name: "Helm Bumper"
             only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -74,67 +74,67 @@ jobs:
           only_mention_fail: smark,fb,muscles
   datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
-      steps:
-        - name: 'Checkout develop branch of jade-data-repo'
-          uses: actions/checkout@v2
-          with:
-            fetch-depth: 0
-            ref: develop
-        - name: 'Fetch latest jade-data-repo image tag'
-          id: apiprevioustag
-          uses: "broadinstitute/github-action-get-previous-tag@master"
-          env:
-            GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        - name: '[datarepo-helm] Checkout repo'
-          uses: actions/checkout@v2
-          with:
-            repository: 'broadinstitute/datarepo-helm'
-            token: ${{ secrets.HELM_REPO_TOKEN }}
-            path: datarepo-helm
-        - name: "[datarepo-helm] [value.yaml] Update image tag"
-          uses: docker://mikefarah/yq:3
-          with:
-            args: yq w -i datarepo-helm/charts/datarepo-api/values.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-        - name: "[datarepo-helm] [Chart.yaml] Update appVersion"
-          uses: docker://mikefarah/yq:3
-          with:
-            args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml appVersion ${{ steps.apiprevioustag.outputs.tag }}"
-        - name: "Fetch chart version and bump"
-          id: chartversion
-          run: |
-            version=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq r datarepo-helm/charts/datarepo-api/Chart.yaml 'version')
-            a=(`echo $version | sed 's/\./ /g'`)
-            ((a[2]++))
-            printf "increase default api version: ${a[2]}\n\n"
-            chartversion="${a[0]}.${a[1]}.${a[2]}"
-            echo "::set-output name=chartversion::$chartversion"
-        - name: "[datarepo-helm] [Chart.yaml] Update chart version"
-          uses: docker://mikefarah/yq:3
-          with:
-            args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
-        - name: [datarepo-helm] Create pull request
-          uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
-          id: create-pr
-          with:
-            token: ${{ secrets.HELM_DEF_REPO_TOKEN }}
-            path: datarepo-helm
-            commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
-            committer: imagetagbot <robot@jade.team>
-            author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-            title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
-            branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
-            body: |
-              Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
-              *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
-            labels: "datarepo,automerge,version-update"
-        - name: "Notify Slack"
-          if: always()
-          uses: broadinstitute/action-slack@v3.8.0
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          with:
-            status: ${{ job.status }}
-            fields: job,repo,message,author,took
-            author_name: "Helm Bumper"
-            only_mention_fail: smark,fb,muscles
+    steps:
+      - name: 'Checkout develop branch of jade-data-repo'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: develop
+      - name: 'Fetch latest jade-data-repo image tag'
+        id: apiprevioustag
+        uses: "broadinstitute/github-action-get-previous-tag@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: '[datarepo-helm] Checkout repo'
+        uses: actions/checkout@v2
+        with:
+          repository: 'broadinstitute/datarepo-helm'
+          token: ${{ secrets.HELM_REPO_TOKEN }}
+          path: datarepo-helm
+      - name: "[datarepo-helm] [value.yaml] Update image tag"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i datarepo-helm/charts/datarepo-api/values.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: "[datarepo-helm] [Chart.yaml] Update appVersion"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml appVersion ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: "Fetch chart version and bump"
+        id: chartversion
+        run: |
+          version=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq r datarepo-helm/charts/datarepo-api/Chart.yaml 'version')
+          a=(`echo $version | sed 's/\./ /g'`)
+          ((a[2]++))
+          printf "increase default api version: ${a[2]}\n\n"
+          chartversion="${a[0]}.${a[1]}.${a[2]}"
+          echo "::set-output name=chartversion::$chartversion"
+      - name: "[datarepo-helm] [Chart.yaml] Update chart version"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
+      - name: [datarepo-helm] Create pull request
+        uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
+        id: create-pr
+        with:
+          token: ${{ secrets.HELM_DEF_REPO_TOKEN }}
+          path: datarepo-helm
+          commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
+          committer: imagetagbot <robot@jade.team>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
+          branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
+          body: |
+            Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
+            *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
+          labels: "datarepo,automerge,version-update"
+      - name: "Notify Slack"
+        if: always()
+        uses: broadinstitute/action-slack@v3.8.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: job,repo,message,author,took
+          author_name: "Helm Bumper"
+          only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -71,8 +71,7 @@ jobs:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
           channel: "#jade-alerts"
-          username: "Helm Bumper"
-          text: "Update datarepo-api version in datarepo-helm-defintions for Integration namespaces"
+          author_name: "Helm Bumper"
           only_mention_fail: smark,fb,muscles
     datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
@@ -139,6 +138,5 @@ jobs:
             status: ${{ job.status }}
             fields: job,repo,message,author,took
             channel: "#jade-alerts"
-            username: "Helm Bumper"
-            text: "Update datarepo-api version in datarepo-helm chart"
+            author_name: "Helm Bumper"
             only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -61,17 +61,19 @@ jobs:
             Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
             *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "datarepo,automerge,version-update"
-      - name: Slack job status
+      - name: "Notify Slack"
         if: always()
         uses: broadinstitute/action-slack@v3.8.0
-        with:
-          status: ${{ job.status }}
-          author_name: api_helm_bumper
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-          only_mention_fail: smark,fb,muscles
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: job,repo,message,author,took
+          channel: "#jade-alerts"
+          username: "Helm Bumper"
+          text: "Update datarepo-api version in datarepo-helm-defintions for Integration namespaces"
+          only_mention_fail: smark,fb,muscles
     datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
       steps:
@@ -127,14 +129,16 @@ jobs:
               Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
               *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
             labels: "datarepo,automerge,version-update"
-        - name: Slack job status
+        - name: "Notify Slack"
           if: always()
           uses: broadinstitute/action-slack@v3.8.0
-          with:
-            status: ${{ job.status }}
-            author_name: api_helm_bumper
-            fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-            only_mention_fail: smark,fb,muscles
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          with:
+            status: ${{ job.status }}
+            fields: job,repo,message,author,took
+            channel: "#jade-alerts"
+            username: "Helm Bumper"
+            text: "Update datarepo-api version in datarepo-helm chart"
+            only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -69,7 +69,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          fields: job,repo,message,author,tfook
+          fields: job,repo,message,author,took
           author_name: "[API] [datarepo-helm-definitions] Verion update for Integration namespaces"
           only_mention_fail: smark,fb,muscles
   datarepo_helm_chart_update:
@@ -136,5 +136,5 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
-          author_name: "[API] [datarepo-helm] Verion update for Helm Charts"
+          author_name: "[API] [datarepo-helm] Version update for Helm Charts"
           only_mention_fail: smark,fb,muscles

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -3,132 +3,66 @@ on:
   workflow_dispatch: {}
 jobs:
 # new integration image updater
-  #integration_helm_tag_update:
-  #  runs-on: ubuntu-20.04
-  #  steps:
-  #    - name: Checkout
-  #      uses: actions/checkout@v2
-  #      with:
-  #        fetch-depth: 0
-  #        ref: develop
-  #    - name: 'Get Previous tag'
-  #      id: apiprevioustag
-  #      uses: "broadinstitute/github-action-get-previous-tag@master"
-  #      env:
-  #        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-  #    - name: 'Checkout datarepo-helm-definitions repo'
-  #      uses: actions/checkout@v2
-  #      with:
-  #        repository: 'broadinstitute/datarepo-helm-definitions'
-  #        token: ${{ secrets.HELM_REPO_TOKEN }}
-  #        path: datarepo-helm-definitions
-  #    - name: "integration-1 find and replace"
-  #      uses: docker://mikefarah/yq:3.3.4
-  #      with:
-  #        args: yq w -i datarepo-helm-definitions/integration/integration-1/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-  #    - name: "integration-2 find and replace"
-  #      uses: docker://mikefarah/yq:3.3.4
-  #      with:
-  #        args: yq w -i datarepo-helm-definitions/integration/integration-2/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-  #    - name: "integration-3 find and replace"
-  #      uses: docker://mikefarah/yq:3.3.4
-  #      with:
-  #        args: yq w -i datarepo-helm-definitions/integration/integration-3/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-  #    - name: "integration-4 find and replace"
-  #      uses: docker://mikefarah/yq:3.3.4
-  #      with:
-  #        args: yq w -i datarepo-helm-definitions/integration/integration-4/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-  #    - name: "integration-5 find and replace"
-  #      uses: docker://mikefarah/yq:3.3.4
-  #      with:
-  #        args: yq w -i datarepo-helm-definitions/integration/integration-5/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-  #    - name: "integration-6 find and replace"
-  #      uses: docker://mikefarah/yq:3.3.4
-  #      with:
-  #        args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-  #    - name: Create pull request
-  #      uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
-  #      id: create-pr
-  #      with:
-  #        token: ${{ secrets.TERRA_HELMFILE_TOKEN }}
-  #        path: datarepo-helm-definitions
-  #        commit-message: "Datarepo api tag version update: ${{ steps.apiprevioustag.outputs.tag }}"
-  #        committer: datarepo-bot <noreply@github.com>
-  #        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-  #        title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
-  #        branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
-  #        body: |
-  #          Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
-  #          *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
-  #        labels: "datarepo,automerge,version-update"
-  #    - name: Slack job status
-  #      if: always()
-  #      uses: broadinstitute/action-slack@v3.8.0
-  #      with:
-  #        status: ${{ job.status }}
-  #        author_name: api_helm_bumper
-  #        fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-  #        only_mention_fail: smark,fb,muscles
-  #      env:
-  #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  datarepo_helm_chart_update:
+  integration_helm_tag_update:
     runs-on: ubuntu-20.04
     steps:
-      - name: 'Checkout develop branch of jade-data-repo'
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: develop
-      - name: 'Fetch latest jade-data-repo image tag'
+      - name: 'Get Previous tag'
         id: apiprevioustag
         uses: "broadinstitute/github-action-get-previous-tag@master"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: '[datarepo-helm] Checkout repo'
+      - name: 'Checkout datarepo-helm-definitions repo'
         uses: actions/checkout@v2
         with:
-          repository: 'broadinstitute/datarepo-helm'
+          repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.HELM_REPO_TOKEN }}
-          path: datarepo-helm
-      - name: "[datarepo-helm] [value.yaml] Update image tag"
-        uses: docker://mikefarah/yq:3
+          path: datarepo-helm-definitions
+      - name: "integration-1 find and replace"
+        uses: docker://mikefarah/yq:3.3.4
         with:
-          args: yq w -i datarepo-helm/charts/datarepo-api/values.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
-      - name: "[datarepo-helm] [Chart.yaml] Update appVersion"
-        uses: docker://mikefarah/yq:3
+          args: yq w -i datarepo-helm-definitions/integration/integration-1/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: "integration-2 find and replace"
+        uses: docker://mikefarah/yq:3.3.4
         with:
-          args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml appVersion ${{ steps.apiprevioustag.outputs.tag }}"
-      - name: "Fetch chart version and bump"
-        id: chartversion
-        run: |
-          version=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq r datarepo-helm/charts/datarepo-api/Chart.yaml 'version')
-          a=(`echo $version | sed 's/\./ /g'`)
-          ((a[2]++))
-          printf "increase default api version: ${a[2]}\n\n"
-          chartversion="${a[0]}.${a[1]}.${a[2]}"
-          echo "::set-output name=chartversion::$chartversion"
-      - name: "[datarepo-helm] [Chart.yaml] Update chart version"
-        uses: docker://mikefarah/yq:3
+          args: yq w -i datarepo-helm-definitions/integration/integration-2/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: "integration-3 find and replace"
+        uses: docker://mikefarah/yq:3.3.4
         with:
-          args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
-      - name: "[datarepo-helm] Create pull request"
+          args: yq w -i datarepo-helm-definitions/integration/integration-3/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: "integration-4 find and replace"
+        uses: docker://mikefarah/yq:3.3.4
+        with:
+          args: yq w -i datarepo-helm-definitions/integration/integration-4/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: "integration-5 find and replace"
+        uses: docker://mikefarah/yq:3.3.4
+        with:
+          args: yq w -i datarepo-helm-definitions/integration/integration-5/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: "integration-6 find and replace"
+        uses: docker://mikefarah/yq:3.3.4
+        with:
+          args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+      - name: Create pull request
         uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
         id: create-pr
         with:
           token: ${{ secrets.TERRA_HELMFILE_TOKEN }}
-          path: datarepo-helm
-          commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
+          path: datarepo-helm-definitions
+          commit-message: "Datarepo api tag version update: ${{ steps.apiprevioustag.outputs.tag }}"
           committer: datarepo-bot <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: "Datarepo-api version update: ${{ steps.apiprevioustag.outputs.tag }}"
+          title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
           branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
           body: |
             Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
             *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "datarepo,automerge,version-update"
       - name: Slack job status
-        if: false #always()
+        if: always()
         uses: broadinstitute/action-slack@v3.8.0
         with:
           status: ${{ job.status }}
@@ -138,3 +72,69 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    datarepo_helm_chart_update:
+    runs-on: ubuntu-20.04
+      steps:
+        - name: 'Checkout develop branch of jade-data-repo'
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            ref: develop
+        - name: 'Fetch latest jade-data-repo image tag'
+          id: apiprevioustag
+          uses: "broadinstitute/github-action-get-previous-tag@master"
+          env:
+            GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        - name: '[datarepo-helm] Checkout repo'
+          uses: actions/checkout@v2
+          with:
+            repository: 'broadinstitute/datarepo-helm'
+            token: ${{ secrets.HELM_REPO_TOKEN }}
+            path: datarepo-helm
+        - name: "[datarepo-helm] [value.yaml] Update image tag"
+          uses: docker://mikefarah/yq:3
+          with:
+            args: yq w -i datarepo-helm/charts/datarepo-api/values.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
+        - name: "[datarepo-helm] [Chart.yaml] Update appVersion"
+          uses: docker://mikefarah/yq:3
+          with:
+            args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml appVersion ${{ steps.apiprevioustag.outputs.tag }}"
+        - name: "Fetch chart version and bump"
+          id: chartversion
+          run: |
+            version=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq r datarepo-helm/charts/datarepo-api/Chart.yaml 'version')
+            a=(`echo $version | sed 's/\./ /g'`)
+            ((a[2]++))
+            printf "increase default api version: ${a[2]}\n\n"
+            chartversion="${a[0]}.${a[1]}.${a[2]}"
+            echo "::set-output name=chartversion::$chartversion"
+        - name: "[datarepo-helm] [Chart.yaml] Update chart version"
+          uses: docker://mikefarah/yq:3
+          with:
+            args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
+        - name: [datarepo-helm] Create pull request
+          uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
+          id: create-pr
+          with:
+            token: ${{ secrets.HELM_DEF_REPO_TOKEN }}
+            path: datarepo-helm
+            commit-message: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
+            committer: imagetagbot <robot@jade.team>
+            author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+            title: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
+            branch: "version-update/${{ steps.apiprevioustag.outputs.tag }}"
+            body: |
+              Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
+              *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
+            labels: "datarepo,automerge,version-update"
+        - name: Slack job status
+          if: always()
+          uses: broadinstitute/action-slack@v3.8.0
+          with:
+            status: ${{ job.status }}
+            author_name: api_helm_bumper
+            fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+            only_mention_fail: smark,fb,muscles
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
### Update hem charts on jade-data-repo version bump
- datarepo-helm PR - https://github.com/broadinstitute/datarepo-helm/pull/93
- example passing action: https://github.com/DataBiosphere/jade-data-repo/actions/runs/575490207

- Updated Slack notifications in jade-spam channel:
![image](https://user-images.githubusercontent.com/13254229/108239229-aae12380-7117-11eb-8a0e-5c1071f85a39.png)
