### PR TITLE
DR-1626 - Use common liquibase code; remove liquibase from build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ buildscript {
 
 plugins {
     id "com.google.cloud.tools.jib" version "1.6.1"
-    id 'org.liquibase.gradle' version '2.0.1'
     id "org.gradle.test-retry" version "1.2.0"
     id 'antlr'
     id 'com.github.spotbugs' version '4.5.1'
@@ -210,7 +209,7 @@ dependencies {
         implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
         implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.1'
     } else {
-        implementation 'bio.terra:terra-common-lib:0.0.16-SNAPSHOT'
+        implementation 'bio.terra:terra-common-lib:0.0.17-SNAPSHOT'
     }
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -232,10 +231,6 @@ dependencies {
 
     // Findbugs annotations, so we can selectively suppress findbugs findings
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
-
-    liquibaseRuntime 'org.liquibase:liquibase-core:3.8.0'
-    liquibaseRuntime 'org.postgresql:postgresql:42.2.7'
-    liquibaseRuntime 'ch.qos.logback:logback-classic:1.2.3'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
@@ -365,19 +360,6 @@ task setupGeneratedDir(type: Copy) {
     into file('build/gen-expanded/app/classes')
 }
 tasks.jib.dependsOn setupGeneratedDir
-
-liquibase {
-    activities {
-        datarepo {
-            changeLogFile project.ext.dbDatarepoChangesetFile
-            url project.ext.dbDatarepoUri
-            username project.ext.dbDatarepoUsername
-            password project.ext.dbDatarepoPassword
-            logLevel 'debug'
-        }
-    }
-}
-
 
 // -- Test tasks --
 // The default 'test' task runs all of the unit tests.

--- a/src/main/java/bio/terra/service/upgrade/Migrate.java
+++ b/src/main/java/bio/terra/service/upgrade/Migrate.java
@@ -68,10 +68,8 @@ public class Migrate {
         try {
             if (allowDropAllOnStart && migrateConfiguration.getDropAllOnStart()) {
                 liquibaseMigrator.initialize(changesetFile, dataSource);
-            } else {
-                if (migrateConfiguration.getUpdateAllOnStart()) {
-                    liquibaseMigrator.upgrade(changesetFile, dataSource);
-                }
+            } else if (migrateConfiguration.getUpdateAllOnStart()) {
+                liquibaseMigrator.upgrade(changesetFile, dataSource);
             }
         } catch (bio.terra.common.migrate.MigrateException ex) {
             throw new MigrateException("Failed to migrate database from " + changesetFile, ex);


### PR DESCRIPTION
Rearranged the Migrate code to use the common lib for the actual liquibase work.

Consolidated the logging into one log statement with the state of all of the configuration (drop, update, allowDrop).

In the old code, you could say "dropAll, and do not upgradeAll", which is pretty useless. See the documentation in the code for how the booleans map to actions now.

