### PR TITLE
DR-1708: "Alpha Nightly Promotion": Switch tokens and add slack notifications

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -4,8 +4,8 @@ on:
   #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
-    - cron: '0 14 * * 5' # Fridays at 2:00 pm 
-    - cron: '0 23 * * 0-4' # Sun - Thurs 11:00 pm
+    - cron: '0 18 * * 5' # Fridays at 1:00 pm EST; 6PM UTC
+    - cron: '0 3 * * 1-5' # Sun - Thurs 10:00 pm EST; 3AM UTC
 env:
   chartVersion: 0.1.70
 jobs:

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -64,6 +64,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required to work with job field
         with:
           status: ${{ job.status }}
           fields: job,repo,message

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -4,8 +4,8 @@ on:
   #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
   schedule:
-    - cron: '* 14 * * 5' # Fridays at 2:00 pm 
-    - cron: '* 23 * * 0-4' # Sun - Thurs 11:00 pm
+    - cron: '0 14 * * 5' # Fridays at 2:00 pm 
+    - cron: '0 23 * * 0-4' # Sun - Thurs 11:00 pm
 env:
   chartVersion: 0.1.70
 jobs:

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/terra-helmfile'
-          token: ${{ secrets.TERRA_HELMFILE_TOKEN }}
+          token: ${{ secrets.BROADBOT_TOKEN}}
           path: terra-helmfile
           persist-credentials: false
       - name: "Find and replace Datarepo version in versions.yaml"
@@ -47,7 +47,7 @@ jobs:
         uses: broadinstitute/create-pull-request@v3.5.0 # forked from peter-evans/create-pull-request
         id: create-pr
         with:
-          token: ${{ secrets.TERRA_HELMFILE_TOKEN }}
+          token: ${{ secrets.BROADBOT_TOKEN }}
           path: terra-helmfile
           commit-message: "Datarepo version update: ${{ steps.apiprevioustag.outputs.tag }}"
           committer: datarepo-bot <noreply@github.com>

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -58,3 +58,15 @@ jobs:
             Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
             *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge,version-update"
+      - name: "Notify Slack"
+        if: always()
+        uses: broadinstitute/action-slack@v3.8.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: job,repo,message
+          channel: "#jade-alerts"
+          username: "Data Repo tests"
+          text: "Alpha Nightly Promotion"


### PR DESCRIPTION
Successful Run: https://github.com/DataBiosphere/jade-data-repo/actions/runs/654076838
1. Expired token - TBD if we want to actually switch to BROADBOT or just update the TERRA_HELMFILE_TOKEN
2. Add #jade-alerts slack notification
![image](https://user-images.githubusercontent.com/13254229/111151360-ba605a80-8565-11eb-8864-23e53e0b70d2.png)
