### PR TITLE
Make dataset storage region configurable

### DIFF
--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -132,6 +132,15 @@ public class Dataset implements FSContainerInterface {
         return this;
     }
 
+    public Storage getStorage() {
+        return datasetSummary.getStorage();
+    }
+
+    public Dataset storage(Storage storage) {
+        datasetSummary.storage(storage);
+        return this;
+    }
+
     public UUID getDefaultProfileId() {
         return datasetSummary.getDefaultProfileId();
     }
@@ -167,4 +176,6 @@ public class Dataset implements FSContainerInterface {
         this.projectResource = projectResource;
         return this;
     }
+
+
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -316,6 +316,7 @@ public class DatasetDao {
         tableDao.createTables(dataset.getId(), dataset.getTables());
         relationshipDao.createDatasetRelationships(dataset);
         assetDao.createAssets(dataset);
+        // storageDao.createDatasetStorage -- insert into dataset_storage table
 
         logger.debug("end of createAndLock datasetId: {} for flightId: {}", dataset.getId(), flightId);
     }
@@ -448,6 +449,7 @@ public class DatasetDao {
                 sql += " AND flightid IS NULL";
             }
             MapSqlParameterSource params = new MapSqlParameterSource().addValue("id", id);
+            // would need storage info here (to enable querying)
             return jdbcTemplate.queryForObject(sql, params, new DatasetSummaryMapper());
         } catch (EmptyResultDataAccessException ex) {
             throw new DatasetNotFoundException("Dataset not found for id " + id.toString());
@@ -465,6 +467,8 @@ public class DatasetDao {
             throw new DatasetNotFoundException("Dataset not found for name " + name);
         }
     }
+
+    // public DatasetSummary retrieveSummaryByRegion(String region)
 
     /**
      * Fetch a list of all the available datasets.
@@ -528,7 +532,6 @@ public class DatasetDao {
                 .defaultProfileId(rs.getObject("default_profile_id", UUID.class))
                 .projectResourceId(rs.getObject("project_resource_id", UUID.class))
                 .createdDate(rs.getTimestamp("created_date").toInstant());
-
         }
     }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -15,6 +15,7 @@ import bio.terra.model.DatePartitionOptionsModel;
 import bio.terra.model.IntPartitionOptionsModel;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
+import bio.terra.model.StorageSpecificationModel;
 import bio.terra.model.TableModel;
 
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ public final class DatasetJsonConversion {
         Map<String, Relationship> relationshipsMap = new HashMap<>();
         List<AssetSpecification> assetSpecifications = new ArrayList<>();
         UUID defaultProfileId = UUID.fromString(datasetRequest.getDefaultProfileId());
+
         DatasetSpecificationModel datasetSpecification = datasetRequest.getSchema();
         datasetSpecification.getTables().forEach(tableModel ->
                 tablesMap.put(tableModel.getName(), tableModelToTable(tableModel)));
@@ -52,10 +54,14 @@ public final class DatasetJsonConversion {
                 assetSpecifications.add(assetModelToAssetSpecification(asset, tablesMap, relationshipsMap)));
         }
 
+        StorageSpecificationModel storageSpecification = datasetRequest.getStorage();
+        Storage storage = new Storage().region(storageSpecification.getRegion());
+
         return new Dataset(new DatasetSummary()
                 .name(datasetRequest.getName())
                 .description(datasetRequest.getDescription())
-                .defaultProfileId(defaultProfileId))
+                .defaultProfileId(defaultProfileId)
+                .storage(storage))
                 .tables(new ArrayList<>(tablesMap.values()))
                 .relationships(new ArrayList<>(relationshipsMap.values()))
                 .assetSpecifications(assetSpecifications);
@@ -68,7 +74,7 @@ public final class DatasetJsonConversion {
                 .description(dataset.getDescription())
                 .createdDate(dataset.getCreatedDate().toString())
                 .defaultProfileId(dataset.getDefaultProfileId().toString());
-
+                //.storage(datasetStorageSpecificationModelFromDataset(dataset))
     }
 
     public static DatasetModel populateDatasetModelFromDataset(Dataset dataset) {
@@ -80,6 +86,7 @@ public final class DatasetJsonConversion {
                 .createdDate(dataset.getCreatedDate().toString())
                 .schema(datasetSpecificationModelFromDatasetSchema(dataset))
                 .dataProject(dataset.getProjectResource().getGoogleProjectId());
+                //.storage(datasetStorageSpecificationModelFromDataset(dataset))
     }
 
     public static DatasetSpecificationModel datasetSpecificationModelFromDatasetSchema(Dataset dataset) {

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -10,6 +10,7 @@ public class DatasetSummary {
     private UUID defaultProfileId;
     private UUID projectResourceId;
     private Instant createdDate;
+    private Storage storage;
 
     public UUID getId() {
         return id;
@@ -62,6 +63,15 @@ public class DatasetSummary {
 
     public DatasetSummary createdDate(Instant createdDate) {
         this.createdDate = createdDate;
+        return this;
+    }
+
+    public Storage getStorage() {
+        return storage;
+    }
+
+    public DatasetSummary storage (Storage storage) {
+        this.storage = storage;
         return this;
     }
 }

--- a/src/main/java/bio/terra/service/dataset/Storage.java
+++ b/src/main/java/bio/terra/service/dataset/Storage.java
@@ -1,0 +1,27 @@
+package bio.terra.service.dataset;
+
+import java.util.UUID;
+
+public class Storage {
+    private UUID id;
+    private String region;
+
+    public Storage id(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Storage region(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+}

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsConfiguration.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Profile;
 @ConfigurationProperties(prefix = "datarepo.gcs")
 public class GcsConfiguration {
     private String bucket;
-    private String region;
+    private String region;  // this value is currently set by the application property datarepo.gcs.region
     private int connectTimeoutSeconds;
     private int readTimeoutSeconds;
 

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -69,7 +69,7 @@ public class ResourceService {
             dataLocationSelector.projectIdForFile(datasetName, billingProfile),
             billingProfile,
             null);
-
+        // need storage info here, not just datasetName
         return bucketService.getOrCreateBucket(
             dataLocationSelector.bucketForFile(datasetName, billingProfile),
             projectResource,

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -119,7 +119,7 @@ public class BigQueryPdao {
                 bigQueryProject.deleteDataset(datasetName);
             }
 
-            bigQueryProject.createDataset(datasetName, dataset.getDescription());
+            bigQueryProject.createDataset(datasetName, dataset.getDescription()); // need to specify region
             bigQueryProject.createTable(
                 datasetName, PDAO_LOAD_HISTORY_TABLE, buildLoadDatasetSchema());
             for (DatasetTable table : dataset.getTables()) {

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -84,9 +84,10 @@ public final class BigQueryProject {
     }
 
     public DatasetId createDataset(String name, String description) {
-        DatasetInfo datasetInfo = DatasetInfo.newBuilder(name)
-            .setDescription(description)
-            .build();
+        DatasetInfo.Builder builder = DatasetInfo.newBuilder(name);
+        builder.setDescription(description);
+        builder.setLocation("eu-west2"); // replace with dataset region
+        DatasetInfo datasetInfo = builder.build();
         return bigQuery.create(datasetInfo).getDatasetId();
     }
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2669,6 +2669,8 @@ components:
           $ref: '#/components/schemas/UniqueIdProperty'
         schema:
           $ref: '#/components/schemas/DatasetSpecificationModel'
+        storage:
+          $ref: '#/components/schemas/StorageSpecificationModel'
       description: >
         Complete definition of a dataset without the id (used to create a dataset)
     EnumerateDatasetModel:
@@ -2834,6 +2836,15 @@ components:
         as the unique identifier. The list of relationships provides the instructions
         for how to connect the tables. Asset tables have to be connected in a relationship
         hierarchy. So there cannot be two paths to the same table from the root.
+    StorageSpecificationModel:
+      type: object
+      properties:
+        region:
+          type: string
+          default: 'us-central1'
+        provider:
+          type: string
+          default: 'gcp'
     DatasetSpecificationModel:
       required:
         - tables

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -36,4 +36,5 @@
     <include file="changesets/20201024_resourcemanagerrefactor3.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20201106_resourcedeletemarks.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210304_allowlongdatasetandsnapshotnames.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20210406_datasetstorage.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20210406_datasetstorage.yaml
+++ b/src/main/resources/db/changesets/20210406_datasetstorage.yaml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: dataset_storage
+      author: se
+      changes:
+        - createTable:
+            tableName: dataset_storage
+            columns:
+              - column:
+                  name: id
+                  type: ${uuid_type}
+                  defaultValueComputed: ${uuid_function}
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: dataset_id
+                  type: ${uuid_type}
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_storage_dataset
+                    references: dataset(id)
+                    deleteCascade: true
+              - column:
+                  name: region
+                  type: ${identifier_type}
+                  constraints:
+                    nullable: false


### PR DESCRIPTION
This PR shows one possible way to specify a region on dataset creation, store that information, and get that information. This mainly includes comments to show which areas of the codebase are involved in making this change.

Note:
- This PR assumes one region per dataset, but instead (as proposed in the design doc) this would be an array of StorageSpecificationModel objects in the request schema.
- The DatasetResponseModel also needs to include these schema changes