### PR TITLE
DR-1781 Make cloud storage metadata cloud agnostic

### DIFF
--- a/src/main/java/bio/terra/app/model/AzureCloudResource.java
+++ b/src/main/java/bio/terra/app/model/AzureCloudResource.java
@@ -18,6 +18,7 @@ public enum AzureCloudResource implements CloudResource {
         return value;
     }
 
+    @Override
     public String getValue() {
         return value;
     }

--- a/src/main/java/bio/terra/app/model/AzureCloudResource.java
+++ b/src/main/java/bio/terra/app/model/AzureCloudResource.java
@@ -3,12 +3,14 @@ package bio.terra.app.model;
 /**
  * Google cloud resources used by TDR.
  */
-public enum GoogleCloudResource implements CloudResource {
-    BIGQUERY("bigquery"), FIRESTORE("firestore"), BUCKET("bucket");
+public enum AzureCloudResource implements CloudResource {
+    APPLICATION_DEPLOYMENT("application_deployment"),
+    STORAGE_ACCOUNT("storage_account"),
+    SYNAPSE_WORKSPACE("synapse_workspace");
 
     private final String value;
 
-    GoogleCloudResource(String value) {
+    AzureCloudResource(String value) {
         this.value = value;
     }
 
@@ -20,8 +22,8 @@ public enum GoogleCloudResource implements CloudResource {
         return value;
     }
 
-    public static GoogleCloudResource fromValue(String text) {
-        for (GoogleCloudResource resource : GoogleCloudResource.values()) {
+    public static AzureCloudResource fromValue(String text) {
+        for (AzureCloudResource resource : AzureCloudResource.values()) {
             if (resource.value.equalsIgnoreCase(text)) {
                 return resource;
             }

--- a/src/main/java/bio/terra/app/model/AzureCloudResource.java
+++ b/src/main/java/bio/terra/app/model/AzureCloudResource.java
@@ -1,7 +1,7 @@
 package bio.terra.app.model;
 
 /**
- * Google cloud resources used by TDR.
+ * Azure cloud resources used by TDR.
  */
 public enum AzureCloudResource implements CloudResource {
     APPLICATION_DEPLOYMENT("application_deployment"),

--- a/src/main/java/bio/terra/app/model/AzureRegion.java
+++ b/src/main/java/bio/terra/app/model/AzureRegion.java
@@ -92,7 +92,8 @@ public enum AzureRegion implements CloudRegion {
     }
 
     /**
-     * Differs from ofValue in that this does not fail if no value is found
+     * Differs from {@link #valueOf(String)} in that this does not fail if no value is found, and uses
+     * a case insensitive compare
      * @param text region to look up
      * @return A GoogleRegion or null if none is found
      */

--- a/src/main/java/bio/terra/app/model/AzureRegion.java
+++ b/src/main/java/bio/terra/app/model/AzureRegion.java
@@ -83,6 +83,7 @@ public enum AzureRegion implements CloudRegion {
         this.value = value;
     }
 
+    @Override
     public String getValue() {
         return value;
     }

--- a/src/main/java/bio/terra/app/model/AzureRegion.java
+++ b/src/main/java/bio/terra/app/model/AzureRegion.java
@@ -96,7 +96,7 @@ public enum AzureRegion implements CloudRegion {
      * Differs from {@link #valueOf(String)} in that this does not fail if no value is found, and uses
      * a case insensitive compare
      * @param text region to look up
-     * @return A GoogleRegion or null if none is found
+     * @return An AzureRegion or null if none is found
      */
     public static AzureRegion fromName(String text) {
         for (AzureRegion region : AzureRegion.values()) {

--- a/src/main/java/bio/terra/app/model/AzureRegion.java
+++ b/src/main/java/bio/terra/app/model/AzureRegion.java
@@ -1,0 +1,121 @@
+package bio.terra.app.model;
+
+import java.util.Optional;
+
+/**
+ * Valid regions in Azure.
+ */
+public enum AzureRegion implements CloudRegion {
+    EAST_US("eastus"),
+    EAST_US_2("eastus2"),
+    SOUTH_CENTRAL_US("southcentralus"),
+    WEST_US_2("westus2"),
+    WEST_US_3("westus3"),
+    AUSTRALIA_EAST("australiaeast"),
+    SOUTHEAST_ASIA("southeastasia"),
+    NORTH_EUROPE("northeurope"),
+    SWEDEN_CENTRAL("swedencentral"),
+    UK_SOUTH("uksouth"),
+    WEST_EUROPE("westeurope"),
+    CENTRAL_US("centralus"),
+    NORTH_CENTRAL_US("northcentralus"),
+    WEST_US("westus"),
+    SOUTH_AFRICA_NORTH("southafricanorth"),
+    CENTRAL_INDIA("centralindia"),
+    EAST_ASIA("eastasia"),
+    JAPAN_EAST("japaneast"),
+    JIO_INDIA_WEST("jioindiawest"),
+    KOREA_CENTRAL("koreacentral"),
+    CANADA_CENTRAL("canadacentral"),
+    FRANCE_CENTRAL("francecentral"),
+    GERMANY_WEST_CENTRAL("germanywestcentral"),
+    NORWAY_EAST("norwayeast"),
+    SWITZERLAND_NORTH("switzerlandnorth"),
+    UAE_NORTH("uaenorth"),
+    BRAZIL_SOUTH("brazilsouth"),
+    CENTRAL_US_STAGE("centralusstage"),
+    EAST_US_STAGE("eastusstage"),
+    EAST_US_2_STAGE("eastus2stage"),
+    NORTH_CENTRAL_US_STAGE("northcentralusstage"),
+    SOUTH_CENTRAL_US_STAGE("southcentralusstage"),
+    WEST_US_STAGE("westusstage"),
+    WEST_US_2_STAGE("westus2stage"),
+    ASIA("asia"),
+    ASIA_PACIFIC("asiapacific"),
+    AUSTRALIA("australia"),
+    BRAZIL("brazil"),
+    CANADA("canada"),
+    EUROPE("europe"),
+    GLOBAL("global"),
+    INDIA("india"),
+    JAPAN("japan"),
+    UNITED_KINGDOM("uk"),
+    UNITED_STATES("unitedstates"),
+    EAST_ASIA_STAGE("eastasiastage"),
+    SOUTHEAST_ASIA_STAGE("southeastasiastage"),
+    CENTRAL_US_EUAP("centraluseuap"),
+    EAST_US_2_EUAP("eastus2euap"),
+    WEST_CENTRAL_US("westcentralus"),
+    SOUTH_AFRICA_WEST("southafricawest"),
+    AUSTRALIA_CENTRAL("australiacentral"),
+    AUSTRALIA_CENTRAL_2("australiacentral2"),
+    AUSTRALIA_SOUTHEAST("australiasoutheast"),
+    JAPAN_WEST("japanwest"),
+    JIO_INDIA_CENTRAL("jioindiacentral"),
+    KOREA_SOUTH("koreasouth"),
+    SOUTH_INDIA("southindia"),
+    WEST_INDIA("westindia"),
+    CANADA_EAST("canadaeast"),
+    FRANCE_SOUTH("francesouth"),
+    GERMANY_NORTH("germanynorth"),
+    NORWAY_WEST("norwaywest"),
+    SWEDEN_SOUTH("swedensouth"),
+    SWITZERLAND_WEST("switzerlandwest"),
+    UK_WEST("ukwest"),
+    UAE_CENTRAL("uaecentral"),
+    BRAZIL_SOUTHEAST("brazilsoutheast");
+
+    public static final AzureRegion DEFAULT_AZURE_REGION = AzureRegion.CENTRAL_US;
+
+    private final String value;
+
+    AzureRegion(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    /**
+     * Differs from ofValue in that this does not fail if no value is found
+     * @param text region to look up
+     * @return A GoogleRegion or null if none is found
+     */
+    public static AzureRegion fromName(String text) {
+        for (AzureRegion region : AzureRegion.values()) {
+            if (region.name().equalsIgnoreCase(text)) {
+                return region;
+            }
+        }
+        return null;
+    }
+
+    public static AzureRegion fromValue(String text) {
+        for (AzureRegion region : AzureRegion.values()) {
+            if (region.value.equalsIgnoreCase(text)) {
+                return region;
+            }
+        }
+        return null;
+    }
+
+    public static AzureRegion fromValueWithDefault(String text) {
+        return Optional.ofNullable(AzureRegion.fromValue(text)).orElse(AzureRegion.DEFAULT_AZURE_REGION);
+    }
+
+}

--- a/src/main/java/bio/terra/app/model/CloudRegion.java
+++ b/src/main/java/bio/terra/app/model/CloudRegion.java
@@ -17,7 +17,16 @@ import java.io.IOException;
  */
 @JsonDeserialize(using = CloudRegion.CloudRegionDeserializer.class)
 public interface CloudRegion {
+
+    /**
+     * Returns the implementing enumeration name
+     */
     String name();
+
+    /**
+     * Return the region string that the cloud provider can understand
+     */
+    String getValue();
 
     class CloudRegionDeserializer extends StdDeserializer<CloudRegion> {
 

--- a/src/main/java/bio/terra/app/model/CloudRegion.java
+++ b/src/main/java/bio/terra/app/model/CloudRegion.java
@@ -1,0 +1,62 @@
+package bio.terra.app.model;
+
+
+import bio.terra.common.EnumUtils;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+
+/**
+ * Represents regions across different cloud providers
+ */
+@JsonDeserialize(using = CloudRegion.CloudRegionDeserializer.class)
+public interface CloudRegion {
+    String name();
+
+    class CloudRegionDeserializer extends StdDeserializer<CloudRegion> {
+
+        public CloudRegionDeserializer() {
+            this(CloudRegion.class);
+        }
+        public CloudRegionDeserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        public CloudRegion deserialize(
+            JsonParser jsonParser,
+            DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+            if (node.isNull()) {
+                return null;
+            }
+            if (!node.isTextual()) {
+                throw new InvalidFormatException(
+                    jsonParser,
+                    "Invalid representation of CloudRegion",
+                    node,
+                    CloudRegion.class);
+            }
+            String value = node.textValue();
+            CloudRegion region = EnumUtils.valueOfLenient(GoogleRegion.class, value);
+            if (region != null) {
+                return region;
+            }
+            region = EnumUtils.valueOfLenient(AzureRegion.class, value);
+            if (region != null) {
+                return region;
+            }
+            throw new InvalidFormatException(
+                jsonParser,
+                String.format("Unrecognized CloudRegion: %s", value),
+                node,
+                CloudRegion.class);
+        }
+    }
+}

--- a/src/main/java/bio/terra/app/model/CloudResource.java
+++ b/src/main/java/bio/terra/app/model/CloudResource.java
@@ -1,0 +1,60 @@
+package bio.terra.app.model;
+
+import bio.terra.common.EnumUtils;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+
+/**
+ * Represents resource types across different cloud providers
+ */
+@JsonDeserialize(using = CloudResource.CloudResourceDeserializer.class)
+public interface CloudResource {
+    String name();
+
+    class CloudResourceDeserializer extends StdDeserializer<CloudResource> {
+
+        public CloudResourceDeserializer() {
+            this(CloudResource.class);
+        }
+        public CloudResourceDeserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        public CloudResource deserialize(
+            JsonParser jsonParser,
+            DeserializationContext ctxt) throws IOException {
+            JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+            if (node.isNull()) {
+                return null;
+            }
+            if (!node.isTextual()) {
+                throw new InvalidFormatException(
+                    jsonParser,
+                    "Invalid representation of CloudResource",
+                    node,
+                    CloudResource.class);
+            }
+            String value = node.textValue();
+            CloudResource resource = EnumUtils.valueOfLenient(GoogleCloudResource.class, value);
+            if (resource != null) {
+                return resource;
+            }
+            resource = EnumUtils.valueOfLenient(AzureCloudResource.class, value);
+            if (resource != null) {
+                return resource;
+            }
+            throw new InvalidFormatException(
+                jsonParser,
+                String.format("Unrecognized CloudResource: %s", value),
+                node,
+                CloudResource.class);
+        }
+    }
+}

--- a/src/main/java/bio/terra/app/model/CloudResource.java
+++ b/src/main/java/bio/terra/app/model/CloudResource.java
@@ -15,7 +15,16 @@ import java.io.IOException;
  */
 @JsonDeserialize(using = CloudResource.CloudResourceDeserializer.class)
 public interface CloudResource {
+
+    /**
+     * Returns the implementing enumeration name
+     */
     String name();
+
+    /**
+     * Return the resource value that is exposed to the user
+     */
+    String getValue();
 
     class CloudResourceDeserializer extends StdDeserializer<CloudResource> {
 

--- a/src/main/java/bio/terra/app/model/GoogleCloudResource.java
+++ b/src/main/java/bio/terra/app/model/GoogleCloudResource.java
@@ -16,6 +16,7 @@ public enum GoogleCloudResource implements CloudResource {
         return value;
     }
 
+    @Override
     public String getValue() {
         return value;
     }

--- a/src/main/java/bio/terra/app/model/GoogleRegion.java
+++ b/src/main/java/bio/terra/app/model/GoogleRegion.java
@@ -1,14 +1,16 @@
 package bio.terra.app.model;
 
+import bio.terra.model.CloudPlatform;
 import bio.terra.service.dataset.StorageResource;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Valid regions in Google.
  */
-public enum GoogleRegion {
+public enum GoogleRegion implements CloudRegion {
         ASIA_EAST2("asia-east2"),
         ASIA_EAST1("asia-east1", "asia-east2"),
         ASIA_NORTHEAST1("asia-northeast1"),
@@ -64,6 +66,10 @@ public enum GoogleRegion {
         return fromValue(bucketFallbackRegion);
     }
 
+    public String getValue() {
+        return value;
+    }
+
     public String toString() {
         return value;
     }
@@ -82,8 +88,10 @@ public enum GoogleRegion {
     }
 
     public static boolean matchingRegionWithFallbacks(List<StorageResource> storage, GoogleRegion region) {
-        for (StorageResource resource : storage) {
-            switch (resource.getCloudResource()) {
+        List<StorageResource> gcpStorage =
+            storage.stream().filter(s -> s.getCloudPlatform() == CloudPlatform.GCP).collect(Collectors.toList());
+        for (StorageResource resource : gcpStorage) {
+            switch ((GoogleCloudResource) resource.getCloudResource()) {
                 case BIGQUERY:
                     if (resource.getRegion() != region) {
                         return false;

--- a/src/main/java/bio/terra/app/model/GoogleRegion.java
+++ b/src/main/java/bio/terra/app/model/GoogleRegion.java
@@ -1,6 +1,7 @@
 package bio.terra.app.model;
 
 import bio.terra.model.CloudPlatform;
+import bio.terra.service.dataset.GoogleStorageResource;
 import bio.terra.service.dataset.StorageResource;
 
 import java.util.List;
@@ -66,6 +67,7 @@ public enum GoogleRegion implements CloudRegion {
         return fromValue(bucketFallbackRegion);
     }
 
+    @Override
     public String getValue() {
         return value;
     }
@@ -87,11 +89,14 @@ public enum GoogleRegion implements CloudRegion {
         return Optional.ofNullable(GoogleRegion.fromValue(text)).orElse(GoogleRegion.DEFAULT_GOOGLE_REGION);
     }
 
-    public static boolean matchingRegionWithFallbacks(List<StorageResource> storage, GoogleRegion region) {
-        List<StorageResource> gcpStorage =
-            storage.stream().filter(s -> s.getCloudPlatform() == CloudPlatform.GCP).collect(Collectors.toList());
-        for (StorageResource resource : gcpStorage) {
-            switch ((GoogleCloudResource) resource.getCloudResource()) {
+    public static boolean matchingRegionWithFallbacks(
+        List<? extends StorageResource<?, ?>> storage, GoogleRegion region) {
+        var gcpStorage = storage.stream()
+            .filter(s -> s.getCloudPlatform() == CloudPlatform.GCP)
+            .map(s -> (GoogleStorageResource) s)
+            .collect(Collectors.toList());
+        for (GoogleStorageResource resource : gcpStorage) {
+            switch (resource.getCloudResource()) {
                 case BIGQUERY:
                     if (resource.getRegion() != region) {
                         return false;

--- a/src/main/java/bio/terra/common/EnumUtils.java
+++ b/src/main/java/bio/terra/common/EnumUtils.java
@@ -1,0 +1,25 @@
+package bio.terra.common;
+
+import java.util.EnumSet;
+
+/**
+ * Utility methods for code that tends to be repeated in different enums
+ */
+public final class EnumUtils {
+
+    private EnumUtils() {
+    }
+
+    /**
+     * Returns the value of the enum where the name matches value in a case-insensitive way.
+     * Returns null if name is not matched
+     */
+    public static <E extends Enum<E>> E valueOfLenient(Class<E> clazz, String value) {
+        for (E en : EnumSet.allOf(clazz)) {
+            if (en.name().equalsIgnoreCase(value)) {
+                return en;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/bio/terra/service/dataset/AzureStorageResource.java
+++ b/src/main/java/bio/terra/service/dataset/AzureStorageResource.java
@@ -1,0 +1,88 @@
+package bio.terra.service.dataset;
+
+import bio.terra.app.model.AzureCloudResource;
+import bio.terra.app.model.AzureRegion;
+import bio.terra.app.model.CloudRegion;
+import bio.terra.app.model.CloudResource;
+import bio.terra.model.CloudPlatform;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@JsonTypeName("azure")
+public class AzureStorageResource implements StorageResource {
+
+    private UUID datasetId;
+    private CloudPlatform cloudPlatform;
+    private AzureCloudResource cloudResource;
+    private AzureRegion region;
+
+    AzureStorageResource() {
+        this.cloudPlatform = CloudPlatform.AZURE;
+    }
+
+    @Override
+    public UUID getDatasetId() {
+        return datasetId;
+    }
+
+    @Override
+    public AzureStorageResource datasetId(UUID datasetId) {
+        this.datasetId = datasetId;
+        return this;
+    }
+
+    @Override
+    public CloudPlatform getCloudPlatform() {
+        return cloudPlatform;
+    }
+
+    @Override
+    public CloudResource getCloudResource() {
+        return cloudResource;
+    }
+
+    @Override
+    public AzureStorageResource cloudResource(CloudResource cloudResource) {
+        this.cloudResource = (AzureCloudResource) cloudResource;
+        return this;
+    }
+
+    @Override
+    public CloudRegion getRegion() {
+        return region;
+    }
+
+    @Override
+    public AzureStorageResource region(CloudRegion region) {
+        this.region = (AzureRegion) region;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AzureStorageResource that = (AzureStorageResource) o;
+        return Objects.equals(datasetId, that.datasetId) &&
+            cloudPlatform == that.cloudPlatform &&
+            cloudResource == that.cloudResource &&
+            region == that.region;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(datasetId, cloudPlatform, cloudResource, region);
+    }
+
+    @Override
+    public String toString() {
+        return "StorageResource{" +
+            "datasetId=" + datasetId +
+            ", cloudPlatform=" + cloudPlatform +
+            ", cloudResource=" + cloudResource +
+            ", region=" + region +
+            '}';
+    }
+}

--- a/src/main/java/bio/terra/service/dataset/AzureStorageResource.java
+++ b/src/main/java/bio/terra/service/dataset/AzureStorageResource.java
@@ -2,87 +2,20 @@ package bio.terra.service.dataset;
 
 import bio.terra.app.model.AzureCloudResource;
 import bio.terra.app.model.AzureRegion;
-import bio.terra.app.model.CloudRegion;
-import bio.terra.app.model.CloudResource;
 import bio.terra.model.CloudPlatform;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import java.util.Objects;
 import java.util.UUID;
 
 @JsonTypeName("azure")
-public class AzureStorageResource implements StorageResource {
+public class AzureStorageResource extends StorageResource<AzureCloudResource, AzureRegion> {
 
-    private UUID datasetId;
-    private CloudPlatform cloudPlatform;
-    private AzureCloudResource cloudResource;
-    private AzureRegion region;
-
-    AzureStorageResource() {
-        this.cloudPlatform = CloudPlatform.AZURE;
-    }
-
-    @Override
-    public UUID getDatasetId() {
-        return datasetId;
-    }
-
-    @Override
-    public AzureStorageResource datasetId(UUID datasetId) {
-        this.datasetId = datasetId;
-        return this;
+    public AzureStorageResource(UUID datasetId, AzureCloudResource cloudResource, AzureRegion region) {
+        super(datasetId, cloudResource, region);
     }
 
     @Override
     public CloudPlatform getCloudPlatform() {
-        return cloudPlatform;
-    }
-
-    @Override
-    public CloudResource getCloudResource() {
-        return cloudResource;
-    }
-
-    @Override
-    public AzureStorageResource cloudResource(CloudResource cloudResource) {
-        this.cloudResource = (AzureCloudResource) cloudResource;
-        return this;
-    }
-
-    @Override
-    public CloudRegion getRegion() {
-        return region;
-    }
-
-    @Override
-    public AzureStorageResource region(CloudRegion region) {
-        this.region = (AzureRegion) region;
-        return this;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        AzureStorageResource that = (AzureStorageResource) o;
-        return Objects.equals(datasetId, that.datasetId) &&
-            cloudPlatform == that.cloudPlatform &&
-            cloudResource == that.cloudResource &&
-            region == that.region;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(datasetId, cloudPlatform, cloudResource, region);
-    }
-
-    @Override
-    public String toString() {
-        return "StorageResource{" +
-            "datasetId=" + datasetId +
-            ", cloudPlatform=" + cloudPlatform +
-            ", cloudResource=" + cloudResource +
-            ", region=" + region +
-            '}';
+        return CloudPlatform.AZURE;
     }
 }

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -159,11 +159,11 @@ public class Dataset implements FSContainerInterface {
         return this;
     }
 
-    public List<StorageResource> getStorage() {
+    public List<? extends StorageResource<?, ?>> getStorage() {
         return datasetSummary.getStorage();
     }
 
-    public Dataset storage(List<StorageResource> storage) {
+    public Dataset storage(List<? extends StorageResource<?, ?>> storage) {
         datasetSummary.storage(storage);
         return this;
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -548,7 +548,7 @@ public class DatasetDao {
 
     private class DatasetSummaryMapper implements RowMapper<DatasetSummary> {
         public DatasetSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
-            List<StorageResource> storageResources;
+            List<? extends StorageResource<?, ?>> storageResources;
             try {
                 storageResources = objectMapper.readValue(rs.getString("storage"),
                         new TypeReference<>() {});

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -64,7 +64,7 @@ public final class DatasetJsonConversion {
         CloudPlatform cloudPlatform = Optional.ofNullable(datasetRequest.getCloudPlatform())
             .orElse(DEFAULT_CLOUD_PLATFORM);
 
-        final List<StorageResource> storageResources;
+        final List<? extends StorageResource<?, ?>> storageResources;
         if (cloudPlatform == CloudPlatform.GCP) {
             storageResources = createGcpStorageResourceValues(datasetRequest);
         } else {
@@ -85,7 +85,7 @@ public final class DatasetJsonConversion {
         return GoogleRegion.fromValueWithDefault(datasetRequestModel.getRegion());
     }
 
-    private static List<StorageResource> createGcpStorageResourceValues(DatasetRequestModel datasetRequestModel) {
+    private static List<GoogleStorageResource> createGcpStorageResourceValues(DatasetRequestModel datasetRequestModel) {
         final GoogleRegion region = getRegionFromDatasetRequestModel(datasetRequestModel);
         return Arrays.stream(GoogleCloudResource.values()).map(resource -> {
             final GoogleRegion finalRegion;
@@ -96,9 +96,7 @@ public final class DatasetJsonConversion {
                     break;
                 default: finalRegion = region;
             }
-            return StorageResource.getGoogleInstance()
-                .region(finalRegion)
-                .cloudResource(resource);
+            return new GoogleStorageResource(null, resource, finalRegion);
         }).collect(Collectors.toList());
     }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -1,5 +1,6 @@
 package bio.terra.service.dataset;
 
+import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.Column;
 import bio.terra.common.PdaoConstant;
@@ -15,7 +16,6 @@ import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.DatePartitionOptionsModel;
-import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.model.IntPartitionOptionsModel;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
@@ -96,8 +96,7 @@ public final class DatasetJsonConversion {
                     break;
                 default: finalRegion = region;
             }
-            return new StorageResource()
-                .cloudPlatform(CloudPlatform.GCP)
+            return StorageResource.getGoogleInstance()
                 .region(finalRegion)
                 .cloudResource(resource);
         }).collect(Collectors.toList());

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class DatasetRequestValidator implements Validator {
 
     private static final List<String> SUPPORTED_GOOGLE_REGIONS =
-        Arrays.stream(GoogleRegion.values()).map(GoogleRegion::toString).collect(Collectors.toUnmodifiableList());
+        Arrays.stream(GoogleRegion.values()).map(GoogleRegion::getValue).collect(Collectors.toUnmodifiableList());
 
     @Override
     public boolean supports(Class<?> clazz) {

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -1,6 +1,7 @@
 package bio.terra.service.dataset;
 
-import bio.terra.app.model.GoogleCloudResource;
+import bio.terra.app.model.CloudRegion;
+import bio.terra.app.model.CloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.service.dataset.exception.StorageResourceNotFoundException;
 
@@ -14,6 +15,7 @@ public class DatasetSummary {
     private String description;
     private UUID defaultProfileId;
     private UUID projectResourceId;
+    private UUID applicationDeploymentResourceId;
     private Instant createdDate;
     private List<StorageResource> storage;
 
@@ -62,6 +64,15 @@ public class DatasetSummary {
         return this;
     }
 
+    public UUID getApplicationDeploymentResourceId() {
+        return applicationDeploymentResourceId;
+    }
+
+    public DatasetSummary applicationDeploymentResourceId(UUID applicationDeploymentResourceId) {
+        this.applicationDeploymentResourceId = applicationDeploymentResourceId;
+        return this;
+    }
+
     public Instant getCreatedDate() {
         return createdDate;
     }
@@ -80,7 +91,7 @@ public class DatasetSummary {
         return this;
     }
 
-    public GoogleRegion getStorageResourceRegion(GoogleCloudResource storageResource) {
+    public CloudRegion getStorageResourceRegion(CloudResource storageResource) {
         return storage.stream()
             .filter(resource -> resource.getCloudResource() == storageResource)
             .findFirst()

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -17,7 +17,7 @@ public class DatasetSummary {
     private UUID projectResourceId;
     private UUID applicationDeploymentResourceId;
     private Instant createdDate;
-    private List<StorageResource> storage;
+    private List<? extends StorageResource<?, ?>> storage;
 
     public UUID getId() {
         return id;
@@ -82,11 +82,11 @@ public class DatasetSummary {
         return this;
     }
 
-    public List<StorageResource> getStorage() {
+    public List<? extends StorageResource<?, ?>> getStorage() {
         return storage;
     }
 
-    public DatasetSummary storage(List<StorageResource> storage) {
+    public DatasetSummary storage(List<? extends StorageResource<?, ?>> storage) {
         this.storage = storage;
         return this;
     }

--- a/src/main/java/bio/terra/service/dataset/GoogleStorageResource.java
+++ b/src/main/java/bio/terra/service/dataset/GoogleStorageResource.java
@@ -1,0 +1,104 @@
+package bio.terra.service.dataset;
+
+import bio.terra.app.model.CloudRegion;
+import bio.terra.app.model.CloudResource;
+import bio.terra.app.model.GoogleCloudResource;
+import bio.terra.app.model.GoogleRegion;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.StorageResourceModel;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@JsonTypeName("gcp")
+public class GoogleStorageResource implements StorageResource {
+    private UUID datasetId;
+    private final CloudPlatform cloudPlatform;
+    private GoogleCloudResource cloudResource;
+    private GoogleRegion region;
+
+    @JsonCreator
+    public GoogleStorageResource() {
+        cloudPlatform = CloudPlatform.GCP;
+    }
+
+    @Override
+    public UUID getDatasetId() {
+        return datasetId;
+    }
+
+    @Override
+    public GoogleStorageResource datasetId(UUID datasetId) {
+        this.datasetId = datasetId;
+        return this;
+    }
+
+    @Override
+    public CloudPlatform getCloudPlatform() {
+        return cloudPlatform;
+    }
+
+    @Override
+    public CloudResource getCloudResource() {
+        return cloudResource;
+    }
+
+    @Override
+    public GoogleStorageResource cloudResource(CloudResource cloudResource) {
+        this.cloudResource = (GoogleCloudResource) cloudResource;
+        return this;
+    }
+
+    @Override
+    public CloudRegion getRegion() {
+        return region;
+    }
+
+    @Override
+    public GoogleStorageResource region(CloudRegion region) {
+        this.region = (GoogleRegion) region;
+        return this;
+    }
+
+    @Override
+    public StorageResourceModel toModel() {
+        GoogleRegion regionOverride = region;
+        if (cloudResource == GoogleCloudResource.FIRESTORE) {
+            regionOverride = region.getRegionOrFallbackFirestoreRegion();
+        } else if (cloudResource == GoogleCloudResource.BUCKET) {
+            regionOverride = region.getRegionOrFallbackBucketRegion();
+        }
+        return new StorageResourceModel()
+            .cloudPlatform(getCloudPlatform())
+            .cloudResource(getCloudResource().toString())
+            .region(regionOverride.toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GoogleStorageResource that = (GoogleStorageResource) o;
+        return Objects.equals(datasetId, that.datasetId) &&
+            cloudPlatform == that.cloudPlatform &&
+            cloudResource == that.cloudResource &&
+            region == that.region;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(datasetId, cloudPlatform, cloudResource, region);
+    }
+
+    @Override
+    public String toString() {
+        return "StorageResource{" +
+            "datasetId=" + datasetId +
+            ", cloudPlatform=" + cloudPlatform +
+            ", cloudResource=" + cloudResource +
+            ", region=" + region +
+            '}';
+    }
+}

--- a/src/main/java/bio/terra/service/dataset/GoogleStorageResource.java
+++ b/src/main/java/bio/terra/service/dataset/GoogleStorageResource.java
@@ -1,104 +1,21 @@
 package bio.terra.service.dataset;
 
-import bio.terra.app.model.CloudRegion;
-import bio.terra.app.model.CloudResource;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.CloudPlatform;
-import bio.terra.model.StorageResourceModel;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import java.util.Objects;
 import java.util.UUID;
 
 @JsonTypeName("gcp")
-public class GoogleStorageResource implements StorageResource {
-    private UUID datasetId;
-    private final CloudPlatform cloudPlatform;
-    private GoogleCloudResource cloudResource;
-    private GoogleRegion region;
+public class GoogleStorageResource extends StorageResource<GoogleCloudResource, GoogleRegion> {
 
-    @JsonCreator
-    public GoogleStorageResource() {
-        cloudPlatform = CloudPlatform.GCP;
-    }
-
-    @Override
-    public UUID getDatasetId() {
-        return datasetId;
-    }
-
-    @Override
-    public GoogleStorageResource datasetId(UUID datasetId) {
-        this.datasetId = datasetId;
-        return this;
+    public GoogleStorageResource(UUID datasetId, GoogleCloudResource cloudResource, GoogleRegion region) {
+        super(datasetId, cloudResource, region);
     }
 
     @Override
     public CloudPlatform getCloudPlatform() {
-        return cloudPlatform;
-    }
-
-    @Override
-    public CloudResource getCloudResource() {
-        return cloudResource;
-    }
-
-    @Override
-    public GoogleStorageResource cloudResource(CloudResource cloudResource) {
-        this.cloudResource = (GoogleCloudResource) cloudResource;
-        return this;
-    }
-
-    @Override
-    public CloudRegion getRegion() {
-        return region;
-    }
-
-    @Override
-    public GoogleStorageResource region(CloudRegion region) {
-        this.region = (GoogleRegion) region;
-        return this;
-    }
-
-    @Override
-    public StorageResourceModel toModel() {
-        GoogleRegion regionOverride = region;
-        if (cloudResource == GoogleCloudResource.FIRESTORE) {
-            regionOverride = region.getRegionOrFallbackFirestoreRegion();
-        } else if (cloudResource == GoogleCloudResource.BUCKET) {
-            regionOverride = region.getRegionOrFallbackBucketRegion();
-        }
-        return new StorageResourceModel()
-            .cloudPlatform(getCloudPlatform())
-            .cloudResource(getCloudResource().toString())
-            .region(regionOverride.toString());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        GoogleStorageResource that = (GoogleStorageResource) o;
-        return Objects.equals(datasetId, that.datasetId) &&
-            cloudPlatform == that.cloudPlatform &&
-            cloudResource == that.cloudResource &&
-            region == that.region;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(datasetId, cloudPlatform, cloudResource, region);
-    }
-
-    @Override
-    public String toString() {
-        return "StorageResource{" +
-            "datasetId=" + datasetId +
-            ", cloudPlatform=" + cloudPlatform +
-            ", cloudResource=" + cloudResource +
-            ", region=" + region +
-            '}';
+        return CloudPlatform.GCP;
     }
 }

--- a/src/main/java/bio/terra/service/dataset/StorageResourceDao.java
+++ b/src/main/java/bio/terra/service/dataset/StorageResourceDao.java
@@ -47,7 +47,7 @@ public class StorageResourceDao {
     }
 
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
-    public List<StorageResource> getStorageResourcesByDatasetId(UUID datasetId) {
+    public List<StorageResource<?, ?>> getStorageResourcesByDatasetId(UUID datasetId) {
         try {
             MapSqlParameterSource params = new MapSqlParameterSource()
                 .addValue("dataset_id", datasetId);
@@ -59,7 +59,7 @@ public class StorageResourceDao {
     }
 
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
-    public List<StorageResource> getStorageResourcesForDatasetIds(List<UUID> datasetIds) {
+    public List<StorageResource<?, ?>> getStorageResourcesForDatasetIds(List<UUID> datasetIds) {
         if (datasetIds.isEmpty()) {
             return Collections.emptyList();
         }
@@ -73,32 +73,32 @@ public class StorageResourceDao {
     }
 
 
-    private static class StorageResourceMapper implements RowMapper<StorageResource> {
-        public StorageResource mapRow(ResultSet rs, int rowNum) throws SQLException {
+    private static class StorageResourceMapper implements RowMapper<StorageResource<?, ?>> {
+        public StorageResource<?, ?> mapRow(ResultSet rs, int rowNum) throws SQLException {
             final CloudPlatform cloudPlatform = CloudPlatform.valueOf(rs.getString("cloud_platform"));
             switch (cloudPlatform) {
-                case GCP: return StorageResource.getGoogleInstance()
-                    .datasetId(UUID.fromString(rs.getString("dataset_id")))
-                    .cloudResource(GoogleCloudResource.valueOf(rs.getString("cloud_resource")))
-                    .region(GoogleRegion.valueOf(rs.getString("region")));
-                case AZURE: return StorageResource.getAzureInstance()
-                    .datasetId(UUID.fromString(rs.getString("dataset_id")))
-                    .cloudResource(AzureCloudResource.valueOf(rs.getString("cloud_resource")))
-                    .region(AzureRegion.valueOf(rs.getString("region")));
+                case GCP: return new GoogleStorageResource(
+                    UUID.fromString(rs.getString("dataset_id")),
+                    GoogleCloudResource.valueOf(rs.getString("cloud_resource")),
+                    GoogleRegion.valueOf(rs.getString("region")));
+                case AZURE: return new AzureStorageResource(
+                    UUID.fromString(rs.getString("dataset_id")),
+                    AzureCloudResource.valueOf(rs.getString("cloud_resource")),
+                    AzureRegion.valueOf(rs.getString("region")));
                 default: throw new IllegalArgumentException("Unrecognized cloud platform");
             }
         }
     }
 
     @Transactional(propagation =  Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-    public void createStorageAttributes(List<StorageResource> storageResources, UUID datasetId) {
+    public void createStorageAttributes(List<? extends StorageResource<?, ?>> storageResources, UUID datasetId) {
         logger.debug("Create Operation: createStorageAttributes datasetId: {}", datasetId);
 
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("dataset_id", datasetId);
 
         List<String> valuesList = new ArrayList<>();
-        for (StorageResource storageResource : storageResources) {
+        for (StorageResource<?, ?> storageResource : storageResources) {
             String regionParam = storageResource.getCloudResource() + "_region";
             String cloudResourceParam = storageResource.getCloudResource() + "_cloudResource";
             String platformParam = storageResource.getCloudResource() + "_cloudPlatform";

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -1,8 +1,5 @@
 package bio.terra.service.resourcemanagement;
 
-import static bio.terra.service.resourcemanagement.google.GoogleProjectService.PermissionOp.ENABLE_PERMISSIONS;
-import static bio.terra.service.resourcemanagement.google.GoogleProjectService.PermissionOp.REVOKE_PERMISSIONS;
-
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
@@ -17,6 +14,11 @@ import bio.terra.service.resourcemanagement.google.GoogleBucketService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectService;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,10 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+
+import static bio.terra.service.resourcemanagement.google.GoogleProjectService.PermissionOp.ENABLE_PERMISSIONS;
+import static bio.terra.service.resourcemanagement.google.GoogleProjectService.PermissionOp.REVOKE_PERMISSIONS;
 
 @Component
 public class ResourceService {
@@ -69,7 +70,8 @@ public class ResourceService {
 
         final GoogleProjectResource datasetProject = getProjectResource(dataset.getProjectResourceId());
         String sourceDatasetGoogleProjectId = datasetProject.getGoogleProjectId();
-        final GoogleRegion region = dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
+        final GoogleRegion region =
+            (GoogleRegion) dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
         // Every bucket needs to live in a project, so we get or create a project first
         return projectService.getOrCreateProject(
             dataLocationSelector.projectIdForFile(dataset, sourceDatasetGoogleProjectId, billingProfile),
@@ -97,7 +99,7 @@ public class ResourceService {
         return bucketService.getOrCreateBucket(
             dataLocationSelector.bucketForFile(projectResource.getGoogleProjectId()),
             projectResource,
-            dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.BUCKET),
+            (GoogleRegion) dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.BUCKET),
             flightId);
     }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -66,7 +66,7 @@ public class SnapshotCreateFlight extends Flight {
         // TODO note that with multi-dataset snapshots this will need to change
         List<Dataset> sourceDatasets = snapshotService.getSourceDatasetsFromSnapshotRequest(snapshotReq);
         UUID datasetId = sourceDatasets.get(0).getId();
-        GoogleRegion firestoreRegion = sourceDatasets.get(0)
+        GoogleRegion firestoreRegion = (GoogleRegion) sourceDatasets.get(0)
             .getDatasetSummary()
             .getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
         addStep(new LockDatasetStep(datasetDao, datasetId, false));

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -115,7 +115,8 @@ public class BigQueryPdao {
                 bigQueryProject.deleteDataset(datasetName);
             }
 
-            GoogleRegion region = dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.BIGQUERY);
+            GoogleRegion region =
+                (GoogleRegion) dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.BIGQUERY);
 
             bigQueryProject.createDataset(datasetName, dataset.getDescription(), region);
             bigQueryProject.createTable(
@@ -346,7 +347,7 @@ public class BigQueryPdao {
         }
 
         // TODO: When we support multiple datasets per snapshot, this will need to be reworked
-        GoogleRegion representativeRegion = snapshot.getFirstSnapshotSource()
+        GoogleRegion representativeRegion = (GoogleRegion) snapshot.getFirstSnapshotSource()
             .getDataset()
             .getDatasetSummary()
             .getStorageResourceRegion(GoogleCloudResource.BIGQUERY);

--- a/src/test/java/bio/terra/app/model/CloudRegionTest.java
+++ b/src/test/java/bio/terra/app/model/CloudRegionTest.java
@@ -1,0 +1,65 @@
+package bio.terra.app.model;
+
+import bio.terra.common.category.Unit;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class CloudRegionTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testDeserializeHappyPath() throws JsonProcessingException {
+        assertThat(objectMapper.readValue("\"EUROPE_WEST1\"", CloudRegion.class),
+            equalTo(GoogleRegion.EUROPE_WEST1));
+        assertThat(objectMapper.readValue("\"FRANCE_SOUTH\"", CloudRegion.class),
+            equalTo(AzureRegion.FRANCE_SOUTH));
+    }
+
+    @Test
+    public void testDeserializeBadRegionValue() {
+        assertThat(
+            assertThrows(
+                InvalidFormatException.class,
+                () -> objectMapper.readValue("\"EUROPE_WEST100\"", CloudRegion.class),
+                "bad regions don't deserialize").getMessage(),
+            containsString("Unrecognized CloudRegion: EUROPE_WEST100"));
+    }
+
+    @Test
+    public void testDeserializeBadRegionFormat() {
+        assertThat(
+            assertThrows(
+                InvalidFormatException.class,
+                () -> objectMapper.readValue("123", CloudRegion.class),
+                "numbers don't deserialize")
+                .getMessage(),
+            containsString("Invalid representation of CloudRegion"));
+
+        assertThat(
+            assertThrows(
+                InvalidFormatException.class,
+                () -> objectMapper.readValue("{\"foo\": \"bar\"}", CloudRegion.class),
+                "objects don't deserialize")
+                .getMessage(),
+            containsString("Invalid representation of CloudRegion"));
+    }
+}

--- a/src/test/java/bio/terra/app/model/CloudResourceTest.java
+++ b/src/test/java/bio/terra/app/model/CloudResourceTest.java
@@ -1,0 +1,65 @@
+package bio.terra.app.model;
+
+import bio.terra.common.category.Unit;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class CloudResourceTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testDeserializeHappyPath() throws JsonProcessingException {
+        assertThat(objectMapper.readValue("\"BIGQUERY\"", CloudResource.class),
+            equalTo(GoogleCloudResource.BIGQUERY));
+        assertThat(objectMapper.readValue("\"STORAGE_ACCOUNT\"", CloudResource.class),
+            equalTo(AzureCloudResource.STORAGE_ACCOUNT));
+    }
+
+    @Test
+    public void testDeserializeBadResourceValue() {
+        assertThat(
+            assertThrows(
+                InvalidFormatException.class,
+                () -> objectMapper.readValue("\"SMALLQUERY\"", CloudResource.class),
+                "bad resources don't deserialize").getMessage(),
+            containsString("Unrecognized CloudResource: SMALLQUERY"));
+    }
+
+    @Test
+    public void testDeserializeBadResourceFormat() {
+        assertThat(
+            assertThrows(
+                InvalidFormatException.class,
+                () -> objectMapper.readValue("123", CloudResource.class),
+                "numbers don't deserialize")
+                .getMessage(),
+            containsString("Invalid representation of CloudResource"));
+
+        assertThat(
+            assertThrows(
+                InvalidFormatException.class,
+                () -> objectMapper.readValue("{\"foo\": \"bar\"}", CloudResource.class),
+                "objects don't deserialize")
+                .getMessage(),
+            containsString("Invalid representation of CloudResource"));
+    }
+}

--- a/src/test/java/bio/terra/common/fixtures/JsonLoader.java
+++ b/src/test/java/bio/terra/common/fixtures/JsonLoader.java
@@ -1,5 +1,6 @@
 package bio.terra.common.fixtures;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,11 @@ public class JsonLoader {
     public <T> T loadObject(final String resourcePath, final Class<T> resourceClass) throws IOException {
         final String json = loadJson(resourcePath);
         return objectMapper.readerFor(resourceClass).readValue(json);
+    }
+
+    public <T> T loadObject(final String resourcePath, final TypeReference<T> typeReference) throws IOException {
+        final String json = loadJson(resourcePath);
+        return objectMapper.readerFor(typeReference).readValue(json);
     }
 
     public ClassLoader getClassLoader() {

--- a/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
@@ -1,6 +1,7 @@
 package bio.terra.service.dataset;
 
 import bio.terra.app.model.GoogleCloudResource;
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.ProfileFixtures;
@@ -21,6 +22,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,12 +32,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -287,7 +288,7 @@ public class DatasetBucketDaoTest {
         bucketForFile = googleBucketService.getOrCreateBucket(
             gcsConfiguration.getBucket(),
             projectResource,
-            dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.BUCKET),
+            (GoogleRegion) dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.BUCKET),
             ingestFileFlightId);
         return bucketForFile.getResourceId();
     }

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -236,7 +236,7 @@ public class DatasetDaoTest {
             fromDB.getAssetSpecifications().forEach(this::assertAssetSpecs);
 
             for (GoogleCloudResource resource: GoogleCloudResource.values()) {
-                GoogleRegion region = fromDB.getDatasetSummary().getStorageResourceRegion(resource);
+                GoogleRegion region = (GoogleRegion) fromDB.getDatasetSummary().getStorageResourceRegion(resource);
                 assertThat(String.format("dataset %s region is set", resource),
                     region,
                     equalTo(testSettingRegion));
@@ -258,7 +258,7 @@ public class DatasetDaoTest {
             Dataset fromDB = datasetDao.retrieve(datasetId);
 
             for (GoogleCloudResource resource: GoogleCloudResource.values()) {
-                GoogleRegion region = fromDB.getDatasetSummary().getStorageResourceRegion(resource);
+                GoogleRegion region = (GoogleRegion) fromDB.getDatasetSummary().getStorageResourceRegion(resource);
                 GoogleRegion expectedRegion =
                     (resource == GoogleCloudResource.BIGQUERY) ? GoogleRegion.US : GoogleRegion.US_EAST4;
                 assertThat(String.format("dataset %s region is set to %s", resource, region.name()),

--- a/src/test/java/bio/terra/service/dataset/StorageResourceTest.java
+++ b/src/test/java/bio/terra/service/dataset/StorageResourceTest.java
@@ -1,0 +1,72 @@
+package bio.terra.service.dataset;
+
+import bio.terra.app.model.AzureCloudResource;
+import bio.terra.app.model.AzureRegion;
+import bio.terra.app.model.GoogleCloudResource;
+import bio.terra.app.model.GoogleRegion;
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.JsonLoader;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class StorageResourceTest {
+
+    @Autowired
+    private JsonLoader jsonLoader;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final List<StorageResource> model = List.of(
+        StorageResource.getAzureInstance()
+            .cloudResource(AzureCloudResource.APPLICATION_DEPLOYMENT)
+            .region(AzureRegion.CENTRAL_US)
+            .datasetId(UUID.fromString("a3d54871-8cdc-4549-8410-28005df9cbaf")),
+        StorageResource.getGoogleInstance()
+            .cloudResource(GoogleCloudResource.BUCKET)
+            .region(GoogleRegion.US_EAST1)
+            .datasetId(UUID.fromString("a3d54871-8cdc-4549-8410-28005df9cbaf")));
+
+    @Test
+    public void testDeserialization() throws IOException {
+        List<StorageResource> storageResource =
+            jsonLoader.loadObject("storage-account.json", new TypeReference<>() {});
+        assertThat(storageResource, equalTo(model));
+    }
+
+    @Test
+    public void testDeserializationMixedCloudResourcesFail() throws IOException {
+        assertThrows(JsonMappingException.class, () ->
+            jsonLoader.loadObject("storage-account.mixedcloud.json",
+                new TypeReference<List<StorageResource>>() {}),
+            "mixed cloud resources don't deserialize");
+    }
+
+    @Test
+    public void testSerialization() throws IOException {
+        String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(model);
+        System.err.println(json);
+        List<StorageResource> storageResource = objectMapper.readValue(json, new TypeReference<>() {});
+        assertThat(storageResource, equalTo(model));
+    }
+}

--- a/src/test/java/bio/terra/service/dataset/StorageResourceTest.java
+++ b/src/test/java/bio/terra/service/dataset/StorageResourceTest.java
@@ -37,19 +37,19 @@ public class StorageResourceTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private final List<StorageResource> model = List.of(
-        StorageResource.getAzureInstance()
-            .cloudResource(AzureCloudResource.APPLICATION_DEPLOYMENT)
-            .region(AzureRegion.CENTRAL_US)
-            .datasetId(UUID.fromString("a3d54871-8cdc-4549-8410-28005df9cbaf")),
-        StorageResource.getGoogleInstance()
-            .cloudResource(GoogleCloudResource.BUCKET)
-            .region(GoogleRegion.US_EAST1)
-            .datasetId(UUID.fromString("a3d54871-8cdc-4549-8410-28005df9cbaf")));
+    private final List<? extends StorageResource<?, ?>> model = List.of(
+        new AzureStorageResource(
+            UUID.fromString("a3d54871-8cdc-4549-8410-28005df9cbaf"),
+            AzureCloudResource.APPLICATION_DEPLOYMENT,
+            AzureRegion.CENTRAL_US),
+        new GoogleStorageResource(
+            UUID.fromString("a3d54871-8cdc-4549-8410-28005df9cbaf"),
+            GoogleCloudResource.BUCKET,
+            GoogleRegion.US_EAST1));
 
     @Test
     public void testDeserialization() throws IOException {
-        List<StorageResource> storageResource =
+        List<? extends StorageResource<?, ?>> storageResource =
             jsonLoader.loadObject("storage-account.json", new TypeReference<>() {});
         assertThat(storageResource, equalTo(model));
     }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.google;
 
+import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.category.Unit;
@@ -24,6 +25,13 @@ import static org.mockito.ArgumentMatchers.any;
 
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 @Category(Unit.class)
 @RunWith(MockitoJUnitRunner.class)
 public class ResourceServiceUnitTest {
@@ -42,9 +50,9 @@ public class ResourceServiceUnitTest {
     private final UUID datasetId = UUID.randomUUID();
 
     private final DatasetSummary datasetSummary = new DatasetSummary().storage(List.of(
-        new StorageResource().region(GoogleRegion.DEFAULT_GOOGLE_REGION).cloudResource(
+        StorageResource.getGoogleInstance().region(GoogleRegion.DEFAULT_GOOGLE_REGION).cloudResource(
             GoogleCloudResource.BUCKET),
-        new StorageResource().region(GoogleRegion.DEFAULT_GOOGLE_REGION).cloudResource(
+        StorageResource.getGoogleInstance().region(GoogleRegion.DEFAULT_GOOGLE_REGION).cloudResource(
             GoogleCloudResource.FIRESTORE)
         ));
     private final Dataset dataset = new Dataset(datasetSummary).id(datasetId);

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
@@ -1,18 +1,13 @@
 package bio.terra.service.resourcemanagement.google;
 
-import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.category.Unit;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetSummary;
-import bio.terra.service.dataset.StorageResource;
+import bio.terra.service.dataset.GoogleStorageResource;
 import bio.terra.service.resourcemanagement.OneProjectPerResourceSelector;
 import bio.terra.service.resourcemanagement.ResourceService;
-
-import java.util.List;
-import java.util.UUID;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -21,11 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
-import static org.mockito.ArgumentMatchers.any;
 
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,11 +41,8 @@ public class ResourceServiceUnitTest {
     private final UUID datasetId = UUID.randomUUID();
 
     private final DatasetSummary datasetSummary = new DatasetSummary().storage(List.of(
-        StorageResource.getGoogleInstance().region(GoogleRegion.DEFAULT_GOOGLE_REGION).cloudResource(
-            GoogleCloudResource.BUCKET),
-        StorageResource.getGoogleInstance().region(GoogleRegion.DEFAULT_GOOGLE_REGION).cloudResource(
-            GoogleCloudResource.FIRESTORE)
-        ));
+        new GoogleStorageResource(datasetId, GoogleCloudResource.BUCKET, GoogleRegion.DEFAULT_GOOGLE_REGION),
+        new GoogleStorageResource(datasetId, GoogleCloudResource.FIRESTORE, GoogleRegion.DEFAULT_GOOGLE_REGION)));
     private final Dataset dataset = new Dataset(datasetSummary).id(datasetId);
 
     private final GoogleProjectResource projectResource = new GoogleProjectResource()

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -1,7 +1,9 @@
 package bio.terra.service.snapshot;
 
-import bio.terra.app.model.GoogleRegion;
+import bio.terra.app.model.CloudRegion;
+import bio.terra.app.model.CloudResource;
 import bio.terra.app.model.GoogleCloudResource;
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.Column;
 import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.Relationship;
@@ -399,15 +401,15 @@ public class SnapshotDaoTest {
                 makeName(snapshotName, index),
                 equalTo(summary.getName()));
 
-            Map<GoogleCloudResource, StorageResource> storageMap = summary.getStorage().stream()
+            Map<CloudResource, StorageResource> storageMap = summary.getStorage().stream()
                     .collect(Collectors.toMap(StorageResource::getCloudResource, Function.identity()));
 
             Snapshot fromDB = snapshotDao.retrieveSnapshot(snapshotIds.get(index));
             SnapshotSource source = fromDB.getFirstSnapshotSource();
 
             for (GoogleCloudResource resource: GoogleCloudResource.values()) {
-                GoogleRegion sourceRegion = source.getDataset().getDatasetSummary().getStorageResourceRegion(resource);
-                GoogleRegion snapshotRegion = storageMap.get(resource).getRegion();
+                CloudRegion sourceRegion = source.getDataset().getDatasetSummary().getStorageResourceRegion(resource);
+                CloudRegion snapshotRegion = storageMap.get(resource).getRegion();
                 assertThat("snapshot includes expected source dataset storage regions",
                     snapshotRegion,
                     equalTo(sourceRegion));

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoUnitTest.java
@@ -10,7 +10,6 @@ import bio.terra.common.category.Unit;
 import bio.terra.common.exception.PdaoException;
 import bio.terra.common.fixtures.DatasetFixtures;
 import bio.terra.grammar.exception.InvalidQueryException;
-import bio.terra.model.CloudPlatform;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SnapshotRequestRowIdModel;
 import bio.terra.model.SnapshotRequestRowIdTableModel;
@@ -694,10 +693,9 @@ public class BigQueryPdaoUnitTest {
                             .profileId(PROFILE_1_ID)
                             .googleProjectId(DATASET_PROJECT_ID))
                         .tables(List.of(tbl1, tbl2))
-                        .storage(List.of(new StorageResource()
+                        .storage(List.of(StorageResource.getGoogleInstance()
                             .datasetId(DATASET_ID)
                             .cloudResource(GoogleCloudResource.BIGQUERY)
-                            .cloudPlatform(CloudPlatform.GCP)
                             .region(GoogleRegion.NORTHAMERICA_NORTHEAST1))))
                     .assetSpecification(new AssetSpecification()
                         .rootTable(new AssetTable()

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoUnitTest.java
@@ -20,7 +20,7 @@ import bio.terra.service.dataset.AssetSpecification;
 import bio.terra.service.dataset.AssetTable;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetTable;
-import bio.terra.service.dataset.StorageResource;
+import bio.terra.service.dataset.GoogleStorageResource;
 import bio.terra.service.filedata.google.bq.BigQueryConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.RowIdMatch;
@@ -693,10 +693,10 @@ public class BigQueryPdaoUnitTest {
                             .profileId(PROFILE_1_ID)
                             .googleProjectId(DATASET_PROJECT_ID))
                         .tables(List.of(tbl1, tbl2))
-                        .storage(List.of(StorageResource.getGoogleInstance()
-                            .datasetId(DATASET_ID)
-                            .cloudResource(GoogleCloudResource.BIGQUERY)
-                            .region(GoogleRegion.NORTHAMERICA_NORTHEAST1))))
+                        .storage(List.of(new GoogleStorageResource(
+                            DATASET_ID,
+                            GoogleCloudResource.BIGQUERY,
+                            GoogleRegion.NORTHAMERICA_NORTHEAST1))))
                     .assetSpecification(new AssetSpecification()
                         .rootTable(new AssetTable()
                             .datasetTable(tbl1))

--- a/src/test/resources/storage-account.json
+++ b/src/test/resources/storage-account.json
@@ -1,0 +1,14 @@
+[
+  {
+    "region": "CENTRAL_US",
+    "datasetId": "a3d54871-8cdc-4549-8410-28005df9cbaf",
+    "cloudPlatform": "azure",
+    "cloudResource": "APPLICATION_DEPLOYMENT"
+  },
+  {
+    "region": "US_EAST1",
+    "datasetId": "a3d54871-8cdc-4549-8410-28005df9cbaf",
+    "cloudPlatform": "gcp",
+    "cloudResource": "BUCKET"
+  }
+]

--- a/src/test/resources/storage-account.mixedcloud.json
+++ b/src/test/resources/storage-account.mixedcloud.json
@@ -1,0 +1,14 @@
+[
+  {
+    "region": "US_EAST1",
+    "datasetId": "a3d54871-8cdc-4549-8410-28005df9cbaf",
+    "cloudPlatform": "azure",
+    "cloudResource": "APPLICATION_DEPLOYMENT"
+  },
+  {
+    "region": "CENTRAL_US",
+    "datasetId": "a3d54871-8cdc-4549-8410-28005df9cbaf",
+    "cloudPlatform": "gcp",
+    "cloudResource": "BUCKET"
+  }
+]


### PR DESCRIPTION
This PR abstracts out the notion of storage, regions and resource types into interfaces and adds Azure equivalent implementations

There's some interesting deserialization code in here for figuring out, based on a region string or a resource type string, if it is an azure or google cloud option.