### PR TITLE
DR-1667 Actually return JSON parsing errors to the user

### DIFF
--- a/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
+++ b/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
@@ -31,7 +31,7 @@ public class ApiValidationExceptionHandler extends ResponseEntityExceptionHandle
     protected ResponseEntity<Object> handleExceptionInternal(
         Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {
 
-        if (HttpStatus.INTERNAL_SERVER_ERROR.equals(status)) {
+        if (HttpStatus.INTERNAL_SERVER_ERROR == status) {
             request.setAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, ex, WebRequest.SCOPE_REQUEST);
         }
 
@@ -73,4 +73,3 @@ public class ApiValidationExceptionHandler extends ResponseEntityExceptionHandle
         return builder.toString();
     }
 }
-

--- a/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
+++ b/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
@@ -35,8 +35,11 @@ public class ApiValidationExceptionHandler extends ResponseEntityExceptionHandle
             request.setAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, ex, WebRequest.SCOPE_REQUEST);
         }
 
-        Object responseBody = body == null ? new ErrorModel().message(status.name() + " - see error details")
-            .addErrorDetailItem(ex.getMessage()) : body;
+        Object responseBody = body;
+        if (responseBody == null) {
+            responseBody = new ErrorModel().message(status + " - see error details")
+                .addErrorDetailItem(ex.getMessage());
+        }
 
         return new ResponseEntity<>(responseBody, headers, status);
     }

--- a/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
+++ b/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
@@ -6,12 +6,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.util.WebUtils;
 
 import java.util.List;
 
@@ -19,6 +21,25 @@ import static java.util.stream.Collectors.toList;
 
 @ControllerAdvice
 public class ApiValidationExceptionHandler extends ResponseEntityExceptionHandler {
+
+    /**
+     * Since the default {@link ResponseEntityExceptionHandler#handleExceptionInternal}
+     * method is often passed a null body, we override it and substitute the exception's error message
+     * into an ErrorModel and return that in the response instead.
+     */
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+        Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {
+
+        if (HttpStatus.INTERNAL_SERVER_ERROR.equals(status)) {
+            request.setAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, ex, WebRequest.SCOPE_REQUEST);
+        }
+
+        Object responseBody = body == null ? new ErrorModel().message(status.name() + " - see error details")
+            .addErrorDetailItem(ex.getMessage()) : body;
+
+        return new ResponseEntity<>(responseBody, headers, status);
+    }
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(

--- a/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
@@ -122,7 +122,7 @@ public class DatasetValidationsTest {
     }
 
     @Test
-    public void TestJsonParsingErrors() throws Exception {
+    public void testJsonParsingErrors() throws Exception {
         String invalidSchema = "{\"name\":\"no_response\"," +
             "\"description\":\"Invalid dataset schema leads to no response body\"," +
             "\"defaultProfileId\":\"390e7a85-d47f-4531-b612-165fc977d3bd\"," +

--- a/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
@@ -122,6 +122,27 @@ public class DatasetValidationsTest {
     }
 
     @Test
+    public void TestJsonParsingErrors() throws Exception {
+        String invalidSchema = "{\"name\":\"no_response\"," +
+            "\"description\":\"Invalid dataset schema leads to no response body\"," +
+            "\"defaultProfileId\":\"390e7a85-d47f-4531-b612-165fc977d3bd\"," +
+            "\"schema\":{\"tables\":[{\"name\":\"table\",\"columns\":" +
+            "[{\"name\":\"column\",\"datatype\":\"fileref\",\"is_array\":true}]" +
+            ",\"primaryKey\":[\"column\"],\"partitionMode\":\"date\"," +
+            "\"datePartitionOptions\":{\"column\":\"datarepo_ingest_date\"}}]}}";
+        MvcResult result = mvc.perform(post("/api/repository/v1/datasets")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(invalidSchema))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        String responseBody = response.getContentAsString();
+        assertTrue("Json parsing errors are logged and returned",
+            responseBody.contains("JSON parse error: Unrecognized field \\\"is_array\\\""));
+    }
+
+    @Test
     public void testDuplicateTableNames() throws Exception {
         ColumnModel column = new ColumnModel().name("id").datatype("string");
         TableModel table = new TableModel()

--- a/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
@@ -127,9 +127,7 @@ public class DatasetValidationsTest {
             "\"description\":\"Invalid dataset schema leads to no response body\"," +
             "\"defaultProfileId\":\"390e7a85-d47f-4531-b612-165fc977d3bd\"," +
             "\"schema\":{\"tables\":[{\"name\":\"table\",\"columns\":" +
-            "[{\"name\":\"column\",\"datatype\":\"fileref\",\"is_array\":true}]" +
-            ",\"primaryKey\":[\"column\"],\"partitionMode\":\"date\"," +
-            "\"datePartitionOptions\":{\"column\":\"datarepo_ingest_date\"}}]}}";
+            "[{\"name\":\"column\",\"datatype\":\"fileref\",\"is_array\":true}]}]}}";
         MvcResult result = mvc.perform(post("/api/repository/v1/datasets")
             .contentType(MediaType.APPLICATION_JSON)
             .content(invalidSchema))


### PR DESCRIPTION
Currently, if we don’t specifically specify a `handler` method for one of the errors listed below, TDR will swallow the error and just return 400 with a `null` body. Instead, lets always return the exceptions message to user and be more specific when we deem it necessary.
```
HttpRequestMethodNotSupportedException.class,
HttpMediaTypeNotSupportedException.class,
HttpMediaTypeNotAcceptableException.class,
MissingPathVariableException.class,
MissingServletRequestParameterException.class,
ServletRequestBindingException.class,
ConversionNotSupportedException.class,
TypeMismatchException.class,
HttpMessageNotReadableException.class,
HttpMessageNotWritableException.class,
MethodArgumentNotValidException.class,
MissingServletRequestPartException.class,
BindException.class,
NoHandlerFoundException.class,
AsyncRequestTimeoutException.class
```