### PR TITLE
[DR-1851] Azure Blob copier and BlobCrl

### DIFF
--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -73,9 +73,9 @@ public class BlobContainerClientFactory {
     blobContainerSasTokenCreds = null;
   }
 
-  public BlobContainerClientFactory(String containerURLWithSASToken) {
+  public BlobContainerClientFactory(String containerURLWithSasToken) {
 
-    BlobUrlParts blobUrl = BlobUrlParts.parse(containerURLWithSASToken);
+    BlobUrlParts blobUrl = BlobUrlParts.parse(containerURLWithSasToken);
 
     blobContainerSasTokenCreds =
         new AzureSasCredential(blobUrl.getCommonSasQueryParameters().encode());

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -3,7 +3,12 @@ package bio.terra.service.filedata.azure.util;
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.HttpClient;
-import com.azure.storage.blob.*;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.BlobUrlParts;
 import com.azure.storage.blob.models.UserDelegationKey;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
@@ -13,7 +18,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Locale;
 import java.util.Objects;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A class that wraps the SDK container client and facilities the creation of SAS Urls for blobs by

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 public class BlobContainerClientFactory {
 
   public static final int EXPIRATION_DAYS = 7;
-  private static final HttpClient httpClient = HttpClient.createDefault();
+  private final HttpClient httpClient = HttpClient.createDefault();
 
   private final BlobContainerClient blobContainerClient;
 

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -1,0 +1,188 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.core.credential.AzureSasCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpClient;
+import com.azure.storage.blob.*;
+import com.azure.storage.blob.models.UserDelegationKey;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.common.sas.SasProtocol;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import java.util.Objects;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * A class that wraps the SDK container client and facilities the creation of SAS Urls for blobs by
+ * abstracting the different strategies that depend on the authentication mechanism.
+ */
+public class BlobContainerClientFactory {
+
+  public static final int EXPIRATION_DAYS = 7;
+  private static final HttpClient httpClient = HttpClient.createDefault();
+
+  private final BlobContainerClient blobContainerClient;
+
+  private final SasTokenGeneratorStrategy sasTokenGeneratorStrategy;
+  private final AzureSasCredential blobContainerSASTokenCreds;
+  private BlobServiceClient blobServiceClient;
+  private UserDelegationKey delegationKey;
+
+  public BlobContainerClientFactory(String accountName, String accountKey, String containerName) {
+
+    if (StringUtils.isBlank(accountName)) {
+      throw new IllegalArgumentException("The account name is either null or empty.");
+    }
+
+    if (StringUtils.isBlank(accountKey)) {
+      throw new IllegalArgumentException("The account key is either null or empty.");
+    }
+
+    if (StringUtils.isBlank(containerName)) {
+      throw new IllegalArgumentException("The container name is either null or empty.");
+    }
+
+    this.blobContainerClient =
+        createBlobServiceClientUsingSharedKey(accountName, accountKey)
+            .getBlobContainerClient(containerName);
+    this.sasTokenGeneratorStrategy = SasTokenGeneratorStrategy.SharedKey;
+    this.blobContainerSASTokenCreds = null;
+  }
+
+  public BlobContainerClientFactory(
+      String accountName, TokenCredential azureCredential, String containerName) {
+
+    if (StringUtils.isBlank(accountName)) {
+      throw new IllegalArgumentException("The account name is either null or empty.");
+    }
+
+    if (StringUtils.isBlank(containerName)) {
+      throw new IllegalArgumentException("The container name is either null or empty.");
+    }
+
+    this.blobServiceClient =
+        createBlobServiceClientUsingTokenCredentials(
+            accountName,
+            Objects.requireNonNull(azureCredential, "Azure token credentials are null."));
+    this.blobContainerClient = this.blobServiceClient.getBlobContainerClient(containerName);
+
+    this.sasTokenGeneratorStrategy = SasTokenGeneratorStrategy.UserDelegatedKey;
+    this.blobContainerSASTokenCreds = null;
+  }
+
+  public BlobContainerClientFactory(String containerURLWithSASToken) {
+
+    BlobUrlParts blobUrl = BlobUrlParts.parse(containerURLWithSASToken);
+
+    this.blobContainerSASTokenCreds =
+        new AzureSasCredential(blobUrl.getCommonSasQueryParameters().encode());
+    this.blobContainerClient =
+        new BlobContainerClientBuilder()
+            .httpClient(httpClient)
+            .endpoint(
+                String.format(
+                    Locale.ROOT,
+                    "https://%s/%s",
+                    blobUrl.getHost(),
+                    blobUrl.getBlobContainerName()))
+            .credential(this.blobContainerSASTokenCreds)
+            .buildClient();
+
+    this.sasTokenGeneratorStrategy = SasTokenGeneratorStrategy.ContainerSasToken;
+  }
+
+  public BlobContainerClient getBlobContainerClient() {
+    return this.blobContainerClient;
+  }
+
+  public String createReadOnlySASUrlForBlob(String blobName) {
+    if (this.sasTokenGeneratorStrategy.equals(SasTokenGeneratorStrategy.SharedKey)) {
+      return createReadOnlySasUrlForBlobUsingClient(blobName);
+    }
+
+    if (this.sasTokenGeneratorStrategy.equals(SasTokenGeneratorStrategy.ContainerSasToken)) {
+      return createReadOnlySasUrlForBlobUsingContainerSAS(blobName);
+    }
+
+    if (this.sasTokenGeneratorStrategy.equals(SasTokenGeneratorStrategy.UserDelegatedKey)) {
+      return createReadOnlySasUrlForBlobUsingUserDelegatedSas(blobName);
+    }
+
+    throw new RuntimeException("Failed to generate SAS token for blob. Invalid strategy set.");
+  }
+
+  private synchronized String createReadOnlySasUrlForBlobUsingUserDelegatedSas(String blobName) {
+
+    if (this.delegationKey == null
+        || this.delegationKey.getSignedExpiry().isBefore(OffsetDateTime.now(ZoneOffset.UTC))) {
+      OffsetDateTime keyExpiry = OffsetDateTime.now(ZoneOffset.UTC).plusDays(EXPIRATION_DAYS);
+      this.delegationKey = this.blobServiceClient.getUserDelegationKey(null, keyExpiry);
+    }
+
+    BlobServiceSasSignatureValues sasSignatureValues = createSasSignatureValues();
+
+    BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
+    String sasToken = blobClient.generateUserDelegationSas(sasSignatureValues, this.delegationKey);
+
+    return String.format(
+        "%s/%s?%s", blobContainerClient.getBlobContainerUrl(), blobClient.getBlobName(), sasToken);
+  }
+
+  private String createReadOnlySasUrlForBlobUsingContainerSAS(String blobName) {
+    return String.format(
+        "%s/%s?%s",
+        this.blobContainerClient.getBlobContainerUrl(),
+        blobName,
+        this.blobContainerSASTokenCreds.getSignature());
+  }
+
+  private String createReadOnlySasUrlForBlobUsingClient(String blobName) {
+
+    BlobServiceSasSignatureValues sasSignatureValues = createSasSignatureValues();
+
+    BlobClient blobClient = this.blobContainerClient.getBlobClient(blobName);
+    String sasToken = blobClient.generateSas(sasSignatureValues);
+
+    return String.format(
+        "%s/%s?%s",
+        this.blobContainerClient.getBlobContainerUrl(), blobClient.getBlobName(), sasToken);
+  }
+
+  private BlobServiceSasSignatureValues createSasSignatureValues() {
+
+    BlobSasPermission permissions = new BlobSasPermission().setReadPermission(true);
+
+    OffsetDateTime expiryTime = OffsetDateTime.now().plusDays(1);
+    SasProtocol sasProtocol = SasProtocol.HTTPS_ONLY;
+
+    // build the token
+    return new BlobServiceSasSignatureValues(expiryTime, permissions).setProtocol(sasProtocol);
+  }
+
+  private BlobServiceClient createBlobServiceClientUsingSharedKey(
+      String accountName, String accountKey) {
+    return new BlobServiceClientBuilder()
+        .credential(new StorageSharedKeyCredential(accountName, accountKey))
+        .httpClient(httpClient)
+        .endpoint(String.format(Locale.ROOT, "https://%s.blob.core.windows.net", accountName))
+        .buildClient();
+  }
+
+  private BlobServiceClient createBlobServiceClientUsingTokenCredentials(
+      String accountName, TokenCredential credentials) {
+    return new BlobServiceClientBuilder()
+        .credential(credentials)
+        .httpClient(httpClient)
+        .endpoint(String.format(Locale.ROOT, "https://%s.blob.core.windows.net", accountName))
+        .buildClient();
+  }
+
+  public enum SasTokenGeneratorStrategy {
+    SharedKey,
+    ContainerSasToken,
+    UserDelegatedKey
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -27,7 +27,7 @@ public class BlobContainerClientFactory {
   private final BlobContainerClient blobContainerClient;
 
   private final SasTokenGeneratorStrategy sasTokenGeneratorStrategy;
-  private final AzureSasCredential blobContainerSASTokenCreds;
+  private final AzureSasCredential blobContainerSasTokenCreds;
   private BlobServiceClient blobServiceClient;
   private UserDelegationKey delegationKey;
 
@@ -49,7 +49,7 @@ public class BlobContainerClientFactory {
         createBlobServiceClientUsingSharedKey(accountName, accountKey)
             .getBlobContainerClient(containerName);
     sasTokenGeneratorStrategy = SasTokenGeneratorStrategy.SharedKey;
-    blobContainerSASTokenCreds = null;
+    blobContainerSasTokenCreds = null;
   }
 
   public BlobContainerClientFactory(
@@ -70,14 +70,14 @@ public class BlobContainerClientFactory {
     blobContainerClient = blobServiceClient.getBlobContainerClient(containerName);
 
     sasTokenGeneratorStrategy = SasTokenGeneratorStrategy.UserDelegatedKey;
-    blobContainerSASTokenCreds = null;
+    blobContainerSasTokenCreds = null;
   }
 
   public BlobContainerClientFactory(String containerURLWithSASToken) {
 
     BlobUrlParts blobUrl = BlobUrlParts.parse(containerURLWithSASToken);
 
-    blobContainerSASTokenCreds =
+    blobContainerSasTokenCreds =
         new AzureSasCredential(blobUrl.getCommonSasQueryParameters().encode());
     blobContainerClient =
         new BlobContainerClientBuilder()
@@ -88,7 +88,7 @@ public class BlobContainerClientFactory {
                     "https://%s/%s",
                     blobUrl.getHost(),
                     blobUrl.getBlobContainerName()))
-            .credential(this.blobContainerSASTokenCreds)
+            .credential(blobContainerSasTokenCreds)
             .buildClient();
 
     sasTokenGeneratorStrategy = SasTokenGeneratorStrategy.ContainerSasToken;
@@ -136,7 +136,7 @@ public class BlobContainerClientFactory {
         "%s/%s?%s",
         blobContainerClient.getBlobContainerUrl(),
         blobName,
-        blobContainerSASTokenCreds.getSignature());
+        blobContainerSasTokenCreds.getSignature());
   }
 
   private String createReadOnlySasUrlForBlobUsingClient(String blobName) {

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopier.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopier.java
@@ -1,0 +1,229 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobUrlParts;
+import com.azure.storage.blob.models.BlobCopyInfo;
+import com.azure.storage.blob.models.BlobListDetails;
+import com.azure.storage.blob.models.ListBlobsOptions;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BlobContainerCopier {
+
+  private static final int MIN_LIST_OPERATION_TIMEOUT_IN_SECONDS = 10;
+  private static final int MIN_POLLING_INTERVAL_IN_SECONDS = 2;
+  private static final Logger logger = LoggerFactory.getLogger(BlobContainerCopier.class);
+  private final BlobContainerClientFactory destinationClientFactory;
+
+  private String blobSourcePrefix = "";
+
+  private BlobContainerClientFactory sourceClientFactory;
+  private String sourceBlobUrl;
+  private String destinationBlobName;
+  private Duration listOperationTimeout = Duration.ofSeconds(MIN_LIST_OPERATION_TIMEOUT_IN_SECONDS);
+  private Duration pollingInterval = Duration.ofSeconds(MIN_POLLING_INTERVAL_IN_SECONDS);
+
+  private List<BlobCopySourceDestinationPair> sourceDestinationPairs;
+
+  public BlobContainerCopier(BlobContainerClientFactory destinationClientFactory) {
+    this.destinationClientFactory =
+        Objects.requireNonNull(
+            destinationClientFactory, "Destination client factory is required and can't be null");
+  }
+
+  /**
+   * Begins an asynchronous copy operation between storage accounts. The backend storage service
+   * performs the copy operation. The method returns an instance of the {@link
+   * BlobContainerCopySyncPoller} which facilitates the management and getting the status of the
+   * copy operation.
+   *
+   * @return an instance of {@link BlobContainerCopySyncPoller} that is associated with the copy
+   *     operation.
+   */
+  public BlobContainerCopySyncPoller beginCopyOperation() {
+
+    if (this.sourceClientFactory != null) {
+      logger.info("Starting copy operation using a container as a source");
+      return beginCopyOperationUsingSourceBlobContainerClient();
+    }
+
+    if (StringUtils.isNotBlank(this.sourceBlobUrl)) {
+      logger.info("Starting copy operation using a signed blob URL as the source");
+      return beginCopyOperationUsingBlobSignedUrl();
+    }
+
+    throw new IllegalArgumentException(
+        "The copy operation can't be started. " + "The source information is missing or invalid");
+  }
+
+  public void setDestinationBlobName(String destinationBlobName) {
+    this.destinationBlobName = destinationBlobName;
+  }
+
+  public void setSourceDestinationPairs(
+      List<BlobCopySourceDestinationPair> sourceDestinationPairs) {
+    this.sourceDestinationPairs = sourceDestinationPairs;
+  }
+
+  public void setSourceBlobUrl(String sourceBlobUrl) {
+    this.sourceBlobUrl = sourceBlobUrl;
+  }
+
+  public void setBlobSourcePrefix(String blobSourcePrefix) {
+    this.blobSourcePrefix =
+        Objects.requireNonNull(blobSourcePrefix, "Blob source prefix must not be null");
+  }
+
+  public void setListOperationTimeout(Duration listOperationTimeout) {
+    this.listOperationTimeout = listOperationTimeout;
+  }
+
+  public void setPollingInterval(Duration pollingInterval) {
+    this.pollingInterval = pollingInterval;
+  }
+
+  public void setSourceClientFactory(BlobContainerClientFactory sourceClientFactory) {
+    this.sourceClientFactory = sourceClientFactory;
+  }
+
+  public BlobContainerClientFactory getDestinationClientFactory() {
+    return destinationClientFactory;
+  }
+
+  public String getBlobSourcePrefix() {
+    return blobSourcePrefix;
+  }
+
+  public BlobContainerClientFactory getSourceClientFactory() {
+    return sourceClientFactory;
+  }
+
+  public String getSourceBlobUrl() {
+    return sourceBlobUrl;
+  }
+
+  public String getDestinationBlobName() {
+    return destinationBlobName;
+  }
+
+  public List<BlobCopySourceDestinationPair> getSourceDestinationPairs() {
+    return sourceDestinationPairs;
+  }
+
+  private BlobContainerCopySyncPoller beginCopyOperationUsingBlobSignedUrl() {
+    BlobUrlParts blobUrlParts = BlobUrlParts.parse(this.sourceBlobUrl);
+
+    String sourceBlobName = blobUrlParts.getBlobName();
+    String destinationBlobName = this.destinationBlobName;
+    if (StringUtils.isBlank(this.destinationBlobName)) {
+      destinationBlobName = sourceBlobName;
+    }
+
+    return new BlobContainerCopySyncPoller(
+        Collections.singletonList(
+            beginBlobCopyFromSASUrl(sourceBlobName, this.sourceBlobUrl, destinationBlobName)));
+  }
+
+  private BlobContainerCopySyncPoller beginCopyOperationUsingSourceBlobContainerClient() {
+    if (this.sourceDestinationPairs != null) {
+      logger.info("Copy operation using source and destination pairs.");
+      return beginCopyOperationUsingDestinationPairs(this.sourceDestinationPairs);
+    }
+
+    return new BlobContainerCopySyncPoller(
+        beginCopyOperationFromListOfSources(this.blobSourcePrefix));
+  }
+
+  private BlobContainerCopySyncPoller beginCopyOperationUsingDestinationPairs(
+      List<BlobCopySourceDestinationPair> sourceDestinationPairs) {
+
+    List<BlobCopySourceDestinationPair> pairs =
+        Objects.requireNonNull(sourceDestinationPairs, "sourceDestinationInfos must not be null");
+
+    if (pairs.isEmpty()) {
+      throw new RuntimeException("The source and destination pair list is empty.");
+    }
+
+    return new BlobContainerCopySyncPoller(
+        beginCopyOperationFromListOfSourceDestinationPairs(pairs));
+  }
+
+  private List<SyncPoller<BlobCopyInfo, Void>> beginCopyOperationFromListOfSources(
+      String blobPrefix) {
+
+    ListBlobsOptions options = createListBlobsOptions(blobPrefix);
+    logger.info("List operation from the source using the prefix: '{}'", this.blobSourcePrefix);
+
+    return this.sourceClientFactory
+        .getBlobContainerClient()
+        .listBlobs(options, listOperationTimeout)
+        .stream()
+        .map(b -> beginBlobCopy(b.getName(), b.getName()))
+        .filter(
+            Objects::nonNull) // remove nulls as beginBlobCopy returns null when an empty blob is
+        // requested.
+        .collect(Collectors.toList());
+  }
+
+  private List<SyncPoller<BlobCopyInfo, Void>> beginCopyOperationFromListOfSourceDestinationPairs(
+      List<BlobCopySourceDestinationPair> blobCopySourceDestinationPairs) {
+
+    return blobCopySourceDestinationPairs.stream()
+        .map(b -> beginBlobCopy(b.getSourceBlobName(), b.getDestinationBlobName()))
+        .filter(
+            Objects::nonNull) // remove nulls as beginBlobCopy returns null when an empty blob is
+        // requested.
+        .collect(Collectors.toList());
+  }
+
+  private SyncPoller<BlobCopyInfo, Void> beginBlobCopy(
+      String sourceBlobName, String destinationBlobName) {
+
+    // Azure blob copy does not support empty files.
+    if (isSourceBlobEmpty(sourceBlobName)) {
+      logger.warn("Blob {} is empty. Copy operation is not allowed", sourceBlobName);
+      return null;
+    }
+
+    String sourceSASUrl = this.sourceClientFactory.createReadOnlySASUrlForBlob(sourceBlobName);
+    return beginBlobCopyFromSASUrl(sourceBlobName, sourceSASUrl, destinationBlobName);
+  }
+
+  private SyncPoller<BlobCopyInfo, Void> beginBlobCopyFromSASUrl(
+      String sourceName, String sourceSASUrl, String destinationBlobName) {
+    if (StringUtils.isBlank(destinationBlobName)) {
+      logger.debug(
+          "Destination blob name is blank. The source name: {}, will be used.", sourceName);
+      destinationBlobName = sourceName;
+    }
+
+    BlobClient blobClient =
+        this.destinationClientFactory.getBlobContainerClient().getBlobClient(destinationBlobName);
+
+    return blobClient.beginCopy(sourceSASUrl, this.pollingInterval);
+  }
+
+  private boolean isSourceBlobEmpty(String sourceName) {
+    return this.sourceClientFactory
+            .getBlobContainerClient()
+            .getBlobClient(sourceName)
+            .getProperties()
+            .getBlobSize()
+        == 0;
+  }
+
+  private ListBlobsOptions createListBlobsOptions(String blobPrefix) {
+    ListBlobsOptions options = new ListBlobsOptions();
+    BlobListDetails details = new BlobListDetails();
+    options.setDetails(details);
+    options.setPrefix(blobPrefix);
+    return options;
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopier.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopier.java
@@ -211,12 +211,8 @@ public class BlobContainerCopier {
   }
 
   private boolean isSourceBlobEmpty(String sourceName) {
-    return this.sourceClientFactory
-            .getBlobContainerClient()
-            .getBlobClient(sourceName)
-            .getProperties()
-            .getBlobSize()
-        == 0;
+    BlobClient client = this.sourceClientFactory.getBlobContainerClient().getBlobClient(sourceName);
+    return client.getProperties().getBlobSize() == 0;
   }
 
   private ListBlobsOptions createListBlobsOptions(String blobPrefix) {

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
@@ -4,7 +4,7 @@ import com.azure.storage.blob.BlobUrlParts;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
 
 /** Builder for the {@link BlobContainerCopier} */
@@ -83,10 +83,10 @@ public final class BlobContainerCopierBuilder {
   }
 
   public String appendBlobGuidanceToErrorMessage(String errorMsg) {
-    return errorMsg +
-        " The URL format must be:" +
-        "https://{account name}.blob.core.windows.net/{container name}/{blob name}" +
-        "?{valid SAS with read permissions}";
+    return errorMsg
+        + " The URL format must be:"
+        + "https://{account name}.blob.core.windows.net/{container name}/{blob name}"
+        + "?{valid SAS with read permissions}";
   }
 
   public BlobContainerCopierBuilder pollingInterval(Duration pollingInterval) {

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
@@ -78,7 +78,7 @@ public final class BlobContainerCopierBuilder {
 
     if (Strings.isEmpty(permissions) || !permissions.contains("r")) {
       throw new IllegalArgumentException(
-          appendBlobGuidanceToErrorMessage("List permission is required."));
+          appendBlobGuidanceToErrorMessage("Read permission is required."));
     }
 
     this.sourceBlobUrl = url;
@@ -118,7 +118,7 @@ public final class BlobContainerCopierBuilder {
     return this;
   }
 
-  public BlobContainerCopier buildCopier() {
+  public BlobContainerCopier build() {
     BlobContainerCopier copier = new BlobContainerCopier(this.destinationClientFactory);
 
     copier.setPollingInterval(this.pollingInterval);

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
@@ -33,19 +33,18 @@ public final class BlobContainerCopierBuilder {
 
   public BlobContainerCopierBuilder sourceDestinationPairs(
       List<BlobCopySourceDestinationPair> pairs) {
-    this.sourceDestinationPairs = pairs;
+    sourceDestinationPairs = pairs;
     return this;
   }
 
   public BlobContainerCopierBuilder sourceClientFactory(BlobContainerClientFactory factory) {
-    this.sourceClientFactory =
-        Objects.requireNonNull(factory, "Source client factory can't be null");
+    sourceClientFactory = Objects.requireNonNull(factory, "Source client factory can't be null");
 
     return this;
   }
 
   public BlobContainerCopierBuilder destinationClientFactory(BlobContainerClientFactory factory) {
-    this.destinationClientFactory =
+    destinationClientFactory =
         Objects.requireNonNull(factory, "Destination client factory can't be null");
 
     return this;
@@ -53,7 +52,7 @@ public final class BlobContainerCopierBuilder {
 
   public BlobContainerCopierBuilder sourceContainerPrefix(String prefix) {
 
-    this.sourceContainerPrefix = Objects.requireNonNull(prefix, "The prefix can't be null");
+    sourceContainerPrefix = Objects.requireNonNull(prefix, "The prefix can't be null");
 
     return this;
   }
@@ -78,7 +77,7 @@ public final class BlobContainerCopierBuilder {
           appendBlobGuidanceToErrorMessage("Read permission is required."));
     }
 
-    this.sourceBlobUrl = url;
+    sourceBlobUrl = url;
 
     return this;
   }
@@ -116,21 +115,21 @@ public final class BlobContainerCopierBuilder {
   }
 
   public BlobContainerCopier build() {
-    BlobContainerCopier copier = new BlobContainerCopier(this.destinationClientFactory);
+    BlobContainerCopier copier = new BlobContainerCopier(destinationClientFactory);
 
-    copier.setPollingInterval(this.pollingInterval);
-    copier.setListOperationTimeout(this.listOperationTimeout);
-    copier.setBlobSourcePrefix(this.sourceContainerPrefix);
-    copier.setSourceDestinationPairs(this.sourceDestinationPairs);
+    copier.setPollingInterval(pollingInterval);
+    copier.setListOperationTimeout(listOperationTimeout);
+    copier.setBlobSourcePrefix(sourceContainerPrefix);
+    copier.setSourceDestinationPairs(sourceDestinationPairs);
 
-    if (this.sourceClientFactory != null) {
-      copier.setSourceClientFactory(this.sourceClientFactory);
+    if (sourceClientFactory != null) {
+      copier.setSourceClientFactory(sourceClientFactory);
       return copier;
     }
 
-    if (StringUtils.isNotBlank(this.sourceBlobUrl)) {
-      copier.setSourceBlobUrl(this.sourceBlobUrl);
-      copier.setDestinationBlobName(this.destinationBlobName);
+    if (StringUtils.isNotBlank(sourceBlobUrl)) {
+      copier.setSourceBlobUrl(sourceBlobUrl);
+      copier.setDestinationBlobName(destinationBlobName);
       return copier;
     }
 

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
@@ -83,11 +83,10 @@ public final class BlobContainerCopierBuilder {
   }
 
   public String appendBlobGuidanceToErrorMessage(String errorMsg) {
-    return new StringBuilder(errorMsg)
-        .append(" The URL format must be:")
-        .append("https://{account name}.blob.core.windows.net/{container name}/{blob name}")
-        .append("?{valid SAS with read permissions}")
-        .toString();
+    return errorMsg +
+        " The URL format must be:" +
+        "https://{account name}.blob.core.windows.net/{container name}/{blob name}" +
+        "?{valid SAS with read permissions}";
   }
 
   public BlobContainerCopierBuilder pollingInterval(Duration pollingInterval) {

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
@@ -14,20 +14,17 @@ public final class BlobContainerCopierBuilder {
   public static final int DEFAULT_POLLING_INTERVAL_IN_SECONDS = 5;
   private static final int MIN_POLLING_INTERVAL = 2;
   private static final int MIN_LIST_TIMEOUT = 10;
+  private static final String EMPTY_PREFIX = "";
 
   private BlobContainerClientFactory sourceClientFactory;
   private BlobContainerClientFactory destinationClientFactory;
-  private String sourceContainerPrefix;
+  private String sourceContainerPrefix = EMPTY_PREFIX;
   private String sourceBlobUrl;
   private Duration pollingInterval = Duration.ofSeconds(DEFAULT_POLLING_INTERVAL_IN_SECONDS);
   private Duration listOperationTimeout =
       Duration.ofSeconds(DEFAULT_LIST_OPERATION_TIMEOUT_IN_SECONDS);
   private List<BlobCopySourceDestinationPair> sourceDestinationPairs;
   private String destinationBlobName;
-
-  public BlobContainerCopierBuilder() {
-    this.sourceContainerPrefix = "";
-  }
 
   public BlobContainerCopierBuilder destinationBlobName(String destinationBlobName) {
     this.destinationBlobName = destinationBlobName;

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilder.java
@@ -1,0 +1,145 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.storage.blob.BlobUrlParts;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.util.Strings;
+
+/** Builder for the {@link BlobContainerCopier} */
+public final class BlobContainerCopierBuilder {
+
+  public static final int DEFAULT_LIST_OPERATION_TIMEOUT_IN_SECONDS = 30;
+  public static final int DEFAULT_POLLING_INTERVAL_IN_SECONDS = 5;
+  private static final int MIN_POLLING_INTERVAL = 2;
+  private static final int MIN_LIST_TIMEOUT = 10;
+
+  private BlobContainerClientFactory sourceClientFactory;
+  private BlobContainerClientFactory destinationClientFactory;
+  private String sourceContainerPrefix;
+  private String sourceBlobUrl;
+  private Duration pollingInterval = Duration.ofSeconds(DEFAULT_POLLING_INTERVAL_IN_SECONDS);
+  private Duration listOperationTimeout =
+      Duration.ofSeconds(DEFAULT_LIST_OPERATION_TIMEOUT_IN_SECONDS);
+  private List<BlobCopySourceDestinationPair> sourceDestinationPairs;
+  private String destinationBlobName;
+
+  public BlobContainerCopierBuilder() {
+    this.sourceContainerPrefix = "";
+  }
+
+  public BlobContainerCopierBuilder destinationBlobName(String destinationBlobName) {
+    this.destinationBlobName = destinationBlobName;
+    return this;
+  }
+
+  public BlobContainerCopierBuilder sourceDestinationPairs(
+      List<BlobCopySourceDestinationPair> pairs) {
+    this.sourceDestinationPairs = pairs;
+    return this;
+  }
+
+  public BlobContainerCopierBuilder sourceClientFactory(BlobContainerClientFactory factory) {
+    this.sourceClientFactory =
+        Objects.requireNonNull(factory, "Source client factory can't be null");
+
+    return this;
+  }
+
+  public BlobContainerCopierBuilder destinationClientFactory(BlobContainerClientFactory factory) {
+    this.destinationClientFactory =
+        Objects.requireNonNull(factory, "Destination client factory can't be null");
+
+    return this;
+  }
+
+  public BlobContainerCopierBuilder sourceContainerPrefix(String prefix) {
+
+    this.sourceContainerPrefix = Objects.requireNonNull(prefix, "The prefix can't be null");
+
+    return this;
+  }
+
+  public BlobContainerCopierBuilder sourceBlobUrl(String url) {
+    BlobUrlParts blobUrl = BlobUrlParts.parse(url);
+
+    if (Strings.isEmpty(blobUrl.getBlobContainerName())) {
+      throw new IllegalArgumentException(
+          appendBlobGuidanceToErrorMessage("Container name is missing."));
+    }
+
+    if (Strings.isEmpty(blobUrl.getBlobName())) {
+      throw new IllegalArgumentException(
+          appendBlobGuidanceToErrorMessage("URL must contain a blob name."));
+    }
+
+    String permissions = blobUrl.getCommonSasQueryParameters().getPermissions();
+
+    if (Strings.isEmpty(permissions) || !permissions.contains("r")) {
+      throw new IllegalArgumentException(
+          appendBlobGuidanceToErrorMessage("List permission is required."));
+    }
+
+    this.sourceBlobUrl = url;
+
+    return this;
+  }
+
+  public String appendBlobGuidanceToErrorMessage(String errorMsg) {
+    return new StringBuilder(errorMsg)
+        .append(" The URL format must be:")
+        .append("https://{account name}.blob.core.windows.net/{container name}/{blob name}")
+        .append("?{valid SAS with read permissions}")
+        .toString();
+  }
+
+  public BlobContainerCopierBuilder pollingInterval(Duration pollingInterval) {
+    Objects.requireNonNull(pollingInterval, "Invalid polling interval. It can't be null");
+
+    if (pollingInterval.getSeconds() < MIN_POLLING_INTERVAL) {
+      throw new IllegalArgumentException(
+          "Polling interval can't be less than " + MIN_POLLING_INTERVAL + " seconds");
+    }
+    this.pollingInterval = pollingInterval;
+
+    return this;
+  }
+
+  public BlobContainerCopierBuilder listOperationTimeOut(Duration listOperationTimeout) {
+    Objects.requireNonNull(listOperationTimeout, "Invalid timeout value. It can't be null");
+
+    if (listOperationTimeout.getSeconds() < MIN_LIST_TIMEOUT) {
+      throw new IllegalArgumentException(
+          "List polling timeout can't be less than " + MIN_LIST_TIMEOUT + " seconds");
+    }
+    this.listOperationTimeout = listOperationTimeout;
+
+    return this;
+  }
+
+  public BlobContainerCopier buildCopier() {
+    BlobContainerCopier copier = new BlobContainerCopier(this.destinationClientFactory);
+
+    copier.setPollingInterval(this.pollingInterval);
+    copier.setListOperationTimeout(this.listOperationTimeout);
+    copier.setBlobSourcePrefix(this.sourceContainerPrefix);
+    copier.setSourceDestinationPairs(this.sourceDestinationPairs);
+
+    if (this.sourceClientFactory != null) {
+      copier.setSourceClientFactory(this.sourceClientFactory);
+      return copier;
+    }
+
+    if (StringUtils.isNotBlank(this.sourceBlobUrl)) {
+      copier.setSourceBlobUrl(this.sourceBlobUrl);
+      copier.setDestinationBlobName(this.destinationBlobName);
+      return copier;
+    }
+
+    throw new IllegalArgumentException(
+        "The builder can't create the copier. "
+            + "You must provide a valid source blob client manager "
+            + "or a blob URL with SAS token with read permission.");
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfo.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfo.java
@@ -29,10 +29,7 @@ public class BlobContainerCopyInfo {
   public LongRunningOperationStatus getCopyStatus() {
 
     List<LongRunningOperationStatus> distinctStatuses =
-        this.pollResponses.stream()
-            .map(PollResponse::getStatus)
-            .distinct()
-            .collect(Collectors.toList());
+        pollResponses.stream().map(PollResponse::getStatus).distinct().collect(Collectors.toList());
 
     if (distinctStatuses.size() == 1
         && distinctStatuses.contains(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED)) {

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfo.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfo.java
@@ -28,28 +28,23 @@ public class BlobContainerCopyInfo {
    */
   public LongRunningOperationStatus getCopyStatus() {
 
-    List<LongRunningOperationStatus> distinctStatuses =
-        pollResponses.stream().map(PollResponse::getStatus).distinct().collect(Collectors.toList());
+    var distinctStatuses =
+        pollResponses.stream().map(PollResponse::getStatus).collect(Collectors.toSet());
 
     if (distinctStatuses.size() == 1
         && distinctStatuses.contains(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED)) {
       return LongRunningOperationStatus.SUCCESSFULLY_COMPLETED;
     }
 
-    if (distinctStatuses.contains(LongRunningOperationStatus.FAILED)) {
-      return LongRunningOperationStatus.FAILED;
-    }
-
-    if (distinctStatuses.contains(LongRunningOperationStatus.USER_CANCELLED)) {
-      return LongRunningOperationStatus.USER_CANCELLED;
-    }
-
-    if (distinctStatuses.contains(LongRunningOperationStatus.IN_PROGRESS)) {
-      return LongRunningOperationStatus.IN_PROGRESS;
-    }
-
-    if (distinctStatuses.contains(LongRunningOperationStatus.NOT_STARTED)) {
-      return LongRunningOperationStatus.NOT_STARTED;
+    for (var status :
+        List.of(
+            LongRunningOperationStatus.FAILED,
+            LongRunningOperationStatus.USER_CANCELLED,
+            LongRunningOperationStatus.IN_PROGRESS,
+            LongRunningOperationStatus.NOT_STARTED)) {
+      if (distinctStatuses.contains(status)) {
+        return status;
+      }
     }
 
     throw new RuntimeException("Invalid operation status returned");

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfo.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfo.java
@@ -1,0 +1,60 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.core.util.polling.LongRunningOperationStatus;
+import com.azure.core.util.polling.PollResponse;
+import com.azure.storage.blob.models.BlobCopyInfo;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class encapsulates all poll responses for a given copy operation. From the responses the
+ * status of the operation is determined.
+ */
+public class BlobContainerCopyInfo {
+  private final List<PollResponse<BlobCopyInfo>> pollResponses;
+
+  public BlobContainerCopyInfo(List<PollResponse<BlobCopyInfo>> pollResponses) {
+    this.pollResponses = pollResponses;
+  }
+
+  /**
+   * Returns the status of the copy operation from the individual poll responses. The implementation
+   * follows the these rules in order: SUCCESSFULLY_COMPLETED: When all operations are completed
+   * successful. FAILED: When at least one operation has FAILED. USER_CANCELLED: When at least one
+   * operation has been cancelled. IN_PROGRESS: When at least one operation is in progress.
+   * NOT_STARTED: When at least one operation has not started.
+   *
+   * @return The status of the long running operation.
+   */
+  public LongRunningOperationStatus getCopyStatus() {
+
+    List<LongRunningOperationStatus> distinctStatuses =
+        this.pollResponses.stream()
+            .map(PollResponse::getStatus)
+            .distinct()
+            .collect(Collectors.toList());
+
+    if (distinctStatuses.size() == 1
+        && distinctStatuses.contains(LongRunningOperationStatus.SUCCESSFULLY_COMPLETED)) {
+      return LongRunningOperationStatus.SUCCESSFULLY_COMPLETED;
+    }
+
+    if (distinctStatuses.contains(LongRunningOperationStatus.FAILED)) {
+      return LongRunningOperationStatus.FAILED;
+    }
+
+    if (distinctStatuses.contains(LongRunningOperationStatus.USER_CANCELLED)) {
+      return LongRunningOperationStatus.USER_CANCELLED;
+    }
+
+    if (distinctStatuses.contains(LongRunningOperationStatus.IN_PROGRESS)) {
+      return LongRunningOperationStatus.IN_PROGRESS;
+    }
+
+    if (distinctStatuses.contains(LongRunningOperationStatus.NOT_STARTED)) {
+      return LongRunningOperationStatus.NOT_STARTED;
+    }
+
+    throw new RuntimeException("Invalid operation status returned");
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopySyncPoller.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopySyncPoller.java
@@ -1,0 +1,84 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.core.util.polling.LongRunningOperationStatus;
+import com.azure.core.util.polling.PollResponse;
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.storage.blob.models.BlobCopyInfo;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BlobContainerCopySyncPoller implements SyncPoller<BlobContainerCopyInfo, Void> {
+
+  private final List<SyncPoller<BlobCopyInfo, Void>> blobCopyPollerList;
+
+  public BlobContainerCopySyncPoller(List<SyncPoller<BlobCopyInfo, Void>> blobCopyPollerList) {
+    this.blobCopyPollerList = blobCopyPollerList;
+  }
+
+  @Override
+  public PollResponse<BlobContainerCopyInfo> poll() {
+    BlobContainerCopyInfo pollResult =
+        new BlobContainerCopyInfo(
+            blobCopyPollerList.stream().map(SyncPoller::poll).collect(Collectors.toList()));
+
+    return new PollResponse<>(pollResult.getCopyStatus(), pollResult);
+  }
+
+  @Override
+  public PollResponse<BlobContainerCopyInfo> waitForCompletion() {
+
+    BlobContainerCopyInfo waitResult =
+        new BlobContainerCopyInfo(
+            this.blobCopyPollerList.stream()
+                .map(SyncPoller::waitForCompletion)
+                .collect(Collectors.toList()));
+
+    return new PollResponse<>(waitResult.getCopyStatus(), waitResult);
+  }
+
+  @Override
+  public PollResponse<BlobContainerCopyInfo> waitForCompletion(Duration timeout) {
+    BlobContainerCopyInfo waitResult =
+        new BlobContainerCopyInfo(
+            this.blobCopyPollerList.stream()
+                .map(p -> p.waitForCompletion(timeout))
+                .collect(Collectors.toList()));
+
+    return new PollResponse<>(waitResult.getCopyStatus(), waitResult);
+  }
+
+  @Override
+  public PollResponse<BlobContainerCopyInfo> waitUntil(LongRunningOperationStatus statusToWaitFor) {
+    BlobContainerCopyInfo waitResult =
+        new BlobContainerCopyInfo(
+            this.blobCopyPollerList.stream()
+                .map(p -> p.waitUntil(statusToWaitFor))
+                .collect(Collectors.toList()));
+
+    return new PollResponse<>(waitResult.getCopyStatus(), waitResult);
+  }
+
+  @Override
+  public PollResponse<BlobContainerCopyInfo> waitUntil(
+      Duration timeout, LongRunningOperationStatus statusToWaitFor) {
+    BlobContainerCopyInfo waitResult =
+        new BlobContainerCopyInfo(
+            this.blobCopyPollerList.stream()
+                .map(p -> p.waitUntil(timeout, statusToWaitFor))
+                .collect(Collectors.toList()));
+
+    return new PollResponse<>(waitResult.getCopyStatus(), waitResult);
+  }
+
+  @Override
+  public Void getFinalResult() {
+    this.blobCopyPollerList.forEach(SyncPoller::getFinalResult);
+    return null;
+  }
+
+  @Override
+  public void cancelOperation() {
+    this.blobCopyPollerList.forEach(SyncPoller::cancelOperation);
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopySyncPoller.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopySyncPoller.java
@@ -30,7 +30,7 @@ public class BlobContainerCopySyncPoller implements SyncPoller<BlobContainerCopy
 
     BlobContainerCopyInfo waitResult =
         new BlobContainerCopyInfo(
-            this.blobCopyPollerList.stream()
+            blobCopyPollerList.stream()
                 .map(SyncPoller::waitForCompletion)
                 .collect(Collectors.toList()));
 
@@ -41,7 +41,7 @@ public class BlobContainerCopySyncPoller implements SyncPoller<BlobContainerCopy
   public PollResponse<BlobContainerCopyInfo> waitForCompletion(Duration timeout) {
     BlobContainerCopyInfo waitResult =
         new BlobContainerCopyInfo(
-            this.blobCopyPollerList.stream()
+            blobCopyPollerList.stream()
                 .map(p -> p.waitForCompletion(timeout))
                 .collect(Collectors.toList()));
 
@@ -52,7 +52,7 @@ public class BlobContainerCopySyncPoller implements SyncPoller<BlobContainerCopy
   public PollResponse<BlobContainerCopyInfo> waitUntil(LongRunningOperationStatus statusToWaitFor) {
     BlobContainerCopyInfo waitResult =
         new BlobContainerCopyInfo(
-            this.blobCopyPollerList.stream()
+            blobCopyPollerList.stream()
                 .map(p -> p.waitUntil(statusToWaitFor))
                 .collect(Collectors.toList()));
 
@@ -64,7 +64,7 @@ public class BlobContainerCopySyncPoller implements SyncPoller<BlobContainerCopy
       Duration timeout, LongRunningOperationStatus statusToWaitFor) {
     BlobContainerCopyInfo waitResult =
         new BlobContainerCopyInfo(
-            this.blobCopyPollerList.stream()
+            blobCopyPollerList.stream()
                 .map(p -> p.waitUntil(timeout, statusToWaitFor))
                 .collect(Collectors.toList()));
 
@@ -73,12 +73,12 @@ public class BlobContainerCopySyncPoller implements SyncPoller<BlobContainerCopy
 
   @Override
   public Void getFinalResult() {
-    this.blobCopyPollerList.forEach(SyncPoller::getFinalResult);
+    blobCopyPollerList.forEach(SyncPoller::getFinalResult);
     return null;
   }
 
   @Override
   public void cancelOperation() {
-    this.blobCopyPollerList.forEach(SyncPoller::cancelOperation);
+    blobCopyPollerList.forEach(SyncPoller::cancelOperation);
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCopySourceDestinationPair.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCopySourceDestinationPair.java
@@ -1,0 +1,20 @@
+package bio.terra.service.filedata.azure.util;
+
+/** Represents a pair/tuple of source and destination blob names. */
+public final class BlobCopySourceDestinationPair {
+  private final String sourceBlobName;
+  private final String destinationBlobName;
+
+  public BlobCopySourceDestinationPair(String sourceBlobName, String destinationBlobName) {
+    this.sourceBlobName = sourceBlobName;
+    this.destinationBlobName = destinationBlobName;
+  }
+
+  public String getSourceBlobName() {
+    return sourceBlobName;
+  }
+
+  public String getDestinationBlobName() {
+    return destinationBlobName;
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -3,7 +3,6 @@ package bio.terra.service.filedata.azure.util;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobProperties;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang.StringUtils;
@@ -33,7 +32,7 @@ public class BlobCrl {
   public BlobContainerCopier createBlobContainerCopier(
       BlobContainerClientFactory clientFactory, String blobPrefix) {
     return new BlobContainerCopierBuilder()
-        .destinationClientFactory(this.blobContainerClientFactory)
+        .destinationClientFactory(blobContainerClientFactory)
         .sourceClientFactory(clientFactory)
         .sourceContainerPrefix(blobPrefix)
         .build();
@@ -51,7 +50,7 @@ public class BlobCrl {
   public BlobContainerCopier createBlobContainerCopier(
       BlobContainerClientFactory clientFactory, List<BlobCopySourceDestinationPair> pairs) {
     return new BlobContainerCopierBuilder()
-        .destinationClientFactory(this.blobContainerClientFactory)
+        .destinationClientFactory(blobContainerClientFactory)
         .sourceClientFactory(clientFactory)
         .sourceDestinationPairs(pairs)
         .build();
@@ -75,10 +74,10 @@ public class BlobCrl {
     }
 
     return new BlobContainerCopierBuilder()
-        .destinationClientFactory(this.blobContainerClientFactory)
+        .destinationClientFactory(blobContainerClientFactory)
         .sourceClientFactory(clientFactory)
         .sourceDestinationPairs(
-            Arrays.asList(new BlobCopySourceDestinationPair(sourceBlobName, destinationBlobName)))
+            List.of(new BlobCopySourceDestinationPair(sourceBlobName, destinationBlobName)))
         .build();
   }
 
@@ -95,7 +94,7 @@ public class BlobCrl {
   public BlobContainerCopier createBlobContainerCopier(URL sourceUrl, String destinationBlobName) {
 
     return new BlobContainerCopierBuilder()
-        .destinationClientFactory(this.blobContainerClientFactory)
+        .destinationClientFactory(blobContainerClientFactory)
         .sourceBlobUrl(
             Objects.requireNonNull(
                     sourceUrl,
@@ -111,7 +110,7 @@ public class BlobCrl {
    * @param blobName blob name to delete.
    */
   public void deleteBlob(String blobName) {
-    this.blobContainerClientFactory.getBlobContainerClient().getBlobClient(blobName).delete();
+    blobContainerClientFactory.getBlobContainerClient().getBlobClient(blobName).delete();
   }
 
   /**
@@ -121,7 +120,7 @@ public class BlobCrl {
    * @return Instance of {@link BlobProperties}
    */
   public BlobProperties getBlobProperties(String blobName) {
-    return this.blobContainerClientFactory
+    return blobContainerClientFactory
         .getBlobContainerClient()
         .getBlobClient(blobName)
         .getProperties();
@@ -130,8 +129,7 @@ public class BlobCrl {
   /** Creates a the container in the storage account if it does not exist. */
   public void createContainerNameIfNotExists() {
 
-    BlobContainerClient blobContainerClient =
-        this.blobContainerClientFactory.getBlobContainerClient();
+    BlobContainerClient blobContainerClient = blobContainerClientFactory.getBlobContainerClient();
 
     if (!blobContainerClient.exists()) {
       blobContainerClient.create();

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -1,0 +1,142 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobProperties;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * High-level API that enables copy, delete, and get blob properties operations on Azure Blob
+ * storage.
+ */
+public class BlobCrl {
+
+  private final BlobContainerClientFactory blobContainerClientFactory;
+
+  public BlobCrl(BlobContainerClientFactory clientFactory) {
+    this.blobContainerClientFactory =
+        Objects.requireNonNull(clientFactory, "Client factory is null");
+  }
+
+  /**
+   * Creates a new instance of {@link BlobContainerCopier} that uses the {@link
+   * BlobContainerClientFactory} specified in the constructor as the destination storage account.
+   *
+   * @param clientFactory client factory of the source storage account and container.
+   * @param blobPrefix prefix filter to use when listing the sources from the source container. If
+   *     blank all blobs in the container will be copied.
+   * @return new instance of {@link BlobContainerClientFactory}.
+   */
+  public BlobContainerCopier createBlobContainerCopier(
+      BlobContainerClientFactory clientFactory, String blobPrefix) {
+    return new BlobContainerCopierBuilder()
+        .destinationClientFactory(this.blobContainerClientFactory)
+        .sourceClientFactory(clientFactory)
+        .sourceContainerPrefix(blobPrefix)
+        .buildCopier();
+  }
+
+  /**
+   * Creates a new instance of {@link BlobContainerCopier} that uses the {@link
+   * BlobContainerClientFactory} specified in the constructor as the destination storage account.
+   *
+   * @param clientFactory client factory of the source storage account and container.
+   * @param pairs source and destination pairs to copy. If the destination is null or empty the
+   *     source name will be used.
+   * @return new instance of {@link BlobContainerClientFactory}.
+   */
+  public BlobContainerCopier createBlobContainerCopier(
+      BlobContainerClientFactory clientFactory, List<BlobCopySourceDestinationPair> pairs) {
+    return new BlobContainerCopierBuilder()
+        .destinationClientFactory(this.blobContainerClientFactory)
+        .sourceClientFactory(clientFactory)
+        .sourceDestinationPairs(pairs)
+        .buildCopier();
+  }
+
+  /**
+   * Creates a new instance of {@link BlobContainerCopier} that uses the {@link
+   * BlobContainerClientFactory} specified in the constructor as the destination storage account.
+   *
+   * @param clientFactory client factory of the source storage account and container.
+   * @param sourceBlobName source blob name.
+   * @param destinationBlobName destination blob name. If null or empty the source name will be
+   *     used.
+   * @return new instance of {@link BlobContainerClientFactory}.
+   */
+  public BlobContainerCopier createBlobContainerCopier(
+      BlobContainerClientFactory clientFactory, String sourceBlobName, String destinationBlobName) {
+
+    if (StringUtils.isBlank(sourceBlobName)) {
+      throw new IllegalArgumentException("sourceBlobName is required. It's null or empty.");
+    }
+
+    return new BlobContainerCopierBuilder()
+        .destinationClientFactory(this.blobContainerClientFactory)
+        .sourceClientFactory(clientFactory)
+        .sourceDestinationPairs(
+            Arrays.asList(new BlobCopySourceDestinationPair(sourceBlobName, destinationBlobName)))
+        .buildCopier();
+  }
+
+  /**
+   * Creates a new instance of {@link BlobContainerCopier} that uses the {@link
+   * BlobContainerClientFactory} specified in the constructor as the destination storage account.
+   *
+   * @param clientFactory client factory of the source storage account and container.
+   * @param sourceUrl source blob URL. The URL must include in the query string a SAS token with
+   *     read access.
+   * @param destinationBlobName destination blob name. If null or empty the source name will be
+   *     used.
+   * @return new instance of {@link BlobContainerClientFactory}.
+   */
+  public BlobContainerCopier createBlobContainerCopier(
+      BlobContainerClientFactory clientFactory, URL sourceUrl, String destinationBlobName) {
+
+    return new BlobContainerCopierBuilder()
+        .destinationClientFactory(this.blobContainerClientFactory)
+        .sourceBlobUrl(
+            Objects.requireNonNull(
+                    sourceUrl,
+                    "Source Blob URL is null. It must be a valid URL with read permissions")
+                .toString())
+        .destinationBlobName(destinationBlobName)
+        .buildCopier();
+  }
+
+  /**
+   * Deletes the specified blob in the container.
+   *
+   * @param blobName blob name to delete.
+   */
+  public void deleteBlob(String blobName) {
+    this.blobContainerClientFactory.getBlobContainerClient().getBlobClient(blobName).delete();
+  }
+
+  /**
+   * Returns the blob properties.
+   *
+   * @param blobName blob name.
+   * @return Instance of {@link BlobProperties}
+   */
+  public BlobProperties getBlobProperties(String blobName) {
+    return this.blobContainerClientFactory
+        .getBlobContainerClient()
+        .getBlobClient(blobName)
+        .getProperties();
+  }
+
+  /** Creates a the container in the storage account if it does not exist. */
+  public void createContainerNameIfNotExists() {
+
+    BlobContainerClient blobContainerClient =
+        this.blobContainerClientFactory.getBlobContainerClient();
+
+    if (!blobContainerClient.exists()) {
+      blobContainerClient.create();
+    }
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -36,7 +36,7 @@ public class BlobCrl {
         .destinationClientFactory(this.blobContainerClientFactory)
         .sourceClientFactory(clientFactory)
         .sourceContainerPrefix(blobPrefix)
-        .buildCopier();
+        .build();
   }
 
   /**
@@ -54,7 +54,7 @@ public class BlobCrl {
         .destinationClientFactory(this.blobContainerClientFactory)
         .sourceClientFactory(clientFactory)
         .sourceDestinationPairs(pairs)
-        .buildCopier();
+        .build();
   }
 
   /**
@@ -79,7 +79,7 @@ public class BlobCrl {
         .sourceClientFactory(clientFactory)
         .sourceDestinationPairs(
             Arrays.asList(new BlobCopySourceDestinationPair(sourceBlobName, destinationBlobName)))
-        .buildCopier();
+        .build();
   }
 
   /**
@@ -104,7 +104,7 @@ public class BlobCrl {
                     "Source Blob URL is null. It must be a valid URL with read permissions")
                 .toString())
         .destinationBlobName(destinationBlobName)
-        .buildCopier();
+        .build();
   }
 
   /**

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -5,7 +5,7 @@ import com.azure.storage.blob.models.BlobProperties;
 import java.net.URL;
 import java.util.List;
 import java.util.Objects;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * High-level API that enables copy, delete, and get blob properties operations on Azure Blob

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -86,15 +86,13 @@ public class BlobCrl {
    * Creates a new instance of {@link BlobContainerCopier} that uses the {@link
    * BlobContainerClientFactory} specified in the constructor as the destination storage account.
    *
-   * @param clientFactory client factory of the source storage account and container.
    * @param sourceUrl source blob URL. The URL must include in the query string a SAS token with
    *     read access.
    * @param destinationBlobName destination blob name. If null or empty the source name will be
    *     used.
    * @return new instance of {@link BlobContainerClientFactory}.
    */
-  public BlobContainerCopier createBlobContainerCopier(
-      BlobContainerClientFactory clientFactory, URL sourceUrl, String destinationBlobName) {
+  public BlobContainerCopier createBlobContainerCopier(URL sourceUrl, String destinationBlobName) {
 
     return new BlobContainerCopierBuilder()
         .destinationClientFactory(this.blobContainerClientFactory)

--- a/src/test/java/bio/terra/app/configuration/ConnectedTestConfiguration.java
+++ b/src/test/java/bio/terra/app/configuration/ConnectedTestConfiguration.java
@@ -19,6 +19,24 @@ public class ConnectedTestConfiguration {
   private UUID targetSubscriptionId;
   private String targetResourceGroupName;
   private String targetApplicationName;
+  private String sourceStorageAccountName;
+  private String destinationStorageAccountName;
+
+  public String getSourceStorageAccountName() {
+    return sourceStorageAccountName;
+  }
+
+  public void setSourceStorageAccountName(String sourceStorageAccountName) {
+    this.sourceStorageAccountName = sourceStorageAccountName;
+  }
+
+  public String getDestinationStorageAccountName() {
+    return destinationStorageAccountName;
+  }
+
+  public void setDestinationStorageAccountName(String destinationStorageAccountName) {
+    this.destinationStorageAccountName = destinationStorageAccountName;
+  }
 
   public String getIngestbucket() {
     return ingestbucket;

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -70,37 +70,37 @@ public class BlobContainerClientFactoryTest {
   }
 
   @Test
-  public void testCreateReadOnlySASUrlForBlobUsingTokenCreds_URLIsGeneratedAndIsValid() {
+  public void testCreateReadOnlySasUrlForBlobUsingTokenCreds_UrlIsGeneratedAndIsValid() {
 
     BlobContainerClientFactory factory =
         new BlobContainerClientFactory(accountName, tokenCredential, containerName);
 
-    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySASUrlForBlob(blobName));
+    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySasUrlForBlob(blobName));
 
     assertThat(blobClient.exists(), is(true));
   }
 
   @Test
-  public void testCreateReadOnlySASUrlForBlobUsingContainerSasCreds_URLIsGeneratedAndIsValid() {
+  public void testCreateReadOnlySasUrlForBlobUsingContainerSasCreds_UrlIsGeneratedAndIsValid() {
 
     BlobContainerClientFactory factory =
         new BlobContainerClientFactory(
             blobIOTestUtility.generateSourceContainerUrlWithSasReadAndListPermissions(
                 getSourceStorageAccountPrimarySharedKey()));
 
-    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySASUrlForBlob(blobName));
+    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySasUrlForBlob(blobName));
 
     assertThat(blobClient.exists(), is(true));
   }
 
   @Test
-  public void testCreateReadOnlySASUrlForBlobUsingSharedKeyCreds_URLIsGeneratedAndIsValid() {
+  public void testCreateReadOnlySasUrlForBlobUsingSharedKeyCreds_UrlIsGeneratedAndIsValid() {
 
     BlobContainerClientFactory factory =
         new BlobContainerClientFactory(
             accountName, getSourceStorageAccountPrimarySharedKey(), containerName);
 
-    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySASUrlForBlob(blobName));
+    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySasUrlForBlob(blobName));
 
     assertThat(blobClient.exists(), is(true));
   }
@@ -113,15 +113,15 @@ public class BlobContainerClientFactoryTest {
 
   private String getSourceStorageAccountPrimarySharedKey() {
     AzureResourceManager client =
-        this.azureResourceConfiguration.getClient(
-            this.connectedTestConfiguration.getTargetTenantId(),
-            this.connectedTestConfiguration.getTargetSubscriptionId());
+        azureResourceConfiguration.getClient(
+            connectedTestConfiguration.getTargetTenantId(),
+            connectedTestConfiguration.getTargetSubscriptionId());
 
     return client
         .storageAccounts()
         .getByResourceGroup(
-            this.connectedTestConfiguration.getTargetResourceGroupName(),
-            this.connectedTestConfiguration.getSourceStorageAccountName())
+            connectedTestConfiguration.getTargetResourceGroupName(),
+            connectedTestConfiguration.getSourceStorageAccountName())
         .getKeys()
         .iterator()
         .next()

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -7,13 +7,11 @@ import static org.hamcrest.Matchers.is;
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
-import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobClientBuilder;
 import com.azure.storage.blob.BlobUrlParts;
-import com.azure.storage.common.StorageSharedKeyCredential;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,8 +51,6 @@ public class BlobContainerClientFactoryTest {
   private String containerName;
   private String blobName;
   private TokenCredential tokenCredential;
-  private AzureSasCredential sasCredential;
-  private StorageSharedKeyCredential sharedKeyCredential;
 
   @Before
   public void setUp() {
@@ -68,11 +64,6 @@ public class BlobContainerClientFactoryTest {
     accountName = connectedTestConfiguration.getSourceStorageAccountName();
     tokenCredential = azureResourceConfiguration.getAppToken();
     containerName = blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
-    String sharedKey = getSourceStorageAccountPrimarySharedKey();
-    sasCredential =
-        new AzureSasCredential(
-            blobIOTestUtility.generateContainerSasTokenWithReadAndListPermissions(sharedKey));
-    sharedKeyCredential = new StorageSharedKeyCredential(accountName, sharedKey);
     blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
   }
 

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -28,12 +28,8 @@ import org.springframework.test.context.junit4.SpringRunner;
  *
  * <UL>
  *   <LI>AZURE_CREDENTIALS_APPLICATIONID
- *   <LI>AZURE_CREDENTIALS_HOMETENANTID
  *   <LI>AZURE_CREDENTIALS_SECRET
  * </UL>
- *
- * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage
- * accounts.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -65,7 +61,7 @@ public class BlobContainerClientFactoryTest {
     tokenCredential =
         azureResourceConfiguration.getAppToken(connectedTestConfiguration.getTargetTenantId());
     containerName = blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
-    blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
+    blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).iterator().next();
   }
 
   @After
@@ -112,9 +108,7 @@ public class BlobContainerClientFactoryTest {
   private BlobClient getBlobClientFromUrl(String blobUrl) {
     BlobUrlParts parts = BlobUrlParts.parse(blobUrl);
 
-    BlobClient blobClient =
-        new BlobClientBuilder().endpoint(parts.toUrl().toString()).buildClient();
-    return blobClient;
+    return new BlobClientBuilder().endpoint(parts.toUrl().toString()).buildClient();
   }
 
   private String getSourceStorageAccountPrimarySharedKey() {
@@ -129,9 +123,8 @@ public class BlobContainerClientFactoryTest {
             this.connectedTestConfiguration.getTargetResourceGroupName(),
             this.connectedTestConfiguration.getSourceStorageAccountName())
         .getKeys()
-        .stream()
-        .findFirst()
-        .get()
+        .iterator()
+        .next()
         .value();
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -1,0 +1,144 @@
+package bio.terra.service.filedata.azure.util;
+
+import static bio.terra.service.filedata.azure.util.BlobIOTestUtility.MiB;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.category.Connected;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import com.azure.core.credential.AzureSasCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
+import com.azure.storage.blob.BlobUrlParts;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Note: To run these tests the following must be set:
+ *
+ * <UL>
+ *   <LI>AZURE_CREDENTIALS_APPLICATIONID
+ *   <LI>AZURE_CREDENTIALS_HOMETENANTID
+ *   <LI>AZURE_CREDENTIALS_SECRET
+ * </UL>
+ *
+ * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage
+ * accounts.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Category(Connected.class)
+public class BlobContainerClientFactoryTest {
+
+  @Autowired private AzureResourceConfiguration azureResourceConfiguration;
+
+  @Autowired private ConnectedTestConfiguration connectedTestConfiguration;
+
+  private BlobIOTestUtility blobIOTestUtility;
+  private String accountName;
+  private String containerName;
+  private String blobName;
+  private TokenCredential tokenCredential;
+  private AzureSasCredential sasCredential;
+  private StorageSharedKeyCredential sharedKeyCredential;
+
+  @Before
+  public void setUp() {
+
+    blobIOTestUtility =
+        new BlobIOTestUtility(
+            azureResourceConfiguration.getAppToken(),
+            connectedTestConfiguration.getSourceStorageAccountName(),
+            connectedTestConfiguration.getDestinationStorageAccountName());
+
+    accountName = connectedTestConfiguration.getSourceStorageAccountName();
+    tokenCredential = azureResourceConfiguration.getAppToken();
+    containerName = blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
+    String sharedKey = getSourceStorageAccountPrimarySharedKey();
+    sasCredential =
+        new AzureSasCredential(
+            blobIOTestUtility.generateContainerSasTokenWithReadAndListPermissions(sharedKey));
+    sharedKeyCredential = new StorageSharedKeyCredential(accountName, sharedKey);
+    blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    blobIOTestUtility.deleteContainers();
+  }
+
+  @Test
+  public void testCreateReadOnlySASUrlForBlobUsingTokenCreds_URLIsGeneratedAndIsValid() {
+
+    BlobContainerClientFactory factory =
+        new BlobContainerClientFactory(accountName, tokenCredential, containerName);
+
+    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySASUrlForBlob(blobName));
+
+    assertThat(blobClient.exists(), is(true));
+  }
+
+  @Test
+  public void testCreateReadOnlySASUrlForBlobUsingContainerSasCreds_URLIsGeneratedAndIsValid() {
+
+    BlobContainerClientFactory factory =
+        new BlobContainerClientFactory(
+            blobIOTestUtility.generateSourceContainerUrlWithSasReadAndListPermissions(
+                getSourceStorageAccountPrimarySharedKey()));
+
+    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySASUrlForBlob(blobName));
+
+    assertThat(blobClient.exists(), is(true));
+  }
+
+  @Test
+  public void testCreateReadOnlySASUrlForBlobUsingSharedKeyCreds_URLIsGeneratedAndIsValid() {
+
+    BlobContainerClientFactory factory =
+        new BlobContainerClientFactory(
+            accountName, getSourceStorageAccountPrimarySharedKey(), containerName);
+
+    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySASUrlForBlob(blobName));
+
+    assertThat(blobClient.exists(), is(true));
+  }
+
+  private BlobClient getBlobClientFromUrl(String blobUrl) {
+    BlobUrlParts parts = BlobUrlParts.parse(blobUrl);
+
+    BlobClient blobClient =
+        new BlobClientBuilder().endpoint(parts.toUrl().toString()).buildClient();
+    return blobClient;
+  }
+
+  private String getSourceStorageAccountPrimarySharedKey() {
+    AzureResourceManager client =
+        this.azureResourceConfiguration.getClient(
+            this.connectedTestConfiguration.getTargetSubscriptionId());
+
+    return client
+        .storageAccounts()
+        .getByResourceGroup(
+            this.connectedTestConfiguration.getTargetResourceGroupName(),
+            this.connectedTestConfiguration.getSourceStorageAccountName())
+        .getKeys()
+        .stream()
+        .findFirst()
+        .get()
+        .value();
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -57,12 +57,13 @@ public class BlobContainerClientFactoryTest {
 
     blobIOTestUtility =
         new BlobIOTestUtility(
-            azureResourceConfiguration.getAppToken(),
+            azureResourceConfiguration.getAppToken(connectedTestConfiguration.getTargetTenantId()),
             connectedTestConfiguration.getSourceStorageAccountName(),
             connectedTestConfiguration.getDestinationStorageAccountName());
 
     accountName = connectedTestConfiguration.getSourceStorageAccountName();
-    tokenCredential = azureResourceConfiguration.getAppToken();
+    tokenCredential =
+        azureResourceConfiguration.getAppToken(connectedTestConfiguration.getTargetTenantId());
     containerName = blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
     blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
   }
@@ -119,6 +120,7 @@ public class BlobContainerClientFactoryTest {
   private String getSourceStorageAccountPrimarySharedKey() {
     AzureResourceManager client =
         this.azureResourceConfiguration.getClient(
+            this.connectedTestConfiguration.getTargetTenantId(),
             this.connectedTestConfiguration.getTargetSubscriptionId());
 
     return client

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -27,9 +27,9 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Note: To run these tests the following must be set:
  *
  * <UL>
- *   <LI>AZURE_CREDENTIALS_APPLICATIONID
- *   <LI>AZURE_CREDENTIALS_HOMETENANTID
- *   <LI>AZURE_CREDENTIALS_SECRET
+ *   <LI>AZURE_CREDENTIALS_APPLICATIONID</LI>
+ *   <LI>AZURE_CREDENTIALS_HOMETENANTID</LI>
+ *   <LI>AZURE_CREDENTIALS_SECRET</LI>
  * </UL>
  *
  * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -27,9 +27,9 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Note: To run these tests the following must be set:
  *
  * <UL>
- *   <LI>AZURE_CREDENTIALS_APPLICATIONID</LI>
- *   <LI>AZURE_CREDENTIALS_HOMETENANTID</LI>
- *   <LI>AZURE_CREDENTIALS_SECRET</LI>
+ *   <LI>AZURE_CREDENTIALS_APPLICATIONID
+ *   <LI>AZURE_CREDENTIALS_HOMETENANTID
+ *   <LI>AZURE_CREDENTIALS_SECRET
  * </UL>
  *
  * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
@@ -28,7 +28,7 @@ public class BlobContainerCopierBuilderTest {
         new BlobContainerCopierBuilder()
             .sourceClientFactory(sourceFactory)
             .destinationClientFactory(destinationFactory)
-            .buildCopier();
+            .build();
 
     assertThat(
         copier,
@@ -45,7 +45,7 @@ public class BlobContainerCopierBuilderTest {
             .sourceClientFactory(sourceFactory)
             .destinationClientFactory(destinationFactory)
             .sourceDestinationPairs(pairs)
-            .buildCopier();
+            .build();
 
     assertThat(
         copier,
@@ -66,7 +66,7 @@ public class BlobContainerCopierBuilderTest {
             .sourceBlobUrl(sourceBlobUrl)
             .destinationBlobName(destinationBlobName)
             .destinationClientFactory(destinationFactory)
-            .buildCopier();
+            .build();
 
     assertThat(
         copier,
@@ -78,7 +78,6 @@ public class BlobContainerCopierBuilderTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testSourceFactoryIsMissing_ThrowsIllegalArgumentException() {
-    copier =
-        new BlobContainerCopierBuilder().destinationClientFactory(destinationFactory).buildCopier();
+    copier = new BlobContainerCopierBuilder().destinationClientFactory(destinationFactory).build();
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
@@ -1,0 +1,84 @@
+package bio.terra.service.filedata.azure.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import bio.terra.common.category.Unit;
+import java.util.List;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@Category(Unit.class)
+public class BlobContainerCopierBuilderTest {
+
+  @Mock private BlobContainerClientFactory sourceFactory;
+  @Mock private BlobContainerClientFactory destinationFactory;
+  @Mock private List<BlobCopySourceDestinationPair> pairs;
+
+  private BlobContainerCopier copier;
+
+  @Test
+  public void testBuildCopierUsingSourceAndDestinationFactories_CopierIsBuilt() {
+
+    copier =
+        new BlobContainerCopierBuilder()
+            .sourceClientFactory(sourceFactory)
+            .destinationClientFactory(destinationFactory)
+            .buildCopier();
+
+    assertThat(
+        copier,
+        allOf(
+            hasProperty("sourceClientFactory", equalTo(sourceFactory)),
+            hasProperty("destinationClientFactory", equalTo(destinationFactory))));
+  }
+
+  @Test
+  public void testBuildCopierUsingSourceAndDestinationFactoriesWithPairs_CopierIsBuilt() {
+
+    copier =
+        new BlobContainerCopierBuilder()
+            .sourceClientFactory(sourceFactory)
+            .destinationClientFactory(destinationFactory)
+            .sourceDestinationPairs(pairs)
+            .buildCopier();
+
+    assertThat(
+        copier,
+        allOf(
+            hasProperty("sourceClientFactory", equalTo(sourceFactory)),
+            hasProperty("destinationClientFactory", equalTo(destinationFactory)),
+            hasProperty("sourceDestinationPairs", equalTo(pairs))));
+  }
+
+  @Test
+  public void testBuildCopierUsingSourceBlobUrlAndDestinationFactories_CopierIsBuilt() {
+
+    String sourceBlobUrl = "http://mytest.blob.core.windows.net/mytest/test?sp=rl";
+    String destinationBlobName = "destBlobName";
+
+    copier =
+        new BlobContainerCopierBuilder()
+            .sourceBlobUrl(sourceBlobUrl)
+            .destinationBlobName(destinationBlobName)
+            .destinationClientFactory(destinationFactory)
+            .buildCopier();
+
+    assertThat(
+        copier,
+        allOf(
+            hasProperty("sourceBlobUrl", equalTo(sourceBlobUrl)),
+            hasProperty("destinationBlobName", equalTo(destinationBlobName)),
+            hasProperty("destinationClientFactory", equalTo(destinationFactory))));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSourceFactoryIsMissing_ThrowsIllegalArgumentException() {
+    copier =
+        new BlobContainerCopierBuilder().destinationClientFactory(destinationFactory).buildCopier();
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
@@ -58,7 +58,7 @@ public class BlobContainerCopierBuilderTest {
   @Test
   public void testBuildCopierUsingSourceBlobUrlAndDestinationFactories_CopierIsBuilt() {
 
-    String sourceBlobUrl = "http://mytest.blob.core.windows.net/mytest/test?sp=rl";
+    String sourceBlobUrl = "https://mytest.blob.core.windows.net/mytest/test?sp=rl";
     String destinationBlobName = "destBlobName";
 
     copier =

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
@@ -1,7 +1,9 @@
 package bio.terra.service.filedata.azure.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
 
 import bio.terra.common.category.Unit;
 import java.util.List;

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierBuilderTest.java
@@ -9,9 +9,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(SpringRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 @Category(Unit.class)
 public class BlobContainerCopierBuilderTest {
 

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -99,7 +99,7 @@ public class BlobContainerCopierTest {
     poller.waitForCompletion();
 
     assertThat(
-        this.blobIOTestUtility.getDestinationBlobContainerClient().getBlobClient(blobName).exists(),
+        blobIOTestUtility.getDestinationBlobContainerClient().getBlobClient(blobName).exists(),
         is(true));
   }
 
@@ -127,7 +127,7 @@ public class BlobContainerCopierTest {
     sourceDestinationPairs.forEach(
         b ->
             assertThat(
-                this.blobIOTestUtility
+                blobIOTestUtility
                     .getDestinationBlobContainerClient()
                     .getBlobClient(b.getDestinationBlobName())
                     .exists(),
@@ -151,10 +151,7 @@ public class BlobContainerCopierTest {
     blobs.forEach(
         b ->
             assertThat(
-                this.blobIOTestUtility
-                    .getDestinationBlobContainerClient()
-                    .getBlobClient(b)
-                    .exists(),
+                blobIOTestUtility.getDestinationBlobContainerClient().getBlobClient(b).exists(),
                 is(true)));
   }
 
@@ -166,12 +163,12 @@ public class BlobContainerCopierTest {
 
     BlobContainerCopier copier =
         new BlobContainerCopier(blobIOTestUtility.createDestinationClientFactory());
-    copier.setSourceBlobUrl(sourceFactory.createReadOnlySASUrlForBlob(blobName));
+    copier.setSourceBlobUrl(sourceFactory.createReadOnlySasUrlForBlob(blobName));
 
     copier.beginCopyOperation().waitForCompletion();
 
     assertThat(
-        this.blobIOTestUtility.getDestinationBlobContainerClient().getBlobClient(blobName).exists(),
+        blobIOTestUtility.getDestinationBlobContainerClient().getBlobClient(blobName).exists(),
         is(true));
   }
 
@@ -183,12 +180,12 @@ public class BlobContainerCopierTest {
 
     BlobContainerCopier copier =
         new BlobContainerCopier(blobIOTestUtility.createDestinationClientFactory());
-    copier.setSourceBlobUrl(sourceFactory.createReadOnlySASUrlForBlob(blobName));
+    copier.setSourceBlobUrl(sourceFactory.createReadOnlySasUrlForBlob(blobName));
     copier.setDestinationBlobName(destinationBlobName);
     copier.beginCopyOperation().waitForCompletion();
 
     assertThat(
-        this.blobIOTestUtility
+        blobIOTestUtility
             .getDestinationBlobContainerClient()
             .getBlobClient(destinationBlobName)
             .exists(),
@@ -197,15 +194,15 @@ public class BlobContainerCopierTest {
 
   private String getSourceStorageAccountPrimarySharedKey() {
     AzureResourceManager client =
-        this.azureResourceConfiguration.getClient(
-            this.connectedTestConfiguration.getTargetTenantId(),
-            this.connectedTestConfiguration.getTargetSubscriptionId());
+        azureResourceConfiguration.getClient(
+            connectedTestConfiguration.getTargetTenantId(),
+            connectedTestConfiguration.getTargetSubscriptionId());
 
     return client
         .storageAccounts()
         .getByResourceGroup(
-            this.connectedTestConfiguration.getTargetResourceGroupName(),
-            this.connectedTestConfiguration.getSourceStorageAccountName())
+            connectedTestConfiguration.getTargetResourceGroupName(),
+            connectedTestConfiguration.getSourceStorageAccountName())
         .getKeys()
         .iterator()
         .next()
@@ -225,9 +222,9 @@ public class BlobContainerCopierTest {
 
   private BlobContainerClientFactory createSourceClientFactoryWithSharedKey() {
     String sourceContainer =
-        this.blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
+        blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
     return new BlobContainerClientFactory(
-        this.connectedTestConfiguration.getSourceStorageAccountName(),
+        connectedTestConfiguration.getSourceStorageAccountName(),
         getSourceStorageAccountPrimarySharedKey(),
         sourceContainer);
   }
@@ -235,15 +232,14 @@ public class BlobContainerCopierTest {
   private BlobContainerCopier createBlobCopierWithTokenCredsInSource(Duration pollingInterval) {
 
     BlobContainerCopier copier =
-        new BlobContainerCopier(this.blobIOTestUtility.createDestinationClientFactory());
+        new BlobContainerCopier(blobIOTestUtility.createDestinationClientFactory());
     copier.setPollingInterval(pollingInterval);
     String sourceContainer =
-        this.blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
+        blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
     copier.setSourceClientFactory(
         new BlobContainerClientFactory(
-            this.connectedTestConfiguration.getSourceStorageAccountName(),
-            this.azureResourceConfiguration.getAppToken(
-                this.connectedTestConfiguration.getTargetTenantId()),
+            connectedTestConfiguration.getSourceStorageAccountName(),
+            azureResourceConfiguration.getAppToken(connectedTestConfiguration.getTargetTenantId()),
             sourceContainer));
 
     return copier;
@@ -252,7 +248,7 @@ public class BlobContainerCopierTest {
   private BlobContainerCopier createBlobCopierWithSasCredsInSource(Duration pollingInterval) {
 
     BlobContainerCopier copier =
-        new BlobContainerCopier(this.blobIOTestUtility.createDestinationClientFactory());
+        new BlobContainerCopier(blobIOTestUtility.createDestinationClientFactory());
     copier.setPollingInterval(pollingInterval);
     copier.setSourceClientFactory(createSourceClientFactoryWithSasCreds());
 
@@ -261,7 +257,7 @@ public class BlobContainerCopierTest {
 
   private BlobContainerClientFactory createSourceClientFactoryWithSasCreds() {
     return new BlobContainerClientFactory(
-        this.blobIOTestUtility.generateSourceContainerUrlWithSasReadAndListPermissions(
+        blobIOTestUtility.generateSourceContainerUrlWithSasReadAndListPermissions(
             getSourceStorageAccountPrimarySharedKey()));
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -28,9 +28,9 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Note: To run these tests the following must be set:
  *
  * <UL>
- *   <LI>AZURE_CREDENTIALS_APPLICATIONID
- *   <LI>AZURE_CREDENTIALS_HOMETENANTID
- *   <LI>AZURE_CREDENTIALS_SECRET
+ *   <LI>AZURE_CREDENTIALS_APPLICATIONID</LI>
+ *   <LI>AZURE_CREDENTIALS_HOMETENANTID</LI>
+ *   <LI>AZURE_CREDENTIALS_SECRET</LI>
  * </UL>
  *
  * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -1,0 +1,270 @@
+package bio.terra.service.filedata.azure.util;
+
+import static bio.terra.service.filedata.azure.util.BlobIOTestUtility.MiB;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.category.Connected;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import com.azure.resourcemanager.AzureResourceManager;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Note: To run these tests the following must be set:
+ *
+ * <UL>
+ *   <LI>AZURE_CREDENTIALS_APPLICATIONID
+ *   <LI>AZURE_CREDENTIALS_HOMETENANTID
+ *   <LI>AZURE_CREDENTIALS_SECRET
+ * </UL>
+ *
+ * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage
+ * accounts.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Category(Connected.class)
+public class BlobContainerCopierTest {
+
+  @Autowired private AzureResourceConfiguration azureResourceConfiguration;
+
+  @Autowired private ConnectedTestConfiguration connectedTestConfiguration;
+
+  private static final int POLL_INTERVAL_IN_SECONDS = 2;
+  private BlobIOTestUtility blobIOTestUtility;
+  private Stream<BlobContainerCopier> copiersStream;
+
+  @Before
+  public void setUp() {
+
+    blobIOTestUtility =
+        new BlobIOTestUtility(
+            azureResourceConfiguration.getAppToken(),
+            connectedTestConfiguration.getSourceStorageAccountName(),
+            connectedTestConfiguration.getDestinationStorageAccountName());
+
+    Duration pollDuration = Duration.ofSeconds(POLL_INTERVAL_IN_SECONDS);
+    BlobContainerCopier copierWithSharedKeyCredentials =
+        createBlobCopierWithSharedKeyInSource(pollDuration);
+    BlobContainerCopier copierWithSasCredentials =
+        createBlobCopierWithSasCredsInSource(pollDuration);
+    BlobContainerCopier copierWithTokenCredentials =
+        createBlobCopierWithTokenCredsInSource(pollDuration);
+
+    copiersStream =
+        Stream.of(
+            copierWithSharedKeyCredentials, copierWithTokenCredentials, copierWithSasCredentials);
+  }
+
+  @After
+  public void cleanUp() {
+    blobIOTestUtility.deleteContainers();
+  }
+  /*
+  Tests in this class should be parameterized tests. However, since we are using
+  JUnit 4 the implementation would be convoluted. Instead, the execution pattern
+  followed here should make it easier to migrate to JUnit 5 when appropriate.
+
+  Migration approach:
+  - Make each of the _Impl a parameterized test - @ParameterizedTest annotation
+  - Convert the Stream of copiers to a method source.
+   */
+
+  @Test
+  public void testCopySingleFile_FileIsCopied() {
+    copiersStream.forEach(this::testCopySingleFile_FileIsCopied_Impl);
+  }
+
+  private void testCopySingleFile_FileIsCopied_Impl(BlobContainerCopier copier) {
+    String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
+
+    BlobCopySourceDestinationPair pair = new BlobCopySourceDestinationPair(blobName, "");
+    copier.setSourceDestinationPairs(Collections.singletonList(pair));
+
+    BlobContainerCopySyncPoller poller = copier.beginCopyOperation();
+
+    poller.waitForCompletion();
+
+    assertThat(
+        this.blobIOTestUtility.getDestinationBlobContainerClient().getBlobClient(blobName).exists(),
+        is(true));
+  }
+
+  @Test
+  public void testCopy2FilesWithDestinationNames_FilesAreCopiedWithDestinationNames() {
+    copiersStream.forEach(
+        this::testCopy2FilesWithDestinationNames_FilesAreCopiedWithDestinationNames_Impl);
+  }
+
+  private void testCopy2FilesWithDestinationNames_FilesAreCopiedWithDestinationNames_Impl(
+      BlobContainerCopier copier) {
+    List<String> blobs = blobIOTestUtility.uploadSourceFiles(2, MiB / 10);
+
+    List<BlobCopySourceDestinationPair> sourceDestinationPairs =
+        blobs.stream()
+            .map(b -> new BlobCopySourceDestinationPair(b, "foo" + b))
+            .collect(Collectors.toList());
+
+    copier.setSourceDestinationPairs(sourceDestinationPairs);
+
+    BlobContainerCopySyncPoller poller = copier.beginCopyOperation();
+
+    poller.waitForCompletion();
+
+    sourceDestinationPairs.forEach(
+        b ->
+            assertThat(
+                this.blobIOTestUtility
+                    .getDestinationBlobContainerClient()
+                    .getBlobClient(b.getDestinationBlobName())
+                    .exists(),
+                is(true)));
+  }
+
+  @Test
+  public void testCopy5FilesUsingEmptyPrefix_AllFilesAreCopied() {
+    copiersStream.forEach(this::testCopy5FilesUsingEmptyPrefix_AllFilesAreCopied_Impl);
+  }
+
+  private void testCopy5FilesUsingEmptyPrefix_AllFilesAreCopied_Impl(BlobContainerCopier copier) {
+    List<String> blobs = blobIOTestUtility.uploadSourceFiles(5, MiB / 10);
+
+    copier.setBlobSourcePrefix("");
+
+    BlobContainerCopySyncPoller poller = copier.beginCopyOperation();
+
+    poller.waitForCompletion();
+
+    blobs.forEach(
+        b ->
+            assertThat(
+                this.blobIOTestUtility
+                    .getDestinationBlobContainerClient()
+                    .getBlobClient(b)
+                    .exists(),
+                is(true)));
+  }
+
+  @Test
+  public void testCopySingleBLobWithSignedURl_FileIsCopied() {
+    String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
+
+    BlobContainerClientFactory sourceFactory = createSourceClientFactoryWithSharedKey();
+
+    BlobContainerCopier copier =
+        new BlobContainerCopier(blobIOTestUtility.createDestinationClientFactory());
+    copier.setSourceBlobUrl(sourceFactory.createReadOnlySASUrlForBlob(blobName));
+
+    copier.beginCopyOperation().waitForCompletion();
+
+    assertThat(
+        this.blobIOTestUtility.getDestinationBlobContainerClient().getBlobClient(blobName).exists(),
+        is(true));
+  }
+
+  @Test
+  public void testCopySingleBLobWithSignedURlAndDestinationName_FileCopiedWithDestinationName() {
+    String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
+    String destinationBlobName = "myBlob";
+    BlobContainerClientFactory sourceFactory = createSourceClientFactoryWithSharedKey();
+
+    BlobContainerCopier copier =
+        new BlobContainerCopier(blobIOTestUtility.createDestinationClientFactory());
+    copier.setSourceBlobUrl(sourceFactory.createReadOnlySASUrlForBlob(blobName));
+    copier.setDestinationBlobName(destinationBlobName);
+    copier.beginCopyOperation().waitForCompletion();
+
+    assertThat(
+        this.blobIOTestUtility
+            .getDestinationBlobContainerClient()
+            .getBlobClient(destinationBlobName)
+            .exists(),
+        is(true));
+  }
+
+  private String getSourceStorageAccountPrimarySharedKey() {
+    AzureResourceManager client =
+        this.azureResourceConfiguration.getClient(
+            this.connectedTestConfiguration.getTargetSubscriptionId());
+
+    return client
+        .storageAccounts()
+        .getByResourceGroup(
+            this.connectedTestConfiguration.getTargetResourceGroupName(),
+            this.connectedTestConfiguration.getSourceStorageAccountName())
+        .getKeys()
+        .stream()
+        .findFirst()
+        .get()
+        .value();
+  }
+
+  private BlobContainerCopier createBlobCopierWithSharedKeyInSource(Duration pollingInterval) {
+
+    BlobContainerCopier copier =
+        new BlobContainerCopier(this.blobIOTestUtility.createDestinationClientFactory());
+    copier.setPollingInterval(pollingInterval);
+
+    copier.setSourceClientFactory(createSourceClientFactoryWithSharedKey());
+
+    return copier;
+  }
+
+  private BlobContainerClientFactory createSourceClientFactoryWithSharedKey() {
+    String sourceContainer =
+        this.blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
+    return new BlobContainerClientFactory(
+        this.connectedTestConfiguration.getSourceStorageAccountName(),
+        getSourceStorageAccountPrimarySharedKey(),
+        sourceContainer);
+  }
+
+  private BlobContainerCopier createBlobCopierWithTokenCredsInSource(Duration pollingInterval) {
+
+    BlobContainerCopier copier =
+        new BlobContainerCopier(this.blobIOTestUtility.createDestinationClientFactory());
+    copier.setPollingInterval(pollingInterval);
+    String sourceContainer =
+        this.blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
+    copier.setSourceClientFactory(
+        new BlobContainerClientFactory(
+            this.connectedTestConfiguration.getSourceStorageAccountName(),
+            this.azureResourceConfiguration.getAppToken(),
+            sourceContainer));
+
+    return copier;
+  }
+
+  private BlobContainerCopier createBlobCopierWithSasCredsInSource(Duration pollingInterval) {
+
+    BlobContainerCopier copier =
+        new BlobContainerCopier(this.blobIOTestUtility.createDestinationClientFactory());
+    copier.setPollingInterval(pollingInterval);
+    copier.setSourceClientFactory(createSourceClientFactoryWithSasCreds());
+
+    return copier;
+  }
+
+  private BlobContainerClientFactory createSourceClientFactoryWithSasCreds() {
+    return new BlobContainerClientFactory(
+        this.blobIOTestUtility.generateSourceContainerUrlWithSasReadAndListPermissions(
+            getSourceStorageAccountPrimarySharedKey()));
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -29,12 +29,8 @@ import org.springframework.test.context.junit4.SpringRunner;
  *
  * <UL>
  *   <LI>AZURE_CREDENTIALS_APPLICATIONID
- *   <LI>AZURE_CREDENTIALS_HOMETENANTID
  *   <LI>AZURE_CREDENTIALS_SECRET
  * </UL>
- *
- * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage
- * accounts.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -93,7 +89,7 @@ public class BlobContainerCopierTest {
   }
 
   private void testCopySingleFile_FileIsCopied_Impl(BlobContainerCopier copier) {
-    String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
+    String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).iterator().next();
 
     BlobCopySourceDestinationPair pair = new BlobCopySourceDestinationPair(blobName, "");
     copier.setSourceDestinationPairs(Collections.singletonList(pair));
@@ -164,7 +160,7 @@ public class BlobContainerCopierTest {
 
   @Test
   public void testCopySingleBlobWithSignedURl_FileIsCopied() {
-    String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
+    String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).iterator().next();
 
     BlobContainerClientFactory sourceFactory = createSourceClientFactoryWithSharedKey();
 
@@ -181,7 +177,7 @@ public class BlobContainerCopierTest {
 
   @Test
   public void testCopySingleBLobWithSignedURlAndDestinationName_FileCopiedWithDestinationName() {
-    String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
+    String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).iterator().next();
     String destinationBlobName = "myBlob";
     BlobContainerClientFactory sourceFactory = createSourceClientFactoryWithSharedKey();
 
@@ -211,9 +207,8 @@ public class BlobContainerCopierTest {
             this.connectedTestConfiguration.getTargetResourceGroupName(),
             this.connectedTestConfiguration.getSourceStorageAccountName())
         .getKeys()
-        .stream()
-        .findFirst()
-        .get()
+        .iterator()
+        .next()
         .value();
   }
 

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -28,9 +28,9 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Note: To run these tests the following must be set:
  *
  * <UL>
- *   <LI>AZURE_CREDENTIALS_APPLICATIONID</LI>
- *   <LI>AZURE_CREDENTIALS_HOMETENANTID</LI>
- *   <LI>AZURE_CREDENTIALS_SECRET</LI>
+ *   <LI>AZURE_CREDENTIALS_APPLICATIONID
+ *   <LI>AZURE_CREDENTIALS_HOMETENANTID
+ *   <LI>AZURE_CREDENTIALS_SECRET
  * </UL>
  *
  * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -56,7 +56,7 @@ public class BlobContainerCopierTest {
 
     blobIOTestUtility =
         new BlobIOTestUtility(
-            azureResourceConfiguration.getAppToken(),
+            azureResourceConfiguration.getAppToken(connectedTestConfiguration.getTargetTenantId()),
             connectedTestConfiguration.getSourceStorageAccountName(),
             connectedTestConfiguration.getDestinationStorageAccountName());
 
@@ -163,7 +163,7 @@ public class BlobContainerCopierTest {
   }
 
   @Test
-  public void testCopySingleBLobWithSignedURl_FileIsCopied() {
+  public void testCopySingleBlobWithSignedURl_FileIsCopied() {
     String blobName = blobIOTestUtility.uploadSourceFiles(1, MiB / 10).stream().findFirst().get();
 
     BlobContainerClientFactory sourceFactory = createSourceClientFactoryWithSharedKey();
@@ -202,6 +202,7 @@ public class BlobContainerCopierTest {
   private String getSourceStorageAccountPrimarySharedKey() {
     AzureResourceManager client =
         this.azureResourceConfiguration.getClient(
+            this.connectedTestConfiguration.getTargetTenantId(),
             this.connectedTestConfiguration.getTargetSubscriptionId());
 
     return client
@@ -246,7 +247,8 @@ public class BlobContainerCopierTest {
     copier.setSourceClientFactory(
         new BlobContainerClientFactory(
             this.connectedTestConfiguration.getSourceStorageAccountName(),
-            this.azureResourceConfiguration.getAppToken(),
+            this.azureResourceConfiguration.getAppToken(
+                this.connectedTestConfiguration.getTargetTenantId()),
             sourceContainer));
 
     return copier;

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfoTest.java
@@ -1,0 +1,78 @@
+package bio.terra.service.filedata.azure.util;
+
+import static com.azure.core.util.polling.LongRunningOperationStatus.*;
+import static com.azure.storage.blob.models.CopyStatusType.PENDING;
+import static com.azure.storage.blob.models.CopyStatusType.SUCCESS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.azure.core.util.polling.LongRunningOperationStatus;
+import com.azure.core.util.polling.PollResponse;
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.storage.blob.models.BlobCopyInfo;
+import com.azure.storage.blob.models.CopyStatusType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlobContainerCopyInfoTest {
+  private BlobContainerCopyInfo blobContainerCopyInfo;
+
+  @Mock private SyncPoller<BlobCopyInfo, Void> poller;
+
+  private static Stream<Arguments> getCopyStatusScenario() {
+    return Stream.of(
+        Arguments.of(SUCCESSFULLY_COMPLETED, new CopyStatusType[] {SUCCESS}),
+        Arguments.of(SUCCESSFULLY_COMPLETED, new CopyStatusType[] {SUCCESS, SUCCESS}),
+        Arguments.of(FAILED, new CopyStatusType[] {SUCCESS, CopyStatusType.FAILED}),
+        Arguments.of(
+            FAILED, new CopyStatusType[] {SUCCESS, CopyStatusType.FAILED, CopyStatusType.FAILED}),
+        Arguments.of(FAILED, new CopyStatusType[] {SUCCESS, PENDING, CopyStatusType.FAILED}),
+        Arguments.of(
+            USER_CANCELLED, new CopyStatusType[] {SUCCESS, PENDING, CopyStatusType.ABORTED}),
+        Arguments.of(IN_PROGRESS, new CopyStatusType[] {SUCCESS, PENDING, PENDING}));
+  }
+
+  @ParameterizedTest
+  @MethodSource("getCopyStatusScenario")
+  void getCopyStatus_ScenarioIsProvided_ExpectedStatusIsReturned(
+      LongRunningOperationStatus expectedStatus, CopyStatusType... statuses) {
+    blobContainerCopyInfo = new BlobContainerCopyInfo(createPollResponses(statuses));
+
+    assertThat(blobContainerCopyInfo.getCopyStatus(), equalTo(expectedStatus));
+  }
+
+  private List<PollResponse<BlobCopyInfo>> createPollResponses(CopyStatusType... statuses) {
+
+    return Arrays.stream(statuses)
+        .map(
+            s ->
+                new PollResponse<>(
+                    toLongRunningOperationStatus(s),
+                    new BlobCopyInfo("source", "123", s, "etag", null, null)))
+        .collect(Collectors.toList());
+  }
+
+  private LongRunningOperationStatus toLongRunningOperationStatus(CopyStatusType statusType) {
+    switch (statusType) {
+      case SUCCESS:
+        return SUCCESSFULLY_COMPLETED;
+      case FAILED:
+        return FAILED;
+      case ABORTED:
+        return USER_CANCELLED;
+      case PENDING:
+        return IN_PROGRESS;
+    }
+
+    return NOT_STARTED;
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
@@ -25,12 +25,8 @@ import org.springframework.test.context.junit4.SpringRunner;
  *
  * <UL>
  *   <LI>AZURE_CREDENTIALS_APPLICATIONID
- *   <LI>AZURE_CREDENTIALS_HOMETENANTID
  *   <LI>AZURE_CREDENTIALS_SECRET
  * </UL>
- *
- * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage
- * accounts.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
@@ -24,9 +24,9 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Note: To run these tests the following must be set:
  *
  * <UL>
- *   <LI>AZURE_CREDENTIALS_APPLICATIONID</LI>
- *   <LI>AZURE_CREDENTIALS_HOMETENANTID</LI>
- *   <LI>AZURE_CREDENTIALS_SECRET</LI>
+ *   <LI>AZURE_CREDENTIALS_APPLICATIONID
+ *   <LI>AZURE_CREDENTIALS_HOMETENANTID
+ *   <LI>AZURE_CREDENTIALS_SECRET
  * </UL>
  *
  * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
@@ -24,9 +24,9 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Note: To run these tests the following must be set:
  *
  * <UL>
- *   <LI>AZURE_CREDENTIALS_APPLICATIONID
- *   <LI>AZURE_CREDENTIALS_HOMETENANTID
- *   <LI>AZURE_CREDENTIALS_SECRET
+ *   <LI>AZURE_CREDENTIALS_APPLICATIONID</LI>
+ *   <LI>AZURE_CREDENTIALS_HOMETENANTID</LI>
+ *   <LI>AZURE_CREDENTIALS_SECRET</LI>
  * </UL>
  *
  * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
@@ -80,7 +80,4 @@ public class BlobCrlTest {
 
     assertThat(properties.getBlobSize(), equalTo(MiB / 10));
   }
-
-  @Test
-  public void createContainerNameIfNotExists() {}
 }

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
@@ -1,0 +1,90 @@
+package bio.terra.service.filedata.azure.util;
+
+import static bio.terra.service.filedata.azure.util.BlobIOTestUtility.MiB;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.category.Connected;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import com.azure.storage.blob.models.BlobProperties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Note: To run these tests the following must be set:
+ *
+ * <UL>
+ *   <LI>AZURE_CREDENTIALS_APPLICATIONID
+ *   <LI>AZURE_CREDENTIALS_HOMETENANTID
+ *   <LI>AZURE_CREDENTIALS_SECRET
+ * </UL>
+ *
+ * Where AZURE_CREDENTIALS_HOMETENANTID must be the tenant of the source and destination storage
+ * accounts.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Category(Connected.class)
+public class BlobCrlTest {
+
+  @Autowired private AzureResourceConfiguration azureResourceConfiguration;
+
+  @Autowired private ConnectedTestConfiguration connectedTestConfiguration;
+
+  private BlobIOTestUtility blobIOTestUtility;
+
+  private BlobCrl blobCrl;
+
+  @Before
+  public void setUp() throws Exception {
+    blobIOTestUtility =
+        new BlobIOTestUtility(
+            azureResourceConfiguration.getAppToken(),
+            connectedTestConfiguration.getSourceStorageAccountName(),
+            connectedTestConfiguration.getDestinationStorageAccountName());
+
+    blobCrl = new BlobCrl(blobIOTestUtility.createDestinationClientFactory());
+  }
+
+  @After
+  public void cleanUp() {
+    blobIOTestUtility.deleteContainers();
+  }
+
+  @Test
+  public void testDeleteBlob_BlobDoesNotExists() {
+    String blobName = "myBlob";
+    blobIOTestUtility.uploadDestinationFile(blobName, MiB / 10);
+
+    blobCrl.deleteBlob(blobName);
+
+    assertThat(
+        blobIOTestUtility.getDestinationBlobContainerClient().getBlobClient(blobName).exists(),
+        is(false));
+  }
+
+  @Test
+  public void testGetBlobProperties_SizeInPropetiesMatches() {
+    String blobName = "myBlob";
+    blobIOTestUtility.uploadDestinationFile(blobName, MiB / 10);
+
+    BlobProperties properties = blobCrl.getBlobProperties(blobName);
+
+    assertThat(properties.getBlobSize(), equalTo(MiB / 10));
+  }
+
+  @Test
+  public void createContainerNameIfNotExists() {}
+}

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
@@ -51,7 +51,7 @@ public class BlobCrlTest {
   public void setUp() throws Exception {
     blobIOTestUtility =
         new BlobIOTestUtility(
-            azureResourceConfiguration.getAppToken(),
+            azureResourceConfiguration.getAppToken(connectedTestConfiguration.getTargetTenantId()),
             connectedTestConfiguration.getSourceStorageAccountName(),
             connectedTestConfiguration.getDestinationStorageAccountName());
 
@@ -76,7 +76,7 @@ public class BlobCrlTest {
   }
 
   @Test
-  public void testGetBlobProperties_SizeInPropetiesMatches() {
+  public void testGetBlobProperties_SizeInPropertiesMatches() {
     String blobName = "myBlob";
     blobIOTestUtility.uploadDestinationFile(blobName, MiB / 10);
 

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
@@ -122,14 +122,6 @@ public class BlobIOTestUtility {
     return blobName;
   }
 
-  public String getSourceContainerEndpoint() {
-    return this.sourceBlobContainerClient.getBlobContainerUrl();
-  }
-
-  public String getDestinationContainerEndpoint() {
-    return this.destinationBlobContainerClient.getBlobContainerUrl();
-  }
-
   private InputStream createInputStream(long length) {
     return new InputStream() {
       private long dataProduced;

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
@@ -1,5 +1,7 @@
 package bio.terra.service.filedata.azure.util;
 
+import static bio.terra.service.resourcemanagement.AzureDataLocationSelector.armUniqueString;
+
 import com.azure.core.credential.TokenCredential;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
@@ -16,6 +18,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang.RandomStringUtils;
 
 /**
  * Test component that facilitates the creation and deletion of data in Azure storage for testing
@@ -93,7 +96,7 @@ public class BlobIOTestUtility {
   }
 
   private String generateNewTempContainerName() {
-    return UUID.randomUUID().toString().toLowerCase().replace("-", "").substring(0, 30);
+    return armUniqueString(RandomStringUtils.random(10), 30);
   }
 
   public List<String> uploadSourceFiles(int numOfFiles, long length) {

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
@@ -133,7 +133,7 @@ public class BlobIOTestUtility {
   private InputStream createInputStream(long length) {
     return new InputStream() {
       private long dataProduced;
-      private Random rand = new Random();
+      private final Random rand = new Random();
 
       @Override
       public int read() throws IOException {

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
@@ -37,7 +37,7 @@ public class BlobIOTestUtility {
   private final BlobContainerClient destinationBlobContainerClient;
   private String sourceContainerName;
   private String destinationContainerName;
-  private final String STORAGE_ENDPOINT_PATTERN = "https://%s.blob.core.windows.net/%s";
+  private static final String STORAGE_ENDPOINT_PATTERN = "https://%s.blob.core.windows.net/%s";
   private final TokenCredential tokenCredential;
 
   public BlobIOTestUtility(

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
@@ -1,0 +1,157 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.common.sas.SasProtocol;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Test component that facilitates the creation and deletion of data in Azure storage for testing
+ * copy operations.
+ */
+public class BlobIOTestUtility {
+  private static final String SOURCE_BLOB_NAME = "myTestBlob";
+  static final long MiB = 1024 * 1024;
+  private final BlobContainerClient sourceBlobContainerClient;
+
+  public BlobContainerClient getSourceBlobContainerClient() {
+    return sourceBlobContainerClient;
+  }
+
+  public BlobContainerClient getDestinationBlobContainerClient() {
+    return destinationBlobContainerClient;
+  }
+
+  private final BlobContainerClient destinationBlobContainerClient;
+  private String sourceContainerName;
+  private String destinationContainerName;
+  private final String STORAGE_ENDPOINT_PATTERN = "https://%s.blob.core.windows.net/%s";
+  private final TokenCredential tokenCredential;
+
+  public BlobIOTestUtility(
+      TokenCredential tokenCredential, String sourceAccountName, String destinationAccountName) {
+    this.sourceContainerName = generateNewTempContainerName();
+    this.destinationContainerName = generateNewTempContainerName();
+    this.sourceBlobContainerClient =
+        createBlobContainerClient(tokenCredential, this.sourceContainerName, sourceAccountName);
+    this.destinationBlobContainerClient =
+        createBlobContainerClient(
+            tokenCredential, this.destinationContainerName, destinationAccountName);
+    this.sourceBlobContainerClient.create();
+    this.destinationBlobContainerClient.create();
+    this.tokenCredential = tokenCredential;
+  }
+
+  private BlobContainerClient createBlobContainerClient(
+      TokenCredential credential, String containerName, String accountName) {
+
+    return new BlobContainerClientBuilder()
+        .credential(credential)
+        .endpoint(String.format(Locale.ROOT, STORAGE_ENDPOINT_PATTERN, accountName, containerName))
+        .buildClient();
+  }
+
+  public String generateSourceContainerUrlWithSasReadAndListPermissions(String accountKey) {
+    String sasToken = generateContainerSasTokenWithReadAndListPermissions(accountKey);
+
+    return String.format(
+        "%s?%s", this.getSourceBlobContainerClient().getBlobContainerUrl(), sasToken);
+  }
+
+  public String generateContainerSasTokenWithReadAndListPermissions(String accountKey) {
+    BlobSasPermission permissions =
+        new BlobSasPermission().setReadPermission(true).setListPermission(true);
+
+    OffsetDateTime expiryTime = OffsetDateTime.now().plusDays(1);
+    SasProtocol sasProtocol = SasProtocol.HTTPS_ONLY;
+
+    // build the token
+    BlobServiceSasSignatureValues sasSignatureValues =
+        new BlobServiceSasSignatureValues(expiryTime, permissions).setProtocol(sasProtocol);
+
+    BlobContainerClient blobContainerClient =
+        new BlobContainerClientBuilder()
+            .credential(
+                new StorageSharedKeyCredential(
+                    this.sourceBlobContainerClient.getAccountName(), accountKey))
+            .endpoint(this.sourceBlobContainerClient.getBlobContainerUrl())
+            .buildClient();
+
+    return blobContainerClient.generateSas(sasSignatureValues);
+  }
+
+  private String generateNewTempContainerName() {
+    return UUID.randomUUID().toString().toLowerCase().replace("-", "").substring(0, 30);
+  }
+
+  public List<String> uploadSourceFiles(int numOfFiles, long length) {
+    return Stream.iterate(0, n -> n + 1)
+        .limit(numOfFiles)
+        .map(
+            i ->
+                uploadSourceFile(
+                    String.format("%s/%s%s", i, SOURCE_BLOB_NAME, UUID.randomUUID().toString()),
+                    length))
+        .collect(Collectors.toList());
+  }
+
+  public String uploadSourceFile(String blobName, long length) {
+    sourceBlobContainerClient.getBlobClient(blobName).upload(createInputStream(length), length);
+    return blobName;
+  }
+
+  public String uploadDestinationFile(String blobName, long length) {
+    destinationBlobContainerClient
+        .getBlobClient(blobName)
+        .upload(createInputStream(length), length);
+    return blobName;
+  }
+
+  public String getSourceContainerEndpoint() {
+    return this.sourceBlobContainerClient.getBlobContainerUrl();
+  }
+
+  public String getDestinationContainerEndpoint() {
+    return this.destinationBlobContainerClient.getBlobContainerUrl();
+  }
+
+  private InputStream createInputStream(long length) {
+    return new InputStream() {
+      private long dataProduced;
+      private Random rand = new Random();
+
+      @Override
+      public int read() throws IOException {
+        if (dataProduced == length) {
+          return -1;
+        }
+        dataProduced++;
+        return rand.nextInt(100 - 65) + 65; // starting at "A"
+      }
+    };
+  }
+
+  public void deleteContainers() {
+    destinationBlobContainerClient.delete();
+    sourceBlobContainerClient.delete();
+  }
+
+  public BlobContainerClientFactory createDestinationClientFactory() {
+    return new BlobContainerClientFactory(
+        this.destinationBlobContainerClient.getAccountName(),
+        this.tokenCredential,
+        this.destinationContainerName);
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
@@ -38,22 +38,21 @@ public class BlobIOTestUtility {
   }
 
   private final BlobContainerClient destinationBlobContainerClient;
-  private String sourceContainerName;
   private String destinationContainerName;
   private static final String STORAGE_ENDPOINT_PATTERN = "https://%s.blob.core.windows.net/%s";
   private final TokenCredential tokenCredential;
 
   public BlobIOTestUtility(
       TokenCredential tokenCredential, String sourceAccountName, String destinationAccountName) {
-    this.sourceContainerName = generateNewTempContainerName();
-    this.destinationContainerName = generateNewTempContainerName();
-    this.sourceBlobContainerClient =
-        createBlobContainerClient(tokenCredential, this.sourceContainerName, sourceAccountName);
-    this.destinationBlobContainerClient =
+    String sourceContainerName = generateNewTempContainerName();
+    destinationContainerName = generateNewTempContainerName();
+    sourceBlobContainerClient =
+        createBlobContainerClient(tokenCredential, sourceContainerName, sourceAccountName);
+    destinationBlobContainerClient =
         createBlobContainerClient(
-            tokenCredential, this.destinationContainerName, destinationAccountName);
-    this.sourceBlobContainerClient.create();
-    this.destinationBlobContainerClient.create();
+            tokenCredential, destinationContainerName, destinationAccountName);
+    sourceBlobContainerClient.create();
+    destinationBlobContainerClient.create();
     this.tokenCredential = tokenCredential;
   }
 
@@ -69,8 +68,7 @@ public class BlobIOTestUtility {
   public String generateSourceContainerUrlWithSasReadAndListPermissions(String accountKey) {
     String sasToken = generateContainerSasTokenWithReadAndListPermissions(accountKey);
 
-    return String.format(
-        "%s?%s", this.getSourceBlobContainerClient().getBlobContainerUrl(), sasToken);
+    return String.format("%s?%s", getSourceBlobContainerClient().getBlobContainerUrl(), sasToken);
   }
 
   public String generateContainerSasTokenWithReadAndListPermissions(String accountKey) {
@@ -88,8 +86,8 @@ public class BlobIOTestUtility {
         new BlobContainerClientBuilder()
             .credential(
                 new StorageSharedKeyCredential(
-                    this.sourceBlobContainerClient.getAccountName(), accountKey))
-            .endpoint(this.sourceBlobContainerClient.getBlobContainerUrl())
+                    sourceBlobContainerClient.getAccountName(), accountKey))
+            .endpoint(sourceBlobContainerClient.getBlobContainerUrl())
             .buildClient();
 
     return blobContainerClient.generateSas(sasSignatureValues);
@@ -105,8 +103,7 @@ public class BlobIOTestUtility {
         .map(
             i ->
                 uploadSourceFile(
-                    String.format("%s/%s%s", i, SOURCE_BLOB_NAME, UUID.randomUUID().toString()),
-                    length))
+                    String.format("%s/%s%s", i, SOURCE_BLOB_NAME, UUID.randomUUID()), length))
         .collect(Collectors.toList());
   }
 
@@ -145,8 +142,6 @@ public class BlobIOTestUtility {
 
   public BlobContainerClientFactory createDestinationClientFactory() {
     return new BlobContainerClientFactory(
-        this.destinationBlobContainerClient.getAccountName(),
-        this.tokenCredential,
-        this.destinationContainerName);
+        destinationBlobContainerClient.getAccountName(), tokenCredential, destinationContainerName);
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobIOTestUtility.java
@@ -18,7 +18,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * Test component that facilitates the creation and deletion of data in Azure storage for testing

--- a/src/test/resources/application-connectedtest.properties
+++ b/src/test/resources/application-connectedtest.properties
@@ -7,6 +7,8 @@ ct.targetTenantId=efc08443-0082-4d6c-8931-c5794c156abd
 ct.targetResourceGroupName=TDR_connected
 ct.targetSubscriptionId=71d52ec1-5886-480a-9d6e-ed98cbf1f69f
 ct.targetApplicationName=connectedapp
+ct.sourceStorageAccountName=tdrconnectedsrc1
+ct.destinationStorageAccountName=tdrconnecteddest1
 
 # This second billing account should NOT be used for general testing
 # we do not want to spend funds on this billing account


### PR DESCRIPTION
Initial PR of Azure Blob Copier utility.  

The PR includes the following classes:

`BlobContainerCopier` - Enables asynchronous copy operations between storage accounts using the Azure backend. With the following capabilities:
  - Copy of  blobs from a source to a destination container in a different or  same storage account. 
  - Source filtering by a prefix.
  - Destination blob names can be overwritten.
  - Sources can be accessed by providing any of the following:
    - Token credentials (using a SP with Contributor access)
    - Shared Key. 
    - Container SAS token with list and read permissions.
    - Blob SAS token with read permissions.

`BlobCrl` - High-level API that enables copy, delete, and get blob properties operations on Azure Blob storage. With the following capabilities:
 -  Facilitates the creation of instances of `BlobContainerCopier` for common copy scenarios.
 -  Delete blobs from a container.
 -  Get Blob properties (e.g. Size, MD5 etc.)

`BlobContainerCopierBuilder` - Builder of `BlobContainerCopier`.

`BlobContainerClientFactory` - Wraps the SDK container client  and facilities the creation of SAS Urls for blobs by
 abstracting the different strategies that depend on the authentication mechanism.
 
`BlobContainerCopySyncPoller` - An implementation of `SyncPoller<>` , which provides the following functionality to simplify the task of executing long-running copy operations.
It provides the following functionality:
 - Querying the current state of the long-running operation.
- Requesting cancellation of long-running operation.
- Fetching final result of long-running operation.
- Wait for long-running operation to complete, with an optional timeout.
- Wait for long-running operation to reach a specific state.

Additional comments:
- To run the tests the `AZURE_CREDENTIALS_HOMETENANTID` environment variable must be set to the Tenant of the storage accounts. 



