### PR TITLE
DR-1623 Provide SAM url configurations API

### DIFF
--- a/src/main/java/bio/terra/app/configuration/SamConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/SamConfiguration.java
@@ -1,4 +1,4 @@
-package bio.terra.service.iam.sam;
+package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
+++ b/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
@@ -5,6 +5,7 @@ import bio.terra.controller.UnauthenticatedApi;
 import bio.terra.model.RepositoryConfigurationModel;
 import bio.terra.model.RepositoryStatusModel;
 import bio.terra.service.configuration.StatusService;
+import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.service.job.JobService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -33,6 +34,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
     private final JobService jobService;
     private final Environment env;
     private final StatusService statusService;
+    private final SamConfiguration samConfiguration;
 
     private static final String DEFAULT_SEMVER = "1.0.0-UNKNOWN";
     private static final String DEFAULT_GITHASH = "00000000";
@@ -47,7 +49,8 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
         OauthConfiguration oauthConfig,
         JobService jobService,
         Environment env,
-        StatusService statusService
+        StatusService statusService,
+        SamConfiguration samConfiguration
     ) {
         this.objectMapper = objectMapper;
         this.request = request;
@@ -55,6 +58,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
         this.jobService = jobService;
         this.env = env;
         this.statusService = statusService;
+        this.samConfiguration = samConfiguration;
 
         Properties properties = new Properties();
         try (InputStream versionFile = getClass().getClassLoader().getResourceAsStream("version.properties")) {
@@ -89,7 +93,8 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
             .clientId(oauthConfig.getClientId())
             .activeProfiles(Arrays.asList(env.getActiveProfiles()))
             .semVer(semVer)
-            .gitHash(gitHash);
+            .gitHash(gitHash)
+            .samUrl(samConfiguration.getBasePath());
 
         return new ResponseEntity<>(configurationModel, HttpStatus.OK);
     }

--- a/src/main/java/bio/terra/service/configuration/ConfigurationService.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigurationService.java
@@ -9,7 +9,7 @@ import bio.terra.model.ConfigModel;
 import bio.terra.service.configuration.exception.ConfigNotFoundException;
 import bio.terra.service.configuration.exception.DuplicateConfigNameException;
 import bio.terra.service.filedata.google.gcs.GcsConfiguration;
-import bio.terra.service.iam.sam.SamConfiguration;
+import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -1,5 +1,6 @@
 package bio.terra.service.iam.sam;
 
+import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.exception.DataRepoException;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -1,7 +1,7 @@
 package bio.terra.service.resourcemanagement;
 
 import bio.terra.model.BillingProfileModel;
-import bio.terra.service.iam.sam.SamConfiguration;
+import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.service.resourcemanagement.exception.GoogleResourceNotFoundException;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.service.resourcemanagement.google.GoogleBucketService;

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3571,6 +3571,10 @@ components:
         gitHash:
           type: string
           description: the git hash of the data repository
+        samUrl:
+          type: string
+          format: uri
+          description: the URI of SAM this instance uses
     ConfigModel:
       type: object
       properties:

--- a/src/test/java/bio/terra/service/configuration/ConfigServiceTest.java
+++ b/src/test/java/bio/terra/service/configuration/ConfigServiceTest.java
@@ -9,7 +9,7 @@ import bio.terra.model.ConfigModel;
 import bio.terra.model.ConfigParameterModel;
 import bio.terra.service.configuration.exception.ConfigNotFoundException;
 import bio.terra.service.configuration.exception.DuplicateConfigNameException;
-import bio.terra.service.iam.sam.SamConfiguration;
+import bio.terra.app.configuration.SamConfiguration;
 import org.apache.commons.codec.binary.StringUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/src/test/java/bio/terra/service/iam/sam/SamRetryIntegrationTest.java
+++ b/src/test/java/bio/terra/service/iam/sam/SamRetryIntegrationTest.java
@@ -1,5 +1,6 @@
 package bio.terra.service.iam.sam;
 
+import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.integration.DataRepoFixtures;


### PR DESCRIPTION
In order to make the UI use the right SAM endpoint for each deployment, we need to provide it through the `configurations` endpoint on the server. At the same time, I'm moving `SamConfiguration.java` in to `bio.terra.app.configuration` so that it lives along with other application config files and conforms to the standard Spring application layout.  