### PR TITLE
DR-1628 Add a dataProjectPrefix property to allow specifying the prefix to use when naming projects

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/OneProjectPerProfileIdSelector.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/OneProjectPerProfileIdSelector.java
@@ -39,7 +39,7 @@ public class OneProjectPerProfileIdSelector implements DataLocationSelector {
     private String getSuffixForProfileId(BillingProfileModel billingProfile) {
         String lowercaseProfileName = billingProfile.getProfileName().toLowerCase();
         String profileSuffix = "-" + lowercaseProfileName.replaceAll("[^a-z-0-9]", "-");
-        // The project id below is the name of the core project
-        return resourceConfiguration.getProjectId() + profileSuffix;
+        // The project id below is an application level prefix or, if that is emoty, the name of the core project
+        return resourceConfiguration.getDataProjectPrefixToUse() + profileSuffix;
     }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
@@ -113,10 +113,10 @@ public class GoogleResourceConfiguration {
     }
 
     public String getDataProjectPrefixToUse() {
-        if (StringUtils.isAllBlank(getProjectId())) {
-            return getDataProjectPrefix();
-        } else {
+        if (StringUtils.isAllBlank(getDataProjectPrefix())) {
             return getProjectId();
+        } else {
+            return getDataProjectPrefix();
         }
     }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
@@ -2,6 +2,7 @@ package bio.terra.service.resourcemanagement.google;
 
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +18,7 @@ public class GoogleResourceConfiguration {
     private String parentResourceType;
     private String parentResourceId;
     private String singleDataProjectId;
+    private String dataProjectPrefix;
     private String defaultFirestoreLocation;
     private boolean allowReuseExistingProjects;
     private boolean allowReuseExistingBuckets;
@@ -69,6 +71,14 @@ public class GoogleResourceConfiguration {
         this.singleDataProjectId = singleDataProjectId;
     }
 
+    public String getDataProjectPrefix() {
+        return dataProjectPrefix;
+    }
+
+    public void setDataProjectPrefix(String dataProjectPrefix) {
+        this.dataProjectPrefix = dataProjectPrefix;
+    }
+
     public boolean getAllowReuseExistingProjects() {
         return allowReuseExistingProjects;
     }
@@ -100,5 +110,13 @@ public class GoogleResourceConfiguration {
             .setProjectId(projectId)
             .build()
             .getService();
+    }
+
+    public String getDataProjectPrefixToUse() {
+        if (StringUtils.isAllBlank(getProjectId())) {
+            return getDataProjectPrefix();
+        } else {
+            return getProjectId();
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -71,6 +71,8 @@ google.projectCreateTimeoutSeconds=600
 google.parentResourceType=folder
 google.parentResourceId=270278425081
 google.singleDataProjectId=${GOOGLE_CLOUD_DATA_PROJECT}
+# Used to create a data project when using one-project-per-billing-profile.  If empty, uses the google.projectid value
+google.dataProjectPrefix=
 google.allowReuseExistingBuckets=false
 google.allowReuseExistingProjects=false
 google.defaultFirestoreLocation=us-central

--- a/src/test/java/bio/terra/service/resourcemanagement/OneProjectPerProfileIdSelectorTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/OneProjectPerProfileIdSelectorTest.java
@@ -114,7 +114,7 @@ public class OneProjectPerProfileIdSelectorTest {
         resourceConfiguration.setDataProjectPrefix("PREFIX");
         String projectIdWithPrefix = oneProjectPerProfileIdSelector.projectIdForDataset(datasetName, billingProfile);
         String expectedProfileIdWithPrefix =
-            resourceConfiguration.getProjectId() + "-" + billingProfile.getProfileName();
+            resourceConfiguration.getDataProjectPrefix() + "-" + billingProfile.getProfileName();
         assertThat("Project ID is what we expect after changing prefix", projectIdWithPrefix,
             equalTo(expectedProfileIdWithPrefix));
     }


### PR DESCRIPTION
This will carry us over until we choose a safer method of naming projects and buckets