### PR TITLE
DR-1961 Labels for RBS-created projects

### DIFF
--- a/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
+++ b/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
@@ -1,13 +1,11 @@
 package bio.terra.common;
 
-import bio.terra.buffer.model.HandoutRequestBody;
 import bio.terra.buffer.model.ResourceInfo;
 import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,10 +21,7 @@ public class GetResourceBufferProjectStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) {
     FlightMap workingMap = context.getWorkingMap();
-    String handoutRequestId = UUID.randomUUID().toString();
-    logger.info("Using request ID: {} to get project from RBS", handoutRequestId);
-    HandoutRequestBody request = new HandoutRequestBody().handoutRequestId(handoutRequestId);
-    ResourceInfo resource = bufferService.handoutResource(request);
+    ResourceInfo resource = bufferService.handoutResource();
     String projectId = resource.getCloudResourceUid().getGoogleProjectUid().getProjectId();
     logger.info("Retrieved project from RBS with ID: {}", projectId);
 

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetInitializeProjectStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetInitializeProjectStep.java
@@ -32,10 +32,14 @@ public class CreateDatasetInitializeProjectStep implements Step {
     GoogleRegion region =
         CloudPlatformWrapper.of(datasetRequestModel.getCloudPlatform())
             .getGoogleRegionFromDatasetRequestModel(datasetRequestModel);
+
+    UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
+
     // Since we find projects by their names, this is idempotent. If this step fails and is rerun,
     // Either the project record will have been created and we will find it, or we will create it.
     UUID projectResourceId =
-        resourceService.getOrCreateDatasetProject(profileModel, projectId, region);
+        resourceService.getOrCreateDatasetProject(
+            profileModel, projectId, region, datasetRequestModel.getName(), datasetId);
     workingMap.put(DatasetWorkingMapKeys.PROJECT_RESOURCE_ID, projectResourceId);
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetInitializeProjectStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetInitializeProjectStep.java
@@ -33,7 +33,7 @@ public class CreateDatasetInitializeProjectStep implements Step {
         CloudPlatformWrapper.of(datasetRequestModel.getCloudPlatform());
     GoogleRegion region =
         platformWrapper.getGoogleRegionFromDatasetRequestModel(datasetRequestModel);
-    Boolean isAzure = platformWrapper.isAzure();
+    boolean isAzure = platformWrapper.isAzure();
 
     UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
 

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetInitializeProjectStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetInitializeProjectStep.java
@@ -29,9 +29,11 @@ public class CreateDatasetInitializeProjectStep implements Step {
     BillingProfileModel profileModel =
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     String projectId = workingMap.get(DatasetWorkingMapKeys.GOOGLE_PROJECT_ID, String.class);
-    GoogleRegion region =
-        CloudPlatformWrapper.of(datasetRequestModel.getCloudPlatform())
-            .getGoogleRegionFromDatasetRequestModel(datasetRequestModel);
+    CloudPlatformWrapper platformWrapper =
+        CloudPlatformWrapper.of(datasetRequestModel.getCloudPlatform());
+    GoogleRegion region = platformWrapper
+        .getGoogleRegionFromDatasetRequestModel(datasetRequestModel);
+    Boolean isAzure = platformWrapper.isAzure();
 
     UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
 
@@ -39,7 +41,7 @@ public class CreateDatasetInitializeProjectStep implements Step {
     // Either the project record will have been created and we will find it, or we will create it.
     UUID projectResourceId =
         resourceService.getOrCreateDatasetProject(
-            profileModel, projectId, region, datasetRequestModel.getName(), datasetId);
+            profileModel, projectId, region, datasetRequestModel.getName(), datasetId, isAzure);
     workingMap.put(DatasetWorkingMapKeys.PROJECT_RESOURCE_ID, projectResourceId);
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetInitializeProjectStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetInitializeProjectStep.java
@@ -31,8 +31,8 @@ public class CreateDatasetInitializeProjectStep implements Step {
     String projectId = workingMap.get(DatasetWorkingMapKeys.GOOGLE_PROJECT_ID, String.class);
     CloudPlatformWrapper platformWrapper =
         CloudPlatformWrapper.of(datasetRequestModel.getCloudPlatform());
-    GoogleRegion region = platformWrapper
-        .getGoogleRegionFromDatasetRequestModel(datasetRequestModel);
+    GoogleRegion region =
+        platformWrapper.getGoogleRegionFromDatasetRequestModel(datasetRequestModel);
     Boolean isAzure = platformWrapper.isAzure();
 
     UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -64,7 +64,7 @@ public class DatasetCreateFlight extends Flight {
     // Get a new google project from RBS and store it in the working map
     addStep(new GetResourceBufferProjectStep(bufferService));
 
-    // Generate the dateset id and stored it in the working map
+    // Generate the dateset id and store it in the working map
     addStep(new CreateDatasetIdStep());
 
     // Get or initialize the project where the dataset resources will be created

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -64,6 +64,9 @@ public class DatasetCreateFlight extends Flight {
     // Get a new google project from RBS and store it in the working map
     addStep(new GetResourceBufferProjectStep(bufferService));
 
+    // Generate the dateset id and stored it in the working map
+    addStep(new CreateDatasetIdStep());
+
     // Get or initialize the project where the dataset resources will be created
     addStep(new CreateDatasetInitializeProjectStep(resourceService, datasetRequest));
 
@@ -83,9 +86,6 @@ public class DatasetCreateFlight extends Flight {
           new CreateDatasetGetOrCreateContainerStep(
               resourceService, datasetRequest, azureContainerPdao, ContainerType.DATA));
     }
-
-    // Generate the dateset id and stored it in the working map
-    addStep(new CreateDatasetIdStep());
 
     // Create dataset metadata objects in postgres and lock the dataset
     addStep(new CreateDatasetMetadataStep(datasetDao, datasetRequest));

--- a/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
@@ -15,6 +15,7 @@ import bio.terra.service.resourcemanagement.exception.BufferServiceAPIException;
 import bio.terra.service.resourcemanagement.exception.BufferServiceAuthorizationException;
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,10 +85,12 @@ public class BufferService {
    * Retrieve a single resource from the Buffer Service. The instance and pool are already
    * configured.
    *
-   * @param requestBody
    * @return ResourceInfo
    */
-  public ResourceInfo handoutResource(HandoutRequestBody requestBody) {
+  public ResourceInfo handoutResource() {
+    String handoutRequestId = UUID.randomUUID().toString();
+    logger.info("Using request ID: {} to get project from RBS", handoutRequestId);
+    HandoutRequestBody requestBody = new HandoutRequestBody().handoutRequestId(handoutRequestId);
     try {
       BufferApi bufferApi = bufferApi(bufferServiceConfiguration.getInstanceUrl());
       ResourceInfo info =

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -23,6 +23,9 @@ import bio.terra.service.resourcemanagement.google.GoogleBucketService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectService;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -304,17 +307,18 @@ public class ResourceService {
       String projectId,
       GoogleRegion region,
       String datasetName,
-      UUID datasetId)
+      UUID datasetId,
+      Boolean isAzure)
       throws InterruptedException {
 
-    Map<String, String> labels =
-        Map.of(
-            "dataset-name",
-            datasetName,
-            "dataset-id",
-            datasetId.toString(),
-            "project-usage",
-            "dataset");
+    Map<String, String> labels = new HashMap<>();
+        labels.put("dataset-name", datasetName);
+        labels.put("dataset-id", datasetId.toString());
+        labels.put("project-usage","dataset");
+
+    if (isAzure) {
+      labels.put("is-azure", "true");
+    }
 
     GoogleProjectResource googleProjectResource =
         projectService.initializeGoogleProject(

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -23,9 +23,6 @@ import bio.terra.service.resourcemanagement.google.GoogleBucketService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectService;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -312,9 +309,9 @@ public class ResourceService {
       throws InterruptedException {
 
     Map<String, String> labels = new HashMap<>();
-        labels.put("dataset-name", datasetName);
-        labels.put("dataset-id", datasetId.toString());
-        labels.put("project-usage","dataset");
+    labels.put("dataset-name", datasetName);
+    labels.put("dataset-id", datasetId.toString());
+    labels.put("project-usage", "dataset");
 
     if (isAzure) {
       labels.put("is-azure", "true");

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -79,11 +79,17 @@ public class ResourceService {
       Dataset dataset, BillingProfileModel billingProfile, String projectId)
       throws GoogleResourceException, InterruptedException {
 
+    Map<String, String> labels =
+        Map.of(
+            "dataset-name", dataset.getName(),
+            "dataset-id", dataset.getId().toString(),
+            "project-usage", "bucket");
+
     final GoogleRegion region =
         (GoogleRegion)
             dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
     // Every bucket needs to live in a project, so we get or create a project first
-    return projectService.initializeGoogleProject(projectId, billingProfile, null, region);
+    return projectService.initializeGoogleProject(projectId, billingProfile, null, region, labels);
   }
 
   /**
@@ -255,11 +261,33 @@ public class ResourceService {
    * @return project resource id
    */
   public UUID initializeSnapshotProject(
-      BillingProfileModel billingProfile, String projectId, GoogleRegion region)
+      BillingProfileModel billingProfile,
+      String projectId,
+      GoogleRegion region,
+      List<Dataset> sourceDatasets,
+      String snapshotName,
+      UUID snapshotId)
       throws InterruptedException {
 
+    String datasetNames =
+        sourceDatasets.stream().map(Dataset::getName).collect(Collectors.joining(","));
+
+    String datasetIds =
+        sourceDatasets.stream()
+            .map(Dataset::getId)
+            .map(UUID::toString)
+            .collect(Collectors.joining(","));
+
+    Map<String, String> labels =
+        Map.of(
+            "dataset-names", datasetNames,
+            "dataset-ids", datasetIds,
+            "snapshot-name", snapshotName,
+            "snapshot-id", snapshotId.toString(),
+            "project-usage", "snapshot");
+
     GoogleProjectResource googleProjectResource =
-        projectService.initializeGoogleProject(projectId, billingProfile, null, region);
+        projectService.initializeGoogleProject(projectId, billingProfile, null, region, labels);
 
     return googleProjectResource.getId();
   }
@@ -272,12 +300,25 @@ public class ResourceService {
    * @return project resource id
    */
   public UUID getOrCreateDatasetProject(
-      BillingProfileModel billingProfile, String projectId, GoogleRegion region)
+      BillingProfileModel billingProfile,
+      String projectId,
+      GoogleRegion region,
+      String datasetName,
+      UUID datasetId)
       throws InterruptedException {
+
+    Map<String, String> labels =
+        Map.of(
+            "dataset-name",
+            datasetName,
+            "dataset-id",
+            datasetId.toString(),
+            "project-usage",
+            "dataset");
 
     GoogleProjectResource googleProjectResource =
         projectService.initializeGoogleProject(
-            projectId, billingProfile, getStewardPolicy(), region);
+            projectId, billingProfile, getStewardPolicy(), region, labels);
 
     return googleProjectResource.getId();
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -1,7 +1,6 @@
 package bio.terra.service.resourcemanagement.google;
 
 import bio.terra.app.model.GoogleRegion;
-import bio.terra.buffer.model.HandoutRequestBody;
 import bio.terra.buffer.model.ResourceInfo;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.dataset.Dataset;
@@ -41,6 +40,7 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -48,11 +48,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -78,6 +80,8 @@ public class GoogleProjectService {
   private final GoogleResourceConfiguration resourceConfiguration;
   private final BufferService bufferService;
   private final DatasetBucketDao datasetBucketDao;
+  private final Environment environment;
+
   private static final String GS_BUCKET_PATTERN = "[a-z0-9\\-\\.\\_]{3,63}";
 
   @Autowired
@@ -86,12 +90,14 @@ public class GoogleProjectService {
       GoogleResourceConfiguration resourceConfiguration,
       GoogleBillingService billingService,
       BufferService bufferService,
-      DatasetBucketDao datasetBucketDao) {
+      DatasetBucketDao datasetBucketDao,
+      Environment environment) {
     this.resourceDao = resourceDao;
     this.resourceConfiguration = resourceConfiguration;
     this.billingService = billingService;
     this.bufferService = bufferService;
     this.datasetBucketDao = datasetBucketDao;
+    this.environment = environment;
   }
 
   /**
@@ -125,9 +131,7 @@ public class GoogleProjectService {
     // Case 3 -
     // Condition: Ingest Billing profile != source dataset billing profile && project does NOT exist
     // Action: Request a new project
-    HandoutRequestBody request =
-        new HandoutRequestBody().handoutRequestId(UUID.randomUUID().toString());
-    ResourceInfo resource = bufferService.handoutResource(request);
+    ResourceInfo resource = bufferService.handoutResource();
     return resource.getCloudResourceUid().getGoogleProjectUid().getProjectId();
   }
 
@@ -150,6 +154,7 @@ public class GoogleProjectService {
    * @param billingProfile previously authorized billing profile
    * @param roleIdentityMapping permissions to set
    * @param region region of dataset/snapshot
+   * @param labels labels to add to the project
    * @return project resource object
    * @throws InterruptedException if shutting down
    */
@@ -157,7 +162,8 @@ public class GoogleProjectService {
       String googleProjectId,
       BillingProfileModel billingProfile,
       Map<String, List<String>> roleIdentityMapping,
-      GoogleRegion region)
+      GoogleRegion region,
+      Map<String, String> labels)
       throws InterruptedException {
 
     try {
@@ -186,7 +192,7 @@ public class GoogleProjectService {
     if (project == null) {
       throw new GoogleResourceException("Could not get project after handout");
     }
-    return initializeProject(project, billingProfile, roleIdentityMapping, false, region);
+    return initializeProject(project, billingProfile, roleIdentityMapping, false, region, labels);
   }
 
   public GoogleProjectResource getProjectResourceById(UUID id) {
@@ -233,7 +239,8 @@ public class GoogleProjectService {
       BillingProfileModel billingProfile,
       Map<String, List<String>> roleIdentityMapping,
       boolean setBilling,
-      GoogleRegion region)
+      GoogleRegion region,
+      Map<String, String> labels)
       throws InterruptedException {
 
     String googleProjectNumber = project.getProjectNumber().toString();
@@ -252,6 +259,7 @@ public class GoogleProjectService {
     }
     enableServices(googleProjectResource, region);
     updateIamPermissions(roleIdentityMapping, googleProjectId, PermissionOp.ENABLE_PERMISSIONS);
+    addLabelsToProject(googleProjectResource.getGoogleProjectId(), labels);
 
     UUID id = resourceDao.createProject(googleProjectResource);
     googleProjectResource.id(id);
@@ -279,6 +287,43 @@ public class GoogleProjectService {
   void deleteGoogleProject(UUID resourceId) {
     GoogleProjectResource projectResource = resourceDao.retrieveProjectByIdForDelete(resourceId);
     deleteGoogleProject(projectResource.getGoogleProjectId());
+  }
+
+  /**
+   * Google requires labels to consist of only lowercase, alphanumeric, "_", and "-" characters.
+   *
+   * @param string String to clean
+   * @return The cleaned String
+   */
+  private String cleanForLabels(String string) {
+    return string.toLowerCase(Locale.ROOT).trim().replaceAll("[^a-z0-9_-]", "-");
+  }
+
+  public void addLabelsToProject(String googleProjectId, Map<String, String> labels) {
+    final Stream<Map.Entry<String, String>> additionalLabels;
+    if (Arrays.stream(environment.getActiveProfiles())
+        .anyMatch(env -> env.contains("test") || env.contains("int"))) {
+      additionalLabels = Stream.of(Map.entry("project-for-test", "true"));
+    } else {
+      additionalLabels = Stream.empty();
+    }
+
+    try {
+      CloudResourceManager resourceManager = cloudResourceManager();
+      Project project = resourceManager.projects().get(googleProjectId).execute();
+      Map<String, String> cleanedLabels =
+          Stream.concat(
+                  Stream.concat(project.getLabels().entrySet().stream(), additionalLabels),
+                  labels.entrySet().stream()
+                      .map(
+                          e -> Map.entry(cleanForLabels(e.getKey()), cleanForLabels(e.getValue()))))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1));
+      project.setLabels(cleanedLabels);
+      logger.info("Adding labels to project {}", googleProjectId);
+      resourceManager.projects().update(googleProjectId, project).execute();
+    } catch (IOException | GeneralSecurityException ex) {
+      throw new GoogleResourceException("Encountered error while updating project labels", ex);
+    }
   }
 
   @VisibleForTesting
@@ -323,12 +368,7 @@ public class GoogleProjectService {
       enableFirestore(appengine(), projectResource.getGoogleProjectId(), region, timeout);
 
     } catch (IOException | GeneralSecurityException e) {
-      // In development we are reusing projects. The TDR service account may not have permission to
-      // properly enable the services on a developer's project. In those cases, we do not want to
-      // error on failure. That result in issues down the line if we require enabling new services.
-      if (!resourceConfiguration.getAllowReuseExistingProjects()) {
-        throw new GoogleResourceException("Could not enable services", e);
-      }
+      throw new GoogleResourceException("Could not enable services", e);
     }
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
@@ -1,11 +1,7 @@
 package bio.terra.service.resourcemanagement.google;
 
-import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.FirestoreOptions;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -15,11 +11,6 @@ public class GoogleResourceConfiguration {
   private String applicationName;
   private long projectCreateTimeoutSeconds;
   private String projectId;
-  private String parentResourceType;
-  private String parentResourceId;
-  private String singleDataProjectId;
-  private String dataProjectPrefix;
-  private String defaultFirestoreLocation;
   private int firestoreRetries;
   private boolean allowReuseExistingProjects;
   private boolean allowReuseExistingBuckets;
@@ -48,38 +39,6 @@ public class GoogleResourceConfiguration {
     this.projectId = projectId;
   }
 
-  public String getParentResourceType() {
-    return parentResourceType;
-  }
-
-  public void setParentResourceType(String parentResourceType) {
-    this.parentResourceType = parentResourceType;
-  }
-
-  public String getParentResourceId() {
-    return parentResourceId;
-  }
-
-  public void setParentResourceId(String parentResourceId) {
-    this.parentResourceId = parentResourceId;
-  }
-
-  public String getSingleDataProjectId() {
-    return singleDataProjectId;
-  }
-
-  public void setSingleDataProjectId(String singleDataProjectId) {
-    this.singleDataProjectId = singleDataProjectId;
-  }
-
-  public String getDataProjectPrefix() {
-    return dataProjectPrefix;
-  }
-
-  public void setDataProjectPrefix(String dataProjectPrefix) {
-    this.dataProjectPrefix = dataProjectPrefix;
-  }
-
   public boolean getAllowReuseExistingProjects() {
     return allowReuseExistingProjects;
   }
@@ -96,33 +55,11 @@ public class GoogleResourceConfiguration {
     this.allowReuseExistingBuckets = allowReuseExistingBuckets;
   }
 
-  public String getDefaultFirestoreLocation() {
-    return defaultFirestoreLocation;
-  }
-
-  public void setDefaultFirestoreLocation(String defaultFirestoreLocation) {
-    this.defaultFirestoreLocation = defaultFirestoreLocation;
-  }
-
   public int getFirestoreRetries() {
     return firestoreRetries;
   }
 
   public void setFirestoreRetries(int firestoreRetries) {
     this.firestoreRetries = firestoreRetries;
-  }
-
-  // TODO: Is this used?
-  @Bean("firestore")
-  public Firestore firestore() {
-    return FirestoreOptions.newBuilder().setProjectId(projectId).build().getService();
-  }
-
-  public String getDataProjectPrefixToUse() {
-    if (StringUtils.isAllBlank(getDataProjectPrefix())) {
-      return getProjectId();
-    } else {
-      return getDataProjectPrefix();
-    }
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotInitializeProjectStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotInitializeProjectStep.java
@@ -2,6 +2,7 @@ package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.BillingProfileModel;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
@@ -9,15 +10,24 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import java.util.List;
 import java.util.UUID;
 
 public class CreateSnapshotInitializeProjectStep implements Step {
   private final ResourceService resourceService;
   private final GoogleRegion region;
+  private final List<Dataset> sourceDatasets;
+  private final String snapshotName;
 
-  public CreateSnapshotInitializeProjectStep(ResourceService resourceService, GoogleRegion region) {
+  public CreateSnapshotInitializeProjectStep(
+      ResourceService resourceService,
+      GoogleRegion region,
+      List<Dataset> sourceDatasets,
+      String snapshotName) {
     this.resourceService = resourceService;
     this.region = region;
+    this.sourceDatasets = sourceDatasets;
+    this.snapshotName = snapshotName;
   }
 
   @Override
@@ -27,10 +37,13 @@ public class CreateSnapshotInitializeProjectStep implements Step {
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     String projectId = workingMap.get(SnapshotWorkingMapKeys.GOOGLE_PROJECT_ID, String.class);
 
+    UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
+
     // Since we find projects by their names, this is idempotent. If this step fails and is rerun,
-    // Either the project will have been created8and we will find it, or we will create.
+    // Either the project will have been created and we will find it, or we will create.
     UUID projectResourceId =
-        resourceService.initializeSnapshotProject(profileModel, projectId, region);
+        resourceService.initializeSnapshotProject(
+            profileModel, projectId, region, sourceDatasets, snapshotName, snapshotId);
     workingMap.put(SnapshotWorkingMapKeys.PROJECT_RESOURCE_ID, projectResourceId);
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -85,12 +85,14 @@ public class SnapshotCreateFlight extends Flight {
     // Get a new google project from RBS and store it in the working map
     addStep(new GetResourceBufferProjectStep(bufferService));
 
-    // Get or initialize the project where the snapshot resources will be created
-    addStep(new CreateSnapshotInitializeProjectStep(resourceService, firestoreRegion));
-
     // create the snapshot metadata object in postgres and lock it
     // mint a snapshot id and put it in the working map
     addStep(new CreateSnapshotIdStep(snapshotReq));
+
+    // Get or initialize the project where the snapshot resources will be created
+    addStep(
+        new CreateSnapshotInitializeProjectStep(
+            resourceService, firestoreRegion, sourceDatasets, snapshotName));
 
     addStep(new CreateSnapshotMetadataStep(snapshotDao, snapshotService, snapshotReq));
 

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -898,6 +898,8 @@ public class ConnectedOperations {
     this.deleteOnTeardown = deleteOnTeardown;
   }
 
+  public void addLabelsToGoogleProject(String googleProjectId, Map<String, String> labels) {}
+
   public void teardown() throws Exception {
     // call the reset configuration endpoint to disable all faults
     resetConfiguration();

--- a/src/test/java/bio/terra/service/profile/GoogleBillingServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/GoogleBillingServiceTest.java
@@ -6,14 +6,15 @@ import static org.junit.Assert.assertTrue;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleRegion;
+import bio.terra.buffer.model.ResourceInfo;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.profile.google.GoogleBillingService;
+import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectService;
-import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import com.google.api.client.util.Lists;
 import com.google.cloud.billing.v1.ProjectBillingInfo;
 import java.util.HashMap;
@@ -42,11 +43,12 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class GoogleBillingServiceTest {
   private final Logger logger = LoggerFactory.getLogger(GoogleBillingServiceTest.class);
 
-  @Autowired private GoogleResourceConfiguration resourceConfiguration;
   @Autowired private GoogleProjectService projectService;
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private GoogleBillingService googleBillingService;
   @Autowired private ConnectedTestConfiguration testConfig;
+  @Autowired private BufferService bufferService;
+
   @MockBean private IamProviderInterface samService;
 
   private BillingProfileModel profile;
@@ -138,11 +140,13 @@ public class GoogleBillingServiceTest {
     Map<String, List<String>> roleToStewardMap = new HashMap<>();
     roleToStewardMap.put(role, stewardsGroupEmailList);
 
+    ResourceInfo resourceInfo = bufferService.handoutResource();
     // create project metadata
     return projectService.initializeGoogleProject(
-        resourceConfiguration.getSingleDataProjectId(),
+        resourceInfo.getCloudResourceUid().getGoogleProjectUid().getProjectId(),
         profile,
         roleToStewardMap,
-        GoogleRegion.DEFAULT_GOOGLE_REGION);
+        GoogleRegion.DEFAULT_GOOGLE_REGION,
+        Map.of("test-name", "google-billing-service-test"));
   }
 }

--- a/src/test/java/bio/terra/service/profile/ProfileServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileServiceTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleRegion;
+import bio.terra.buffer.model.ResourceInfo;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.model.BillingProfileModel;
@@ -14,9 +15,9 @@ import bio.terra.model.BillingProfileUpdateModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.profile.google.GoogleBillingService;
+import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectService;
-import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
 import com.google.api.client.util.Lists;
 import java.util.HashMap;
@@ -52,8 +53,8 @@ public class ProfileServiceTest {
   @Autowired private ProfileDao profileDao;
   @Autowired private ConnectedTestConfiguration testConfig;
   @Autowired private GoogleProjectService googleProjectService;
-  @Autowired private GoogleResourceConfiguration resourceConfiguration;
   @Autowired private ProfileService profileService;
+  @Autowired private BufferService bufferService;
   @MockBean private IamProviderInterface samService;
 
   private BillingProfileModel profile;
@@ -160,11 +161,14 @@ public class ProfileServiceTest {
     Map<String, List<String>> roleToStewardMap = new HashMap<>();
     roleToStewardMap.put(role, stewardsGroupEmailList);
 
+    ResourceInfo resourceInfo = bufferService.handoutResource();
+
     // create project metadata
     return googleProjectService.initializeGoogleProject(
-        resourceConfiguration.getSingleDataProjectId(),
+        resourceInfo.getCloudResourceUid().getGoogleProjectUid().getProjectId(),
         profile,
         roleToStewardMap,
-        GoogleRegion.DEFAULT_GOOGLE_REGION);
+        GoogleRegion.DEFAULT_GOOGLE_REGION,
+        Map.of("test-name", "profile-service-test"));
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/RBSConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/RBSConnectedTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
-import bio.terra.buffer.model.HandoutRequestBody;
 import bio.terra.buffer.model.ResourceInfo;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Connected;
@@ -31,6 +30,7 @@ import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
@@ -86,11 +86,10 @@ public class RBSConnectedTest {
 
   @Test
   public void testProjectHandout() {
-    String handoutRequestId = UUID.randomUUID().toString();
-    HandoutRequestBody request = new HandoutRequestBody().handoutRequestId(handoutRequestId);
-    ResourceInfo resource = bufferService.handoutResource(request);
+    ResourceInfo resource = bufferService.handoutResource();
     String projectId = resource.getCloudResourceUid().getGoogleProjectUid().getProjectId();
     Project project = projectService.getProject(projectId);
+    projectService.addLabelsToProject(projectId, Map.of("test-name", "rbs-connected-test"));
     assertThat(
         "The project requested from RBS is active", project.getLifecycleState(), equalTo("ACTIVE"));
   }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleRegion;
+import bio.terra.buffer.model.ResourceInfo;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.JsonLoader;
@@ -23,7 +24,7 @@ import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.load.LoadDao;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.BucketResourceLockTester;
-import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.exception.GoogleResourceNotFoundException;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import com.google.api.client.util.Lists;
@@ -62,14 +63,14 @@ public class BucketResourceTest {
   @Autowired private ConfigurationService configService;
   @Autowired private DatasetBucketDao datasetBucketDao;
   @Autowired private JsonLoader jsonLoader;
-  @Autowired private GoogleResourceConfiguration resourceConfiguration;
   @Autowired private GoogleBucketService bucketService;
   @Autowired private GoogleProjectService projectService;
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private GoogleResourceDao resourceDao;
-  @Autowired private ResourceService resourceService;
   @Autowired private ProfileService profileService;
   @Autowired private ConnectedTestConfiguration testConfig;
+  @Autowired private BufferService bufferService;
+
   @MockBean private IamProviderInterface samService;
 
   private BucketResourceUtils bucketResourceUtils = new BucketResourceUtils();
@@ -387,11 +388,14 @@ public class BucketResourceTest {
     Map<String, List<String>> roleToStewardMap = new HashMap<>();
     roleToStewardMap.put(role, stewardsGroupEmailList);
 
+    ResourceInfo resourceInfo = bufferService.handoutResource();
+
     // create project metadata
     return projectService.initializeGoogleProject(
-        resourceConfiguration.getSingleDataProjectId(),
+        resourceInfo.getCloudResourceUid().getGoogleProjectUid().getProjectId(),
         profile,
         roleToStewardMap,
-        GoogleRegion.DEFAULT_GOOGLE_REGION);
+        GoogleRegion.DEFAULT_GOOGLE_REGION,
+        Map.of("test-name", "bucket-resource-test"));
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceConnectedTest.java
@@ -6,9 +6,7 @@ import static org.hamcrest.Matchers.not;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleRegion;
-import bio.terra.buffer.model.HandoutRequestBody;
 import bio.terra.buffer.model.ResourceInfo;
-import bio.terra.common.category.OnDemand;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.resourcemanagement.BufferService;
@@ -17,11 +15,9 @@ import com.google.api.services.cloudresourcemanager.model.Project;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -33,7 +29,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @AutoConfigureMockMvc
 @SpringBootTest
 @ActiveProfiles({"google", "connectedtest"})
-@Category(OnDemand.class)
 public class ResourceServiceConnectedTest {
 
   @Autowired private GoogleResourceConfiguration resourceConfiguration;
@@ -56,10 +51,7 @@ public class ResourceServiceConnectedTest {
 
   @Test
   public void createAndDeleteProjectTest() throws Exception {
-    // the project id can't be more than 30 characters
-    HandoutRequestBody request =
-        new HandoutRequestBody().handoutRequestId(UUID.randomUUID().toString());
-    ResourceInfo resource = bufferService.handoutResource(request);
+    ResourceInfo resource = bufferService.handoutResource();
     String projectId = resource.getCloudResourceUid().getGoogleProjectUid().getProjectId();
 
     String role = "roles/bigquery.jobUser";
@@ -71,7 +63,11 @@ public class ResourceServiceConnectedTest {
 
     GoogleProjectResource projectResource =
         projectService.initializeGoogleProject(
-            projectId, profile, roleToStewardMap, GoogleRegion.DEFAULT_GOOGLE_REGION);
+            projectId,
+            profile,
+            roleToStewardMap,
+            GoogleRegion.DEFAULT_GOOGLE_REGION,
+            Map.of("test-name", "resource-service-connected-test"));
 
     Project project = projectService.getProject(projectId);
     assertThat("the project is active", project.getLifecycleState(), equalTo("ACTIVE"));

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -672,7 +672,7 @@ public class BigQueryPdaoTest {
     projectService.addLabelsToProject(googleProjectId, Map.of("test-name", "bigquery-pdao-test"));
     UUID projectId =
         resourceService.getOrCreateDatasetProject(
-            profileModel, googleProjectId, region, dataset.getName(), dataset.getId());
+            profileModel, googleProjectId, region, dataset.getName(), dataset.getId(), false);
     dataset
         .projectResourceId(projectId)
         .projectResource(resourceService.getProjectResource(projectId));

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -12,7 +12,6 @@ import static org.junit.Assert.assertEquals;
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
-import bio.terra.buffer.model.HandoutRequestBody;
 import bio.terra.buffer.model.ResourceInfo;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.PdaoConstant;
@@ -37,7 +36,7 @@ import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
-import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
+import bio.terra.service.resourcemanagement.google.GoogleProjectService;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.tabulardata.exception.BadExternalFileException;
@@ -88,9 +87,9 @@ public class BigQueryPdaoTest {
   @Autowired private BigQueryPdao bigQueryPdao;
   @Autowired private DatasetDao datasetDao;
   @Autowired private SnapshotDao snapshotDao;
-  @Autowired private GoogleResourceConfiguration googleResourceConfiguration;
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private ResourceService resourceService;
+  @Autowired private GoogleProjectService projectService;
   @Autowired private BufferService bufferService;
 
   @MockBean private IamProviderInterface samService;
@@ -539,7 +538,11 @@ public class BigQueryPdaoTest {
   @Test
   public void testGetSnapshotTableData() throws Exception {
     UUID profileId = profileModel.getId();
-    String dataProjectId = googleResourceConfiguration.getSingleDataProjectId();
+    ResourceInfo resourceInfo = bufferService.handoutResource();
+
+    String dataProjectId = resourceInfo.getCloudResourceUid().getGoogleProjectUid().getProjectId();
+    projectService.addLabelsToProject(dataProjectId, Map.of("test-name", "bigquery-pdao-test"));
+
     Snapshot snapshot =
         new Snapshot()
             .projectResource(
@@ -664,12 +667,12 @@ public class BigQueryPdaoTest {
             .getGoogleRegionFromDatasetRequestModel(datasetRequest);
     Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
     dataset.id(UUID.randomUUID());
-    String handoutRequestId = UUID.randomUUID().toString();
-    HandoutRequestBody request = new HandoutRequestBody().handoutRequestId(handoutRequestId);
-    ResourceInfo resource = bufferService.handoutResource(request);
+    ResourceInfo resource = bufferService.handoutResource();
     String googleProjectId = resource.getCloudResourceUid().getGoogleProjectUid().getProjectId();
+    projectService.addLabelsToProject(googleProjectId, Map.of("test-name", "bigquery-pdao-test"));
     UUID projectId =
-        resourceService.getOrCreateDatasetProject(profileModel, googleProjectId, region);
+        resourceService.getOrCreateDatasetProject(
+            profileModel, googleProjectId, region, dataset.getName(), dataset.getId());
     dataset
         .projectResourceId(projectId)
         .projectResource(resourceService.getProjectResource(projectId));

--- a/src/test/resources/application-connectedtest.properties
+++ b/src/test/resources/application-connectedtest.properties
@@ -2,7 +2,7 @@
 ct.ingestBucket=jade-testdata
 ct.nonDefaultRegionIngestBucket=jade-testdata-useastregion
 ct.ingestRequesterPaysBucket=jade_testbucket_requester_pays
-ct.googleBillingAccountId=00708C-45D19D-27AAFA
+ct.googleBillingAccountId=01A82E-CA8A14-367457
 ct.targetTenantId=efc08443-0082-4d6c-8931-c5794c156abd
 ct.targetResourceGroupName=TDR_connected
 ct.targetSubscriptionId=71d52ec1-5886-480a-9d6e-ed98cbf1f69f


### PR DESCRIPTION
Adding labels to projects created by RBS is really helpful in tracking down what projects belong to who. We want to make sure that we can easily trace projects to TDR datasets, snapshots, and buckets so that we can delete orphaned ones. This will also enable us to track azure-backed datasets that are still in the transition phase.

While I was in the code, I ripped out a bunch of single-project stuff still being used in testing. 