### PR TITLE
[DR-1648] Increase dataset and snapshot name size limit

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2516,9 +2516,18 @@ components:
       pattern: ^[a-zA-Z0-9][_a-zA-Z0-9]*$
       type: string
       description: >
-        Dataset, table, and column names follow this pattern. This should be used for the name of any object in the
+        Dataset column names follow this pattern. This should be used for the name of any object in the
         system. It enforces BigQuery naming rules except it disallows a leading underscore so we avoid collisions with
-        any extra columns the DR adds. For table names, this is shorter than what BigQuery allows.
+        any extra columns the DR adds.
+    DatasetSnapshotNameProperty:
+      maxLength: 512
+      minLength: 1
+      pattern: ^[a-zA-Z0-9][_a-zA-Z0-9]*$
+      type: string
+      description: >
+        Dataset and snapshot names follow this pattern. It enforces BigQuery naming rules except it disallows a
+        leading underscore so we avoid collisions with any extra columns the DR adds. This is shorter than
+        what BigQuery allows.
     UniqueIdProperty:
       pattern: ^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}
       type: string
@@ -2609,7 +2618,7 @@ components:
         id:
           $ref: '#/components/schemas/UniqueIdProperty'
         name:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/DatasetSnapshotNameProperty'
         description:
           type: string
           description: Description of the dataset
@@ -2634,7 +2643,7 @@ components:
         id:
           $ref: '#/components/schemas/UniqueIdProperty'
         name:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/DatasetSnapshotNameProperty'
         description:
           type: string
           description: Description of the dataset
@@ -2653,7 +2662,7 @@ components:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/DatasetSnapshotNameProperty'
         description:
           type: string
           description: Description of the dataset
@@ -2901,7 +2910,7 @@ components:
         dataset_id:
           $ref: '#/components/schemas/UniqueIdProperty'
         dataset:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/DatasetSnapshotNameProperty'
         table:
           $ref: '#/components/schemas/ObjectNameProperty'
         path:
@@ -3198,7 +3207,7 @@ components:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/DatasetSnapshotNameProperty'
         description:
           type: string
           description: Description of the snapshot
@@ -3228,7 +3237,7 @@ components:
       type: object
       properties:
         datasetName:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/DatasetSnapshotNameProperty'
         mode:
           type: string
           enum:
@@ -3308,7 +3317,7 @@ components:
         id:
           $ref: '#/components/schemas/UniqueIdProperty'
         name:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/DatasetSnapshotNameProperty'
         description:
           type: string
           description: Description of the snapshot
@@ -3337,7 +3346,7 @@ components:
         id:
           $ref: '#/components/schemas/UniqueIdProperty'
         name:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/DatasetSnapshotNameProperty'
         description:
           type: string
           description: Description of the snapshot

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2516,18 +2516,17 @@ components:
       pattern: ^[a-zA-Z0-9][_a-zA-Z0-9]*$
       type: string
       description: >
-        Dataset column names follow this pattern. This should be used for the name of any object in the
+        Table and column names follow this pattern. This should be used for the name of any object in the
         system. It enforces BigQuery naming rules except it disallows a leading underscore so we avoid collisions with
-        any extra columns the DR adds.
+        any extra columns the DR adds. For table and column names, this is shorter than what BigQuery allows.
     DatasetSnapshotNameProperty:
       maxLength: 512
       minLength: 1
       pattern: ^[a-zA-Z0-9][_a-zA-Z0-9]*$
       type: string
       description: >
-        Dataset and snapshot names follow this pattern. It enforces BigQuery naming rules except it disallows a
-        leading underscore so we avoid collisions with any extra columns the DR adds. This is shorter than
-        what BigQuery allows.
+        Dataset and snapshot names follow this pattern. It is the same as ObjectNameProperty, but has
+        a greater maxLength.
     UniqueIdProperty:
       pattern: ^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}
       type: string

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2520,7 +2520,7 @@ components:
         system. It enforces BigQuery naming rules except it disallows a leading underscore so we avoid collisions with
         any extra columns the DR adds. For table and column names, this is shorter than what BigQuery allows.
     DatasetSnapshotNameProperty:
-      maxLength: 512
+      maxLength: 511
       minLength: 1
       pattern: ^[a-zA-Z0-9][_a-zA-Z0-9]*$
       type: string

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -10,7 +10,7 @@
 
     <property name="identifier_type" value="varchar(63)"/>
     <property name="description_type" value="varchar(2047)"/>
-    <property name="dataset_snapshot_identifier_type" value="varchar(512)"/>
+    <property name="dataset_snapshot_identifier_type" value="varchar(511)"/>
 
     <include file="changesets/20181203_datasettable.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20190214_snapshots.yaml" relativeToChangelogFile="true"/>

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -10,6 +10,7 @@
 
     <property name="identifier_type" value="varchar(63)"/>
     <property name="description_type" value="varchar(2047)"/>
+    <property name="dataset_snapshot_identifier_type" value="varchar(512)"/>
 
     <include file="changesets/20181203_datasettable.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20190214_snapshots.yaml" relativeToChangelogFile="true"/>
@@ -34,4 +35,5 @@
     <include file="changesets/20201024_resourcemanagerrefactor2.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20201024_resourcemanagerrefactor3.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20201106_resourcedeletemarks.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20210304_allowlongdatasetandsnapshotnames.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20210304_allowlongdatasetandsnapshotnames.yaml
+++ b/src/main/resources/db/changesets/20210304_allowlongdatasetandsnapshotnames.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: allowlongdatasetandsnapshotnames
+      author: sehsan
+      changes:
+        - modifyDataType:
+            tableName: dataset
+            columnName: name
+            newDataType: ${dataset_snapshot_identifier_type}
+        - modifyDataType:
+            tableName: snapshot
+            columnName: name
+            newDataType: ${dataset_snapshot_identifier_type}

--- a/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
@@ -301,8 +301,8 @@ public class DatasetValidationsTest {
         errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(""));
         checkValidationErrorModel(errorModel, new String[]{"Size", "Pattern"});
 
-        // Make a 64 character string, it should be considered too long by the validation.
-        String tooLong = StringUtils.repeat("a", 64);
+        // Make a 513 character string, it should be considered too long by the validation.
+        String tooLong = StringUtils.repeat("a", 513);
         errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(tooLong));
         checkValidationErrorModel(errorModel, new String[]{"Size"});
     }

--- a/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
@@ -301,8 +301,8 @@ public class DatasetValidationsTest {
         errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(""));
         checkValidationErrorModel(errorModel, new String[]{"Size", "Pattern"});
 
-        // Make a 513 character string, it should be considered too long by the validation.
-        String tooLong = StringUtils.repeat("a", 513);
+        // Make a 512 character string, it should be considered too long by the validation.
+        String tooLong = StringUtils.repeat("a", 512);
         errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(tooLong));
         checkValidationErrorModel(errorModel, new String[]{"Size"});
     }

--- a/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
@@ -170,9 +170,9 @@ public class SnapshotValidationTest {
         errorModel = expectBadSnapshotCreateRequest(snapshotByAssetRequest);
         checkValidationErrorModel(errorModel, new String[]{"Size", "Pattern"});
 
-        // Make a 513 character string, it should be considered too long by the validation.
-        // Note: a 512 character string, we are okay with
-        String tooLong = StringUtils.repeat("a", 513);
+        // Make a 512 character string, it should be considered too long by the validation.
+        // Note: a 511 character string, we are okay with
+        String tooLong = StringUtils.repeat("a", 512);
         snapshotByAssetRequest.name(tooLong);
         errorModel = expectBadSnapshotCreateRequest(snapshotByAssetRequest);
         checkValidationErrorModel(errorModel, new String[]{"Size"});
@@ -222,8 +222,8 @@ public class SnapshotValidationTest {
         errorModel = expectBadSnapshotCreateRequest(snapshotByAssetRequest);
         checkValidationErrorModel(errorModel, new String[]{"Size", "Pattern"});
 
-        // Make a 513 character string, it should be considered too long by the validation.
-        String tooLong = StringUtils.repeat("a", 513);
+        // Make a 512 character string, it should be considered too long by the validation.
+        String tooLong = StringUtils.repeat("a", 512);
         contents.setDatasetName(tooLong);
         errorModel = expectBadSnapshotCreateRequest(snapshotByAssetRequest);
         checkValidationErrorModel(errorModel, new String[]{"Size"});

--- a/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
@@ -170,9 +170,9 @@ public class SnapshotValidationTest {
         errorModel = expectBadSnapshotCreateRequest(snapshotByAssetRequest);
         checkValidationErrorModel(errorModel, new String[]{"Size", "Pattern"});
 
-        // Make a 64 character string, it should be considered too long by the validation.
-        // Note: a 63 character string, we are okay with
-        String tooLong = StringUtils.repeat("a", 64);
+        // Make a 513 character string, it should be considered too long by the validation.
+        // Note: a 512 character string, we are okay with
+        String tooLong = StringUtils.repeat("a", 513);
         snapshotByAssetRequest.name(tooLong);
         errorModel = expectBadSnapshotCreateRequest(snapshotByAssetRequest);
         checkValidationErrorModel(errorModel, new String[]{"Size"});
@@ -222,8 +222,8 @@ public class SnapshotValidationTest {
         errorModel = expectBadSnapshotCreateRequest(snapshotByAssetRequest);
         checkValidationErrorModel(errorModel, new String[]{"Size", "Pattern"});
 
-        // Make a 64 character string, it should be considered too long by the validation.
-        String tooLong = StringUtils.repeat("a", 64);
+        // Make a 513 character string, it should be considered too long by the validation.
+        String tooLong = StringUtils.repeat("a", 513);
         contents.setDatasetName(tooLong);
         errorModel = expectBadSnapshotCreateRequest(snapshotByAssetRequest);
         checkValidationErrorModel(errorModel, new String[]{"Size"});


### PR DESCRIPTION
Change the size limit from 63 to 512 in both the database and API schema validation. 