### PR TITLE
DR-1908 Fix broken DRS Lookup

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -12,7 +12,6 @@ import bio.terra.datarepo.model.DeleteResponseModel;
 import bio.terra.datarepo.model.IngestRequestModel;
 import bio.terra.datarepo.model.IngestResponseModel;
 import bio.terra.datarepo.model.JobModel;
-import bio.terra.datarepo.model.PolicyMemberRequest;
 import bio.terra.datarepo.model.SnapshotModel;
 import bio.terra.datarepo.model.SnapshotSummaryModel;
 import com.google.cloud.storage.BlobId;
@@ -156,10 +155,6 @@ public class RetrieveSnapshot extends SimpleDataset {
         DataRepoUtils.expectJobSuccess(
             repositoryApi, createSnapshotJobResponse, SnapshotSummaryModel.class);
 
-    repositoryApi.addSnapshotPolicyMember(
-        snapshotSummaryModel.getId(),
-        "steward",
-        new PolicyMemberRequest().email("nmalfroy.dev@gmail.com"));
     logger.info(
         "Successfully created snapshot: {} with user {} ",
         snapshotSummaryModel.getName(),

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -183,8 +183,10 @@ public class SnapshotsApiController implements SnapshotsApi {
             defaultValue = RETRIEVE_INCLUDE_DEFAULT_VALUE
         ) List<SnapshotRequestAccessIncludeModel> include
     ) {
+        logger.info("Verifying user access");
         iamService.verifyAuthorization(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT,
                 id.toString(), IamAction.READ_DATA);
+        logger.info("Retrieving snapshot");
         SnapshotModel snapshotModel = snapshotService.retrieveAvailableSnapshotModel(id, include);
         return new ResponseEntity<>(snapshotModel, HttpStatus.OK);
     }

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -183,10 +183,10 @@ public class SnapshotsApiController implements SnapshotsApi {
             defaultValue = RETRIEVE_INCLUDE_DEFAULT_VALUE
         ) List<SnapshotRequestAccessIncludeModel> include
     ) {
-        logger.info("Verifying user access");
+        logger.debug("Verifying user access");
         iamService.verifyAuthorization(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT,
                 id.toString(), IamAction.READ_DATA);
-        logger.info("Retrieving snapshot");
+        logger.debug("Retrieving snapshot");
         SnapshotModel snapshotModel = snapshotService.retrieveAvailableSnapshotModel(id, include);
         return new ResponseEntity<>(snapshotModel, HttpStatus.OK);
     }

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -3,6 +3,7 @@ package bio.terra.service.dataset;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.service.filedata.FSContainerInterface;
+import bio.terra.service.filedata.google.firestore.FireStoreProject;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import org.apache.commons.lang3.StringUtils;
 
@@ -175,5 +176,10 @@ public class Dataset implements FSContainerInterface {
     public Dataset projectResource(GoogleProjectResource projectResource) {
         this.projectResource = projectResource;
         return this;
+    }
+
+    @Override
+    public FireStoreProject firestoreConnection() {
+        return FireStoreProject.get(getProjectResource().getGoogleProjectId());
     }
 }

--- a/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
+++ b/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata;
 
+import bio.terra.service.filedata.google.firestore.FireStoreProject;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 
 import java.util.UUID;
@@ -9,4 +10,5 @@ import java.util.UUID;
 public interface FSContainerInterface {
     UUID getId();
     GoogleProjectResource getProjectResource();
+    FireStoreProject firestoreConnection();
 }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -192,7 +192,7 @@ public class FireStoreDao {
                                  int enumerateDepth) throws InterruptedException {
         Firestore fsItemFirestore =
             FireStoreProject.get(container.getProjectResource().getGoogleProjectId()).getFirestore();
-        Firestore metadataFirestore = getMetadataFirestoreConnection(container);
+        Firestore metadataFirestore = container.firestoreConnection().getFirestore();
         String containerId = container.getId().toString();
 
         FireStoreDirectoryEntry fireStoreDirectoryEntry =
@@ -221,7 +221,7 @@ public class FireStoreDao {
                                int enumerateDepth) throws InterruptedException {
         Firestore fsItemFirestore =
             FireStoreProject.get(container.getProjectResource().getGoogleProjectId()).getFirestore();
-        Firestore metadataFirestore = getMetadataFirestoreConnection(container);
+        Firestore metadataFirestore = container.firestoreConnection().getFirestore();
         String datasetId = container.getId().toString();
 
         FireStoreDirectoryEntry fireStoreDirectoryEntry = directoryDao.retrieveById(fsItemFirestore, datasetId, fileId);
@@ -559,21 +559,6 @@ public class FireStoreDao {
             logger.info("Snapshot compute updating batch of {} directory entries", batchSize);
             directoryDao.batchStoreDirectoryEntry(firestore, snapshotId, updateBatch);
             updateBatch.clear();
-        }
-    }
-
-    private Firestore getMetadataFirestoreConnection(FSContainerInterface container) {
-        if (container instanceof Dataset) {
-            return FireStoreProject.get(container.getProjectResource().getGoogleProjectId()).getFirestore();
-        } else if (container instanceof Snapshot) {
-            String datasetProjectId = ((Snapshot) container).getFirstSnapshotSource()
-                .getDataset()
-                .getProjectResource()
-                .getGoogleProjectId();
-            return FireStoreProject.get(datasetProjectId).getFirestore();
-        } else {
-            throw new IllegalArgumentException("Unrecognized FSContainerInterface implementation: " +
-                container.getClass());
         }
     }
 

--- a/src/main/java/bio/terra/service/snapshot/DatasetProject.java
+++ b/src/main/java/bio/terra/service/snapshot/DatasetProject.java
@@ -1,19 +1,18 @@
 package bio.terra.service.snapshot;
 
-import java.util.List;
 import java.util.UUID;
 
-public class SnapshotProject {
+public class DatasetProject {
     private UUID id;
     private String name;
     private UUID profileId;
     private String dataProject; // Project id of the snapshot data project--which is a string and feels like a name
-    private List<DatasetProject> sourceDatasetProjects;
+
     public UUID getId() {
         return id;
     }
 
-    public SnapshotProject id(UUID id) {
+    public DatasetProject id(UUID id) {
         this.id = id;
         return this;
     }
@@ -22,7 +21,7 @@ public class SnapshotProject {
         return name;
     }
 
-    public SnapshotProject name(String name) {
+    public DatasetProject name(String name) {
         this.name = name;
         return this;
     }
@@ -31,7 +30,7 @@ public class SnapshotProject {
         return profileId;
     }
 
-    public SnapshotProject profileId(UUID profileId) {
+    public DatasetProject profileId(UUID profileId) {
         this.profileId = profileId;
         return this;
     }
@@ -40,22 +39,8 @@ public class SnapshotProject {
         return dataProject;
     }
 
-    public SnapshotProject dataProject(String dataProject) {
+    public DatasetProject dataProject(String dataProject) {
         this.dataProject = dataProject;
         return this;
     }
-
-    public List<DatasetProject> getSourceDatasetProjects() {
-        return sourceDatasetProjects;
-    }
-
-    public DatasetProject getFirstSourceDatasetProject() {
-        return sourceDatasetProjects.iterator().next();
-    }
-    public SnapshotProject sourceDatasetProjects(List<DatasetProject> sourceDatasetProjects) {
-        this.sourceDatasetProjects = sourceDatasetProjects;
-        return this;
-    }
-
-
 }

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -3,6 +3,7 @@ package bio.terra.service.snapshot;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.service.filedata.FSContainerInterface;
+import bio.terra.service.filedata.google.firestore.FireStoreProject;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
 
@@ -145,5 +146,14 @@ public class Snapshot implements FSContainerInterface {
         Map<UUID, Column> result = new HashMap<>();
         getTables().forEach(t -> t.getColumns().forEach(c -> result.put(c.getId(), c)));
         return result;
+    }
+
+    @Override
+    public FireStoreProject firestoreConnection() {
+        String datasetProjectId = getFirstSnapshotSource()
+            .getDataset()
+            .getProjectResource()
+            .getGoogleProjectId();
+        return FireStoreProject.get(datasetProjectId);
     }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -255,7 +255,7 @@ public class SnapshotDao {
      */
     @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE, readOnly = true)
     public Snapshot retrieveSnapshot(UUID snapshotId, boolean onlyRetrieveAvailable) {
-        logger.info("retrieve snapshot id: " + snapshotId);
+        logger.debug("retrieve snapshot id: " + snapshotId);
         String sql = "SELECT * FROM snapshot WHERE id = :id";
         if (onlyRetrieveAvailable) { // exclude snapshots that are exclusively locked
             sql += " AND flightid IS NULL";

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -255,7 +255,7 @@ public class SnapshotDao {
      */
     @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE, readOnly = true)
     public Snapshot retrieveSnapshot(UUID snapshotId, boolean onlyRetrieveAvailable) {
-        logger.debug("retrieve snapshot id: " + snapshotId);
+        logger.info("retrieve snapshot id: " + snapshotId);
         String sql = "SELECT * FROM snapshot WHERE id = :id";
         if (onlyRetrieveAvailable) { // exclude snapshots that are exclusively locked
             sql += " AND flightid IS NULL";

--- a/src/main/java/bio/terra/service/snapshot/SnapshotProject.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotProject.java
@@ -9,6 +9,7 @@ public class SnapshotProject {
     private UUID profileId;
     private String dataProject; // Project id of the snapshot data project--which is a string and feels like a name
     private List<DatasetProject> sourceDatasetProjects;
+
     public UUID getId() {
         return id;
     }
@@ -52,6 +53,7 @@ public class SnapshotProject {
     public DatasetProject getFirstSourceDatasetProject() {
         return sourceDatasetProjects.iterator().next();
     }
+
     public SnapshotProject sourceDatasetProjects(List<DatasetProject> sourceDatasetProjects) {
         this.sourceDatasetProjects = sourceDatasetProjects;
         return this;

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -31,6 +31,7 @@ import bio.terra.model.JobModel;
 import bio.terra.model.PolicyMemberRequest;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotRequestModel;
+import bio.terra.model.SnapshotRequestAccessIncludeModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.filedata.DrsResponse;
 import bio.terra.service.iam.IamResourceType;
@@ -367,13 +368,26 @@ public class DataRepoFixtures {
         return snapshotResponse.getResponseObject().get();
     }
 
-    public DataRepoResponse<SnapshotModel> getSnapshotRaw(TestConfiguration.User user, UUID snapshotId)
+    public DataRepoResponse<SnapshotModel> getSnapshotRaw(TestConfiguration.User user,
+                                                          UUID snapshotId,
+                                                          List<SnapshotRequestAccessIncludeModel> include)
         throws Exception {
-        return dataRepoClient.get(user, "/api/repository/v1/snapshots/" + snapshotId, SnapshotModel.class);
+        String includeParam;
+        if  (include != null && !include.isEmpty()) {
+            includeParam =
+                "?" + include.stream().map(i -> "include=" + i.toString()).collect(Collectors.joining("&"));
+        } else {
+            includeParam = "";
+        }
+        return dataRepoClient.get(user,
+            "/api/repository/v1/snapshots/" + snapshotId + includeParam,
+            SnapshotModel.class);
     }
 
-    public SnapshotModel getSnapshot(TestConfiguration.User user, UUID snapshotId) throws Exception {
-        DataRepoResponse<SnapshotModel> response = getSnapshotRaw(user, snapshotId);
+    public SnapshotModel getSnapshot(TestConfiguration.User user,
+                                     UUID snapshotId,
+                                     List<SnapshotRequestAccessIncludeModel> include) throws Exception {
+        DataRepoResponse<SnapshotModel> response = getSnapshotRaw(user, snapshotId, include);
         assertThat("dataset is successfully retrieved", response.getStatusCode(), equalTo(HttpStatus.OK));
         assertTrue("dataset get response is present", response.getResponseObject().isPresent());
         return response.getResponseObject().get();

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -389,7 +389,7 @@ public class DatasetIntegrationTest extends UsersBase {
                 profileId,
                 requestModelAll);
         snapshotIds.add(snapshotSummaryAll.getId());
-        SnapshotModel snapshotAll = dataRepoFixtures.getSnapshot(steward(), snapshotSummaryAll.getId());
+        SnapshotModel snapshotAll = dataRepoFixtures.getSnapshot(steward(), snapshotSummaryAll.getId(), null);
         // The steward is the custodian in this case, so is a reader in big query.
         BigQuery bigQueryAll = BigQueryFixtures.getBigQuery(snapshotAll.getDataProject(), stewardToken);
 
@@ -426,7 +426,7 @@ public class DatasetIntegrationTest extends UsersBase {
                 requestModelLess);
         snapshotIds.add(snapshotSummaryLess.getId());
 
-        SnapshotModel snapshotLess = dataRepoFixtures.getSnapshot(steward(), snapshotSummaryLess.getId());
+        SnapshotModel snapshotLess = dataRepoFixtures.getSnapshot(steward(), snapshotSummaryLess.getId(), null);
         BigQuery bigQueryLess = BigQueryFixtures.getBigQuery(snapshotLess.getDataProject(), stewardToken);
 
         // make sure the old counts stayed the same

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -97,7 +97,7 @@ public class DrsTest extends UsersBase {
         custodianToken = authService.getDirectAccessAuthToken(custodian().getEmail());
         String stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
         EncodeFixture.SetupResult setupResult = encodeFixture.setupEncode(steward(), custodian(), reader());
-        snapshotModel = dataRepoFixtures.getSnapshot(steward(), setupResult.getSummaryModel().getId());
+        snapshotModel = dataRepoFixtures.getSnapshot(steward(), setupResult.getSummaryModel().getId(), null);
         profileId = setupResult.getProfileId();
         datasetId = setupResult.getDatasetId();
         AuthenticatedUserRequest authenticatedStewardRequest =

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -97,7 +97,7 @@ public class DrsTest extends UsersBase {
         custodianToken = authService.getDirectAccessAuthToken(custodian().getEmail());
         String stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
         EncodeFixture.SetupResult setupResult = encodeFixture.setupEncode(steward(), custodian(), reader());
-        snapshotModel = dataRepoFixtures.getSnapshot(custodian(), setupResult.getSummaryModel().getId());
+        snapshotModel = dataRepoFixtures.getSnapshot(steward(), setupResult.getSummaryModel().getId());
         profileId = setupResult.getProfileId();
         datasetId = setupResult.getDatasetId();
         AuthenticatedUserRequest authenticatedStewardRequest =

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -14,6 +14,7 @@ import bio.terra.model.BulkLoadFileResultModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotRequestAccessIncludeModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.filedata.google.gcs.GcsChannelWriter;
 import bio.terra.service.iam.IamResourceType;
@@ -142,7 +143,10 @@ public class EncodeFixture {
         // issues have shown. We make a BigQuery request as the test to see that READER has access.
         // We need to get the snapshot, rather than the snapshot summary in order to make a query.
         // TODO: Add dataProject to SnapshotSummaryModel?
-        SnapshotModel snapshotModel = dataRepoFixtures.getSnapshot(custodian, snapshotSummary.getId());
+        SnapshotModel snapshotModel =
+            dataRepoFixtures.getSnapshot(custodian,
+                snapshotSummary.getId(),
+                List.of(SnapshotRequestAccessIncludeModel.ACCESS_INFORMATION));
         String readerToken = authService.getDirectAccessAuthToken(reader.getEmail());
         BigQuery bigQueryReader = BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), readerToken);
         logger.info("Checking BQ access for snapshot {} in data project {} with BQ dataset named {}",

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -145,8 +145,15 @@ public class EncodeFixture {
         SnapshotModel snapshotModel = dataRepoFixtures.getSnapshot(custodian, snapshotSummary.getId());
         String readerToken = authService.getDirectAccessAuthToken(reader.getEmail());
         BigQuery bigQueryReader = BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), readerToken);
-        BigQueryFixtures.hasAccess(bigQueryReader, snapshotModel.getDataProject(), snapshotModel.getName());
+        logger.info("Checking BQ access for snapshot {} in data project {} with BQ dataset named {}",
+            snapshotModel.getName(),
+            snapshotModel.getAccessInformation().getBigQuery().getProjectId(),
+            snapshotModel.getAccessInformation().getBigQuery().getDatasetName());
+        BigQueryFixtures.hasAccess(bigQueryReader,
+            snapshotModel.getAccessInformation().getBigQuery().getProjectId(),
+            snapshotModel.getAccessInformation().getBigQuery().getDatasetName());
 
+        logger.info("Successfully checked access");
         return new SetupResult(profileId, datasetId, snapshotSummary);
     }
 

--- a/src/test/java/bio/terra/service/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/iam/AccessTest.java
@@ -18,6 +18,7 @@ import bio.terra.model.FileModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestResponseModel;
 import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotRequestAccessIncludeModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.configuration.ConfigEnum;
 import com.google.auth.oauth2.AccessToken;
@@ -170,10 +171,15 @@ public class AccessTest extends UsersBase {
                 profileId,
                 "ingest-test-snapshot.json");
 
-        SnapshotModel snapshotModel = dataRepoFixtures.getSnapshot(custodian(), snapshotSummaryModel.getId());
+        SnapshotModel snapshotModel =
+            dataRepoFixtures.getSnapshot(custodian(),
+                snapshotSummaryModel.getId(),
+                List.of(SnapshotRequestAccessIncludeModel.ACCESS_INFORMATION));
         BigQuery bigQuery = BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), readerToken);
         try {
-            BigQueryFixtures.datasetExists(bigQuery, snapshotModel.getDataProject(), snapshotModel.getName());
+            BigQueryFixtures.datasetExists(bigQuery,
+                snapshotModel.getAccessInformation().getBigQuery().getProjectId(),
+                snapshotModel.getAccessInformation().getBigQuery().getDatasetName());
             fail("reader shouldn't be able to access bq dataset before it is shared with them");
         } catch (IllegalStateException e) {
             assertThat("checking message for exception error",
@@ -244,7 +250,7 @@ public class AccessTest extends UsersBase {
             "file-acl-test-snapshot.json");
         snapshotIds.add(snapshotSummaryModel.getId());
         SnapshotModel snapshotModel = dataRepoFixtures.getSnapshot(custodian(),
-                snapshotSummaryModel.getId());
+                snapshotSummaryModel.getId(), null);
 
         dataRepoFixtures.addSnapshotPolicyMember(
             custodian(),

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
@@ -109,7 +109,7 @@ public class AzureResourceConfigurationTest {
         logger.info("Making sure storage account was deleted");
         // Make sure the storage account is deleted.  Timing affects what errors is thrown so wait until the final state
         // error is thrown.
-        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.waitAtMost(5, TimeUnit.MINUTES).untilAsserted(() -> {
             try {
                 client.storageAccounts().getById(storageAccount.id());
             } catch (ManagementException e) {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -313,6 +313,30 @@ public class SnapshotDaoTest {
             assertTrue("snapshot filter by name and region returns correct snapshot source region",
                     snapshot.getFirstSnapshotSource().getDataset().getDatasetSummary()
                             .datasetStorageContainsRegion(GoogleRegion.DEFAULT_GOOGLE_REGION));
+
+            // Test retrieve SnapshotProject object
+            SnapshotProject snapshotProject = snapshotDao.retrieveSnapshotProject(s.getId(), true);
+            assertThat("snapshot project id matches", snapshotProject.getId(), equalTo(s.getId()));
+            assertThat("snapshot project name matches", snapshotProject.getName(), equalTo(s.getName()));
+            assertThat("snapshot project profile id matches", snapshotProject.getProfileId(),
+                equalTo(snapshot.getProfileId()));
+            assertThat("snapshot project data project name matches", snapshotProject.getDataProject(),
+                equalTo(snapshot.getProjectResource().getGoogleProjectId()));
+            assertThat("snapshot project has a single source dataset",
+                snapshotProject.getSourceDatasetProjects().size(),
+                equalTo(1));
+            assertThat("dataset project id matches",
+                snapshotProject.getFirstSourceDatasetProject().getId(),
+                equalTo(snapshot.getFirstSnapshotSource().getDataset().getId()));
+            assertThat("dataset project name matches",
+                snapshotProject.getFirstSourceDatasetProject().getName(),
+                equalTo(snapshot.getFirstSnapshotSource().getDataset().getName()));
+            assertThat("dataset project profile id matches",
+                snapshotProject.getFirstSourceDatasetProject().getProfileId(),
+                equalTo(snapshot.getFirstSnapshotSource().getDataset().getProjectResource().getProfileId()));
+            assertThat("dataset project data project name matches",
+                snapshotProject.getFirstSourceDatasetProject().getDataProject(),
+                equalTo(snapshot.getFirstSnapshotSource().getDataset().getProjectResource().getGoogleProjectId()));
         }
 
         MetadataEnumeration<SnapshotSummary> summaryEnum = snapshotDao.retrieveSnapshots(0, 2, null,

--- a/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
@@ -148,7 +148,7 @@ public class SnapshotTest extends UsersBase {
             equalTo(HttpStatus.UNAUTHORIZED));
 
         DataRepoResponse<SnapshotModel> getSnapResp = dataRepoFixtures.getSnapshotRaw(
-            discoverer(), snapshotSummary.getId());
+            discoverer(), snapshotSummary.getId(), null);
         assertThat("Discoverer is not authorized to get a dataSnapshot",
             getSnapResp.getStatusCode(),
             equalTo(HttpStatus.UNAUTHORIZED));
@@ -239,7 +239,7 @@ public class SnapshotTest extends UsersBase {
                 requestModel);
         TimeUnit.SECONDS.sleep(10);
         createdSnapshotIds.add(snapshotSummary.getId());
-        SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId());
+        SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
         assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
         assertEquals("new snapshot has the correct number of tables",
             requestModel.getContents().get(0).getRowIdSpec().getTables().size(),
@@ -269,7 +269,7 @@ public class SnapshotTest extends UsersBase {
                 requestModel);
         TimeUnit.SECONDS.sleep(10);
         createdSnapshotIds.add(snapshotSummary.getId());
-        SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId());
+        SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
         assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
     }
 
@@ -288,7 +288,7 @@ public class SnapshotTest extends UsersBase {
                 requestModel);
         TimeUnit.SECONDS.sleep(10);
         createdSnapshotIds.add(snapshotSummary.getId());
-        SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId());
+        SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
         assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
         assertEquals("all 5 relationships come through", snapshot.getRelationships().size(), 5);
     }
@@ -348,7 +348,7 @@ public class SnapshotTest extends UsersBase {
                 profileId,
                 requestModel);
         createdSnapshotIds.add(snapshotSummary.getId());
-        SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId());
+        SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
         assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
         assertEquals("There should be 5 snapshot relationships", snapshot.getRelationships().size(), 5);
 


### PR DESCRIPTION
Fixes bug where Drs lookups fail because they are reading file metadata from the wrong Firestore connection.

Added a check to the testrunner smoke test that would have caught this on nightly alpha and staging smoke tests