### PR TITLE
DR-1634 Add the ability to select what information is returned from retrieveSnapshot and retrieveDataset

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
@@ -18,6 +18,7 @@ import com.google.cloud.storage.BlobId;
 import common.utils.FileUtils;
 import common.utils.StorageUtils;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,7 +122,8 @@ public class CreateSnapshot extends SimpleDataset {
       logger.info("Successfully created snapshot: {}", snapshotSummaryModel.getName());
 
       // now go and retrieve the file Id that should be stored in the snapshot
-      snapshotModel = repositoryApi.retrieveSnapshot(snapshotSummaryModel.getId());
+      snapshotModel =
+          repositoryApi.retrieveSnapshot(snapshotSummaryModel.getId(), Collections.emptyList());
     } catch (Exception e) {
       logger.error("Error in journey", e);
       e.printStackTrace();

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
@@ -24,6 +24,7 @@ import common.utils.StorageUtils;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -156,7 +157,8 @@ public class DRSLookup extends SimpleDataset {
     }
 
     // now go and retrieve the file Id that should be stored in the snapshot
-    snapshotModel = repositoryApi.retrieveSnapshot(snapshotSummaryModel.getId());
+    snapshotModel =
+        repositoryApi.retrieveSnapshot(snapshotSummaryModel.getId(), Collections.emptyList());
 
     TableModel tableModel =
         snapshotModel.getTables().get(0); // There is only 1 table, so just grab the first

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/DatasetCustodianPermissions.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/DatasetCustodianPermissions.java
@@ -14,6 +14,7 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.TableResult;
 import common.utils.BigQueryUtils;
+import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +40,8 @@ public class DatasetCustodianPermissions extends SimpleDataset {
     // fetch the full dataset model, which has the data project property
     ApiClient datasetCreatorClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
     RepositoryApi repositoryApi = new RepositoryApi(datasetCreatorClient);
-    datasetModel = repositoryApi.retrieveDataset(datasetSummaryModel.getId());
+    datasetModel =
+        repositoryApi.retrieveDataset(datasetSummaryModel.getId(), Collections.emptyList());
   }
 
   public void userJourney(TestUserSpecification testUser) throws Exception {
@@ -121,7 +123,7 @@ public class DatasetCustodianPermissions extends SimpleDataset {
       RepositoryApi repositoryApi, String datasetId) throws ApiException {
     boolean caughtAccessException = false;
     try {
-      DatasetModel datasetModel = repositoryApi.retrieveDataset(datasetId);
+      DatasetModel datasetModel = repositoryApi.retrieveDataset(datasetId, Collections.emptyList());
       logger.debug(
           "Successfully retrieved dataset: name = {}, data project = {}",
           datasetModel.getName(),

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
@@ -3,6 +3,7 @@ package scripts.testscripts;
 import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.model.DatasetModel;
+import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import runner.config.TestUserSpecification;
@@ -20,7 +21,8 @@ public class RetrieveDataset extends SimpleDataset {
   public void userJourney(TestUserSpecification testUser) throws Exception {
     ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
     RepositoryApi repositoryApi = new RepositoryApi(apiClient);
-    DatasetModel datasetModel = repositoryApi.retrieveDataset(datasetSummaryModel.getId());
+    DatasetModel datasetModel =
+        repositoryApi.retrieveDataset(datasetSummaryModel.getId(), Collections.emptyList());
     logger.info(
         "Successfully retrieved dataset: name = {}, data project = {}",
         datasetModel.getName(),

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -18,6 +18,7 @@ import common.utils.StorageUtils;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -160,7 +161,8 @@ public class RetrieveSnapshot extends SimpleDataset {
     ApiClient apiClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
     RepositoryApi repositoryApi = new RepositoryApi(apiClient);
 
-    SnapshotModel snapshotModel = repositoryApi.retrieveSnapshot(snapshotSummaryModel.getId());
+    SnapshotModel snapshotModel =
+        repositoryApi.retrieveSnapshot(snapshotSummaryModel.getId(), Collections.emptyList());
     logger.debug(
         "Successfully retrieved snaphot: {}, data project: {}",
         snapshotModel.getName(),

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/SnapshotScaleDelete.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/SnapshotScaleDelete.java
@@ -8,6 +8,7 @@ import bio.terra.datarepo.model.JobModel;
 import bio.terra.datarepo.model.SnapshotModel;
 import bio.terra.datarepo.model.SnapshotSummaryModel;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +80,8 @@ public class SnapshotScaleDelete extends SimpleDataset {
     for (int i = 0; i < snapshotList.size(); i++) {
       SnapshotModel snapshot;
       try {
-        snapshot = repositoryApi.retrieveSnapshot(snapshotList.get(i).getId());
+        snapshot =
+            repositoryApi.retrieveSnapshot(snapshotList.get(i).getId(), Collections.emptyList());
       } catch (ApiException e) {
         snapshot = null;
         logger.info("Snapshot already deleted: {}", snapshotList.get(i).getName());

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/SoftDeleteDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/SoftDeleteDataset.java
@@ -107,7 +107,7 @@ public class SoftDeleteDataset extends SimpleDataset {
     logger.info("Successfully loaded data into dataset: {}", ingestResponse.getDataset());
 
     String datasetId = datasetSummaryModel.getId();
-    DatasetModel datasetModel = repositoryApi.retrieveDataset(datasetId);
+    DatasetModel datasetModel = repositoryApi.retrieveDataset(datasetId, Collections.emptyList());
     String dataProject = datasetModel.getDataProject();
     String tableName = datasetModel.getSchema().getTables().get(0).getName();
 

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -7,9 +7,10 @@ import bio.terra.controller.DatasetsApi;
 import bio.terra.model.AssetModel;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadRequestModel;
-import bio.terra.model.DatasetModel;
-import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DataDeletionRequest;
+import bio.terra.model.DatasetModel;
+import bio.terra.model.DatasetRequestAccessIncludeModel;
+import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.EnumerateDatasetModel;
 import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.FileLoadModel;
@@ -59,6 +60,8 @@ import static bio.terra.app.utils.ControllerUtils.jobToResponse;
 public class DatasetsApiController implements DatasetsApi {
 
     private Logger logger = LoggerFactory.getLogger(DatasetsApiController.class);
+
+    public static final String RETRIEVE_INCLUDE_DEFAULT_VALUE = "SCHEMA,PROFILE,DATA_PROJECT,STORAGE";
 
     private final ObjectMapper objectMapper;
     private final HttpServletRequest request;
@@ -126,9 +129,14 @@ public class DatasetsApiController implements DatasetsApi {
     }
 
     @Override
-    public ResponseEntity<DatasetModel> retrieveDataset(@PathVariable("id") String id) {
+    public ResponseEntity<DatasetModel> retrieveDataset(
+        @PathVariable("id") String id,
+        @Valid @RequestParam(value = "include", required = false, defaultValue = RETRIEVE_INCLUDE_DEFAULT_VALUE)
+            List<DatasetRequestAccessIncludeModel> include
+    ) {
         iamService.verifyAuthorization(getAuthenticatedInfo(), IamResourceType.DATASET, id, IamAction.READ_DATASET);
-        return new ResponseEntity<>(datasetService.retrieveAvailableDatasetModel(UUID.fromString(id)), HttpStatus.OK);
+        return new ResponseEntity<>(datasetService.retrieveAvailableDatasetModel(UUID.fromString(id), include),
+            HttpStatus.OK);
     }
 
     @Override

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -12,7 +12,7 @@ import bio.terra.model.PolicyMemberRequest;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
 import bio.terra.model.SnapshotModel;
-import bio.terra.model.SnapshotRequestAccessInclude;
+import bio.terra.model.SnapshotRequestAccessIncludeModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.AssetModelValidator;
@@ -180,7 +180,7 @@ public class SnapshotsApiController implements SnapshotsApi {
             value = "include",
             required = false,
             defaultValue = RETRIEVE_INCLUDE_DEFAULT_VALUE
-        ) List<SnapshotRequestAccessInclude> include
+        ) List<SnapshotRequestAccessIncludeModel> include
     ) {
         iamService.verifyAuthorization(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id, IamAction.READ_DATA);
         SnapshotModel snapshotModel = snapshotService.retrieveAvailableSnapshotModel(UUID.fromString(id), include);

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -12,6 +12,7 @@ import bio.terra.model.PolicyMemberRequest;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
 import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotRequestAccessInclude;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.AssetModelValidator;
@@ -171,9 +172,16 @@ public class SnapshotsApiController implements SnapshotsApi {
     }
 
     @Override
-    public ResponseEntity<SnapshotModel> retrieveSnapshot(@PathVariable("id") String id) {
+    public ResponseEntity<SnapshotModel> retrieveSnapshot(
+        @PathVariable("id") String id,
+        @Valid @RequestParam(
+            value = "include",
+            required = false,
+            defaultValue = "SOURCES,TABLES,RELATIONSHIPS,PROFILE,DATA_PROJECT"
+        ) List<SnapshotRequestAccessInclude> include
+    ) {
         iamService.verifyAuthorization(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id, IamAction.READ_DATA);
-        SnapshotModel snapshotModel = snapshotService.retrieveAvailableSnapshotModel(UUID.fromString(id));
+        SnapshotModel snapshotModel = snapshotService.retrieveAvailableSnapshotModel(UUID.fromString(id), include);
         return new ResponseEntity<>(snapshotModel, HttpStatus.OK);
     }
 

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -58,6 +58,8 @@ public class SnapshotsApiController implements SnapshotsApi {
 
     private Logger logger = LoggerFactory.getLogger(SnapshotsApiController.class);
 
+    public static final String RETRIEVE_INCLUDE_DEFAULT_VALUE = "SOURCES,TABLES,RELATIONSHIPS,PROFILE,DATA_PROJECT";
+
     private final ObjectMapper objectMapper;
     private final HttpServletRequest request;
     private final JobService jobService;
@@ -177,7 +179,7 @@ public class SnapshotsApiController implements SnapshotsApi {
         @Valid @RequestParam(
             value = "include",
             required = false,
-            defaultValue = "SOURCES,TABLES,RELATIONSHIPS,PROFILE,DATA_PROJECT"
+            defaultValue = RETRIEVE_INCLUDE_DEFAULT_VALUE
         ) List<SnapshotRequestAccessInclude> include
     ) {
         iamService.verifyAuthorization(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id, IamAction.READ_DATA);

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -90,7 +90,7 @@ public class DatasetService {
      * Note that this method will only return a dataset if it is NOT exclusively locked.
      * It is intended for user-facing calls (e.g. from RepositoryApiController), not internal calls that may require
      * an exclusively locked dataset to be returned (e.g. dataset deletion).
-     * @param id in UUID formant
+     * @param id in UUID format
      * @return a DatasetModel = API output-friendly representation of the Dataset
      */
     public DatasetModel retrieveAvailableDatasetModel(UUID id, List<DatasetRequestAccessIncludeModel> include) {

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -46,8 +46,7 @@ public final class MetadataDataAccessUtils {
         return makAccessInfo(
             snapshot.getName(),
             snapshot.getProjectResource().getGoogleProjectId(),
-            snapshot.getTables()
-        );
+            snapshot.getTables());
     }
 
     /**
@@ -57,8 +56,7 @@ public final class MetadataDataAccessUtils {
         return makAccessInfo(
             BigQueryPdao.prefixName(dataset.getName()),
             dataset.getProjectResource().getGoogleProjectId(),
-            dataset.getTables()
-        );
+            dataset.getTables());
     }
 
     private static AccessInfoModel makAccessInfo(
@@ -107,8 +105,7 @@ public final class MetadataDataAccessUtils {
                     .add("table_address", st.getQualifiedName())
                     .render())
                 )
-                .collect(Collectors.toList()))
-        );
+                .collect(Collectors.toList())));
 
         return accessInfoModel;
     }

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -1,0 +1,102 @@
+package bio.terra.service.resourcemanagement;
+
+import bio.terra.common.Table;
+import bio.terra.model.AccessInfoModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.tabulardata.google.BigQueryPdao;
+import org.stringtemplate.v4.ST;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utilities for building strings to access metadata
+ */
+public final class MetadataDataAccessUtils {
+    private static final String BIGQUERY_DATASET_LINK = "https://console.cloud.google.com/bigquery?project=<project>&" +
+        "ws=!<dataset>&d=<dataset>&p=<project>&page=<page>";
+    private static final String BIGQUERY_TABLE_LINK = BIGQUERY_DATASET_LINK + "&t=<table>";
+    private static final String BIGQUERY_TABLE_ADDRESS = "<project>.<dataset>.<table>";
+    private static final String BIGQUERY_BASE_QUERY = "SELECT * FROM `<table_address>` LIMIT 1000";
+
+    private MetadataDataAccessUtils() {
+    }
+
+    /**
+     * Nature of the page to link to in the BigQuery UI
+     */
+    enum LinkPage {
+        DATASET("dataset"),
+        TABLE("table");
+        private final String value;
+        LinkPage(final String value) {
+            this.value = value;
+        }
+    }
+
+    /**
+     * Generate an {@link AccessInfoModel} from a Snapshot
+     */
+    public static AccessInfoModel accessInfoFromSnapshot(final Snapshot snapshot) {
+        return makAccessInfo(
+            snapshot.getName(),
+            snapshot.getProjectResource().getGoogleProjectId(),
+            snapshot.getTables()
+        );
+    }
+
+    /**
+     * Generate an {@link AccessInfoModel} from a Dataset
+     */
+    public static AccessInfoModel accessInfoFromDataset(final Dataset dataset) {
+        return makAccessInfo(
+            BigQueryPdao.prefixName(dataset.getName()),
+            dataset.getProjectResource().getGoogleProjectId(),
+            dataset.getTables()
+        );
+    }
+
+    private static AccessInfoModel makAccessInfo(
+        final String bqDatasetName,
+        final String googleProjectId,
+        final List<? extends Table> tables
+    ) {
+        AccessInfoModel accessInfoModel = new AccessInfoModel();
+
+        // Currently, only BigQuery is supported.  Parquet specific information will be added here
+        accessInfoModel.bigQuery(new bio.terra.model.AccessInfoBigQueryModel()
+            .datasetName(bqDatasetName)
+            .projectId(googleProjectId)
+            .link(new ST(BIGQUERY_DATASET_LINK)
+                .add("project", googleProjectId)
+                .add("dataset", bqDatasetName)
+                .add("page", LinkPage.DATASET.value)
+                .render())
+            .tables(tables.stream()
+                .map(t -> new bio.terra.model.AccessInfoBigQueryModelTable()
+                    .name(t.getName())
+                    .link(new ST(BIGQUERY_TABLE_LINK)
+                        .add("project", googleProjectId)
+                        .add("dataset", bqDatasetName)
+                        .add("table", t.getName())
+                        .add("page", LinkPage.TABLE.value)
+                        .render())
+                    .qualifiedName(new ST(BIGQUERY_TABLE_ADDRESS)
+                        .add("project", googleProjectId)
+                        .add("dataset", bqDatasetName)
+                        .add("table", t.getName())
+                        .render())
+                )
+                // Use the address that was already rendered
+                .map(st -> st.sampleQuery(new ST(BIGQUERY_BASE_QUERY)
+                    .add("table_address", st.getQualifiedName())
+                    .render())
+                )
+                .collect(Collectors.toList()))
+        );
+
+        return accessInfoModel;
+    }
+
+}

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -169,7 +169,7 @@ public class SnapshotService {
      * Note that this method will only return a snapshot if it is NOT exclusively locked.
      * It is intended for user-facing calls (e.g. from RepositoryApiController), not internal calls that may require
      * an exclusively locked snapshot to be returned (e.g. snapshot deletion).
-     * @param id in UUID formant
+     * @param id in UUID format
      * @return a SnapshotModel = API output-friendly representation of the Snapshot
      */
     public SnapshotModel retrieveAvailableSnapshotModel(UUID id) {
@@ -177,15 +177,15 @@ public class SnapshotService {
     }
 
     /**
-     * Convenience wrapper around fetching an existing Snapshot object and converting it to a Model object.
+     * Convenience wrapper around fetching an existing Snapshot object and converting it to a Model object.<p/>
      * Unlike the Snapshot object, the Model object includes a reference to the associated cloud project.
      *
      * Note that this method will only return a snapshot if it is NOT exclusively locked.
      * It is intended for user-facing calls (e.g. from RepositoryApiController), not internal calls that may require
      * an exclusively locked snapshot to be returned (e.g. snapshot deletion).
-     * @param id in UUID formant
+     * @param id in UUID format
      * @param include a list of what information to include
-     * @return a SnapshotModel = API output-friendly representation of the Snapshot
+     * @return an API output-friendly representation of the Snapshot
      */
     public SnapshotModel retrieveAvailableSnapshotModel(UUID id,
                                                         List<SnapshotRequestAccessIncludeModel> include) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -13,11 +13,11 @@ import bio.terra.model.EnumerateSnapshotModel;
 import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
-import bio.terra.model.SnapshotAccessInfoModel;
-import bio.terra.model.SnapshotAccessInfoModelBigQuery;
-import bio.terra.model.SnapshotAccessInfoModelBigQueryTable;
+import bio.terra.model.AccessInfoModel;
+import bio.terra.model.AccessInfoBigQueryModel;
+import bio.terra.model.AccessInfoBigQueryModelTable;
 import bio.terra.model.SnapshotModel;
-import bio.terra.model.SnapshotRequestAccessInclude;
+import bio.terra.model.SnapshotRequestAccessIncludeModel;
 import bio.terra.model.SnapshotRequestAssetModel;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SnapshotRequestModel;
@@ -196,7 +196,7 @@ public class SnapshotService {
      * @return a SnapshotModel = API output-friendly representation of the Snapshot
      */
     public SnapshotModel retrieveAvailableSnapshotModel(UUID id,
-                                                        List<SnapshotRequestAccessInclude> include) {
+                                                        List<SnapshotRequestAccessIncludeModel> include) {
         Snapshot snapshot = retrieveAvailable(id);
         return populateSnapshotModelFromSnapshot(snapshot, include);
     }
@@ -522,7 +522,7 @@ public class SnapshotService {
     }
 
     private SnapshotModel populateSnapshotModelFromSnapshot(Snapshot snapshot,
-                                                            List<SnapshotRequestAccessInclude> include) {
+                                                            List<SnapshotRequestAccessIncludeModel> include) {
         SnapshotModel snapshotModel = new SnapshotModel()
             .id(snapshot.getId().toString())
             .name(snapshot.getName())
@@ -530,36 +530,36 @@ public class SnapshotService {
             .createdDate(snapshot.getCreatedDate().toString());
 
         // In case NONE is specified, this should supersede any other value being passed in
-        if (include.contains(SnapshotRequestAccessInclude.NONE)) {
+        if (include.contains(SnapshotRequestAccessIncludeModel.NONE)) {
             return snapshotModel;
         }
 
-        if (include.contains(SnapshotRequestAccessInclude.SOURCES)) {
+        if (include.contains(SnapshotRequestAccessIncludeModel.SOURCES)) {
             snapshotModel.source(snapshot.getSnapshotSources()
                 .stream()
                 .map(this::makeSourceModelFromSource)
                 .collect(Collectors.toList()));
         }
-        if (include.contains(SnapshotRequestAccessInclude.TABLES)) {
+        if (include.contains(SnapshotRequestAccessIncludeModel.TABLES)) {
             snapshotModel.tables(snapshot.getTables()
                 .stream()
                 .map(this::makeTableModelFromTable)
                 .collect(Collectors.toList()));
         }
-        if (include.contains(SnapshotRequestAccessInclude.RELATIONSHIPS)) {
+        if (include.contains(SnapshotRequestAccessIncludeModel.RELATIONSHIPS)) {
             snapshotModel.relationships(snapshot.getRelationships()
                 .stream()
                 .map(this::makeRelationshipModelFromRelationship)
                 .collect(Collectors.toList()));
         }
-        if (include.contains(SnapshotRequestAccessInclude.PROFILE)) {
+        if (include.contains(SnapshotRequestAccessIncludeModel.PROFILE)) {
             snapshotModel.profileId(snapshot.getProfileId().toString());
         }
-        if (include.contains(SnapshotRequestAccessInclude.DATA_PROJECT)) {
+        if (include.contains(SnapshotRequestAccessIncludeModel.DATA_PROJECT)) {
             snapshotModel.dataProject(snapshot.getProjectResource().getGoogleProjectId());
         }
-        if (include.contains(SnapshotRequestAccessInclude.ACCESS_INFORMATION)) {
-            snapshotModel.accessInformation(makeSnapshotAccessInfoModelFromSnapshot(snapshot));
+        if (include.contains(SnapshotRequestAccessIncludeModel.ACCESS_INFORMATION)) {
+            snapshotModel.accessInformation(makeAccessInfoModelFromSnapshot(snapshot));
         }
         return snapshotModel;
     }
@@ -602,11 +602,11 @@ public class SnapshotService {
         return sourceModel;
     }
 
-    private SnapshotAccessInfoModel makeSnapshotAccessInfoModelFromSnapshot(Snapshot snapshot) {
-        SnapshotAccessInfoModel accessInfoModel = new SnapshotAccessInfoModel();
+    private AccessInfoModel makeAccessInfoModelFromSnapshot(Snapshot snapshot) {
+        AccessInfoModel accessInfoModel = new AccessInfoModel();
 
         // Currently, only BigQuery is supported.  Parquet specific information will be added here
-        accessInfoModel.bigQuery(new SnapshotAccessInfoModelBigQuery()
+        accessInfoModel.bigQuery(new AccessInfoBigQueryModel()
             .datasetName(snapshot.getName())
             .projectId(snapshot.getProjectResource().getGoogleProjectId())
             .link(new ST(BIGQUERY_BASE_LINK)
@@ -614,7 +614,7 @@ public class SnapshotService {
                 .add("dataset", snapshot.getName())
                 .render())
             .tables(snapshot.getTables().stream()
-                .map(t -> new SnapshotAccessInfoModelBigQueryTable()
+                .map(t -> new AccessInfoBigQueryModelTable()
                     .name(t.getName())
                     .address(new ST(BIGQUERY_TABLE_ADDRESS)
                         .add("project", snapshot.getProjectResource().getGoogleProjectId())
@@ -652,9 +652,9 @@ public class SnapshotService {
             .arrayOf(column.isArrayOf());
     }
 
-    private static List<SnapshotRequestAccessInclude> getDefaultIncludes() {
+    private static List<SnapshotRequestAccessIncludeModel> getDefaultIncludes() {
         return Arrays.stream(StringUtils.split(SnapshotsApiController.RETRIEVE_INCLUDE_DEFAULT_VALUE, ','))
-            .map(SnapshotRequestAccessInclude::fromValue)
+            .map(SnapshotRequestAccessIncludeModel::fromValue)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -874,7 +874,7 @@ public class BigQueryPdao {
         return refIdArray;
     }
 
-    public String prefixName(String name) {
+    public static String prefixName(String name) {
         return PDAO_PREFIX + name;
     }
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -616,6 +616,15 @@ paths:
           required: true
           schema:
             type: string
+        - name: include
+          in: query
+          description: A list of what to include with the snapshot object
+          required: false
+          schema:
+            type: array
+            items:
+              default: "SOURCES,TABLES,RELATIONSHIPS,PROFILE,DATA_PROJECT"
+              $ref: '#/components/schemas/SnapshotRequestAccessInclude'
       responses:
         200:
           description: Snapshot
@@ -3382,6 +3391,12 @@ components:
             $ref: '#/components/schemas/UniqueIdProperty'
       description: >
         A specification of a table, columns, and row ids to go into a snapshot.
+    SnapshotRequestAccessInclude:
+      type: string
+      description: >
+        Type of information to include in the response
+      enum: [ NONE, SOURCES, TABLES, RELATIONSHIPS, ACCESS_INFORMATION, PROFILE, DATA_PROJECT ]
+
     SnapshotSummaryModel:
       type: object
       properties:
@@ -3441,8 +3456,42 @@ components:
         dataProject:
           type: string
           description: Project id of the snapshot data project
+        accessInformation:
+          $ref: '#/components/schemas/SnapshotAccessInfoModel'
+          description: How to access the metadata for the snapshot
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
+    SnapshotAccessInfoModel:
+      type: object
+      properties:
+        bigQuery:
+          $ref: '#/components/schemas/SnapshotAccessInfoModelBigQuery'
+    SnapshotAccessInfoModelBigQuery:
+      type: object
+      properties:
+        datasetName:
+          type: string
+          required: true
+        projectId:
+          type: string
+          required: true
+        link:
+          type: string
+          required: true
+        tables:
+          type: array
+          items:
+            $ref: '#/components/schemas/SnapshotAccessInfoModelBigQueryTable'
+          required: true
+    SnapshotAccessInfoModelBigQueryTable:
+      type: object
+      properties:
+        name:
+          type: string
+          required: true
+        sampleQuery:
+          type: string
+          required: true
     SnapshotSourceModel:
       required:
         - asset

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -624,7 +624,7 @@ paths:
             type: array
             items:
               default: "SOURCES,TABLES,RELATIONSHIPS,PROFILE,DATA_PROJECT"
-              $ref: '#/components/schemas/SnapshotRequestAccessInclude'
+              $ref: '#/components/schemas/SnapshotRequestAccessIncludeModel'
       responses:
         200:
           description: Snapshot
@@ -3391,7 +3391,7 @@ components:
             $ref: '#/components/schemas/UniqueIdProperty'
       description: >
         A specification of a table, columns, and row ids to go into a snapshot.
-    SnapshotRequestAccessInclude:
+    SnapshotRequestAccessIncludeModel:
       type: string
       description: >
         Type of information to include in the response
@@ -3457,18 +3457,20 @@ components:
           type: string
           description: Project id of the snapshot data project
         accessInformation:
-          $ref: '#/components/schemas/SnapshotAccessInfoModel'
+          $ref: '#/components/schemas/AccessInfoModel'
           description: How to access the metadata for the snapshot
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
-    SnapshotAccessInfoModel:
+    AccessInfoModel:
       type: object
+      description: >
+        How to access the metadata for a snapshot or dataset
       properties:
         bigQuery:
-          $ref: '#/components/schemas/SnapshotAccessInfoModelBigQuery'
-    SnapshotAccessInfoModelBigQuery:
+          $ref: '#/components/schemas/AccessInfoBigQueryModel'
+    AccessInfoBigQueryModel:
       description: >
-        General information on where snapshot tabular data lives in BigQuery
+        General information on where snapshot or dataset tabular data lives in BigQuery
       type: object
       required:
         - datasetName
@@ -3479,7 +3481,7 @@ components:
         datasetName:
           type: string
           description: >
-            Name of the BigQuery dataset where snapshot tabular data lives
+            Name of the BigQuery dataset where snapshot or dataset tabular data lives
         projectId:
           type: string
           description: >
@@ -3493,11 +3495,11 @@ components:
           description: >
             Information on each table in the BigQuery dataset
           items:
-            $ref: '#/components/schemas/SnapshotAccessInfoModelBigQueryTable'
-    SnapshotAccessInfoModelBigQueryTable:
+            $ref: '#/components/schemas/AccessInfoBigQueryModelTable'
+    AccessInfoBigQueryModelTable:
       type: object
       description: >
-        Information on a snapshot table in a BigQuery dataset
+        Information on a snapshot or dataset table in a BigQuery dataset
       required:
         - name
         - sampleQuery

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -622,8 +622,8 @@ paths:
           required: false
           schema:
             type: array
+            default: "SOURCES,TABLES,RELATIONSHIPS,PROFILE,DATA_PROJECT"
             items:
-              default: "SOURCES,TABLES,RELATIONSHIPS,PROFILE,DATA_PROJECT"
               $ref: '#/components/schemas/SnapshotRequestAccessIncludeModel'
       responses:
         200:
@@ -1089,6 +1089,15 @@ paths:
           required: true
           schema:
             type: string
+        - name: include
+          in: query
+          description: A list of what to include with the dataset object
+          required: false
+          schema:
+            type: array
+            default: "SCHEMA,PROFILE,DATA_PROJECT,STORAGE"
+            items:
+              $ref: '#/components/schemas/DatasetRequestAccessIncludeModel'
       responses:
         200:
           description: Dataset
@@ -2695,6 +2704,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageResourceModel'
+        accessInformation:
+          $ref: '#/components/schemas/AccessInfoModel'
       description: >
         Complete definition of a dataset.
     DatasetSummaryModel:
@@ -2740,6 +2751,11 @@ components:
           $ref: '#/components/schemas/CloudPlatform'
       description: >
         Complete definition of a dataset without the id (used to create a dataset)
+    DatasetRequestAccessIncludeModel:
+      type: string
+      description: >
+        Type of information to include in the response
+      enum: [ NONE, SCHEMA, ACCESS_INFORMATION, PROFILE, DATA_PROJECT, STORAGE ]
     EnumerateDatasetModel:
       type: object
       properties:
@@ -3396,7 +3412,6 @@ components:
       description: >
         Type of information to include in the response
       enum: [ NONE, SOURCES, TABLES, RELATIONSHIPS, ACCESS_INFORMATION, PROFILE, DATA_PROJECT ]
-
     SnapshotSummaryModel:
       type: object
       properties:
@@ -3458,7 +3473,6 @@ components:
           description: Project id of the snapshot data project
         accessInformation:
           $ref: '#/components/schemas/AccessInfoModel'
-          description: How to access the metadata for the snapshot
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
     AccessInfoModel:
@@ -3489,7 +3503,7 @@ components:
         link:
           type: string
           description: >
-            The link to access BigQuery in the Google Cloud console
+            The link to access the BigQuery dataset UI in Google Cloud console
         tables:
           type: array
           description: >
@@ -3503,16 +3517,20 @@ components:
       required:
         - name
         - sampleQuery
-        - address
+        - qualifiedName
       properties:
         name:
           type: string
           description: >
             The name of the BigQuery table
-        address:
+        qualifiedName:
           type: string
           description: >
             The fully qualified name of the BigQuery table
+        link:
+          type: string
+          description: >
+            The link to access the BigQuery table UI in Google Cloud console
         sampleQuery:
           type: string
           description: >

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3488,6 +3488,7 @@ components:
       type: object
       required:
         - datasetName
+        - datasetId
         - projectId
         - link
         - tables
@@ -3496,6 +3497,10 @@ components:
           type: string
           description: >
             Name of the BigQuery dataset where snapshot or dataset tabular data lives
+        datasetId:
+          type: string
+          description: >
+            Unique ID of the BigQuery dataset where snapshot or dataset tabular data lives
         projectId:
           type: string
           description: >
@@ -3516,6 +3521,7 @@ components:
         Information on a snapshot or dataset table in a BigQuery dataset
       required:
         - name
+        - id
         - sampleQuery
         - qualifiedName
       properties:
@@ -3523,6 +3529,10 @@ components:
           type: string
           description: >
             The name of the BigQuery table
+        id:
+          type: string
+          description: >
+            The unique id of the BigQuery table
         qualifiedName:
           type: string
           description: >

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3467,31 +3467,54 @@ components:
         bigQuery:
           $ref: '#/components/schemas/SnapshotAccessInfoModelBigQuery'
     SnapshotAccessInfoModelBigQuery:
+      description: >
+        General information on where snapshot tabular data lives in BigQuery
       type: object
+      required:
+        - datasetName
+        - projectId
+        - link
+        - tables
       properties:
         datasetName:
           type: string
-          required: true
+          description: >
+            Name of the BigQuery dataset where snapshot tabular data lives
         projectId:
           type: string
-          required: true
+          description: >
+            Project id of the project where tabular data in BigQuery lives
         link:
           type: string
-          required: true
+          description: >
+            The link to access BigQuery in the Google Cloud console
         tables:
           type: array
+          description: >
+            Information on each table in the BigQuery dataset
           items:
             $ref: '#/components/schemas/SnapshotAccessInfoModelBigQueryTable'
-          required: true
     SnapshotAccessInfoModelBigQueryTable:
       type: object
+      description: >
+        Information on a snapshot table in a BigQuery dataset
+      required:
+        - name
+        - sampleQuery
+        - address
       properties:
         name:
           type: string
-          required: true
+          description: >
+            The name of the BigQuery table
+        address:
+          type: string
+          description: >
+            The fully qualified name of the BigQuery table
         sampleQuery:
           type: string
-          required: true
+          description: >
+            An example query that can be used to select data from this table
     SnapshotSourceModel:
       required:
         - asset

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -175,6 +175,7 @@ public class DatasetJsonConversionTest {
                     .bigQuery(new bio.terra.model.AccessInfoBigQueryModel()
                         .datasetName(expectedDatasetName)
                         .projectId(DATASET_DATA_PROJECT)
+                        .datasetId(DATASET_DATA_PROJECT + ":" + expectedDatasetName)
                         .link("https://console.cloud.google.com/bigquery?project=" + DATASET_DATA_PROJECT +
                             "&ws=!" + expectedDatasetName + "&d=" + expectedDatasetName + "&p=" + DATASET_DATA_PROJECT +
                             "&page=dataset")
@@ -184,6 +185,7 @@ public class DatasetJsonConversionTest {
                             .link("https://console.cloud.google.com/bigquery?project=" + DATASET_DATA_PROJECT +
                                 "&ws=!" + expectedDatasetName + "&d=" + expectedDatasetName + "&p=" +
                                 DATASET_DATA_PROJECT + "&page=table&t=" + DATASET_TABLE_NAME)
+                            .id(DATASET_DATA_PROJECT + ":" + expectedDatasetName + "." + DATASET_TABLE_NAME)
                             .sampleQuery("SELECT * FROM `" + DATASET_DATA_PROJECT + "." + expectedDatasetName + "." +
                                 DATASET_TABLE_NAME + "` LIMIT 1000")
                         ))

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -1,0 +1,196 @@
+package bio.terra.service.dataset;
+
+import bio.terra.common.Column;
+import bio.terra.common.category.Unit;
+import bio.terra.model.AccessInfoModel;
+import bio.terra.model.AssetModel;
+import bio.terra.model.AssetTableModel;
+import bio.terra.model.ColumnModel;
+import bio.terra.model.DatasetModel;
+import bio.terra.model.DatasetRequestAccessIncludeModel;
+import bio.terra.model.DatasetSpecificationModel;
+import bio.terra.model.TableDataType;
+import bio.terra.model.TableModel;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+@Category(Unit.class)
+public class DatasetJsonConversionTest {
+
+    private static final UUID DATASET_PROFILE_ID = UUID.randomUUID();
+    private static final String DATASET_NAME = "dataset_name";
+    private static final UUID DATASET_ID = UUID.randomUUID();
+    private static final Instant DATASET_CREATION_DATE = Instant.now();
+    private static final String DATASET_DESCRIPTION = "dataset description";
+    private static final String DATASET_DATA_PROJECT = "dataset_name_data";
+    private static final String DATASET_TABLE_NAME = "table_a";
+    private static final UUID DATASET_TABLE_ID = UUID.randomUUID();
+    private static final String DATASET_COLUMN_NAME = "column_a";
+    private static final TableDataType DATASET_COLUMN_TYPE = TableDataType.STRING;
+    private static final UUID DATASET_COLUMN_ID = UUID.randomUUID();
+    private static final String DATASET_ASSET_NAME = "asset1";
+    private static final UUID DATASET_ASSET_ID = UUID.randomUUID();
+
+    private Dataset dataset;
+    private DatasetModel datasetModel;
+
+    @Before
+    public void setUp() throws Exception {
+        Column datasetColumn = new Column()
+            .id(DATASET_COLUMN_ID)
+            .name(DATASET_COLUMN_NAME)
+            .arrayOf(false)
+            .type(DATASET_COLUMN_TYPE);
+        DatasetTable datasetTable = new DatasetTable()
+            .id(DATASET_TABLE_ID)
+            .name(DATASET_TABLE_NAME)
+            .rawTableName(DATASET_TABLE_NAME)
+            .columns(List.of(datasetColumn))
+            .primaryKey(List.of(new Column()
+                .id(DATASET_COLUMN_ID)
+                .name(DATASET_COLUMN_NAME)
+                .type(DATASET_COLUMN_TYPE)
+            ))
+            .bigQueryPartitionConfig(BigQueryPartitionConfigV1.none());
+
+        AssetColumn assetColumn = new AssetColumn()
+            .id(DATASET_COLUMN_ID)
+            .datasetTable(datasetTable)
+            .datasetColumn(datasetColumn);
+
+        AssetTable assetTable = new AssetTable()
+            .datasetTable(datasetTable)
+            .columns(List.of(assetColumn));
+
+        dataset = new Dataset()
+            .id(DATASET_ID)
+            .createdDate(DATASET_CREATION_DATE)
+            .name(DATASET_NAME)
+            .description(DATASET_DESCRIPTION)
+            .tables(List.of(datasetTable))
+            .assetSpecifications(List.of(new AssetSpecification()
+                .id(DATASET_ASSET_ID)
+                .name(DATASET_ASSET_NAME)
+                .assetTables(List.of(assetTable))
+                .rootTable(assetTable)
+                .rootColumn(assetColumn)
+                .assetRelationships(Collections.emptyList())
+            ))
+            .defaultProfileId(DATASET_PROFILE_ID)
+            .projectResource(new GoogleProjectResource()
+                .googleProjectId(DATASET_DATA_PROJECT)
+            );
+
+        datasetModel = new DatasetModel()
+            .name(DATASET_NAME)
+            .id(DATASET_ID.toString())
+            .description(DATASET_DESCRIPTION)
+            .createdDate(DATASET_CREATION_DATE.toString())
+            .defaultProfileId(DATASET_PROFILE_ID.toString())
+            .schema(new DatasetSpecificationModel()
+                .addTablesItem(new TableModel()
+                    .name(DATASET_TABLE_NAME)
+                    .addPrimaryKeyItem(DATASET_COLUMN_NAME)
+                    .addColumnsItem(new ColumnModel()
+                        .name(DATASET_COLUMN_NAME)
+                        .datatype(DATASET_COLUMN_TYPE)
+                        .arrayOf(false)
+                    )
+                )
+                .relationships(Collections.emptyList())
+                .assets(List.of(new AssetModel()
+                    .name(DATASET_ASSET_NAME)
+                    .addTablesItem(new AssetTableModel()
+                        .name(DATASET_TABLE_NAME)
+                        .addColumnsItem(DATASET_COLUMN_NAME)
+                    )
+                    .rootTable(DATASET_TABLE_NAME)
+                    .rootColumn(DATASET_COLUMN_NAME)
+                    .follow(Collections.emptyList())
+                ))
+            )
+            .dataProject(DATASET_DATA_PROJECT);
+    }
+
+
+    @Test
+    public void populateDatasetModelFromDataset() {
+        assertThat(
+            DatasetJsonConversion.populateDatasetModelFromDataset(
+                dataset,
+                List.of(
+                    DatasetRequestAccessIncludeModel.SCHEMA,
+                    DatasetRequestAccessIncludeModel.PROFILE,
+                    DatasetRequestAccessIncludeModel.DATA_PROJECT
+                )
+            ),
+            equalTo(datasetModel)
+        );
+    }
+
+    @Test
+    public void populateDatasetModelFromDatasetNone() throws IOException {
+        assertThat(
+            DatasetJsonConversion.populateDatasetModelFromDataset(
+                dataset,
+                List.of(
+                    DatasetRequestAccessIncludeModel.NONE,
+                    DatasetRequestAccessIncludeModel.PROFILE
+                )
+            ),
+            equalTo(datasetModel
+                .dataProject(null)
+                .defaultProfileId(null)
+                .schema(null)
+            )
+        );
+    }
+
+    @Test
+    public void populateDatasetModelFromDatasetAccessInfo() {
+        String expectedDatasetName = "datarepo_" + DATASET_NAME;
+        assertThat(
+            DatasetJsonConversion.populateDatasetModelFromDataset(
+                dataset,
+                List.of(
+                    DatasetRequestAccessIncludeModel.ACCESS_INFORMATION
+                )
+            ),
+            equalTo(datasetModel
+                .dataProject(null)
+                .defaultProfileId(null)
+                .schema(null)
+                .accessInformation(new AccessInfoModel()
+                    .bigQuery(new bio.terra.model.AccessInfoBigQueryModel()
+                        .datasetName(expectedDatasetName)
+                        .projectId(DATASET_DATA_PROJECT)
+                        .link("https://console.cloud.google.com/bigquery?project=" + DATASET_DATA_PROJECT +
+                            "&ws=!" + expectedDatasetName + "&d=" + expectedDatasetName + "&p=" + DATASET_DATA_PROJECT +
+                            "&page=dataset")
+                        .tables(List.of(new bio.terra.model.AccessInfoBigQueryModelTable()
+                            .name(DATASET_TABLE_NAME)
+                            .qualifiedName(DATASET_DATA_PROJECT + "." + expectedDatasetName + "." + DATASET_TABLE_NAME)
+                            .link("https://console.cloud.google.com/bigquery?project=" + DATASET_DATA_PROJECT +
+                                "&ws=!" + expectedDatasetName + "&d=" + expectedDatasetName + "&p=" +
+                                DATASET_DATA_PROJECT + "&page=table&t=" + DATASET_TABLE_NAME)
+                            .sampleQuery("SELECT * FROM `" + DATASET_DATA_PROJECT + "." + expectedDatasetName + "." +
+                                DATASET_TABLE_NAME + "` LIMIT 1000")
+                        ))
+                    )
+                )
+            )
+        );
+    }
+
+}

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -10,6 +10,7 @@ import bio.terra.common.fixtures.ResourceFixtures;
 import bio.terra.model.AssetModel;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
+import bio.terra.model.DatasetRequestAccessIncludeModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.JobModel;
@@ -39,6 +40,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -370,4 +372,21 @@ public class DatasetServiceTest {
 
         datasetDao.delete(datasetId);
     }
+
+    @Test
+    public void retrieveDatasetDefault() throws SQLException, IOException {
+        UUID datasetId = createDataset("dataset-create-test.json");
+        Dataset dataset = datasetDao.retrieve(datasetId);
+        assertThat(
+            "dataset info defaults are expected",
+            datasetService.retrieveModel(dataset),
+            equalTo(datasetService.retrieveModel(dataset, List.of(
+                DatasetRequestAccessIncludeModel.SCHEMA,
+                DatasetRequestAccessIncludeModel.PROFILE,
+                DatasetRequestAccessIncludeModel.DATA_PROJECT,
+                DatasetRequestAccessIncludeModel.STORAGE
+            )))
+        );
+    }
+
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1,0 +1,179 @@
+package bio.terra.service.snapshot;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.SnapshotAccessInfoModel;
+import bio.terra.model.SnapshotAccessInfoModelBigQuery;
+import bio.terra.model.SnapshotAccessInfoModelBigQueryTable;
+import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotRequestAccessInclude;
+import bio.terra.model.TableModel;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
+import bio.terra.service.job.JobService;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.tabulardata.google.BigQueryPdao;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@Category(Unit.class)
+public class SnapshotServiceTest {
+
+    private static final String SNAPSHOT_NAME = "snapshotName";
+    private static final String SNAPSHOT_DESCRIPTION = "snapshotDescription";
+    private static final String SNAPSHOT_DATA_PROJECT = "tdrdataproject";
+    private static final String SNAPSHOT_TABLE_NAME = "tableA";
+
+
+    @Mock
+    private JobService jobService;
+    @Mock
+    private DatasetService datasetService;
+    @Mock
+    private FireStoreDependencyDao dependencyDao;
+    @Mock
+    private BigQueryPdao bigQueryPdao;
+    @Mock
+    private SnapshotDao snapshotDao;
+
+    private UUID snapshotId;
+    private UUID snapshotTableId;
+    private UUID profileId;
+    private Instant createdDate;
+
+    private SnapshotService service;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        service = new SnapshotService(jobService, datasetService, dependencyDao, bigQueryPdao, snapshotDao);
+
+        snapshotId = UUID.randomUUID();
+        snapshotTableId = UUID.randomUUID();
+        profileId = UUID.randomUUID();
+        createdDate = Instant.now();
+    }
+
+    @Test
+    public void testRetrieveSnapshot() {
+        mockSnapshot();
+        assertThat(service.retrieveAvailableSnapshotModel(snapshotId), equalTo(
+            new SnapshotModel()
+                .id(snapshotId.toString())
+                .name(SNAPSHOT_NAME)
+                .description(SNAPSHOT_DESCRIPTION)
+                .createdDate(createdDate.toString())
+                .source(Collections.emptyList())
+                .tables(List.of(new TableModel()
+                    .name(SNAPSHOT_TABLE_NAME)
+                ))
+                .relationships(Collections.emptyList())
+                .profileId(profileId.toString())
+                .dataProject(SNAPSHOT_DATA_PROJECT)
+        ));
+    }
+
+    @Test
+    public void testRetrieveSnapshotNoFields() {
+        mockSnapshot();
+        assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(SnapshotRequestAccessInclude.NONE)),
+            equalTo(new SnapshotModel()
+                .id(snapshotId.toString())
+                .name(SNAPSHOT_NAME)
+                .description(SNAPSHOT_DESCRIPTION)
+                .createdDate(createdDate.toString())));
+    }
+
+    @Test
+    public void testRetrieveSnapshotDefaultFields() {
+        mockSnapshot();
+        assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(
+            SnapshotRequestAccessInclude.SOURCES,
+            SnapshotRequestAccessInclude.TABLES,
+            SnapshotRequestAccessInclude.RELATIONSHIPS,
+            SnapshotRequestAccessInclude.PROFILE,
+            SnapshotRequestAccessInclude.DATA_PROJECT)),
+            equalTo(service.retrieveAvailableSnapshotModel(snapshotId)));
+    }
+
+    @Test
+    public void testRetrieveSnapshotOnlyAccessInfo() {
+        mockSnapshot();
+        assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(
+            SnapshotRequestAccessInclude.ACCESS_INFORMATION)),
+            equalTo(new SnapshotModel()
+                .id(snapshotId.toString())
+                .name(SNAPSHOT_NAME)
+                .description(SNAPSHOT_DESCRIPTION)
+                .createdDate(createdDate.toString())
+                .accessInformation(new SnapshotAccessInfoModel()
+                    .bigQuery(new SnapshotAccessInfoModelBigQuery()
+                        .datasetName(SNAPSHOT_NAME)
+                        .projectId(SNAPSHOT_DATA_PROJECT)
+                        .link("https://console.cloud.google.com/bigquery?project=" + SNAPSHOT_DATA_PROJECT)
+                        .tables(List.of(new SnapshotAccessInfoModelBigQueryTable()
+                            .name(SNAPSHOT_TABLE_NAME)
+                            .sampleQuery("SELECT * FROM `" + SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." +
+                                SNAPSHOT_TABLE_NAME + "` LIMIT 1000")
+                        ))
+                    )
+                )));
+    }
+
+    @Test
+    public void testRetrieveSnapshotMultiInfo() {
+        mockSnapshot();
+        assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(
+            SnapshotRequestAccessInclude.ACCESS_INFORMATION,
+            SnapshotRequestAccessInclude.SOURCES
+            )),
+            equalTo(new SnapshotModel()
+                .id(snapshotId.toString())
+                .name(SNAPSHOT_NAME)
+                .description(SNAPSHOT_DESCRIPTION)
+                .createdDate(createdDate.toString())
+                .source(Collections.emptyList())
+                .accessInformation(new SnapshotAccessInfoModel()
+                    .bigQuery(new SnapshotAccessInfoModelBigQuery()
+                        .datasetName(SNAPSHOT_NAME)
+                        .projectId(SNAPSHOT_DATA_PROJECT)
+                        .link("https://console.cloud.google.com/bigquery?project=" + SNAPSHOT_DATA_PROJECT)
+                        .tables(List.of(new SnapshotAccessInfoModelBigQueryTable()
+                            .name(SNAPSHOT_TABLE_NAME)
+                            .sampleQuery("SELECT * FROM `" + SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." +
+                                SNAPSHOT_TABLE_NAME + "` LIMIT 1000")
+                        ))
+                    )
+                )));
+    }
+
+    private void mockSnapshot() {
+        when(snapshotDao.retrieveAvailableSnapshot(snapshotId))
+            .thenReturn(new Snapshot()
+                .id(snapshotId)
+                .name(SNAPSHOT_NAME)
+                .description(SNAPSHOT_DESCRIPTION)
+                .createdDate(createdDate)
+                .profileId(profileId)
+                .projectResource(new GoogleProjectResource()
+                    .profileId(profileId)
+                    .googleProjectId(SNAPSHOT_DATA_PROJECT)
+                )
+                .snapshotTables(List.of(new SnapshotTable()
+                    .name(SNAPSHOT_TABLE_NAME)
+                    .id(snapshotTableId)
+                ))
+            );
+    }
+}

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1,11 +1,11 @@
 package bio.terra.service.snapshot;
 
 import bio.terra.common.category.Unit;
-import bio.terra.model.SnapshotAccessInfoModel;
-import bio.terra.model.SnapshotAccessInfoModelBigQuery;
-import bio.terra.model.SnapshotAccessInfoModelBigQueryTable;
+import bio.terra.model.AccessInfoModel;
+import bio.terra.model.AccessInfoBigQueryModel;
+import bio.terra.model.AccessInfoBigQueryModelTable;
 import bio.terra.model.SnapshotModel;
-import bio.terra.model.SnapshotRequestAccessInclude;
+import bio.terra.model.SnapshotRequestAccessIncludeModel;
 import bio.terra.model.TableModel;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
@@ -41,6 +41,7 @@ public class SnapshotServiceTest {
     @Mock
     private DatasetService datasetService;
     @Mock
+
     private FireStoreDependencyDao dependencyDao;
     @Mock
     private BigQueryPdao bigQueryPdao;
@@ -87,7 +88,7 @@ public class SnapshotServiceTest {
     @Test
     public void testRetrieveSnapshotNoFields() {
         mockSnapshot();
-        assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(SnapshotRequestAccessInclude.NONE)),
+        assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(SnapshotRequestAccessIncludeModel.NONE)),
             equalTo(new SnapshotModel()
                 .id(snapshotId.toString())
                 .name(SNAPSHOT_NAME)
@@ -99,11 +100,11 @@ public class SnapshotServiceTest {
     public void testRetrieveSnapshotDefaultFields() {
         mockSnapshot();
         assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(
-            SnapshotRequestAccessInclude.SOURCES,
-            SnapshotRequestAccessInclude.TABLES,
-            SnapshotRequestAccessInclude.RELATIONSHIPS,
-            SnapshotRequestAccessInclude.PROFILE,
-            SnapshotRequestAccessInclude.DATA_PROJECT)),
+            SnapshotRequestAccessIncludeModel.SOURCES,
+            SnapshotRequestAccessIncludeModel.TABLES,
+            SnapshotRequestAccessIncludeModel.RELATIONSHIPS,
+            SnapshotRequestAccessIncludeModel.PROFILE,
+            SnapshotRequestAccessIncludeModel.DATA_PROJECT)),
             equalTo(service.retrieveAvailableSnapshotModel(snapshotId)));
     }
 
@@ -111,20 +112,20 @@ public class SnapshotServiceTest {
     public void testRetrieveSnapshotOnlyAccessInfo() {
         mockSnapshot();
         assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(
-            SnapshotRequestAccessInclude.ACCESS_INFORMATION)),
+            SnapshotRequestAccessIncludeModel.ACCESS_INFORMATION)),
             equalTo(new SnapshotModel()
                 .id(snapshotId.toString())
                 .name(SNAPSHOT_NAME)
                 .description(SNAPSHOT_DESCRIPTION)
                 .createdDate(createdDate.toString())
-                .accessInformation(new SnapshotAccessInfoModel()
-                    .bigQuery(new SnapshotAccessInfoModelBigQuery()
+                .accessInformation(new AccessInfoModel()
+                    .bigQuery(new AccessInfoBigQueryModel()
                         .datasetName(SNAPSHOT_NAME)
                         .projectId(SNAPSHOT_DATA_PROJECT)
                         .link("https://console.cloud.google.com/bigquery?project=" + SNAPSHOT_DATA_PROJECT +
                             "&ws=!" + SNAPSHOT_NAME + "&d=" + SNAPSHOT_NAME + "&p=" + SNAPSHOT_DATA_PROJECT +
                             "&page=dataset")
-                        .tables(List.of(new SnapshotAccessInfoModelBigQueryTable()
+                        .tables(List.of(new AccessInfoBigQueryModelTable()
                             .name(SNAPSHOT_TABLE_NAME)
                             .address(SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." + SNAPSHOT_TABLE_NAME)
                             .sampleQuery("SELECT * FROM `" + SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." +
@@ -138,8 +139,8 @@ public class SnapshotServiceTest {
     public void testRetrieveSnapshotMultiInfo() {
         mockSnapshot();
         assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(
-            SnapshotRequestAccessInclude.PROFILE,
-            SnapshotRequestAccessInclude.SOURCES
+            SnapshotRequestAccessIncludeModel.PROFILE,
+            SnapshotRequestAccessIncludeModel.SOURCES
             )),
             equalTo(new SnapshotModel()
                 .id(snapshotId.toString())

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -121,9 +121,12 @@ public class SnapshotServiceTest {
                     .bigQuery(new SnapshotAccessInfoModelBigQuery()
                         .datasetName(SNAPSHOT_NAME)
                         .projectId(SNAPSHOT_DATA_PROJECT)
-                        .link("https://console.cloud.google.com/bigquery?project=" + SNAPSHOT_DATA_PROJECT)
+                        .link("https://console.cloud.google.com/bigquery?project=" + SNAPSHOT_DATA_PROJECT +
+                            "&ws=!" + SNAPSHOT_NAME + "&d=" + SNAPSHOT_NAME + "&p=" + SNAPSHOT_DATA_PROJECT +
+                            "&page=dataset")
                         .tables(List.of(new SnapshotAccessInfoModelBigQueryTable()
                             .name(SNAPSHOT_TABLE_NAME)
+                            .address(SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." + SNAPSHOT_TABLE_NAME)
                             .sampleQuery("SELECT * FROM `" + SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." +
                                 SNAPSHOT_TABLE_NAME + "` LIMIT 1000")
                         ))
@@ -135,7 +138,7 @@ public class SnapshotServiceTest {
     public void testRetrieveSnapshotMultiInfo() {
         mockSnapshot();
         assertThat(service.retrieveAvailableSnapshotModel(snapshotId, List.of(
-            SnapshotRequestAccessInclude.ACCESS_INFORMATION,
+            SnapshotRequestAccessInclude.PROFILE,
             SnapshotRequestAccessInclude.SOURCES
             )),
             equalTo(new SnapshotModel()
@@ -144,18 +147,7 @@ public class SnapshotServiceTest {
                 .description(SNAPSHOT_DESCRIPTION)
                 .createdDate(createdDate.toString())
                 .source(Collections.emptyList())
-                .accessInformation(new SnapshotAccessInfoModel()
-                    .bigQuery(new SnapshotAccessInfoModelBigQuery()
-                        .datasetName(SNAPSHOT_NAME)
-                        .projectId(SNAPSHOT_DATA_PROJECT)
-                        .link("https://console.cloud.google.com/bigquery?project=" + SNAPSHOT_DATA_PROJECT)
-                        .tables(List.of(new SnapshotAccessInfoModelBigQueryTable()
-                            .name(SNAPSHOT_TABLE_NAME)
-                            .sampleQuery("SELECT * FROM `" + SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." +
-                                SNAPSHOT_TABLE_NAME + "` LIMIT 1000")
-                        ))
-                    )
-                )));
+                .profileId(profileId.toString())));
     }
 
     private void mockSnapshot() {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -121,6 +121,7 @@ public class SnapshotServiceTest {
                 .accessInformation(new AccessInfoModel()
                     .bigQuery(new AccessInfoBigQueryModel()
                         .datasetName(SNAPSHOT_NAME)
+                        .datasetId(SNAPSHOT_DATA_PROJECT + ":" + SNAPSHOT_NAME)
                         .projectId(SNAPSHOT_DATA_PROJECT)
                         .link("https://console.cloud.google.com/bigquery?project=" + SNAPSHOT_DATA_PROJECT +
                             "&ws=!" + SNAPSHOT_NAME + "&d=" + SNAPSHOT_NAME + "&p=" + SNAPSHOT_DATA_PROJECT +
@@ -131,8 +132,9 @@ public class SnapshotServiceTest {
                             .link("https://console.cloud.google.com/bigquery?project=" + SNAPSHOT_DATA_PROJECT +
                                 "&ws=!" + SNAPSHOT_NAME + "&d=" + SNAPSHOT_NAME + "&p=" + SNAPSHOT_DATA_PROJECT +
                                 "&page=table&t=" + SNAPSHOT_TABLE_NAME)
+                            .id(SNAPSHOT_DATA_PROJECT + ":" + SNAPSHOT_NAME + "." + SNAPSHOT_TABLE_NAME)
                             .sampleQuery("SELECT * FROM `" + SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." +
-                                SNAPSHOT_TABLE_NAME + "` LIMIT 1000")
+                            SNAPSHOT_TABLE_NAME + "` LIMIT 1000")
                         ))
                     )
                 )));

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -127,7 +127,10 @@ public class SnapshotServiceTest {
                             "&page=dataset")
                         .tables(List.of(new AccessInfoBigQueryModelTable()
                             .name(SNAPSHOT_TABLE_NAME)
-                            .address(SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." + SNAPSHOT_TABLE_NAME)
+                            .qualifiedName(SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." + SNAPSHOT_TABLE_NAME)
+                            .link("https://console.cloud.google.com/bigquery?project=" + SNAPSHOT_DATA_PROJECT +
+                                "&ws=!" + SNAPSHOT_NAME + "&d=" + SNAPSHOT_NAME + "&p=" + SNAPSHOT_DATA_PROJECT +
+                                "&page=table&t=" + SNAPSHOT_TABLE_NAME)
                             .sampleQuery("SELECT * FROM `" + SNAPSHOT_DATA_PROJECT + "." + SNAPSHOT_NAME + "." +
                                 SNAPSHOT_TABLE_NAME + "` LIMIT 1000")
                         ))


### PR DESCRIPTION
Note: Defaults are kept the same to maintain backwards compatibility

This adds options to the retrieve snapshot and dataset endpoints:
![image](https://user-images.githubusercontent.com/5633787/117090849-7e58a300-ad27-11eb-8c5f-944bbb099e80.png)


And adds the ability to return information for accessing bigquery data, e.g.:
```
{
  "id": "<snapshot/dataset id>",
  "name": "name",
  ...
  "accessInformation": {
    "bigQuery": {
      "datasetName": "<bq dataset name>",
      "datasetId": "<data project id>:<bq dataset name>",
      "projectId": "<data project id>",
      "link": "https://console.cloud.google.com/bigquery?project=<data project id>...",
      "tables": [
        {
          "name": "<table name>",
          "id": "<data project id>:<bq dataset name>.<table name>",
          "qualifiedName": "<data project id>.<bq dataset name>.<table name>",
          "sampleQuery": "SELECT * FROM `<data project id>.<bq dataset name>.<table name>` LIMIT 1000"
        }
      ]
    }
  }
}
```