### PR TITLE
DR-1946 Fix spotless discrepancies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -501,5 +501,5 @@ compileGeneratedJava.dependsOn swaggerSources.server.code
 compileGeneratedJava.dependsOn generateGrammarSource
 classes.dependsOn generatedClasses
 compileJava.dependsOn compileGeneratedJava
-compileJava.dependsOn spotlessApply
+compileJava.dependsOn spotlessCheck
 ideaModule.dependsOn swaggerSources.server.code

--- a/build.gradle
+++ b/build.gradle
@@ -427,6 +427,7 @@ spotless {
         target project.fileTree(project.rootDir) {
             include '**/*.java'
             exclude 'build/**/*.*'
+            exclude '**/generated/**/*.*'
         }
         googleJavaFormat()
     }

--- a/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
+++ b/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
@@ -17,38 +17,25 @@ public class StairwayLoggingHooks implements StairwayHook {
   private static final String StepLogFormat =
       "Operation: {}, flightClass: {}, flightId: {}, stepClass: {}, "
           + "stepIndex: {}, direction: {}, timestamp: {}";
-  /**
-   * Id of the flight
-   */
+  /** Id of the flight */
   private static final String FLIGHT_ID_KEY = "flightId";
-  /**
-   * Class of the flight
-   */
+  /** Class of the flight */
   private static final String FLIGHT_CLASS_KEY = "flightClass";
-  /**
-   * Class of the flight step
-   */
+  /** Class of the flight step */
   private static final String FLIGHT_STEP_CLASS_KEY = "flightStepClass";
-  /**
-   * Direction of the step (START, DO, UNDO or SWITCH)
-   */
+  /** Direction of the step (START, DO, UNDO or SWITCH) */
   private static final String FLIGHT_STEP_DIRECTION_KEY = "flightStepDirection";
-  /**
-   * The step's execution order
-   */
+  /** The step's execution order */
   private static final String FLIGHT_STEP_NUMBER_KEY = "flightStepNumber";
-  /**
-   * The type of operation primarily being logged (startFlight, startStep, endStep or endFlight)
-   */
+  /** The type of operation primarily being logged (startFlight, startStep, endStep or endFlight) */
   private static final String FLIGHT_OPERATION_KEY = "flightStepOperation";
-
 
   private static final String FLIGHT_OPERATION_START = "startFlight";
   private static final String FLIGHT_OPERATION_END = "endFlight";
   private static final String FLIGHT_STEP_OPERATION_START = "startStep";
   private static final String FLIGHT_STEP_OPERATION_END = "endStep";
 
-    private static final Logger logger = LoggerFactory.getLogger(StairwayHook.class);
+  private static final Logger logger = LoggerFactory.getLogger(StairwayHook.class);
 
   private final PerformanceLogger performanceLogger;
 
@@ -60,25 +47,30 @@ public class StairwayLoggingHooks implements StairwayHook {
   @Override
   public HookAction startFlight(FlightContext context) {
     MDC.put(FLIGHT_ID_KEY, context.getFlightId());
-        MDC.put(FLIGHT_CLASS_KEY, context.getFlightClassName());
-        MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_OPERATION_START);
-        logger.info(FlightLogFormat, FLIGHT_OPERATION_START,
+    MDC.put(FLIGHT_CLASS_KEY, context.getFlightClassName());
+    MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_OPERATION_START);
+    logger.info(
+        FlightLogFormat,
+        FLIGHT_OPERATION_START,
         context.getFlightClassName(),
         context.getFlightId(),
         Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
-    performanceLogger.log(context.getFlightId(), context.getFlightClassName(), FLIGHT_OPERATION_START);
+    performanceLogger.log(
+        context.getFlightId(), context.getFlightClassName(), FLIGHT_OPERATION_START);
     return HookAction.CONTINUE;
   }
 
   @Override
   public HookAction startStep(FlightContext context) {
     MDC.put(FLIGHT_ID_KEY, context.getFlightId());
-        MDC.put(FLIGHT_CLASS_KEY, context.getFlightClassName());
-        MDC.put(FLIGHT_STEP_CLASS_KEY, context.getStepClassName());
-        MDC.put(FLIGHT_STEP_DIRECTION_KEY, context.getDirection().toString());
-        MDC.put(FLIGHT_STEP_NUMBER_KEY, Integer.toString(context.getStepIndex()));
-        MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_STEP_OPERATION_START);
-        logger.info(StepLogFormat, FLIGHT_STEP_OPERATION_START,
+    MDC.put(FLIGHT_CLASS_KEY, context.getFlightClassName());
+    MDC.put(FLIGHT_STEP_CLASS_KEY, context.getStepClassName());
+    MDC.put(FLIGHT_STEP_DIRECTION_KEY, context.getDirection().toString());
+    MDC.put(FLIGHT_STEP_NUMBER_KEY, Integer.toString(context.getStepIndex()));
+    MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_STEP_OPERATION_START);
+    logger.info(
+        StepLogFormat,
+        FLIGHT_STEP_OPERATION_START,
         context.getFlightClassName(),
         context.getFlightId(),
         context.getStepClassName(),
@@ -92,19 +84,24 @@ public class StairwayLoggingHooks implements StairwayHook {
   @Override
   public HookAction endFlight(FlightContext context) {
     MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_OPERATION_END);
-        logger.info(FlightLogFormat, FLIGHT_OPERATION_END,
+    logger.info(
+        FlightLogFormat,
+        FLIGHT_OPERATION_END,
         context.getFlightClassName(),
         context.getFlightId(),
         Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
-    performanceLogger.log(context.getFlightId(), context.getFlightClassName(), FLIGHT_OPERATION_END);
-        clearMdcKeys();
+    performanceLogger.log(
+        context.getFlightId(), context.getFlightClassName(), FLIGHT_OPERATION_END);
+    clearMdcKeys();
     return HookAction.CONTINUE;
   }
 
   @Override
   public HookAction endStep(FlightContext context) {
     MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_STEP_OPERATION_END);
-        logger.info(StepLogFormat, FLIGHT_STEP_OPERATION_END,
+    logger.info(
+        StepLogFormat,
+        FLIGHT_STEP_OPERATION_END,
         context.getFlightClassName(),
         context.getFlightId(),
         context.getStepClassName(),
@@ -118,19 +115,19 @@ public class StairwayLoggingHooks implements StairwayHook {
         FLIGHT_STEP_OPERATION_END,
         context.getStepIndex());
     clearMdcKeys();
-        return HookAction.CONTINUE;
-    }
+    return HookAction.CONTINUE;
+  }
 
-    private void clearMdcKeys() {
-        MDC.remove(FLIGHT_ID_KEY);
-        MDC.remove(FLIGHT_CLASS_KEY);
-        MDC.remove(FLIGHT_STEP_CLASS_KEY);
-        MDC.remove(FLIGHT_STEP_DIRECTION_KEY);
-        MDC.remove(FLIGHT_STEP_NUMBER_KEY);
-        MDC.remove(FLIGHT_OPERATION_KEY);
-    }
+  private void clearMdcKeys() {
+    MDC.remove(FLIGHT_ID_KEY);
+    MDC.remove(FLIGHT_CLASS_KEY);
+    MDC.remove(FLIGHT_STEP_CLASS_KEY);
+    MDC.remove(FLIGHT_STEP_DIRECTION_KEY);
+    MDC.remove(FLIGHT_STEP_NUMBER_KEY);
+    MDC.remove(FLIGHT_OPERATION_KEY);
+  }
 
-    private String getStepTimerName(final String flightId) {
-        return String.format("stairwayStep%s", flightId);
-    }
+  private String getStepTimerName(final String flightId) {
+    return String.format("stairwayStep%s", flightId);
+  }
 }


### PR DESCRIPTION
I noticed this after merging my changes.  It's not great that we can check in code that doesn't meet the google code standard.  So, this PR also makes sure that spotless check fails if the code doesn't match the Google code style.  It's then up to the developer to then run `./gradlew spotlessApply`