### PR TITLE
DR-1668 fix: Need to designate 0 for minute; Convert to UTC

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -4,8 +4,8 @@ on:
   #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
-    - cron: '0 14 * * 5' # Fridays at 2:00 pm 
-    - cron: '0 23 * * 0-4' # Sun - Thurs 11:00 pm
+    - cron: '0 18 * * 5' # Fridays at 1:00 pm EST; 6PM UTC
+    - cron: '0 3 * * 1-5' # Sun - Thurs 10:00 pm EST; 3AM UTC
 env:
   chartVersion: 0.1.70
 jobs:

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -4,8 +4,8 @@ on:
   #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
-    - cron: '* 14 * * 5' # Fridays at 2:00 pm 
-    - cron: '* 23 * * 0-4' # Sun - Thurs 11:00 pm
+    - cron: '0 14 * * 5' # Fridays at 2:00 pm 
+    - cron: '0 23 * * 0-4' # Sun - Thurs 11:00 pm
 env:
   chartVersion: 0.1.70
 jobs:


### PR DESCRIPTION
I realized the alpha promotion action is running way too often. Turns out I messed up the cron schedule.
Current schedule: * 14 * * 5  =>  "At every minute past hour 14 on Friday.”
Should be: 0 14 * * => "At 14:00 on Friday."

I also realized that I set the times according to EST, but they're read as UTC. So, I think I've done the correct time translation (please correct me). And then I gave us another hour to handle the shifting EST time, but not shifting UTC time. 