### PR TITLE
DR-1775 Fix non UUID resources enumerate endpoints

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -113,7 +113,6 @@ jobs:
         env:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
-      #TODO - add back tests in PRSmokeTests.json after DR-1775 is addressed
       - name: "Run Test Runner smoke tests via Gradle"
         uses: broadinstitute/datarepo-actions/actions/main@0.60.0
         with:

--- a/datarepo-clienttests/src/main/resources/suites/PRSmokeTests.json
+++ b/datarepo-clienttests/src/main/resources/suites/PRSmokeTests.json
@@ -7,6 +7,8 @@
       "basicexamples/BasicAuthenticated.json",
       "basicexamples/BasicUnauthenticated.json",
       "basicexamples/LookupDataset.json",
-      "functional/BillingProfileInUse.json"
+      "functional/BillingProfileAccess.json",
+      "functional/BillingProfileInUse.json",
+      "functional/BillingProfileOwnerHandoff.json"
     ]
 }

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -2,6 +2,7 @@ package bio.terra.common;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -36,12 +37,15 @@ public final class ValidationUtils {
         return Pattern.matches(VALID_PATH, path);
     }
 
-    public static boolean isValidUUID(String uuid) {
+    public static boolean isValidUuid(String uuid) {
+        return convertToUuid(uuid).isPresent();
+    }
+
+    public static Optional<UUID> convertToUuid(String uuid) {
         try {
-            UUID.fromString(uuid);
-            return true;
+            return Optional.of(UUID.fromString(uuid));
         } catch (IllegalArgumentException e) {
-            return false;
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -2,6 +2,7 @@ package bio.terra.common;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 public final class ValidationUtils {
@@ -33,5 +34,14 @@ public final class ValidationUtils {
 
     public static boolean isValidPath(String path) {
         return Pattern.matches(VALID_PATH, path);
+    }
+
+    public static boolean isValidUUID(String uuid) {
+        try {
+            UUID.fromString(uuid);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -147,9 +147,7 @@ public class SamIam implements IamProviderInterface {
                 // Convert valid UUID's to Optional<UUID> objects
                 .map(ValidationUtils::convertToUuid)
                 // Only return valid values
-                .filter(Optional::isPresent)
-                // Unbox the UUID
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .collect(Collectors.toList());
         }
     }

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -142,8 +143,13 @@ public class SamIam implements IamProviderInterface {
         try (Stream<ResourceAndAccessPolicy> resultStream =
                  samResourceApi.listResourcesAndPolicies(iamResourceType.toString()).stream()) {
             return resultStream
-                .filter(resource -> ValidationUtils.isValidUUID(resource.getResourceId()))
-                .map(resource -> UUID.fromString(resource.getResourceId()))
+                .map(ResourceAndAccessPolicy::getResourceId)
+                // Convert valid UUID's to Optional<UUID> objects
+                .map(ValidationUtils::convertToUuid)
+                // Only return valid values
+                .filter(Optional::isPresent)
+                // Unbox the UUID
+                .map(Optional::get)
                 .collect(Collectors.toList());
         }
     }

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -86,11 +86,18 @@ public class SamIam implements IamProviderInterface {
         return new ResourcesApi(getApiClient(accessToken));
     }
 
-    private GoogleApi samGoogleApi(String accessToken) {
+    @VisibleForTesting
+    StatusApi samStatusApi() {
+        return new StatusApi(getUnauthApiClient());
+    }
+
+    @VisibleForTesting
+    GoogleApi samGoogleApi(String accessToken) {
         return new GoogleApi(getApiClient(accessToken));
     }
 
-    private UsersApi samUsersApi(String accessToken) {
+    @VisibleForTesting
+    UsersApi samUsersApi(String accessToken) {
         return new UsersApi(getApiClient(accessToken));
     }
 
@@ -315,6 +322,7 @@ public class SamIam implements IamProviderInterface {
         ResourcesApi samResourceApi = samResourcesApi(userReq.getRequiredToken());
         logger.debug("SAM request: " + req.toString());
 
+        // Simply ensure that the call can complete
         createResourceCorrectCall(samResourceApi.getApiClient(), IamResourceType.SPEND_PROFILE.toString(), req);
     }
 
@@ -572,7 +580,7 @@ public class SamIam implements IamProviderInterface {
     public RepositoryStatusModelSystems samStatus() {
         try {
             return SamRetry.retry(configurationService, () -> {
-                StatusApi samApi = new StatusApi(getUnauthApiClient());
+                StatusApi samApi = samStatusApi();
                 SystemStatus status = samApi.getSystemStatus();
                 return new RepositoryStatusModelSystems()
                     .ok(status.getOk())

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -1,6 +1,7 @@
 package bio.terra.service.iam.sam;
 
 import bio.terra.app.configuration.SamConfiguration;
+import bio.terra.common.ValidationUtils;
 import bio.terra.common.exception.DataRepoException;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
@@ -80,7 +81,8 @@ public class SamIam implements IamProviderInterface {
         return apiClient;
     }
 
-    private ResourcesApi samResourcesApi(String accessToken) {
+    @VisibleForTesting
+    ResourcesApi samResourcesApi(String accessToken) {
         return new ResourcesApi(getApiClient(accessToken));
     }
 
@@ -133,6 +135,7 @@ public class SamIam implements IamProviderInterface {
         try (Stream<ResourceAndAccessPolicy> resultStream =
                  samResourceApi.listResourcesAndPolicies(iamResourceType.toString()).stream()) {
             return resultStream
+                .filter(resource -> ValidationUtils.isValidUUID(resource.getResourceId()))
                 .map(resource -> UUID.fromString(resource.getResourceId()))
                 .collect(Collectors.toList());
         }

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -1,7 +1,7 @@
 package bio.terra.common;
 
 import bio.terra.common.category.Unit;
-import org.apache.commons.lang3.RandomStringUtils;
+import liquibase.util.StringUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -41,7 +41,7 @@ public class ValidationUtilsTest {
     @Test
     public void testDescriptionFormats() throws Exception {
         assertThat(ValidationUtils.isValidDescription("somedescription")).isTrue();
-        assertThat(ValidationUtils.isValidDescription(RandomStringUtils.randomAlphanumeric(5_000))).isFalse();
+        assertThat(ValidationUtils.isValidDescription(StringUtils.repeat("X", 5_000))).isFalse();
     }
 
     @Test

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -1,37 +1,58 @@
 package bio.terra.common;
 
 import bio.terra.common.category.Unit;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Category(Unit.class)
 public class ValidationUtilsTest {
 
     @Test
     public void testEmailFormats() throws Exception {
-        assert ValidationUtils.isValidEmail("john@somewhere.com");
-        assert ValidationUtils.isValidEmail("john.foo@somewhere.com");
-        assert ValidationUtils.isValidEmail("john.foo+label@somewhere.com");
-        assert ValidationUtils.isValidEmail("john@192.168.1.10");
-        assert ValidationUtils.isValidEmail("john+label@192.168.1.10");
-        assert ValidationUtils.isValidEmail("john.foo@someserver");
-        assert ValidationUtils.isValidEmail("JOHN.FOO@somewhere.com");
-        assert !ValidationUtils.isValidEmail("@someserver");
-        assert !ValidationUtils.isValidEmail("@someserver.com");
-        assert !ValidationUtils.isValidEmail("john@.");
-        assert !ValidationUtils.isValidEmail(".@somewhere.com");
+        assertThat(ValidationUtils.isValidEmail("john@somewhere.com")).isTrue();
+        assertThat(ValidationUtils.isValidEmail("john.foo@somewhere.com")).isTrue();
+        assertThat(ValidationUtils.isValidEmail("john.foo+label@somewhere.com")).isTrue();
+        assertThat(ValidationUtils.isValidEmail("john@192.168.1.10")).isTrue();
+        assertThat(ValidationUtils.isValidEmail("john+label@192.168.1.10")).isTrue();
+        assertThat(ValidationUtils.isValidEmail("john.foo@someserver")).isTrue();
+        assertThat(ValidationUtils.isValidEmail("JOHN.FOO@somewhere.com")).isTrue();
+        assertThat(ValidationUtils.isValidEmail("@someserver")).isFalse();
+        assertThat(ValidationUtils.isValidEmail("@someserver.com")).isFalse();
+        assertThat(ValidationUtils.isValidEmail("john@.")).isFalse();
+        assertThat(ValidationUtils.isValidEmail(".@somewhere.com")).isFalse();
     }
 
     @Test
-    public void testUUID() {
-        assert ValidationUtils.isValidUUID("2c297e7c-b303-4243-af6a-76cd9d3b0ca8");
-        assert !ValidationUtils.isValidUUID("not a uuid");
+    public void testHasDuplicates() {
+        assertThat(ValidationUtils.hasDuplicates(Arrays.asList("a", "a", "b", "c"))).isTrue();
+        assertThat(ValidationUtils.hasDuplicates(Arrays.asList(1, 1, 2, 3))).isTrue();
+        assertThat(ValidationUtils.hasDuplicates(Arrays.asList("a", "b", "c"))).isFalse();
+        assertThat(ValidationUtils.hasDuplicates(Arrays.asList(1, 2, 3))).isFalse();
+        assertThat(ValidationUtils.hasDuplicates(Collections.emptyList())).isFalse();
+        assertThat(ValidationUtils.hasDuplicates(Collections.singletonList("a"))).isFalse();
+    }
+
+    @Test
+    public void testDescriptionFormats() throws Exception {
+        assertThat(ValidationUtils.isValidDescription("somedescription")).isTrue();
+        assertThat(ValidationUtils.isValidDescription(RandomStringUtils.randomAlphanumeric(5_000))).isFalse();
+    }
+
+    @Test
+    public void testPathFormats() throws Exception {
+        assertThat(ValidationUtils.isValidPath("/some_path")).isTrue();
+        assertThat(ValidationUtils.isValidPath("some_path")).isFalse();
+    }
+
+    @Test
+    public void testUUIDFormats() {
+        assertThat(ValidationUtils.isValidUUID("2c297e7c-b303-4243-af6a-76cd9d3b0ca8")).isTrue();
+        assertThat(ValidationUtils.isValidUUID("not a uuid")).isFalse();
     }
 }

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -51,8 +51,11 @@ public class ValidationUtilsTest {
     }
 
     @Test
-    public void testUUIDFormats() {
-        assertThat(ValidationUtils.isValidUUID("2c297e7c-b303-4243-af6a-76cd9d3b0ca8")).isTrue();
-        assertThat(ValidationUtils.isValidUUID("not a uuid")).isFalse();
+    public void testUuidFormats() {
+        assertThat(ValidationUtils.isValidUuid("2c297e7c-b303-4243-af6a-76cd9d3b0ca8")).isTrue();
+        assertThat(ValidationUtils.convertToUuid("2c297e7c-b303-4243-af6a-76cd9d3b0ca8")).isPresent();
+        assertThat(ValidationUtils.isValidUuid("not a uuid")).isFalse();
+        assertThat(ValidationUtils.convertToUuid("not a uuid")).isEmpty();
+
     }
 }

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -28,4 +28,10 @@ public class ValidationUtilsTest {
         assert !ValidationUtils.isValidEmail("john@.");
         assert !ValidationUtils.isValidEmail(".@somewhere.com");
     }
+
+    @Test
+    public void testUUID() {
+        assert ValidationUtils.isValidUUID("2c297e7c-b303-4243-af6a-76cd9d3b0ca8");
+        assert !ValidationUtils.isValidUUID("not a uuid");
+    }
 }

--- a/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
@@ -12,7 +12,6 @@ import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamRole;
-import org.assertj.core.util.Maps;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
@@ -30,16 +29,15 @@ import org.junit.experimental.categories.Category;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,13 +53,13 @@ public class SamIamTest {
     @Mock
     private ApiClient apiClient;
     @Mock
-    private ResourcesApi samResourceApi = mock(ResourcesApi.class);
+    private ResourcesApi samResourceApi;
     @Mock
-    private StatusApi samStatusApi = mock(StatusApi.class);
+    private StatusApi samStatusApi;
     @Mock
-    private GoogleApi samGoogleApi = mock(GoogleApi.class);
+    private GoogleApi samGoogleApi;
     @Mock
-    private UsersApi samUsersApi = mock(UsersApi.class);
+    private UsersApi samUsersApi;
 
     @Mock
     private AuthenticatedUserRequest userReq;
@@ -141,7 +139,7 @@ public class SamIamTest {
         final String goodId = UUID.randomUUID().toString();
         final String badId = "badUUID";
         when(samResourceApi.listResourcesAndPolicies(IamResourceType.SPEND_PROFILE.getSamResourceName()))
-            .thenReturn(Arrays.asList(
+            .thenReturn(List.of(
                 new ResourceAndAccessPolicy().resourceId(goodId),
                 new ResourceAndAccessPolicy().resourceId(badId)
             ));
@@ -172,7 +170,7 @@ public class SamIamTest {
     public void testGetStatus() throws ApiException {
         when(samStatusApi.getSystemStatus()).thenReturn(new SystemStatus()
             .ok(true)
-            .systems(Maps.newHashMap("GooglePubSub", Maps.newHashMap("ok", true)))
+            .systems(Map.of("GooglePubSub", Map.of("ok", true)))
         );
         assertThat(samIam.samStatus()).isEqualTo(
             new RepositoryStatusModelSystems()
@@ -271,20 +269,20 @@ public class SamIamTest {
             ));
 
         assertThat(samIam.retrievePolicyEmails(userReq, IamResourceType.SPEND_PROFILE, id))
-            .isEqualTo(Maps.newHashMap(IamRole.CUSTODIAN, policyEmail));
+            .isEqualTo(Map.of(IamRole.CUSTODIAN, policyEmail));
     }
 
     @Test
     public void testCreateDataset() throws InterruptedException, ApiException {
         final UUID datasetId = UUID.randomUUID();
         // Note: in our case, policies have a 1:1 relationship with roles
-        final List<IamRole> allPolicies = Arrays.asList(
+        final List<IamRole> allPolicies = List.of(
             IamRole.ADMIN,
             IamRole.STEWARD,
             IamRole.CUSTODIAN,
             IamRole.SNAPSHOT_CREATOR
         );
-        final List<IamRole> syncedPolicies = Arrays.asList(
+        final List<IamRole> syncedPolicies = List.of(
             IamRole.STEWARD,
             IamRole.CUSTODIAN,
             IamRole.SNAPSHOT_CREATOR
@@ -295,7 +293,7 @@ public class SamIamTest {
                 IamResourceType.DATASET.getSamResourceName(),
                 datasetId.toString(),
                 policy.toString())
-            ).thenReturn(Maps.newHashMap("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
+            ).thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
         }
 
         assertThat(samIam.createDatasetResource(userReq, datasetId))
@@ -309,13 +307,13 @@ public class SamIamTest {
     public void testCreateSnapshot() throws InterruptedException, ApiException {
         final UUID snapshotId = UUID.randomUUID();
         // Note: in our case, policies have a 1:1 relationship with roles
-        final List<IamRole> allPolicies = Arrays.asList(
+        final List<IamRole> allPolicies = List.of(
             IamRole.ADMIN,
             IamRole.STEWARD,
             IamRole.READER,
             IamRole.DISCOVERER
         );
-        final List<IamRole> syncedPolicies = Arrays.asList(
+        final List<IamRole> syncedPolicies = List.of(
             IamRole.STEWARD,
             IamRole.READER
         );
@@ -325,7 +323,7 @@ public class SamIamTest {
                 IamResourceType.DATASNAPSHOT.getSamResourceName(),
                 snapshotId.toString(),
                 policy.toString())
-            ).thenReturn(Maps.newHashMap("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
+            ).thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
         }
 
         assertThat(samIam.createSnapshotResource(userReq, snapshotId, Collections.emptyList()))
@@ -339,7 +337,7 @@ public class SamIamTest {
     public void testCreateProfile() throws InterruptedException, ApiException {
         final UUID profileId = UUID.randomUUID();
         // Note: in our case, policies have a 1:1 relationship with roles
-        final List<IamRole> allPolicies = Arrays.asList(
+        final List<IamRole> allPolicies = List.of(
             IamRole.ADMIN,
             IamRole.OWNER,
             IamRole.USER
@@ -350,7 +348,7 @@ public class SamIamTest {
                 IamResourceType.DATASNAPSHOT.getSamResourceName(),
                 profileId.toString(),
                 policy.toString())
-            ).thenReturn(Maps.newHashMap("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
+            ).thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
         }
 
         samIam.createProfileResource(userReq, profileId.toString());

--- a/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
@@ -1,15 +1,65 @@
 package bio.terra.service.iam.sam;
 
 
+import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.category.Unit;
+import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.iam.IamResourceType;
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
+import org.broadinstitute.dsde.workbench.client.sam.model.ResourceAndAccessPolicy;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @Category(Unit.class)
 public class SamIamTest {
+
+    @Mock
+    private SamConfiguration samConfig;
+    @Mock
+    private ConfigurationService configurationService;
+    @Mock
+    ResourcesApi samApi = mock(ResourcesApi.class);
+    @Mock
+    StatusApi samStatusApi = mock(StatusApi.class);
+    @Mock
+    AuthenticatedUserRequest userReq;
+
+    SamIam samIam;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        samIam = spy(new SamIam(samConfig, configurationService));
+        when(userReq.getRequiredToken()).thenReturn("some_token");
+        when(configurationService.getParameterValue(ConfigEnum.SAM_RETRY_MAXIMUM_WAIT_SECONDS))
+            .thenReturn(1);
+        when(configurationService.getParameterValue(ConfigEnum.SAM_RETRY_INITIAL_WAIT_SECONDS))
+            .thenReturn(0);
+        when(configurationService.getParameterValue(ConfigEnum.SAM_OPERATION_TIMEOUT_SECONDS))
+            .thenReturn(1);
+        // Mock out samApi and samStatusApi in individual tests
+        doAnswer(a -> samApi).when(samIam).samResourcesApi(anyString());
+
+    }
 
     @Test
     public void testExtractErrorMessageSimple() {
@@ -57,4 +107,19 @@ public class SamIamTest {
 
         assertThat(SamIam.extractErrorMessage(errorReport)).isEqualTo("FOO: BAR: (BAZ1, BAZ2: QUX)");
     }
+
+    @Test
+    public void testIgnoresNonUUIDResourceName() throws ApiException, InterruptedException {
+        String goodId = UUID.randomUUID().toString();
+        String badId = "badUUID";
+        when(samApi.listResourcesAndPolicies(IamResourceType.SPEND_PROFILE.getSamResourceName()))
+            .thenReturn(Arrays.asList(
+                new ResourceAndAccessPolicy().resourceId(goodId),
+                new ResourceAndAccessPolicy().resourceId(badId)
+            ));
+
+        List<UUID> uuids = samIam.listAuthorizedResources(userReq, IamResourceType.SPEND_PROFILE);
+        assertThat(uuids).containsExactly(UUID.fromString(goodId));
+    }
+
 }

--- a/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
@@ -3,15 +3,27 @@ package bio.terra.service.iam.sam;
 
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.category.Unit;
+import bio.terra.model.PolicyModel;
+import bio.terra.model.RepositoryStatusModelSystems;
+import bio.terra.model.UserStatusInfo;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamResourceType;
+import bio.terra.service.iam.IamRole;
+import org.assertj.core.util.Maps;
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembership;
+import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntry;
 import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
 import org.broadinstitute.dsde.workbench.client.sam.model.ResourceAndAccessPolicy;
+import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -19,14 +31,18 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @Category(Unit.class)
@@ -37,28 +53,40 @@ public class SamIamTest {
     @Mock
     private ConfigurationService configurationService;
     @Mock
-    ResourcesApi samApi = mock(ResourcesApi.class);
+    private ApiClient apiClient;
     @Mock
-    StatusApi samStatusApi = mock(StatusApi.class);
+    private ResourcesApi samResourceApi = mock(ResourcesApi.class);
     @Mock
-    AuthenticatedUserRequest userReq;
+    private StatusApi samStatusApi = mock(StatusApi.class);
+    @Mock
+    private GoogleApi samGoogleApi = mock(GoogleApi.class);
+    @Mock
+    private UsersApi samUsersApi = mock(UsersApi.class);
 
-    SamIam samIam;
+    @Mock
+    private AuthenticatedUserRequest userReq;
+
+    private SamIam samIam;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         samIam = spy(new SamIam(samConfig, configurationService));
-        when(userReq.getRequiredToken()).thenReturn("some_token");
+        final String userToken = "some_token";
+        when(userReq.getRequiredToken()).thenReturn(userToken);
         when(configurationService.getParameterValue(ConfigEnum.SAM_RETRY_MAXIMUM_WAIT_SECONDS))
-            .thenReturn(1);
+            .thenReturn(0);
         when(configurationService.getParameterValue(ConfigEnum.SAM_RETRY_INITIAL_WAIT_SECONDS))
             .thenReturn(0);
         when(configurationService.getParameterValue(ConfigEnum.SAM_OPERATION_TIMEOUT_SECONDS))
-            .thenReturn(1);
-        // Mock out samApi and samStatusApi in individual tests
-        doAnswer(a -> samApi).when(samIam).samResourcesApi(anyString());
-
+            .thenReturn(0);
+        // Mock out samApi, samStatusApi, samGoogleApi, and samUsersApi in individual tests as needed
+        doAnswer(a -> samResourceApi).when(samIam).samResourcesApi(userToken);
+        doAnswer(a -> samStatusApi).when(samIam).samStatusApi();
+        doAnswer(a -> samGoogleApi).when(samIam).samGoogleApi(userToken);
+        doAnswer(a -> samUsersApi).when(samIam).samUsersApi(userToken);
+        // Mock out the lower level client in individual as needed
+        when(samResourceApi.getApiClient()).thenAnswer(a -> apiClient);
     }
 
     @Test
@@ -110,9 +138,9 @@ public class SamIamTest {
 
     @Test
     public void testIgnoresNonUUIDResourceName() throws ApiException, InterruptedException {
-        String goodId = UUID.randomUUID().toString();
-        String badId = "badUUID";
-        when(samApi.listResourcesAndPolicies(IamResourceType.SPEND_PROFILE.getSamResourceName()))
+        final String goodId = UUID.randomUUID().toString();
+        final String badId = "badUUID";
+        when(samResourceApi.listResourcesAndPolicies(IamResourceType.SPEND_PROFILE.getSamResourceName()))
             .thenReturn(Arrays.asList(
                 new ResourceAndAccessPolicy().resourceId(goodId),
                 new ResourceAndAccessPolicy().resourceId(badId)
@@ -122,4 +150,259 @@ public class SamIamTest {
         assertThat(uuids).containsExactly(UUID.fromString(goodId));
     }
 
+    @Test
+    public void testAuthorization() throws ApiException, InterruptedException {
+        when(samResourceApi.resourcePermissionV2(
+            IamResourceType.SPEND_PROFILE.getSamResourceName(),
+            "my-id",
+            IamAction.READ_DATA.toString()
+        )).thenReturn(true);
+        when(samResourceApi.resourcePermissionV2(
+            IamResourceType.SPEND_PROFILE.getSamResourceName(),
+            "my-id",
+            IamAction.ALTER_POLICIES.toString()
+        )).thenReturn(false);
+        assertThat(samIam.isAuthorized(userReq, IamResourceType.SPEND_PROFILE, "my-id", IamAction.READ_DATA))
+            .isTrue();
+        assertThat(samIam.isAuthorized(userReq, IamResourceType.SPEND_PROFILE, "my-id", IamAction.ALTER_POLICIES))
+            .isFalse();
+    }
+
+    @Test
+    public void testGetStatus() throws ApiException {
+        when(samStatusApi.getSystemStatus()).thenReturn(new SystemStatus()
+            .ok(true)
+            .systems(Maps.newHashMap("GooglePubSub", Maps.newHashMap("ok", true)))
+        );
+        assertThat(samIam.samStatus()).isEqualTo(
+            new RepositoryStatusModelSystems()
+                .ok(true)
+                .message("{GooglePubSub={ok=true}}")
+        );
+    }
+
+    @Test
+    public void testGetStatusException() throws ApiException {
+        when(samStatusApi.getSystemStatus()).thenThrow(new ApiException("BOOM!"));
+        assertThat(samIam.samStatus()).isEqualTo(
+            new RepositoryStatusModelSystems()
+                .ok(false)
+                .message("Sam status check failed: bio.terra.service.iam.exception.IamInternalServerErrorException: " +
+                    "BOOM!")
+        );
+    }
+
+    @Test
+    public void testGetUserInfo() throws ApiException {
+        final String userSubjectId = "userid";
+        final String userEmail = "a@a.com";
+        when(samUsersApi.getUserStatusInfo())
+            .thenReturn(new org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo()
+                .userSubjectId(userSubjectId)
+                .userEmail(userEmail)
+                .enabled(true)
+            );
+
+        assertThat(samIam.getUserInfo(userReq))
+            .isEqualTo(new UserStatusInfo()
+                .userSubjectId(userSubjectId)
+                .userEmail(userEmail)
+                .enabled(true)
+            );
+    }
+
+    @Test
+    public void testHasActions() throws ApiException, InterruptedException {
+        when(samResourceApi.resourceActions(
+            IamResourceType.SPEND_PROFILE.getSamResourceName(),
+            "my-id-1"
+        )).thenReturn(Collections.singletonList(IamAction.READ_DATA.toString()));
+        when(samResourceApi.resourceActions(
+            IamResourceType.SPEND_PROFILE.getSamResourceName(),
+            "my-id-2"
+        )).thenReturn(Collections.emptyList());
+        assertThat(samIam.hasActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-1"))
+            .isTrue();
+        assertThat(samIam.hasActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-2"))
+            .isFalse();
+    }
+
+    @Test
+    public void testDeleteResource() throws InterruptedException, ApiException {
+        final UUID datasetId = UUID.randomUUID();
+        samIam.deleteDatasetResource(userReq, datasetId);
+        // Verify that the correct Sam API call was made
+        verify(samResourceApi, times(1))
+            .deleteResource(eq(IamResourceType.DATASET.getSamResourceName()), eq(datasetId.toString()));
+
+        final UUID snapshotId = UUID.randomUUID();
+        samIam.deleteSnapshotResource(userReq, snapshotId);
+        verify(samResourceApi, times(1))
+            .deleteResource(eq(IamResourceType.DATASNAPSHOT.getSamResourceName()), eq(snapshotId.toString()));
+
+        final UUID profileId = UUID.randomUUID();
+        samIam.deleteProfileResource(userReq, profileId.toString());
+        verify(samResourceApi, times(1))
+            .deleteResource(eq(IamResourceType.SPEND_PROFILE.getSamResourceName()), eq(profileId.toString()));
+    }
+
+    @Test
+    public void testRetrievePoliciesAndEmails() throws ApiException, InterruptedException {
+        final UUID id = UUID.randomUUID();
+        final String policyEmail = "policygroup@firecloud.org";
+        final String memberEmail = "a@a.com";
+        when(samResourceApi.listResourcePolicies(
+            IamResourceType.SPEND_PROFILE.getSamResourceName(),
+            id.toString()
+        )).thenReturn(Collections.singletonList(
+            new AccessPolicyResponseEntry()
+                .policyName(IamRole.CUSTODIAN.toString())
+                .email(policyEmail)
+                .policy(new AccessPolicyMembership().addMemberEmailsItem(
+                    memberEmail
+                ))
+        ));
+
+        assertThat(samIam.retrievePolicies(userReq, IamResourceType.SPEND_PROFILE, id))
+            .isEqualTo(Collections.singletonList(
+                new PolicyModel()
+                    .name(IamRole.CUSTODIAN.toString())
+                    .addMembersItem(memberEmail)
+            ));
+
+        assertThat(samIam.retrievePolicyEmails(userReq, IamResourceType.SPEND_PROFILE, id))
+            .isEqualTo(Maps.newHashMap(IamRole.CUSTODIAN, policyEmail));
+    }
+
+    @Test
+    public void testCreateDataset() throws InterruptedException, ApiException {
+        final UUID datasetId = UUID.randomUUID();
+        // Note: in our case, policies have a 1:1 relationship with roles
+        final List<IamRole> allPolicies = Arrays.asList(
+            IamRole.ADMIN,
+            IamRole.STEWARD,
+            IamRole.CUSTODIAN,
+            IamRole.SNAPSHOT_CREATOR
+        );
+        final List<IamRole> syncedPolicies = Arrays.asList(
+            IamRole.STEWARD,
+            IamRole.CUSTODIAN,
+            IamRole.SNAPSHOT_CREATOR
+        );
+
+        for (IamRole policy : allPolicies) {
+            when(samGoogleApi.syncPolicy(
+                IamResourceType.DATASET.getSamResourceName(),
+                datasetId.toString(),
+                policy.toString())
+            ).thenReturn(Maps.newHashMap("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
+        }
+
+        assertThat(samIam.createDatasetResource(userReq, datasetId))
+            .isEqualTo(syncedPolicies.stream().collect(Collectors.toMap(
+                p -> p,
+                p -> "policygroup-" + p + "@firecloud.org"
+            )));
+    }
+
+    @Test
+    public void testCreateSnapshot() throws InterruptedException, ApiException {
+        final UUID snapshotId = UUID.randomUUID();
+        // Note: in our case, policies have a 1:1 relationship with roles
+        final List<IamRole> allPolicies = Arrays.asList(
+            IamRole.ADMIN,
+            IamRole.STEWARD,
+            IamRole.READER,
+            IamRole.DISCOVERER
+        );
+        final List<IamRole> syncedPolicies = Arrays.asList(
+            IamRole.STEWARD,
+            IamRole.READER
+        );
+
+        for (IamRole policy : allPolicies) {
+            when(samGoogleApi.syncPolicy(
+                IamResourceType.DATASNAPSHOT.getSamResourceName(),
+                snapshotId.toString(),
+                policy.toString())
+            ).thenReturn(Maps.newHashMap("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
+        }
+
+        assertThat(samIam.createSnapshotResource(userReq, snapshotId, Collections.emptyList()))
+            .isEqualTo(syncedPolicies.stream().collect(Collectors.toMap(
+                p -> p,
+                p -> "policygroup-" + p + "@firecloud.org"
+            )));
+    }
+
+    @Test
+    public void testCreateProfile() throws InterruptedException, ApiException {
+        final UUID profileId = UUID.randomUUID();
+        // Note: in our case, policies have a 1:1 relationship with roles
+        final List<IamRole> allPolicies = Arrays.asList(
+            IamRole.ADMIN,
+            IamRole.OWNER,
+            IamRole.USER
+        );
+
+        for (IamRole policy : allPolicies) {
+            when(samGoogleApi.syncPolicy(
+                IamResourceType.DATASNAPSHOT.getSamResourceName(),
+                profileId.toString(),
+                policy.toString())
+            ).thenReturn(Maps.newHashMap("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
+        }
+
+        samIam.createProfileResource(userReq, profileId.toString());
+    }
+
+    @Test
+    public void testAddPolicy() throws InterruptedException, ApiException {
+        final UUID id = UUID.randomUUID();
+        final String userEmail = "a@a.com";
+        when(samResourceApi.getPolicy(
+            IamResourceType.SPEND_PROFILE.getSamResourceName(),
+            id.toString(),
+            IamRole.OWNER.toString())
+        ).thenReturn(new AccessPolicyMembership()
+            .memberEmails(Collections.singletonList(userEmail)));
+        final PolicyModel policyModel =
+            samIam.addPolicyMember(userReq, IamResourceType.SPEND_PROFILE, id, IamRole.OWNER.toString(), userEmail);
+        assertThat(policyModel)
+            .isEqualTo(new PolicyModel()
+                .name(IamRole.OWNER.toString())
+                .addMembersItem(userEmail)
+            );
+        verify(samResourceApi, times(1)).addUserToPolicy(
+            IamResourceType.SPEND_PROFILE.getSamResourceName(),
+            id.toString(),
+            IamRole.OWNER.toString(),
+            userEmail
+        );
+    }
+
+    @Test
+    public void testDeletePolicy() throws InterruptedException, ApiException {
+        final UUID id = UUID.randomUUID();
+        final String userEmail = "a@a.com";
+        when(samResourceApi.getPolicy(
+            IamResourceType.SPEND_PROFILE.getSamResourceName(),
+            id.toString(),
+            IamRole.OWNER.toString())
+        ).thenReturn(new AccessPolicyMembership()
+            .memberEmails(Collections.emptyList()));
+        final PolicyModel policyModel =
+            samIam.deletePolicyMember(userReq, IamResourceType.SPEND_PROFILE, id, IamRole.OWNER.toString(), userEmail);
+        assertThat(policyModel)
+            .isEqualTo(new PolicyModel()
+                .name(IamRole.OWNER.toString())
+                .members(Collections.emptyList())
+            );
+        verify(samResourceApi, times(1)).removeUserFromPolicy(
+            IamResourceType.SPEND_PROFILE.getSamResourceName(),
+            id.toString(),
+            IamRole.OWNER.toString(),
+            userEmail
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where if a user has access to a resource that was created in sam directly for a dataset, snapshot or billing profile that is not named with a UUID, enumerating resources of that type fail.  The behavior is now that those resources, if they are returned from Sam, are ignored by TDR.

A big note in this PR, I took this as an opportunity to unit test the `SamIAm` class by adding mocking to the test.  I think this could serve as a good example of mocking tests that depend on outside services.  I used this approach to test the change for this PR and also backfilled the tests for this class. We now have 90% branch coverage in this class

I also cleaned up and filled out unit tests for the `ValidationUtils` class.

This is a bit of a big PR but it's broken up into commits, which should help with reviews