### PR TITLE
DR-1510, DR-1661: Use merger for perf test run; Bump datarepo-actions version across workflows

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -40,7 +40,7 @@ jobs:
           path: datarepo-helm-definitions
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -57,13 +57,13 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
@@ -79,7 +79,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -48,7 +48,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -78,22 +78,22 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an availble namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -102,27 +102,27 @@ jobs:
           helm_gcloud_sqlproxy_chart_version: 0.19.7
           helm_oidc_proxy_chart_version: 0.0.19
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'waitfordeployment'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.36.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
       - name: "Notify Jade Slack on nightly test run"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -9,7 +9,6 @@ env:
   TDR_LOG_APPENDER: Console-Standard
   #variables needed for datarepo-actions/actions/main
   GOOGLE_SA_CERT: 'jade-dev-account.pem'
-  GOOGLE_PROJECT: broad-jade-perf
 on:
   workflow_dispatch: {}
   schedule:
@@ -78,6 +77,7 @@ jobs:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
+          google_project: broad-jade-perf
       - name: 'Checkout datarepo-helm-definitions repo'
         uses: actions/checkout@v2
         with:
@@ -148,6 +148,7 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.39.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
+          google_project: broad-jade-perf
       - name: "Notify Jade Slack"
         if: always()
         uses: broadinstitute/action-slack@v3.8.0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -98,8 +98,10 @@ jobs:
           SWITCH_DIRECTORIES: "true"
           MERGE_BRANCH: master
       - name: "Install Helmfile"
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/setup-helmfile@v0.6.0 #Forked from mamezou-tech/setup-helmfile
-      - name: "Use helmfile to delete and reapply helm for api pod"
+      - name: "Use helmfile reapply helm for api pod to update version"
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm-definitions/perf/datarepo/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_VERSION }}
       - name: "[datarepo-helm-definitions] Merge version update"
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/datarepo-actions/actions/merger@0.39.0
         env:
           COMMIT_MESSAGE:  "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_VERSION }}"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -70,26 +70,11 @@ jobs:
             gcloud container clusters get-credentials ${K8_CLUSTER} --zone ${GOOGLE_ZONE}
           fi
       - name: "Whitelist Runner IP"
-        run: |
-          CUR_IPS=$(gcloud container clusters describe ${K8_CLUSTER} --format json | \
-            jq -r '[.masterAuthorizedNetworksConfig.cidrBlocks[] | .cidrBlock]')
-            RUNNER_IP=$(curl 'https://api.ipify.org/?format=text' | xargs printf '[ "%s/32" ]')
-            NEW_IPS=$(printf '%s\n' $CUR_IPS $RUNNER_IP | jq -s -r 'add | unique | join(",")')
-          for i in {1..5}; do
-            if gcloud container clusters update ${K8_CLUSTER} \
-              --enable-master-authorized-networks \
-              --master-authorized-networks ${NEW_IPS}; then
-              echo "Successful whitelist"
-              break
-            else
-              echo "Failed to whitelist - Retrying"
-              sleep 15
-              if [ i == 5 ]; then
-                echo "Failed to whitelist - Terminating"
-                exit 1
-              fi
-            fi
-          done
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
+        with:
+          actions_subcommand: 'gcp_whitelist'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
       - name: 'Checkout datarepo-helm-definitions repo'
         uses: actions/checkout@v2
         with:
@@ -157,17 +142,9 @@ jobs:
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Clean whitelisted Runner IP"
         if: always()
-        run: |
-          # export the original IP list so it can be restored during cleanup
-          CUR_IPS=$(gcloud container clusters describe ${K8_CLUSTER} --format json | \
-            jq -r '[ .masterAuthorizedNetworksConfig.cidrBlocks[] | .cidrBlock ]')
-          RUNNER_IP=$(curl 'https://api.ipify.org/?format=text' | xargs printf '[ "%s/32" ]')
-          RUNNER_IP=$(echo ${RUNNER_IP}| jq -r '.[0]')
-          RESTORE_IPS=$(printf '%s\n' $CUR_IPS | jq -r --arg RUNNER_IP "$RUNNER_IP" '. - [ $RUNNER_IP ] | unique | join(",")')
-          # restore the original list of authorized IPs if they exist
-          gcloud container clusters update ${K8_CLUSTER} \
-            --enable-master-authorized-networks \
-            --master-authorized-networks ${RESTORE_IPS}
+        uses: broadinstitute/datarepo-actions/actions/main@0.39.0
+        with:
+          actions_subcommand: 'gcp_whitelist_clean'
       - name: "Notify Jade Slack"
         if: always()
         uses: broadinstitute/action-slack@v3.8.0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -78,19 +78,19 @@ jobs:
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
           google_project: broad-jade-perf
-      - name: 'Checkout datarepo-helm-definitions repo'
+      - name: '[Update API version on Perf] Checkout datarepo-helm-definitions repo'
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
-      - name: "Update perf image tag with semVer"
+      - name: "[Update API version on Perf] Update perf image tag with semVer"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i datarepo-helm-definitions/perf/datarepo/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_VERSION }}
-      - name: "[datarepo-helm-definitions] Merge version update"
+      - name: "[Update API version on Perf] [datarepo-helm-definitions] Merge version update"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/datarepo-actions/actions/merger@0.39.0
         env:
@@ -98,10 +98,10 @@ jobs:
           GITHUB_REPO: datarepo-helm-definitions
           SWITCH_DIRECTORIES: "true"
           MERGE_BRANCH: master
-      - name: "Install Helmfile"
+      - name: "[Update API version on Perf] Install Helmfile"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: broadinstitute/setup-helmfile@v0.6.0 #Forked from mamezou-tech/setup-helmfile
-      - name: "Use helmfile reapply helm for api pod to update version"
+      - name: "[Update API version on Perf] Use helmfile reapply helm for api pod to update version"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           helmfile --version
@@ -109,7 +109,7 @@ jobs:
           echo "Apply helm updates, including updated data-repo version"
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
-      - name: "Wait for Perf Cluster to come back up with correct version"
+      - name: "[Update API version on Perf] Wait for Perf Cluster to come back up with correct version"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -R '. | try fromjson catch {"semVer":"failedToContact"}' | jq -r '.semVer|rtrimstr("-SNAPSHOT")')

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -79,6 +79,7 @@ jobs:
           secret_id: ${{ secrets.SECRET_ID }}
           google_project: broad-jade-perf
       - name: 'Checkout datarepo-helm-definitions repo'
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
@@ -109,6 +110,7 @@ jobs:
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Wait for Perf Cluster to come back up with correct version"
+        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         run: |
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -R '. | try fromjson catch {"semVer":"failedToContact"}' | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           RETRY_COUNT=0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -102,9 +102,6 @@ jobs:
         run: |
           helmfile --version
           cd ${GITHUB_WORKSPACE}/${workingDir}/datarepo-helm-definitions/perf
-          echo "Killing perf api pod to force db migration (can be removed after DR-1544 is complete)"
-          helm delete -n perf perf-jade-datarepo-api
-          sleep 15
           echo "Apply helm updates, including updated data-repo version"
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -94,28 +94,20 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
-          token: ${{ secrets.HELM_REPO_TOKEN }}
+          token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Update perf image tag with semVer"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: docker://mikefarah/yq:3.3.4
         with:
           args: yq w -i datarepo-helm-definitions/perf/datarepo/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_VERSION }}
-      - name: "Create datarepo-helm-definition pull request with updated perf image tag"
-        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
-        uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
-        with:
-          token: ${{ secrets.HELM_REPO_TOKEN }}
-          path: datarepo-helm-definitions
-          commit-message: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_VERSION }}"
-          committer: datarepo-bot <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_VERSION }}"
-          branch: "version-update-${{ steps.read_property.outputs.LATEST_VERSION }}"
-          body: |
-            Update versions in perf env to reflect image tag ${{ steps.read_property.outputs.LATEST_VERSION }}.
-            *Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
-          labels: "datarepo,automerge,version-update"
+      - name: "[datarepo-helm-definitions] Merge version update"
+        uses: broadinstitute/datarepo-actions/actions/merger@0.39.0
+        env:
+          COMMIT_MESSAGE:  "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_VERSION }}"
+          GITHUB_REPO: datarepo-helm-definitions
+          SWITCH_DIRECTORIES: "true"
+          MERGE_BRANCH: master
       - name: "Install Helmfile"
         uses: broadinstitute/setup-helmfile@v0.6.0 #Forked from mamezou-tech/setup-helmfile
       - name: "Use helmfile to delete and reapply helm for api pod"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -109,8 +109,14 @@ jobs:
           echo "Apply helm updates, including updated data-repo version"
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
-      - name: "[Update API version on Perf] Wait for Perf Cluster to come back up with correct version"
-        if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
+      - name: "Cycle pods to clear lingering artifacts if not doing version bump"
+        if: ${{ steps.read_property.outputs.LATEST_VERSION == steps.read_property.outputs.CURRENT_SEMVER }}
+        run: |
+          echo "Cycle API pods to trigger migrations to run and clear out database"
+          kubectl delete pods -n perf -l app.kubernetes.io/name=datarepo-api
+          echo "Sleep 45 seconds to give the pods a chance to start cycling before checking if up and on correct version"
+          sleep 45
+      - name: "Wait for Perf Cluster to come back up with correct version"
         run: |
           PERF_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -R '. | try fromjson catch {"semVer":"failedToContact"}' | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           RETRY_COUNT=0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -1,13 +1,15 @@
 name: Update Perf Env and Run Nightly Test Runner Tests
 env:
   GOOGLE_APPLICATION_CREDENTIALS: /tmp/jade-dev-account.json
-  GOOGLE_SA_CERT: 'jade-dev-account.pem'
   GOOGLE_CLOUD_PROJECT: broad-jade-perf
   GOOGLE_CLOUD_DATA_PROJECT: broad-jade-perf-data2
   TEST_RUNNER_SERVER_SPECIFICATION_FILE: perf.json
   GOOGLE_ZONE: us-central1
   K8_CLUSTER: jade-master-us-central1
   TDR_LOG_APPENDER: Console-Standard
+  #variables needed for datarepo-actions/actions/main
+  GOOGLE_SA_CERT: 'jade-dev-account.pem'
+  GOOGLE_PROJECT: broad-jade-perf
 on:
   workflow_dispatch: {}
   schedule:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -6,7 +6,7 @@ env:
   TEST_RUNNER_SERVER_SPECIFICATION_FILE: perf.json
   GOOGLE_ZONE: us-central1
   K8_CLUSTER: jade-master-us-central1
-  TDR_LOG_APPENDER: Console-Standard  
+  TDR_LOG_APPENDER: Console-Standard
 on:
   workflow_dispatch: {}
   schedule:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -1,6 +1,7 @@
 name: Update Perf Env and Run Nightly Test Runner Tests
 env:
   GOOGLE_APPLICATION_CREDENTIALS: /tmp/jade-dev-account.json
+  GOOGLE_SA_CERT: 'jade-dev-account.pem'
   GOOGLE_CLOUD_PROJECT: broad-jade-perf
   GOOGLE_CLOUD_DATA_PROJECT: broad-jade-perf-data2
   TEST_RUNNER_SERVER_SPECIFICATION_FILE: perf.json

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -6,9 +6,7 @@ env:
   TEST_RUNNER_SERVER_SPECIFICATION_FILE: perf.json
   GOOGLE_ZONE: us-central1
   K8_CLUSTER: jade-master-us-central1
-  TDR_LOG_APPENDER: Console-Standard
-  #variables needed for datarepo-actions/actions/main
-  GOOGLE_SA_CERT: 'jade-dev-account.pem'
+  TDR_LOG_APPENDER: Console-Standard  
 on:
   workflow_dispatch: {}
   schedule:
@@ -73,6 +71,8 @@ jobs:
           fi
       - name: "Whitelist Runner IP"
         uses: broadinstitute/datarepo-actions/actions/main@0.39.0
+        env:
+          GOOGLE_SA_CERT: 'jade-dev-account.pem'
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
@@ -146,6 +146,8 @@ jobs:
       - name: "Clean whitelisted Runner IP"
         if: always()
         uses: broadinstitute/datarepo-actions/actions/main@0.39.0
+        env:
+          GOOGLE_SA_CERT: 'jade-dev-account.pem'
         with:
           actions_subcommand: 'gcp_whitelist_clean'
           google_project: broad-jade-perf


### PR DESCRIPTION
Includes a few changes:
- bump to new version of datarepo-actions
- Use "merger" action instead of "create PR" in Nightly Perf Test action
- Started using common whitelist action (I'm not totally sure why this started failing, but I figured it was better to use the common action instead of fixing the one-off bit of code)
- Remove "helm delete" call that used to delete the pod in order to force migrations to run in perf. We no longer need this b/c migrations run on every startup (thanks @samanehsan !!) 
- In place of the "helm delete", added a call to cycle the api pods (as opposed to a full deployment delete) in order to clear out the database in case of failed previous test run