### PR TITLE
Fix issue where idx- prefix wasn't prepended on query search API

### DIFF
--- a/src/main/java/bio/terra/app/configuration/ElasticSearchConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ElasticSearchConfiguration.java
@@ -9,6 +9,8 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ElasticSearchConfiguration {
+
+    // This Bean isn't injected directly. Its definition enables injecting RestHighLevelClient.
     @Bean
     public RestClientBuilder restClientBuilder(
             @Value("${elasticsearch.hostname}") String hostname,

--- a/src/main/java/bio/terra/app/controller/SearchApiController.java
+++ b/src/main/java/bio/terra/app/controller/SearchApiController.java
@@ -100,7 +100,7 @@ public class SearchApiController implements SearchApi {
         Integer limit) {
 
         List<UUID> accessibleIds =
-            iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT).subList(0, 10);
+            iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT);
 
         final List<String> snapshotIds = searchQueryRequest.getSnapshotIds();
 

--- a/src/main/java/bio/terra/app/controller/SearchApiController.java
+++ b/src/main/java/bio/terra/app/controller/SearchApiController.java
@@ -24,11 +24,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -101,10 +100,13 @@ public class SearchApiController implements SearchApi {
         Integer limit) {
 
         List<UUID> accessibleIds =
-            iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT);
+            iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT).subList(0, 10);
+
+        final List<String> snapshotIds = searchQueryRequest.getSnapshotIds();
 
         Set<UUID> requestIds =
-            searchQueryRequest.getSnapshotIds().stream().map(UUID::fromString).collect(Collectors.toSet());
+            snapshotIds == null || snapshotIds.isEmpty() ? Collections.emptySet() :
+                snapshotIds.stream().map(UUID::fromString).collect(Collectors.toSet());
 
         Set<UUID> inaccessibleIds = new HashSet<>(requestIds);
         accessibleIds.forEach(inaccessibleIds::remove);

--- a/src/main/java/bio/terra/service/search/SearchService.java
+++ b/src/main/java/bio/terra/service/search/SearchService.java
@@ -141,7 +141,7 @@ public class SearchService {
             GetAliasesResponse response = client.indices().getAlias(new GetAliasesRequest(), RequestOptions.DEFAULT);
             return response.getAliases().keySet();
         } catch (IOException e) {
-            throw new SearchException("Error gett ES indexes", e);
+            throw new SearchException("Error getting indexes", e);
         }
     }
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4080,12 +4080,10 @@ components:
           description: Summary of this index for searching
     SearchQueryRequest:
       required:
-        - snapshotIds
         - query
       type: object
       properties:
         snapshotIds:
-          minItems: 1
           type: array
           items:
             $ref: '#/components/schemas/UniqueIdProperty'


### PR DESCRIPTION
- modify openapi yaml to support omitting the snapshot ID list
- change controller code to use UUIDs instead of strings
- fix issue where snapshot list is omitted and user can see non-indexed snapshots (https://broadworkbench.atlassian.net/browse/DR-1861)