### PR TITLE
DR-1572 Use later BouncyCastleVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,6 +252,21 @@ dependencies {
     generatedCompile group: "io.swagger.core.v3", name: "swagger-annotations"
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+    constraints {
+        compile('org.bouncycastle:bcpg-jdk15on:1.68') {
+            because '1.66 has security vulnerabilities'
+        }
+        compile('org.bouncycastle:bcpkix-jdk15on:1.68') {
+            because '1.66 has security vulnerabilities'
+        }
+        compile('org.bouncycastle:bcprov-ext-jdk15on:1.68') {
+            because '1.66 has security vulnerabilities'
+        }
+        compile('org.bouncycastle:bcprov-jdk15on:1.68') {
+            because '1.66 has security vulnerabilities'
+        }
+    }
 }
 
 def getGitHash = { ->


### PR DESCRIPTION
Security scans showed that we're transitively requiring BouncyCastle version 1.66, which has vulnerabilites. We can force the use of 1.68 by using gradle's `constrains` mechanism.