### PR TITLE
Fix some bugs in BigQueryPDao and add a bunch of unit tests

### DIFF
--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -159,6 +159,15 @@ public class Dataset implements FSContainerInterface {
         return this;
     }
 
+    public List<StorageResource> getStorage() {
+        return datasetSummary.getStorage();
+    }
+
+    public Dataset storage(List<StorageResource> storage) {
+        datasetSummary.storage(storage);
+        return this;
+    }
+
     public GoogleProjectResource getProjectResource() {
         return projectResource;
     }

--- a/src/main/java/bio/terra/service/snapshot/RowIdMatch.java
+++ b/src/main/java/bio/terra/service/snapshot/RowIdMatch.java
@@ -26,13 +26,15 @@ public class RowIdMatch {
         unmatchedInputValues = new ArrayList<>();
     }
 
-    public void addMatch(String inputValue, String rowId) {
+    public RowIdMatch addMatch(String inputValue, String rowId) {
         matchedInputValues.add(inputValue);
         matchingRowIds.add(rowId);
+        return this;
     }
 
-    public void addMismatch(String inputValue) {
+    public RowIdMatch addMismatch(String inputValue) {
         unmatchedInputValues.add(inputValue);
+        return this;
     }
 
     public List<String> getMatchedInputValues() {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
@@ -74,7 +74,7 @@ public class CreateSnapshotFireStoreDataStep implements Step {
 
                         String bigQueryTimer = performanceLogger.timerStart();
                         List<String> refIds = bigQueryPdao.getSnapshotRefIds(snapshotSource.getDataset(),
-                            snapshot.getName(),
+                            snapshot,
                             mapTable.getFromTable().getName(),
                             mapTable.getFromTable().getId().toString(),
                             mapColumn.getFromColumn());

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -486,7 +486,7 @@ public class BigQueryPdao {
         "<selectStatements; separator=\" UNION ALL \">";
 
     private static final String validateSnapshotSizeTemplate =
-        "SELECT <rowId> FROM `<snapshotProject>.<snapshot>.<dataRepoTable>`";
+        "SELECT <rowId> FROM `<snapshotProject>.<snapshot>.<dataRepoTable>` LIMIT 1";
 
 
     public String createSnapshotTableFromLiveViews(

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -1256,8 +1256,8 @@ public class BigQueryPdao {
             "JOIN UNNEST(T.<toColumn>) AS flat_to ON flat_from = flat_to)";
 
     private static final String joinTablesToTestForMissingRowIds =
-        "SELECT COUNT(*) FROM <snapshotProject>.<snapshotDatasetName>.<tempTable> " +
-            "LEFT JOIN <datasetProject>.<datasetDatasetName>.<datasetTable> USING ( <commonColumn> ) " +
+        "SELECT COUNT(*) FROM `<snapshotProject>.<snapshotDatasetName>.<tempTable>` " +
+            "LEFT JOIN `<datasetProject>.<datasetDatasetName>.<datasetTable>` USING ( <commonColumn> ) " +
             "WHERE <datasetTable>.<commonColumn> IS NULL";
 
     private static final String loadRootRowIdsFromTempTableTemplate =

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -55,6 +55,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.ViewDefinition;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -92,20 +93,25 @@ public class BigQueryPdao {
 
     private final String datarepoDnsName;
     private final BigQueryConfiguration bigQueryConfiguration;
+    private final BigQueryProjectProvider bigQueryProjectProvider;
 
     @Autowired
     public BigQueryPdao(ApplicationConfiguration applicationConfiguration,
-                        BigQueryConfiguration bigQueryConfiguration) {
+                        BigQueryConfiguration bigQueryConfiguration,
+                        BigQueryProjectProvider bigQueryProjectProvider) {
         this.datarepoDnsName = applicationConfiguration.getDnsName();
         this.bigQueryConfiguration = bigQueryConfiguration;
+        this.bigQueryProjectProvider = bigQueryProjectProvider;
     }
 
-    public BigQueryProject bigQueryProjectForDataset(Dataset dataset) {
-        return BigQueryProject.get(dataset.getProjectResource().getGoogleProjectId());
+    @VisibleForTesting
+    BigQueryProject bigQueryProjectForDataset(Dataset dataset) {
+        return bigQueryProjectProvider.apply(dataset.getProjectResource().getGoogleProjectId());
     }
 
-    private BigQueryProject bigQueryProjectForSnapshot(Snapshot snapshot) {
-        return BigQueryProject.get(snapshot.getProjectResource().getGoogleProjectId());
+    @VisibleForTesting
+    BigQueryProject bigQueryProjectForSnapshot(Snapshot snapshot) {
+        return bigQueryProjectProvider.apply(snapshot.getProjectResource().getGoogleProjectId());
     }
 
     public void createDataset(Dataset dataset) throws InterruptedException {
@@ -1307,6 +1313,7 @@ public class BigQueryPdao {
             .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
             .build();
 
+        System.err.println(queryConfig);
         executeQueryWithRetry(bigQuery, queryConfig);
     }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -486,7 +486,7 @@ public class BigQueryPdao {
         "<selectStatements; separator=\" UNION ALL \">";
 
     private static final String validateSnapshotSizeTemplate =
-        "SELECT COUNT(1) FROM <snapshotProject>.<snapshot>.<dataRepoTable>";
+        "SELECT <rowId> FROM `<snapshotProject>.<snapshot>.<dataRepoTable>`";
 
 
     public String createSnapshotTableFromLiveViews(
@@ -551,6 +551,7 @@ public class BigQueryPdao {
         snapshotBigQueryProject.query(sqlTemplate.render());
 
         ST sqlValidateSnapshotTemplate = new ST(validateSnapshotSizeTemplate);
+        sqlValidateSnapshotTemplate.add("rowId", PDAO_ROW_ID_COLUMN);
         sqlValidateSnapshotTemplate.add("snapshotProject", snapshotProjectId);
         sqlValidateSnapshotTemplate.add("snapshot", snapshotName);
         sqlValidateSnapshotTemplate.add("dataRepoTable", PDAO_ROW_ID_TABLE);
@@ -1315,7 +1316,6 @@ public class BigQueryPdao {
             .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
             .build();
 
-        System.err.println(queryConfig);
         executeQueryWithRetry(bigQuery, queryConfig);
     }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -26,26 +26,19 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public final class BigQueryProject {
     private static final Logger logger = LoggerFactory.getLogger(BigQueryProject.class);
-    private static final ConcurrentHashMap<String, BigQueryProject> bigQueryProjectCache = new ConcurrentHashMap<>();
     private final String projectId;
     private final BigQuery bigQuery;
 
-    private BigQueryProject(String projectId) {
+    BigQueryProject(String projectId) {
         logger.info("Retrieving Bigquery project for project id: {}", projectId);
         this.projectId = projectId;
         bigQuery = BigQueryOptions.newBuilder()
             .setProjectId(projectId)
             .build()
             .getService();
-    }
-
-    public static BigQueryProject get(String projectId) {
-        bigQueryProjectCache.computeIfAbsent(projectId, BigQueryProject::new);
-        return bigQueryProjectCache.get(projectId);
     }
 
     public String getProjectId() {

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProjectProvider.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProjectProvider.java
@@ -1,0 +1,21 @@
+package bio.terra.service.tabulardata.google;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Given a projectId, returns a {@link BigQueryProject} object while caching
+ */
+@Component
+public class BigQueryProjectProvider implements Function<String, BigQueryProject> {
+    private static final ConcurrentHashMap<String, BigQueryProject> BQ_PROJECT_CACHE = new ConcurrentHashMap<>();
+
+    @Override
+    public BigQueryProject apply(String projectId) {
+        BQ_PROJECT_CACHE.computeIfAbsent(projectId, BigQueryProject::new);
+        return BQ_PROJECT_CACHE.get(projectId);
+    }
+
+}

--- a/src/test/java/bio/terra/common/BQTestUtils.java
+++ b/src/test/java/bio/terra/common/BQTestUtils.java
@@ -1,0 +1,70 @@
+package bio.terra.common;
+
+import bio.terra.service.tabulardata.google.BigQueryProject;
+import com.google.cloud.PageImpl;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.TableResult;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Helper methods for mocking out BigQuery responses
+ */
+public final class BQTestUtils {
+
+    private BQTestUtils() {
+    }
+
+    public static void mockBQQuery(BigQueryProject mockBQProject,
+                                   String sql,
+                                   Schema schema,
+                                   List<Map<String, String>> results
+    ) {
+        try {
+            when(mockBQProject.query(sql)).thenAnswer(mockAnswer(schema, results));
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Error mocking query execution");
+        }
+    }
+
+    public static void mockBQQuery(BigQuery mockBQ,
+                                   QueryJobConfiguration sql,
+                                   Schema schema,
+                                   List<Map<String, String>> results
+    ) {
+        try {
+            when(mockBQ.query(sql)).thenAnswer(mockAnswer(schema, results));
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Error mocking query execution");
+        }
+    }
+
+    private static Answer<TableResult> mockAnswer(Schema schema,
+                                                  List<Map<String, String>> results) {
+        return a -> new TableResult(
+            schema,
+            results.size(),
+            new PageImpl<>(null, null, convertValues(results, schema)));
+    }
+
+    private static List<FieldValueList> convertValues(List<Map<String, String>> results, Schema schema) {
+        // Note: using a little bit of a convoluted approach for constructing the values list but we need
+        // to maintain the order
+        return results.stream()
+            .map(r -> FieldValueList.of(schema.getFields().stream()
+                .map(f -> FieldValue.of(FieldValue.Attribute.PRIMITIVE, r.get(f.getName())))
+                .collect(Collectors.toList()), schema.getFields()))
+            .collect(Collectors.toList());
+    }
+
+
+}

--- a/src/test/java/bio/terra/common/TestUtils.java
+++ b/src/test/java/bio/terra/common/TestUtils.java
@@ -6,6 +6,7 @@ import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.service.tabulardata.google.BigQueryProject;
+import bio.terra.service.tabulardata.google.BigQueryProjectProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
@@ -163,7 +164,7 @@ public final class TestUtils {
     public static BigQueryProject bigQueryProjectForDatasetName(DatasetDao datasetDao,
                                                                 String datasetName) throws InterruptedException {
         Dataset dataset = datasetDao.retrieveByName(datasetName);
-        return BigQueryProject.get(dataset.getProjectResource().getGoogleProjectId());
+        return new BigQueryProjectProvider().apply(dataset.getProjectResource().getGoogleProjectId());
     }
 
     private static final String selectFromBigQueryDatasetTemplate =
@@ -216,6 +217,4 @@ public final class TestUtils {
         }
         return null;
     }
-
 }
-

--- a/src/test/java/bio/terra/common/fixtures/DatasetFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/DatasetFixtures.java
@@ -1,5 +1,6 @@
 package bio.terra.common.fixtures;
 
+import bio.terra.common.Column;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
 import bio.terra.model.ColumnModel;
@@ -10,10 +11,13 @@ import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
+import bio.terra.service.dataset.DatasetTable;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 
 public final class DatasetFixtures {
@@ -99,5 +103,33 @@ public final class DatasetFixtures {
             .description("This is a sample dataset definition")
             .defaultProfileId(UUID.randomUUID().toString())
             .schema(buildSchema());
+    }
+
+    /**
+     * Use method to generate a DatasetTable.  Individual values can be mutated by tests if needed
+     */
+    public static DatasetTable generateDatasetTable(String name,
+                                                    TableDataType baseType,
+                                                    List<String> columnNames) {
+        if (columnNames.isEmpty()) {
+            throw new RuntimeException("Number of columns must be greater than 0");
+        }
+        List<Column> columns = columnNames.stream()
+            .map(c -> new Column()
+                .id(UUID.randomUUID())
+                .name(c)
+                .arrayOf(false)
+                .type(baseType)
+            )
+            .collect(Collectors.toList());
+        DatasetTable datasetTable = new DatasetTable()
+            .id(UUID.randomUUID())
+            .name(name)
+            .rawTableName(name)
+            .columns(columns)
+            .primaryKey(columns.subList(0, 0));
+        datasetTable.getColumns().forEach(c -> c.table(datasetTable));
+
+        return datasetTable;
     }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
@@ -24,6 +24,7 @@ import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.tabulardata.google.BigQueryProject;
+import bio.terra.service.tabulardata.google.BigQueryProjectProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.bigquery.FieldValue;
@@ -461,7 +462,7 @@ public class EncodeFileTest {
     private String getFileRefIdFromSnapshot(SnapshotSummaryModel snapshotSummary) throws InterruptedException {
         Snapshot snapshot = snapshotDao.retrieveSnapshotByName(snapshotSummary.getName());
         String googleProjectId = snapshot.getProjectResource().getGoogleProjectId();
-        BigQueryProject bigQueryProject = BigQueryProject.get(googleProjectId);
+        BigQueryProject bigQueryProject = new BigQueryProjectProvider().apply(googleProjectId);
 
         StringBuilder builder = new StringBuilder()
             .append("SELECT file_ref FROM `")

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -32,6 +32,7 @@ import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import bio.terra.service.tabulardata.google.BigQueryProject;
+import bio.terra.service.tabulardata.google.BigQueryProjectProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.FieldValue;
@@ -896,7 +897,8 @@ public class SnapshotConnectedTest {
     // Technically a helper method, but so specific to testExcludeLockedFromSnapshotFileLookups, likely not re-useable
     private String getFileRefIdFromSnapshot(SnapshotSummaryModel snapshotSummary) throws InterruptedException {
         Snapshot snapshot = snapshotDao.retrieveSnapshotByName(snapshotSummary.getName());
-        BigQueryProject bigQueryProject = BigQueryProject.get(snapshot.getProjectResource().getGoogleProjectId());
+        BigQueryProject bigQueryProject = new BigQueryProjectProvider()
+            .apply(snapshot.getProjectResource().getGoogleProjectId());
         BigQuery bigQuery = bigQueryProject.getBigQuery();
 
         ST sqlTemplate = new ST(queryForRefIdTemplate);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -41,7 +41,6 @@ public class SnapshotServiceTest {
     @Mock
     private DatasetService datasetService;
     @Mock
-
     private FireStoreDependencyDao dependencyDao;
     @Mock
     private BigQueryPdao bigQueryPdao;
@@ -77,8 +76,7 @@ public class SnapshotServiceTest {
                 .createdDate(createdDate.toString())
                 .source(Collections.emptyList())
                 .tables(List.of(new TableModel()
-                    .name(SNAPSHOT_TABLE_NAME)
-                ))
+                    .name(SNAPSHOT_TABLE_NAME)))
                 .relationships(Collections.emptyList())
                 .profileId(profileId.toString())
                 .dataProject(SNAPSHOT_DATA_PROJECT)
@@ -166,12 +164,10 @@ public class SnapshotServiceTest {
                 .profileId(profileId)
                 .projectResource(new GoogleProjectResource()
                     .profileId(profileId)
-                    .googleProjectId(SNAPSHOT_DATA_PROJECT)
-                )
+                    .googleProjectId(SNAPSHOT_DATA_PROJECT))
                 .snapshotTables(List.of(new SnapshotTable()
                     .name(SNAPSHOT_TABLE_NAME)
-                    .id(snapshotTableId)
-                ))
+                    .id(snapshotTableId)))
             );
     }
 }

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoUnitTest.java
@@ -1,0 +1,747 @@
+package bio.terra.service.tabulardata.google;
+
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.app.model.GoogleCloudResource;
+import bio.terra.app.model.GoogleRegion;
+import bio.terra.common.BQTestUtils;
+import bio.terra.common.Relationship;
+import bio.terra.common.category.Unit;
+import bio.terra.common.exception.PdaoException;
+import bio.terra.common.fixtures.DatasetFixtures;
+import bio.terra.grammar.exception.InvalidQueryException;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.SnapshotRequestContentsModel;
+import bio.terra.model.SnapshotRequestRowIdModel;
+import bio.terra.model.SnapshotRequestRowIdTableModel;
+import bio.terra.model.TableDataType;
+import bio.terra.service.dataset.AssetColumn;
+import bio.terra.service.dataset.AssetRelationship;
+import bio.terra.service.dataset.AssetSpecification;
+import bio.terra.service.dataset.AssetTable;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.StorageResource;
+import bio.terra.service.filedata.google.bq.BigQueryConfiguration;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.snapshot.RowIdMatch;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotMapColumn;
+import bio.terra.service.snapshot.SnapshotMapTable;
+import bio.terra.service.snapshot.SnapshotSource;
+import bio.terra.service.snapshot.SnapshotTable;
+import bio.terra.service.snapshot.exception.MismatchedValueException;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.ViewDefinition;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_COLUMN;
+import static bio.terra.common.PdaoConstant.PDAO_TABLE_ID_COLUMN;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@Category(Unit.class)
+public class BigQueryPdaoUnitTest {
+
+
+    private static final UUID DATASET_ID = UUID.randomUUID();
+    private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+    private static final UUID PROFILE_1_ID = UUID.randomUUID();
+    private static final String SNAPSHOT_NAME = "snapshotName";
+    private static final String SNAPSHOT_PROJECT_ID = "snapshot_data";
+    private static final String DATASET_PROJECT_ID = "dataset_data";
+    private static final Instant SNAPSHOT_CREATION = Instant.now();
+    private static final String DATASET_NAME = "datasetName";
+    private static final String SNAPSHOT_DESCRIPTION = "snapshotDescription";
+    private static final String TABLE_1_NAME = "tableA";
+    private static final UUID TABLE_1_ID = UUID.randomUUID();
+    private static final UUID SNAPSHOT_TABLE_1_ID = UUID.randomUUID();
+    private static final String TABLE_1_COL1_NAME = "col1a";
+    private static final UUID TABLE_1_COL1_ID = UUID.randomUUID();
+    private static final UUID SNAPSHOT_TABLE_1_COL1_ID = UUID.randomUUID();
+    private static final String TABLE_1_COL2_NAME = "col2a";
+    private static final UUID TABLE_1_COL2_ID = UUID.randomUUID();
+    private static final UUID SNAPSHOT_TABLE_1_COL2_ID = UUID.randomUUID();
+
+    private static final String TABLE_2_NAME = "tableB";
+    private static final UUID TABLE_2_ID = UUID.randomUUID();
+    private static final UUID SNAPSHOT_TABLE_2_ID = UUID.randomUUID();
+    private static final String TABLE_2_COL1_NAME = "col1b";
+    private static final UUID TABLE_2_COL1_ID = UUID.randomUUID();
+    private static final UUID SNAPSHOT_TABLE_2_COL1_ID = UUID.randomUUID();
+    private static final String TABLE_2_COL2_NAME = "col2b";
+    private static final UUID TABLE_2_COL2_ID = UUID.randomUUID();
+    private static final UUID SNAPSHOT_TABLE_2_COL2_ID = UUID.randomUUID();
+    private static final String TABLE_2_COL3_NAME = "col3b";
+    private static final UUID TABLE_2_COL3_ID = UUID.randomUUID();
+    private static final UUID SNAPSHOT_TABLE_2_COL3_ID = UUID.randomUUID();
+
+    @Mock
+    private ApplicationConfiguration applicationConfiguration;
+    @Mock
+    private BigQueryConfiguration bigQueryConfiguration;
+    @Mock
+    private BigQueryProject bigQueryProjectSnapshot;
+    @Mock
+    private BigQuery bigQuerySnapshot;
+    @Mock
+    private BigQueryProject bigQueryProjectDataset;
+    @Mock
+    private BigQuery bigQueryDataset;
+    @Mock
+    private BigQueryProjectProvider bigQueryProjectProvider;
+
+    private Snapshot snapshot;
+    private BigQueryPdao dao;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(bigQueryProjectSnapshot.getProjectId()).thenReturn(SNAPSHOT_PROJECT_ID);
+        when(bigQueryProjectSnapshot.getBigQuery()).thenReturn(bigQuerySnapshot);
+        when(bigQueryProjectProvider.apply(SNAPSHOT_PROJECT_ID)).thenReturn(bigQueryProjectSnapshot);
+
+        when(bigQueryProjectDataset.getProjectId()).thenReturn(DATASET_PROJECT_ID);
+        when(bigQueryProjectDataset.getBigQuery()).thenReturn(bigQueryDataset);
+        when(bigQueryProjectProvider.apply(DATASET_PROJECT_ID)).thenReturn(bigQueryProjectDataset);
+
+        dao = new BigQueryPdao(applicationConfiguration, bigQueryConfiguration, bigQueryProjectProvider);
+        snapshot = mockSnapshot();
+    }
+
+    @Test
+    public void testGetRefIds() throws InterruptedException {
+        String value1 = "value1";
+        String value2 = "value2";
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectDataset,
+            "SELECT " + TABLE_1_COL1_NAME + " " +
+                "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "`",
+            Schema.of(Field.of(TABLE_1_COL1_NAME, LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of(TABLE_1_COL1_NAME, value1),
+                Map.of(TABLE_1_COL1_NAME, value2)));
+
+        DatasetTable table = snapshot.getFirstSnapshotSource().getDataset().getTables().get(0);
+        assertThat(
+            dao.getRefIds(snapshot.getFirstSnapshotSource().getDataset(), table.getName(), table.getColumns().get(0)),
+            equalTo(List.of(value1, value2))
+        );
+    }
+
+    @Test
+    public void testGetSnapshotRefIds() throws InterruptedException {
+        String value1 = "value1";
+        String value2 = "value2";
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectSnapshot,
+            "SELECT " + TABLE_1_COL1_NAME + " " +
+                "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` S, " +
+                "`" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` R " +
+                "WHERE S.datarepo_row_id = R.datarepo_row_id AND " +
+                    "R.datarepo_table_id = '" +  TABLE_1_ID + "'",
+            Schema.of(Field.of(TABLE_1_COL1_NAME, LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of(TABLE_1_COL1_NAME, value1),
+                Map.of(TABLE_1_COL1_NAME, value2)));
+
+        DatasetTable table = snapshot.getFirstSnapshotSource().getDataset().getTables().get(0);
+        assertThat(
+            dao.getSnapshotRefIds(
+                snapshot.getFirstSnapshotSource().getDataset(),
+                snapshot,
+                table.getName(),
+                table.getId().toString(),
+                table.getColumns().get(0)),
+            equalTo(List.of(value1, value2))
+        );
+    }
+
+    @Test
+    public void testMapValuesToRows() throws InterruptedException {
+        String input1 = "input1";
+        String input2 = "input2";
+
+        String drRowId1 = UUID.randomUUID().toString();
+        String drRowId2 = UUID.randomUUID().toString();
+
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectDataset,
+            "SELECT T.datarepo_row_id, V.input_value FROM (" +
+                "SELECT input_value FROM UNNEST(['" + input1 + "','" + input2 + "']) AS input_value) AS V " +
+                "LEFT JOIN `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` AS T " +
+                "ON V.input_value = CAST(T." + TABLE_1_COL1_NAME + " AS STRING)",
+            Schema.of(
+                Field.of("datarepo_row_id", LegacySQLTypeName.STRING),
+                Field.of("input_value", LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of("datarepo_row_id", drRowId1, "input_value", input1),
+                Map.of("datarepo_row_id", drRowId2, "input_value", input2)));
+
+        assertThat(dao.mapValuesToRows(snapshot.getFirstSnapshotSource(), List.of(input1, input2)),
+            samePropertyValuesAs(new RowIdMatch().addMatch(input1, drRowId1).addMatch(input2, drRowId2)));
+    }
+
+    @Test
+    public void testMapValuesToRowsWithMismatch() throws InterruptedException {
+        String ipt1 = "input1";
+        String ipt2 = "input2";
+        String ipt3 = "input3";
+
+        String drRowId1 = UUID.randomUUID().toString();
+        String drRowId2 = UUID.randomUUID().toString();
+
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectDataset,
+            "SELECT T.datarepo_row_id, V.input_value FROM (" +
+                "SELECT input_value FROM UNNEST(['" + ipt1 + "','" + ipt2 + "','" + ipt3 + "']) AS input_value) AS V " +
+                "LEFT JOIN `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` AS T " +
+                "ON V.input_value = CAST(T." + TABLE_1_COL1_NAME + " AS STRING)",
+            Schema.of(
+                Field.of("datarepo_row_id", LegacySQLTypeName.STRING),
+                Field.of("input_value", LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of("datarepo_row_id", drRowId1, "input_value", ipt1),
+                Map.of("datarepo_row_id", drRowId2, "input_value", ipt2),
+                Map.of("input_value", ipt3)));
+
+        // Check that mismatches are also identified
+        assertThat(dao.mapValuesToRows(snapshot.getFirstSnapshotSource(), List.of(ipt1, ipt2, ipt3)),
+            samePropertyValuesAs(new RowIdMatch().addMatch(ipt1, drRowId1).addMatch(ipt2, drRowId2).addMismatch(ipt3)));
+    }
+
+    @Test
+    public void testCreateSnapshotEmptyRowIds() throws InterruptedException {
+        mockNumRowIds(snapshot, TABLE_1_NAME, 0);
+
+        dao.createSnapshot(snapshot, Collections.emptyList());
+
+        verify(bigQueryProjectSnapshot, times(1)).createDataset(
+            SNAPSHOT_NAME, SNAPSHOT_DESCRIPTION, GoogleRegion.NORTHAMERICA_NORTHEAST1
+        );
+
+        // Note: explicitly building up sql to make it easier to verify
+        verify(bigQuerySnapshot, times(1)).create(
+            TableInfo.of(
+                TableId.of(SNAPSHOT_NAME, TABLE_1_NAME),
+                ViewDefinition.of(
+                    "SELECT datarepo_row_id, " +
+                        TABLE_1_COL1_NAME + "," +
+                        TABLE_1_COL2_NAME + " " +
+                        "FROM (SELECT S.datarepo_row_id, " +
+                        TABLE_1_COL1_NAME + "," +
+                        TABLE_1_COL2_NAME + " " +
+                        "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` S, " +
+                        "`" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` R " +
+                        "WHERE S.datarepo_row_id = R.datarepo_row_id AND R.datarepo_table_id = " +
+                        "'" + TABLE_1_ID + "')")));
+
+        verify(bigQuerySnapshot, times(1)).create(
+            TableInfo.of(
+                TableId.of(SNAPSHOT_NAME, TABLE_2_NAME),
+                ViewDefinition.of(
+                    "SELECT datarepo_row_id, " +
+                        TABLE_2_COL1_NAME + "," +
+                        TABLE_2_COL2_NAME + "," +
+                        TABLE_2_COL3_NAME + " " +
+                        "FROM (SELECT S.datarepo_row_id, " +
+                        TABLE_2_COL2_NAME + " AS " + TABLE_2_COL1_NAME + "," +
+                        TABLE_2_COL1_NAME + " AS " + TABLE_2_COL2_NAME + "," +
+                        "NULL AS " + TABLE_2_COL3_NAME + " " +
+                        "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_2_NAME + "` S, " +
+                        "`" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` R " +
+                        "WHERE S.datarepo_row_id = R.datarepo_row_id AND R.datarepo_table_id = " +
+                        "'" + TABLE_2_ID + "')")));
+    }
+
+    @Test
+    public void testCreateSnapshotMismatchedRowIdCounts() throws InterruptedException {
+        mockNumRowIds(snapshot, TABLE_1_NAME, 0);
+
+        assertThrows(
+            PdaoException.class,
+            () -> dao.createSnapshot(snapshot, List.of(UUID.randomUUID().toString())),
+            "Invalid row ids supplied");
+    }
+
+    @Test
+    public void testCreateSnapshotWithRowIds() throws InterruptedException {
+        String drRowId1 = UUID.randomUUID().toString();
+        String drRowId2 = UUID.randomUUID().toString();
+        String rootTblId =
+            snapshot.getFirstSnapshotSource().getAssetSpecification().getRootTable().getTable().getId().toString();
+        mockNumRowIds(snapshot, TABLE_1_NAME, 2);
+
+        dao.createSnapshot(snapshot, List.of(drRowId1,  drRowId2));
+
+        verify(bigQueryProjectSnapshot, times(1)).createDataset(
+            SNAPSHOT_NAME, SNAPSHOT_DESCRIPTION, GoogleRegion.NORTHAMERICA_NORTHEAST1
+        );
+
+        // Verify that the rowIds are properly copied
+        verify(bigQueryProjectSnapshot, times(1)).query(
+            "INSERT INTO `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` " +
+                "(datarepo_table_id,datarepo_row_id) " +
+                "SELECT '" + rootTblId + "' AS datarepo_table_id, T.row_id AS datarepo_row_id FROM (" +
+                "SELECT row_id FROM UNNEST(['" + drRowId1 + "','" + drRowId2 + "']) AS row_id" +
+                ") AS T");
+
+        // Verify the result of the relationship walk are written to the rowid table
+        verify(bigQuerySnapshot, times(1)).query(
+            QueryJobConfiguration.newBuilder(
+                "WITH merged_table AS (SELECT DISTINCT '" + TABLE_2_ID + "' AS datarepo_table_id, " +
+                    "T.datarepo_row_id " +
+                    "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_2_NAME + "` T, " +
+                    "`" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` F, " +
+                    "`" + SNAPSHOT_PROJECT_ID + "." +  SNAPSHOT_NAME + ".datarepo_row_ids` R " +
+                    "WHERE R.datarepo_table_id = '" + TABLE_1_ID + "' AND " +
+                    "R.datarepo_row_id = F.datarepo_row_id AND T." + TABLE_2_COL1_NAME + " = " +
+                    "F." + TABLE_1_COL1_NAME + ") " +
+                    "SELECT datarepo_table_id,datarepo_row_id FROM merged_table WHERE " +
+                    "datarepo_row_id NOT IN (SELECT datarepo_row_id " +
+                    "FROM `" + SNAPSHOT_PROJECT_ID + "." +  SNAPSHOT_NAME + ".datarepo_row_ids`)")
+                .setDestinationTable(TableId.of(SNAPSHOT_NAME, "datarepo_row_ids"))
+                .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
+                .build());
+
+        verify(bigQuerySnapshot, times(1)).create(
+            TableInfo.of(
+                TableId.of(SNAPSHOT_NAME, TABLE_1_NAME),
+                ViewDefinition.of(
+                    "SELECT datarepo_row_id, " +
+                        TABLE_1_COL1_NAME + "," +
+                        TABLE_1_COL2_NAME + " " +
+                        "FROM (SELECT S.datarepo_row_id, " +
+                        TABLE_1_COL1_NAME + "," +
+                        TABLE_1_COL2_NAME + " " +
+                        "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` S, " +
+                        "`" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` R " +
+                        "WHERE S.datarepo_row_id = R.datarepo_row_id AND R.datarepo_table_id = " +
+                        "'" + TABLE_1_ID + "')")));
+
+        verify(bigQuerySnapshot, times(1)).create(
+            TableInfo.of(
+                TableId.of(SNAPSHOT_NAME, TABLE_2_NAME),
+                ViewDefinition.of(
+                    "SELECT datarepo_row_id, " +
+                        TABLE_2_COL1_NAME + "," +
+                        TABLE_2_COL2_NAME + "," +
+                        TABLE_2_COL3_NAME + " " +
+                        "FROM (SELECT S.datarepo_row_id, " +
+                        TABLE_2_COL2_NAME + " AS " + TABLE_2_COL1_NAME + "," +
+                        TABLE_2_COL1_NAME + " AS " + TABLE_2_COL2_NAME + "," +
+                        "NULL AS " + TABLE_2_COL3_NAME + " " +
+                        "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_2_NAME + "` S, " +
+                        "`" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` R " +
+                        "WHERE S.datarepo_row_id = R.datarepo_row_id AND R.datarepo_table_id = " +
+                        "'" + TABLE_2_ID + "')")));
+    }
+
+    @Test
+    public void testCreateSnapshotWithLiveViews() throws InterruptedException {
+        // Make sure that validation is called and returns
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectSnapshot,
+            "SELECT datarepo_row_id FROM `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids`",
+            Schema.of(Field.of("cnt", LegacySQLTypeName.NUMERIC)),
+            List.of(Map.of("cnt", UUID.randomUUID().toString())));
+
+        dao.createSnapshotWithLiveViews(snapshot, snapshot.getFirstSnapshotSource().getDataset());
+
+        // Make sure that rowId table is created
+        verify(bigQueryProjectSnapshot, times(1))
+            .createTable(snapshot.getName(), "datarepo_row_ids", Schema.of(
+                Field.of(PDAO_TABLE_ID_COLUMN, LegacySQLTypeName.STRING),
+                Field.of(PDAO_ROW_ID_COLUMN, LegacySQLTypeName.STRING)));
+
+        // Make sure that rowIds are inserted
+        verify(bigQueryProjectSnapshot, times(1)).
+            query("INSERT INTO `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` " +
+                "(datarepo_table_id, datarepo_row_id) " +
+                "(SELECT '" + TABLE_1_ID + "', datarepo_row_id " +
+                "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "`) " +
+                "UNION ALL " +
+                "(SELECT '" + TABLE_2_ID + "', datarepo_row_id " +
+                "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_2_NAME + "`)");
+    }
+
+    @Test
+    public void testCreateSnapshotWithLiveViewsValidationFails() throws InterruptedException {
+        // Make validation return that no records will be in snapshot
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectSnapshot,
+            "SELECT datarepo_row_id FROM `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids`",
+            Schema.of(Field.of("cnt", LegacySQLTypeName.NUMERIC)),
+            Collections.emptyList());
+
+        assertThrows(
+            PdaoException.class,
+            () -> dao.createSnapshotWithLiveViews(snapshot, snapshot.getFirstSnapshotSource().getDataset()),
+            "This snapshot is empty");
+    }
+
+    @Test
+    public void testQueryForRowIds() throws InterruptedException {
+        String query = "SELECT datarepo_row_id " +
+            "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` " +
+            "WHERE " + TABLE_1_NAME + "." + TABLE_1_COL2_NAME + " = 'abc'";
+
+        QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query)
+            .setDestinationTable(TableId.of(SNAPSHOT_NAME, "datarepo_temp"))
+            .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
+            .build();
+        String drRowId1 = UUID.randomUUID().toString();
+        String drRowId2 = UUID.randomUUID().toString();
+
+        // Mock query that is passed in
+        BQTestUtils.mockBQQuery(
+            bigQuerySnapshot,
+            queryConfig,
+            Schema.of(Field.of("datarepo_row_id", LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of("datarepo_row_id", drRowId1),
+                Map.of("datarepo_row_id", drRowId2)));
+
+        // Mock validation query
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectSnapshot,
+            "SELECT COUNT(*) FROM `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_temp` " +
+                "LEFT JOIN `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` " +
+                "USING ( datarepo_row_id ) " +
+                "WHERE " + TABLE_1_NAME + ".datarepo_row_id IS NULL",
+            Schema.of(Field.of("cnt", LegacySQLTypeName.STRING)),
+            List.of(Map.of("cnt", "0")));
+
+        AssetSpecification assetSpecification = snapshot.getFirstSnapshotSource().getAssetSpecification();
+        AssetTable rootTable = assetSpecification.getRootTable();
+        dao.queryForRowIds(assetSpecification, snapshot, query);
+
+        verify(bigQueryProjectSnapshot, times(1)).query(
+            "INSERT INTO `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` " +
+                "(datarepo_table_id,datarepo_row_id) " +
+                "SELECT '" + rootTable.getTable().getId() + "' AS datarepo_table_id, T.row_id AS datarepo_row_id " +
+                "FROM (SELECT datarepo_row_id AS row_id " +
+                "FROM `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_temp` ) AS T");
+    }
+
+    @Test
+    public void testQueryForRowIdsQueryIsEmpty() throws InterruptedException {
+        String query = "SELECT datarepo_row_id " +
+            "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` " +
+            "WHERE " + TABLE_1_NAME + "." + TABLE_1_COL2_NAME + " = 'abc'";
+
+        QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query)
+            .setDestinationTable(TableId.of(SNAPSHOT_NAME, "datarepo_temp"))
+            .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
+            .build();
+
+        // Mock query that is passed in
+        BQTestUtils.mockBQQuery(
+            bigQuerySnapshot,
+            queryConfig,
+            Schema.of(Field.of("datarepo_row_id", LegacySQLTypeName.STRING)),
+            Collections.emptyList());
+        assertThrows(
+            InvalidQueryException.class, () ->
+            dao.queryForRowIds(snapshot.getFirstSnapshotSource().getAssetSpecification(), snapshot, query),
+            "Query returned 0 results");
+    }
+
+    @Test
+    public void testQueryForRowIdsValidationFails() throws InterruptedException {
+        String query = "SELECT datarepo_row_id " +
+            "FROM `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` " +
+            "WHERE " + TABLE_1_NAME + "." + TABLE_1_COL2_NAME + " = 'abc'";
+
+        QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query)
+            .setDestinationTable(TableId.of(SNAPSHOT_NAME, "datarepo_temp"))
+            .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
+            .build();
+        String drRowId1 = UUID.randomUUID().toString();
+        String drRowId2 = UUID.randomUUID().toString();
+
+        // Mock query that is passed in
+        BQTestUtils.mockBQQuery(
+            bigQuerySnapshot,
+            queryConfig,
+            Schema.of(Field.of("datarepo_row_id", LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of("datarepo_row_id", drRowId1),
+                Map.of("datarepo_row_id", drRowId2)));
+
+        // Mock validation query
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectSnapshot,
+            "SELECT COUNT(*) FROM `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_temp` " +
+                "LEFT JOIN `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` " +
+                "USING ( datarepo_row_id ) " +
+                "WHERE " + TABLE_1_NAME + ".datarepo_row_id IS NULL",
+            Schema.of(Field.of("cnt", LegacySQLTypeName.STRING)),
+            List.of(Map.of("cnt", "1")));
+
+        assertThrows(
+            MismatchedValueException.class, () ->
+            dao.queryForRowIds(snapshot.getFirstSnapshotSource().getAssetSpecification(), snapshot, query),
+            "Query results did not match dataset root row ids");
+    }
+
+    @Test
+    public void testMatchRowIds() throws InterruptedException {
+        String drRowId1 = UUID.randomUUID().toString();
+        String drRowId2 = UUID.randomUUID().toString();
+
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectDataset,
+            "SELECT T.datarepo_row_id, V.input_value FROM (" +
+                "SELECT input_value FROM UNNEST(['" + drRowId1 + "','" + drRowId2 + "']) AS input_value) AS V " +
+                "LEFT JOIN `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` AS T " +
+                "ON V.input_value = CAST(T.datarepo_row_id AS STRING)",
+            Schema.of(
+                Field.of("datarepo_row_id", LegacySQLTypeName.STRING),
+                Field.of("input_value", LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of("datarepo_row_id", drRowId1, "input_value", drRowId1),
+                Map.of("datarepo_row_id", drRowId2, "input_value", drRowId2)));
+
+        assertThat(dao.matchRowIds(snapshot.getFirstSnapshotSource(), TABLE_1_NAME, List.of(drRowId1, drRowId2)),
+            samePropertyValuesAs(new RowIdMatch().addMatch(drRowId1, drRowId1).addMatch(drRowId2, drRowId2)));
+    }
+
+    @Test
+    public void testMatchRowIdsWithMismatch() throws InterruptedException {
+        String drRowId1 = UUID.randomUUID().toString();
+        String drRowId2 = UUID.randomUUID().toString();
+        String drRowId3 = UUID.randomUUID().toString();
+
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectDataset,
+            "SELECT T.datarepo_row_id, V.input_value FROM (" +
+                "SELECT input_value FROM UNNEST(['" + drRowId1 + "','" + drRowId2 + "','" + drRowId3 + "']) AS " +
+                "input_value) AS V " +
+                "LEFT JOIN `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` AS T " +
+                "ON V.input_value = CAST(T.datarepo_row_id AS STRING)",
+            Schema.of(
+                Field.of("datarepo_row_id", LegacySQLTypeName.STRING),
+                Field.of("input_value", LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of("datarepo_row_id", drRowId1, "input_value", drRowId1),
+                Map.of("datarepo_row_id", drRowId2, "input_value", drRowId2),
+                Map.of("input_value", drRowId3)));
+
+        assertThat(
+            dao.matchRowIds(snapshot.getFirstSnapshotSource(), TABLE_1_NAME, List.of(drRowId1, drRowId2, drRowId3)),
+            samePropertyValuesAs(new RowIdMatch()
+                .addMatch(drRowId1, drRowId1)
+                .addMatch(drRowId2, drRowId2)
+                .addMismatch(drRowId3)));
+    }
+
+    @Test
+    public void testCreateSnapshotWithProvidedIds() throws InterruptedException {
+        String drRowId1 = UUID.randomUUID().toString();
+        String drRowId2 = UUID.randomUUID().toString();
+
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectDataset,
+            "SELECT T.datarepo_row_id, V.input_value FROM (" +
+                "SELECT input_value FROM UNNEST(['" + drRowId1 + "','" + drRowId2 + "']) AS input_value) AS V " +
+                "LEFT JOIN `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` AS T " +
+                "ON V.input_value = CAST(T.datarepo_row_id AS STRING)",
+            Schema.of(
+                Field.of("datarepo_row_id", LegacySQLTypeName.STRING),
+                Field.of("input_value", LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of("datarepo_row_id", drRowId1, "input_value", drRowId1),
+                Map.of("datarepo_row_id", drRowId2, "input_value", drRowId2)));
+
+        mockNumRowIds(snapshot, TABLE_2_NAME, 2);
+
+        SnapshotRequestContentsModel requestModel = new SnapshotRequestContentsModel()
+            .rowIdSpec(new SnapshotRequestRowIdModel()
+                .addTablesItem(new SnapshotRequestRowIdTableModel()
+                    .addRowIdsItem(drRowId1).addRowIdsItem(drRowId2)
+                    .addColumnsItem(TABLE_2_COL1_NAME)
+                    .addColumnsItem(TABLE_2_COL2_NAME)
+                    .tableName(TABLE_2_NAME)));
+        dao.createSnapshotWithProvidedIds(snapshot, requestModel);
+
+        // Verify that the rowIds are properly copied
+        verify(bigQueryProjectSnapshot, times(1)).query(
+            "INSERT INTO `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` " +
+                "(datarepo_table_id,datarepo_row_id) " +
+                "SELECT '" + TABLE_2_ID + "' AS datarepo_table_id, T.row_id AS datarepo_row_id FROM (" +
+                "SELECT row_id FROM UNNEST(['" + drRowId1 + "','" + drRowId2 + "']) AS row_id" +
+                ") AS T");
+    }
+
+    @Test
+    public void testCreateSnapshotWithProvidedIdsWithInvalidRowIds() throws InterruptedException {
+        String drRowId1 = UUID.randomUUID().toString();
+        String drRowId2 = UUID.randomUUID().toString();
+
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectDataset,
+            "SELECT T.datarepo_row_id, V.input_value FROM (" +
+                "SELECT input_value FROM UNNEST(['" + drRowId1 + "','" + drRowId2 + "']) AS input_value) AS V " +
+                "LEFT JOIN `" + DATASET_PROJECT_ID + ".datarepo_" + DATASET_NAME + "." + TABLE_1_NAME + "` AS T " +
+                "ON V.input_value = CAST(T.datarepo_row_id AS STRING)",
+            Schema.of(
+                Field.of("datarepo_row_id", LegacySQLTypeName.STRING),
+                Field.of("input_value", LegacySQLTypeName.STRING)),
+            List.of(
+                Map.of("datarepo_row_id", drRowId1, "input_value", drRowId1),
+                Map.of("datarepo_row_id", drRowId2, "input_value", drRowId2)));
+
+        mockNumRowIds(snapshot, TABLE_2_NAME, 0);
+
+        SnapshotRequestContentsModel requestModel = new SnapshotRequestContentsModel()
+            .rowIdSpec(new SnapshotRequestRowIdModel()
+                .addTablesItem(new SnapshotRequestRowIdTableModel()
+                    .addRowIdsItem(drRowId1).addRowIdsItem(drRowId2)
+                    .addColumnsItem(TABLE_2_COL1_NAME)
+                    .addColumnsItem(TABLE_2_COL2_NAME)
+                    .tableName(TABLE_2_NAME)));
+        assertThrows(
+            PdaoException.class,
+            () -> dao.createSnapshotWithProvidedIds(snapshot, requestModel),
+            "Invalid row ids supplied");
+
+        // Verify that the rowIds are properly copied (make sure that it still actually happens)
+        verify(bigQueryProjectSnapshot, times(1)).query(
+            "INSERT INTO `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` " +
+                "(datarepo_table_id,datarepo_row_id) " +
+                "SELECT '" + TABLE_2_ID + "' AS datarepo_table_id, T.row_id AS datarepo_row_id FROM (" +
+                "SELECT row_id FROM UNNEST(['" + drRowId1 + "','" + drRowId2 + "']) AS row_id" +
+                ") AS T");
+    }
+
+    private Snapshot mockSnapshot() {
+        DatasetTable tbl1 = DatasetFixtures.generateDatasetTable(
+            TABLE_1_NAME,
+            TableDataType.STRING,
+            List.of(TABLE_1_COL1_NAME, TABLE_1_COL2_NAME))
+            .id(TABLE_1_ID);
+        tbl1.getColumns().get(0).id(TABLE_1_COL1_ID);
+        tbl1.getColumns().get(1).id(TABLE_1_COL2_ID);
+
+        DatasetTable tbl2 = DatasetFixtures.generateDatasetTable(
+            TABLE_2_NAME,
+            TableDataType.STRING,
+            List.of(TABLE_2_COL1_NAME, TABLE_2_COL2_NAME, TABLE_2_COL3_NAME))
+            .id(TABLE_2_ID);
+        tbl2.getColumns().get(0).id(TABLE_2_COL1_ID);
+        tbl2.getColumns().get(1).id(TABLE_2_COL2_ID);
+        tbl2.getColumns().get(2).id(TABLE_2_COL3_ID);
+
+        SnapshotTable snpTbl1 = new SnapshotTable()
+            .id(SNAPSHOT_TABLE_1_ID)
+            .name(tbl1.getName())
+            .columns(tbl1.getColumns());
+        snpTbl1.getColumns().get(0).id(SNAPSHOT_TABLE_1_COL1_ID);
+        snpTbl1.getColumns().get(1).id(SNAPSHOT_TABLE_1_COL2_ID);
+
+        SnapshotTable snpTbl2 = new SnapshotTable()
+            .id(SNAPSHOT_TABLE_2_ID)
+            .name(tbl2.getName())
+            .columns(tbl2.getColumns());
+        snpTbl2.getColumns().get(0).id(SNAPSHOT_TABLE_2_COL1_ID);
+        snpTbl2.getColumns().get(1).id(SNAPSHOT_TABLE_2_COL2_ID);
+        snpTbl2.getColumns().get(2).id(SNAPSHOT_TABLE_2_COL3_ID);
+
+        return new Snapshot()
+            .id(SNAPSHOT_ID)
+            .name(SNAPSHOT_NAME)
+            .description(SNAPSHOT_DESCRIPTION)
+            .createdDate(SNAPSHOT_CREATION)
+            .profileId(PROFILE_1_ID)
+            .projectResource(new GoogleProjectResource()
+                .profileId(PROFILE_1_ID)
+                .googleProjectId(SNAPSHOT_PROJECT_ID))
+            .snapshotTables(List.of(
+                snpTbl1,
+                snpTbl2))
+            .snapshotSources(List.of(
+                new SnapshotSource()
+                    .dataset(new Dataset()
+                        .id(DATASET_ID)
+                        .name(DATASET_NAME)
+                        .projectResource(new GoogleProjectResource()
+                            .profileId(PROFILE_1_ID)
+                            .googleProjectId(DATASET_PROJECT_ID))
+                        .tables(List.of(tbl1, tbl2))
+                        .storage(List.of(new StorageResource()
+                            .datasetId(DATASET_ID)
+                            .cloudResource(GoogleCloudResource.BIGQUERY)
+                            .cloudPlatform(CloudPlatform.GCP)
+                            .region(GoogleRegion.NORTHAMERICA_NORTHEAST1))))
+                    .assetSpecification(new AssetSpecification()
+                        .rootTable(new AssetTable()
+                            .datasetTable(tbl1))
+                        .rootColumn(new AssetColumn()
+                            .datasetTable(tbl1)
+                            .datasetColumn(tbl1.getColumns().get(0)))
+                        .assetRelationships(List.of(
+                            new AssetRelationship()
+                                .datasetRelationship(new Relationship()
+                                    .fromTable(tbl1).fromColumn(tbl1.getColumns().get(0))
+                                    .toTable(tbl2).toColumn(tbl2.getColumns().get(0))))))
+                    .snapshotMapTables(List.of(
+                        new SnapshotMapTable().fromTable(tbl1).toTable(snpTbl1)
+                            .snapshotMapColumns(List.of(
+                                new SnapshotMapColumn()
+                                    .fromColumn(tbl1.getColumns().get(0)).toColumn(snpTbl1.getColumns().get(0)),
+                                new SnapshotMapColumn()
+                                    .fromColumn(tbl1.getColumns().get(1)).toColumn(snpTbl1.getColumns().get(1)))),
+                        new SnapshotMapTable().fromTable(tbl2).toTable(snpTbl2)
+                            // Note: purposefully not mapping the third column and swappign the first two\
+                            // for special handling
+                            .snapshotMapColumns(List.of(
+                                new SnapshotMapColumn()
+                                    .fromColumn(tbl2.getColumns().get(0)).toColumn(snpTbl2.getColumns().get(1)),
+                                new SnapshotMapColumn()
+                                    .fromColumn(tbl2.getColumns().get(1)).toColumn(snpTbl2.getColumns().get(0))))))));
+    }
+
+    private void mockNumRowIds(Snapshot snapshot, String tableName, int numRowIds) {
+        String datasetProjectId =
+            snapshot.getFirstSnapshotSource().getDataset().getProjectResource().getGoogleProjectId();
+        String datasetName =
+            snapshot.getFirstSnapshotSource().getDataset().getName();
+        String snapshotProjectId =
+            snapshot.getProjectResource().getGoogleProjectId();
+        String snapshotName = snapshot.getName();
+        BQTestUtils.mockBQQuery(
+            bigQueryProjectSnapshot,
+            "SELECT COUNT(1) " +
+                "FROM `" + datasetProjectId + ".datarepo_" + datasetName + "." + tableName + "` AS T, " +
+                "`" + snapshotProjectId + "." + snapshotName + ".datarepo_row_ids` AS R " +
+                "WHERE R.datarepo_row_id = T.datarepo_row_id",
+            Schema.of(Field.of("val", LegacySQLTypeName.NUMERIC)),
+            List.of(Map.of("val", Integer.toString(numRowIds))));
+    }
+
+}

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoUnitTest.java
@@ -366,7 +366,8 @@ public class BigQueryPdaoUnitTest {
         // Make sure that validation is called and returns
         BQTestUtils.mockBQQuery(
             bigQueryProjectSnapshot,
-            "SELECT datarepo_row_id FROM `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids`",
+            "SELECT datarepo_row_id FROM `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` " +
+                "LIMIT 1",
             Schema.of(Field.of("cnt", LegacySQLTypeName.NUMERIC)),
             List.of(Map.of("cnt", UUID.randomUUID().toString())));
 
@@ -394,7 +395,8 @@ public class BigQueryPdaoUnitTest {
         // Make validation return that no records will be in snapshot
         BQTestUtils.mockBQQuery(
             bigQueryProjectSnapshot,
-            "SELECT datarepo_row_id FROM `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids`",
+            "SELECT datarepo_row_id FROM `" + SNAPSHOT_PROJECT_ID + "." + SNAPSHOT_NAME + ".datarepo_row_ids` " +
+                "LIMIT 1",
             Schema.of(Field.of("cnt", LegacySQLTypeName.NUMERIC)),
             Collections.emptyList());
 

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Like it says on the tin, fixes some bugs in the PDao SQL generation and adds a bunch of unit tests for the code branches that get called for snapshot creation - about 50% of the BigQueryPdao class.  A couple of notes:
- Added some utility methods to make it easier to test BQ
- Added config to allow mockito to mock final classes (that's the random text file I commit at the end)
- Modified a couple of classes to make them easier to test