### PR TITLE
Fix the Firestore tests and correct checkstyle warning

### DIFF
--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -2,7 +2,6 @@ package bio.terra.service.filedata.google.firestore;
 
 import bio.terra.common.category.Connected;
 import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.FirestoreOptions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +56,7 @@ public class FireStoreDaoTest {
 
     @Before
     public void setup() throws Exception {
-        firestore = FirestoreOptions.getDefaultInstance().getService();
+        firestore = TestFirestoreProvider.getFirestore();
         pretendDatasetId = UUID.randomUUID().toString();
         collectionId = "fsdaoDset_" + pretendDatasetId;
         snapshotId = "fsdaoSnap_" + pretendDatasetId;

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
@@ -3,7 +3,6 @@ package bio.terra.service.filedata.google.firestore;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.StringListCompare;
 import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.FirestoreOptions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -53,7 +52,7 @@ public class FireStoreDirectoryDaoTest {
     public void setup() throws Exception {
         pretendDatasetId = UUID.randomUUID().toString();
         collectionId = "directoryDaoTest_" + pretendDatasetId;
-        firestore = FirestoreOptions.getDefaultInstance().getService();
+        firestore = TestFirestoreProvider.getFirestore();
     }
 
     @Test

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
@@ -10,7 +10,6 @@ import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.FirestoreOptions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -62,7 +61,7 @@ public class FireStoreFileDaoTest {
     public void setup() throws Exception {
         configurationService.reset();
         datasetId = UUID.randomUUID().toString();
-        firestore = FirestoreOptions.getDefaultInstance().getService();
+        firestore = TestFirestoreProvider.getFirestore();
     }
 
     @Test

--- a/src/test/java/bio/terra/service/filedata/google/firestore/TestFirestoreProvider.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/TestFirestoreProvider.java
@@ -1,0 +1,17 @@
+package bio.terra.service.filedata.google.firestore;
+
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+
+public final class TestFirestoreProvider {
+
+    private TestFirestoreProvider() {}
+
+    public static Firestore getFirestore() {
+        return FirestoreOptions.getDefaultInstance()
+            .toBuilder()
+            .setProjectId(System.getenv("GOOGLE_CLOUD_DATA_PROJECT"))
+            .build()
+            .getService();
+    }
+}

--- a/src/test/java/bio/terra/service/load/LoadUnitTest.java
+++ b/src/test/java/bio/terra/service/load/LoadUnitTest.java
@@ -109,7 +109,7 @@ public class LoadUnitTest {
     public void getLoadTagTest() throws Exception {
         // Should get tag from working map
         FlightMap inputParams = new FlightMap();
-        FlightContext flightContext = new FlightContext(inputParams, null, Collections.EMPTY_LIST);
+        FlightContext flightContext = new FlightContext(inputParams, null, Collections.emptyList());
         FlightMap workingMap = flightContext.getWorkingMap();
         workingMap.put(LoadMapKeys.LOAD_TAG, LoadTagsUsedByTest.LOADTAG_1.getTag());
 
@@ -119,7 +119,7 @@ public class LoadUnitTest {
         // Should get from input Params
         FlightMap inputParams1 = new FlightMap();
         inputParams1.put(LoadMapKeys.LOAD_TAG, LoadTagsUsedByTest.LOADTAG_1.getTag());
-        flightContext = new FlightContext(inputParams1, null, Collections.EMPTY_LIST);
+        flightContext = new FlightContext(inputParams1, null, Collections.emptyList());
         workingMap = flightContext.getWorkingMap();
         workingMap.put(LoadMapKeys.LOAD_TAG, LoadTagsUsedByTest.LOADTAG_2.getTag());
 
@@ -130,7 +130,7 @@ public class LoadUnitTest {
     @Test(expected = LoadLockFailureException.class)
     public void getLoadTagFailTest() throws Exception {
         FlightMap inputParams = new FlightMap();
-        FlightContext flightContext = new FlightContext(inputParams, null, Collections.EMPTY_LIST);
+        FlightContext flightContext = new FlightContext(inputParams, null, Collections.emptyList());
         loadService.getLoadTag(flightContext);
     }
 }


### PR DESCRIPTION
When testing on personal deployments, the Firestore tests need to respect the `GOOGLE_CLOUD_DATA_PROJECT` env var. 

In `LoadUnitTest`, we were using an unchecked empty list generator, causing `checkstyle` to throw a warning. There's a type-checked method that can be called to satisfy the warning.  