### PR TITLE
Distinct SQL query to remedy DRS endpoints

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
@@ -41,7 +41,7 @@ public class GoogleResourceDao {
         " WHERE marked_for_delete = false AND profile_id = :profile_id";
 
     private static final String sqlBucketRetrieve =
-        "SELECT p.id AS project_resource_id, google_project_id, google_project_number, profile_id," +
+        "SELECT distinct p.id AS project_resource_id, google_project_id, google_project_number, profile_id," +
             " b.id AS bucket_resource_id, name, sr.region as region, flightid " +
             "FROM bucket_resource b " +
             "JOIN project_resource p ON b.project_resource_id = p.id " +


### PR DESCRIPTION
Unbork the DRS enpoints by `distinct`ing the project resource query. Since we join on the `storage_resource` table now, and dev doesn't enforce "one project per dataset", we end up getting ALL dataset buckets back, which are actually the same bucket. This doesn't exist in prod, but we should fix it for dev.