### PR TITLE
DR-2005 Make it possible to create Azure snapshots

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -303,7 +303,7 @@ public class DrsService {
             .accessId(accessId)
             .region(region.toString());
 
-    return Collections.singletonList(httpsAccessMethod);
+    return List.of(httpsAccessMethod);
   }
 
   private DRSObject drsObjectFromFSDir(FSDir fsDir, String snapshotId) {

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -2,7 +2,9 @@ package bio.terra.service.filedata;
 
 import bio.terra.app.controller.exception.TooManyRequestsException;
 import bio.terra.app.logging.PerformanceLogger;
+import bio.terra.app.model.AzureRegion;
 import bio.terra.app.model.GoogleRegion;
+import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.model.DRSAccessMethod;
 import bio.terra.model.DRSAccessMethod.TypeEnum;
 import bio.terra.model.DRSAccessURL;
@@ -22,6 +24,7 @@ import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamService;
 import bio.terra.service.job.JobService;
 import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.Snapshot;
@@ -237,10 +240,30 @@ public class DrsService {
       FSFile fsFile, String snapshotId, AuthenticatedUserRequest authUser) {
     DRSObject fileObject = makeCommonDrsObject(fsFile, snapshotId);
 
+    List<DRSAccessMethod> accessMethods;
+    CloudPlatformWrapper platformWrapper = CloudPlatformWrapper.of(fsFile.getCloudPlatform());
+    if (platformWrapper.isGcp()) {
+      accessMethods = getDrsAccessMethodsOnGcp(fsFile, authUser);
+    } else if (platformWrapper.isAzure()) {
+      accessMethods = getDrsAccessMethodsOnAzure(fsFile);
+    } else {
+      throw new IllegalArgumentException("Unrecognized cloud platform");
+    }
+
+    fileObject
+        .mimeType(fsFile.getMimeType())
+        .checksums(fileService.makeChecksums(fsFile))
+        .accessMethods(accessMethods);
+
+    return fileObject;
+  }
+
+  private List<DRSAccessMethod> getDrsAccessMethodsOnGcp(
+      FSFile fsFile, AuthenticatedUserRequest authUser) {
+    DRSAccessURL gsAccessURL = new DRSAccessURL().url(fsFile.getGspath());
+
     GoogleBucketResource bucketResource =
         resourceService.lookupBucketMetadata(fsFile.getBucketResourceId());
-
-    DRSAccessURL gsAccessURL = new DRSAccessURL().url(fsFile.getGspath());
 
     GoogleRegion region = bucketResource.getRegion();
     String accessId = "gcp-" + region.getValue();
@@ -262,16 +285,25 @@ public class DrsService {
             .accessUrl(httpsAccessURL)
             .region(bucketResource.getRegion().toString());
 
-    List<DRSAccessMethod> accessMethods = new ArrayList<>();
-    accessMethods.add(gsAccessMethod);
-    accessMethods.add(httpsAccessMethod);
+    return List.of(gsAccessMethod, httpsAccessMethod);
+  }
 
-    fileObject
-        .mimeType(fsFile.getMimeType())
-        .checksums(fileService.makeChecksums(fsFile))
-        .accessMethods(accessMethods);
+  private List<DRSAccessMethod> getDrsAccessMethodsOnAzure(FSFile fsFile) {
+    DRSAccessURL accessURL = new DRSAccessURL().url(fsFile.getGspath());
 
-    return fileObject;
+    AzureStorageAccountResource storageAccountResource =
+        resourceService.lookupStorageAccountMetadata(fsFile.getBucketResourceId());
+
+    AzureRegion region = storageAccountResource.getRegion();
+    String accessId = "az-" + region.getValue();
+    DRSAccessMethod httpsAccessMethod =
+        new DRSAccessMethod()
+            .type(DRSAccessMethod.TypeEnum.HTTPS)
+            .accessUrl(accessURL)
+            .accessId(accessId)
+            .region(region.toString());
+
+    return Collections.singletonList(httpsAccessMethod);
   }
 
   private DRSObject drsObjectFromFSDir(FSDir fsDir, String snapshotId) {

--- a/src/main/java/bio/terra/service/filedata/FSFile.java
+++ b/src/main/java/bio/terra/service/filedata/FSFile.java
@@ -106,7 +106,7 @@ public class FSFile extends FSItem {
   // explicitly
   public CloudPlatform getCloudPlatform() {
     try {
-      URI url = new URI(getGspath());
+      URI url = new URI(getGspath().replaceAll("[^A-Za-z0-9/\\-.:]", ""));
       if (url.getScheme().equalsIgnoreCase("gs")) {
         return CloudPlatform.GCP;
       } else if (url.getScheme().equalsIgnoreCase("https")

--- a/src/main/java/bio/terra/service/filedata/FSFile.java
+++ b/src/main/java/bio/terra/service/filedata/FSFile.java
@@ -1,5 +1,8 @@
 package bio.terra.service.filedata;
 
+import bio.terra.model.CloudPlatform;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.UUID;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -97,6 +100,24 @@ public class FSFile extends FSItem {
   public FSFile loadTag(String loadTag) {
     this.loadTag = loadTag;
     return this;
+  }
+
+  // TODO: once metadata is collocated with the underlying cloud platform, this can be set
+  // explicitly
+  public CloudPlatform getCloudPlatform() {
+    try {
+      URI url = new URI(getGspath());
+      if (url.getScheme().equalsIgnoreCase("gs")) {
+        return CloudPlatform.GCP;
+      } else if (url.getScheme().equalsIgnoreCase("https")
+          && url.getHost().endsWith("core.windows.net")) {
+        return CloudPlatform.AZURE;
+      } else {
+        throw new IllegalArgumentException("Unrecognized url format: " + getGspath());
+      }
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid URL", e);
+    }
   }
 
   @Override

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -561,8 +561,10 @@ public class FireStoreDao {
 
     for (FireStoreDirectoryEntry dirItem : enumComputed) {
       totalSize = totalSize + dirItem.getSize();
-      crc32cCollection.add(StringUtils.lowerCase(dirItem.getChecksumCrc32c()));
-      if (dirItem.getChecksumMd5() != null) {
+      if (!StringUtils.isEmpty(dirItem.getChecksumCrc32c())) {
+        crc32cCollection.add(StringUtils.lowerCase(dirItem.getChecksumCrc32c()));
+      }
+      if (!StringUtils.isEmpty(dirItem.getChecksumMd5())) {
         md5Collection.add(StringUtils.lowerCase(dirItem.getChecksumMd5()));
       }
     }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -557,15 +557,15 @@ public class FireStoreDao {
     // Collect the ingredients for computing this directory's checksums and size
     List<String> md5Collection = new ArrayList<>();
     List<String> crc32cCollection = new ArrayList<>();
-    Long totalSize = 0L;
+    long totalSize = 0L;
 
     for (FireStoreDirectoryEntry dirItem : enumComputed) {
       totalSize = totalSize + dirItem.getSize();
       if (!StringUtils.isEmpty(dirItem.getChecksumCrc32c())) {
-        crc32cCollection.add(StringUtils.lowerCase(dirItem.getChecksumCrc32c()));
+        crc32cCollection.add(dirItem.getChecksumCrc32c().toLowerCase());
       }
       if (!StringUtils.isEmpty(dirItem.getChecksumMd5())) {
-        md5Collection.add(StringUtils.lowerCase(dirItem.getChecksumMd5()));
+        md5Collection.add(dirItem.getChecksumMd5().toLowerCase());
       }
     }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -15,6 +15,7 @@ import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentReso
 import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
+import bio.terra.service.resourcemanagement.exception.AzureResourceNotFoundException;
 import bio.terra.service.resourcemanagement.exception.GoogleResourceException;
 import bio.terra.service.resourcemanagement.exception.GoogleResourceNamingException;
 import bio.terra.service.resourcemanagement.exception.GoogleResourceNotFoundException;
@@ -234,6 +235,22 @@ public class ResourceService {
    */
   public GoogleBucketResource lookupBucketMetadata(String bucketResourceId) {
     return bucketService.getBucketResourceById(UUID.fromString(bucketResourceId), false);
+  }
+
+  /**
+   * Fetch an existing storage_account metadata row. Note this method does not check for the
+   * existence of the underlying cloud resource. This method is intended for places where an
+   * existence check on the associated cloud resource might be too much overhead (e.g. DRS lookups).
+   * Most storage account lookups should use the lookupStorageAccount method instead, which has
+   * additional overhead but will catch metadata corruption errors sooner.
+   *
+   * @param storageAccountId our identifier for the storage account
+   * @return a reference to the storage account as a POJO AzureStorageAccountResource
+   * @throws AzureResourceNotFoundException if the storage_account metadata row does not exist
+   */
+  public AzureStorageAccountResource lookupStorageAccountMetadata(String storageAccountId) {
+    return storageAccountService.getStorageAccountResourceById(
+        UUID.fromString(storageAccountId), false);
   }
 
   /**

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FSFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FSFileTest.java
@@ -19,6 +19,11 @@ public class FSFileTest {
         new FSFile().gspath("gs://mybucket/test.txt").getCloudPlatform(),
         equalTo(CloudPlatform.GCP));
     assertThat(
+        new FSFile()
+            .gspath("gs://mybucket/dsid/fid/file with space and #hash%percent+plus.txt")
+            .getCloudPlatform(),
+        equalTo(CloudPlatform.GCP));
+    assertThat(
         new FSFile().gspath("https://myacct.blob.core.windows.net/fs/test.txt").getCloudPlatform(),
         equalTo(CloudPlatform.AZURE));
     assertThrows(

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FSFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FSFileTest.java
@@ -1,0 +1,31 @@
+package bio.terra.service.filedata.google.firestore;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.CloudPlatform;
+import bio.terra.service.filedata.FSFile;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Unit.class)
+public class FSFileTest {
+
+  @Test
+  public void testCloudPlatformDetection() {
+    assertThat(
+        new FSFile().gspath("gs://mybucket/test.txt").getCloudPlatform(),
+        equalTo(CloudPlatform.GCP));
+    assertThat(
+        new FSFile().gspath("https://myacct.blob.core.windows.net/fs/test.txt").getCloudPlatform(),
+        equalTo(CloudPlatform.AZURE));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new FSFile().gspath("ftp://notsupported.txt").getCloudPlatform());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new FSFile().gspath("https://myhost.com/notsupported.txt").getCloudPlatform());
+  }
+}


### PR DESCRIPTION
This makes it not fail for cases where users try to create snapshots of Azure-backed datasets

Note: this also makes it so that the Drs endpoint works for Azure backed snapshots.  This is accomplished by inferring the cloud platform from an `FSItem` based on the gspath value but we can clean this up to use constants when we switch to use Firestore for GCP FSItems vs. Azure storage tables for Azure FSItems

The output looks like:
![image](https://user-images.githubusercontent.com/5633787/128077041-c3fb8978-ecb6-45ef-bfb1-6f5b1eedbe97.png)
