### PR TITLE
DR-1510: Checkout jade-data-repo with broad bot user

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -38,7 +38,7 @@ jobs:
           path: datarepo-helm-definitions
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions@sh-test
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -55,13 +55,13 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions@sh-test
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions@sh-test
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
@@ -77,7 +77,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions@sh-test
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -29,8 +29,7 @@ jobs:
       - name: Checkout Develop branch of jade-data-repo
         uses: actions/checkout@v2
         with:
-          #TODO - revert before merging
-          #ref: develop
+          ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Checkout datarepo-helm-definitions repo'
         uses: actions/checkout@v2
@@ -40,7 +39,7 @@ jobs:
           path: datarepo-helm-definitions
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions@sh-test
+        uses: broadinstitute/datarepo-actions@0.36.0
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -57,13 +56,13 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions@sh-test
+        uses: broadinstitute/datarepo-actions@0.36.0
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions@sh-test
+        uses: broadinstitute/datarepo-actions@0.36.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
@@ -79,7 +78,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions@sh-test
+        uses: broadinstitute/datarepo-actions@0.36.0
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}
@@ -92,7 +91,7 @@ jobs:
           workflow: Update API Helm Image Tags
           token: ${{ secrets.WORKFLOW_DISPATCH }}
       - name: Slack job status
-        if: false #always()
+        if: always()
         uses: broadinstitute/action-slack@v3.8.0
         with:
           status: ${{ job.status }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -29,7 +29,9 @@ jobs:
       - name: Checkout Develop branch of jade-data-repo
         uses: actions/checkout@v2
         with:
-          ref: develop
+          #TODO - revert before merging
+          #ref: develop
+          token: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Checkout datarepo-helm-definitions repo'
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -90,7 +90,7 @@ jobs:
           workflow: Update API Helm Image Tags
           token: ${{ secrets.WORKFLOW_DISPATCH }}
       - name: Slack job status
-        if: always()
+        if: false #always()
         uses: broadinstitute/action-slack@v3.8.0
         with:
           status: ${{ job.status }}

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ plugins {
 
 allprojects {
     group 'bio.terra'
-    version '1.21.0-SNAPSHOT'
+    version '1.23.0-SNAPSHOT'
 
     ext {
         resourceDir = "${rootDir}/src/main/resources/api"

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ plugins {
 
 allprojects {
     group 'bio.terra'
-    version '1.23.0-SNAPSHOT'
+    version '1.24.0-SNAPSHOT'
 
     ext {
         resourceDir = "${rootDir}/src/main/resources/api"


### PR DESCRIPTION
Test Run: https://github.com/DataBiosphere/jade-data-repo/runs/1938466742?check_suite_focus=true
![Screen Shot 2021-02-19 at 4 06 40 PM](https://user-images.githubusercontent.com/13254229/108561746-c2154200-72cc-11eb-99ff-4862e094259b.png)

I added special rule for my branch to test:
![image](https://user-images.githubusercontent.com/13254229/108561888-f852c180-72cc-11eb-96bf-4a32e1033029.png)
