### PR TITLE
DR-1782 Create firestore in dataset region

### DIFF
--- a/src/main/java/bio/terra/app/model/GoogleRegion.java
+++ b/src/main/java/bio/terra/app/model/GoogleRegion.java
@@ -29,15 +29,26 @@ public enum GoogleRegion {
         US_WEST2("us-west2"),
         US_WEST3("us-west3"),
         US_WEST4("us-west4"),
-        US("us");
+        US("us", GoogleRegion.US_CENTRAL1);
 
 
     public static final GoogleRegion DEFAULT_GOOGLE_REGION = GoogleRegion.US_CENTRAL1;
 
     private final String value;
+    private final GoogleRegion firestoreFallbackRegion;
 
     GoogleRegion(String value) {
         this.value = value;
+        this.firestoreFallbackRegion = this;
+    }
+
+    GoogleRegion(String value, GoogleRegion firestoreFallbackRegion) {
+        this.value = value;
+        this.firestoreFallbackRegion = firestoreFallbackRegion;
+    }
+
+    public GoogleRegion getFirestoreFallbackRegion() {
+        return firestoreFallbackRegion;
     }
 
     public String toString() {

--- a/src/main/java/bio/terra/app/model/GoogleRegion.java
+++ b/src/main/java/bio/terra/app/model/GoogleRegion.java
@@ -1,5 +1,7 @@
 package bio.terra.app.model;
 
+import java.util.Optional;
+
 /**
  * Valid regions in Google.
  */
@@ -62,5 +64,9 @@ public enum GoogleRegion {
             }
         }
         return null;
+    }
+
+    public static GoogleRegion fromValueWithDefault(String text) {
+        return Optional.ofNullable(GoogleRegion.fromValue(text)).orElse(GoogleRegion.DEFAULT_GOOGLE_REGION);
     }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -66,7 +66,7 @@ public final class DatasetJsonConversion {
 
         final List<StorageResource> storageResources;
         if (cloudPlatform == CloudPlatform.GCP) {
-            storageResources = createGcpStorageResourceValues(datasetRequest.getRegion());
+            storageResources = createGcpStorageResourceValues(datasetRequest);
         } else {
             throw new UnsupportedOperationException(cloudPlatform + " is not a recognized Cloud Platform");
         }
@@ -81,18 +81,18 @@ public final class DatasetJsonConversion {
                 .assetSpecifications(assetSpecifications);
     }
 
-    private static List<StorageResource> createGcpStorageResourceValues(String providedRegion) {
-        final GoogleRegion region = Optional.ofNullable(providedRegion)
+    public static GoogleRegion getRegionFromDatasetRequestModel(DatasetRequestModel datasetRequestModel) {
+        return Optional.ofNullable(datasetRequestModel.getRegion())
             .map(GoogleRegion::fromValue)
             .orElse(GoogleRegion.DEFAULT_GOOGLE_REGION);
+    }
+
+    private static List<StorageResource> createGcpStorageResourceValues(DatasetRequestModel datasetRequestModel) {
+        final GoogleRegion region = getRegionFromDatasetRequestModel(datasetRequestModel);
         return Arrays.stream(GoogleCloudResource.values()).map(resource -> {
-            // TODO: Firestore will always be in us-central1 for now, but will likely change in the future.
-            GoogleRegion dbRegion = (resource.equals(GoogleCloudResource.FIRESTORE)) ?
-                GoogleRegion.DEFAULT_GOOGLE_REGION :
-                region;
             return new StorageResource()
                 .cloudPlatform(CloudPlatform.GCP)
-                .region(dbRegion)
+                .region(region)
                 .cloudResource(resource);
         }).collect(Collectors.toList());
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -82,19 +82,15 @@ public final class DatasetJsonConversion {
     }
 
     public static GoogleRegion getRegionFromDatasetRequestModel(DatasetRequestModel datasetRequestModel) {
-        return Optional.ofNullable(datasetRequestModel.getRegion())
-            .map(GoogleRegion::fromValue)
-            .orElse(GoogleRegion.DEFAULT_GOOGLE_REGION);
+        return GoogleRegion.fromValueWithDefault(datasetRequestModel.getRegion());
     }
 
     private static List<StorageResource> createGcpStorageResourceValues(DatasetRequestModel datasetRequestModel) {
         final GoogleRegion region = getRegionFromDatasetRequestModel(datasetRequestModel);
-        return Arrays.stream(GoogleCloudResource.values()).map(resource -> {
-            return new StorageResource()
-                .cloudPlatform(CloudPlatform.GCP)
-                .region(region)
-                .cloudResource(resource);
-        }).collect(Collectors.toList());
+        return Arrays.stream(GoogleCloudResource.values()).map(resource -> new StorageResource()
+             .cloudPlatform(CloudPlatform.GCP)
+             .region(region)
+             .cloudResource(resource)).collect(Collectors.toList());
     }
 
     public static DatasetSummaryModel datasetSummaryModelFromDatasetSummary(DatasetSummary datasetSummary) {

--- a/src/main/java/bio/terra/service/dataset/StorageResourceDao.java
+++ b/src/main/java/bio/terra/service/dataset/StorageResourceDao.java
@@ -95,7 +95,13 @@ public class StorageResourceDao {
             String platformParam = storageResource.getCloudResource() + "_cloudPlatform";
             valuesList.add(String.format("(:dataset_id, :%s, :%s, :%s)",
                 regionParam, cloudResourceParam, platformParam));
-            params.addValue(regionParam, storageResource.getRegion().name());
+
+            if (storageResource.getCloudResource() == GoogleCloudResource.FIRESTORE) {
+                params.addValue(regionParam, storageResource.getRegion().getFirestoreFallbackRegion().name());
+            } else {
+                params.addValue(regionParam, storageResource.getRegion().name());
+            }
+
             params.addValue(cloudResourceParam, storageResource.getCloudResource().name());
             params.addValue(platformParam, storageResource.getCloudPlatform().name());
         }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateProjectStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateProjectStep.java
@@ -1,7 +1,9 @@
 package bio.terra.service.dataset.flight.create;
 
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.dataset.DatasetJsonConversion;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.ResourceService;
@@ -26,10 +28,11 @@ public class CreateDatasetGetOrCreateProjectStep implements Step {
     public StepResult doStep(FlightContext context) throws InterruptedException {
         FlightMap workingMap = context.getWorkingMap();
         BillingProfileModel profileModel = workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+        GoogleRegion region = DatasetJsonConversion.getRegionFromDatasetRequestModel(datasetRequestModel);
         // Since we find projects by their names, this is idempotent. If this step fails and is rerun,
         // Either the project will have been created and we will find it, or we will create it.
         UUID projectResourceId =
-            resourceService.getOrCreateDatasetProject(datasetRequestModel.getName(), profileModel);
+            resourceService.getOrCreateDatasetProject(datasetRequestModel.getName(), profileModel, region);
         workingMap.put(DatasetWorkingMapKeys.PROJECT_RESOURCE_ID, projectResourceId);
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -129,19 +129,21 @@ public class ResourceService {
     /**
      * Create a new project for a snapshot, if none exists already.
      *
-     * @param snapshotName   name of the snapshot
-     * @param billingProfile authorized billing profile to pay for the project
-     * @param region         the region to create the Firestore in
+     * @param snapshotName      name of the snapshot
+     * @param billingProfile    authorized billing profile to pay for the project
+     * @param firestoreRegion   the region to create the Firestore in
      * @return project resource id
      */
-    public UUID getOrCreateSnapshotProject(String snapshotName, BillingProfileModel billingProfile, GoogleRegion region)
+    public UUID getOrCreateSnapshotProject(String snapshotName,
+                                           BillingProfileModel billingProfile,
+                                           GoogleRegion firestoreRegion)
         throws InterruptedException {
 
         GoogleProjectResource googleProjectResource = projectService.getOrCreateProject(
             dataLocationSelector.projectIdForSnapshot(snapshotName, billingProfile),
             billingProfile,
             null,
-            region);
+            firestoreRegion);
 
         return googleProjectResource.getId();
     }

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -1,6 +1,7 @@
 package bio.terra.service.resourcemanagement;
 
 import bio.terra.app.model.GoogleCloudResource;
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.service.dataset.Dataset;
@@ -67,11 +68,13 @@ public class ResourceService {
                                                          BillingProfileModel billingProfile,
                                                          String flightId) throws InterruptedException {
         final String datasetName = dataset.getName();
+        final GoogleRegion region = dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
         // Every bucket needs to live in a project, so we get or create a project first
         final GoogleProjectResource projectResource = projectService.getOrCreateProject(
             dataLocationSelector.projectIdForFile(datasetName, billingProfile),
             billingProfile,
-            null);
+            null,
+            region);
 
         return bucketService.getOrCreateBucket(
             dataLocationSelector.bucketForFile(datasetName, billingProfile),
@@ -128,15 +131,17 @@ public class ResourceService {
      *
      * @param snapshotName   name of the snapshot
      * @param billingProfile authorized billing profile to pay for the project
+     * @param region         the region to create the Firestore in
      * @return project resource id
      */
-    public UUID getOrCreateSnapshotProject(String snapshotName, BillingProfileModel billingProfile)
+    public UUID getOrCreateSnapshotProject(String snapshotName, BillingProfileModel billingProfile, GoogleRegion region)
         throws InterruptedException {
 
         GoogleProjectResource googleProjectResource = projectService.getOrCreateProject(
             dataLocationSelector.projectIdForSnapshot(snapshotName, billingProfile),
             billingProfile,
-            null);
+            null,
+            region);
 
         return googleProjectResource.getId();
     }
@@ -146,15 +151,18 @@ public class ResourceService {
      *
      * @param datasetName    name of the dataset
      * @param billingProfile authorized billing profile to pay for the project
+     * @param region         the region to ceraate
      * @return project resource id
      */
     public UUID getOrCreateDatasetProject(String datasetName,
-                                          BillingProfileModel billingProfile) throws InterruptedException {
+                                          BillingProfileModel billingProfile,
+                                          GoogleRegion region) throws InterruptedException {
 
         GoogleProjectResource googleProjectResource = projectService.getOrCreateProject(
             dataLocationSelector.projectIdForDataset(datasetName, billingProfile),
             billingProfile,
-            getStewardPolicy());
+            getStewardPolicy(),
+            region);
 
         return googleProjectResource.getId();
     }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.google;
 
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.profile.google.GoogleBillingService;
@@ -100,13 +101,15 @@ public class GoogleProjectService {
      * @param googleProjectId     google's id of the project
      * @param billingProfile      previously authorized billing profile
      * @param roleIdentityMapping permissions to set
+     * @param region              region to use for Firestore
      * @return project resource object
      * @throws InterruptedException if shutting down
      */
     public GoogleProjectResource getOrCreateProject(
         String googleProjectId,
         BillingProfileModel billingProfile,
-        Map<String, List<String>> roleIdentityMapping)
+        Map<String, List<String>> roleIdentityMapping,
+        GoogleRegion region)
         throws InterruptedException {
 
         try {
@@ -130,10 +133,10 @@ public class GoogleProjectService {
         // came from, what resources they contain, who is paying for them.
         Project existingProject = getProject(googleProjectId);
         if (existingProject != null && resourceConfiguration.getAllowReuseExistingProjects()) {
-            return initializeProject(existingProject, billingProfile, roleIdentityMapping, false);
+            return initializeProject(existingProject, billingProfile, roleIdentityMapping, false, region);
         }
 
-        return newProject(googleProjectId, billingProfile, roleIdentityMapping);
+        return newProject(googleProjectId, billingProfile, roleIdentityMapping, region);
     }
 
     public GoogleProjectResource getProjectResourceById(UUID id) {
@@ -183,13 +186,15 @@ public class GoogleProjectService {
      * @param requestedProjectId  suggested name for the project
      * @param billingProfile      authorized billing profile that'll pay for the project
      * @param roleIdentityMapping iam roles to be granted on the project
+     * @param region              region the project should use for Firestore
      * @return a populated project resource object
      * @throws InterruptedException if the flight is interrupted during execution
      */
     private GoogleProjectResource newProject(
         String requestedProjectId,
         BillingProfileModel billingProfile,
-        Map<String, List<String>> roleIdentityMapping)
+        Map<String, List<String>> roleIdentityMapping,
+        GoogleRegion region)
         throws InterruptedException {
 
         ensureValidProjectId(requestedProjectId);
@@ -221,7 +226,7 @@ public class GoogleProjectService {
                 throw new GoogleResourceException("Could not get project after creation");
             }
 
-            return initializeProject(project, billingProfile, roleIdentityMapping, true);
+            return initializeProject(project, billingProfile, roleIdentityMapping, true, region);
         } catch (IOException | GeneralSecurityException e) {
             throw new GoogleResourceException("Could not create project", e);
         }
@@ -233,7 +238,8 @@ public class GoogleProjectService {
         Project project,
         BillingProfileModel billingProfile,
         Map<String, List<String>> roleIdentityMapping,
-        boolean setBilling)
+        boolean setBilling,
+        GoogleRegion region)
         throws InterruptedException {
 
         String googleProjectNumber = project.getProjectNumber().toString();
@@ -249,7 +255,7 @@ public class GoogleProjectService {
             // The billing profile has already been authorized so we do no further checking here
             billingService.assignProjectBilling(billingProfile, googleProjectResource);
         }
-        enableServices(googleProjectResource);
+        enableServices(googleProjectResource, region);
         updateIamPermissions(roleIdentityMapping, googleProjectId, PermissionOp.ENABLE_PERMISSIONS);
 
         UUID id = resourceDao.createProject(googleProjectResource);
@@ -280,7 +286,7 @@ public class GoogleProjectService {
     }
 
     @VisibleForTesting
-    void enableServices(GoogleProjectResource projectResource) throws InterruptedException {
+    void enableServices(GoogleProjectResource projectResource, GoogleRegion region) throws InterruptedException {
         try {
             ServiceUsage serviceUsage = serviceUsage();
             String projectNumberString = "projects/" + projectResource.getGoogleProjectNumber();
@@ -318,7 +324,7 @@ public class GoogleProjectService {
             enableFirestore(
                 appengine(),
                 projectResource.getGoogleProjectId(),
-                resourceConfiguration.getDefaultFirestoreLocation(),
+                region,
                 timeout
             );
 
@@ -448,18 +454,18 @@ public class GoogleProjectService {
      * Enable Firestore in native mode in an existing project
      * @param appengine appengine client
      * @param googleProjectId name of the google project to create the Firestore DB in
-     * @param locationId location of the Firestore DB
+     * @param region location of the Firestore DB
      * @param timeout how long to wait for the creation operation
      */
     private static void enableFirestore(final Appengine appengine,
                                         final String googleProjectId,
-                                        final String locationId,
+                                        final GoogleRegion region,
                                         final long timeout) throws IOException, InterruptedException {
-        logger.info("Enabling Firestore in project {} in location {}", googleProjectId, locationId);
+        logger.info("Enabling Firestore in project {} in location {}", googleProjectId, region.toString());
         // Create a request object
         Appengine.Apps.Create createRequest = appengine.apps().create(new Application()
             .setId(googleProjectId)
-            .setLocationId(locationId)
+            .setLocationId(region.toString())
             .setDatabaseType(FIRESTORE_DB_TYPE)
         );
 
@@ -472,6 +478,11 @@ public class GoogleProjectService {
         // Wait for the Firestore creation to finish
         blockUntilAppengineOperationComplete(appengine, operation, googleProjectId, timeout);
         logger.info("Firestore was enabled successfully");
+    }
+
+    public GoogleRegion getFirestoreRegion(final String googleProjectId) throws IOException, GeneralSecurityException {
+        String location = appengine().apps().get(googleProjectId).execute().getLocationId();
+        return GoogleRegion.fromValue(location);
     }
 
     /**

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -461,11 +461,12 @@ public class GoogleProjectService {
                                         final String googleProjectId,
                                         final GoogleRegion region,
                                         final long timeout) throws IOException, InterruptedException {
-        logger.info("Enabling Firestore in project {} in location {}", googleProjectId, region.toString());
+        logger.info("Enabling Firestore in project {} in location {}", googleProjectId,
+            region.getFirestoreFallbackRegion());
         // Create a request object
         Appengine.Apps.Create createRequest = appengine.apps().create(new Application()
             .setId(googleProjectId)
-            .setLocationId(region.toString())
+            .setLocationId(region.getFirestoreFallbackRegion().toString())
             .setDatabaseType(FIRESTORE_DB_TYPE)
         );
 

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -480,11 +480,6 @@ public class GoogleProjectService {
         logger.info("Firestore was enabled successfully");
     }
 
-    public GoogleRegion getFirestoreRegion(final String googleProjectId) throws IOException, GeneralSecurityException {
-        String location = appengine().apps().get(googleProjectId).execute().getLocationId();
-        return GoogleRegion.fromValue(location);
-    }
-
     /**
      * Poll the app engine api until an operation completes. It is possible to hit quota issues
      * here, so the timeout is set to 10 seconds.

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -297,9 +297,16 @@ public class SnapshotService {
     }
 
     public List<UUID> getSourceDatasetIdsFromSnapshotRequest(SnapshotRequestModel snapshotRequestModel) {
+        return getSourceDatasetsFromSnapshotRequest(snapshotRequestModel)
+            .stream()
+            .map(Dataset::getId)
+            .collect(Collectors.toList());
+    }
+
+    public List<Dataset> getSourceDatasetsFromSnapshotRequest(SnapshotRequestModel snapshotRequestModel) {
         return snapshotRequestModel.getContents()
             .stream()
-            .map(c -> datasetService.retrieveByName(c.getDatasetName()).getId())
+            .map(c -> datasetService.retrieveByName(c.getDatasetName()))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotGetOrCreateProjectStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotGetOrCreateProjectStep.java
@@ -16,14 +16,14 @@ import java.util.UUID;
 public class CreateSnapshotGetOrCreateProjectStep implements Step {
     private final ResourceService resourceService;
     private final SnapshotRequestModel snapshotRequestModel;
-    private final GoogleRegion region;
+    private final GoogleRegion firestoreRegion;
 
     public CreateSnapshotGetOrCreateProjectStep(ResourceService resourceService,
                                                 SnapshotRequestModel snapshotRequestModel,
-                                                GoogleRegion region) {
+                                                GoogleRegion firestoreRegion) {
         this.resourceService = resourceService;
         this.snapshotRequestModel = snapshotRequestModel;
-        this.region = region;
+        this.firestoreRegion = firestoreRegion;
     }
 
     @Override
@@ -33,7 +33,7 @@ public class CreateSnapshotGetOrCreateProjectStep implements Step {
         // Since we find projects by their names, this is idempotent. If this step fails and is rerun,
         // Either the project will have been created8and we will find it, or we will create.
         UUID projectResourceId =
-            resourceService.getOrCreateSnapshotProject(snapshotRequestModel.getName(), profileModel, region);
+            resourceService.getOrCreateSnapshotProject(snapshotRequestModel.getName(), profileModel, firestoreRegion);
         workingMap.put(SnapshotWorkingMapKeys.PROJECT_RESOURCE_ID, projectResourceId);
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotGetOrCreateProjectStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotGetOrCreateProjectStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.snapshot.flight.create;
 
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.service.profile.flight.ProfileMapKeys;
@@ -15,11 +16,14 @@ import java.util.UUID;
 public class CreateSnapshotGetOrCreateProjectStep implements Step {
     private final ResourceService resourceService;
     private final SnapshotRequestModel snapshotRequestModel;
+    private final GoogleRegion region;
 
     public CreateSnapshotGetOrCreateProjectStep(ResourceService resourceService,
-                                                SnapshotRequestModel snapshotRequestModel) {
+                                                SnapshotRequestModel snapshotRequestModel,
+                                                GoogleRegion region) {
         this.resourceService = resourceService;
         this.snapshotRequestModel = snapshotRequestModel;
+        this.region = region;
     }
 
     @Override
@@ -29,7 +33,7 @@ public class CreateSnapshotGetOrCreateProjectStep implements Step {
         // Since we find projects by their names, this is idempotent. If this step fails and is rerun,
         // Either the project will have been created8and we will find it, or we will create.
         UUID projectResourceId =
-            resourceService.getOrCreateSnapshotProject(snapshotRequestModel.getName(), profileModel);
+            resourceService.getOrCreateSnapshotProject(snapshotRequestModel.getName(), profileModel, region);
         workingMap.put(SnapshotWorkingMapKeys.PROJECT_RESOURCE_ID, projectResourceId);
         return StepResult.getStepResultSuccess();
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -66,7 +66,7 @@ public class SnapshotCreateFlight extends Flight {
         // TODO note that with multi-dataset snapshots this will need to change
         List<Dataset> sourceDatasets = snapshotService.getSourceDatasetsFromSnapshotRequest(snapshotReq);
         UUID datasetId = sourceDatasets.get(0).getId();
-        GoogleRegion region = sourceDatasets.get(0)
+        GoogleRegion firestoreRegion = sourceDatasets.get(0)
             .getDatasetSummary()
             .getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
         addStep(new LockDatasetStep(datasetDao, datasetId, false));
@@ -76,7 +76,7 @@ public class SnapshotCreateFlight extends Flight {
         addStep(new AuthorizeBillingProfileUseStep(profileService, snapshotReq.getProfileId(), userReq));
 
         // Get or create the project where the snapshot resources will be created
-        addStep(new CreateSnapshotGetOrCreateProjectStep(resourceService, snapshotReq, region));
+        addStep(new CreateSnapshotGetOrCreateProjectStep(resourceService, snapshotReq, firestoreRegion));
 
         // create the snapshot metadata object in postgres and lock it
         // mint a snapshot id and put it in the working map

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -1,8 +1,11 @@
 package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.app.logging.PerformanceLogger;
+import bio.terra.app.model.GoogleCloudResource;
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.flight.LockDatasetStep;
@@ -61,8 +64,11 @@ public class SnapshotCreateFlight extends Flight {
 
         // Lock the source dataset while adding ACLs to avoid a race condition
         // TODO note that with multi-dataset snapshots this will need to change
-        List<UUID> sourceDatasetIds = snapshotService.getSourceDatasetIdsFromSnapshotRequest(snapshotReq);
-        UUID datasetId = sourceDatasetIds.get(0);
+        List<Dataset> sourceDatasets = snapshotService.getSourceDatasetsFromSnapshotRequest(snapshotReq);
+        UUID datasetId = sourceDatasets.get(0).getId();
+        GoogleRegion region = sourceDatasets.get(0)
+            .getDatasetSummary()
+            .getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
         addStep(new LockDatasetStep(datasetDao, datasetId, false));
 
         // Make sure this user is allowed to use the billing profile and that the underlying
@@ -70,7 +76,7 @@ public class SnapshotCreateFlight extends Flight {
         addStep(new AuthorizeBillingProfileUseStep(profileService, snapshotReq.getProfileId(), userReq));
 
         // Get or create the project where the snapshot resources will be created
-        addStep(new CreateSnapshotGetOrCreateProjectStep(resourceService, snapshotReq));
+        addStep(new CreateSnapshotGetOrCreateProjectStep(resourceService, snapshotReq, region));
 
         // create the snapshot metadata object in postgres and lock it
         // mint a snapshot id and put it in the working map

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -154,7 +154,7 @@ public class DatasetDaoTest {
         List<DatasetSummary> filteredDefaultRegionDatasets = filterDefaultRegionEnum.getItems();
         assertThat("dataset filter by default GCS region returns correct total",
             filteredDefaultRegionDatasets.size(),
-            equalTo(2));
+            equalTo(1));
         assertTrue("dataset filter by default GCS region returns correct datasets",
             filteredDefaultRegionDatasets
                 .stream()

--- a/src/test/java/bio/terra/service/profile/GoogleBillingServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/GoogleBillingServiceTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.profile;
 
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.model.BillingProfileModel;
@@ -137,6 +138,7 @@ public class GoogleBillingServiceTest {
         return projectService.getOrCreateProject(
             resourceConfiguration.getSingleDataProjectId(),
             profile,
-            roleToStewardMap);
+            roleToStewardMap,
+            GoogleRegion.DEFAULT_GOOGLE_REGION);
     }
 }

--- a/src/test/java/bio/terra/service/profile/ProfileServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileServiceTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.profile;
 
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.model.BillingProfileModel;
@@ -162,6 +163,7 @@ public class ProfileServiceTest {
         return googleProjectService.getOrCreateProject(
             resourceConfiguration.getSingleDataProjectId(),
             profile,
-            roleToStewardMap);
+            roleToStewardMap,
+            GoogleRegion.DEFAULT_GOOGLE_REGION);
     }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
@@ -45,10 +45,10 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalToIgnoringCase;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
@@ -356,9 +356,10 @@ public class BucketResourceTest {
 
         // create project metadata
         return projectService.getOrCreateProject(
-                resourceConfiguration.getSingleDataProjectId(),
-                profile,
-                roleToStewardMap);
+            resourceConfiguration.getSingleDataProjectId(),
+            profile,
+            roleToStewardMap,
+            GoogleRegion.DEFAULT_GOOGLE_REGION);
     }
 
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceOnDemandTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceOnDemandTest.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.google;
 
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.category.OnDemand;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -24,6 +25,7 @@ public class GoogleProjectServiceOnDemandTest {
         // Note, runner needs to populate in a project id and number before running
         projectService.enableServices(new GoogleProjectResource()
             .googleProjectId("")
-            .googleProjectNumber(""));
+            .googleProjectNumber(""),
+            GoogleRegion.DEFAULT_GOOGLE_REGION);
     }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.resourcemanagement.google;
 
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.category.OnDemand;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.model.BillingProfileModel;
@@ -64,7 +65,7 @@ public class ResourceServiceTest {
         roleToStewardMap.put(role, stewardsGroupEmailList);
 
         GoogleProjectResource projectResource =
-            projectService.getOrCreateProject(projectId, profile, roleToStewardMap);
+            projectService.getOrCreateProject(projectId, profile, roleToStewardMap, GoogleRegion.DEFAULT_GOOGLE_REGION);
 
         Project project = projectService.getProject(projectId);
         assertThat("the project is active",

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.tabulardata.google;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleCloudResource;
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.PdaoConstant;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Connected;
@@ -567,7 +568,8 @@ public class BigQueryPdaoTest {
         datasetRequest
             .defaultProfileId(profileModel.getId())
             .name(datasetName);
-        UUID projectId = resourceService.getOrCreateDatasetProject(datasetName, profileModel);
+        GoogleRegion region = DatasetJsonConversion.getRegionFromDatasetRequestModel(datasetRequest);
+        UUID projectId = resourceService.getOrCreateDatasetProject(datasetName, profileModel, region);
         Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest)
             .projectResourceId(projectId)
             .projectResource(resourceService.getProjectResource(projectId));


### PR DESCRIPTION
When creating a project, we need to create the Firestore in the datasets region. This PR passes the dataset region through to the `enableFirestore` method.

I'm not sure how to test this, since we rely on a single project for our tests.