### PR TITLE
More spotless build refinement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,14 @@ trim_trailing_whitespace=true
 insert_final_newline=true
 indent_style=space
 indent_size=4
+max_line_length = 100
+ij_visual_guides = 100
+
+[*.java]
+indent_size = 2
+ij_continuation_indent_size = 4
+ij_java_indent_case_from_switch = true
+ij_java_wrap_comments = true
 
 [*.json]
 indent_style=space

--- a/build.gradle
+++ b/build.gradle
@@ -425,9 +425,7 @@ liquibase {
 spotless {
     java {
         target project.fileTree(project.rootDir) {
-            include '**/*.java'
-            exclude 'build/**/*.*'
-            exclude '**/generated/**/*.*'
+            include 'src/**/*.java'
         }
         googleJavaFormat()
     }
@@ -502,5 +500,13 @@ compileGeneratedJava.dependsOn swaggerSources.server.code
 compileGeneratedJava.dependsOn generateGrammarSource
 classes.dependsOn generatedClasses
 compileJava.dependsOn compileGeneratedJava
-compileJava.dependsOn spotlessCheck
 ideaModule.dependsOn swaggerSources.server.code
+
+// Run spotless check when running in github actions, otherwise run spotless apply.
+compileJava {
+    if (System.getProperty('CI')) {
+        dependsOn(spotlessCheck)
+    } else {
+        dependsOn(spotlessApply)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -504,7 +504,7 @@ ideaModule.dependsOn swaggerSources.server.code
 
 // Run spotless check when running in github actions, otherwise run spotless apply.
 compileJava {
-    if (System.getProperty('CI')) {
+    if (System.getenv('CI')) {
         dependsOn(spotlessCheck)
     } else {
         dependsOn(spotlessApply)

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -38,7 +38,7 @@ dependencies {
         swaggerAnnotations = "2.1.5"
         jersey = "2.30.1"
 
-        datarepoClient = "1.110.0-SNAPSHOT"
+        datarepoClient = "1.129.0-SNAPSHOT"
         samClient = "0.1-9435410-SNAP"
     }
 

--- a/src/main/java/bio/terra/app/utils/TimUtils.java
+++ b/src/main/java/bio/terra/app/utils/TimUtils.java
@@ -93,7 +93,7 @@ public final class TimUtils {
     String t = s.substring(PREFIX.length()).replaceAll(COLON, ":").replaceAll(PERIOD, ".");
     int len = CAPITAL.length();
     int index;
-    while ((index = t.indexOf(CAPITAL)) != -1) {
+                     while ((index = t.indexOf(CAPITAL)) != -1) {
       t =
           t.substring(0, index)
               + Character.toUpperCase(t.charAt(index + len))

--- a/src/main/java/bio/terra/app/utils/TimUtils.java
+++ b/src/main/java/bio/terra/app/utils/TimUtils.java
@@ -93,7 +93,7 @@ public final class TimUtils {
     String t = s.substring(PREFIX.length()).replaceAll(COLON, ":").replaceAll(PERIOD, ".");
     int len = CAPITAL.length();
     int index;
-                     while ((index = t.indexOf(CAPITAL)) != -1) {
+    while ((index = t.indexOf(CAPITAL)) != -1) {
       t =
           t.substring(0, index)
               + Character.toUpperCase(t.charAt(index + len))


### PR DESCRIPTION
- use `spotlessCheck` in CI, use `spotlessApply` locally
- only include top level sources in spotless scan
- updated `.editorconfig` to use google style settings for Java

Also updated client dependency for clienttests to a more recent version, to fix issues with `UUID` vs `String`

The `CI` environment variable is from https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables

A failed build that shows `spotlessCheck` in action is here: https://github.com/DataBiosphere/jade-data-repo/runs/3022156049?check_suite_focus=true