### PR TITLE
DR-1668  - Update Alpha Promotion Action Schedule

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -10,7 +10,6 @@ env:
   chartVersion: 0.1.68
 jobs:
   alpha_promotion:
-    if: false
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -1,8 +1,12 @@
 name: Alpha Nightly Promotion
 on:
   workflow_dispatch: {}
+  #Note: We're scheduling this to run before the alpha deploy job
+  # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
-    - cron: '30 2 * * *' # run at 2:30 AM UTC
+    - cron:
+      - '* 14 * * 5'     # Fridays at 2:00 pm
+      - '* 23 * * 0-4'   # Sun - Thurs 11:00 pm
 env:
   chartVersion: 0.1.68
 jobs:

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -4,7 +4,8 @@ on:
   #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
-    - cron: '* 14 * * 5' # Fridays at 2:00 pm & Sun - Thurs 11:00 pm
+    - cron: '* 14 * * 5' # Fridays at 2:00 pm 
+    - cron: '* 23 * * 0-4' # Sun - Thurs 11:00 pm
 env:
   chartVersion: 0.1.68
 jobs:

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -4,7 +4,7 @@ on:
   #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
-    - cron: '* 14 * * 5\n* 23 * * 0-4' # Fridays at 2:00 pm & Sun - Thurs 11:00 pm
+    - cron: '* 14 * * 5' # Fridays at 2:00 pm & Sun - Thurs 11:00 pm
 env:
   chartVersion: 0.1.68
 jobs:

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -11,6 +11,7 @@ env:
   chartVersion: 0.1.68
 jobs:
   alpha_promotion:
+    if: false
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -4,9 +4,7 @@ on:
   #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
-    - cron:
-      - '* 14 * * 5'     # Fridays at 2:00 pm
-      - '* 23 * * 0-4'   # Sun - Thurs 11:00 pm
+    - cron: ['* 14 * * 5', '* 23 * * 0-4'] # Fridays at 2:00 pm & Sun - Thurs 11:00 pm
 env:
   chartVersion: 0.1.68
 jobs:

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -1,7 +1,7 @@
 name: Alpha Nightly Promotion
 on:
   workflow_dispatch: {}
-  #Note: We're scheduling this to run before the alpha deploy job
+  #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
     - cron:

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -4,7 +4,7 @@ on:
   #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
-    - cron: ['* 14 * * 5', '* 23 * * 0-4'] # Fridays at 2:00 pm & Sun - Thurs 11:00 pm
+    - cron: '* 14 * * 5\n* 23 * * 0-4' # Fridays at 2:00 pm & Sun - Thurs 11:00 pm
 env:
   chartVersion: 0.1.68
 jobs:


### PR DESCRIPTION
We should only promote to alpha right before a scheduled alpha-deploy job. Otherwise, we will get in a bad state where the version on alpha does not match the version in terra-helmfile. The version in terra-helmfile is what gets promoted to staging/production. Therefore, we can get into a state where a version that has never hit alpha is deployed to staging/production. 

Old Alpha Promotion schedule:
- Nightly at 9:30PM

New Alpha Promotion schedule:
- '* 14 * * 5' # Fridays at 2:00 pm 
-  '* 23 * * 0-4' # Sun - Thurs 11:00 pm

New Jenkins Alpha deploy schedule (https://github.com/broadinstitute/dsp-jenkins/pull/499):
- '1 15 * * 5' - Friday Afternoon: 3:01 PM
- '30 0 * * 1-5' Early Morning - 12:30AM - Monday - Friday

So, we will run alpha promotion about an hour before alpha deploy.

Review notes:
- I can't totally test this new schedule, so definitely looking for sanity checks here!
- I think the syntax for two cron schedules is right, but again, not sure. It passes basic checks by github actions: https://github.com/DataBiosphere/jade-data-repo/actions/runs/618997493
