### PR TITLE
DR-1584: use datasetcreator to retrieve snapshot

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -156,7 +156,7 @@ public class RetrieveSnapshot extends SimpleDataset {
         datasetCreator.name);
   }
 
-  public void userJourney() throws Exception {
+  public void userJourney(TestUserSpecification testUser) throws Exception {
     ApiClient apiClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
     RepositoryApi repositoryApi = new RepositoryApi(apiClient);
 

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -156,8 +156,8 @@ public class RetrieveSnapshot extends SimpleDataset {
         datasetCreator.name);
   }
 
-  public void userJourney(TestUserSpecification testUser) throws Exception {
-    ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
+  public void userJourney() throws Exception {
+    ApiClient apiClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
     RepositoryApi repositoryApi = new RepositoryApi(apiClient);
 
     SnapshotModel snapshotModel = repositoryApi.retrieveSnapshot(snapshotSummaryModel.getId());


### PR DESCRIPTION
Follow up to this PR: https://github.com/DataBiosphere/jade-data-repo/pull/819

Note: as my comment indicates, this is a bit hacky b/c userJourney() still requires that we accept a test user in the argument.  The root issue here is that this test user is random, so they don't have access to retrieve the snapshot. We should take a more detailed look at how we want to re-work the test users to accommodate our new permission model. 