### PR TITLE
Add support for a no-op encode for TIM names

### DIFF
--- a/src/main/java/bio/terra/app/utils/TimUtils.java
+++ b/src/main/java/bio/terra/app/utils/TimUtils.java
@@ -12,24 +12,33 @@ public final class TimUtils {
     private static final String PREFIX = "tim__";
 
     /**
-     * Encode a TIM name for ElasticSearch or BigQuery use.
+     * Encode a TIM name for ElasticSearch or BigQuery use. If the input string doesn't need
+     * encoding, the original string will be returned.
      *
      * @param s the TIM name
-     * @return an encoded name
+     * @return an encoded name, or the original if no encoding is needed
      */
     public static String encode(String s) {
         StringBuilder result = new StringBuilder(PREFIX);
+        // Keep track of encodings we use. Only colon or period encodings are required.
+        var needsEncoding = false;
         for (char c : s.toCharArray()) {
             if (Character.isUpperCase(c)) {
                 result.append(CAPITAL);
                 result.append(Character.toLowerCase(c));
             } else if (c == ':') {
                 result.append(COLON);
+                needsEncoding = true;
             } else if (c == '.') {
                 result.append(PERIOD);
+                needsEncoding = true;
             } else {
                 result.append(c);
             }
+        }
+        if (!needsEncoding) {
+            // If no encoding was needed, return the original string.
+            return s;
         }
         return result.toString();
     }

--- a/src/test/java/bio/terra/app/utils/TimUtilsTest.java
+++ b/src/test/java/bio/terra/app/utils/TimUtilsTest.java
@@ -41,4 +41,9 @@ public class TimUtilsTest {
     public void noDecode() {
         assertThat(TimUtils.decode("a__b"), is("a__b"));
     }
+
+    @Test
+    public void noEncode() {
+        assertThat(TimUtils.encode("an_Ordinary_column"), is("an_Ordinary_column"));
+    }
 }


### PR DESCRIPTION
In the case where the passed string doesn't need any encoding, the original string is returned.