### PR TITLE
[PF-785] Consume Stairway fix for flight logs with duplicate timestamps.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,7 +202,7 @@ dependencies {
         implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
         implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.1'
     } else {
-        implementation 'bio.terra:stairway:0.0.50-SNAPSHOT'
+        implementation 'bio.terra:stairway:0.0.52-SNAPSHOT'
     }
 
     // Similar development mode for pointing to terra common library


### PR DESCRIPTION
Bump stairway version to get a [stairway fix](https://github.com/DataBiosphere/stairway/pull/76) for handling flight logs with duplicate timestamps.