### PR TITLE
DR-1717 Azure billing info

### DIFF
--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -33,7 +33,7 @@ public class ProfileDao {
     // SQL select string constants
     private static final String SQL_SELECT_LIST =
         "id, name, biller, billing_account_id, description, cloud_platform, " +
-            "tenant, subscription, resource_group, created_date, created_by";
+            "tenant_id, subscription_id, resource_group_id, created_date, created_by";
 
     private static final String SQL_GET = "SELECT " + SQL_SELECT_LIST
         + " FROM billing_profile WHERE id = :id";
@@ -59,18 +59,18 @@ public class ProfileDao {
     public BillingProfileModel createBillingProfile(BillingProfileRequestModel profileRequest, String creator) {
         String sql = "INSERT INTO billing_profile"
             + " (id, name, biller, billing_account_id, description, cloud_platform, " +
-            "     tenant, subscription, resource_group, created_by) VALUES "
+            "     tenant_id, subscription_id, resource_group_id, created_by) VALUES "
             + " (:id, :name, :biller, :billing_account_id, :description, :cloud_platform, " +
-            "     :tenant, :subscription, :resource_group, :created_by)";
+            "     :tenant_id, :subscription_id, :resource_group_id, :created_by)";
 
         String cloudPlatform = Optional.ofNullable(profileRequest.getCloudPlatform())
             .or(() -> Optional.of(CloudPlatform.GCP))
             .map(Enum::name)
             .get();
-        UUID tenant = Optional.ofNullable(profileRequest.getTenant()).map(UUID::fromString).orElse(null);
-        UUID subscription = Optional.ofNullable(profileRequest.getSubscription())
+        UUID tenantId = Optional.ofNullable(profileRequest.getTenantId()).map(UUID::fromString).orElse(null);
+        UUID subscriptionId = Optional.ofNullable(profileRequest.getSubscriptionId())
             .map(UUID::fromString).orElse(null);
-        UUID resourceGroup = Optional.ofNullable(profileRequest.getResourceGroup())
+        UUID resourceGroupId = Optional.ofNullable(profileRequest.getResourceGroupId())
             .map(UUID::fromString).orElse(null);
 
         MapSqlParameterSource params = new MapSqlParameterSource()
@@ -80,9 +80,9 @@ public class ProfileDao {
             .addValue("billing_account_id", profileRequest.getBillingAccountId())
             .addValue("description", profileRequest.getDescription())
             .addValue("cloud_platform", cloudPlatform)
-            .addValue("tenant", tenant)
-            .addValue("subscription", subscription)
-            .addValue("resource_group", resourceGroup)
+            .addValue("tenant_id", tenantId)
+            .addValue("subscription_id", subscriptionId)
+            .addValue("resource_group_id", resourceGroupId)
             .addValue("created_by", creator);
 
         DaoKeyHolder keyHolder = new DaoKeyHolder();
@@ -95,9 +95,9 @@ public class ProfileDao {
             .billingAccountId(keyHolder.getString("billing_account_id"))
             .description(keyHolder.getString("description"))
             .cloudPlatform(CloudPlatform.valueOf(keyHolder.getString("cloud_platform")))
-            .tenant(keyHolder.getString("tenant"))
-            .subscription(keyHolder.getString("subscription"))
-            .resourceGroup(keyHolder.getString("resource_group"))
+            .tenantId(keyHolder.getString("tenant_id"))
+            .subscriptionId(keyHolder.getString("subscription_id"))
+            .resourceGroupId(keyHolder.getString("resource_group_id"))
             .createdBy(keyHolder.getString("created_by"))
             .createdDate(keyHolder.getTimestamp("created_date").toInstant().toString());
     }
@@ -128,9 +128,9 @@ public class ProfileDao {
             .billingAccountId(keyHolder.getString("billing_account_id"))
             .description(keyHolder.getString("description"))
             .cloudPlatform(CloudPlatform.valueOf(keyHolder.getString("cloud_platform")))
-            .tenant(keyHolder.getString("tenant"))
-            .subscription(keyHolder.getString("subscription"))
-            .resourceGroup(keyHolder.getString("resource_group"))
+            .tenantId(keyHolder.getString("tenant_id"))
+            .subscriptionId(keyHolder.getString("subscription_id"))
+            .resourceGroupId(keyHolder.getString("resource_group_id"))
             .createdBy(keyHolder.getString("created_by"))
             .createdDate(keyHolder.getTimestamp("created_date").toInstant().toString());
     }
@@ -201,9 +201,9 @@ public class ProfileDao {
                 .billingAccountId(rs.getString("billing_account_id"))
                 .description(rs.getString("description"))
                 .cloudPlatform(CloudPlatform.valueOf(rs.getString("cloud_platform")))
-                .tenant(rs.getString("tenant"))
-                .subscription(rs.getString("subscription"))
-                .resourceGroup(rs.getString("resource_group"))
+                .tenantId(rs.getString("tenant_id"))
+                .subscriptionId(rs.getString("subscription_id"))
+                .resourceGroupId(rs.getString("resource_group_id"))
                 .createdDate(rs.getTimestamp("created_date").toInstant().toString())
                 .createdBy(rs.getString("created_by"));
         }

--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -33,7 +33,7 @@ public class ProfileDao {
     // SQL select string constants
     private static final String SQL_SELECT_LIST =
         "id, name, biller, billing_account_id, description, cloud_platform, " +
-            "tenant_id, subscription_id, resource_group_id, created_date, created_by";
+            "tenant_id, subscription_id, resource_group_name, created_date, created_by";
 
     private static final String SQL_GET = "SELECT " + SQL_SELECT_LIST
         + " FROM billing_profile WHERE id = :id";
@@ -59,9 +59,9 @@ public class ProfileDao {
     public BillingProfileModel createBillingProfile(BillingProfileRequestModel profileRequest, String creator) {
         String sql = "INSERT INTO billing_profile"
             + " (id, name, biller, billing_account_id, description, cloud_platform, " +
-            "     tenant_id, subscription_id, resource_group_id, created_by) VALUES "
+            "     tenant_id, subscription_id, resource_group_name, created_by) VALUES "
             + " (:id, :name, :biller, :billing_account_id, :description, :cloud_platform, " +
-            "     :tenant_id, :subscription_id, :resource_group_id, :created_by)";
+            "     :tenant_id, :subscription_id, :resource_group_name, :created_by)";
 
         String cloudPlatform = Optional.ofNullable(profileRequest.getCloudPlatform())
             .or(() -> Optional.of(CloudPlatform.GCP))
@@ -70,8 +70,7 @@ public class ProfileDao {
         UUID tenantId = Optional.ofNullable(profileRequest.getTenantId()).map(UUID::fromString).orElse(null);
         UUID subscriptionId = Optional.ofNullable(profileRequest.getSubscriptionId())
             .map(UUID::fromString).orElse(null);
-        UUID resourceGroupId = Optional.ofNullable(profileRequest.getResourceGroupId())
-            .map(UUID::fromString).orElse(null);
+        String resourceGroupName = Optional.ofNullable(profileRequest.getResourceGroupName()).orElse(null);
 
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("id", UUID.fromString(profileRequest.getId()))
@@ -82,7 +81,7 @@ public class ProfileDao {
             .addValue("cloud_platform", cloudPlatform)
             .addValue("tenant_id", tenantId)
             .addValue("subscription_id", subscriptionId)
-            .addValue("resource_group_id", resourceGroupId)
+            .addValue("resource_group_name", resourceGroupName)
             .addValue("created_by", creator);
 
         DaoKeyHolder keyHolder = new DaoKeyHolder();
@@ -97,7 +96,7 @@ public class ProfileDao {
             .cloudPlatform(CloudPlatform.valueOf(keyHolder.getString("cloud_platform")))
             .tenantId(keyHolder.getString("tenant_id"))
             .subscriptionId(keyHolder.getString("subscription_id"))
-            .resourceGroupId(keyHolder.getString("resource_group_id"))
+            .resourceGroupName(keyHolder.getString("resource_group_name"))
             .createdBy(keyHolder.getString("created_by"))
             .createdDate(keyHolder.getTimestamp("created_date").toInstant().toString());
     }
@@ -130,7 +129,7 @@ public class ProfileDao {
             .cloudPlatform(CloudPlatform.valueOf(keyHolder.getString("cloud_platform")))
             .tenantId(keyHolder.getString("tenant_id"))
             .subscriptionId(keyHolder.getString("subscription_id"))
-            .resourceGroupId(keyHolder.getString("resource_group_id"))
+            .resourceGroupName(keyHolder.getString("resource_group_name"))
             .createdBy(keyHolder.getString("created_by"))
             .createdDate(keyHolder.getTimestamp("created_date").toInstant().toString());
     }
@@ -203,7 +202,7 @@ public class ProfileDao {
                 .cloudPlatform(CloudPlatform.valueOf(rs.getString("cloud_platform")))
                 .tenantId(rs.getString("tenant_id"))
                 .subscriptionId(rs.getString("subscription_id"))
-                .resourceGroupId(rs.getString("resource_group_id"))
+                .resourceGroupName(rs.getString("resource_group_name"))
                 .createdDate(rs.getTimestamp("created_date").toInstant().toString())
                 .createdBy(rs.getString("created_by"));
         }

--- a/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
+++ b/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
@@ -2,6 +2,7 @@ package bio.terra.service.profile;
 
 import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.model.CloudPlatform;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -43,6 +44,8 @@ public class ProfileRequestValidator implements Validator {
         return Pattern.matches(VALID_BILLING_ACCOUNT_ID_REGEX, billingAccountId);
     }
 
+    // Spotbugs thinks this is useless. Its not.
+    @SuppressFBWarnings
     public static void isValidCloudPlatform(BillingProfileRequestModel billingProfileRequestModel, Errors errors) {
         if (billingProfileRequestModel.getCloudPlatform() == CloudPlatform.AZURE) {
             String errorCode = "For Azure, a valid UUID `%s` must be provided";

--- a/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
+++ b/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
@@ -47,28 +47,25 @@ public class ProfileRequestValidator implements Validator {
     public static void isValidCloudPlatform(BillingProfileRequestModel billingProfileRequestModel, Errors errors) {
         if (billingProfileRequestModel.getCloudPlatform() == CloudPlatform.AZURE) {
             String errorCode = "For Azure, a valid UUID `%s` must be provided";
-            if (billingProfileRequestModel.getTenant() == null ||
-                !ValidationUtils.isValidUuid(billingProfileRequestModel.getTenant())) {
+            if (billingProfileRequestModel.getTenantId() == null) {
                 errors.rejectValue("tenant", String.format(errorCode, "tenant"));
             }
-            if (billingProfileRequestModel.getSubscription() == null ||
-                !ValidationUtils.isValidUuid(billingProfileRequestModel.getSubscription())) {
+            if (billingProfileRequestModel.getSubscriptionId() == null) {
                 errors.rejectValue("subscription", String.format(errorCode, "subscription"));
             }
-            if (billingProfileRequestModel.getResourceGroup() == null ||
-                !ValidationUtils.isValidUuid(billingProfileRequestModel.getResourceGroup())) {
+            if (billingProfileRequestModel.getResourceGroupId() == null) {
                 errors.rejectValue("resourceGroup", String.format(errorCode, "resourceGroup"));
             }
         } else {
             // GCP is the default cloud platform, so there should be no Azure info from here on.
             String errorCode = "For GCP, no Azure information should be provided";
-            if (billingProfileRequestModel.getTenant() != null) {
+            if (billingProfileRequestModel.getTenantId() != null) {
                 errors.rejectValue("tenant", errorCode);
             }
-            if (billingProfileRequestModel.getSubscription() != null) {
+            if (billingProfileRequestModel.getSubscriptionId() != null) {
                 errors.rejectValue("subscription", errorCode);
             }
-            if (billingProfileRequestModel.getResourceGroup() != null) {
+            if (billingProfileRequestModel.getResourceGroupId() != null) {
                 errors.rejectValue("resourceGroup", errorCode);
             }
         }

--- a/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
+++ b/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
@@ -1,6 +1,5 @@
 package bio.terra.service.profile;
 
-import bio.terra.common.ValidationUtils;
 import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.model.CloudPlatform;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
+++ b/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
@@ -50,25 +50,27 @@ public class ProfileRequestValidator implements Validator {
         if (billingProfileRequestModel.getCloudPlatform() == CloudPlatform.AZURE) {
             String errorCode = "For Azure, a valid UUID `%s` must be provided";
             if (billingProfileRequestModel.getTenantId() == null) {
-                errors.rejectValue("tenant", String.format(errorCode, "tenant"));
+                errors.rejectValue("tenantId", String.format(errorCode, "tenantId"));
             }
             if (billingProfileRequestModel.getSubscriptionId() == null) {
-                errors.rejectValue("subscription", String.format(errorCode, "subscription"));
+                errors.rejectValue("subscriptionId", String.format(errorCode, "subscriptionId"));
             }
-            if (billingProfileRequestModel.getResourceGroupId() == null) {
-                errors.rejectValue("resourceGroup", String.format(errorCode, "resourceGroup"));
+            if (billingProfileRequestModel.getResourceGroupName() == null
+                || billingProfileRequestModel.getResourceGroupName().isEmpty()) {
+                errors.rejectValue("resourceGroupName",
+                    "For Azure, a non-empty resourceGroupName must be provided");
             }
         } else {
             // GCP is the default cloud platform, so there should be no Azure info from here on.
             String errorCode = "For GCP, no Azure information should be provided";
             if (billingProfileRequestModel.getTenantId() != null) {
-                errors.rejectValue("tenant", errorCode);
+                errors.rejectValue("tenantId", errorCode);
             }
             if (billingProfileRequestModel.getSubscriptionId() != null) {
-                errors.rejectValue("subscription", errorCode);
+                errors.rejectValue("subscriptionId", errorCode);
             }
-            if (billingProfileRequestModel.getResourceGroupId() != null) {
-                errors.rejectValue("resourceGroup", errorCode);
+            if (billingProfileRequestModel.getResourceGroupName() != null) {
+                errors.rejectValue("resourceGroupName", errorCode);
             }
         }
     }

--- a/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
+++ b/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
@@ -1,6 +1,8 @@
 package bio.terra.service.profile;
 
+import bio.terra.common.ValidationUtils;
 import bio.terra.model.BillingProfileRequestModel;
+import bio.terra.model.CloudPlatform;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -34,10 +36,41 @@ public class ProfileRequestValidator implements Validator {
                 errors.rejectValue("id",
                     "The billing profile id must be specified");
             }
+            isValidCloudPlatform(billingProfileRequestModel, errors);
         }
     }
 
     public static boolean isValidAccountId(String billingAccountId) {
         return Pattern.matches(VALID_BILLING_ACCOUNT_ID_REGEX, billingAccountId);
+    }
+
+    public static void isValidCloudPlatform(BillingProfileRequestModel billingProfileRequestModel, Errors errors) {
+        if (billingProfileRequestModel.getCloudPlatform() == CloudPlatform.AZURE) {
+            String errorCode = "For Azure, a valid UUID `%s` must be provided";
+            if (billingProfileRequestModel.getTenant() == null ||
+                !ValidationUtils.isValidUuid(billingProfileRequestModel.getTenant())) {
+                errors.rejectValue("tenant", String.format(errorCode, "tenant"));
+            }
+            if (billingProfileRequestModel.getSubscription() == null ||
+                !ValidationUtils.isValidUuid(billingProfileRequestModel.getSubscription())) {
+                errors.rejectValue("subscription", String.format(errorCode, "subscription"));
+            }
+            if (billingProfileRequestModel.getResourceGroup() == null ||
+                !ValidationUtils.isValidUuid(billingProfileRequestModel.getResourceGroup())) {
+                errors.rejectValue("resourceGroup", String.format(errorCode, "resourceGroup"));
+            }
+        } else {
+            // GCP is the default cloud platform, so there should be no Azure info from here on.
+            String errorCode = "For GCP, no Azure information should be provided";
+            if (billingProfileRequestModel.getTenant() != null) {
+                errors.rejectValue("tenant", errorCode);
+            }
+            if (billingProfileRequestModel.getSubscription() != null) {
+                errors.rejectValue("subscription", errorCode);
+            }
+            if (billingProfileRequestModel.getResourceGroup() != null) {
+                errors.rejectValue("resourceGroup", errorCode);
+            }
+        }
     }
 }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2733,14 +2733,14 @@ components:
           description: Free text that describes the profile
         cloud_platform:
           $ref: '#/components/schemas/CloudPlatform'
-        tenant:
-          type: string
+        tenantId:
+          $ref: '#/components/schemas/UniqueIdProperty'
           description: An optional tenant id for Azure
-        subscription:
-          type: string
+        subscriptionId:
+          $ref: '#/components/schemas/UniqueIdProperty'
           description: an optional subscription id for Azure
-        resource_group:
-          type: string
+        resourceGroupId:
+          $ref: '#/components/schemas/UniqueIdProperty'
           description: an optional resource group id for Azure
     BillingProfileUpdateModel:
       required:
@@ -2777,14 +2777,14 @@ components:
           description: Free text that describes the profile
         cloud_platform:
           $ref: '#/components/schemas/CloudPlatform'
-        tenant:
-          type: string
+        tenantId:
+          $ref: '#/components/schemas/UniqueIdProperty'
           description: An optional tenant id for Azure
-        subscription:
-          type: string
+        subscriptionId:
+          $ref: '#/components/schemas/UniqueIdProperty'
           description: an optional subscription id for Azure
-        resource_group:
-          type: string
+        resourceGroupId:
+          $ref: '#/components/schemas/UniqueIdProperty'
           description: an optional resource group id for Azure
         createdDate:
           type: string

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2731,7 +2731,7 @@ components:
         description:
           type: string
           description: Free text that describes the profile
-        cloud_platform:
+        cloudPlatform:
           $ref: '#/components/schemas/CloudPlatform'
         tenantId:
           $ref: '#/components/schemas/UniqueIdProperty'
@@ -2775,7 +2775,7 @@ components:
         description:
           type: string
           description: Free text that describes the profile
-        cloud_platform:
+        cloudPlatform:
           $ref: '#/components/schemas/CloudPlatform'
         tenantId:
           $ref: '#/components/schemas/UniqueIdProperty'

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2739,8 +2739,8 @@ components:
         subscriptionId:
           $ref: '#/components/schemas/UniqueIdProperty'
           description: an optional subscription id for Azure
-        resourceGroupId:
-          $ref: '#/components/schemas/UniqueIdProperty'
+        resourceGroupName:
+          type: string
           description: an optional resource group id for Azure
     BillingProfileUpdateModel:
       required:
@@ -2783,8 +2783,8 @@ components:
         subscriptionId:
           $ref: '#/components/schemas/UniqueIdProperty'
           description: an optional subscription id for Azure
-        resourceGroupId:
-          $ref: '#/components/schemas/UniqueIdProperty'
+        resourceGroupName:
+          type: string
           description: an optional resource group id for Azure
         createdDate:
           type: string

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2741,7 +2741,7 @@ components:
           description: an optional subscription id for Azure
         resourceGroupName:
           type: string
-          description: an optional resource group id for Azure
+          description: an optional resource group name for Azure
     BillingProfileUpdateModel:
       required:
         - id
@@ -2785,7 +2785,7 @@ components:
           description: an optional subscription id for Azure
         resourceGroupName:
           type: string
-          description: an optional resource group id for Azure
+          description: an optional resource group name for Azure
         createdDate:
           type: string
           description: Date the profile was created

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2731,6 +2731,17 @@ components:
         description:
           type: string
           description: Free text that describes the profile
+        cloud_platform:
+          $ref: '#/components/schemas/CloudPlatform'
+        tenant:
+          type: string
+          description: An optional tenant id for Azure
+        subscription:
+          type: string
+          description: an optional subscription id for Azure
+        resource_group:
+          type: string
+          description: an optional resource group id for Azure
     BillingProfileUpdateModel:
       required:
         - id
@@ -2764,6 +2775,17 @@ components:
         description:
           type: string
           description: Free text that describes the profile
+        cloud_platform:
+          $ref: '#/components/schemas/CloudPlatform'
+        tenant:
+          type: string
+          description: An optional tenant id for Azure
+        subscription:
+          type: string
+          description: an optional subscription id for Azure
+        resource_group:
+          type: string
+          description: an optional resource group id for Azure
         createdDate:
           type: string
           description: Date the profile was created

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -39,4 +39,5 @@
     <include file="changesets/20210426_datasetstorage.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210426_datasetstoragemigration.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210510_datasetstoragemigrationcorrected.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20210517_azurebillinginformation.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20210517_azurebillinginformation.yaml
+++ b/src/main/resources/db/changesets/20210517_azurebillinginformation.yaml
@@ -19,5 +19,5 @@ databaseChangeLog:
                   name: subscription_id
                   type: ${uuid_type}
               - column:
-                  name: resource_group_id
-                  type: ${uuid_type}
+                  name: resource_group_name
+                  type: ${identifier_type}

--- a/src/main/resources/db/changesets/20210517_azurebillinginformation.yaml
+++ b/src/main/resources/db/changesets/20210517_azurebillinginformation.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: azure_billing_information
+      author: tl
+      changes:
+        - addColumn:
+            tableName: billing_profile
+            columns:
+              - column:
+                  name: cloud_platform
+                  type: ${identifier_type}
+                  defaultValue: "GCP"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: tenant
+                  type: ${uuid_type}
+              - column:
+                  name: subscription
+                  type: ${uuid_type}
+              - column:
+                  name: resource_group
+                  type: ${uuid_type}

--- a/src/main/resources/db/changesets/20210517_azurebillinginformation.yaml
+++ b/src/main/resources/db/changesets/20210517_azurebillinginformation.yaml
@@ -13,11 +13,11 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
-                  name: tenant
+                  name: tenant_id
                   type: ${uuid_type}
               - column:
-                  name: subscription
+                  name: subscription_id
                   type: ${uuid_type}
               - column:
-                  name: resource_group
+                  name: resource_group_id
                   type: ${uuid_type}

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -140,6 +140,7 @@ public class ConnectedOperations {
         when(samService.listAuthorizedResources(any(), eq(IamResourceType.SPEND_PROFILE)))
             .thenAnswer((Answer<List<UUID>>) invocation
                 -> createdProfileIds.stream().map(UUID::fromString).collect(Collectors.toList()));
+        when(samService.hasActions(any(), eq(IamResourceType.SPEND_PROFILE), any())).thenReturn(true);
 
         doNothing().when(samService).createProfileResource(any(), any());
         doNothing().when(samService).deleteProfileResource(any(), any());

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
@@ -1,0 +1,145 @@
+package bio.terra.service.resourcemanagement;
+
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.category.Connected;
+import bio.terra.common.fixtures.ConnectedOperations;
+import bio.terra.common.fixtures.ProfileFixtures;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.BillingProfileRequestModel;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.ErrorModel;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.iam.IamProviderInterface;
+import bio.terra.service.profile.ProfileDao;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Category(Connected.class)
+public class ProfileConnectedTest {
+
+    @Autowired private ProfileDao profileDao;
+    @Autowired private ConnectedOperations connectedOperations;
+    @Autowired private ConnectedTestConfiguration testConfig;
+    @Autowired private ConfigurationService configService;
+
+    @MockBean
+    private IamProviderInterface samService;
+
+    @Before
+    public void setup() throws Exception {
+        connectedOperations.stubOutSamCalls(samService);
+        configService.reset();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        connectedOperations.teardown();
+        configService.reset();
+    }
+
+    @Test
+    public void testGoogleIsDefault() throws Exception {
+        BillingProfileRequestModel requestModel = ProfileFixtures.randomBillingProfileRequest()
+            .billingAccountId(testConfig.getGoogleBillingAccountId())
+            .cloudPlatform(null);
+        BillingProfileModel profile = connectedOperations.createProfile(requestModel);
+        BillingProfileModel retrievedProfile = connectedOperations.getProfileById(profile.getId());
+        assertThat("GCP is the default cloud provider",
+            retrievedProfile.getCloudPlatform(), equalTo(CloudPlatform.GCP));
+    }
+
+    @Test
+    public void testGoogleInvalidAzureParams() throws Exception {
+        BillingProfileRequestModel gcpRequestModel = ProfileFixtures.randomBillingProfileRequest()
+            .cloudPlatform(CloudPlatform.GCP)
+            .tenant(UUID.randomUUID().toString())
+            .subscription(UUID.randomUUID().toString())
+            .resourceGroup(UUID.randomUUID().toString());
+
+        BillingProfileRequestModel defaultRequestModel = ProfileFixtures.randomBillingProfileRequest()
+            .tenant(UUID.randomUUID().toString())
+            .subscription(UUID.randomUUID().toString())
+            .resourceGroup(UUID.randomUUID().toString());
+
+        for (BillingProfileRequestModel requestModel : List.of(gcpRequestModel, defaultRequestModel)) {
+            ErrorModel errorModel = connectedOperations.createProfileExpectError(requestModel, HttpStatus.BAD_REQUEST);
+
+            assertThat("There are 3 errors returned", errorModel.getErrorDetail().size(), equalTo(3));
+
+            assertThat("GCP request returns tenant error if supplied",
+                errorModel.getErrorDetail(),
+                hasItems(startsWith("tenant")));
+            assertThat("GCP request returns subscription error if supplied",
+                errorModel.getErrorDetail(),
+                hasItems(startsWith("subscription")));
+            assertThat("GCP request returns resourceGroup error if supplied",
+                errorModel.getErrorDetail(),
+                hasItems(startsWith("resourceGroup")));
+        }
+    }
+
+    @Test
+    public void testAzureInvalidMissingParams() throws Exception {
+        BillingProfileRequestModel azureRequestModel = ProfileFixtures.randomBillingProfileRequest()
+            .cloudPlatform(CloudPlatform.AZURE);
+        ErrorModel missingParams = connectedOperations
+            .createProfileExpectError(azureRequestModel, HttpStatus.BAD_REQUEST);
+
+        assertThat("There are 3 errors returned", missingParams.getErrorDetail().size(), equalTo(3));
+
+        assertThat("Azure request returns tenant error if not supplied",
+            missingParams.getErrorDetail(),
+            hasItems(containsString("UUID `tenant`")));
+        assertThat("Azure request returns subscription error if not supplied",
+            missingParams.getErrorDetail(),
+            hasItems(containsString("UUID `subscription`")));
+        assertThat("Azure request returns resourceGroup error if not supplied",
+            missingParams.getErrorDetail(),
+            hasItems(containsString("UUID `resourceGroup`")));
+
+        BillingProfileRequestModel invalidUuidRequest = ProfileFixtures.randomBillingProfileRequest()
+            .cloudPlatform(CloudPlatform.AZURE)
+            .tenant("not-a-valid-uuid")
+            .subscription(UUID.randomUUID().toString())
+            .resourceGroup(UUID.randomUUID().toString());
+
+        ErrorModel invalidUuid = connectedOperations
+            .createProfileExpectError(azureRequestModel, HttpStatus.BAD_REQUEST);
+
+        assertThat("There are 3 errors returned", invalidUuid.getErrorDetail().size(), equalTo(3));
+        assertThat("The server rejects invalid UUID for tenant",
+            invalidUuid.getErrorDetail(),
+            hasItems(containsString("UUID `tenant`")));
+        assertThat("The server rejects invalid UUID for subscription",
+            invalidUuid.getErrorDetail(),
+            hasItems(containsString("UUID `subscription`")));
+        assertThat("The server rejects invalid UUID for resourceGroup",
+            invalidUuid.getErrorDetail(),
+            hasItems(containsString("UUID `resourceGroup`")));
+    }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
@@ -5,10 +5,7 @@ import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.ProfileFixtures;
-import bio.terra.model.BillingProfileModel;
-import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.model.CloudPlatform;
-import bio.terra.model.ErrorModel;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.profile.ProfileDao;
@@ -64,30 +61,30 @@ public class ProfileConnectedTest {
 
     @Test
     public void testGoogleIsDefault() throws Exception {
-        BillingProfileRequestModel requestModel = ProfileFixtures.randomBillingProfileRequest()
+        var requestModel = ProfileFixtures.randomBillingProfileRequest()
             .billingAccountId(testConfig.getGoogleBillingAccountId())
             .cloudPlatform(null);
-        BillingProfileModel profile = connectedOperations.createProfile(requestModel);
-        BillingProfileModel retrievedProfile = connectedOperations.getProfileById(profile.getId());
+        var profile = connectedOperations.createProfile(requestModel);
+        var retrievedProfile = connectedOperations.getProfileById(profile.getId());
         assertThat("GCP is the default cloud provider",
             retrievedProfile.getCloudPlatform(), equalTo(CloudPlatform.GCP));
     }
 
     @Test
     public void testGoogleInvalidAzureParams() throws Exception {
-        BillingProfileRequestModel gcpRequestModel = ProfileFixtures.randomBillingProfileRequest()
+        var gcpRequestModel = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.GCP)
             .tenant(UUID.randomUUID().toString())
             .subscription(UUID.randomUUID().toString())
             .resourceGroup(UUID.randomUUID().toString());
 
-        BillingProfileRequestModel defaultRequestModel = ProfileFixtures.randomBillingProfileRequest()
+        var defaultRequestModel = ProfileFixtures.randomBillingProfileRequest()
             .tenant(UUID.randomUUID().toString())
             .subscription(UUID.randomUUID().toString())
             .resourceGroup(UUID.randomUUID().toString());
 
-        for (BillingProfileRequestModel requestModel : List.of(gcpRequestModel, defaultRequestModel)) {
-            ErrorModel errorModel = connectedOperations.createProfileExpectError(requestModel, HttpStatus.BAD_REQUEST);
+        for (var requestModel : List.of(gcpRequestModel, defaultRequestModel)) {
+            var errorModel = connectedOperations.createProfileExpectError(requestModel, HttpStatus.BAD_REQUEST);
 
             assertThat("There are 3 errors returned", errorModel.getErrorDetail().size(), equalTo(3));
 
@@ -105,9 +102,9 @@ public class ProfileConnectedTest {
 
     @Test
     public void testAzureInvalidMissingParams() throws Exception {
-        BillingProfileRequestModel azureRequestModel = ProfileFixtures.randomBillingProfileRequest()
+        var azureRequestModel = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.AZURE);
-        ErrorModel missingParams = connectedOperations
+        var missingParams = connectedOperations
             .createProfileExpectError(azureRequestModel, HttpStatus.BAD_REQUEST);
 
         assertThat("There are 3 errors returned", missingParams.getErrorDetail().size(), equalTo(3));
@@ -122,14 +119,14 @@ public class ProfileConnectedTest {
             missingParams.getErrorDetail(),
             hasItems(containsString("UUID `resourceGroup`")));
 
-        BillingProfileRequestModel invalidUuidRequest = ProfileFixtures.randomBillingProfileRequest()
+        var invalidUuidRequest = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.AZURE)
             .tenant("not-a-valid-uuid")
             .subscription(UUID.randomUUID().toString())
             .resourceGroup(UUID.randomUUID().toString());
 
-        ErrorModel invalidUuid = connectedOperations
-            .createProfileExpectError(azureRequestModel, HttpStatus.BAD_REQUEST);
+        var invalidUuid = connectedOperations
+            .createProfileExpectError(invalidUuidRequest, HttpStatus.BAD_REQUEST);
 
         assertThat("There are 3 errors returned", invalidUuid.getErrorDetail().size(), equalTo(3));
         assertThat("The server rejects invalid UUID for tenant",

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
@@ -80,9 +80,9 @@ public class ProfileConnectedTest {
         var requestModel = ProfileFixtures.randomBillingProfileRequest()
             .billingAccountId(testConfig.getGoogleBillingAccountId())
             .cloudPlatform(CloudPlatform.AZURE)
-            .tenant(tenant)
-            .subscription(subscription)
-            .resourceGroup(resourceGroup);
+            .tenantId(tenant)
+            .subscriptionId(subscription)
+            .resourceGroupId(resourceGroup);
 
         var profile = connectedOperations.createProfile(requestModel);
 
@@ -93,8 +93,8 @@ public class ProfileConnectedTest {
             equalTo(CloudPlatform.AZURE));
 
         assertThat("Azure billing profile has tenant, subscription, and resourceGroup",
-            List.of(retrievedProfile.getTenant(), retrievedProfile.getSubscription(),
-                retrievedProfile.getResourceGroup()),
+            List.of(retrievedProfile.getTenantId(), retrievedProfile.getSubscriptionId(),
+                retrievedProfile.getResourceGroupId()),
             contains(tenant, subscription, resourceGroup));
     }
 
@@ -102,14 +102,14 @@ public class ProfileConnectedTest {
     public void testGoogleInvalidAzureParams() throws Exception {
         var gcpRequestModel = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.GCP)
-            .tenant(UUID.randomUUID().toString())
-            .subscription(UUID.randomUUID().toString())
-            .resourceGroup(UUID.randomUUID().toString());
+            .tenantId(UUID.randomUUID().toString())
+            .subscriptionId(UUID.randomUUID().toString())
+            .resourceGroupId(UUID.randomUUID().toString());
 
         var defaultRequestModel = ProfileFixtures.randomBillingProfileRequest()
-            .tenant(UUID.randomUUID().toString())
-            .subscription(UUID.randomUUID().toString())
-            .resourceGroup(UUID.randomUUID().toString());
+            .tenantId(UUID.randomUUID().toString())
+            .subscriptionId(UUID.randomUUID().toString())
+            .resourceGroupId(UUID.randomUUID().toString());
 
         for (var requestModel : List.of(gcpRequestModel, defaultRequestModel)) {
             var errorModel = connectedOperations.createProfileExpectError(requestModel, HttpStatus.BAD_REQUEST);
@@ -149,9 +149,9 @@ public class ProfileConnectedTest {
 
         var invalidUuidRequest = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.AZURE)
-            .tenant("not-a-valid-uuid")
-            .subscription("not-a-valid-uuid")
-            .resourceGroup("not-a-valid-uuid");
+            .tenantId("not-a-valid-uuid")
+            .subscriptionId("not-a-valid-uuid")
+            .resourceGroupId("not-a-valid-uuid");
 
         var invalidUuid = connectedOperations
             .createProfileExpectError(invalidUuidRequest, HttpStatus.BAD_REQUEST);

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
@@ -76,13 +76,13 @@ public class ProfileConnectedTest {
     public void testAzureBillingProfile() throws Exception {
         var tenant = UUID.randomUUID().toString();
         var subscription = UUID.randomUUID().toString();
-        var resourceGroup = UUID.randomUUID().toString();
+        var resourceGroup = "resourceGroupName";
         var requestModel = ProfileFixtures.randomBillingProfileRequest()
             .billingAccountId(testConfig.getGoogleBillingAccountId())
             .cloudPlatform(CloudPlatform.AZURE)
             .tenantId(tenant)
             .subscriptionId(subscription)
-            .resourceGroupId(resourceGroup);
+            .resourceGroupName(resourceGroup);
 
         var profile = connectedOperations.createProfile(requestModel);
 
@@ -94,7 +94,7 @@ public class ProfileConnectedTest {
 
         assertThat("Azure billing profile has tenant, subscription, and resourceGroup",
             List.of(retrievedProfile.getTenantId(), retrievedProfile.getSubscriptionId(),
-                retrievedProfile.getResourceGroupId()),
+                retrievedProfile.getResourceGroupName()),
             contains(tenant, subscription, resourceGroup));
     }
 
@@ -104,27 +104,27 @@ public class ProfileConnectedTest {
             .cloudPlatform(CloudPlatform.GCP)
             .tenantId(UUID.randomUUID().toString())
             .subscriptionId(UUID.randomUUID().toString())
-            .resourceGroupId(UUID.randomUUID().toString());
+            .resourceGroupName("resourceGroupName");
 
         var defaultRequestModel = ProfileFixtures.randomBillingProfileRequest()
             .tenantId(UUID.randomUUID().toString())
             .subscriptionId(UUID.randomUUID().toString())
-            .resourceGroupId(UUID.randomUUID().toString());
+            .resourceGroupName("resourceGroupName");
 
         for (var requestModel : List.of(gcpRequestModel, defaultRequestModel)) {
             var errorModel = connectedOperations.createProfileExpectError(requestModel, HttpStatus.BAD_REQUEST);
 
             assertThat("There are 3 errors returned", errorModel.getErrorDetail(), iterableWithSize(3));
 
-            assertThat("GCP request returns tenant error if supplied",
+            assertThat("GCP request returns tenantId error if supplied",
                 errorModel.getErrorDetail(),
-                hasItems(startsWith("tenant")));
-            assertThat("GCP request returns subscription error if supplied",
+                hasItems(startsWith("tenantId")));
+            assertThat("GCP request returns subscriptionId error if supplied",
                 errorModel.getErrorDetail(),
-                hasItems(startsWith("subscription")));
-            assertThat("GCP request returns resourceGroup error if supplied",
+                hasItems(startsWith("subscriptionId")));
+            assertThat("GCP request returns resourceGroupName error if supplied",
                 errorModel.getErrorDetail(),
-                hasItems(startsWith("resourceGroup")));
+                hasItems(startsWith("resourceGroupName")));
         }
     }
 
@@ -137,34 +137,34 @@ public class ProfileConnectedTest {
 
         assertThat("There are 3 errors returned", missingParams.getErrorDetail(), iterableWithSize(3));
 
-        assertThat("Azure request returns tenant error if not supplied",
+        assertThat("Azure request returns tenantId error if not supplied",
             missingParams.getErrorDetail(),
-            hasItems(containsString("UUID `tenant`")));
-        assertThat("Azure request returns subscription error if not supplied",
+            hasItems(containsString("UUID `tenantId`")));
+        assertThat("Azure request returns subscriptionId error if not supplied",
             missingParams.getErrorDetail(),
-            hasItems(containsString("UUID `subscription`")));
-        assertThat("Azure request returns resourceGroup error if not supplied",
+            hasItems(containsString("UUID `subscriptionId`")));
+        assertThat("Azure request returns resourceGroupName error if not supplied",
             missingParams.getErrorDetail(),
-            hasItems(containsString("UUID `resourceGroup`")));
+            hasItems(containsString("non-empty resourceGroupName")));
 
         var invalidUuidRequest = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.AZURE)
             .tenantId("not-a-valid-uuid")
             .subscriptionId("not-a-valid-uuid")
-            .resourceGroupId("not-a-valid-uuid");
+            .resourceGroupName("");
 
         var invalidUuid = connectedOperations
             .createProfileExpectError(invalidUuidRequest, HttpStatus.BAD_REQUEST);
 
         assertThat("There are 3 errors returned", invalidUuid.getErrorDetail(), iterableWithSize(3));
-        assertThat("The server rejects invalid UUID for tenant",
+        assertThat("The server rejects invalid UUID for tenantId",
             invalidUuid.getErrorDetail(),
-            hasItems(containsString("UUID `tenant`")));
-        assertThat("The server rejects invalid UUID for subscription",
+            hasItems(containsString("tenantId: 'Pattern'")));
+        assertThat("The server rejects invalid UUID for subscriptionId",
             invalidUuid.getErrorDetail(),
-            hasItems(containsString("UUID `subscription`")));
-        assertThat("The server rejects invalid UUID for resourceGroup",
+            hasItems(containsString("subscriptionId: 'Pattern'")));
+        assertThat("The server rejects an empty string for resourceGroupName",
             invalidUuid.getErrorDetail(),
-            hasItems(containsString("UUID `resourceGroup`")));
+            hasItems(containsString("non-empty resourceGroupName")));
     }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
@@ -75,12 +75,12 @@ public class ProfileDaoTest {
         var googleBillingProfile = makeProfile();
         var tenant = UUID.randomUUID().toString();
         var subscription = UUID.randomUUID().toString();
-        var resourceGroup = UUID.randomUUID().toString();
+        var resourceGroup = "resourceGroupName";
         var azureBillingProfileRequest = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.AZURE)
             .tenantId(tenant)
             .subscriptionId(subscription)
-            .resourceGroupId(resourceGroup);
+            .resourceGroupName(resourceGroup);
         var azureBillingProfile =
             profileDao.createBillingProfile(azureBillingProfileRequest, "me@me.me");
         var azureProfileId = UUID.fromString(azureBillingProfile.getId());
@@ -98,7 +98,7 @@ public class ProfileDaoTest {
         assertThat("GCP billing profile does not have tenant, subscription, and resourceGroup",
             Arrays.asList(retrievedGoogleBillingProfile.getTenantId(),
                 retrievedGoogleBillingProfile.getSubscriptionId(),
-                retrievedGoogleBillingProfile.getResourceGroupId()),
+                retrievedGoogleBillingProfile.getResourceGroupName()),
             everyItem(is(emptyOrNullString())));
 
         assertThat("Azure cloud platform is correctly stored",
@@ -107,7 +107,7 @@ public class ProfileDaoTest {
 
         assertThat("Azure billing profile has tenant, subscription, and resourceGroup",
             List.of(retrievedAzureBillingProfile.getTenantId(), retrievedAzureBillingProfile.getSubscriptionId(),
-                retrievedAzureBillingProfile.getResourceGroupId()),
+                retrievedAzureBillingProfile.getResourceGroupName()),
             contains(tenant, subscription, resourceGroup));
 
     }

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
@@ -78,9 +78,9 @@ public class ProfileDaoTest {
         var resourceGroup = UUID.randomUUID().toString();
         var azureBillingProfileRequest = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.AZURE)
-            .tenant(tenant)
-            .subscription(subscription)
-            .resourceGroup(resourceGroup);
+            .tenantId(tenant)
+            .subscriptionId(subscription)
+            .resourceGroupId(resourceGroup);
         var azureBillingProfile =
             profileDao.createBillingProfile(azureBillingProfileRequest, "me@me.me");
         var azureProfileId = UUID.fromString(azureBillingProfile.getId());
@@ -96,8 +96,9 @@ public class ProfileDaoTest {
             equalTo(CloudPlatform.GCP));
 
         assertThat("GCP billing profile does not have tenant, subscription, and resourceGroup",
-            Arrays.asList(retrievedGoogleBillingProfile.getTenant(), retrievedGoogleBillingProfile.getSubscription(),
-                retrievedGoogleBillingProfile.getResourceGroup()),
+            Arrays.asList(retrievedGoogleBillingProfile.getTenantId(),
+                retrievedGoogleBillingProfile.getSubscriptionId(),
+                retrievedGoogleBillingProfile.getResourceGroupId()),
             everyItem(is(emptyOrNullString())));
 
         assertThat("Azure cloud platform is correctly stored",
@@ -105,8 +106,8 @@ public class ProfileDaoTest {
             equalTo(CloudPlatform.AZURE));
 
         assertThat("Azure billing profile has tenant, subscription, and resourceGroup",
-            List.of(retrievedAzureBillingProfile.getTenant(), retrievedAzureBillingProfile.getSubscription(),
-                retrievedAzureBillingProfile.getResourceGroup()),
+            List.of(retrievedAzureBillingProfile.getTenantId(), retrievedAzureBillingProfile.getSubscriptionId(),
+                retrievedAzureBillingProfile.getResourceGroupId()),
             contains(tenant, subscription, resourceGroup));
 
     }

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
@@ -21,13 +21,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -91,18 +96,18 @@ public class ProfileDaoTest {
             equalTo(CloudPlatform.GCP));
 
         assertThat("GCP billing profile does not have tenant, subscription, and resourceGroup",
-            new String[]{retrievedGoogleBillingProfile.getTenant(), retrievedGoogleBillingProfile.getSubscription(),
-                retrievedGoogleBillingProfile.getResourceGroup()},
-            equalTo(new String[]{null, null, null}));
+            Arrays.asList(retrievedGoogleBillingProfile.getTenant(), retrievedGoogleBillingProfile.getSubscription(),
+                retrievedGoogleBillingProfile.getResourceGroup()),
+            everyItem(is(emptyOrNullString())));
 
         assertThat("Azure cloud platform is correctly stored",
             retrievedAzureBillingProfile.getCloudPlatform(),
             equalTo(CloudPlatform.AZURE));
 
         assertThat("Azure billing profile has tenant, subscription, and resourceGroup",
-            new String[]{retrievedAzureBillingProfile.getTenant(), retrievedAzureBillingProfile.getSubscription(),
-                retrievedAzureBillingProfile.getResourceGroup()},
-            equalTo(new String[]{tenant, subscription, resourceGroup}));
+            List.of(retrievedAzureBillingProfile.getTenant(), retrievedAzureBillingProfile.getSubscription(),
+                retrievedAzureBillingProfile.getResourceGroup()),
+            contains(tenant, subscription, resourceGroup));
 
     }
 

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
@@ -67,23 +67,23 @@ public class ProfileDaoTest {
 
     @Test
     public void profileCloudProvidersTest() throws Exception {
-        BillingProfileModel googleBillingProfile = makeProfile();
-        String tenant = UUID.randomUUID().toString();
-        String subscription = UUID.randomUUID().toString();
-        String resourceGroup = UUID.randomUUID().toString();
-        BillingProfileRequestModel azureBillingProfileRequest = ProfileFixtures.randomBillingProfileRequest()
+        var googleBillingProfile = makeProfile();
+        var tenant = UUID.randomUUID().toString();
+        var subscription = UUID.randomUUID().toString();
+        var resourceGroup = UUID.randomUUID().toString();
+        var azureBillingProfileRequest = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.AZURE)
             .tenant(tenant)
             .subscription(subscription)
             .resourceGroup(resourceGroup);
-        BillingProfileModel azureBillingProfile =
+        var azureBillingProfile =
             profileDao.createBillingProfile(azureBillingProfileRequest, "me@me.me");
-        UUID azureProfileId = UUID.fromString(azureBillingProfile.getId());
+        var azureProfileId = UUID.fromString(azureBillingProfile.getId());
         profileIds.add(azureProfileId);
 
-        BillingProfileModel retrievedGoogleBillingProfile =
+        var retrievedGoogleBillingProfile =
             profileDao.getBillingProfileById(UUID.fromString(googleBillingProfile.getId()));
-        BillingProfileModel retrievedAzureBillingProfile =
+        var retrievedAzureBillingProfile =
             profileDao.getBillingProfileById(UUID.fromString(azureBillingProfile.getId()));
 
         assertThat("GCP is the default cloud platform",


### PR DESCRIPTION
In order to support Azure, we need to keep track of users' `tenant`, `subscription`, and `resourceGroup`. We also want to track `cloudPlatform` to distinguish between GCP and Azure datasets. For now, since we're only storing data in Azure, not metadata, the `AZURE` `cloudPlatform` value means metadata in GCP and data in Azure. At this time, we only support setting the `cloudPlatform` upon billing profile creation. This is to simplify the scope, since splitting metadata between GCP and Azure would be a huge pain. 

Since `tenant`, `subscription`, and `resourceGroup` are all UUIDs, we do some request validation. I've included tests to hit all the validation cases as well as to test the database updates.