### PR TITLE
DR-1724 DR-1735 Make sure trying to create a snapshot with a non-existent user fails gracefully

### DIFF
--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -595,7 +595,7 @@ public class SamIam implements IamProviderInterface {
         String openParen = (causes.size() > 1 ? "(" : "");
         String closeParen = (causes.size() > 1 ? ")" : "");
         return errorReport.getMessage() + separator +
-            openParen + StringUtils.join(causes, ", ") + closeParen;
+            openParen + String.join(", ", causes) + closeParen;
     }
 
 }

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -20,6 +20,7 @@ import bio.terra.service.iam.exception.IamUnauthorizedException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
@@ -526,13 +527,13 @@ public class SamIam implements IamProviderInterface {
         logger.warn("SAM client exception message: {}", samEx.getMessage());
         logger.warn("SAM client exception details: {}", samEx.getResponseBody());
 
-        // Sometimes the sam message is buried one level down inside of the error report object.
+        // Sometimes the sam message is buried several levels down inside of the error report object.
         // If we find an empty message then we try to deserialize the error report and use that message.
         String message = samEx.getMessage();
         if (StringUtils.isEmpty(message)) {
             try {
                 ErrorReport errorReport = objectMapper.readValue(samEx.getResponseBody(), ErrorReport.class);
-                message = errorReport.getMessage();
+                message = extractErrorMessage(errorReport);
             } catch (JsonProcessingException ex) {
                 logger.debug("Unable to deserialize sam exception response body");
             }
@@ -581,6 +582,20 @@ public class SamIam implements IamProviderInterface {
                 .ok(false)
                 .message(errorMsg + ": " + ex.toString());
         }
+    }
+
+    @VisibleForTesting
+    static String extractErrorMessage(final ErrorReport errorReport) {
+        List<String> causes = new ArrayList<>();
+        for (ErrorReport cause: errorReport.getCauses()) {
+            causes.add(extractErrorMessage(cause));
+        }
+
+        String separator = (causes.isEmpty() ? "" : ": ");
+        String openParen = (causes.size() > 1 ? "(" : "");
+        String closeParen = (causes.size() > 1 ? ")" : "");
+        return errorReport.getMessage() + separator +
+            openParen + StringUtils.join(causes, ", ") + closeParen;
     }
 
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
@@ -1,11 +1,11 @@
 package bio.terra.service.snapshot.flight.create;
 
+import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamRole;
 import bio.terra.service.iam.IamService;
-import bio.terra.service.iam.exception.IamNotFoundException;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -59,7 +59,7 @@ public class SnapshotAuthzIamStep implements Step {
             // suppress exception
             logger.error("NEEDS CLEANUP: delete sam resource for snapshot " + snapshotId.toString());
             logger.warn(ex.getMessage());
-        } catch (IamNotFoundException ex) {
+        } catch (NotFoundException ex) {
             // suppress exception
             logger.warn("Snapshot resource wasn't found to delete", ex);
         }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
@@ -5,6 +5,7 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamRole;
 import bio.terra.service.iam.IamService;
+import bio.terra.service.iam.exception.IamNotFoundException;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -58,6 +59,9 @@ public class SnapshotAuthzIamStep implements Step {
             // suppress exception
             logger.error("NEEDS CLEANUP: delete sam resource for snapshot " + snapshotId.toString());
             logger.warn(ex.getMessage());
+        } catch (IamNotFoundException ex) {
+            // suppress exception
+            logger.warn("Snapshot resource wasn't found to delete", ex);
         }
         return StepResult.getStepResultSuccess();
     }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -297,9 +297,12 @@ public class DataRepoFixtures {
         TestConfiguration.User user,
         String datasetName,
         String profileId,
-        SnapshotRequestModel requestModel) throws Exception {
+        SnapshotRequestModel requestModel,
+        boolean randomizeName) throws Exception {
 
-        requestModel.setName(Names.randomizeName(requestModel.getName()));
+        if (randomizeName) {
+            requestModel.setName(Names.randomizeName(requestModel.getName()));
+        }
         requestModel.getContents().get(0).setDatasetName(datasetName);
         requestModel.setProfileId(profileId);
         String json = TestUtils.mapToJson(requestModel);
@@ -316,7 +319,17 @@ public class DataRepoFixtures {
         String datasetName,
         String profileId,
         SnapshotRequestModel snapshotRequest) throws Exception {
-        DataRepoResponse<JobModel> jobResponse = createSnapshotRaw(user, datasetName, profileId, snapshotRequest);
+        return createSnapshotWithRequest(user, datasetName, profileId, snapshotRequest, true);
+    }
+
+    public SnapshotSummaryModel createSnapshotWithRequest(
+        TestConfiguration.User user,
+        String datasetName,
+        String profileId,
+        SnapshotRequestModel snapshotRequest,
+        boolean randomizeName) throws Exception {
+        DataRepoResponse<JobModel> jobResponse =
+            createSnapshotRaw(user, datasetName, profileId, snapshotRequest, randomizeName);
         return finishCreateSnapshot(user, jobResponse);
     }
 
@@ -325,8 +338,18 @@ public class DataRepoFixtures {
         String datasetName,
         String profileId,
         String filename) throws Exception {
+        return createSnapshot(user, datasetName, profileId, filename, true);
+    }
+
+    public SnapshotSummaryModel createSnapshot(
+        TestConfiguration.User user,
+        String datasetName,
+        String profileId,
+        String filename,
+        boolean randomizeName) throws Exception {
         SnapshotRequestModel requestModel = jsonLoader.loadObject(filename, SnapshotRequestModel.class);
-        DataRepoResponse<JobModel> jobResponse = createSnapshotRaw(user, datasetName, profileId, requestModel);
+        DataRepoResponse<JobModel> jobResponse =
+            createSnapshotRaw(user, datasetName, profileId, requestModel, randomizeName);
         return finishCreateSnapshot(user, jobResponse);
     }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -160,6 +160,7 @@ public class DatasetIntegrationTest extends UsersBase {
 
     @Test
     public void datasetUnauthorizedPermissionsTest() throws Exception {
+        // These should fail because they don't have access to the billing profile
         dataRepoFixtures.createDatasetError(custodian(), profileId, "dataset-minimal.json", HttpStatus.UNAUTHORIZED);
         dataRepoFixtures.createDatasetError(reader(), profileId, "dataset-minimal.json", HttpStatus.UNAUTHORIZED);
 

--- a/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
@@ -1,0 +1,60 @@
+package bio.terra.service.iam.sam;
+
+
+import bio.terra.common.category.Unit;
+import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(Unit.class)
+public class SamIamTest {
+
+    @Test
+    public void testExtractErrorMessageSimple() {
+        ErrorReport errorReport = new ErrorReport()
+            .message("FOO")
+            .source("sam");
+
+        assertThat(SamIam.extractErrorMessage(errorReport)).isEqualTo("FOO");
+    }
+
+    @Test
+    public void testExtractErrorMessageSimpleNested() {
+        ErrorReport errorReport = new ErrorReport()
+            .message("FOO")
+            .source("sam")
+            .addCausesItem(new ErrorReport()
+                .message("BAR")
+                .source("sam"));
+
+        assertThat(SamIam.extractErrorMessage(errorReport)).isEqualTo("FOO: BAR");
+    }
+
+    @Test
+    public void testExtractErrorMessageDeepNested() {
+        ErrorReport errorReport = new ErrorReport()
+            .message("FOO")
+            .source("sam")
+            .addCausesItem(new ErrorReport()
+                .message("BAR")
+                .source("sam")
+                .addCausesItem(
+                    new ErrorReport()
+                        .message("BAZ1")
+                        .source("sam")
+                )
+                .addCausesItem(
+                    new ErrorReport()
+                        .message("BAZ2")
+                        .source("sam")
+                        .addCausesItem(new ErrorReport()
+                            .message("QUX")
+                            .source("sam"))
+                )
+            );
+
+        assertThat(SamIam.extractErrorMessage(errorReport)).isEqualTo("FOO: BAR: (BAZ1, BAZ2: QUX)");
+    }
+}

--- a/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
@@ -297,7 +297,12 @@ public class SnapshotTest extends UsersBase {
         requestModel.setName(snapshotName);
         requestModel.setReaders(Collections.singletonList("bad-user@not-a-real-domain.com"));
         DataRepoResponse<JobModel> jobResponse =
-            dataRepoFixtures.createSnapshotRaw(steward(), datasetSummaryModel.getName(), profileId, requestModel, false);
+            dataRepoFixtures.createSnapshotRaw(
+                steward(),
+                datasetSummaryModel.getName(),
+                profileId,
+                requestModel,
+                false);
         DataRepoResponse<ErrorModel> snapshotResponse =
             dataRepoClient.waitForResponse(steward(), jobResponse, ErrorModel.class);
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
@@ -292,9 +292,6 @@ public class SnapshotTest extends UsersBase {
         SnapshotRequestModel requestModel =
             jsonLoader.loadObject("ingest-test-snapshot.json", SnapshotRequestModel.class);
 
-        String snapshotName = "mysnapshot12345";
-
-        requestModel.setName(snapshotName);
         requestModel.setReaders(Collections.singletonList("bad-user@not-a-real-domain.com"));
         DataRepoResponse<JobModel> jobResponse =
             dataRepoFixtures.createSnapshotRaw(
@@ -303,6 +300,8 @@ public class SnapshotTest extends UsersBase {
                 profileId,
                 requestModel,
                 false);
+        logger.info("Attempting to create the snapshot with the name: {}", requestModel.getName());
+
         DataRepoResponse<ErrorModel> snapshotResponse =
             dataRepoClient.waitForResponse(steward(), jobResponse, ErrorModel.class);
 
@@ -314,6 +313,7 @@ public class SnapshotTest extends UsersBase {
         // There's not a good way in the test to select the snapshots in the DB.  We want to make sure that we can
         // create the snapshot with the same name, proving that, at least, the database doesn't contain an
         // orphaned entry
+        logger.info("Attempting to recreate the snapshot with the same name: {}", requestModel.getName());
         requestModel.setReaders(Collections.emptyList());
         SnapshotSummaryModel snapshotSummary =
             dataRepoFixtures.createSnapshotWithRequest(steward(), datasetSummaryModel.getName(), profileId,


### PR DESCRIPTION
Namely, that the flight doesn't fail dismally.

This PR also makes it so that the errors from Sam are flattened out and returned in a more meaningful manner to the user

Also did a drive-by comment on a dataset test to better describe the behavior (@snf2ye )