### PR TITLE
DR-1890 Verify that user is allowed to link billing accounts to deployed managed applications

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -10,6 +10,7 @@ env:
   # The default Azure credentials to use to authenticate
   AZURE_CREDENTIALS_APPLICATIONID: 22cb243c-f1a5-43d8-8f12-6566bcce6542
   AZURE_CREDENTIALS_HOMETENANTID: fad90753-2022-4456-9b0a-c7e5b934e408
+  JADE_USER_EMAIL: connected-tdr-user@notarealemail.org
 on:
   pull_request:
     branches:

--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -33,7 +33,7 @@ public class ProfileDao {
     // SQL select string constants
     private static final String SQL_SELECT_LIST =
         "id, name, biller, billing_account_id, description, cloud_platform, " +
-            "tenant_id, subscription_id, resource_group_name, created_date, created_by";
+            "tenant_id, subscription_id, resource_group_name, application_deployment_name, created_date, created_by";
 
     private static final String SQL_GET = "SELECT " + SQL_SELECT_LIST
         + " FROM billing_profile WHERE id = :id";
@@ -59,9 +59,9 @@ public class ProfileDao {
     public BillingProfileModel createBillingProfile(BillingProfileRequestModel profileRequest, String creator) {
         String sql = "INSERT INTO billing_profile"
             + " (id, name, biller, billing_account_id, description, cloud_platform, " +
-            "     tenant_id, subscription_id, resource_group_name, created_by) VALUES "
+            "     tenant_id, subscription_id, resource_group_name, application_deployment_name, created_by) VALUES "
             + " (:id, :name, :biller, :billing_account_id, :description, :cloud_platform, " +
-            "     :tenant_id, :subscription_id, :resource_group_name, :created_by)";
+            "     :tenant_id, :subscription_id, :resource_group_name, :application_deployment_name, :created_by)";
 
         String cloudPlatform = Optional.ofNullable(profileRequest.getCloudPlatform())
             .or(() -> Optional.of(CloudPlatform.GCP))
@@ -71,6 +71,8 @@ public class ProfileDao {
         UUID subscriptionId = Optional.ofNullable(profileRequest.getSubscriptionId())
             .map(UUID::fromString).orElse(null);
         String resourceGroupName = Optional.ofNullable(profileRequest.getResourceGroupName()).orElse(null);
+        String applicationDeploymentName =
+            Optional.ofNullable(profileRequest.getApplicationDeploymentName()).orElse(null);
 
         MapSqlParameterSource params = new MapSqlParameterSource()
             .addValue("id", UUID.fromString(profileRequest.getId()))
@@ -82,6 +84,7 @@ public class ProfileDao {
             .addValue("tenant_id", tenantId)
             .addValue("subscription_id", subscriptionId)
             .addValue("resource_group_name", resourceGroupName)
+            .addValue("application_deployment_name", applicationDeploymentName)
             .addValue("created_by", creator);
 
         DaoKeyHolder keyHolder = new DaoKeyHolder();
@@ -97,6 +100,7 @@ public class ProfileDao {
             .tenantId(keyHolder.getString("tenant_id"))
             .subscriptionId(keyHolder.getString("subscription_id"))
             .resourceGroupName(keyHolder.getString("resource_group_name"))
+            .applicationDeploymentName(keyHolder.getString("application_deployment_name"))
             .createdBy(keyHolder.getString("created_by"))
             .createdDate(keyHolder.getTimestamp("created_date").toInstant().toString());
     }
@@ -130,6 +134,7 @@ public class ProfileDao {
             .tenantId(keyHolder.getString("tenant_id"))
             .subscriptionId(keyHolder.getString("subscription_id"))
             .resourceGroupName(keyHolder.getString("resource_group_name"))
+            .applicationDeploymentName(keyHolder.getString("application_deployment_name"))
             .createdBy(keyHolder.getString("created_by"))
             .createdDate(keyHolder.getTimestamp("created_date").toInstant().toString());
     }
@@ -203,6 +208,7 @@ public class ProfileDao {
                 .tenantId(rs.getString("tenant_id"))
                 .subscriptionId(rs.getString("subscription_id"))
                 .resourceGroupName(rs.getString("resource_group_name"))
+                .applicationDeploymentName(rs.getString("application_deployment_name"))
                 .createdDate(rs.getTimestamp("created_date").toInstant().toString())
                 .createdBy(rs.getString("created_by"));
         }

--- a/src/main/java/bio/terra/service/profile/azure/AzureAuthzService.java
+++ b/src/main/java/bio/terra/service/profile/azure/AzureAuthzService.java
@@ -1,0 +1,45 @@
+package bio.terra.service.profile.azure;
+
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.resources.models.GenericResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class AzureAuthzService {
+
+    static final String AUTH_TAG_KEY = "terra-auth";
+
+    private final AzureResourceConfiguration resourceConfiguration;
+
+    @Autowired
+    public AzureAuthzService(AzureResourceConfiguration resourceConfiguration) {
+        this.resourceConfiguration = resourceConfiguration;
+    }
+
+    public boolean canAccess(AuthenticatedUserRequest user,
+                             UUID subscriptionId,
+                             String resourceGroupName,
+                             String applicationDeploymentName) {
+        AzureResourceManager client = resourceConfiguration.getClient(subscriptionId);
+        String applicationResourceId = MetadataDataAccessUtils.getApplicationDeploymentId(
+                subscriptionId,
+                resourceGroupName,
+                applicationDeploymentName);
+        try {
+            GenericResource applicationDeployment = client.genericResources()
+                .getById(applicationResourceId);
+
+            return applicationDeployment.tags()
+                .getOrDefault(AUTH_TAG_KEY, "")
+                .strip().equalsIgnoreCase(user.getEmail());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/bio/terra/service/profile/azure/AzureAuthzService.java
+++ b/src/main/java/bio/terra/service/profile/azure/AzureAuthzService.java
@@ -8,12 +8,13 @@ import com.azure.resourcemanager.resources.models.GenericResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.UUID;
 
 @Service
 public class AzureAuthzService {
 
-    static final String AUTH_TAG_KEY = "terra-auth";
+    static final String AUTH_PARAM_KEY = "authorizedTDRUser";
 
     private final AzureResourceConfiguration resourceConfiguration;
 
@@ -35,8 +36,8 @@ public class AzureAuthzService {
             GenericResource applicationDeployment = client.genericResources()
                 .getById(applicationResourceId);
 
-            return applicationDeployment.tags()
-                .getOrDefault(AUTH_TAG_KEY, "")
+            return ((Map<String, Map<String, Map<String, String>>>) applicationDeployment.properties())
+                .get("parameters").get(AUTH_PARAM_KEY).get("value")
                 .strip().equalsIgnoreCase(user.getEmail());
         } catch (Exception e) {
             return false;

--- a/src/main/java/bio/terra/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
+++ b/src/main/java/bio/terra/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
@@ -1,0 +1,51 @@
+package bio.terra.service.profile.flight.create;
+
+import bio.terra.model.BillingProfileRequestModel;
+import bio.terra.model.CloudPlatform;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.profile.ProfileService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+
+public class CreateProfileVerifyDeployedApplicationStep implements Step {
+    private static final Logger logger = LoggerFactory.getLogger(CreateProfileVerifyDeployedApplicationStep.class);
+
+    private final ProfileService profileService;
+    private final BillingProfileRequestModel request;
+    private final AuthenticatedUserRequest user;
+
+    public CreateProfileVerifyDeployedApplicationStep(ProfileService profileService,
+                                                      BillingProfileRequestModel request,
+                                                      AuthenticatedUserRequest user) {
+        this.profileService = profileService;
+        this.request = request;
+        this.user = user;
+    }
+
+    @Override
+    public StepResult doStep(FlightContext context) throws InterruptedException {
+        if (request.getCloudPlatform() == CloudPlatform.AZURE) {
+            profileService.verifyDeployedApplication(
+                UUID.fromString(request.getSubscriptionId()),
+                request.getResourceGroupName(),
+                request.getApplicationDeploymentName(),
+                user);
+        } else {
+            logger.info("Billing profile is not an Azure billing profile.  Skipping Azure validation");
+        }
+        return StepResult.getStepResultSuccess();
+    }
+
+    @Override
+    public StepResult undoStep(FlightContext context) throws InterruptedException {
+        // Verify account has no side effects to clean up
+        return StepResult.getStepResultSuccess();
+    }
+}
+

--- a/src/main/java/bio/terra/service/profile/flight/create/ProfileCreateFlight.java
+++ b/src/main/java/bio/terra/service/profile/flight/create/ProfileCreateFlight.java
@@ -24,8 +24,8 @@ public class ProfileCreateFlight extends Flight {
 
         addStep(new CreateProfileMetadataStep(profileService, request, user));
         addStep(new CreateProfileVerifyAccountStep(profileService, request, user));
-        addStep(new CreateProfileAuthzIamStep(profileService, request, user));
         addStep(new CreateProfileVerifyDeployedApplicationStep(profileService, request, user));
+        addStep(new CreateProfileAuthzIamStep(profileService, request, user));
     }
 
 }

--- a/src/main/java/bio/terra/service/profile/flight/create/ProfileCreateFlight.java
+++ b/src/main/java/bio/terra/service/profile/flight/create/ProfileCreateFlight.java
@@ -25,6 +25,7 @@ public class ProfileCreateFlight extends Flight {
         addStep(new CreateProfileMetadataStep(profileService, request, user));
         addStep(new CreateProfileVerifyAccountStep(profileService, request, user));
         addStep(new CreateProfileAuthzIamStep(profileService, request, user));
+        addStep(new CreateProfileVerifyDeployedApplicationStep(profileService, request, user));
     }
 
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -4,12 +4,14 @@ import bio.terra.common.Table;
 import bio.terra.model.AccessInfoBigQueryModel;
 import bio.terra.model.AccessInfoBigQueryModelTable;
 import bio.terra.model.AccessInfoModel;
+import bio.terra.model.BillingProfileModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import org.stringtemplate.v4.ST;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -24,6 +26,8 @@ public final class MetadataDataAccessUtils {
     private static final String BIGQUERY_TABLE_ID = "<dataset_id>.<table>";
     private static final String BIGQUERY_BASE_QUERY = "SELECT * FROM `<table_address>` LIMIT 1000";
 
+    private static final String DEPLOYED_APPLICATION_RESOURCE_ID = "/subscriptions/<subscription>/resourceGroups" +
+        "/<resource_group>/providers/Microsoft.Solutions/applications/<application_name>";
     private MetadataDataAccessUtils() {
     }
 
@@ -110,4 +114,33 @@ public final class MetadataDataAccessUtils {
         return accessInfoModel;
     }
 
+    /**
+     * Return the Azure resource ID for the application deployment associated with the specified
+     * {@link BillingProfileModel}
+     * @param profileModel The billing profile to get the application deployment for
+     * @return Azure resource identifier
+     */
+    public static String getApplicationDeploymentId(BillingProfileModel profileModel) {
+        return getApplicationDeploymentId(
+            UUID.fromString(profileModel.getSubscriptionId()),
+            profileModel.getResourceGroupName(),
+            profileModel.getApplicationDeploymentName());
+    }
+
+    /**
+     * Return the Azure resource ID for the application deployment associated with the specified parameters
+     * @param subscriptionId The ID of the subscription into which the application is deployed
+     * @param resourceGroupName The name of the resource group into which the application is deployed
+     * @param applicationDeploymentName The name of the application deployment
+     * @return Azure resource identifier
+     */
+    public static String getApplicationDeploymentId(UUID subscriptionId,
+                                                    String resourceGroupName,
+                                                    String applicationDeploymentName) {
+        return new ST(DEPLOYED_APPLICATION_RESOURCE_ID)
+            .add("subscription", subscriptionId)
+            .add("resource_group", resourceGroupName)
+            .add("application_name", applicationDeploymentName)
+            .render();
+    }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -66,6 +66,15 @@ public class AzureResourceConfiguration {
     }
 
     /**
+     * Get a resource manager client to a user's subscription but through TDR's tenant.
+     * @param subscriptionId The ID of the subscription that will be charged for the resources created with this client
+     * @return An authenticated {@link AzureResourceManager} client
+     */
+    public AzureResourceManager getClient(final UUID subscriptionId) {
+        return getClient(credentials.getHomeTenantId(), subscriptionId);
+    }
+
+    /**
      * Information for authenticating the TDR service against user Azure tenants
      */
     public static class Credentials {

--- a/src/main/java/bio/terra/service/resourcemanagement/exception/InaccessibleApplicationDeploymentException.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/exception/InaccessibleApplicationDeploymentException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.resourcemanagement.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+public class InaccessibleApplicationDeploymentException extends BadRequestException {
+    public InaccessibleApplicationDeploymentException(String message) {
+        super(message);
+    }
+
+    public InaccessibleApplicationDeploymentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InaccessibleApplicationDeploymentException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2754,6 +2754,9 @@ components:
         resourceGroupName:
           type: string
           description: an optional resource group name for Azure
+        applicationDeploymentName:
+          type: string
+          description: an optional name for an application deployment for Azure
     BillingProfileUpdateModel:
       required:
         - id
@@ -2798,6 +2801,9 @@ components:
         resourceGroupName:
           type: string
           description: an optional resource group name for Azure
+        applicationDeploymentName:
+          type: string
+          description: an optional name for an application deployment for Azure
         createdDate:
           type: string
           description: Date the profile was created
@@ -2886,6 +2892,10 @@ components:
           $ref: '#/components/schemas/DatasetSpecificationModel'
         region:
           type: string
+        gcpRegion:
+          type: string
+          description: >
+            This is a temporary parameter until GCP and Azure resources are no longer entwined.  This parameter will disappear shortly
         cloudPlatform:
           $ref: '#/components/schemas/CloudPlatform'
       description: >

--- a/src/main/resources/azure/marketplaceTemplate/createUiDefinition.json
+++ b/src/main/resources/azure/marketplaceTemplate/createUiDefinition.json
@@ -39,7 +39,7 @@
             "type": "Microsoft.Common.TextBox",
             "label": "Email",
             "defaultValue": "",
-            "toolTip": "Please enter the email account for the TDR user that will creating a billing profile from this application deployment",
+            "toolTip": "Please enter the email account for the TDR user that will create a billing profile from this application deployment",
             "constraints": {
               "required": true,
               "regex": "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",

--- a/src/main/resources/azure/marketplaceTemplate/createUiDefinition.json
+++ b/src/main/resources/azure/marketplaceTemplate/createUiDefinition.json
@@ -9,17 +9,17 @@
     "steps": [
       {
         "name": "storageConfig",
-        "label": "Storage settings",
+        "label": "Terra Data Repository settings",
         "subLabel": {
           "preValidation": "Configure the infrastructure settings",
           "postValidation": "Done"
         },
-        "bladeTitle": "Storage settings",
+        "bladeTitle": "Terra Data Repository settings",
         "elements": [
           {
             "name": "storageAccounts",
             "type": "Microsoft.Storage.MultiStorageAccountCombo",
-            "tooltip": "Configure the storage account to use",
+            "tooltip": "Configure the options that will be used when creating storage accounts",
             "label": {
               "prefix": "Storage account name prefix",
               "type": "Storage account type"
@@ -29,11 +29,23 @@
             },
             "constraints": {
               "allowedTypes": [
-                "Premium_LRS",
                 "Standard_LRS",
                 "Standard_GRS"
               ]
             }
+          },
+          {
+            "name": "authorizedTDRUser",
+            "type": "Microsoft.Common.TextBox",
+            "label": "Email",
+            "defaultValue": "",
+            "toolTip": "Please enter the email account for the TDR user that will creating a billing profile from this application deployment",
+            "constraints": {
+              "required": true,
+              "regex": "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+              "validationMessage": "Email is not valid. Please re-enter."
+            },
+            "visible": true
           }
         ]
       }
@@ -41,7 +53,8 @@
     "outputs": {
       "storageAccountNamePrefix": "[steps('storageConfig').storageAccounts.prefix]",
       "storageAccountType": "[steps('storageConfig').storageAccounts.type]",
-      "location": "[location()]"
+      "location": "[location()]",
+      "authorizedTDRUser":"[steps('storageConfig').authorizedTDRUser]"
     }
   }
 }

--- a/src/main/resources/azure/marketplaceTemplate/mainTemplate.json
+++ b/src/main/resources/azure/marketplaceTemplate/mainTemplate.json
@@ -11,6 +11,10 @@
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
+    },
+    "authorizedTDRUser": {
+      "type": "string",
+      "defaultValue": ""
     }
   },
   "variables": {

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -40,4 +40,5 @@
     <include file="changesets/20210426_datasetstoragemigration.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210510_datasetstoragemigrationcorrected.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210517_azurebillinginformation.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20210615_azureappdeploymentinfo.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20210615_azureappdeploymentinfo.yaml
+++ b/src/main/resources/db/changesets/20210615_azureappdeploymentinfo.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: azure_storage
+      author: nm
+      changes:
+        - addColumn:
+            tableName: billing_profile
+            columns:
+              - column:
+                  name: application_deployment_name
+                  type: text

--- a/src/test/java/bio/terra/app/configuration/ConnectedTestConfiguration.java
+++ b/src/test/java/bio/terra/app/configuration/ConnectedTestConfiguration.java
@@ -19,6 +19,7 @@ public class ConnectedTestConfiguration {
     private UUID targetTenantId;
     private UUID targetSubscriptionId;
     private String targetResourceGroupName;
+    private String targetApplicationName;
 
     public String getIngestbucket() {
         return ingestbucket;
@@ -70,6 +71,14 @@ public class ConnectedTestConfiguration {
 
     public UUID getTargetSubscriptionId() {
         return targetSubscriptionId;
+    }
+
+    public void setTargetApplicationName(String targetApplicationName) {
+        this.targetApplicationName = targetApplicationName;
+    }
+
+    public String getTargetApplicationName() {
+        return targetApplicationName;
     }
 
     public void setTargetSubscriptionId(UUID targetSubscriptionId) {

--- a/src/test/java/bio/terra/service/profile/azure/AzureAuthzServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/azure/AzureAuthzServiceTest.java
@@ -1,0 +1,86 @@
+package bio.terra.service.profile.azure;
+
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.resources.models.GenericResource;
+import com.azure.resourcemanager.resources.models.GenericResources;
+import com.google.cloud.resourcemanager.ResourceManagerException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static bio.terra.service.profile.azure.AzureAuthzService.AUTH_TAG_KEY;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+@Category(Unit.class)
+public class AzureAuthzServiceTest {
+
+    private static final String USER_EMAIL = "";
+    private static final UUID SUBSCRIPTION_ID = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    private static final String RESOURCE_GROUP_NAME = "tdr_rg";
+    private static final String APPLICATION_DEPLOYMENT_NAME = "myapp";
+    private static final String RESOURCE_ID = "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups" +
+        "/tdr_rg/providers/Microsoft.Solutions/applications/myapp";
+
+    @Mock
+    private GenericResource genericResource;
+    @Mock
+    private GenericResources genericResources;
+    @Mock
+    private AzureResourceManager resourceManager;
+    @Mock
+    private AzureResourceConfiguration resourceConfiguration;
+
+    private AzureAuthzService azureAuthzService;
+
+    @Before
+    public void setUp() throws Exception {
+        when(genericResource.tags()).thenReturn(Map.of(AUTH_TAG_KEY, USER_EMAIL));
+        when(resourceManager.genericResources()).thenReturn(genericResources);
+        when(resourceConfiguration.getClient(SUBSCRIPTION_ID)).thenReturn(resourceManager);
+        when(genericResources.getById(RESOURCE_ID)).thenReturn(genericResource);
+        azureAuthzService = new AzureAuthzService(resourceConfiguration);
+    }
+
+    @Test
+    public void testValidateHappyPath() {
+        assertThat(azureAuthzService.canAccess(
+            new AuthenticatedUserRequest().email(USER_EMAIL),
+            SUBSCRIPTION_ID,
+            RESOURCE_GROUP_NAME,
+            APPLICATION_DEPLOYMENT_NAME), equalTo(true));
+    }
+
+    @Test
+    public void testValidateUserDoesNotHaveAccess() {
+        assertThat(azureAuthzService.canAccess(
+            new AuthenticatedUserRequest().email("voldemort.admin@test.firecloud.org"),
+            SUBSCRIPTION_ID,
+            RESOURCE_GROUP_NAME,
+            APPLICATION_DEPLOYMENT_NAME), equalTo(false));
+    }
+
+    @Test
+    public void testValidateResourceNotFound() {
+        when(genericResources.getById(RESOURCE_ID))
+            .thenThrow(ResourceManagerException.class);
+
+        assertThat(azureAuthzService.canAccess(
+            new AuthenticatedUserRequest().email(USER_EMAIL),
+            SUBSCRIPTION_ID,
+            RESOURCE_GROUP_NAME,
+            APPLICATION_DEPLOYMENT_NAME), equalTo(false));
+    }
+}

--- a/src/test/java/bio/terra/service/profile/azure/AzureAuthzServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/azure/AzureAuthzServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Map;
 import java.util.UUID;
 
-import static bio.terra.service.profile.azure.AzureAuthzService.AUTH_TAG_KEY;
+import static bio.terra.service.profile.azure.AzureAuthzService.AUTH_PARAM_KEY;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -47,7 +47,9 @@ public class AzureAuthzServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        when(genericResource.tags()).thenReturn(Map.of(AUTH_TAG_KEY, USER_EMAIL));
+        when(genericResource.properties()).thenReturn(Map.of(
+            "parameters", Map.of(AUTH_PARAM_KEY, Map.of(
+                "value", USER_EMAIL))));
         when(resourceManager.genericResources()).thenReturn(genericResources);
         when(resourceConfiguration.getClient(SUBSCRIPTION_ID)).thenReturn(resourceManager);
         when(genericResources.getById(RESOURCE_ID)).thenReturn(genericResource);

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
@@ -27,11 +27,11 @@ import java.util.UUID;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 
 
 @RunWith(SpringRunner.class)
@@ -74,15 +74,17 @@ public class ProfileConnectedTest {
 
     @Test
     public void testAzureBillingProfile() throws Exception {
-        var tenant = UUID.randomUUID().toString();
-        var subscription = UUID.randomUUID().toString();
-        var resourceGroup = "resourceGroupName";
+        var tenant = testConfig.getTargetTenantId();
+        var subscription = testConfig.getTargetSubscriptionId();
+        var resourceGroup = testConfig.getTargetResourceGroupName();
+        var applicationName = testConfig.getTargetApplicationName();
         var requestModel = ProfileFixtures.randomBillingProfileRequest()
             .billingAccountId(testConfig.getGoogleBillingAccountId())
             .cloudPlatform(CloudPlatform.AZURE)
-            .tenantId(tenant)
-            .subscriptionId(subscription)
-            .resourceGroupName(resourceGroup);
+            .tenantId(tenant.toString())
+            .subscriptionId(subscription.toString())
+            .resourceGroupName(resourceGroup)
+            .applicationDeploymentName(applicationName);
 
         var profile = connectedOperations.createProfile(requestModel);
 
@@ -92,10 +94,10 @@ public class ProfileConnectedTest {
             retrievedProfile.getCloudPlatform(),
             equalTo(CloudPlatform.AZURE));
 
-        assertThat("Azure billing profile has tenant, subscription, and resourceGroup",
+        assertThat("Azure billing profile has tenant, subscription, resourceGroup, and applicationName",
             List.of(retrievedProfile.getTenantId(), retrievedProfile.getSubscriptionId(),
-                retrievedProfile.getResourceGroupName()),
-            contains(tenant, subscription, resourceGroup));
+                retrievedProfile.getResourceGroupName(), retrievedProfile.getApplicationDeploymentName()),
+            contains(tenant.toString(), subscription.toString(), resourceGroup, applicationName));
     }
 
     @Test

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
@@ -1,7 +1,9 @@
 package bio.terra.service.resourcemanagement;
 
 
+import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.ValidationUtils;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.ProfileFixtures;
@@ -14,6 +16,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -40,11 +44,13 @@ import static org.junit.Assert.assertThat;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 public class ProfileConnectedTest {
+    private static final Logger logger = LoggerFactory.getLogger(ProfileConnectedTest.class);
 
     @Autowired private ProfileDao profileDao;
     @Autowired private ConnectedOperations connectedOperations;
     @Autowired private ConnectedTestConfiguration testConfig;
     @Autowired private ConfigurationService configService;
+    @Autowired private ApplicationConfiguration applicationConfiguration;
 
     @MockBean
     private IamProviderInterface samService;
@@ -74,6 +80,9 @@ public class ProfileConnectedTest {
 
     @Test
     public void testAzureBillingProfile() throws Exception {
+        if (!ValidationUtils.isValidEmail(applicationConfiguration.getUserEmail())) {
+            logger.info("Skipping test since default user was not set");
+        }
         var tenant = testConfig.getTargetTenantId();
         var subscription = testConfig.getTargetSubscriptionId();
         var resourceGroup = testConfig.getTargetResourceGroupName();

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
@@ -76,11 +76,13 @@ public class ProfileDaoTest {
         var tenant = UUID.randomUUID().toString();
         var subscription = UUID.randomUUID().toString();
         var resourceGroup = "resourceGroupName";
+        var applicationName = "applicationName";
         var azureBillingProfileRequest = ProfileFixtures.randomBillingProfileRequest()
             .cloudPlatform(CloudPlatform.AZURE)
             .tenantId(tenant)
             .subscriptionId(subscription)
-            .resourceGroupName(resourceGroup);
+            .resourceGroupName(resourceGroup)
+            .applicationDeploymentName(applicationName);
         var azureBillingProfile =
             profileDao.createBillingProfile(azureBillingProfileRequest, "me@me.me");
         var azureProfileId = UUID.fromString(azureBillingProfile.getId());
@@ -95,20 +97,22 @@ public class ProfileDaoTest {
             retrievedGoogleBillingProfile.getCloudPlatform(),
             equalTo(CloudPlatform.GCP));
 
-        assertThat("GCP billing profile does not have tenant, subscription, and resourceGroup",
+        assertThat("GCP billing profile does not have tenant, subscription, resourceGroup, or applicationName",
             Arrays.asList(retrievedGoogleBillingProfile.getTenantId(),
                 retrievedGoogleBillingProfile.getSubscriptionId(),
-                retrievedGoogleBillingProfile.getResourceGroupName()),
+                retrievedGoogleBillingProfile.getResourceGroupName(),
+                retrievedGoogleBillingProfile.getApplicationDeploymentName()),
             everyItem(is(emptyOrNullString())));
 
         assertThat("Azure cloud platform is correctly stored",
             retrievedAzureBillingProfile.getCloudPlatform(),
             equalTo(CloudPlatform.AZURE));
 
-        assertThat("Azure billing profile has tenant, subscription, and resourceGroup",
+        assertThat("Azure billing profile has tenant, subscription, resourceGroup, and applicationName",
             List.of(retrievedAzureBillingProfile.getTenantId(), retrievedAzureBillingProfile.getSubscriptionId(),
-                retrievedAzureBillingProfile.getResourceGroupName()),
-            contains(tenant, subscription, resourceGroup));
+                retrievedAzureBillingProfile.getResourceGroupName(),
+                retrievedAzureBillingProfile.getApplicationDeploymentName()),
+            contains(tenant, subscription, resourceGroup, applicationName));
 
     }
 

--- a/src/test/resources/application-connectedtest.properties
+++ b/src/test/resources/application-connectedtest.properties
@@ -6,6 +6,7 @@ ct.googleBillingAccountId=00708C-45D19D-27AAFA
 ct.targetTenantId=efc08443-0082-4d6c-8931-c5794c156abd
 ct.targetResourceGroupName=TDR_connected
 ct.targetSubscriptionId=71d52ec1-5886-480a-9d6e-ed98cbf1f69f
+ct.targetApplicationName=connectedapp
 
 # This second billing account should NOT be used for general testing
 # we do not want to spend funds on this billing account


### PR DESCRIPTION
This PR adds a new field to the billing profile for the application deployment name and makes sure that when creating an Azure billing profile, we verify that the `terra-auth` tag has been set to the email of the authenticated Terra user.