### PR TITLE
Ignore multiple buckets returned in Dev

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
@@ -374,8 +374,6 @@ public class GoogleResourceDao {
                     .region(region);
             });
 
-        if (googleResourceConfiguration.getAllowReuseExistingBuckets())
-
         if (bucketResources.size() > 1) {
             //TODO This is only here because of the dev case. It should be removed when we start using RBS in dev.
             if (googleResourceConfiguration.getAllowReuseExistingBuckets()) {


### PR DESCRIPTION
We need to insert a shim so that dev doesn't break because it violates the one-bucket-per-dataset requirement.