### PR TITLE
DR-1660 Properly re-execute when updating file dependencies in Firestore

### DIFF
--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -166,7 +166,7 @@ public class FireStoreUtils {
 
     /**
      * Perform the specified Firestore operation against a specified list of inputs in batch.
-     * @param inputs A list containing the inputs to the function to be applied in batch
+     * @param inputs A list containing the inputs to the function to be applied in batch.  Note: it's a bad idea to pass futures in as the input and just have generator be an identity function since the future does not re-resolve after an initial execution
      * @param generator A generator that provides a future given an input from the inputs parameter
      * @param <T> The class of the objects in the input list
      * @param <V> The class of the objects that will result when the generated futures resolve

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -166,7 +166,9 @@ public class FireStoreUtils {
 
     /**
      * Perform the specified Firestore operation against a specified list of inputs in batch.
-     * @param inputs A list containing the inputs to the function to be applied in batch.  Note: it's a bad idea to pass futures in as the input and just have generator be an identity function since the future does not re-resolve after an initial execution
+     * @param inputs A list containing the inputs to the function to be applied in batch.  Note: it's a bad idea to
+     *               pass futures in as the input and just have generator be an identity function since the future does
+     *               not re-resolve after an initial execution
      * @param generator A generator that provides a future given an input from the inputs parameter
      * @param <T> The class of the objects in the input list
      * @param <V> The class of the objects that will result when the generated futures resolve


### PR DESCRIPTION
It looks like in this particular case, we weren't properly re-executing the future with the batch processor.  Basically, the first time it failed, it looks like our code would hold on to that initial future execution and not try to re-execute.

TLDR: It's not a good idea to use futures as an input to the `FirestoreUtils.batchOperation` function