### PR TITLE
DR-1882 Fix the smoke tests

### DIFF
--- a/datarepo-clienttests/.gitignore
+++ b/datarepo-clienttests/.gitignore
@@ -20,3 +20,9 @@ hs_err_pid*
 target
 .gradle
 build
+
+# exclude property override that allows using jar for local client build
+# To use, build the jars at the top level with ./gradlew :datarepo-client:jar then add the following to you local
+# gradle.properties as:
+# datarepoclientjar=<absolute path to repo root>/datarepo-client/build/libs/<newest file>.jar
+gradle.properties

--- a/datarepo-clienttests/.gitignore
+++ b/datarepo-clienttests/.gitignore
@@ -22,7 +22,7 @@ target
 build
 
 # exclude property override that allows using jar for local client build
-# To use, build the jars at the top level with ./gradlew :datarepo-client:jar then add the following to you local
+# To use, build the jars at the top level with ./gradlew :datarepo-client:jar then add the following to your local
 # gradle.properties as:
 # datarepoclientjar=<absolute path to repo root>/datarepo-client/build/libs/<newest file>.jar
 gradle.properties

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -115,7 +115,7 @@ public class RetrieveSnapshot extends SimpleDataset {
     byte[] fileRefBytes = jsonLine.getBytes(StandardCharsets.UTF_8);
     String jsonFileName = FileUtils.randomizeName("this-better-pass") + ".json";
     String dirInCloud = "scratch/testRetrieveSnapshot/";
-    String fileRefName = dirInCloud + "/" + jsonFileName;
+    String fileRefName = dirInCloud + jsonFileName;
 
     String scratchFileBucketName = "jade-testdata";
     BlobId scratchFileTabularData =


### PR DESCRIPTION
Make sure that we are loading the data correctly (e.g. giving it the right path...BQ doesn't appear to recognize the double `//` in the load file path

I also added gradle.properties to the git ignore list which makes it easier to keep a local copy to test client changes (this has been an ongoing annoyance)