### PR TITLE
DR-1708: switch from HELM_REPO_TOKEN to BROADBOT_TOKEN

### DIFF
--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -128,7 +128,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: 'broadinstitute/datarepo-helm'
-        token: ${{ secrets.HELM_REPO_TOKEN }}
+        token: ${{ secrets.BROADBOT_TOKEN }}
         path: datarepo-helm
     - name: "[UI][Cherry-pick to public GCR] Read UI version from datarepo-helm" 
       id: datarepohelm

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
-          token: ${{ secrets.HELM_REPO_TOKEN }}
+          token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Bump the tag to a new version"
         id: bumperstep
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'DataBiosphere/jade-data-repo-ui'
-          token: ${{ secrets.HELM_REPO_TOKEN }}
+          token: ${{ secrets.BROADBOT_TOKEN }}
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'


### PR DESCRIPTION
Run w/ changes: https://github.com/DataBiosphere/jade-data-repo/runs/2130406856?check_suite_focus=true