### PR TITLE
One way to implement FutureUtilsTest without thread pools.

### DIFF
--- a/src/main/java/bio/terra/common/FutureUtils.java
+++ b/src/main/java/bio/terra/common/FutureUtils.java
@@ -2,77 +2,52 @@ package bio.terra.common;
 
 import bio.terra.app.controller.exception.ApiException;
 
-import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public final class FutureUtils {
-
-    private FutureUtils() {
-    }
-
-    public static <T> List<T> waitFor(final List<Future<T>> futures) {
-        return waitFor(futures, Optional.empty());
-    }
+public enum FutureUtils {
+    _UNUSED;
 
     /**
      * Wait for a list of {@link Future} objects to complete and returns a list of the resolved values.
      * If any of the threads fail, throws the first found instance of failure (non-deterministic) but waits for all
      * futures to resolve.
      * @param futures The {@link List} of futures to wait for
-     * @param maxThreadWait The maximum of time to wait per thread
      * @param <T> The type that should be returned for the list of futures
      * @return The resolved values of the futures.  There is no guarantee that the order of returned values matches the
      * order of the passed in futures
      */
-    public static <T> List<T> waitFor(final List<Future<T>> futures,
-                                      final Optional<Duration> maxThreadWait) {
-
-        final AtomicReference<Optional<ApiException>> foundFailure = new AtomicReference<>(Optional.empty());
+    public static <T> List<T> waitFor(final List<Future<T>> futures) {
+        final AtomicReference<ApiException> foundFailure = new AtomicReference<>();
         try (Stream<Future<T>> stream = futures.stream()) {
             List<T> returnList = stream
                 .map(f -> {
                     try {
-                        // If a failure was found, all subsequent tasks should be canceled
-                        if (foundFailure.get().isPresent()) {
-                            f.cancel(true);
-                        } else if (maxThreadWait.isPresent()) {
-                            return f.get(maxThreadWait.get().toMillis(), TimeUnit.MILLISECONDS);
-                        } else {
+                        if (foundFailure.get() == null) {
                             return f.get();
                         }
-                    } catch (TimeoutException e) {
-                        if (!foundFailure.get().isPresent()) {
-                            foundFailure.set(Optional.of(new ApiException("Thread timed out", e)));
-                            // Cancel the thread
-                            f.cancel(true);
-                        }
+                        // If a failure was found, all subsequent tasks should be canceled
+                        f.cancel(true);
                     } catch (InterruptedException e) {
-                        if (!foundFailure.get().isPresent()) {
-                            foundFailure.set(Optional.of(new ApiException("Thread was interrupted", e)));
-                        }
+                        foundFailure.compareAndSet(null, new ApiException("Thread was interrupted", e));
                     } catch (ExecutionException e) {
-                        if (!foundFailure.get().isPresent()) {
-                            foundFailure.set(Optional.of(new ApiException("Error executing thread", e)));
-                        }
+                        foundFailure.compareAndSet(null, new ApiException("Error executing thread", e));
                     }
-                    // Returning null here but this will ultimately result in throwing an exception to results should
-                    // never be read
+                    // The return value here is ignored because this will ultimately result in throwing an exception,
+                    // since foundFailure must be non-null if this line is reached.
                     return null;
                 })
                 .collect(Collectors.toList());
 
             // Throw an exception if any of the tasks failed
-            foundFailure.get().ifPresent(e -> {
+            final ApiException e = foundFailure.get();
+            if (e != null) {
                 throw e;
-            });
+            }
             return returnList;
         }
     }

--- a/src/test/java/bio/terra/common/FutureUtilsTest.java
+++ b/src/test/java/bio/terra/common/FutureUtilsTest.java
@@ -1,246 +1,140 @@
 package bio.terra.common;
 
 import bio.terra.common.category.Unit;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.IterableUtils;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
 @Category(Unit.class)
 public class FutureUtilsTest {
-    private static Logger logger = LoggerFactory.getLogger(FutureUtilsTest.class);
 
-    private ThreadPoolExecutor executorService;
+    private static class FutureImpl<V> implements Future<V> {
 
-    @Before
-    public void setUp() throws Exception {
-        executorService = new ThreadPoolExecutor(
-            3,
-            3,
-            0,
-            TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(10)
-        );
-    }
+        boolean isCancelled = false;
 
-    @After
-    public void afterClass() throws Exception {
-        if (executorService != null) {
-            executorService.shutdownNow();
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return isCancelled = true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return isCancelled;
+        }
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            return null;
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return null;
         }
     }
 
     @Test
     public void testWaitForTasks() {
         final AtomicInteger counter = new AtomicInteger(0);
-        final Callable<Integer> action = () -> {
-            try {
-                TimeUnit.SECONDS.sleep(1);
+        final Future<Integer> action = new FutureImpl<>() {
+            @Override
+            public Integer get() {
                 return counter.getAndIncrement();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
             }
         };
-
         final List<Future<Integer>> futures = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            futures.add(executorService.submit(action));
+            futures.add(action);
         }
 
         final List<Integer> resolved = FutureUtils.waitFor(futures);
-        assertThat(resolved).containsAll(IntStream.range(0, 10).boxed().collect(Collectors.toList()));
-        assertThat(executorService.getActiveCount()).isZero();
+        assertThat(resolved, containsInAnyOrder(IntStream.range(0, 10).boxed().toArray()));
     }
 
     @Test
-    public void testWaitForTaskAcrossTwoBatches() throws InterruptedException {
+    public void testWaitForTaskAcrossTwoBatches() {
         // Tests two batches of actions being submitted.  The second batch should be shorter (note the sleep).  Ensure
         // that it properly finishes before the first batch and that an exception doesn't cause the first batch to fail
 
-        // Expand the thread queue for this particular test
-        if (executorService != null) {
-            executorService.shutdown();
-        }
-        executorService = new ThreadPoolExecutor(
-            10,
-            10,
-            0,
-            TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(10)
-        );
-
         final AtomicInteger counter1 = new AtomicInteger(0);
-        final Callable<Integer> action1 = () -> {
-            try {
-                TimeUnit.SECONDS.sleep(10);
+        final Future<Integer> action1 = new FutureImpl<>() {
+            @Override
+            public Integer get() {
                 return counter1.getAndIncrement();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
             }
         };
 
         final AtomicInteger counter2 = new AtomicInteger(0);
-        final Callable<Integer> action2 = () -> {
-            try {
+        final Future<Integer> action2 = new FutureImpl<Integer>() {
+            @Override
+            public Integer get() {
                 if (counter2.get() == 0) {
                     throw new RuntimeException("Injected error");
                 }
-                TimeUnit.MILLISECONDS.sleep(500);
                 return counter2.getAndIncrement();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
             }
         };
 
         // Submit the two batches
         final List<Future<Integer>> batch1Futures = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
-            batch1Futures.add(executorService.submit(action1));
+            batch1Futures.add(action1);
         }
 
         final List<Future<Integer>> batch2Futures = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
-            batch2Futures.add(executorService.submit(action2));
+            batch2Futures.add(action2);
         }
 
         assertThatThrownBy(() -> FutureUtils.waitFor(batch2Futures));
 
-        // There should still be at least 3 services running (from the first batch)
-        assertThat(executorService.getActiveCount()).isGreaterThanOrEqualTo(3);
         // Make sure that all tasks from the first batch are still running
-        assertThat(CollectionUtils.collect(batch1Futures, Future::isDone)).doesNotContain(true);
+        assertTrue(batch1Futures.stream().noneMatch(Future::isDone));
 
         final List<Integer> resolved1 = FutureUtils.waitFor(batch1Futures);
-        assertThat(resolved1).containsAll(IntStream.range(0, 3).boxed().collect(Collectors.toList()));
-        assertThat(executorService.getActiveCount()).isZero();
+        assertThat(resolved1, containsInAnyOrder(IntStream.range(0, 3).boxed().toArray()));
     }
 
     @Test
     public void testWaitForTasksSomeFail() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger(0);
-        final Callable<Integer> action = () -> {
-            try {
+        final Future<Integer> action = new FutureImpl<>() {
+            @Override
+            public Integer get() throws ExecutionException {
                 final int count = counter.getAndIncrement();
                 if (count == 5) {
-                    throw new RuntimeException("Injected error");
+                    throw new ExecutionException("Injected error", null);
                 }
-                TimeUnit.SECONDS.sleep(1);
                 return count;
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
             }
         };
 
         final List<Future<Integer>> futures = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            futures.add(executorService.submit(action));
+            futures.add(action);
         }
 
         assertThatThrownBy(() -> FutureUtils.waitFor(futures)).hasMessage("Error executing thread");
-        // Note: adding a sleep since getActiveCount represents an approximation of the number of threads active.
-        // Pausing gives the thread executor a chance to learn that the thread has been canceled
-        TimeUnit.MILLISECONDS.sleep(50);
-        assertThat(executorService.getActiveCount()).isZero();
 
         // Make sure that some tasks after the failure were cancelled
-        assertThat(IterableUtils.countMatches(futures, Future::isCancelled)).isPositive();
-    }
-
-    @Test
-    public void testThreadTimeoutFailure() throws InterruptedException {
-        final AtomicInteger counter = new AtomicInteger(0);
-        // Note: Logging statements left in to make understanding test runs easier
-        final Callable<Integer> action = () -> {
-            try {
-                // On the first iteration, to cause a failure
-                final int count = counter.getAndIncrement();
-                logger.info("Launching {}", count);
-                if (count == 0) {
-                    TimeUnit.SECONDS.sleep(1);
-                } else {
-                    // This should allow all other threads to complete successfully
-                    TimeUnit.MILLISECONDS.sleep(10);
-                }
-                logger.info("Done with {}", count);
-                return count;
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        };
-
-        final List<Future<Integer>> futures = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            futures.add(executorService.submit(action));
-        }
-
-        assertThatThrownBy(() -> FutureUtils.waitFor(futures, Optional.of(Duration.ofMillis(100))))
-            .hasMessage("Thread timed out");
-        // Note: adding a sleep since getActiveCount represents an approximation of the number of threads active.
-        // Pausing gives the thread executor a chance to learn that the thread has been canceled
-        TimeUnit.MILLISECONDS.sleep(50);
-        assertThat(executorService.getActiveCount()).isZero();
-    }
-
-    @Test
-    public void testMaxOutQueue() {
-        final AtomicInteger counter = new AtomicInteger(0);
-        final Callable<Integer> action = () -> {
-            try {
-                TimeUnit.MILLISECONDS.sleep(100);
-                return counter.getAndIncrement();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        };
-
-        final List<Future<Integer>> futures = new ArrayList<>();
-        // Note: we can submit up to 3 running + 10 queue tasks
-        for (int i = 0; i < 13; i++) {
-            futures.add(executorService.submit(action));
-        }
-
-        // Can't accept new threads for now
-        assertThatThrownBy(() -> futures.add(executorService.submit(action)));
-
-        final List<Integer> resolved = FutureUtils.waitFor(futures);
-        assertThat(resolved).containsAll(IntStream.range(0, 13).boxed().collect(Collectors.toList()));
-
-        futures.clear();
-        // Now that queue is empty, we can
-        for (int i = 0; i < 10; i++) {
-            futures.add(executorService.submit(action));
-        }
-
-        final List<Integer> resolvedSecondRound = FutureUtils.waitFor(futures);
-        assertThat(resolvedSecondRound).containsAll(IntStream.range(13, 23).boxed().collect(Collectors.toList()));
-
-        assertThat(executorService.getActiveCount()).isZero();
+        assertTrue(futures.stream().anyMatch(Future::isCancelled));
     }
 }


### PR DESCRIPTION
- removed unused maxThreadWait parameter
- removed use of third party collection utils
- changed assert code to match other uses of hamcrest matchers in the code base
  (org.junit.Assert instead of org.assertj.core.api.Assertions)
- replaced test-and-set with AtomicReference.compareAndSet