### PR TITLE
DR-1560 Correct DRS Error Codes for Failed Auth

### DIFF
--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -12,8 +12,10 @@ import bio.terra.model.DRSError;
 import bio.terra.model.DRSObject;
 import bio.terra.model.DRSServiceInfo;
 import bio.terra.service.filedata.DrsService;
+import bio.terra.service.filedata.exception.InvalidDrsIdException;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.AuthenticatedUserRequestFactory;
+import bio.terra.service.iam.exception.IamForbiddenException;
 import bio.terra.service.iam.exception.IamUnauthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -99,6 +101,18 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
     public ResponseEntity<DRSError> iAmUnauthorizedExceptionHandler(IamUnauthorizedException ex) {
         DRSError error = new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.UNAUTHORIZED.value());
         return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<DRSError> iAmForbiddenExceptionHandler(IamForbiddenException ex) {
+        DRSError error = new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.FORBIDDEN.value());
+        return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<DRSError> invalidDrsIdException(InvalidDrsIdException ex) {
+        DRSError error = new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.BAD_REQUEST.value());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -14,6 +14,7 @@ import bio.terra.model.DRSServiceInfo;
 import bio.terra.service.filedata.DrsService;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.AuthenticatedUserRequestFactory;
+import bio.terra.service.iam.exception.IamUnauthorizedException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +93,12 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
     public ResponseEntity<DRSError> tooManyRequestsExceptionHandler(TooManyRequestsException ex) {
         DRSError error = new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.TOO_MANY_REQUESTS.value());
         return new ResponseEntity<>(error, HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<DRSError> iAmUnauthorizedExceptionHandler(IamUnauthorizedException ex) {
+        DRSError error = new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.UNAUTHORIZED.value());
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler

--- a/src/main/java/bio/terra/service/iam/AuthenticatedUserRequest.java
+++ b/src/main/java/bio/terra/service/iam/AuthenticatedUserRequest.java
@@ -1,6 +1,7 @@
 package bio.terra.service.iam;
 
 import bio.terra.app.controller.exception.ApiException;
+import bio.terra.service.iam.exception.IamUnauthorizedException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
@@ -55,7 +56,7 @@ public class AuthenticatedUserRequest {
     @JsonIgnore
     public String getRequiredToken() {
         if (!token.isPresent()) {
-            throw new ApiException("Token required");
+            throw new IamUnauthorizedException("An OAuth token is required.");
         }
         return token.get();
     }

--- a/src/main/java/bio/terra/service/iam/AuthenticatedUserRequest.java
+++ b/src/main/java/bio/terra/service/iam/AuthenticatedUserRequest.java
@@ -1,6 +1,5 @@
 package bio.terra.service.iam;
 
-import bio.terra.app.controller.exception.ApiException;
 import bio.terra.service.iam.exception.IamUnauthorizedException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang.builder.HashCodeBuilder;

--- a/src/main/java/bio/terra/service/iam/IamService.java
+++ b/src/main/java/bio/terra/service/iam/IamService.java
@@ -3,6 +3,7 @@ package bio.terra.service.iam;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.UserStatusInfo;
 import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.iam.exception.IamForbiddenException;
 import bio.terra.service.iam.exception.IamUnauthorizedException;
 import bio.terra.service.iam.exception.IamUnavailableException;
 import org.apache.commons.collections4.map.LRUMap;
@@ -99,7 +100,7 @@ public class IamService {
                                     IamAction action) {
         String userEmail = userReq.getEmail();
         if (!isAuthorized(userReq, iamResourceType, resourceId, action)) {
-            throw new IamUnauthorizedException("User '" + userEmail + "' does not have required action: " + action);
+            throw new IamForbiddenException("User '" + userEmail + "' does not have required action: " + action);
         }
     }
 

--- a/src/main/java/bio/terra/service/iam/exception/IamForbiddenException.java
+++ b/src/main/java/bio/terra/service/iam/exception/IamForbiddenException.java
@@ -1,0 +1,24 @@
+package bio.terra.service.iam.exception;
+
+import bio.terra.common.exception.UnauthorizedException;
+
+import java.util.List;
+
+public class IamForbiddenException extends UnauthorizedException {
+    public IamForbiddenException(String message) {
+        super(message);
+    }
+
+    public IamForbiddenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public IamForbiddenException(Throwable cause) {
+        super(cause);
+    }
+
+    public IamForbiddenException(String message, List<String> errorDetails) {
+        super(message, errorDetails);
+    }
+
+}

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -12,6 +12,7 @@ import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamRole;
 import bio.terra.service.iam.exception.IamBadRequestException;
 import bio.terra.service.iam.exception.IamConflictException;
+import bio.terra.service.iam.exception.IamForbiddenException;
 import bio.terra.service.iam.exception.IamInternalServerErrorException;
 import bio.terra.service.iam.exception.IamNotFoundException;
 import bio.terra.service.iam.exception.IamUnauthorizedException;
@@ -544,8 +545,7 @@ public class SamIam implements IamProviderInterface {
                 return new IamUnauthorizedException(message, samEx);
             }
             case HttpStatusCodes.STATUS_CODE_FORBIDDEN: {
-                // TODO: This is the wrong exception. See https://broadworkbench.atlassian.net/browse/DR-1482
-                return new IamUnauthorizedException(message, samEx);
+                return new IamForbiddenException(message, samEx);
             }
             case HttpStatusCodes.STATUS_CODE_NOT_FOUND: {
                 return new IamNotFoundException(message, samEx);

--- a/src/main/java/bio/terra/service/iam/sam/SamRetry.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamRetry.java
@@ -5,6 +5,7 @@ import bio.terra.common.exception.DataRepoException;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.iam.exception.IamInternalServerErrorException;
+import bio.terra.service.iam.exception.IamUnauthorizedException;
 import com.google.api.client.http.HttpStatusCodes;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.slf4j.Logger;
@@ -65,6 +66,8 @@ class SamRetry {
                 return function.apply();
             } catch (ApiException ex) {
                 handleApiException(ex);
+            } catch (IamUnauthorizedException ex) {
+                throw ex;
             } catch (Exception ex) {
                 throw new IamInternalServerErrorException("Unexpected exception type: " + ex.toString(), ex);
             }
@@ -81,6 +84,8 @@ class SamRetry {
                 return;
             } catch (ApiException ex) {
                 handleApiException(ex);
+            } catch (IamUnauthorizedException ex) {
+                throw ex;
             } catch (Exception ex) {
                 throw new IamInternalServerErrorException("Unexpected exception type: " + ex.toString(), ex);
             }

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -190,7 +190,7 @@ public class DataRepoClient {
         return makeDrsRequest(path, HttpMethod.GET, entity, responseClass);
     }
 
-    public ResponseEntity<String> madeUnauthenticatedDrsRequest(String path,
+    public ResponseEntity<String> makeUnauthenticatedDrsRequest(String path,
                                                             HttpMethod method) {
         return restTemplate.exchange(
             testConfig.getJadeApiUrl() + path,

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -186,10 +186,13 @@ public class DataRepoClient {
         return makeDrsRequest(path, HttpMethod.GET, entity, responseClass);
     }
 
-    public <T> DrsResponse<T> madeUnauthenticatedDrsRequest(String path,
-                                                            HttpMethod method,
-                                                            Class<T> responseClass) throws Exception {
-        return new DrsResponse<T>(makeRequest(path, method, HttpEntity.EMPTY, responseClass, DRSError.class));
+    public ResponseEntity<String> madeUnauthenticatedDrsRequest(String path,
+                                                            HttpMethod method) {
+        return restTemplate.exchange(
+            testConfig.getJadeApiUrl() + path,
+            method,
+            HttpEntity.EMPTY,
+            String.class);
     }
 
     private <T> DrsResponse<T> makeDrsRequest(String path,

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -186,6 +186,12 @@ public class DataRepoClient {
         return makeDrsRequest(path, HttpMethod.GET, entity, responseClass);
     }
 
+    public <T> DrsResponse<T> madeUnauthenticatedDrsRequest(String path,
+                                                            HttpMethod method,
+                                                            Class<T> responseClass) throws Exception {
+        return new DrsResponse<T>(makeRequest(path, method, HttpEntity.EMPTY, responseClass, DRSError.class));
+    }
+
     private <T> DrsResponse<T> makeDrsRequest(String path,
                                               HttpMethod method,
                                               HttpEntity entity,

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -280,7 +280,8 @@ public class DrsTest extends UsersBase {
 
         String nonExistentSnapshotObjectId = drsObjectId.replace(snapshotModel.getId(), UUID.randomUUID().toString());
         logger.info("Non-existent snapshot DRS Object Id - file: {}", nonExistentSnapshotObjectId);
-        DrsResponse<DRSObject> badSnapshotResponse = dataRepoFixtures.drsGetObjectRaw(reader(), nonExistentSnapshotObjectId);
+        DrsResponse<DRSObject> badSnapshotResponse = dataRepoFixtures.drsGetObjectRaw(reader(),
+            nonExistentSnapshotObjectId);
         assertThat("a 404 NOT_FOUND response is returned",
             badSnapshotResponse.getStatusCode(), equalTo(HttpStatus.NOT_FOUND));
 

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -261,10 +261,12 @@ public class DrsTest extends UsersBase {
         assertThat("a 400 BAD_REQUEST response is returned",
             badRequestResponse.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
 
-        DrsResponse<DRSObject> unauthorizedRequest = dataRepoClient.madeUnauthenticatedDrsRequest(
+        // We need to return a string here so that the test passes both locally and in kubernetes
+        // Locally, we get a json, but in the cloud, we get an HTML response from the proxy
+        DrsResponse<String> unauthorizedRequest = dataRepoClient.madeUnauthenticatedDrsRequest(
             "/ga4gh/drs/v1/objects/" + drsObjectId,
             HttpMethod.GET,
-            DRSObject.class);
+            String.class);
         assertThat("a 401 UNAUTHORIZED response is returned",
             unauthorizedRequest.getStatusCode(), equalTo(HttpStatus.UNAUTHORIZED));
 

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -272,7 +272,7 @@ public class DrsTest extends UsersBase {
         assertThat("a 403 FORBIDDEN response is returned",
             forbiddenResponse.getStatusCode(), equalTo(HttpStatus.FORBIDDEN));
 
-        String nonExistentFileDrsObjectId = String.format("v1_{%s}_{%s}", snapshotModel.getId(), UUID.randomUUID());
+        String nonExistentFileDrsObjectId = String.format("v1_%s_%s", snapshotModel.getId(), UUID.randomUUID());
         logger.info("Non-existent file DRS Object Id - file: {}", nonExistentFileDrsObjectId);
         DrsResponse<DRSObject> badFileResponse = dataRepoFixtures.drsGetObjectRaw(reader(), nonExistentFileDrsObjectId);
         assertThat("a 404 NOT_FOUND response is returned",

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -37,6 +37,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -263,10 +264,9 @@ public class DrsTest extends UsersBase {
 
         // We need to return a string here so that the test passes both locally and in kubernetes
         // Locally, we get a json, but in the cloud, we get an HTML response from the proxy
-        DrsResponse<String> unauthorizedRequest = dataRepoClient.madeUnauthenticatedDrsRequest(
+        ResponseEntity<String> unauthorizedRequest = dataRepoClient.madeUnauthenticatedDrsRequest(
             "/ga4gh/drs/v1/objects/" + drsObjectId,
-            HttpMethod.GET,
-            String.class);
+            HttpMethod.GET);
         assertThat("a 401 UNAUTHORIZED response is returned",
             unauthorizedRequest.getStatusCode(), equalTo(HttpStatus.UNAUTHORIZED));
 

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -266,7 +266,7 @@ public class DrsTest extends UsersBase {
             HttpMethod.GET,
             DRSObject.class);
         assertThat("a 401 UNAUTHORIZED response is returned",
-            badRequestResponse.getStatusCode(), equalTo(HttpStatus.UNAUTHORIZED));
+            unauthorizedRequest.getStatusCode(), equalTo(HttpStatus.UNAUTHORIZED));
 
         DrsResponse<DRSObject> forbiddenResponse = dataRepoFixtures.drsGetObjectRaw(discoverer(), drsObjectId);
         assertThat("a 403 FORBIDDEN response is returned",

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -267,7 +267,7 @@ public class DrsTest extends UsersBase {
 
         // We need to return a string here so that the test passes both locally and in kubernetes
         // Locally, we get a json, but in the cloud, we get an HTML response from the proxy
-        ResponseEntity<String> unauthorizedRequest = dataRepoClient.madeUnauthenticatedDrsRequest(
+        ResponseEntity<String> unauthorizedRequest = dataRepoClient.makeUnauthenticatedDrsRequest(
             "/ga4gh/drs/v1/objects/" + drsObjectId,
             HttpMethod.GET);
         assertThat("a 401 UNAUTHORIZED response is returned",


### PR DESCRIPTION
Instead of a 500 error being returned for authentication/authorization errors, return the right 4xx error.