### PR TITLE
Switch codeowners to jade team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @ddietterich @RoriCremer @snf2ye @fboulnois @nmalfroy @pshapiro4broad @samanehsan @tlangs @tcjiang9 @myessail
+*       @DataBiosphere/jadeteam
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @DataBiosphere/jadeteam
+*       @broadinstitute/datarepo-codeowners
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
I created a new team to track the codeowners of the data repo team instead of manually adding team members via PR. 
https://github.com/orgs/broadinstitute/teams/datarepo-codeowners