### PR TITLE
DR-1952 Refresh token for clienttests before it expires

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
@@ -57,7 +57,7 @@ public class CreateSnapshot extends SimpleDataset {
 
     // wait for the job to complete
     bulkLoadArrayJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, bulkLoadArrayJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, bulkLoadArrayJobResponse, datasetCreator);
     BulkLoadArrayResultModel result =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, bulkLoadArrayJobResponse, BulkLoadArrayResultModel.class);

--- a/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
@@ -160,14 +160,16 @@ public final class DataRepoUtils {
     job = repositoryApi.retrieveJob(job.getId());
     int tryCount = 1;
 
-    var maybeCredentials = Optional.ofNullable(testUser)
-        .map(user -> {
-          try {
-            return AuthenticationUtils.getDelegatedUserCredential(user);
-          } catch (IOException ex) {
-            throw new RuntimeException(ex);
-          }
-        });
+    var maybeCredentials =
+        Optional.ofNullable(testUser)
+            .map(
+                user -> {
+                  try {
+                    return AuthenticationUtils.getDelegatedUserCredential(user);
+                  } catch (IOException ex) {
+                    throw new RuntimeException(ex);
+                  }
+                });
     var credentialsChangedListener =
         new CredentialsChangedListener() {
           @Override

--- a/datarepo-clienttests/src/main/resources/configs/functional/CreateSnapshot.json
+++ b/datarepo-clienttests/src/main/resources/configs/functional/CreateSnapshot.json
@@ -1,7 +1,7 @@
 {
   "name": "CreateSnapshot",
   "description": "Create a snapshot with a lot of files",
-  "serverSpecificationFile": "tldev.json",
+  "serverSpecificationFile": "nmlocalhost.json",
   "billingAccount": "00708C-45D19D-27AAFA",
   "kubernetes": {
     "numberOfInitialPods" : 1
@@ -10,7 +10,7 @@
   "testScripts": [
     {
       "name": "CreateSnapshot",
-      "parameters": [100000],
+      "parameters": [10000],
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 2,

--- a/datarepo-clienttests/src/main/resources/configs/functional/CreateSnapshot.json
+++ b/datarepo-clienttests/src/main/resources/configs/functional/CreateSnapshot.json
@@ -1,7 +1,7 @@
 {
   "name": "CreateSnapshot",
   "description": "Create a snapshot with a lot of files",
-  "serverSpecificationFile": "nmlocalhost.json",
+  "serverSpecificationFile": "tldev.json",
   "billingAccount": "00708C-45D19D-27AAFA",
   "kubernetes": {
     "numberOfInitialPods" : 1
@@ -10,7 +10,7 @@
   "testScripts": [
     {
       "name": "CreateSnapshot",
-      "parameters": [10000],
+      "parameters": [100000],
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 2,


### PR DESCRIPTION
The `CreateSnapshot` test has been failing in the perf env due to the auth token expiring. This PR refreshes the token if it has expired before requests are made in `scripts.utils.DataRepoUtils#pollForRunningJob`. I made the arg for the user nullable as to not need to change all the other invocations of the method, since its only the `CreateSnapshot` test that's failing at this point. 