### PR TITLE
Datarepo helm chart version update: 0.1.46

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '30 2 * * *' # run at 2:30 AM UTC
 env:
-  chartVersion: 0.1.45
+  chartVersion: 0.1.46
 jobs:
   alpha_promotion:
     strategy:


### PR DESCRIPTION
Update versions in **0.1.46**.
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/broadinstitute/datarepo-helm/actions/runs/582500805).*