### PR TITLE
DR-1899 Create containers on dataset creation

### DIFF
--- a/src/main/java/bio/terra/common/CloudPlatformWrapper.java
+++ b/src/main/java/bio/terra/common/CloudPlatformWrapper.java
@@ -112,7 +112,6 @@ public abstract class CloudPlatformWrapper {
     @Override
     public void ensureValidRegion(String region, Errors errors) {
       ensureValidRegion(CloudPlatform.AZURE, region, AzureRegion.SUPPORTED_REGIONS, errors);
-      ensureValidRegion(CloudPlatform.GCP, region, GoogleRegion.SUPPORTED_REGIONS, errors);
     }
 
     @Override

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -5,6 +5,7 @@ import bio.terra.common.PdaoConstant;
 import bio.terra.common.ValidationUtils;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
+import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSpecificationModel;
@@ -407,8 +408,14 @@ public class DatasetRequestValidator implements Validator {
             "InvalidRegionForPlatform",
             "Cannot set a region when a cloudPlatform is not provided.");
       } else {
-        CloudPlatformWrapper.of(datasetRequest.getCloudPlatform())
-            .ensureValidRegion(datasetRequest.getRegion(), errors);
+        CloudPlatformWrapper cloudWrapper =
+            CloudPlatformWrapper.of(datasetRequest.getCloudPlatform());
+        cloudWrapper.ensureValidRegion(datasetRequest.getRegion(), errors);
+
+        if (cloudWrapper.isAzure()) {
+          CloudPlatformWrapper.of(CloudPlatform.GCP)
+              .ensureValidRegion(datasetRequest.getGcpRegion(), errors);
+        }
       }
     }
   }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
@@ -15,7 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CreateDatasetGetOrCreateContainerStep implements Step {
-  private static Logger logger =
+  private static final Logger logger =
       LoggerFactory.getLogger(CreateDatasetGetOrCreateContainerStep.class);
   private final ResourceService resourceService;
   private final DatasetRequestModel datasetRequestModel;

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
@@ -1,0 +1,59 @@
+package bio.terra.service.dataset.flight.create;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.dataset.DatasetJsonConversion;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CreateDatasetGetOrCreateContainerStep implements Step {
+  private static Logger logger =
+      LoggerFactory.getLogger(CreateDatasetGetOrCreateContainerStep.class);
+  private final ResourceService resourceService;
+  private final DatasetRequestModel datasetRequestModel;
+  private final AzureContainerPdao azureContainerPdao;
+  private final AzureStorageAccountResource.ContainerType containerType;
+
+  public CreateDatasetGetOrCreateContainerStep(
+      ResourceService resourceService,
+      DatasetRequestModel datasetRequestModel,
+      AzureContainerPdao azureContainerPdao,
+      AzureStorageAccountResource.ContainerType containerType) {
+    this.resourceService = resourceService;
+    this.datasetRequestModel = datasetRequestModel;
+    this.azureContainerPdao = azureContainerPdao;
+    this.containerType = containerType;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    logger.info("Creating a {} container for an Azure backed dataset", containerType);
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+
+    AzureStorageAccountResource storageAccount =
+        resourceService.getOrCreateStorageAccount(
+            DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel),
+            profileModel,
+            context.getFlightId());
+
+    azureContainerPdao.getOrCreateContainer(profileModel, storageAccount, containerType);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Leaving artifacts on undo
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -16,6 +16,8 @@ import bio.terra.service.profile.ProfileService;
 import bio.terra.service.profile.flight.AuthorizeBillingProfileUseStep;
 import bio.terra.service.resourcemanagement.AzureDataLocationSelector;
 import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -38,6 +40,7 @@ public class DatasetCreateFlight extends Flight {
     ProfileService profileService = appContext.getBean(ProfileService.class);
     AzureDataLocationSelector azureDataLocationSelector =
         appContext.getBean(AzureDataLocationSelector.class);
+    AzureContainerPdao azureContainerPdao = appContext.getBean(AzureContainerPdao.class);
     DatasetStorageAccountDao datasetStorageAccountDao =
         appContext.getBean(DatasetStorageAccountDao.class);
 
@@ -63,6 +66,16 @@ public class DatasetCreateFlight extends Flight {
       addStep(
           new CreateDatasetGetOrCreateStorageAccountStep(
               resourceService, datasetRequest, azureDataLocationSelector));
+
+      // Create the metadata container
+      addStep(
+          new CreateDatasetGetOrCreateContainerStep(
+              resourceService, datasetRequest, azureContainerPdao, ContainerType.METADATA));
+
+      // Create the data container
+      addStep(
+          new CreateDatasetGetOrCreateContainerStep(
+              resourceService, datasetRequest, azureContainerPdao, ContainerType.DATA));
     }
 
     // Generate the dateset id and stored it in the working map

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureAuthService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureAuthService.java
@@ -1,0 +1,52 @@
+package bio.terra.service.resourcemanagement.azure;
+
+import bio.terra.model.BillingProfileModel;
+import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/** Service class for getting Azure authenticated clients */
+@Component
+public class AzureAuthService {
+
+  private final AzureResourceConfiguration configuration;
+
+  @Autowired
+  public AzureAuthService(AzureResourceConfiguration configuration) {
+    this.configuration = configuration;
+  }
+
+  /**
+   * Return an authenticated DataLake client using key-based authentication
+   *
+   * @param profileModel The object containing user tenant information
+   * @param storageAccountResource The storage account that DataLake client should built from
+   * @return an authenticated DataLake client
+   */
+  public DataLakeServiceClient getDataLakeClient(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
+    AzureResourceManager client =
+        configuration.getClient(UUID.fromString(profileModel.getSubscriptionId()));
+
+    // Obtain a secret key for the associated storage account
+    String key =
+        client
+            .storageAccounts()
+            .getByResourceGroup(
+                storageAccountResource.getApplicationResource().getAzureResourceGroupName(),
+                storageAccountResource.getName())
+            .getKeys()
+            .get(0)
+            .value();
+
+    // Create a data lake client by authenticating using the found key
+    return new DataLakeServiceClientBuilder()
+        .credential(new StorageSharedKeyCredential(storageAccountResource.getName(), key))
+        .endpoint("https://" + storageAccountResource.getName() + ".blob.core.windows.net")
+        .buildClient();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
@@ -1,0 +1,52 @@
+package bio.terra.service.resourcemanagement.azure;
+
+import bio.terra.common.exception.PdaoException;
+import bio.terra.model.BillingProfileModel;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AzureContainerPdao {
+
+  private final AzureAuthService authService;
+
+  @Autowired
+  public AzureContainerPdao(AzureAuthService authService) {
+    this.authService = authService;
+  }
+
+  /**
+   * Get or create a container (also known as FileSystem) in an Azure storage account
+   *
+   * @param profileModel The profile that describes information needed to access the storage account
+   * @param storageAccountResource Metadata describing the storage account that contains the
+   *     container
+   * @param containerType The nature of the container
+   * @return A client connection object that can be used to create folders and files
+   */
+  public DataLakeFileSystemClient getOrCreateContainer(
+      BillingProfileModel profileModel,
+      AzureStorageAccountResource storageAccountResource,
+      AzureStorageAccountResource.ContainerType containerType) {
+    DataLakeServiceClient dataLakeClient =
+        authService.getDataLakeClient(profileModel, storageAccountResource);
+
+    try {
+      DataLakeFileSystemClient fileSystemClient =
+          dataLakeClient.getFileSystemClient(
+              storageAccountResource.determineContainer(containerType));
+      // This will 404 if the container doesn't exist
+      fileSystemClient.getProperties();
+      return fileSystemClient;
+    } catch (DataLakeStorageException e) {
+      if (e.getStatusCode() == 404) {
+        return dataLakeClient.createFileSystem(
+            storageAccountResource.determineContainer(containerType));
+      }
+      throw new PdaoException("Could not create a Storage account container");
+    }
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
@@ -6,6 +6,7 @@ import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
 import com.azure.storage.file.datalake.models.DataLakeStorageException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -42,7 +43,7 @@ public class AzureContainerPdao {
       fileSystemClient.getProperties();
       return fileSystemClient;
     } catch (DataLakeStorageException e) {
-      if (e.getStatusCode() == 404) {
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND.value()) {
         return dataLakeClient.createFileSystem(
             storageAccountResource.determineContainer(containerType));
       }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
@@ -101,14 +101,7 @@ public class AzureStorageAccountResource {
   }
 
   public String determineContainer(ContainerType containerType) {
-    switch (containerType) {
-      case DATA:
-        return getDataContainer();
-      case METADATA:
-        return getMetadataContainer();
-      default:
-        throw new IllegalArgumentException("Invalid container type");
-    }
+    return containerType.getContainer(this);
   }
 
   @Override
@@ -161,7 +154,17 @@ public class AzureStorageAccountResource {
   }
 
   public enum ContainerType {
-    DATA,
-    METADATA
+    DATA() {
+      String getContainer(AzureStorageAccountResource account) {
+        return account.getDataContainer();
+      }
+    },
+    METADATA() {
+      String getContainer(AzureStorageAccountResource account) {
+        return account.getMetadataContainer();
+      }
+    };
+
+    abstract String getContainer(AzureStorageAccountResource account);
   }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
@@ -100,6 +100,17 @@ public class AzureStorageAccountResource {
     return this;
   }
 
+  public String determineContainer(ContainerType containerType) {
+    switch (containerType) {
+      case DATA:
+        return getDataContainer();
+      case METADATA:
+        return getMetadataContainer();
+      default:
+        throw new IllegalArgumentException("Invalid container type");
+    }
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -147,5 +158,10 @@ public class AzureStorageAccountResource {
         .append("dbName", dbName)
         .append("region", region)
         .toString();
+  }
+
+  public enum ContainerType {
+    DATA,
+    METADATA
   }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -136,7 +136,7 @@ public class AzureStorageAccountService {
       AzureRegion region,
       String flightId)
       throws InterruptedException {
-
+    logger.info("Creating storage account {}", storageAccountName);
     // Try to get the storage account record and the storage account object
     BillingProfileModel profileModel =
         profileDao.getBillingProfileById(applicationResource.getProfileId());

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
@@ -1,0 +1,99 @@
+package bio.terra.service.resourcemanagement.azure;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.exception.PdaoException;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.FileSystemProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@RunWith(MockitoJUnitRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class AzureContainerPdaoTest {
+
+  @Mock private AzureAuthService authService;
+  @Mock private DataLakeServiceClient dataLakeServiceClient;
+  private AzureStorageAccountResource storageAccountResource;
+  private BillingProfileModel billingProfile;
+  private AzureContainerPdao dao;
+
+  @Before
+  public void setUp() throws Exception {
+    when(authService.getDataLakeClient(any(), any())).thenReturn(dataLakeServiceClient);
+
+    billingProfile = new BillingProfileModel();
+    storageAccountResource =
+        new AzureStorageAccountResource()
+            .name("mystorageaccount")
+            .metadataContainer("md")
+            .dataContainer("d");
+
+    dao = new AzureContainerPdao(authService);
+  }
+
+  @Test
+  public void testGetContainer() {
+    DataLakeFileSystemClient dataLakeFileSystemClient = mock(DataLakeFileSystemClient.class);
+    FileSystemProperties properties = mock(FileSystemProperties.class);
+    when(properties.getETag()).thenReturn("TAG");
+    when(dataLakeFileSystemClient.getProperties()).thenReturn(properties);
+    when(dataLakeServiceClient.getFileSystemClient("d")).thenReturn(dataLakeFileSystemClient);
+
+    DataLakeFileSystemClient returnedClient =
+        dao.getOrCreateContainer(billingProfile, storageAccountResource, ContainerType.DATA);
+
+    assertThat(returnedClient.getProperties().getETag(), equalTo("TAG"));
+    verify(dataLakeServiceClient, times(0)).createFileSystem(any());
+  }
+
+  @Test
+  public void testCreateContainer() {
+    DataLakeFileSystemClient dataLakeFileSystemClient = mock(DataLakeFileSystemClient.class);
+    DataLakeStorageException exception = mock(DataLakeStorageException.class);
+    when(exception.getStatusCode()).thenReturn(404);
+    when(dataLakeFileSystemClient.getProperties()).thenThrow(exception);
+    when(dataLakeServiceClient.getFileSystemClient("d")).thenReturn(dataLakeFileSystemClient);
+
+    dao.getOrCreateContainer(billingProfile, storageAccountResource, ContainerType.DATA);
+
+    verify(dataLakeServiceClient, times(1)).createFileSystem(eq("d"));
+  }
+
+  @Test
+  public void testGetOrCreateContainerNoPermissions() {
+    DataLakeFileSystemClient dataLakeFileSystemClient = mock(DataLakeFileSystemClient.class);
+    DataLakeStorageException exception = mock(DataLakeStorageException.class);
+    when(exception.getStatusCode()).thenReturn(403);
+    when(dataLakeFileSystemClient.getProperties()).thenThrow(exception);
+    when(dataLakeServiceClient.getFileSystemClient("md")).thenReturn(dataLakeFileSystemClient);
+
+    assertThrows(
+        PdaoException.class,
+        () ->
+            dao.getOrCreateContainer(
+                billingProfile, storageAccountResource, ContainerType.METADATA),
+        "Invalid failure causes real error");
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
@@ -24,12 +24,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 
 @RunWith(MockitoJUnitRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
 @Category(Unit.class)
 public class AzureContainerPdaoTest {
 
@@ -72,7 +69,7 @@ public class AzureContainerPdaoTest {
   public void testCreateContainer() {
     DataLakeFileSystemClient dataLakeFileSystemClient = mock(DataLakeFileSystemClient.class);
     DataLakeStorageException exception = mock(DataLakeStorageException.class);
-    when(exception.getStatusCode()).thenReturn(404);
+    when(exception.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND.value());
     when(dataLakeFileSystemClient.getProperties()).thenThrow(exception);
     when(dataLakeServiceClient.getFileSystemClient("d")).thenReturn(dataLakeFileSystemClient);
 
@@ -85,7 +82,7 @@ public class AzureContainerPdaoTest {
   public void testGetOrCreateContainerNoPermissions() {
     DataLakeFileSystemClient dataLakeFileSystemClient = mock(DataLakeFileSystemClient.class);
     DataLakeStorageException exception = mock(DataLakeStorageException.class);
-    when(exception.getStatusCode()).thenReturn(403);
+    when(exception.getStatusCode()).thenReturn(HttpStatus.FORBIDDEN.value());
     when(dataLakeFileSystemClient.getProperties()).thenThrow(exception);
     when(dataLakeServiceClient.getFileSystemClient("md")).thenReturn(dataLakeFileSystemClient);
 


### PR DESCRIPTION
Fairly simple PR that creates containers (AKA filesystems in Azure) as part of dataset creation. 

Of note:
this creates a service method for creating clients. As a followon, I'll move the existing methods in `AzureResourceConfiguration` into here but I don't want to blow up existing PRs