### PR TITLE
Fix slack notification args

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -99,7 +99,7 @@ jobs:
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
           author_name: Integration Test
           mention: fb,muscles
-          mention_if: failure
+          if_mention: failure
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -98,7 +98,8 @@ jobs:
           status: ${{ job.status }}
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
           author_name: Integration Test
-          only_mention_fail: smark,fb,muscles
+          mention: fb,muscles
+          mention_if: failure
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -123,4 +123,4 @@ jobs:
           fields: job,repo,message,author,took
           author_name: "[API] [datarepo-helm] Version update for Helm Charts"
           mention: fb,muscles
-          mention_if: failure
+          if_mention: failure

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -63,7 +63,8 @@ jobs:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
           author_name: "[API] [datarepo-helm-definitions] Version update for Integration namespaces"
-          only_mention_fail: smark,fb,muscles
+          mention: fb,muscles
+          mention_if: failure
   datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
     steps:
@@ -121,4 +122,5 @@ jobs:
           status: ${{ job.status }}
           fields: job,repo,message,author,took
           author_name: "[API] [datarepo-helm] Version update for Helm Charts"
-          only_mention_fail: smark,fb,muscles
+          mention: fb,muscles
+          mention_if: failure


### PR DESCRIPTION
On a recent jade build I noticed this message in the update_image action output. https://github.com/DataBiosphere/jade-data-repo/actions/runs/711721159

```
Unexpected input(s) 'only_mention_fail', valid inputs are ['status', 'fields', 'custom_payload', 'mention', 'if_mention', 'author_name', 'text', 'username', 'icon_emoji', 'icon_url', 'channel', 'job_name', 'github_token']
```

The slack action parameters changed between v2 and v3 but wasn't updated when we changed from v2 to v3. https://github.com/DataBiosphere/jade-data-repo/pull/705

I also removed `smark` from the list.