### PR TITLE
DR-1532 Remove boolean-controlled throw logic in FireStoreDao

### DIFF
--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -161,7 +161,7 @@ public class FileService {
      */
     FSItem lookupFSItem(String datasetId, String fileId, int depth) throws InterruptedException {
         Dataset dataset = datasetService.retrieveAvailable(UUID.fromString(datasetId));
-        return fileDao.retrieveById(dataset, fileId, depth, true);
+        return fileDao.retrieveById(dataset, fileId, depth);
     }
 
     /**
@@ -171,7 +171,7 @@ public class FileService {
      */
     FSItem lookupFSItemByPath(String datasetId, String path, int depth) throws InterruptedException {
         Dataset dataset = datasetService.retrieveAvailable(UUID.fromString(datasetId));
-        return fileDao.retrieveByPath(dataset, path, depth, true);
+        return fileDao.retrieveByPath(dataset, path, depth);
     }
 
     // -- snapshot lookups --
@@ -196,13 +196,13 @@ public class FileService {
     }
 
     FSItem lookupSnapshotFSItem(SnapshotProject snapshot, String fileId, int depth) throws InterruptedException {
-        return fileDao.retrieveBySnapshotAndId(snapshot, fileId, depth, true);
+        return fileDao.retrieveBySnapshotAndId(snapshot, fileId, depth);
     }
 
     FSItem lookupSnapshotFSItemByPath(String snapshotId, String path, int depth) throws InterruptedException {
         // note: this method only returns snapshots that are NOT exclusively locked
         Snapshot snapshot = snapshotService.retrieveAvailable(UUID.fromString(snapshotId));
-        return fileDao.retrieveByPath(snapshot, path, depth, true);
+        return fileDao.retrieveByPath(snapshot, path, depth);
     }
 
     public FileModel fileModelFromFSItem(FSItem fsItem) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileFileStep.java
@@ -56,7 +56,7 @@ public class IngestFileFileStep implements Step {
             try {
                 fileDao.createFileMetadata(dataset, newFile);
                 // Retrieve to build the complete FSItem
-                FSItem fsItem = fileDao.retrieveById(dataset, fileId, 1, true);
+                FSItem fsItem = fileDao.retrieveById(dataset, fileId, 1);
                 workingMap.put(JobMapKeys.RESPONSE.getKeyName(), fileService.fileModelFromFSItem(fsItem));
             } catch (FileSystemAbortTransactionException rex) {
                 return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -277,7 +277,7 @@ public class GcsPdao {
             logger.info("operation {} batch {}", op.name(), count);
             count++;
 
-            List<FSFile> files = fileDao.batchRetrieveById(dataset, batch, 0, true);
+            List<FSFile> files = fileDao.batchRetrieveById(dataset, batch, 0);
 
             try (Stream<FSFile> stream = files.stream()) {
                 List<Future<FSFile>> futures = stream


### PR DESCRIPTION
`throwOnNotFound` was always `true`, so why even pass it?