### PR TITLE
[DR-1931] Add connected test for Azure storage tables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,6 +242,7 @@ dependencies {
     implementation 'com.azure.resourcemanager:azure-resourcemanager:2.4.0'
     implementation 'com.azure:azure-storage-common:12.11.1'
     implementation 'com.azure:azure-storage-file-datalake:12.5.1'
+    implementation 'com.azure:azure-data-tables:12.1.0'
 
     antlr "org.antlr:antlr4:4.8"
     spotbugs 'com.github.spotbugs:spotbugs:4.2.2'

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
@@ -20,6 +21,9 @@ import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.TableServiceClientBuilder;
 import com.azure.data.tables.models.TableEntity;
+import com.azure.data.tables.models.TableTransactionAction;
+import com.azure.data.tables.models.TableTransactionActionType;
+import com.azure.data.tables.models.TableTransactionResult;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.resources.models.Deployment;
 import com.azure.resourcemanager.resources.models.DeploymentMode;
@@ -39,6 +43,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -290,7 +295,11 @@ public class AzureResourceConfigurationTest {
               new TableEntity(datasetId, fileId)
                   .addProperty("fileId", fileId)
                   .addProperty("description", "A test table entry");
-          tableClient.createEntity(entity);
+          List<TableTransactionAction> batch =
+              List.of(new TableTransactionAction(TableTransactionActionType.CREATE,
+           entity));
+          TableTransactionResult batchResult = tableClient.submitTransaction(batch);
+          assertNotNull(batchResult.getTableTransactionActionResponseByRowKey(fileId));
         });
 
     deleteManagedApplication(client, applicationDeployment);

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
@@ -4,8 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
@@ -296,8 +296,7 @@ public class AzureResourceConfigurationTest {
                   .addProperty("fileId", fileId)
                   .addProperty("description", "A test table entry");
           List<TableTransactionAction> batch =
-              List.of(new TableTransactionAction(TableTransactionActionType.CREATE,
-           entity));
+              List.of(new TableTransactionAction(TableTransactionActionType.CREATE, entity));
           TableTransactionResult batchResult = tableClient.submitTransaction(batch);
           assertNotNull(batchResult.getTableTransactionActionResponseByRowKey(fileId));
         });


### PR DESCRIPTION
This is still a WIP...for some reason there's an authentication error with the credential option (but using a connection string works): 
```
2021-07-15 15:34:34,631 ERROR [Test worker] c.a.d.t.TableServiceClientBuilder: A form of authentication is required to create a client. Use a builder's 'credential()', 'sasToken()' or 'connectionString()' methods to set a form of authentication.

bio.terra.service.resourcemanagement.azure.AzureResourceConfigurationTest > testAbilityToDeployApplication FAILED
    org.opentest4j.AssertionFailedError at AzureResourceConfigurationTest.java:237
        Caused by: java.lang.IllegalStateException at AzureResourceConfigurationTest.java:293
```

Edit: **Updating to 12.1.0 fixed this issue!**