### PR TITLE
DR-1863 Enable firestore in correct region

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -170,7 +170,7 @@ public class ResourceService {
      *
      * @param snapshotName      name of the snapshot
      * @param billingProfile    authorized billing profile to pay for the project
-     * @param region           the region of the snapshot
+     * @param region            the region of the snapshot
      * @return project resource id
      */
     public UUID getOrCreateSnapshotProject(String snapshotName,

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -170,19 +170,19 @@ public class ResourceService {
      *
      * @param snapshotName      name of the snapshot
      * @param billingProfile    authorized billing profile to pay for the project
-     * @param firestoreRegion   the region to create the Firestore in
+     * @param region           the region of the snapshot
      * @return project resource id
      */
     public UUID getOrCreateSnapshotProject(String snapshotName,
                                            BillingProfileModel billingProfile,
-                                           GoogleRegion firestoreRegion)
+                                           GoogleRegion region)
         throws InterruptedException {
 
         GoogleProjectResource googleProjectResource = projectService.getOrCreateProject(
             dataLocationSelector.projectIdForSnapshot(snapshotName, billingProfile),
             billingProfile,
             null,
-            firestoreRegion);
+            region);
 
         return googleProjectResource.getId();
     }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -101,7 +101,7 @@ public class GoogleProjectService {
      * @param googleProjectId     google's id of the project
      * @param billingProfile      previously authorized billing profile
      * @param roleIdentityMapping permissions to set
-     * @param firestoreRegion     region to use for Firestore
+     * @param region              region of dataset/snapshot
      * @return project resource object
      * @throws InterruptedException if shutting down
      */
@@ -109,7 +109,7 @@ public class GoogleProjectService {
         String googleProjectId,
         BillingProfileModel billingProfile,
         Map<String, List<String>> roleIdentityMapping,
-        GoogleRegion firestoreRegion)
+        GoogleRegion region)
         throws InterruptedException {
 
         try {
@@ -133,10 +133,10 @@ public class GoogleProjectService {
         // came from, what resources they contain, who is paying for them.
         Project existingProject = getProject(googleProjectId);
         if (existingProject != null && resourceConfiguration.getAllowReuseExistingProjects()) {
-            return initializeProject(existingProject, billingProfile, roleIdentityMapping, false, firestoreRegion);
+            return initializeProject(existingProject, billingProfile, roleIdentityMapping, false, region);
         }
 
-        return newProject(googleProjectId, billingProfile, roleIdentityMapping, firestoreRegion);
+        return newProject(googleProjectId, billingProfile, roleIdentityMapping, region);
     }
 
     public GoogleProjectResource getProjectResourceById(UUID id) {
@@ -186,7 +186,7 @@ public class GoogleProjectService {
      * @param requestedProjectId  suggested name for the project
      * @param billingProfile      authorized billing profile that'll pay for the project
      * @param roleIdentityMapping iam roles to be granted on the project
-     * @param firestoreRegion     region the project should use for Firestore
+     * @param region              region of the dataset/snapshot
      * @return a populated project resource object
      * @throws InterruptedException if the flight is interrupted during execution
      */
@@ -194,7 +194,7 @@ public class GoogleProjectService {
         String requestedProjectId,
         BillingProfileModel billingProfile,
         Map<String, List<String>> roleIdentityMapping,
-        GoogleRegion firestoreRegion)
+        GoogleRegion region)
         throws InterruptedException {
 
         ensureValidProjectId(requestedProjectId);
@@ -226,7 +226,7 @@ public class GoogleProjectService {
                 throw new GoogleResourceException("Could not get project after creation");
             }
 
-            return initializeProject(project, billingProfile, roleIdentityMapping, true, firestoreRegion);
+            return initializeProject(project, billingProfile, roleIdentityMapping, true, region);
         } catch (IOException | GeneralSecurityException e) {
             throw new GoogleResourceException("Could not create project", e);
         }
@@ -239,7 +239,7 @@ public class GoogleProjectService {
         BillingProfileModel billingProfile,
         Map<String, List<String>> roleIdentityMapping,
         boolean setBilling,
-        GoogleRegion firestoreRegion)
+        GoogleRegion region)
         throws InterruptedException {
 
         String googleProjectNumber = project.getProjectNumber().toString();
@@ -255,7 +255,7 @@ public class GoogleProjectService {
             // The billing profile has already been authorized so we do no further checking here
             billingService.assignProjectBilling(billingProfile, googleProjectResource);
         }
-        enableServices(googleProjectResource, firestoreRegion);
+        enableServices(googleProjectResource, region);
         updateIamPermissions(roleIdentityMapping, googleProjectId, PermissionOp.ENABLE_PERMISSIONS);
 
         UUID id = resourceDao.createProject(googleProjectResource);
@@ -287,7 +287,7 @@ public class GoogleProjectService {
 
     @VisibleForTesting
     void enableServices(GoogleProjectResource projectResource,
-                        GoogleRegion firestoreRegion) throws InterruptedException {
+                        GoogleRegion region) throws InterruptedException {
         try {
             ServiceUsage serviceUsage = serviceUsage();
             String projectNumberString = "projects/" + projectResource.getGoogleProjectNumber();
@@ -325,7 +325,7 @@ public class GoogleProjectService {
             enableFirestore(
                 appengine(),
                 projectResource.getGoogleProjectId(),
-                firestoreRegion,
+                region,
                 timeout
             );
 
@@ -455,13 +455,14 @@ public class GoogleProjectService {
      * Enable Firestore in native mode in an existing project
      * @param appengine appengine client
      * @param googleProjectId name of the google project to create the Firestore DB in
-     * @param firestoreRegion location of the Firestore DB
+     * @param region the region of the project
      * @param timeout how long to wait for the creation operation
      */
     private static void enableFirestore(final Appengine appengine,
                                         final String googleProjectId,
-                                        final GoogleRegion firestoreRegion,
+                                        final GoogleRegion region,
                                         final long timeout) throws IOException, InterruptedException {
+        GoogleRegion firestoreRegion = region.getRegionOrFallbackFirestoreRegion();
         logger.info("Enabling Firestore in project {} in location {}", googleProjectId,
             firestoreRegion.toString());
         // Create a request object

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotGetOrCreateProjectStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotGetOrCreateProjectStep.java
@@ -16,14 +16,14 @@ import java.util.UUID;
 public class CreateSnapshotGetOrCreateProjectStep implements Step {
     private final ResourceService resourceService;
     private final SnapshotRequestModel snapshotRequestModel;
-    private final GoogleRegion firestoreRegion;
+    private final GoogleRegion region;
 
     public CreateSnapshotGetOrCreateProjectStep(ResourceService resourceService,
                                                 SnapshotRequestModel snapshotRequestModel,
-                                                GoogleRegion firestoreRegion) {
+                                                GoogleRegion region) {
         this.resourceService = resourceService;
         this.snapshotRequestModel = snapshotRequestModel;
-        this.firestoreRegion = firestoreRegion;
+        this.region = region;
     }
 
     @Override
@@ -33,7 +33,7 @@ public class CreateSnapshotGetOrCreateProjectStep implements Step {
         // Since we find projects by their names, this is idempotent. If this step fails and is rerun,
         // Either the project will have been created8and we will find it, or we will create.
         UUID projectResourceId =
-            resourceService.getOrCreateSnapshotProject(snapshotRequestModel.getName(), profileModel, firestoreRegion);
+            resourceService.getOrCreateSnapshotProject(snapshotRequestModel.getName(), profileModel, region);
         workingMap.put(SnapshotWorkingMapKeys.PROJECT_RESOURCE_ID, projectResourceId);
         return StepResult.getStepResultSuccess();
     }


### PR DESCRIPTION
We didn't actually put firestore in the correct region for dataset creation. We only did it for snapshot creation. This fixes that. I've also renamed stuff because its the actual `enableFirestore` method that gets the fallback region now.