### PR TITLE
Updates to DR-1809

### DIFF
--- a/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
+++ b/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
@@ -135,9 +135,9 @@ public class GoogleBillingService {
         ProjectBillingInfo content = ProjectBillingInfo.newBuilder()
             .setBillingAccountName("billingAccounts/" + billingAccountId)
             .build();
-        try {
-            ProjectBillingInfo billingResponse = cloudBillingClient()
-                .updateProjectBillingInfo("projects/" + projectId, content);
+        try (CloudBillingClient cloudBillingClient = cloudBillingClient()) {
+            ProjectBillingInfo billingResponse = cloudBillingClient
+                    .updateProjectBillingInfo("projects/" + projectId, content);
             return billingResponse.getBillingEnabled();
         } catch (ApiException e) {
             String message = String.format("Could not assign billing account '%s' to project: %s", billingAccountId,
@@ -147,8 +147,8 @@ public class GoogleBillingService {
     }
 
     public ProjectBillingInfo getProjectBilling(String projectId) {
-        try {
-            return cloudBillingClient().getProjectBillingInfo("projects/" + projectId);
+        try (CloudBillingClient cloudBillingClient = cloudBillingClient()) {
+            return cloudBillingClient.getProjectBillingInfo("projects/" + projectId);
         } catch (ApiException e) {
             String message = String.format("Could not retrieve billing account to project: %s", projectId);
             throw new BillingServiceException(message, e);

--- a/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
+++ b/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
@@ -31,7 +31,7 @@ public class GoogleBillingService {
 
     private static Logger logger = LoggerFactory.getLogger(GoogleBillingService.class);
 
-    private static CloudBillingClient cloudBillingClient(AuthenticatedUserRequest user) {
+    private static CloudBillingClient accessClient(AuthenticatedUserRequest user) {
         try {
             // Authentication is provided by the 'gcloud' tool when running locally
             // and by built-in service accounts when running on GAE, GCE, or GKE.
@@ -72,8 +72,8 @@ public class GoogleBillingService {
         }
     }
 
-    private static CloudBillingClient cloudBillingClient() {
-        return cloudBillingClient(null);
+    private static CloudBillingClient accessClient() {
+        return accessClient(null);
     }
 
     /**
@@ -104,7 +104,7 @@ public class GoogleBillingService {
             .setResource(resource.toString())
             .addAllPermissions(permissions)
             .build();
-        try (CloudBillingClient client = cloudBillingClient(user)) {
+        try (CloudBillingClient client = accessClient(user)) {
             logger.info("Testing IAM permission on billing account: {}", billingAccountId);
             TestIamPermissionsResponse response = client.testIamPermissions(permissionsRequest);
             List<String> actualPermissions = response.getPermissionsList();
@@ -135,7 +135,7 @@ public class GoogleBillingService {
         ProjectBillingInfo content = ProjectBillingInfo.newBuilder()
             .setBillingAccountName("billingAccounts/" + billingAccountId)
             .build();
-        try (CloudBillingClient cloudBillingClient = cloudBillingClient()) {
+        try (CloudBillingClient cloudBillingClient = accessClient()) {
             ProjectBillingInfo billingResponse = cloudBillingClient
                     .updateProjectBillingInfo("projects/" + projectId, content);
             return billingResponse.getBillingEnabled();
@@ -147,7 +147,7 @@ public class GoogleBillingService {
     }
 
     public ProjectBillingInfo getProjectBilling(String projectId) {
-        try (CloudBillingClient cloudBillingClient = cloudBillingClient()) {
+        try (CloudBillingClient cloudBillingClient = accessClient()) {
             return cloudBillingClient.getProjectBillingInfo("projects/" + projectId);
         } catch (ApiException e) {
             String message = String.format("Could not retrieve billing account to project: %s", projectId);

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -637,8 +637,15 @@ public class BigQueryPdao {
 
     public void grantReadAccessToSnapshot(Snapshot snapshot, Collection<String> policies) throws InterruptedException {
         // TODO: When we support multiple datasets per snapshot, this will need to be reworked
+        logger.info("granting read access to snapshot");
+        var sourceDataset = snapshot.getFirstSnapshotSource().getDataset();
+        var bigQueryProject = bigQueryProjectForDataset(sourceDataset);
+
+        logger.info(sourceDataset.getName());
+        logger.info(bigQueryProject.toString());
+
         grantReadAccessWorker(
-            bigQueryProjectForDataset(snapshot.getFirstSnapshotSource().getDataset()),
+            bigQueryProject,
             snapshot.getName(),
             policies);
     }

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -642,7 +642,7 @@ public class BigQueryPdao {
         var bigQueryProject = bigQueryProjectForDataset(sourceDataset);
 
         logger.info(sourceDataset.getName());
-        logger.info(bigQueryProject.toString());
+        logger.info(bigQueryProject.getProjectId());
 
         grantReadAccessWorker(
             bigQueryProject,

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -637,15 +637,8 @@ public class BigQueryPdao {
 
     public void grantReadAccessToSnapshot(Snapshot snapshot, Collection<String> policies) throws InterruptedException {
         // TODO: When we support multiple datasets per snapshot, this will need to be reworked
-        logger.info("granting read access to snapshot");
-        var sourceDataset = snapshot.getFirstSnapshotSource().getDataset();
-        var datasetBQProject = bigQueryProjectForDataset(sourceDataset);
-        var bigQueryProject = bigQueryProjectForSnapshot(snapshot);
-        logger.info("Dataset project: " + datasetBQProject.getProjectId());
-        logger.info("Snapshot project:" + bigQueryProject.getProjectId());
-
         grantReadAccessWorker(
-            bigQueryProject,
+            bigQueryProjectForSnapshot(snapshot),
             snapshot.getName(),
             policies);
     }

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -636,7 +636,6 @@ public class BigQueryPdao {
     }
 
     public void grantReadAccessToSnapshot(Snapshot snapshot, Collection<String> policies) throws InterruptedException {
-        // TODO: When we support multiple datasets per snapshot, this will need to be reworked
         grantReadAccessWorker(
             bigQueryProjectForSnapshot(snapshot),
             snapshot.getName(),
@@ -650,14 +649,14 @@ public class BigQueryPdao {
             policies);
     }
 
-    private void grantReadAccessWorker(BigQueryProject datasetBigQueryProject,
+    private void grantReadAccessWorker(BigQueryProject bigQueryProject,
                                        String name,
                                        Collection<String> policyGroupEmails) {
         List<Acl> policyGroupAcls = policyGroupEmails
             .stream()
             .map(email -> Acl.of(new Acl.Group(email), Acl.Role.READER))
             .collect(Collectors.toList());
-        datasetBigQueryProject.addDatasetAcls(name, policyGroupAcls);
+        bigQueryProject.addDatasetAcls(name, policyGroupAcls);
     }
 
     public boolean datasetExists(Dataset dataset) throws InterruptedException {

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -639,10 +639,10 @@ public class BigQueryPdao {
         // TODO: When we support multiple datasets per snapshot, this will need to be reworked
         logger.info("granting read access to snapshot");
         var sourceDataset = snapshot.getFirstSnapshotSource().getDataset();
-        var bigQueryProject = bigQueryProjectForDataset(sourceDataset);
-
-        logger.info(sourceDataset.getName());
-        logger.info(bigQueryProject.getProjectId());
+        var datasetBQProject = bigQueryProjectForDataset(sourceDataset);
+        var bigQueryProject = bigQueryProjectForSnapshot(snapshot);
+        logger.info("Dataset project: " + datasetBQProject.getProjectId());
+        logger.info("Snapshot project:" + bigQueryProject.getProjectId());
 
         grantReadAccessWorker(
             bigQueryProject,

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -129,8 +129,7 @@ public final class BigQueryProject {
 
     public void addDatasetAcls(String datasetId, List<Acl> acls) {
         logger.info("ADD DATASET ACLS");
-        logger.info("dataset id" + datasetId);
-        logger.info(String.valueOf(acls));
+        logger.info("dataset id " + datasetId);
 
         Dataset dataset = bigQuery.getDataset(datasetId);
         logger.info(dataset.toString());

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -128,12 +128,7 @@ public final class BigQueryProject {
     }
 
     public void addDatasetAcls(String datasetId, List<Acl> acls) {
-        logger.info("ADD DATASET ACLS");
-        logger.info("dataset id " + datasetId);
-
         Dataset dataset = bigQuery.getDataset(datasetId);
-        logger.info(dataset.toString());
-
         List<Acl> beforeAcls = dataset.getAcl();
         logger.debug("Before acl: " + StringUtils.join(beforeAcls, ", "));
         ArrayList<Acl> newAcls = new ArrayList<>(beforeAcls);

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -128,7 +128,13 @@ public final class BigQueryProject {
     }
 
     public void addDatasetAcls(String datasetId, List<Acl> acls) {
+        logger.info("ADD DATASET ACLS");
+        logger.info("dataset id" + datasetId);
+        logger.info(String.valueOf(acls));
+
         Dataset dataset = bigQuery.getDataset(datasetId);
+        logger.info(dataset.toString());
+
         List<Acl> beforeAcls = dataset.getAcl();
         logger.debug("Before acl: " + StringUtils.join(beforeAcls, ", "));
         ArrayList<Acl> newAcls = new ArrayList<>(beforeAcls);


### PR DESCRIPTION
1. Fixes null pointer exception in `addDatasetAcls` when creating a snapshot with a different billing profile id

2. Fixes the error with the google cloud billing client not getting closed/shutdown properly:
  - From the [API documentation](https://googleapis.dev/java/google-cloud-billing/latest/): `Note: close() needs to be called on the CloudBillingClient object to clean up resources such as threads. In the example above, try-with-resources is used, which automatically calls close().`