### PR TITLE
DR-1516 Remediate SQL injection opportunity in enumerate endpoints

### DIFF
--- a/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
+++ b/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
@@ -3,7 +3,7 @@ package bio.terra.app.controller;
 
 import bio.terra.common.exception.DataRepoException;
 import bio.terra.model.ErrorModel;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -182,10 +182,10 @@ public class RepositoryApiController implements RepositoryApi {
             @Valid @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit,
             @Valid @RequestParam(value = "sort",
                 required = false,
-                defaultValue = "CREATED_DATE") EnumerateSortByParam sort,
+                defaultValue = "created_date") EnumerateSortByParam sort,
             @Valid @RequestParam(value = "direction",
                 required = false,
-                defaultValue = "ASC") SqlSortDirection direction,
+                defaultValue = "asc") SqlSortDirection direction,
             @Valid @RequestParam(value = "filter", required = false) String filter) {
         ControllerUtils.validateEnumerateParams(offset, limit);
         List<UUID> resources = iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASET);
@@ -367,8 +367,8 @@ public class RepositoryApiController implements RepositoryApi {
     public ResponseEntity<EnumerateSnapshotModel> enumerateSnapshots(
         @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
         @Valid @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit,
-        @Valid @RequestParam(value = "sort", required = false, defaultValue = "CREATED_DATE") EnumerateSortByParam sort,
-        @Valid @RequestParam(value = "direction", required = false, defaultValue = "ASC") SqlSortDirection direction,
+        @Valid @RequestParam(value = "sort", required = false, defaultValue = "created_date") EnumerateSortByParam sort,
+        @Valid @RequestParam(value = "direction", required = false, defaultValue = "asc") SqlSortDirection direction,
         @Valid @RequestParam(value = "filter", required = false) String filter,
         @Valid @RequestParam(value = "datasetIds", required = false) List<String> datasetIds) {
         ControllerUtils.validateEnumerateParams(offset, limit);

--- a/src/main/java/bio/terra/app/controller/RepositoryApiController.java
+++ b/src/main/java/bio/terra/app/controller/RepositoryApiController.java
@@ -17,6 +17,7 @@ import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.EnumerateDatasetModel;
 import bio.terra.model.EnumerateSnapshotModel;
+import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.FileModel;
 import bio.terra.model.IngestRequestModel;
@@ -26,6 +27,7 @@ import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotRequestModel;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.model.UpgradeModel;
 import bio.terra.model.UserStatusInfo;
 import bio.terra.service.configuration.ConfigurationService;
@@ -178,10 +180,14 @@ public class RepositoryApiController implements RepositoryApi {
     public ResponseEntity<EnumerateDatasetModel> enumerateDatasets(
             @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
             @Valid @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit,
-            @Valid @RequestParam(value = "sort", required = false, defaultValue = "created_date") String sort,
-            @Valid @RequestParam(value = "direction", required = false, defaultValue = "asc") String direction,
+            @Valid @RequestParam(value = "sort",
+                required = false,
+                defaultValue = "CREATED_DATE") EnumerateSortByParam sort,
+            @Valid @RequestParam(value = "direction",
+                required = false,
+                defaultValue = "ASC") SqlSortDirection direction,
             @Valid @RequestParam(value = "filter", required = false) String filter) {
-        ControllerUtils.validateEnumerateParams(offset, limit, sort, direction);
+        ControllerUtils.validateEnumerateParams(offset, limit);
         List<UUID> resources = iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASET);
         EnumerateDatasetModel esm = datasetService.enumerate(offset, limit, sort, direction, filter, resources);
         return new ResponseEntity<>(esm, HttpStatus.OK);
@@ -361,11 +367,11 @@ public class RepositoryApiController implements RepositoryApi {
     public ResponseEntity<EnumerateSnapshotModel> enumerateSnapshots(
         @Valid @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
         @Valid @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit,
-        @Valid @RequestParam(value = "sort", required = false, defaultValue = "created_date") String sort,
-        @Valid @RequestParam(value = "direction", required = false, defaultValue = "asc") String direction,
+        @Valid @RequestParam(value = "sort", required = false, defaultValue = "CREATED_DATE") EnumerateSortByParam sort,
+        @Valid @RequestParam(value = "direction", required = false, defaultValue = "ASC") SqlSortDirection direction,
         @Valid @RequestParam(value = "filter", required = false) String filter,
         @Valid @RequestParam(value = "datasetIds", required = false) List<String> datasetIds) {
-        ControllerUtils.validateEnumerateParams(offset, limit, sort, direction);
+        ControllerUtils.validateEnumerateParams(offset, limit);
         List<UUID> resources = iamService.listAuthorizedResources(
             getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT);
         List<UUID> datasetUUIDs = ListUtils.emptyIfNull(datasetIds).stream()

--- a/src/main/java/bio/terra/app/controller/converters/EnumerateSortByParamConverter.java
+++ b/src/main/java/bio/terra/app/controller/converters/EnumerateSortByParamConverter.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.stream.Collectors;
 
 @Component
 public class EnumerateSortByParamConverter
@@ -18,10 +17,7 @@ public class EnumerateSortByParamConverter
     public EnumerateSortByParam convert(String source) {
         EnumerateSortByParam result = EnumerateSortByParam.fromValue(source.toLowerCase());
         if (result == null) {
-            String error = String.format("sort must be one of: (%s).",
-                Arrays.stream(EnumerateSortByParam.values())
-                    .map(EnumerateSortByParam::toString)
-                    .collect(Collectors.joining(", ")));
+            String error = String.format("sort must be one of: %s.", Arrays.toString(EnumerateSortByParam.values()));
             throw new ValidationException("Invalid enumerate parameter(s).", Collections.singletonList(error));
         }
         return result;    }

--- a/src/main/java/bio/terra/app/controller/converters/EnumerateSortByParamConverter.java
+++ b/src/main/java/bio/terra/app/controller/converters/EnumerateSortByParamConverter.java
@@ -1,0 +1,28 @@
+package bio.terra.app.controller.converters;
+
+import bio.terra.app.controller.exception.ValidationException;
+import bio.terra.model.EnumerateSortByParam;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+@Component
+public class EnumerateSortByParamConverter
+    implements Converter<String, EnumerateSortByParam> {
+
+    @Override
+    public EnumerateSortByParam convert(String source) {
+        EnumerateSortByParam result = EnumerateSortByParam.fromValue(source.toLowerCase());
+        if (result == null) {
+            String error = String.format("sort must be one of: (%s).",
+                Arrays.stream(EnumerateSortByParam.values())
+                    .map(EnumerateSortByParam::toString)
+                    .collect(Collectors.joining(", ")));
+            throw new ValidationException("Invalid enumerate parameter(s).", Collections.singletonList(error));
+        }
+        return result;    }
+}

--- a/src/main/java/bio/terra/app/controller/converters/EnumerateSortByParamConverter.java
+++ b/src/main/java/bio/terra/app/controller/converters/EnumerateSortByParamConverter.java
@@ -20,5 +20,6 @@ public class EnumerateSortByParamConverter
             String error = String.format("sort must be one of: %s.", Arrays.toString(EnumerateSortByParam.values()));
             throw new ValidationException("Invalid enumerate parameter(s).", Collections.singletonList(error));
         }
-        return result;    }
+        return result;
+    }
 }

--- a/src/main/java/bio/terra/app/controller/converters/SqlSortDirectionConverter.java
+++ b/src/main/java/bio/terra/app/controller/converters/SqlSortDirectionConverter.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.stream.Collectors;
 
 @Component
 public class SqlSortDirectionConverter
@@ -17,10 +16,7 @@ public class SqlSortDirectionConverter
     public SqlSortDirection convert(String source) {
         SqlSortDirection result = SqlSortDirection.fromValue(source.toLowerCase());
         if (result == null) {
-            String error = String.format("direction must be one of: (%s).",
-                Arrays.stream(SqlSortDirection.values())
-                    .map(SqlSortDirection::toString)
-                    .collect(Collectors.joining(", ")));
+            String error = String.format("direction must be one of: %s.", Arrays.toString(SqlSortDirection.values()));
             throw new ValidationException("Invalid enumerate parameter(s).", Collections.singletonList(error));
         }
         return result;

--- a/src/main/java/bio/terra/app/controller/converters/SqlSortDirectionConverter.java
+++ b/src/main/java/bio/terra/app/controller/converters/SqlSortDirectionConverter.java
@@ -1,0 +1,28 @@
+package bio.terra.app.controller.converters;
+
+import bio.terra.app.controller.exception.ValidationException;
+import bio.terra.model.SqlSortDirection;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+@Component
+public class SqlSortDirectionConverter
+    implements Converter<String, SqlSortDirection> {
+
+    @Override
+    public SqlSortDirection convert(String source) {
+        SqlSortDirection result = SqlSortDirection.fromValue(source.toLowerCase());
+        if (result == null) {
+            String error = String.format("direction must be one of: (%s).",
+                Arrays.stream(SqlSortDirection.values())
+                    .map(SqlSortDirection::toString)
+                    .collect(Collectors.joining(", ")));
+            throw new ValidationException("Invalid enumerate parameter(s).", Collections.singletonList(error));
+        }
+        return result;
+    }
+}

--- a/src/main/java/bio/terra/app/utils/ControllerUtils.java
+++ b/src/main/java/bio/terra/app/utils/ControllerUtils.java
@@ -2,24 +2,18 @@ package bio.terra.app.utils;
 
 import bio.terra.app.controller.exception.ValidationException;
 import bio.terra.model.JobModel;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public final class ControllerUtils {
 
-    // constant used for validation
-    private static final List<String> VALID_SORT_OPTIONS = Arrays.asList("name", "description", "created_date");
-    private static final List<String> VALID_DIRECTION_OPTIONS = Arrays.asList("asc", "desc");
-
     private ControllerUtils() {
     }
 
-    public static void validateEnumerateParams(Integer offset, Integer limit, String sort, String direction) {
+    public static void validateEnumerateParams(Integer offset, Integer limit) {
         List<String> errors = new ArrayList<>();
         if (offset < 0) {
             errors.add("offset must be greater than or equal to 0.");
@@ -27,19 +21,9 @@ public final class ControllerUtils {
         if (limit < 1) {
             errors.add("limit must be greater than or equal to 1.");
         }
-        if (!StringUtils.isEmpty(sort) && !VALID_SORT_OPTIONS.contains(sort)) {
-            errors.add(String.format("sort must be one of: (%s).", String.join(", ", VALID_SORT_OPTIONS)));
-        }
-        if (!StringUtils.isEmpty(direction) && !VALID_DIRECTION_OPTIONS.contains(direction)) {
-            errors.add("direction must be one of: (asc, desc).");
-        }
         if (!errors.isEmpty()) {
             throw new ValidationException("Invalid enumerate parameter(s).", errors);
         }
-    }
-
-    public static void validateEnumerateParams(Integer offset, Integer limit) {
-        validateEnumerateParams(offset, limit, null, null);
     }
 
     public static ResponseEntity<JobModel> jobToResponse(JobModel job) {

--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -1,5 +1,7 @@
 package bio.terra.common;
 
+import bio.terra.model.EnumerateSortByParam;
+import bio.terra.model.SqlSortDirection;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.dao.DataAccessException;
@@ -20,8 +22,8 @@ public final class DaoUtils {
     private DaoUtils() {
     }
 
-    public static String orderByClause(String sort, String direction) {
-        if (sort == null || sort.isEmpty() || direction == null || direction.isEmpty()) {
+    public static String orderByClause(EnumerateSortByParam sort, SqlSortDirection direction) {
+        if (sort == null || direction == null) {
             return "";
         }
         return new StringBuilder(" ORDER BY ")

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -5,6 +5,8 @@ import bio.terra.common.DaoKeyHolder;
 import bio.terra.common.DaoUtils;
 import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.exception.RetryQueryException;
+import bio.terra.model.EnumerateSortByParam;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.exception.DatasetLockException;
@@ -483,8 +485,8 @@ public class DatasetDao {
     public MetadataEnumeration<DatasetSummary> enumerate(
         int offset,
         int limit,
-        String sort,
-        String direction,
+        EnumerateSortByParam sort,
+        SqlSortDirection direction,
         String filter,
         List<UUID> accessibleDatasetIds
     ) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -7,7 +7,9 @@ import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateDatasetModel;
+import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.IngestRequestModel;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.flight.create.AddAssetSpecFlight;
 import bio.terra.service.dataset.flight.create.DatasetCreateFlight;
 import bio.terra.service.dataset.flight.datadelete.DatasetDataDeleteFlight;
@@ -102,8 +104,12 @@ public class DatasetService {
         return DatasetJsonConversion.populateDatasetModelFromDataset(dataset);
     }
 
-    public EnumerateDatasetModel enumerate(
-        int offset, int limit, String sort, String direction, String filter, List<UUID> resources) {
+    public EnumerateDatasetModel enumerate(int offset,
+                                           int limit,
+                                           EnumerateSortByParam sort,
+                                           SqlSortDirection direction,
+                                           String filter,
+                                           List<UUID> resources) {
         if (resources.isEmpty()) {
             return new EnumerateDatasetModel().total(0).items(Collections.emptyList());
         }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -6,6 +6,8 @@ import bio.terra.common.MetadataEnumeration;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.common.DaoKeyHolder;
 import bio.terra.common.DaoUtils;
+import bio.terra.model.EnumerateSortByParam;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import bio.terra.service.snapshot.exception.InvalidSnapshotException;
@@ -389,8 +391,8 @@ public class SnapshotDao {
     public MetadataEnumeration<SnapshotSummary> retrieveSnapshots(
         int offset,
         int limit,
-        String sort,
-        String direction,
+        EnumerateSortByParam sort,
+        SqlSortDirection direction,
         String filter,
         List<UUID> datasetIds,
         List<UUID> accessibleSnapshotIds) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -9,6 +9,7 @@ import bio.terra.grammar.Query;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateSnapshotModel;
+import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.SnapshotModel;
@@ -20,6 +21,7 @@ import bio.terra.model.SnapshotRequestRowIdModel;
 import bio.terra.model.SnapshotRequestRowIdTableModel;
 import bio.terra.model.SnapshotSourceModel;
 import bio.terra.model.SnapshotSummaryModel;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.model.TableModel;
 import bio.terra.service.dataset.AssetColumn;
 import bio.terra.service.dataset.AssetSpecification;
@@ -123,8 +125,8 @@ public class SnapshotService {
     public EnumerateSnapshotModel enumerateSnapshots(
         int offset,
         int limit,
-        String sort,
-        String direction,
+        EnumerateSortByParam sort,
+        SqlSortDirection direction,
         String filter,
         List<UUID> datasetIds,
         List<UUID> resources) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -505,21 +505,14 @@ paths:
           in: query
           description: The field to use for sorting.
           schema:
-            type: string
             default: created_date
-            enum:
-              - name
-              - description
-              - created_date
+            $ref: '#/components/schemas/EnumerateSortByParam'
         - name: direction
           in: query
           description: The direction to sort.
           schema:
-            type: string
-            default: desc
-            enum:
-              - asc
-              - desc
+            default: asc
+            $ref: '#/components/schemas/SqlSortDirection'
         - name: filter
           in: query
           description: Filter the results where this string is a case insensitive match
@@ -984,21 +977,14 @@ paths:
           in: query
           description: The field to use for sorting.
           schema:
-            type: string
             default: created_date
-            enum:
-              - name
-              - description
-              - created_date
+            $ref: '#/components/schemas/EnumerateSortByParam'
         - name: direction
           in: query
           description: The direction to sort.
           schema:
-            type: string
-            default: desc
-            enum:
-              - asc
-              - desc
+            default: asc
+            $ref: '#/components/schemas/SqlSortDirection'
         - name: filter
           in: query
           description: Filter the results where this string is a case insensitive match
@@ -2515,6 +2501,16 @@ components:
       enum: [ boolean, bytes, date, datetime, dirref, fileref, float, float64, integer, int64, numeric, record, string, text, time, timestamp ]
       description: >
         The type of a column in a table.
+    SqlSortDirection:
+      type: string
+      enum: [ asc, desc ]
+      description: >
+        The sort direction of a query result
+    EnumerateSortByParam:
+      type: string
+      enum: [ name, description, created_date ]
+      description: >
+        Fields datasets and snapshots can be sorted by.
     ObjectNameProperty:
       maxLength: 63
       minLength: 1

--- a/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
@@ -365,9 +365,9 @@ public class DatasetValidationsTest {
         expectBadDatasetEnumerateRequest(-1, 0, null, null, expected,
             Arrays.asList("offset must be greater than or equal to 0.", "limit must be greater than or equal to 1."));
         expectBadDatasetEnumerateRequest(0, 10, "invalid", null, expected,
-            Collections.singletonList("sort must be one of: (name, description, created_date)."));
+            Collections.singletonList("sort must be one of: [name, description, created_date]."));
         expectBadDatasetEnumerateRequest(0, 10, "name", "invalid", expected,
-            Collections.singletonList("direction must be one of: (asc, desc)."));
+            Collections.singletonList("direction must be one of: [asc, desc]."));
     }
 
     @Test

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -10,6 +10,8 @@ import bio.terra.common.fixtures.ResourceFixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.model.DatasetRequestModel;
+import bio.terra.model.EnumerateSortByParam;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.exception.DatasetLockException;
 import bio.terra.service.dataset.exception.DatasetNotFoundException;
 import bio.terra.service.profile.ProfileDao;
@@ -113,8 +115,8 @@ public class DatasetDaoTest {
         datasetIds.add(dataset1);
         datasetIds.add(dataset2);
 
-        MetadataEnumeration<DatasetSummary> summaryEnum = datasetDao.enumerate(0, 2, "created_date",
-            "asc", null, datasetIds);
+        MetadataEnumeration<DatasetSummary> summaryEnum = datasetDao.enumerate(0, 2,
+            EnumerateSortByParam.CREATED_DATE, SqlSortDirection.ASC, null, datasetIds);
         List<DatasetSummary> datasets = summaryEnum.getItems();
         assertThat("dataset enumerate limit param works",
             datasets.size(),
@@ -127,7 +129,8 @@ public class DatasetDaoTest {
         // this is skipping the first item returned above
         // so compare the id from the previous retrieve
         assertThat("dataset enumerate offset param works",
-            datasetDao.enumerate(1, 1, "created_date", "asc", null, datasetIds)
+            datasetDao.enumerate(1, 1, EnumerateSortByParam.CREATED_DATE, SqlSortDirection.ASC,
+                null, datasetIds)
                 .getItems().get(0).getId(),
             equalTo(datasets.get(1).getId()));
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -10,7 +10,9 @@ import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.common.fixtures.ResourceFixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetRequestModel;
+import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.SnapshotRequestModel;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.dataset.DatasetUtils;
@@ -256,17 +258,17 @@ public class SnapshotDaoTest {
         testOneEnumerateRange(snapshotIdList, snapshotName, 3, 5);
         testOneEnumerateRange(snapshotIdList, snapshotName, 4, 7);
 
-        testSortingNames(snapshotIdList, snapshotName, 0, 10, "asc");
-        testSortingNames(snapshotIdList, snapshotName, 0, 3, "asc");
-        testSortingNames(snapshotIdList, snapshotName, 1, 3, "asc");
-        testSortingNames(snapshotIdList, snapshotName, 2, 5, "asc");
-        testSortingNames(snapshotIdList, snapshotName, 0, 10, "desc");
-        testSortingNames(snapshotIdList, snapshotName, 0, 3, "desc");
-        testSortingNames(snapshotIdList, snapshotName, 1, 3, "desc");
-        testSortingNames(snapshotIdList, snapshotName, 2, 5, "desc");
+        testSortingNames(snapshotIdList, snapshotName, 0, 10, SqlSortDirection.ASC);
+        testSortingNames(snapshotIdList, snapshotName, 0, 3, SqlSortDirection.ASC);
+        testSortingNames(snapshotIdList, snapshotName, 1, 3, SqlSortDirection.ASC);
+        testSortingNames(snapshotIdList, snapshotName, 2, 5, SqlSortDirection.ASC);
+        testSortingNames(snapshotIdList, snapshotName, 0, 10, SqlSortDirection.DESC);
+        testSortingNames(snapshotIdList, snapshotName, 0, 3, SqlSortDirection.DESC);
+        testSortingNames(snapshotIdList, snapshotName, 1, 3, SqlSortDirection.DESC);
+        testSortingNames(snapshotIdList, snapshotName, 2, 5, SqlSortDirection.DESC);
 
-        testSortingDescriptions(snapshotIdList, "desc");
-        testSortingDescriptions(snapshotIdList, "asc");
+        testSortingDescriptions(snapshotIdList, SqlSortDirection.DESC);
+        testSortingDescriptions(snapshotIdList, SqlSortDirection.ASC);
 
 
         MetadataEnumeration<SnapshotSummary> summaryEnum = snapshotDao.retrieveSnapshots(0, 2, null,
@@ -308,27 +310,27 @@ public class SnapshotDaoTest {
         String snapshotName,
         int offset,
         int limit,
-        String direction) {
-        MetadataEnumeration<SnapshotSummary> summaryEnum = snapshotDao.retrieveSnapshots(offset, limit, "name",
-            direction, null, datasetIds, snapshotIds);
+        SqlSortDirection direction) {
+        MetadataEnumeration<SnapshotSummary> summaryEnum = snapshotDao.retrieveSnapshots(offset, limit,
+            EnumerateSortByParam.NAME, direction, null, datasetIds, snapshotIds);
         List<SnapshotSummary> summaryList = summaryEnum.getItems();
-        int index = (direction.equals("asc")) ? offset : snapshotIds.size() - offset - 1;
+        int index = (direction.equals(SqlSortDirection.ASC)) ? offset : snapshotIds.size() - offset - 1;
         for (SnapshotSummary summary : summaryList) {
             assertThat("correct id", snapshotIds.get(index), equalTo(summary.getId()));
             assertThat("correct name", makeName(snapshotName, index), equalTo(summary.getName()));
-            index += (direction.equals("asc")) ? 1 : -1;
+            index += (direction.equals(SqlSortDirection.ASC)) ? 1 : -1;
         }
     }
 
-    private void testSortingDescriptions(List<UUID> snapshotIds, String direction) {
+    private void testSortingDescriptions(List<UUID> snapshotIds, SqlSortDirection direction) {
         MetadataEnumeration<SnapshotSummary> summaryEnum = snapshotDao.retrieveSnapshots(0, 6,
-            "description", direction, null, datasetIds, snapshotIds);
+            EnumerateSortByParam.DESCRIPTION, direction, null, datasetIds, snapshotIds);
         List<SnapshotSummary> summaryList = summaryEnum.getItems();
         assertThat("the full list comes back", summaryList.size(), equalTo(6));
         String previous = summaryList.get(0).getDescription();
         for (int i = 1; i < summaryList.size(); i++) {
             String next = summaryList.get(i).getDescription();
-            if (direction.equals("asc")) {
+            if (direction.equals(SqlSortDirection.ASC)) {
                 assertThat("ascending order", previous, lessThan(next));
             } else {
                 assertThat("descending order", previous, greaterThan(next));
@@ -343,8 +345,8 @@ public class SnapshotDaoTest {
                                        int offset,
                                        int limit) {
         // We expect the snapshots to be returned in their created order
-        MetadataEnumeration<SnapshotSummary> summaryEnum = snapshotDao.retrieveSnapshots(offset, limit, "created_date",
-            "asc", null, datasetIds, snapshotIds);
+        MetadataEnumeration<SnapshotSummary> summaryEnum = snapshotDao.retrieveSnapshots(offset, limit,
+            EnumerateSortByParam.CREATED_DATE, SqlSortDirection.ASC, null, datasetIds, snapshotIds);
         List<SnapshotSummary> summaryList = summaryEnum.getItems();
         int index = offset;
         for (SnapshotSummary summary : summaryList) {


### PR DESCRIPTION
Currently, we're taking strings in for `sort` and `direction` parameters on enumeration endpoints for datasets and snapshots. While we do check the input and compare it to a known list of good inputs, we should avoid string comparison for validation. This PR tells Swagger to create enums with acceptable values. Conversion utilities are then wired into Spring MVC to handle case differences. This is actually a new feature: _`sort` and `direction` parameters are no longer case sensitive!_ I tailored the implementation so that no tests had to be changed, meaning this isn't a breaking change for users.