### PR TITLE
Remove static as it sets NUM_SHARDS to 0

### DIFF
--- a/src/main/java/bio/terra/service/search/SearchService.java
+++ b/src/main/java/bio/terra/service/search/SearchService.java
@@ -49,7 +49,7 @@ public class SearchService {
     private final RestHighLevelClient client;
 
     @Value("${elasticsearch.numShards}")
-    private static int NUM_SHARDS;
+    private int NUM_SHARDS;
 
     @Autowired
     public SearchService(BigQueryPdao bigQueryPdao, RestHighLevelClient client) {


### PR DESCRIPTION
Setting the variable to `static` makes it use a value of zero instead of the `application.properties` value.