### PR TITLE
DR-1641 Introduce a config property for the number of time to retry Firestore operations

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
@@ -20,6 +20,7 @@ public class GoogleResourceConfiguration {
     private String singleDataProjectId;
     private String dataProjectPrefix;
     private String defaultFirestoreLocation;
+    private int firestoreRetries;
     private boolean allowReuseExistingProjects;
     private boolean allowReuseExistingBuckets;
 
@@ -101,6 +102,14 @@ public class GoogleResourceConfiguration {
 
     public void setDefaultFirestoreLocation(String defaultFirestoreLocation) {
         this.defaultFirestoreLocation = defaultFirestoreLocation;
+    }
+
+    public int getFirestoreRetries() {
+        return firestoreRetries;
+    }
+
+    public void setFirestoreRetries(int firestoreRetries) {
+        this.firestoreRetries = firestoreRetries;
     }
 
     // TODO: Is this used?

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -76,5 +76,6 @@ google.dataProjectPrefix=
 google.allowReuseExistingBuckets=false
 google.allowReuseExistingProjects=false
 google.defaultFirestoreLocation=us-central
+google.firestoreRetries=10
 management.health.probes.enabled=true
 management.endpoints.web.exposure.include=*

--- a/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.filedata.google.firestore;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
+import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -18,7 +19,10 @@ public class BatchOperationTest {
 
     @Before
     public void setup() {
-        fireStoreUtils = new FireStoreUtils();
+        GoogleResourceConfiguration resourceConfiguration = new GoogleResourceConfiguration();
+        resourceConfiguration.setFirestoreRetries(4);
+
+        fireStoreUtils = new FireStoreUtils(resourceConfiguration);
     }
 
     @Test


### PR DESCRIPTION
And change the effective value from 4 to 10