### PR TITLE
DR-1795 Add US, correct current values

### DIFF
--- a/src/main/java/bio/terra/app/model/GoogleRegion.java
+++ b/src/main/java/bio/terra/app/model/GoogleRegion.java
@@ -28,7 +28,8 @@ public enum GoogleRegion {
         US_WEST1("us-west1"),
         US_WEST2("us-west2"),
         US_WEST3("us-west3"),
-        US_WEST4("us-west4");
+        US_WEST4("us-west4"),
+        US("us");
 
 
     public static final GoogleRegion DEFAULT_GOOGLE_REGION = GoogleRegion.US_CENTRAL1;

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -38,4 +38,5 @@
     <include file="changesets/20210304_allowlongdatasetandsnapshotnames.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210426_datasetstorage.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210426_datasetstoragemigration.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20210510_datasetstoragemigrationcorrected.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20210510_datasetstoragemigrationcorrected.yaml
+++ b/src/main/resources/db/changesets/20210510_datasetstoragemigrationcorrected.yaml
@@ -1,7 +1,7 @@
 databaseChangeLog:
   - changeSet:
       id: storage_resource_migration_corrected
-      author: se
+      author: tl
       changes:
         - sql:
             comment: update storage records for existing bigquery datasets

--- a/src/main/resources/db/changesets/20210510_datasetstoragemigrationcorrected.yaml
+++ b/src/main/resources/db/changesets/20210510_datasetstoragemigrationcorrected.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: storage_resource_migration
+      author: se
+      changes:
+        - sql:
+            comment: update storage records for existing bigquery datasets
+            sql: >
+              UPDATE storage_resource
+              SET cloud_resource = 'BIGQUERY', cloud_platform = 'GCP'
+              WHERE cloud_resource = 'bigquery'
+        - sql:
+            comment: update storage records for existing gcs buckets
+            sql: >
+              UPDATE storage_resource
+              SET cloud_resource = 'BUCKET', cloud_platform = 'GCP', region = 'US_CENTRAL1'
+              WHERE cloud_resource = 'bucket' and region = 'us-central1'
+        - sql:
+            comment: update storage records for existing firestore databases
+            sql: >
+              UPDATE storage_resource
+              SET cloud_resource = 'FIRESTORE', cloud_platform = 'GCP', region = 'US_CENTRAL1'
+              WHERE cloud_resource = 'firestore' and region = 'us-central1'

--- a/src/main/resources/db/changesets/20210510_datasetstoragemigrationcorrected.yaml
+++ b/src/main/resources/db/changesets/20210510_datasetstoragemigrationcorrected.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      id: storage_resource_migration
+      id: storage_resource_migration_corrected
       author: se
       changes:
         - sql:


### PR DESCRIPTION
We backfilled the database with the lower-cased values for cloud platform and cloud resource, instead of the enum names. The fix is easy: just replace all instances of the lower-cased values with upper-cased values in the db.