### PR TITLE
Add ErrorProne checker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ plugins {
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id "jacoco"
     id "com.diffplug.spotless" version "5.14.0"
+    id "net.ltgt.errorprone" version "2.0.2"
 }
 
 allprojects {
@@ -166,6 +167,7 @@ configurations {
 }
 
 dependencies {
+    errorprone("com.google.errorprone:error_prone_core:2.8.0")
     // TODO: Unpack the "starter" and include just what we use
     compile 'com.google.cloud:google-cloud-billing:1.1.6'
     compile 'com.google.cloud:google-cloud-resourcemanager:0.118.2-alpha'
@@ -503,6 +505,14 @@ classes.dependsOn generatedClasses
 compileJava.dependsOn compileGeneratedJava
 ideaModule.dependsOn swaggerSources.server.code
 idea.module.sourceDirs += file("$buildDir/generated-src/swagger/src/main/java")
+
+tasks.withType(JavaCompile).configureEach {
+  options.errorprone {
+    disableWarningsInGeneratedCode = true
+    excludedPaths = ".*/build/.*"
+//    checks = [ MissingBrace : net.ltgt.gradle.errorprone.CheckSeverity.DEFAULT ]
+  }
+}
 
 // Run spotless check when running in github actions, otherwise run spotless apply.
 compileJava {

--- a/src/main/java/bio/terra/app/controller/ConfigsApiController.java
+++ b/src/main/java/bio/terra/app/controller/ConfigsApiController.java
@@ -19,8 +19,6 @@ import io.swagger.annotations.Api;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,8 +31,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Controller
 @Api(tags = {"configs"})
 public class ConfigsApiController implements ConfigsApi {
-
-  private static final Logger logger = LoggerFactory.getLogger(ConfigsApiController.class);
 
   private final ObjectMapper objectMapper;
   private final HttpServletRequest request;

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -1,6 +1,5 @@
 package bio.terra.app.controller;
 
-import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.app.controller.exception.TooManyRequestsException;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
@@ -34,26 +33,21 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Api(tags = {"DataRepositoryService"})
 public class DataRepositoryServiceApiController implements DataRepositoryServiceApi {
 
-  private Logger logger = LoggerFactory.getLogger(DataRepositoryServiceApiController.class);
+  private final Logger logger = LoggerFactory.getLogger(DataRepositoryServiceApiController.class);
 
   private final ObjectMapper objectMapper;
   private final HttpServletRequest request;
   private final DrsService drsService;
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
 
-  // needed for local testing w/o proxy
-  private final ApplicationConfiguration appConfig;
-
   @Autowired
   public DataRepositoryServiceApiController(
       ObjectMapper objectMapper,
       HttpServletRequest request,
       DrsService drsService,
-      ApplicationConfiguration appConfig,
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory) {
     this.objectMapper = objectMapper;
     this.request = request;
-    this.appConfig = appConfig;
     this.drsService = drsService;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
   }

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -42,8 +42,6 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -57,8 +55,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 @Api(tags = {"datasets"})
 public class DatasetsApiController implements DatasetsApi {
-
-  private Logger logger = LoggerFactory.getLogger(DatasetsApiController.class);
 
   public static final String RETRIEVE_INCLUDE_DEFAULT_VALUE = "SCHEMA,PROFILE,DATA_PROJECT,STORAGE";
 

--- a/src/main/java/bio/terra/app/controller/JobsApiController.java
+++ b/src/main/java/bio/terra/app/controller/JobsApiController.java
@@ -18,8 +18,6 @@ import io.swagger.annotations.Api;
 import java.util.List;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,8 +30,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 @Api(tags = {"jobs"})
 public class JobsApiController implements JobsApi {
-
-  private Logger logger = LoggerFactory.getLogger(JobsApiController.class);
 
   private final ObjectMapper objectMapper;
   private final HttpServletRequest request;

--- a/src/main/java/bio/terra/app/controller/RegisterApiController.java
+++ b/src/main/java/bio/terra/app/controller/RegisterApiController.java
@@ -11,8 +11,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,8 +21,6 @@ import org.springframework.web.bind.annotation.InitBinder;
 @Controller
 @Api(tags = {"register"})
 public class RegisterApiController implements RegisterApi {
-
-  private Logger logger = LoggerFactory.getLogger(RegisterApiController.class);
 
   private final ObjectMapper objectMapper;
   private final HttpServletRequest request;

--- a/src/main/java/bio/terra/app/controller/UpgradeApiController.java
+++ b/src/main/java/bio/terra/app/controller/UpgradeApiController.java
@@ -15,8 +15,6 @@ import io.swagger.annotations.Api;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -27,8 +25,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Controller
 @Api(tags = {"upgrade"})
 public class UpgradeApiController implements UpgradeApi {
-
-  private Logger logger = LoggerFactory.getLogger(UpgradeApiController.class);
 
   private final ObjectMapper objectMapper;
   private final HttpServletRequest request;

--- a/src/main/java/bio/terra/app/logging/PerformanceLoggerOFF.java
+++ b/src/main/java/bio/terra/app/logging/PerformanceLoggerOFF.java
@@ -18,10 +18,12 @@ public class PerformanceLoggerOFF implements PerformanceLogger {
 
   public PerformanceLoggerOFF() {}
 
+  @Override
   public boolean isEnabled() {
     return false;
   }
 
+  @Override
   public void log(
       String jobId,
       String className,
@@ -30,12 +32,15 @@ public class PerformanceLoggerOFF implements PerformanceLogger {
       long integerCount,
       Object additionalInfo) {}
 
+  @Override
   public String timerStart() {
     return "";
   }
 
+  @Override
   public void timerStart(String timerId) {}
 
+  @Override
   public void timerEndAndLog(
       String timerId,
       String jobId,

--- a/src/main/java/bio/terra/app/logging/PerformanceLoggerON.java
+++ b/src/main/java/bio/terra/app/logging/PerformanceLoggerON.java
@@ -35,9 +35,9 @@ import org.springframework.stereotype.Component;
 @Primary
 public class PerformanceLoggerON implements PerformanceLogger {
 
-  private ObjectMapper objectMapper;
+  private final ObjectMapper objectMapper;
 
-  private static Logger logger = LoggerFactory.getLogger(PerformanceLoggerON.class);
+  private static final Logger logger = LoggerFactory.getLogger(PerformanceLoggerON.class);
   private static final String PerformanceLogFormat =
       "TimestampUTC: {}, JobId: {}, Class: {}, Operation: {}, "
           + "ElapsedTime: {}, IntegerCount: {}, AdditionalInfo: {}";
@@ -60,10 +60,12 @@ public class PerformanceLoggerON implements PerformanceLogger {
     this.objectMapper = new ObjectMapper();
   }
 
+  @Override
   public boolean isEnabled() {
     return true;
   }
 
+  @Override
   public void log(
       String jobId,
       String className,
@@ -80,7 +82,7 @@ public class PerformanceLoggerON implements PerformanceLogger {
         // if we hit a serialization error with the additional information object, log the string
         // anyway
         // and log the error separately for debugging
-        logger.info("Failure serializing additionalInfo to JSON. " + additionalInfo.toString());
+        logger.info("Failure serializing additionalInfo to JSON. " + additionalInfo);
         additionalInfoStr = additionalInfo.toString();
       }
     }
@@ -101,6 +103,7 @@ public class PerformanceLoggerON implements PerformanceLogger {
     return Instant.now().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
   }
 
+  @Override
   public String timerStart() {
     // generate a timer reference id to use for tracking
     long logCounterVal = logCounter.get();
@@ -113,6 +116,7 @@ public class PerformanceLoggerON implements PerformanceLogger {
     return timerId;
   }
 
+  @Override
   public void timerStart(String timerId) {
     // if the timer reference id already exists, overwrite it and log the error separately for
     // debugging
@@ -126,6 +130,7 @@ public class PerformanceLoggerON implements PerformanceLogger {
     startTimeMap.get().put(timerId, startTime);
   }
 
+  @Override
   public void timerEndAndLog(
       String timerId,
       String jobId,

--- a/src/main/java/bio/terra/app/model/AzureCloudResource.java
+++ b/src/main/java/bio/terra/app/model/AzureCloudResource.java
@@ -12,6 +12,7 @@ public enum AzureCloudResource implements CloudResource {
     this.value = value;
   }
 
+  @Override
   public String toString() {
     return value;
   }

--- a/src/main/java/bio/terra/app/model/AzureRegion.java
+++ b/src/main/java/bio/terra/app/model/AzureRegion.java
@@ -94,6 +94,7 @@ public enum AzureRegion implements CloudRegion {
     return value;
   }
 
+  @Override
   public String toString() {
     return value;
   }

--- a/src/main/java/bio/terra/app/model/GoogleCloudResource.java
+++ b/src/main/java/bio/terra/app/model/GoogleCloudResource.java
@@ -12,6 +12,7 @@ public enum GoogleCloudResource implements CloudResource {
     this.value = value;
   }
 
+  @Override
   public String toString() {
     return value;
   }

--- a/src/main/java/bio/terra/app/model/GoogleRegion.java
+++ b/src/main/java/bio/terra/app/model/GoogleRegion.java
@@ -75,6 +75,7 @@ public enum GoogleRegion implements CloudRegion {
     return value;
   }
 
+  @Override
   public String toString() {
     return value;
   }

--- a/src/main/java/bio/terra/app/utils/startup/StartupInitializer.java
+++ b/src/main/java/bio/terra/app/utils/startup/StartupInitializer.java
@@ -1,12 +1,9 @@
 package bio.terra.app.utils.startup;
 
 import bio.terra.service.job.JobService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
 public final class StartupInitializer {
-  private static final Logger logger = LoggerFactory.getLogger(StartupInitializer.class);
 
   private StartupInitializer() {}
 

--- a/src/main/java/bio/terra/common/FlightUtils.java
+++ b/src/main/java/bio/terra/common/FlightUtils.java
@@ -18,13 +18,7 @@ public final class FlightUtils {
 
   private FlightUtils() {}
 
-  /**
-   * Build an error model and set it as the response
-   *
-   * @param context
-   * @param message
-   * @param responseStatus
-   */
+  /** Build an error model and set it as the response */
   public static void setErrorResponse(
       FlightContext context, String message, HttpStatus responseStatus) {
     ErrorModel errorModel = new ErrorModel().message(message);

--- a/src/main/java/bio/terra/grammar/Query.java
+++ b/src/main/java/bio/terra/grammar/Query.java
@@ -11,11 +11,9 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 public class Query {
 
-  private final SQLParser parser;
   private final SQLParser.Query_statementContext queryStatement;
 
-  private Query(SQLParser parser, SQLParser.Query_statementContext queryStatement) {
-    this.parser = parser;
+  private Query(SQLParser.Query_statementContext queryStatement) {
     this.queryStatement = queryStatement;
   }
 
@@ -25,7 +23,7 @@ public class Query {
     SQLParser parser = new SQLParser(new CommonTokenStream(lexer));
     parser.setErrorHandler(new BailErrorStrategy());
     try {
-      return new Query(parser, parser.query_statement());
+      return new Query(parser.query_statement());
     } catch (ParseCancellationException ex) {
       throw new InvalidQueryException("Could not parse query: " + sql, ex);
     }

--- a/src/main/java/bio/terra/service/configuration/ConfigFaultSimple.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigFaultSimple.java
@@ -2,13 +2,8 @@ package bio.terra.service.configuration;
 
 import bio.terra.model.ConfigFaultModel;
 import bio.terra.model.ConfigModel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ConfigFaultSimple extends ConfigFault {
-  private final Logger logger = LoggerFactory.getLogger(ConfigFaultSimple.class);
-
-  // -- Instance methods --
   ConfigFaultSimple(
       ConfigEnum configEnum, ConfigFaultModel.FaultTypeEnum faultType, boolean enabled) {
     super(configEnum, faultType, enabled);

--- a/src/main/java/bio/terra/service/configuration/ConfigurationService.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigurationService.java
@@ -56,12 +56,12 @@ import bio.terra.model.ConfigListModel;
 import bio.terra.model.ConfigModel;
 import bio.terra.service.configuration.exception.ConfigNotFoundException;
 import bio.terra.service.configuration.exception.DuplicateConfigNameException;
-import bio.terra.service.filedata.google.gcs.GcsConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,20 +73,17 @@ public class ConfigurationService {
 
   private final ApplicationConfiguration appConfiguration;
   private final SamConfiguration samConfiguration;
-  private final GcsConfiguration gcsConfiguration;
   private final GoogleResourceConfiguration googleResourceConfiguration;
 
-  private Map<ConfigEnum, ConfigBase> configuration = new HashMap<>();
+  private final Map<ConfigEnum, ConfigBase> configuration = new HashMap<>();
 
   @Autowired
   public ConfigurationService(
       SamConfiguration samConfiguration,
-      GcsConfiguration gcsConfiguration,
       GoogleResourceConfiguration googleResourceConfiguration,
       ApplicationConfiguration appConfiguration) {
     this.appConfiguration = appConfiguration;
     this.samConfiguration = samConfiguration;
-    this.gcsConfiguration = gcsConfiguration;
     this.googleResourceConfiguration = googleResourceConfiguration;
     setConfiguration();
   }
@@ -102,7 +99,7 @@ public class ConfigurationService {
       config.validate(configModel);
     }
 
-    List<ConfigModel> priorConfigList = new LinkedList<>();
+    List<ConfigModel> priorConfigList = new ArrayList<>(groupModel.getGroup().size());
     for (ConfigModel configModel : groupModel.getGroup()) {
       ConfigEnum configEnum = ConfigEnum.lookupByApiName(configModel.getName());
       ConfigBase config = configuration.get(configEnum);
@@ -119,10 +116,10 @@ public class ConfigurationService {
   }
 
   public ConfigListModel getConfigList() {
-    List<ConfigModel> configList = new LinkedList<>();
-    for (ConfigBase config : configuration.values()) {
-      configList.add(config.get());
-    }
+    List<ConfigModel> configList =
+        configuration.values().stream()
+            .map(ConfigBase::get)
+            .collect(Collectors.toUnmodifiableList());
     return new ConfigListModel().items(configList).total(configList.size());
   }
 

--- a/src/main/java/bio/terra/service/dataset/AssetDao.java
+++ b/src/main/java/bio/terra/service/dataset/AssetDao.java
@@ -43,7 +43,6 @@ public class AssetDao {
    *
    * @param assetSpecification the AssetSpecification being created
    * @param datasetId the ID of the dataset corresponding to the AssetSpecification being created
-   * @return
    */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public UUID create(AssetSpecification assetSpecification, UUID datasetId) {

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -110,6 +110,7 @@ public class Dataset implements FSContainerInterface {
     return datasetSummary;
   }
 
+  @Override
   public UUID getId() {
     return datasetSummary.getId();
   }
@@ -182,6 +183,7 @@ public class Dataset implements FSContainerInterface {
     return this;
   }
 
+  @Override
   public GoogleProjectResource getProjectResource() {
     return projectResource;
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
@@ -102,6 +102,7 @@ public class DatasetBucketDao {
   }
 
   private static class DatasetBucketMapper implements RowMapper<String> {
+    @Override
     public String mapRow(ResultSet rs, int rowNum) throws SQLException {
       return rs.getObject("google_project_id", String.class);
     }
@@ -180,12 +181,13 @@ public class DatasetBucketDao {
   }
 
   private static class UuidMapper implements RowMapper<UUID> {
-    private String columnLabel;
+    private final String columnLabel;
 
     UuidMapper(String columnLabel) {
       this.columnLabel = columnLabel;
     }
 
+    @Override
     public UUID mapRow(ResultSet rs, int rowNum) throws SQLException {
       return rs.getObject(this.columnLabel, UUID.class);
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -355,9 +355,6 @@ public class DatasetDao {
    * unlock.
    *
    * @param dataset the dataset object to create
-   * @return the id of the new dataset
-   * @throws SQLException
-   * @throws IOException
    * @throws InvalidDatasetException if a row already exists with this dataset name
    */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
@@ -635,6 +632,7 @@ public class DatasetDao {
   }
 
   private class DatasetSummaryMapper implements RowMapper<DatasetSummary> {
+    @Override
     public DatasetSummary mapRow(ResultSet rs, int rowNum) throws SQLException {
       UUID datasetId = rs.getObject("id", UUID.class);
       List<? extends StorageResource<?, ?>> storageResources;

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -258,7 +258,7 @@ public final class DatasetJsonConversion {
         .to(relationshipTermModelFromColumn(datasetRel.getToTable(), datasetRel.getToColumn()));
   }
 
-  protected static RelationshipTermModel relationshipTermModelFromColumn(Table table, Column col) {
+  private static RelationshipTermModel relationshipTermModelFromColumn(Table table, Column col) {
     return new RelationshipTermModel().table(table.getName()).column(col.getName());
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -28,7 +28,6 @@ import bio.terra.service.job.JobService;
 import bio.terra.service.load.LoadService;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.profile.exception.ProfileNotFoundException;
-import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.exception.AssetNotFoundException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,7 +42,6 @@ import org.springframework.stereotype.Component;
 public class DatasetService {
   private final DatasetDao datasetDao;
   private final JobService jobService; // for handling flight response
-  private final ResourceService resourceService;
   private final LoadService loadService;
   private final ProfileDao profileDao;
 
@@ -51,12 +49,10 @@ public class DatasetService {
   public DatasetService(
       DatasetDao datasetDao,
       JobService jobService,
-      ResourceService resourceService,
       LoadService loadService,
       ProfileDao profileDao) {
     this.datasetDao = datasetDao;
     this.jobService = jobService;
-    this.resourceService = resourceService;
     this.loadService = loadService;
     this.profileDao = profileDao;
   }
@@ -92,7 +88,6 @@ public class DatasetService {
   /**
    * Fetch existing Dataset object using the name.
    *
-   * @param name
    * @return a Dataset object
    */
   public Dataset retrieveByName(String name) {

--- a/src/main/java/bio/terra/service/dataset/DatasetStorageAccountDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetStorageAccountDao.java
@@ -162,12 +162,13 @@ public class DatasetStorageAccountDao {
   }
 
   private static class UuidMapper implements RowMapper<UUID> {
-    private String columnLabel;
+    private final String columnLabel;
 
     UuidMapper(String columnLabel) {
       this.columnLabel = columnLabel;
     }
 
+    @Override
     public UUID mapRow(ResultSet rs, int rowNum) throws SQLException {
       return rs.getObject(this.columnLabel, UUID.class);
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetTable.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTable.java
@@ -23,6 +23,7 @@ public class DatasetTable implements Table {
   private BigQueryPartitionConfigV1 bqPartitionConfig;
   private Long rowCount;
 
+  @Override
   public UUID getId() {
     return id;
   }
@@ -32,6 +33,7 @@ public class DatasetTable implements Table {
     return this;
   }
 
+  @Override
   public String getName() {
     return name;
   }
@@ -59,6 +61,7 @@ public class DatasetTable implements Table {
     return this;
   }
 
+  @Override
   public List<Column> getColumns() {
     return columns;
   }

--- a/src/main/java/bio/terra/service/dataset/StorageResource.java
+++ b/src/main/java/bio/terra/service/dataset/StorageResource.java
@@ -55,7 +55,7 @@ public abstract class StorageResource<Resource extends CloudResource, Region ext
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof StorageResource)) {
       return false;
     }
     StorageResource<?, ?> that = (StorageResource<?, ?>) o;

--- a/src/main/java/bio/terra/service/dataset/StorageResourceDao.java
+++ b/src/main/java/bio/terra/service/dataset/StorageResourceDao.java
@@ -67,11 +67,12 @@ public class StorageResourceDao {
       return jdbcTemplate.query(SQL_GET_LIST, params, new StorageResourceMapper());
     } catch (EmptyResultDataAccessException ex) {
       throw new StorageResourceNotFoundException(
-          "Storage resources not found for dataset enumerate query");
+          "Storage resources not found for dataset enumerate query", ex);
     }
   }
 
   private static class StorageResourceMapper implements RowMapper<StorageResource<?, ?>> {
+    @Override
     public StorageResource<?, ?> mapRow(ResultSet rs, int rowNum) throws SQLException {
       final CloudPlatform cloudPlatform = CloudPlatform.valueOf(rs.getString("cloud_platform"));
       switch (cloudPlatform) {

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzBqJobUserStep.java
@@ -11,13 +11,8 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.Map;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CreateDatasetAuthzBqJobUserStep implements Step {
-  private static final Logger logger =
-      LoggerFactory.getLogger(CreateDatasetAuthzBqJobUserStep.class);
-
   private final DatasetService datasetService;
   private final ResourceService resourceService;
 

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzPrimaryDataStep.java
@@ -21,13 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CreateDatasetAuthzPrimaryDataStep implements Step {
-  private static final Logger logger =
-      LoggerFactory.getLogger(CreateDatasetAuthzPrimaryDataStep.class);
-
   private final BigQueryPdao bigQueryPdao;
   private final DatasetService datasetService;
   private final ConfigurationService configService;

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetCreateStorageAccountLinkStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetCreateStorageAccountLinkStep.java
@@ -1,6 +1,5 @@
 package bio.terra.service.dataset.flight.create;
 
-import bio.terra.model.DatasetRequestModel;
 import bio.terra.service.dataset.DatasetStorageAccountDao;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -12,15 +11,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CreateDatasetCreateStorageAccountLinkStep implements Step {
-  private static Logger logger =
+  private static final Logger logger =
       LoggerFactory.getLogger(CreateDatasetCreateStorageAccountLinkStep.class);
   private final DatasetStorageAccountDao datasetStorageAccountDao;
-  private final DatasetRequestModel datasetRequestModel;
 
   public CreateDatasetCreateStorageAccountLinkStep(
-      DatasetStorageAccountDao datasetStorageAccountDao, DatasetRequestModel datasetRequestModel) {
+      DatasetStorageAccountDao datasetStorageAccountDao) {
     this.datasetStorageAccountDao = datasetStorageAccountDao;
-    this.datasetRequestModel = datasetRequestModel;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -91,8 +91,7 @@ public class DatasetCreateFlight extends Flight {
 
     // For azure backed datasets, add a link co connect the storage account to the dataset
     if (platform.isAzure()) {
-      addStep(
-          new CreateDatasetCreateStorageAccountLinkStep(datasetStorageAccountDao, datasetRequest));
+      addStep(new CreateDatasetCreateStorageAccountLinkStep(datasetStorageAccountDao));
     }
 
     addStep(new CreateDatasetPrimaryDataStep(bigQueryPdao, datasetDao));

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DropExternalTablesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DropExternalTablesStep.java
@@ -12,15 +12,11 @@ import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DropExternalTablesStep implements Step {
 
   private final BigQueryPdao bigQueryPdao;
   private final DatasetService datasetService;
-
-  private static Logger logger = LoggerFactory.getLogger(DropExternalTablesStep.class);
 
   public DropExternalTablesStep(BigQueryPdao bigQueryPdao, DatasetService datasetService) {
     this.bigQueryPdao = bigQueryPdao;

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetMetadataStep.java
@@ -10,8 +10,8 @@ import java.util.UUID;
 import org.springframework.http.HttpStatus;
 
 public class DeleteDatasetMetadataStep implements Step {
-  private DatasetDao datasetDao;
-  private UUID datasetId;
+  private final DatasetDao datasetDao;
+  private final UUID datasetId;
 
   public DeleteDatasetMetadataStep(DatasetDao datasetDao, UUID datasetId) {
     this.datasetDao = datasetDao;
@@ -22,7 +22,7 @@ public class DeleteDatasetMetadataStep implements Step {
   public StepResult doStep(FlightContext context) {
     boolean success = datasetDao.delete(datasetId);
     DeleteResponseModel.ObjectStateEnum stateEnum =
-        (success)
+        success
             ? DeleteResponseModel.ObjectStateEnum.DELETED
             : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
     DeleteResponseModel deleteResponseModel = new DeleteResponseModel().objectState(stateEnum);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
@@ -51,8 +51,7 @@ public class IngestValidateRefsStep implements Step {
 
     int invalidIdCount = invalidRefIds.size();
     if (invalidIdCount != 0) {
-      // Made a string buffer to appease findbugs; it saw + in the loop and said "bad!"
-      StringBuffer errorMessage = new StringBuffer("Invalid file ids found during ingest (");
+      StringBuilder errorMessage = new StringBuilder("Invalid file ids found during ingest (");
 
       List<String> errorDetails = new ArrayList<>();
       int count = 0;
@@ -60,11 +59,11 @@ public class IngestValidateRefsStep implements Step {
         errorDetails.add(badId);
         count++;
         if (count > MAX_ERROR_REF_IDS) {
-          errorMessage.append(MAX_ERROR_REF_IDS + "out of ");
+          errorMessage.append(MAX_ERROR_REF_IDS + " out of ");
           break;
         }
       }
-      errorMessage.append(invalidIdCount + " returned in details)");
+      errorMessage.append(invalidIdCount).append(" returned in details)");
       throw new InvalidFileRefException(errorMessage.toString(), errorDetails);
     }
 

--- a/src/main/java/bio/terra/service/filedata/FSFile.java
+++ b/src/main/java/bio/terra/service/filedata/FSFile.java
@@ -50,41 +50,49 @@ public class FSFile extends FSItem {
   }
 
   // setters for super object, so fluent style works without ordering dependency
+  @Override
   public FSFile fileId(UUID fileId) {
     super.fileId(fileId);
     return this;
   }
 
+  @Override
   public FSFile collectionId(UUID collectionId) {
     super.collectionId(collectionId);
     return this;
   }
 
+  @Override
   public FSFile createdDate(Instant createdDate) {
     super.createdDate(createdDate);
     return this;
   }
 
+  @Override
   public FSFile path(String path) {
     super.path(path);
     return this;
   }
 
+  @Override
   public FSFile checksumCrc32c(String checksumCrc32c) {
     super.checksumCrc32c(checksumCrc32c);
     return this;
   }
 
+  @Override
   public FSFile checksumMd5(String checksumMd5) {
     super.checksumMd5(checksumMd5);
     return this;
   }
 
+  @Override
   public FSFile size(Long size) {
     super.size(size); // Super size it!
     return this;
   }
 
+  @Override
   public FSFile description(String description) {
     super.description(description);
     return this;

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -30,15 +30,11 @@ import bio.terra.service.snapshot.SnapshotService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FileService {
-  private final Logger logger = LoggerFactory.getLogger(FileService.class);
-
   private final JobService jobService;
   private final FireStoreDao fileDao;
   private final DatasetService datasetService;

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -107,7 +107,7 @@ public class AzureBlobStorePdao {
             String.format(
                 "%s/%s",
                 destinationClientFactory.getBlobContainerClient().getBlobContainerUrl(), blobName))
-        .checksumMd5(Base64.getEncoder().encodeToString((blobProperties.getContentMd5())))
+        .checksumMd5(Base64.getEncoder().encodeToString(blobProperties.getContentMd5()))
         .size(blobProperties.getBlobSize())
         .bucketResourceId(storageAccountResource.getResourceId().toString());
   }

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -14,6 +14,7 @@ import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.common.sas.SasProtocol;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Locale;
@@ -173,7 +174,7 @@ public class BlobContainerClientFactory {
 
     BlobSasPermission permissions = new BlobSasPermission().setReadPermission(true);
 
-    OffsetDateTime expiryTime = OffsetDateTime.now().plusDays(1);
+    OffsetDateTime expiryTime = Instant.now().atZone(ZoneOffset.UTC).plusDays(1).toOffsetDateTime();
     SasProtocol sasProtocol = SasProtocol.HTTPS_ONLY;
 
     // build the token

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzurePrimaryDataStep.java
@@ -7,13 +7,8 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DeleteFileAzurePrimaryDataStep implements Step {
-  private static final Logger logger =
-      LoggerFactory.getLogger(DeleteFileAzurePrimaryDataStep.class);
-
   private final AzureBlobStorePdao azureBlobStorePdao;
 
   public DeleteFileAzurePrimaryDataStep(AzureBlobStorePdao azureBlobStorePdao) {

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileDirectoryStep.java
@@ -25,11 +25,12 @@ public class DeleteFileDirectoryStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     try {
-      boolean found = fileDao.deleteDirectoryEntry(dataset, fileId);
-      DeleteResponseModel.ObjectStateEnum stateEnum =
-          (found)
-              ? DeleteResponseModel.ObjectStateEnum.DELETED
-              : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
+      final DeleteResponseModel.ObjectStateEnum stateEnum;
+      if (fileDao.deleteDirectoryEntry(dataset, fileId)) {
+        stateEnum = DeleteResponseModel.ObjectStateEnum.DELETED;
+      } else {
+        stateEnum = DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
+      }
       DeleteResponseModel deleteResponseModel = new DeleteResponseModel().objectState(stateEnum);
       FlightUtils.setResponse(context, deleteResponseModel, HttpStatus.OK);
     } catch (FileSystemAbortTransactionException rex) {

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFilePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFilePrimaryDataStep.java
@@ -9,12 +9,8 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DeleteFilePrimaryDataStep implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(DeleteFilePrimaryDataStep.class);
-
   private final GcsPdao gcsPdao;
   private final ResourceService resourceService;
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkArrayResponseStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkArrayResponseStep.java
@@ -12,15 +12,11 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.List;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 // It expects the following working map data:
 // - LOAD_ID - load id we are working on
 //
 public class IngestBulkArrayResponseStep implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(IngestBulkArrayResponseStep.class);
-
   private final LoadService loadService;
   private final String loadTag;
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkFileResponseStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkFileResponseStep.java
@@ -9,15 +9,11 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 // It expects the following working map data:
 // - LOAD_ID - load id we are working on
 //
 public class IngestBulkFileResponseStep implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(IngestBulkFileResponseStep.class);
-
   private final LoadService loadService;
   private final String loadTag;
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -27,7 +27,7 @@ import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.DuplicateFlightIdSubmittedException;
 import bio.terra.stairway.exception.FlightNotFoundException;
 import bio.terra.stairway.exception.StairwayExecutionException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -222,7 +222,7 @@ public class IngestDriverStep implements Step {
         candidates.getCandidateFiles().size());
 
     int failureCount = candidates.getFailedLoads();
-    List<LoadFile> realRunningLoads = new LinkedList<>();
+    List<LoadFile> realRunningLoads = new ArrayList<>();
 
     for (LoadFile loadFile : candidates.getRunningLoads()) {
       FlightState flightState = context.getStairway().getFlightState(loadFile.getFlightId());

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataLocationStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataLocationStep.java
@@ -12,12 +12,8 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IngestFileAzurePrimaryDataLocationStep implements Step {
-  private static final Logger logger =
-      LoggerFactory.getLogger(IngestFileAzurePrimaryDataLocationStep.class);
   private final ResourceService resourceService;
   private final Dataset dataset;
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileDirectoryStep.java
@@ -15,12 +15,8 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IngestFileDirectoryStep implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(IngestFileDirectoryStep.class);
-
   private final FireStoreDao fileDao;
   private final FireStoreUtils fireStoreUtils;
   private final Dataset dataset;

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileGetOrCreateProject.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileGetOrCreateProject.java
@@ -13,11 +13,8 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IngestFileGetOrCreateProject implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(IngestFileGetOrCreateProject.class);
   private final ResourceService resourceService;
   private final Dataset dataset;
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/ValidateIngestFileDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/ValidateIngestFileDirectoryStep.java
@@ -13,12 +13,8 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ValidateIngestFileDirectoryStep implements Step {
-  private static final Logger logger =
-      LoggerFactory.getLogger(ValidateIngestFileDirectoryStep.class);
   public static final String CREATE_ENTRY_ACTION = "createEntry";
   public static final String CHECK_ENTRY_ACTION = "checkEntry";
 

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -352,7 +352,6 @@ public class FireStoreDao {
    * @param context provides either the file id or the file path, for use in error messages.
    * @return An {@link FSItem} representation of the passed in fireStoreDirectoryEntry with nested
    *     FSItems
-   * @throws InterruptedException
    */
   private FSItem retrieveWorker(
       Firestore fsItemFirestore,
@@ -394,7 +393,6 @@ public class FireStoreDao {
    * @param fireStoreDirectoryEntry The object to enumerate entries within
    * @return An {@link FSItem} representation of the passed in fireStoreDirectoryEntry with nested
    *     FSItems
-   * @throws InterruptedException
    */
   private FSItem makeFSDir(
       Firestore fsItemFirestore,

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
@@ -6,7 +6,6 @@ import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_SNAPSHOT_BATC
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.exception.FileSystemCorruptException;
-import bio.terra.service.resourcemanagement.ResourceService;
 import com.google.api.client.util.Lists;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.CollectionReference;
@@ -36,16 +35,12 @@ public class FireStoreDependencyDao {
   private static final String DEPENDENCY_COLLECTION_NAME = "-dependencies";
 
   private final FireStoreUtils fireStoreUtils;
-  private final ResourceService resourceService;
   private final ConfigurationService configurationService;
 
   @Autowired
   public FireStoreDependencyDao(
-      FireStoreUtils fireStoreUtils,
-      ResourceService resourceService,
-      ConfigurationService configurationService) {
+      FireStoreUtils fireStoreUtils, ConfigurationService configurationService) {
     this.fireStoreUtils = fireStoreUtils;
-    this.resourceService = resourceService;
     this.configurationService = configurationService;
   }
 

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
@@ -19,8 +19,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -36,7 +34,6 @@ import org.springframework.stereotype.Component;
  */
 @Component
 class FireStoreFileDao {
-  private final Logger logger = LoggerFactory.getLogger(FireStoreFileDao.class);
 
   private final FireStoreUtils fireStoreUtils;
   private final ConfigurationService configurationService;

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreProject.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreProject.java
@@ -3,16 +3,13 @@ package bio.terra.service.filedata.google.firestore;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
 import java.util.concurrent.ConcurrentHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class FireStoreProject {
-  private static final Logger logger = LoggerFactory.getLogger(FireStoreProject.class);
   private static final ConcurrentHashMap<String, FireStoreProject> fireStoreProjectCache =
       new ConcurrentHashMap<>();
 
-  private String projectId;
-  private Firestore firestore;
+  private final String projectId;
+  private final Firestore firestore;
 
   private FireStoreProject(String projectId) {
     this.projectId = projectId;

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -346,11 +346,11 @@ public class FireStoreUtils {
     int docCount =
         runTransactionWithRetry(
             firestore,
-            (xn -> {
+            xn -> {
               Query limitedQuery = collectionQuery.limit(1);
               ApiFuture<QuerySnapshot> querySnapshot = xn.get(limitedQuery);
               return querySnapshot.get().getDocuments().size();
-            }),
+            },
             "collectionHasDocuments",
             "Querying firestore and checking if collection is empty");
     return docCount > 0;

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -25,7 +25,7 @@ import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import java.time.Instant;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -258,13 +258,14 @@ public class GcsPdao {
       throws InterruptedException {
 
     // Build all the groups that need to get read access to the files
-    List<Acl.Group> groups = new LinkedList<>();
-    groups.add(new Acl.Group(policies.get(IamRole.READER)));
-    groups.add(new Acl.Group(policies.get(IamRole.CUSTODIAN)));
-    groups.add(new Acl.Group(policies.get(IamRole.STEWARD)));
+    List<Acl.Group> groups =
+        List.of(
+            new Acl.Group(policies.get(IamRole.READER)),
+            new Acl.Group(policies.get(IamRole.CUSTODIAN)),
+            new Acl.Group(policies.get(IamRole.STEWARD)));
 
     // build acls if necessary
-    List<Acl> acls = new LinkedList<>();
+    List<Acl> acls = new ArrayList<>();
     if (op == AclOp.ACL_OP_CREATE) {
       for (Acl.Group group : groups) {
         acls.add(Acl.newBuilder(group, Acl.Role.READER).build());

--- a/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
@@ -3,15 +3,11 @@ package bio.terra.service.iam;
 import bio.terra.app.configuration.ApplicationConfiguration;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class LocalAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
-  private Logger logger = LoggerFactory.getLogger(LocalAuthenticatedUserRequestFactory.class);
-
   // in testing scenarios and when running the server without the proxy not all the
   // header information will be available. default values will be used in these cases.
 
@@ -23,6 +19,7 @@ public class LocalAuthenticatedUserRequestFactory implements AuthenticatedUserRe
   }
 
   // Static method to build an AuthenticatedUserRequest from data available to the controller
+  @Override
   public AuthenticatedUserRequest from(HttpServletRequest servletRequest) {
     HttpServletRequest req = servletRequest;
 

--- a/src/main/java/bio/terra/service/iam/ProxiedAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/ProxiedAuthenticatedUserRequestFactory.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class ProxiedAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
 
   // Method to build an AuthenticatedUserRequest from data available to the controller
+  @Override
   public AuthenticatedUserRequest from(HttpServletRequest servletRequest) {
     String token =
         Optional.ofNullable(servletRequest.getHeader("oidc_access_token"))

--- a/src/main/java/bio/terra/service/iam/sam/CreateResourceCorrectRequest.java
+++ b/src/main/java/bio/terra/service/iam/sam/CreateResourceCorrectRequest.java
@@ -105,7 +105,7 @@ public class CreateResourceCorrectRequest {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof CreateResourceCorrectRequest)) {
       return false;
     }
     CreateResourceCorrectRequest createResourceRequest = (CreateResourceCorrectRequest) o;

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -257,8 +257,7 @@ public class SamIam implements IamProviderInterface {
     SamRetry.retry(
         configurationService, () -> createSnapshotResourceInner(userReq, snapshotId, readersList));
     return SamRetry.retry(
-        configurationService,
-        () -> syncSnapshotResourcePoliciesInner(userReq, snapshotId, readersList));
+        configurationService, () -> syncSnapshotResourcePoliciesInner(userReq, snapshotId));
   }
 
   private void createSnapshotResourceInner(
@@ -284,8 +283,7 @@ public class SamIam implements IamProviderInterface {
   }
 
   private Map<IamRole, String> syncSnapshotResourcePoliciesInner(
-      AuthenticatedUserRequest userReq, UUID snapshotId, List<String> readersList)
-      throws ApiException {
+      AuthenticatedUserRequest userReq, UUID snapshotId) throws ApiException {
     // sync the policies for all roles that have read data action
     Map<IamRole, String> policies = new HashMap<>();
     String policy =

--- a/src/main/java/bio/terra/service/job/JobBuilder.java
+++ b/src/main/java/bio/terra/service/job/JobBuilder.java
@@ -7,9 +7,9 @@ import bio.terra.stairway.FlightMap;
 
 public class JobBuilder {
 
-  private JobService jobServiceRef;
-  private Class<? extends Flight> flightClass;
-  private FlightMap jobParameterMap;
+  private final JobService jobServiceRef;
+  private final Class<? extends Flight> flightClass;
+  private final FlightMap jobParameterMap;
 
   // constructor only takes required parameters
   public JobBuilder(
@@ -41,7 +41,7 @@ public class JobBuilder {
     if (keyName.equals(JobMapKeys.DESCRIPTION.getKeyName())
         || keyName.equals(JobMapKeys.REQUEST.getKeyName())
         || keyName.equals(JobMapKeys.AUTH_USER_INFO.getKeyName())
-        || keyName.equals((JobMapKeys.SUBJECT_ID.getKeyName()))) {
+        || keyName.equals(JobMapKeys.SUBJECT_ID.getKeyName())) {
       throw new InvalidJobParameterException(
           "Required parameters can only be set by the constructor. (" + keyName + ")");
     }

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -17,7 +17,7 @@ public enum JobMapKeys {
   FILE_ID("fileId"),
   ASSET_ID("assetId");
 
-  private String keyName;
+  private final String keyName;
 
   JobMapKeys(String keyName) {
     this.keyName = keyName;

--- a/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
+++ b/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
@@ -5,7 +5,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.HookAction;
 import bio.terra.stairway.StairwayHook;
 import java.time.Instant;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +54,7 @@ public class StairwayLoggingHooks implements StairwayHook {
         FLIGHT_OPERATION_START,
         context.getFlightClassName(),
         context.getFlightId(),
-        Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
+        Instant.now().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT));
     performanceLogger.log(
         context.getFlightId(), context.getFlightClassName(), FLIGHT_OPERATION_START);
     return HookAction.CONTINUE;
@@ -76,7 +76,7 @@ public class StairwayLoggingHooks implements StairwayHook {
         context.getStepClassName(),
         context.getStepIndex(),
         context.getDirection().name(),
-        Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
+        Instant.now().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT));
     performanceLogger.timerStart(getStepTimerName(context.getFlightId()));
     return HookAction.CONTINUE;
   }
@@ -89,7 +89,7 @@ public class StairwayLoggingHooks implements StairwayHook {
         FLIGHT_OPERATION_END,
         context.getFlightClassName(),
         context.getFlightId(),
-        Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
+        Instant.now().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT));
     performanceLogger.log(
         context.getFlightId(), context.getFlightClassName(), FLIGHT_OPERATION_END);
     clearMdcKeys();
@@ -107,7 +107,7 @@ public class StairwayLoggingHooks implements StairwayHook {
         context.getStepClassName(),
         context.getStepIndex(),
         context.getDirection().name(),
-        Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT));
+        Instant.now().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT));
     performanceLogger.timerEndAndLog(
         getStepTimerName(context.getFlightId()),
         context.getFlightId(),

--- a/src/main/java/bio/terra/service/load/LoadService.java
+++ b/src/main/java/bio/terra/service/load/LoadService.java
@@ -11,7 +11,7 @@ import bio.terra.service.load.flight.LoadMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import java.time.Instant;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
@@ -50,13 +50,15 @@ public class LoadService {
   }
 
   /**
+   * If inputTag is missing, create a load tag.
+   *
    * @param inputTag may be null or blank
    * @return either valid inputTag or generated date-time tag.
    */
   public String computeLoadTag(String inputTag) {
     if (StringUtils.isEmpty(inputTag)) {
       return "load-at-"
-          + Instant.now().atZone(ZoneId.of("Z")).format(DateTimeFormatter.ISO_INSTANT);
+          + Instant.now().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
     }
     return inputTag;
   }

--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -201,6 +201,7 @@ public class ProfileDao {
   }
 
   private static class BillingProfileMapper implements RowMapper<BillingProfileModel> {
+    @Override
     public BillingProfileModel mapRow(ResultSet rs, int rowNum) throws SQLException {
       return new BillingProfileModel()
           .id(rs.getObject("id", UUID.class))

--- a/src/main/java/bio/terra/service/profile/ProfileUpdateRequestValidator.java
+++ b/src/main/java/bio/terra/service/profile/ProfileUpdateRequestValidator.java
@@ -8,13 +8,6 @@ import org.springframework.validation.Validator;
 
 @Component
 public class ProfileUpdateRequestValidator implements Validator {
-
-  // This is specific to Google's billing account id representation. This will likely need to be
-  // split into cloud
-  // specific subclasses tagged with profiles.
-  private static final String VALID_BILLING_ACCOUNT_ID_REGEX =
-      "[A-Z0-9]{6}-[A-Z0-9]{6}-[A-Z0-9]{6}";
-
   @Override
   public boolean supports(Class<?> clazz) {
     return true;

--- a/src/main/java/bio/terra/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
+++ b/src/main/java/bio/terra/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
@@ -6,13 +6,8 @@ import bio.terra.service.profile.ProfileService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CreateProfileVerifyDeployedApplicationStep implements Step {
-  private static final Logger logger =
-      LoggerFactory.getLogger(CreateProfileVerifyDeployedApplicationStep.class);
-
   private final ProfileService profileService;
   private final BillingProfileRequestModel request;
   private final AuthenticatedUserRequest user;

--- a/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileApplicationDeploymentMetadata.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileApplicationDeploymentMetadata.java
@@ -8,15 +8,10 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.List;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DeleteProfileApplicationDeploymentMetadata implements Step {
 
   private final ResourceService resourceService;
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(DeleteProfileApplicationDeploymentMetadata.class);
 
   public DeleteProfileApplicationDeploymentMetadata(ResourceService resourceService) {
     this.resourceService = resourceService;

--- a/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileDeleteUnusedProjects.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileDeleteUnusedProjects.java
@@ -8,15 +8,10 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.List;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DeleteProfileDeleteUnusedProjects implements Step {
 
   private final ResourceService resourceService;
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(DeleteProfileDeleteUnusedProjects.class);
 
   public DeleteProfileDeleteUnusedProjects(ResourceService resourceService) {
     this.resourceService = resourceService;

--- a/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileMarkUnusedApplicationDeployments.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileMarkUnusedApplicationDeployments.java
@@ -12,8 +12,6 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.List;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DeleteProfileMarkUnusedApplicationDeployments implements Step {
 
@@ -21,9 +19,6 @@ public class DeleteProfileMarkUnusedApplicationDeployments implements Step {
   private final ResourceService resourceService;
   private final AuthenticatedUserRequest user;
   private final UUID profileId;
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(DeleteProfileMarkUnusedApplicationDeployments.class);
 
   public DeleteProfileMarkUnusedApplicationDeployments(
       ProfileService profileService,

--- a/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileMarkUnusedProjects.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileMarkUnusedProjects.java
@@ -8,16 +8,11 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.List;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DeleteProfileMarkUnusedProjects implements Step {
 
   private final ResourceService resourceService;
   private final UUID profileId;
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(DeleteProfileMarkUnusedProjects.class);
 
   public DeleteProfileMarkUnusedProjects(ResourceService resourceService, UUID profileId) {
     this.resourceService = resourceService;

--- a/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileMetadataStep.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileMetadataStep.java
@@ -7,16 +7,12 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
 public class DeleteProfileMetadataStep implements Step {
 
   private final ProfileService profileService;
   private final UUID profileId;
-
-  private static final Logger logger = LoggerFactory.getLogger(DeleteProfileMetadataStep.class);
 
   public DeleteProfileMetadataStep(ProfileService profileService, UUID profileId) {
     this.profileService = profileService;
@@ -25,11 +21,12 @@ public class DeleteProfileMetadataStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) {
-    boolean success = profileService.deleteProfileMetadata(profileId);
-    DeleteResponseModel.ObjectStateEnum stateEnum =
-        (success)
-            ? DeleteResponseModel.ObjectStateEnum.DELETED
-            : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
+    final DeleteResponseModel.ObjectStateEnum stateEnum;
+    if (profileService.deleteProfileMetadata(profileId)) {
+      stateEnum = DeleteResponseModel.ObjectStateEnum.DELETED;
+    } else {
+      stateEnum = DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
+    }
     DeleteResponseModel deleteResponseModel = new DeleteResponseModel().objectState(stateEnum);
     FlightUtils.setResponse(context, deleteResponseModel, HttpStatus.OK);
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileProjectMetadata.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/DeleteProfileProjectMetadata.java
@@ -8,14 +8,10 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.List;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DeleteProfileProjectMetadata implements Step {
 
   private final ResourceService resourceService;
-
-  private static final Logger logger = LoggerFactory.getLogger(DeleteProfileProjectMetadata.class);
 
   public DeleteProfileProjectMetadata(ResourceService resourceService) {
     this.resourceService = resourceService;

--- a/src/main/java/bio/terra/service/profile/flight/update/ProfileUpdateFlight.java
+++ b/src/main/java/bio/terra/service/profile/flight/update/ProfileUpdateFlight.java
@@ -25,9 +25,9 @@ public class ProfileUpdateFlight extends Flight {
     AuthenticatedUserRequest user =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
-    addStep(new UpdateProfileRetrieveExistingProfileStep(profileService, request, user));
+    addStep(new UpdateProfileRetrieveExistingProfileStep(profileService, request));
     // update billing account id metadata
-    addStep(new UpdateProfileMetadataStep(profileService, request, user));
+    addStep(new UpdateProfileMetadataStep(profileService, request));
     // Make sure valid account before changing in gcloud project
     addStep(new UpdateProfileVerifyAccountStep(profileService, user));
     // Update billing profile in gcloud project

--- a/src/main/java/bio/terra/service/profile/flight/update/UpdateProfileMetadataStep.java
+++ b/src/main/java/bio/terra/service/profile/flight/update/UpdateProfileMetadataStep.java
@@ -2,7 +2,6 @@ package bio.terra.service.profile.flight.update;
 
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileUpdateModel;
-import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.stairway.FlightContext;
@@ -17,16 +16,12 @@ public class UpdateProfileMetadataStep implements Step {
 
   private final ProfileService profileService;
   private final BillingProfileUpdateModel profileRequest;
-  private final AuthenticatedUserRequest user;
   private static final Logger logger = LoggerFactory.getLogger(UpdateProfileMetadataStep.class);
 
   public UpdateProfileMetadataStep(
-      ProfileService profileService,
-      BillingProfileUpdateModel profileRequest,
-      AuthenticatedUserRequest user) {
+      ProfileService profileService, BillingProfileUpdateModel profileRequest) {
     this.profileService = profileService;
     this.profileRequest = profileRequest;
-    this.user = user;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/profile/flight/update/UpdateProfileRetrieveExistingProfileStep.java
+++ b/src/main/java/bio/terra/service/profile/flight/update/UpdateProfileRetrieveExistingProfileStep.java
@@ -2,31 +2,22 @@ package bio.terra.service.profile.flight.update;
 
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileUpdateModel;
-import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class UpdateProfileRetrieveExistingProfileStep implements Step {
 
   private final ProfileService profileService;
   private final BillingProfileUpdateModel profileRequest;
-  private final AuthenticatedUserRequest user;
-  private static final Logger logger =
-      LoggerFactory.getLogger(UpdateProfileRetrieveExistingProfileStep.class);
 
   public UpdateProfileRetrieveExistingProfileStep(
-      ProfileService profileService,
-      BillingProfileUpdateModel profileRequest,
-      AuthenticatedUserRequest user) {
+      ProfileService profileService, BillingProfileUpdateModel profileRequest) {
     this.profileService = profileService;
     this.profileRequest = profileRequest;
-    this.user = user;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/profile/flight/update/UpdateProfileUpdateGCloudProject.java
+++ b/src/main/java/bio/terra/service/profile/flight/update/UpdateProfileUpdateGCloudProject.java
@@ -7,12 +7,8 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class UpdateProfileUpdateGCloudProject implements Step {
-  private static final Logger logger =
-      LoggerFactory.getLogger(UpdateProfileUpdateGCloudProject.class);
   private final GoogleProjectService googleProjectService;
 
   public UpdateProfileUpdateGCloudProject(GoogleProjectService projectService) {

--- a/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
+++ b/src/main/java/bio/terra/service/profile/google/GoogleBillingService.java
@@ -98,8 +98,6 @@ public class GoogleBillingService {
    * <p>The second permission is specific to projects, so we will check for the first permission
    * here.
    *
-   * @param user
-   * @param billingAccountId
    * @return true if a user can act as a billing account *user* (viewer is not enough), false
    *     otherwise
    */
@@ -115,7 +113,7 @@ public class GoogleBillingService {
       logger.info("Testing IAM permission on billing account: {}", billingAccountId);
       TestIamPermissionsResponse response = client.testIamPermissions(permissionsRequest);
       List<String> actualPermissions = response.getPermissionsList();
-      return actualPermissions != null && actualPermissions.equals(permissions);
+      return actualPermissions.equals(permissions);
     } catch (ApiException e) {
       int status = e.getStatusCode().getCode().getHttpStatusCode();
       if (status == 400 || status == 404) {

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -70,7 +70,6 @@ public class ResourceService {
   /**
    * Fetch/create a project
    *
-   * @param dataset
    * @param billingProfile authorized profile for billing account information case we need to create
    *     a project
    * @return a reference to the project as a POJO GoogleProjectResource

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentService.java
@@ -60,7 +60,6 @@ public class AzureApplicationDeploymentService {
    *
    * @param billingProfile previously authorized billing profile
    * @return application deployment resource object
-   * @throws InterruptedException if shutting down
    */
   public AzureApplicationDeploymentResource getOrRegisterApplicationDeployment(
       BillingProfileModel billingProfile) {
@@ -145,7 +144,6 @@ public class AzureApplicationDeploymentService {
    *
    * @param billingProfile authorized billing profile that'll pay for the application deployment
    * @return a populated application deployment resource object
-   * @throws InterruptedException if the flight is interrupted during execution
    */
   private AzureApplicationDeploymentResource newApplicationDeployment(
       BillingProfileModel billingProfile) {

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
@@ -5,7 +5,9 @@ import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.sas.BlobContainerSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.sas.SasProtocol;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -60,7 +62,7 @@ public class AzureContainerPdao {
             .setListPermission(enableList)
             .setDeletePermission(enableDelete);
 
-    OffsetDateTime expiryTime = OffsetDateTime.now().plusDays(1);
+    OffsetDateTime expiryTime = Instant.now().atZone(ZoneOffset.UTC).plusDays(1).toOffsetDateTime();
     SasProtocol sasProtocol = SasProtocol.HTTPS_ONLY;
 
     // build the token

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
@@ -155,11 +155,13 @@ public class AzureStorageAccountResource {
 
   public enum ContainerType {
     DATA() {
+      @Override
       String getContainer(AzureStorageAccountResource account) {
         return account.getDataContainer();
       }
     },
     METADATA() {
+      @Override
       String getContainer(AzureStorageAccountResource account) {
         return account.getMetadataContainer();
       }

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -28,6 +28,7 @@ public class Snapshot implements FSContainerInterface {
   private GoogleProjectResource projectResource;
   private List<Relationship> relationships = Collections.emptyList();
 
+  @Override
   public UUID getId() {
     return id;
   }
@@ -118,6 +119,7 @@ public class Snapshot implements FSContainerInterface {
     return this;
   }
 
+  @Override
   public GoogleProjectResource getProjectResource() {
     return projectResource;
   }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotMapTableDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotMapTableDao.java
@@ -5,7 +5,6 @@ import bio.terra.common.DaoKeyHolder;
 import bio.terra.common.Table;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -69,17 +68,16 @@ public class SnapshotMapTableDao {
             sql,
             new MapSqlParameterSource().addValue("source_id", source.getId()),
             (rs, rowNum) -> {
-              List<SnapshotMapTable> mapTables = new ArrayList<>();
               UUID fromTableId = rs.getObject("from_table_id", UUID.class);
               Optional<DatasetTable> datasetTable = source.getDataset().getTableById(fromTableId);
-              if (!datasetTable.isPresent()) {
+              if (datasetTable.isEmpty()) {
                 throw new CorruptMetadataException(
                     "Dataset table referenced by snapshot source map table was not found!");
               }
 
               UUID toTableId = UUID.fromString(rs.getString("to_table_id"));
               Optional<SnapshotTable> snapshotTable = snapshot.getTableById(toTableId);
-              if (!snapshotTable.isPresent()) {
+              if (snapshotTable.isEmpty()) {
                 throw new CorruptMetadataException(
                     "Snapshot table referenced by snapshot source map table was not found!");
               }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -86,8 +86,7 @@ public class SnapshotService {
    * Kick-off snapshot creation Pre-condition: the snapshot request has been syntax checked by the
    * validator
    *
-   * @param snapshotRequestModel
-   * @returns jobId (flightId) of the job
+   * @return jobId (flightId) of the job
    */
   public String createSnapshot(
       SnapshotRequestModel snapshotRequestModel, AuthenticatedUserRequest userReq) {
@@ -112,7 +111,7 @@ public class SnapshotService {
    * Kick-off snapshot deletion
    *
    * @param id snapshot id to delete
-   * @returns jobId (flightId) of the job
+   * @return jobId (flightId) of the job
    */
   public String deleteSnapshot(UUID id, AuthenticatedUserRequest userReq) {
     String description = "Delete snapshot " + id;
@@ -125,8 +124,6 @@ public class SnapshotService {
   /**
    * Enumerate a range of snapshots ordered by created date for consistent offset processing
    *
-   * @param offset
-   * @param limit
    * @return list of summary models of snapshot
    */
   public EnumerateSnapshotModel enumerateSnapshots(
@@ -158,7 +155,6 @@ public class SnapshotService {
    * Return a single snapshot summary given the snapshot id. This is used in the create snapshot
    * flight to build the model response of the asynchronous job.
    *
-   * @param id
    * @return summary model of the snapshot
    */
   public SnapshotSummaryModel retrieveSnapshotSummary(UUID id) {
@@ -236,7 +232,6 @@ public class SnapshotService {
   /**
    * Fetch existing Snapshot object using the name.
    *
-   * @param name
    * @return a Snapshot object
    */
   public Snapshot retrieveByName(String name) {
@@ -248,7 +243,6 @@ public class SnapshotService {
    * the structure does not have UUIDs or created dates filled in. Those are updated by the DAO when
    * it stores the snapshot in the repository metadata.
    *
-   * @param snapshotRequestModel
    * @return Snapshot
    */
   public Snapshot makeSnapshotFromSnapshotRequest(SnapshotRequestModel snapshotRequestModel) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -11,7 +11,7 @@ public class SnapshotSummary {
   private String description;
   private Instant createdDate;
   private UUID profileId;
-  private List<StorageResource> storage;
+  private List<StorageResource<?, ?>> storage;
 
   public UUID getId() {
     return id;
@@ -58,11 +58,11 @@ public class SnapshotSummary {
     return this;
   }
 
-  public List<StorageResource> getStorage() {
+  public List<StorageResource<?, ?>> getStorage() {
     return storage;
   }
 
-  public SnapshotSummary storage(List<StorageResource> storage) {
+  public SnapshotSummary storage(List<StorageResource<?, ?>> storage) {
     this.storage = storage;
     return this;
   }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTable.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTable.java
@@ -12,6 +12,7 @@ public class SnapshotTable implements Table {
   private List<Column> columns = Collections.emptyList();
   private Long rowCount;
 
+  @Override
   public UUID getId() {
     return id;
   }
@@ -21,6 +22,7 @@ public class SnapshotTable implements Table {
     return this;
   }
 
+  @Override
   public String getName() {
     return name;
   }
@@ -30,6 +32,7 @@ public class SnapshotTable implements Table {
     return this;
   }
 
+  @Override
   public List<Column> getColumns() {
     return columns;
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
@@ -9,13 +9,9 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CreateSnapshotIdStep implements Step {
   private final SnapshotRequestModel snapshotReq;
-
-  private static Logger logger = LoggerFactory.getLogger(CreateSnapshotIdStep.class);
 
   public CreateSnapshotIdStep(SnapshotRequestModel snapshotReq) {
     this.snapshotReq = snapshotReq;

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzFileAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzFileAclStep.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +82,8 @@ public class SnapshotAuthzFileAclStep implements Step {
               + "Message: {}, Reason: {}",
           ex.getMessage(),
           ex.getReason());
-      if (ex.getCode() == 400 && (StringUtils.equals(ex.getReason(), "badRequest"))) {
+      if (ex.getCode() == HttpStatus.SC_BAD_REQUEST
+          && StringUtils.equals(ex.getReason(), "badRequest")) {
         logger.error("[SnapshotACLException] Retrying! Bad Request.");
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
       }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
@@ -6,7 +6,6 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamRole;
 import bio.terra.service.iam.IamService;
-import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -19,18 +18,13 @@ import org.slf4j.LoggerFactory;
 
 public class SnapshotAuthzIamStep implements Step {
   private final IamService sam;
-  private final SnapshotService snapshotService;
   private final SnapshotRequestModel snapshotRequestModel;
   private final AuthenticatedUserRequest userReq;
   private static final Logger logger = LoggerFactory.getLogger(SnapshotAuthzIamStep.class);
 
   public SnapshotAuthzIamStep(
-      IamService sam,
-      SnapshotService snapshotService,
-      SnapshotRequestModel snapshotRequestModel,
-      AuthenticatedUserRequest userReq) {
+      IamService sam, SnapshotRequestModel snapshotRequestModel, AuthenticatedUserRequest userReq) {
     this.sam = sam;
-    this.snapshotService = snapshotService;
     this.snapshotRequestModel = snapshotRequestModel;
     this.userReq = userReq;
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -21,14 +21,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SnapshotAuthzTabularAclStep implements Step {
   private final BigQueryPdao bigQueryPdao;
   private final SnapshotService snapshotService;
   private final ConfigurationService configService;
-  private static final Logger logger = LoggerFactory.getLogger(SnapshotAuthzTabularAclStep.class);
 
   public SnapshotAuthzTabularAclStep(
       BigQueryPdao bigQueryPdao,

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -131,7 +131,7 @@ public class SnapshotCreateFlight extends Flight {
 
     // Create the IAM resource and readers for the snapshot
     // The IAM code contains retries, so we don't make a retry rule here.
-    addStep(new SnapshotAuthzIamStep(iamClient, snapshotService, snapshotReq, userReq));
+    addStep(new SnapshotAuthzIamStep(iamClient, snapshotReq, userReq));
 
     // Make the firestore file system for the snapshot
     addStep(

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
@@ -2,7 +2,6 @@ package bio.terra.service.snapshot.flight.delete;
 
 import bio.terra.common.FlightUtils;
 import bio.terra.model.DeleteResponseModel;
-import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
 import bio.terra.stairway.FlightContext;
@@ -24,8 +23,7 @@ public class DeleteSnapshotMetadataStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) {
-    Snapshot snapshot = null;
-    boolean found = false;
+    boolean found;
     try {
       found = snapshotDao.delete(snapshotId);
     } catch (SnapshotNotFoundException ex) {
@@ -33,7 +31,7 @@ public class DeleteSnapshotMetadataStep implements Step {
     }
 
     DeleteResponseModel.ObjectStateEnum stateEnum =
-        (found)
+        found
             ? DeleteResponseModel.ObjectStateEnum.DELETED
             : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
     DeleteResponseModel deleteResponseModel = new DeleteResponseModel().objectState(stateEnum);

--- a/src/test/java/bio/terra/app/controller/AssetModelValidationTest.java
+++ b/src/test/java/bio/terra/app/controller/AssetModelValidationTest.java
@@ -1,18 +1,9 @@
 package bio.terra.app.controller;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
-import bio.terra.model.AssetModel;
-import bio.terra.model.ErrorModel;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -20,10 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -33,25 +22,6 @@ public class AssetModelValidationTest {
 
   @Autowired private MockMvc mvc;
 
-  private ErrorModel expectBadAssetModel(AssetModel asset) throws Exception {
-    MvcResult result =
-        mvc.perform(
-                post("/api/repository/v1/datasets/assets")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(TestUtils.mapToJson(asset)))
-            .andExpect(status().is4xxClientError())
-            .andReturn();
-
-    MockHttpServletResponse response = result.getResponse();
-    String responseBody = response.getContentAsString();
-
-    assertTrue(
-        "Error model was returned on failure", StringUtils.contains(responseBody, "message"));
-
-    ErrorModel errorModel = TestUtils.mapFromJson(responseBody, ErrorModel.class);
-    return errorModel;
-  }
-
   @Test
   public void testInvalidAssetRequest() throws Exception {
     mvc.perform(
@@ -59,29 +29,5 @@ public class AssetModelValidationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}"))
         .andExpect(status().is4xxClientError());
-  }
-
-  private void checkValidationErrorModel(
-      String context, ErrorModel errorModel, String[] messageCodes) {
-    List<String> details = errorModel.getErrorDetail();
-    int requiredDetailSize = messageCodes.length;
-    assertThat("Got the expected error details", details.size(), equalTo(requiredDetailSize));
-    assertThat(
-        "Main message is right",
-        errorModel.getMessage(),
-        containsString("Validation errors - see error details"));
-    for (int i = 0; i < messageCodes.length; i++) {
-      assertThat(
-          context + ": correct message code (" + i + ")",
-          /**
-           * The global exception handler logs in this format:
-           *
-           * <p><fieldName>: '<messageCode>' (<defaultMessage>)
-           *
-           * <p>We check to see if the code is wrapped in quotes to prevent matching on substrings.
-           */
-          details.get(i),
-          containsString("'" + messageCodes[i] + "'"));
-    }
   }
 }

--- a/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetValidationsTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -29,7 +30,6 @@ import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,8 +57,6 @@ public class DatasetValidationsTest {
 
   @Autowired private MockMvc mvc;
 
-  @Autowired private ObjectMapper objectMapper;
-
   private ErrorModel expectBadDatasetCreateRequest(DatasetRequestModel datasetRequest)
       throws Exception {
     MvcResult result =
@@ -75,8 +73,7 @@ public class DatasetValidationsTest {
     assertTrue(
         "Error model was returned on failure", StringUtils.contains(responseBody, "message"));
 
-    ErrorModel errorModel = TestUtils.mapFromJson(responseBody, ErrorModel.class);
-    return errorModel;
+    return TestUtils.mapFromJson(responseBody, ErrorModel.class);
   }
 
   private void expectBadDatasetEnumerateRequest(
@@ -111,7 +108,7 @@ public class DatasetValidationsTest {
     if (errors == null || errors.isEmpty()) {
       assertTrue("No details expected", (responseErrors == null || responseErrors.size() == 0));
     } else {
-      assertTrue("Same number of errors", responseErrors.size() == errors.size());
+      assertEquals("Same number of errors", responseErrors.size(), errors.size());
       assertArrayEquals("Error details match", responseErrors.toArray(), errors.toArray());
     }
   }

--- a/src/test/java/bio/terra/app/controller/ProfileTest.java
+++ b/src/test/java/bio/terra/app/controller/ProfileTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
-import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
@@ -43,8 +42,6 @@ public class ProfileTest {
   @Autowired private MockMvc mvc;
 
   @Autowired private ObjectMapper objectMapper;
-
-  @Autowired private JsonLoader jsonLoader;
 
   @Test
   public void testCreateReadDelete() throws Exception {

--- a/src/test/java/bio/terra/app/controller/RepositoryApiControllerAccessTest.java
+++ b/src/test/java/bio/terra/app/controller/RepositoryApiControllerAccessTest.java
@@ -34,6 +34,7 @@ public class RepositoryApiControllerAccessTest extends UsersBase {
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
 
+  @Override
   @Before
   public void setup() throws Exception {
     super.setup();

--- a/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
@@ -16,7 +16,6 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRequestQueryModel;
 import bio.terra.model.SnapshotRequestRowIdModel;
 import bio.terra.model.SnapshotRequestRowIdTableModel;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -47,8 +46,6 @@ public class SnapshotValidationTest {
 
   @Autowired private MockMvc mvc;
 
-  @Autowired private ObjectMapper objectMapper;
-
   private SnapshotRequestModel snapshotByAssetRequest;
 
   private SnapshotRequestModel snapshotByRowIdsRequestModel;
@@ -78,8 +75,7 @@ public class SnapshotValidationTest {
     assertTrue(
         "Error model was returned on failure", StringUtils.contains(responseBody, "message"));
 
-    ErrorModel errorModel = TestUtils.mapFromJson(responseBody, ErrorModel.class);
-    return errorModel;
+    return TestUtils.mapFromJson(responseBody, ErrorModel.class);
   }
 
   // Generate a valid snapshot-by-asset request, we will tweak individual pieces to test validation

--- a/src/test/java/bio/terra/common/fixtures/ProfileFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/ProfileFixtures.java
@@ -12,11 +12,11 @@ import java.util.UUID;
 public final class ProfileFixtures {
   private ProfileFixtures() {}
 
-  private static SecureRandom randomGenerator = new SecureRandom();
+  private static final SecureRandom RANDOM_GENERATOR = new SecureRandom();
 
   public static String randomHex(int n) {
     Random r = new Random();
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     while (sb.length() < n) {
       sb.append(Integer.toHexString(r.nextInt(16)));
     }
@@ -98,7 +98,7 @@ public final class ProfileFixtures {
   }
 
   public static String randomizeName(String baseName) {
-    long suffix = randomGenerator.nextLong();
+    long suffix = RANDOM_GENERATOR.nextLong();
     return baseName + Long.toUnsignedString(suffix);
   }
 }

--- a/src/test/java/bio/terra/integration/BigQueryFixtures.java
+++ b/src/test/java/bio/terra/integration/BigQueryFixtures.java
@@ -67,6 +67,11 @@ public final class BigQueryFixtures {
     }
   }
 
+  private static final int RETRY_INITIAL_INTERVAL_SECONDS = 2;
+
+  private static final int RETRY_MAX_INTERVAL_SECONDS = 30;
+  private static final int RETRY_MAX_SLEEP_SECONDS = 420;
+
   /**
    * Run a query in BigQuery with retries
    *
@@ -79,11 +84,6 @@ public final class BigQueryFixtures {
    * @param bigQuery authenticated BigQuery object to use
    * @return TableResult object returned from BigQuery
    */
-  private static final int RETRY_INITIAL_INTERVAL_SECONDS = 2;
-
-  private static final int RETRY_MAX_INTERVAL_SECONDS = 30;
-  private static final int RETRY_MAX_SLEEP_SECONDS = 420;
-
   public static TableResult queryWithRetry(String sql, BigQuery bigQuery)
       throws InterruptedException {
     int sleptSeconds = 0;

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -58,7 +58,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @Category(Integration.class)
 public class FileTest extends UsersBase {
 
-  private static Logger logger = LoggerFactory.getLogger(FileTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(FileTest.class);
 
   @Autowired private AuthService authService;
 
@@ -71,9 +71,9 @@ public class FileTest extends UsersBase {
   private DatasetSummaryModel datasetSummaryModel;
   private UUID datasetId;
   private UUID snapshotId;
-  private List<String> fileIds;
   private UUID profileId;
 
+  @Override
   @Before
   public void setup() throws Exception {
     super.setup();
@@ -85,7 +85,6 @@ public class FileTest extends UsersBase {
         dataRepoFixtures.createDataset(steward(), profileId, "file-acl-test-dataset.json");
     datasetId = datasetSummaryModel.getId();
     snapshotId = null;
-    fileIds = new ArrayList<>();
     logger.info("created dataset " + datasetId);
     dataRepoFixtures.addDatasetPolicyMember(
         steward(), datasetId, IamRole.CUSTODIAN, custodian().getEmail());
@@ -97,14 +96,6 @@ public class FileTest extends UsersBase {
       dataRepoFixtures.deleteSnapshot(custodian(), snapshotId);
     }
     if (datasetId != null) {
-      fileIds.forEach(
-          f -> {
-            try {
-              dataRepoFixtures.deleteFile(steward(), datasetId, f);
-            } catch (Exception e) {
-              e.printStackTrace();
-            }
-          });
       dataRepoFixtures.deleteDataset(steward(), datasetId);
     }
     if (profileId != null) {
@@ -162,7 +153,7 @@ public class FileTest extends UsersBase {
   public void fileParallelFailedLoadTest() throws Exception {
     List<DataRepoResponse<JobModel>> responseList = new ArrayList<>();
     String gsPath = "gs://" + testConfiguration.getIngestbucket() + "/nonexistentfile";
-    String filePath = "/foo" + UUID.randomUUID().toString() + "/bar";
+    String filePath = "/foo" + UUID.randomUUID() + "/bar";
 
     for (int i = 0; i < 20; i++) {
       DataRepoResponse<JobModel> launchResp =
@@ -205,7 +196,7 @@ public class FileTest extends UsersBase {
 
     String json = String.format("{\"file_id\":\"foo\",\"file_ref\":\"%s\"}", fileId);
 
-    String targetPath = "scratch/file" + UUID.randomUUID().toString() + ".json";
+    String targetPath = "scratch/file" + UUID.randomUUID() + ".json";
     BlobInfo targetBlobInfo =
         BlobInfo.newBuilder(BlobId.of(testConfiguration.getIngestbucket(), targetPath)).build();
 
@@ -286,7 +277,7 @@ public class FileTest extends UsersBase {
             .mapToObj(i -> String.format("{\"file_id\":\"foo\",\"file_ref\":\"%s\"}", fileId))
             .collect(Collectors.joining("\n"));
 
-    String targetPath = "scratch/file" + UUID.randomUUID().toString() + ".json";
+    String targetPath = "scratch/file" + UUID.randomUUID() + ".json";
     BlobInfo targetBlobInfo =
         BlobInfo.newBuilder(BlobId.of(testConfiguration.getIngestbucket(), targetPath)).build();
 

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 
 import bio.terra.common.category.Integration;
-import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestResponseModel;
@@ -42,13 +41,12 @@ public class IngestTest extends UsersBase {
 
   @Autowired private DataRepoClient dataRepoClient;
 
-  @Autowired private TestConfiguration testConfig;
-
   private DatasetSummaryModel datasetSummaryModel;
   private UUID datasetId;
   private UUID profileId;
   private final List<UUID> createdSnapshotIds = new ArrayList<>();
 
+  @Override
   @Before
   public void setup() throws Exception {
     super.setup();

--- a/src/test/java/bio/terra/integration/SimpleScenarioFaultTests.java
+++ b/src/test/java/bio/terra/integration/SimpleScenarioFaultTests.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.common.category.Integration;
-import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.model.ConfigFaultCountedModel;
 import bio.terra.model.ConfigFaultModel;
 import bio.terra.model.ConfigGroupModel;
@@ -46,14 +45,11 @@ public class SimpleScenarioFaultTests extends UsersBase {
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
 
-  @Autowired private DataRepoClient dataRepoClient;
-
-  @Autowired private TestConfiguration testConfig;
-
   private UUID profileId;
   private UUID datasetId;
   private UUID snapshotId;
 
+  @Override
   @Before
   public void setup() throws Exception {
     super.setup();

--- a/src/test/java/bio/terra/integration/UsersBase.java
+++ b/src/test/java/bio/terra/integration/UsersBase.java
@@ -1,6 +1,5 @@
 package bio.terra.integration;
 
-import bio.terra.common.auth.AuthService;
 import bio.terra.common.auth.Users;
 import bio.terra.common.configuration.TestConfiguration;
 import org.slf4j.Logger;
@@ -16,9 +15,7 @@ public class UsersBase {
 
   @Autowired private Users users;
 
-  @Autowired private AuthService authService;
-
-  private static Logger logger = LoggerFactory.getLogger(UsersBase.class);
+  private static final Logger logger = LoggerFactory.getLogger(UsersBase.class);
   private TestConfiguration.User admin;
   private TestConfiguration.User steward;
   private TestConfiguration.User custodian;
@@ -27,10 +24,6 @@ public class UsersBase {
 
   public TestConfiguration.User admin() {
     return admin;
-  }
-
-  public TestConfiguration.User admin(String name) {
-    return users.getUserForRole(name, ADMIN_ROLE);
   }
 
   public TestConfiguration.User steward() {
@@ -59,10 +52,6 @@ public class UsersBase {
 
   public TestConfiguration.User discoverer() {
     return discoverer;
-  }
-
-  public TestConfiguration.User discoverer(String name) {
-    return users.getUserForRole(name, DISCOVERER_ROLE);
   }
 
   protected void setup() throws Exception {

--- a/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
@@ -13,7 +13,6 @@ import bio.terra.app.model.AzureRegion;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.TestUtils;
-import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.common.configuration.TestConfiguration.User;
@@ -60,25 +59,23 @@ public class DatasetAzureIntegrationTest extends UsersBase {
   private static final String omopDatasetRegionName = AzureRegion.DEFAULT_AZURE_REGION.toString();
   private static final String omopDatasetGcpRegionName =
       GoogleRegion.DEFAULT_GOOGLE_REGION.toString();
-  private static Logger logger = LoggerFactory.getLogger(DatasetAzureIntegrationTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(DatasetAzureIntegrationTest.class);
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
-  @Autowired private AuthService authService;
   @Autowired private TestConfiguration testConfig;
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;
 
-  private String stewardToken;
   private User steward;
   private UUID datasetId;
   private UUID profileId;
   private BlobIOTestUtility blobIOTestUtility;
 
+  @Override
   @Before
   public void setup() throws Exception {
     super.setup(false);
     // Voldemort is required by this test since the application is deployed with his user authz'ed
     steward = steward("voldemort");
-    stewardToken = authService.getDirectAccessAuthToken(steward.getEmail());
     dataRepoFixtures.resetConfig(steward);
     profileId = dataRepoFixtures.createAzureBillingProfile(steward).getId();
     datasetId = null;

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -44,7 +44,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -71,15 +70,13 @@ public class DatasetServiceTest {
 
   @Autowired private GoogleResourceDao resourceDao;
 
-  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
-
   private BillingProfileModel billingProfile;
   private UUID projectId;
   private ArrayList<String> flightIdsList;
   private ArrayList<UUID> datasetIdList;
 
   private UUID createDataset(DatasetRequestModel datasetRequest, String newName)
-      throws IOException, SQLException {
+      throws IOException {
     datasetRequest
         .name(newName)
         .defaultProfileId(billingProfile.getId())

--- a/src/test/java/bio/terra/service/dataset/DatasetStorageAccountDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetStorageAccountDaoTest.java
@@ -27,8 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,7 +37,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @AutoConfigureMockMvc
 @Category(Unit.class)
 public class DatasetStorageAccountDaoTest {
-  private static final Logger logger = LoggerFactory.getLogger(DatasetStorageAccountDaoTest.class);
   @Autowired private JsonLoader jsonLoader;
 
   @Autowired private DatasetDao datasetDao;
@@ -52,13 +49,11 @@ public class DatasetStorageAccountDaoTest {
 
   @Autowired private AzureResourceDao azureResourceDao;
 
-  private List<UUID> billingProfileIds = new ArrayList<>();
-  private List<UUID> datasetIds = new ArrayList<>();
-  private List<UUID> storageAccountResourceIds = new ArrayList<>();
+  private final List<UUID> datasetIds = new ArrayList<>();
+  private final List<UUID> storageAccountResourceIds = new ArrayList<>();
 
   private UUID applicationId;
   private UUID projectId;
-  private Dataset dataset;
   private BillingProfileModel billingProfile;
   private AzureApplicationDeploymentResource applicationResource;
 
@@ -67,7 +62,6 @@ public class DatasetStorageAccountDaoTest {
     BillingProfileRequestModel profileRequest =
         ProfileFixtures.randomizeAzureBillingProfileRequest();
     billingProfile = profileDao.createBillingProfile(profileRequest, "testUser");
-    billingProfileIds.add(billingProfile.getId());
 
     GoogleProjectResource projectResource = ResourceFixtures.randomProjectResource(billingProfile);
     projectId = resourceDao.createProject(projectResource);
@@ -91,7 +85,7 @@ public class DatasetStorageAccountDaoTest {
 
   @Test
   public void testCreateEntry() throws Exception {
-    UUID datasetId = createDataset("dataset-minimal.json");
+    UUID datasetId = createDataset();
     datasetIds.add(datasetId);
 
     AzureStorageAccountResource storageAccount =
@@ -107,15 +101,15 @@ public class DatasetStorageAccountDaoTest {
         equalTo(List.of(storageAccount.getResourceId())));
   }
 
-  private UUID createDataset(String datasetFile) throws Exception {
+  private UUID createDataset() throws Exception {
     DatasetRequestModel datasetRequest =
-        jsonLoader.loadObject(datasetFile, DatasetRequestModel.class);
+        jsonLoader.loadObject("dataset-minimal.json", DatasetRequestModel.class);
     String newName = datasetRequest.getName() + UUID.randomUUID();
     datasetRequest
         .name(newName)
         .defaultProfileId(billingProfile.getId())
         .cloudPlatform(CloudPlatform.AZURE);
-    dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
+    Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
     dataset.projectResourceId(projectId);
     dataset.applicationDeploymentResourceId(applicationId);
     String createFlightId = UUID.randomUUID().toString();

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -99,9 +99,8 @@ public class DrsTest extends UsersBase {
   private UUID datasetId;
   private Map<IamRole, String> datasetIamRoles;
   private Map<IamRole, String> snapshotIamRoles;
-  private AuthenticatedUserRequest authenticatedStewardRequest;
-  private AuthenticatedUserRequest authenticatedCustodianRequest;
 
+  @Override
   @Before
   public void setup() throws Exception {
     super.setup();
@@ -114,18 +113,17 @@ public class DrsTest extends UsersBase {
         dataRepoFixtures.getSnapshot(steward(), setupResult.getSummaryModel().getId(), null);
     profileId = setupResult.getProfileId();
     datasetId = setupResult.getDatasetId();
-    authenticatedStewardRequest =
+    AuthenticatedUserRequest stewardRequest =
         new AuthenticatedUserRequest().email(steward().getEmail()).token(Optional.of(stewardToken));
-    authenticatedCustodianRequest =
+    AuthenticatedUserRequest custodianRequest =
         new AuthenticatedUserRequest()
             .email(custodian().getEmail())
             .token(Optional.of(custodianToken));
     datasetIamRoles =
-        iamService.retrievePolicyEmails(
-            authenticatedStewardRequest, IamResourceType.DATASET, datasetId);
+        iamService.retrievePolicyEmails(stewardRequest, IamResourceType.DATASET, datasetId);
     snapshotIamRoles =
         iamService.retrievePolicyEmails(
-            authenticatedCustodianRequest, IamResourceType.DATASNAPSHOT, snapshotModel.getId());
+            custodianRequest, IamResourceType.DATASNAPSHOT, snapshotModel.getId());
     logger.info("setup complete");
   }
 
@@ -203,7 +201,7 @@ public class DrsTest extends UsersBase {
 
     try (CloseableHttpClient client = HttpClients.createDefault()) {
       HttpUriRequest request = new HttpHead(drsAccessURL.getUrl());
-      try (CloseableHttpResponse response = client.execute(request); ) {
+      try (CloseableHttpResponse response = client.execute(request)) {
         assertThat(
             "Drs signed URL is accessible",
             response.getStatusLine().getStatusCode(),

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfoTest.java
@@ -1,6 +1,10 @@
 package bio.terra.service.filedata.azure.util;
 
-import static com.azure.core.util.polling.LongRunningOperationStatus.*;
+import static com.azure.core.util.polling.LongRunningOperationStatus.FAILED;
+import static com.azure.core.util.polling.LongRunningOperationStatus.IN_PROGRESS;
+import static com.azure.core.util.polling.LongRunningOperationStatus.NOT_STARTED;
+import static com.azure.core.util.polling.LongRunningOperationStatus.SUCCESSFULLY_COMPLETED;
+import static com.azure.core.util.polling.LongRunningOperationStatus.USER_CANCELLED;
 import static com.azure.storage.blob.models.CopyStatusType.PENDING;
 import static com.azure.storage.blob.models.CopyStatusType.SUCCESS;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -8,7 +12,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.azure.core.util.polling.LongRunningOperationStatus;
 import com.azure.core.util.polling.PollResponse;
-import com.azure.core.util.polling.SyncPoller;
 import com.azure.storage.blob.models.BlobCopyInfo;
 import com.azure.storage.blob.models.CopyStatusType;
 import java.util.Arrays;
@@ -19,14 +22,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BlobContainerCopyInfoTest {
-  private BlobContainerCopyInfo blobContainerCopyInfo;
-
-  @Mock private SyncPoller<BlobCopyInfo, Void> poller;
 
   private static Stream<Arguments> getCopyStatusScenario() {
     return Stream.of(
@@ -45,13 +44,13 @@ class BlobContainerCopyInfoTest {
   @MethodSource("getCopyStatusScenario")
   void getCopyStatus_ScenarioIsProvided_ExpectedStatusIsReturned(
       LongRunningOperationStatus expectedStatus, CopyStatusType... statuses) {
-    blobContainerCopyInfo = new BlobContainerCopyInfo(createPollResponses(statuses));
+    BlobContainerCopyInfo blobContainerCopyInfo =
+        new BlobContainerCopyInfo(createPollResponses(statuses));
 
     assertThat(blobContainerCopyInfo.getCopyStatus(), equalTo(expectedStatus));
   }
 
   private List<PollResponse<BlobCopyInfo>> createPollResponses(CopyStatusType... statuses) {
-
     return Arrays.stream(statuses)
         .map(
             s ->

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata.flight.ingest;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -21,7 +22,6 @@ import bio.terra.stairway.Stairway;
 import bio.terra.stairway.StepResult;
 import java.util.Collections;
 import java.util.UUID;
-import junit.framework.TestCase;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -30,7 +30,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @Category(Unit.class)
-public class IngestDriverStepTest extends TestCase {
+public class IngestDriverStepTest {
 
   @MockBean private LoadService loadService;
 

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFileDirectoryStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFileDirectoryStepTest.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata.flight.ingest;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -16,7 +17,6 @@ import bio.terra.stairway.Stairway;
 import bio.terra.stairway.StepResult;
 import java.util.Collections;
 import java.util.UUID;
-import junit.framework.TestCase;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -25,7 +25,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @Category(Unit.class)
-public class IngestFileDirectoryStepTest extends TestCase {
+public class IngestFileDirectoryStepTest {
 
   @MockBean private FireStoreDao fireStoreDaoService;
 

--- a/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
@@ -8,7 +8,6 @@ import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.category.Unit;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
-import bio.terra.service.filedata.google.gcs.GcsConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +27,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class BatchOperationTest {
 
   @Autowired private SamConfiguration samConfiguration;
-  @Autowired private GcsConfiguration gcsConfiguration;
   @Autowired private ApplicationConfiguration appConfiguration;
 
   private FireStoreUtils fireStoreUtils;

--- a/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
@@ -38,8 +38,7 @@ public class BatchOperationTest {
     GoogleResourceConfiguration resourceConfiguration = new GoogleResourceConfiguration();
     resourceConfiguration.setFirestoreRetries(4);
     ConfigurationService configurationService =
-        new ConfigurationService(
-            samConfiguration, gcsConfiguration, resourceConfiguration, appConfiguration);
+        new ConfigurationService(samConfiguration, resourceConfiguration, appConfiguration);
 
     fireStoreUtils = new FireStoreUtils(configurationService);
   }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -3,8 +3,6 @@ package bio.terra.service.filedata.google.firestore;
 import bio.terra.common.TestUtils;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.configuration.TestConfiguration;
-import bio.terra.common.fixtures.JsonLoader;
-import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadArrayResultModel;
@@ -18,7 +16,6 @@ import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.filedata.google.gcs.GcsChannelWriter;
 import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamRole;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
@@ -41,9 +38,6 @@ import org.springframework.test.context.ActiveProfiles;
 public class EncodeFixture {
   private static final Logger logger = LoggerFactory.getLogger(EncodeFixture.class);
 
-  @Autowired private JsonLoader jsonLoader;
-  @Autowired private ObjectMapper objectMapper;
-  @Autowired private DataRepoClient dataRepoClient;
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private AuthService authService;
   @Autowired private TestConfiguration testConfiguration;

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -21,8 +21,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,8 +33,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 public class FireStoreDaoTest {
-  private final Logger logger =
-      LoggerFactory.getLogger("bio.terra.service.filedata.google.firestore.FireStoreDaoTest");
 
   @Autowired private FireStoreDirectoryDao directoryDao;
 

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
@@ -27,8 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -41,14 +39,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 public class FireStoreFileDaoTest {
-  private final Logger logger =
-      LoggerFactory.getLogger("bio.terra.service.filedata.google.firestore.FireStoreFileDaoTest");
-  private final Long FILE_SIZE = 42L;
-  private final Long CHANGED_FILE_SIZE = 22L;
+  private static final long FILE_SIZE = 42;
+  private static final long CHANGED_FILE_SIZE = 22;
 
   @Autowired private FireStoreFileDao fileDao;
-
-  @Autowired private FireStoreUtils fireStoreUtils;
 
   @Autowired private ConfigurationService configurationService;
 
@@ -105,7 +99,7 @@ public class FireStoreFileDaoTest {
     }
 
     List<String> fileIds =
-        fileList.stream().map(fsf -> fsf.getFileId()).collect(Collectors.toList());
+        fileList.stream().map(FireStoreFile::getFileId).collect(Collectors.toList());
 
     List<String> deleteIds = new ArrayList<>();
 

--- a/src/test/java/bio/terra/service/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/iam/AccessTest.java
@@ -85,6 +85,7 @@ public class AccessTest extends UsersBase {
   private UUID profileId;
   private List<UUID> snapshotIds;
 
+  @Override
   @Before
   public void setup() throws Exception {
     super.setup();
@@ -232,7 +233,7 @@ public class AccessTest extends UsersBase {
 
     // Ingest one row into the study 'file' table with a reference to that ingested file
     String json = String.format("{\"file_id\":\"foo\",\"file_ref\":\"%s\"}", fileModel.getFileId());
-    String targetPath = "scratch/file" + UUID.randomUUID().toString() + ".json";
+    String targetPath = "scratch/file" + UUID.randomUUID() + ".json";
     BlobInfo targetBlobInfo =
         BlobInfo.newBuilder(BlobId.of(testConfiguration.getIngestbucket(), targetPath)).build();
 
@@ -364,7 +365,7 @@ public class AccessTest extends UsersBase {
     Assert.assertEquals(7, results.getTotalRows());
   }
 
-  private boolean canReadBlob(Storage storage, BlobId blobId) throws Exception {
+  private boolean canReadBlob(Storage storage, BlobId blobId) {
     try (ReadChannel reader = storage.reader(blobId)) {
       ByteBuffer bytes = ByteBuffer.allocate(64 * 1024);
       int bytesRead = reader.read(bytes);

--- a/src/test/java/bio/terra/service/job/JobTestShutdownFlightLauncher.java
+++ b/src/test/java/bio/terra/service/job/JobTestShutdownFlightLauncher.java
@@ -2,7 +2,7 @@ package bio.terra.service.job;
 
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.job.exception.JobServiceShutdownException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -11,11 +11,11 @@ import org.slf4j.LoggerFactory;
 public class JobTestShutdownFlightLauncher implements Runnable {
   private static final Logger logger = LoggerFactory.getLogger(JobTestShutdownFlightLauncher.class);
 
-  private List<String> flightIdList;
-  private int flightPerSecond;
-  private Integer flightWaitSeconds;
-  private JobService jobService;
-  private AuthenticatedUserRequest testUser;
+  private final List<String> flightIdList;
+  private final int flightPerSecond;
+  private final Integer flightWaitSeconds;
+  private final JobService jobService;
+  private final AuthenticatedUserRequest testUser;
 
   public JobTestShutdownFlightLauncher(
       int flightPerSecond,
@@ -27,20 +27,20 @@ public class JobTestShutdownFlightLauncher implements Runnable {
     this.jobService = jobService;
     this.testUser = testUser;
 
-    flightIdList = new LinkedList<>();
+    flightIdList = new ArrayList<>();
   }
 
   @Override
   public void run() {
     for (int i = 0; true; i++) {
       try {
-        String jobid =
+        String jobId =
             jobService
                 .newJob("flight #" + i, JobTestShutdownFlight.class, null, testUser)
                 .addParameter("flightWaitSeconds", flightWaitSeconds)
                 .submit();
-        flightIdList.add(jobid);
-        logger.info("Launched flight #" + i + "  jobid: " + jobid);
+        flightIdList.add(jobId);
+        logger.info("Launched flight #" + i + "  jobId: " + jobId);
         TimeUnit.SECONDS.sleep(flightPerSecond);
       } catch (JobServiceShutdownException ex) {
         logger.info("Caught JobServiceShutdownException");

--- a/src/test/java/bio/terra/service/load/LoadDaoUnitTest.java
+++ b/src/test/java/bio/terra/service/load/LoadDaoUnitTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 
 import bio.terra.common.category.Unit;
 import bio.terra.model.BulkLoadFileModel;
-import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.FSFileInfo;
 import bio.terra.service.load.exception.LoadLockedException;
 import java.util.ArrayList;
@@ -34,14 +33,12 @@ public class LoadDaoUnitTest {
 
   @Autowired private LoadDao loadDao;
 
-  @Autowired private ConfigurationService configService;
-
   private enum LoadTagsUsedByTest {
     LOADTAG_MY("myLoadTag"),
     LOADTAG_SERIAL("serialLoadTag"),
     LOADTAG_CONCURRENT("concurrentLoadTag"),
     LOADTAG_CONFLICT("conflictLoadTag");
-    private String tag;
+    private final String tag;
 
     public String getTag() {
       return tag;
@@ -65,7 +62,7 @@ public class LoadDaoUnitTest {
     FLIGHT_H("flightIdH"),
     FLIGHT_X("flightIdX"),
     FLIGHT_Y("flightIdY");
-    private String id;
+    private final String id;
 
     public String getId() {
       return id;

--- a/src/test/java/bio/terra/service/load/LoadUnitTest.java
+++ b/src/test/java/bio/terra/service/load/LoadUnitTest.java
@@ -30,7 +30,7 @@ public class LoadUnitTest {
   private enum LoadTagsUsedByTest {
     LOADTAG_1("myLoadTag1"),
     LOADTAG_2("myLoadTag2");
-    private String tag;
+    private final String tag;
 
     public String getTag() {
       return tag;
@@ -44,7 +44,7 @@ public class LoadUnitTest {
   private enum FlightIdsUsedByTest {
     FLIGHT_1("myFlightId1"),
     FLIGHT_2("myFlightId2");
-    private String id;
+    private final String id;
 
     public String getId() {
       return id;

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
@@ -17,7 +17,6 @@ import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.model.CloudPlatform;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.iam.IamProviderInterface;
-import bio.terra.service.profile.ProfileDao;
 import java.util.List;
 import java.util.UUID;
 import org.junit.After;
@@ -43,7 +42,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class ProfileConnectedTest {
   private static final Logger logger = LoggerFactory.getLogger(ProfileConnectedTest.class);
 
-  @Autowired private ProfileDao profileDao;
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private ConnectedTestConfiguration testConfig;
   @Autowired private ConfigurationService configService;

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
@@ -16,7 +16,6 @@ import bio.terra.model.BillingProfileUpdateModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.EnumerateBillingProfileModel;
 import bio.terra.service.profile.ProfileDao;
-import bio.terra.service.profile.ProfileService;
 import bio.terra.service.profile.exception.ProfileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,8 +41,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class ProfileDaoTest {
 
   @Autowired private ProfileDao profileDao;
-
-  @Autowired private ProfileService profileService;
 
   private ArrayList<UUID> profileIds;
 
@@ -71,7 +68,7 @@ public class ProfileDaoTest {
   }
 
   @Test
-  public void profileCloudProvidersTest() throws Exception {
+  public void profileCloudProvidersTest() {
     var googleBillingProfile = makeProfile();
     var tenant = UUID.randomUUID();
     var subscription = UUID.randomUUID();
@@ -175,7 +172,7 @@ public class ProfileDaoTest {
   }
 
   @Test
-  public void profileEnumerateTest() throws Exception {
+  public void profileEnumerateTest() {
     Map<UUID, String> profileIdToAccountId = new HashMap<>();
     List<UUID> accessibleProfileId = new ArrayList<>();
     for (int i = 0; i < 6; i++) {

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
@@ -43,6 +43,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -406,8 +407,6 @@ public class AzureResourceConfigurationTest {
 
       String storageEndpoint = outputs.get("storageEndpoint").get("value");
 
-      String storageAccountName = outputs.get("storageAccountName").get("value");
-
       String fileSystemName = outputs.get("fileSystemName").get("value");
 
       logger.info(
@@ -417,12 +416,7 @@ public class AzureResourceConfigurationTest {
           fileSystemName);
 
       return new ManagedApplicationDeployment(
-          resourceReference.id(),
-          deploymentName,
-          deploymentName,
-          storageEndpoint,
-          storageAccountName,
-          fileSystemName);
+          resourceReference.id(), deploymentName, deploymentName, storageEndpoint);
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse template", e);
     }
@@ -447,29 +441,21 @@ public class AzureResourceConfigurationTest {
     private final String applicationResourceGroup;
     // The endpoint to use to connect to the storage account created when deploying the application
     private final String storageEndpoint;
-    // The name of the storage account
-    private final String storageAccountName;
-    // The name of the filesystem created when deploying the application
-    private final String fileSystemName;
 
     ManagedApplicationDeployment(
         String applicationDeploymentId,
         String applicationDeploymentName,
         String applicationResourceGroup,
-        String storageEndpoint,
-        String storageAccountName,
-        String fileSystemName) {
+        String storageEndpoint) {
       this.applicationDeploymentId = applicationDeploymentId;
       this.applicationDeploymentName = applicationDeploymentName;
       this.applicationResourceGroup = applicationResourceGroup;
       this.storageEndpoint = storageEndpoint;
-      this.storageAccountName = storageAccountName;
-      this.fileSystemName = fileSystemName;
     }
   }
 
   private String generateSas(DataLakeFileClient client) {
-    OffsetDateTime expiryTime = OffsetDateTime.now().plusHours(1);
+    OffsetDateTime expiryTime = OffsetDateTime.now(ZoneId.systemDefault()).plusHours(1);
     FileSystemSasPermission permission =
         new FileSystemSasPermission().setReadPermission(true).setWritePermission(false);
 

--- a/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
@@ -21,8 +21,6 @@ import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.DatasetBucketDao;
 import bio.terra.service.iam.IamProviderInterface;
-import bio.terra.service.load.LoadDao;
-import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.BucketResourceLockTester;
 import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.exception.GoogleResourceNotFoundException;
@@ -59,7 +57,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class BucketResourceTest {
   private final Logger logger = LoggerFactory.getLogger(BucketResourceTest.class);
 
-  @Autowired private LoadDao loadDao;
   @Autowired private ConfigurationService configService;
   @Autowired private DatasetBucketDao datasetBucketDao;
   @Autowired private JsonLoader jsonLoader;
@@ -67,17 +64,15 @@ public class BucketResourceTest {
   @Autowired private GoogleProjectService projectService;
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private GoogleResourceDao resourceDao;
-  @Autowired private ProfileService profileService;
   @Autowired private ConnectedTestConfiguration testConfig;
   @Autowired private BufferService bufferService;
 
   @MockBean private IamProviderInterface samService;
 
-  private BucketResourceUtils bucketResourceUtils = new BucketResourceUtils();
+  private final BucketResourceUtils bucketResourceUtils = new BucketResourceUtils();
   private BillingProfileModel profile;
   private Storage storage;
   private List<GoogleBucketResource> bucketResources;
-  private boolean allowReuseExistingBuckets;
   private GoogleProjectResource projectResource;
   private UUID datasetId;
 
@@ -142,8 +137,7 @@ public class BucketResourceTest {
       String flightId = "bucketRegionsTest_" + region;
 
       // create the bucket and metadata
-      GoogleBucketResource bucketResource =
-          createBucket(bucketName, projectResource, region, flightId);
+      createBucket(bucketName, projectResource, region, flightId);
 
       // Get the Bucket
       Bucket cloudBucket = bucketService.getCloudBucket(bucketName);

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceConnectedTest.java
@@ -31,7 +31,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 public class ResourceServiceConnectedTest {
 
-  @Autowired private GoogleResourceConfiguration resourceConfiguration;
   @Autowired private GoogleProjectService projectService;
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private ConnectedTestConfiguration testConfig;

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
@@ -15,7 +15,6 @@ import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetStorageAccountDao;
 import bio.terra.service.dataset.DatasetSummary;
 import bio.terra.service.dataset.GoogleStorageResource;
-import bio.terra.service.resourcemanagement.AzureDataLocationSelector;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
 import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentService;
@@ -29,7 +28,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @Category(Unit.class)
@@ -45,10 +43,6 @@ public class ResourceServiceUnitTest {
   @Mock private DatasetStorageAccountDao datasetStorageAccountDao;
 
   @Mock private AzureApplicationDeploymentService applicationDeploymentService;
-
-  @Mock private GoogleProjectService googleProjectService;
-
-  @Mock private AzureDataLocationSelector azureDataLocationSelector;
 
   private final UUID billingProfileId = UUID.randomUUID();
 
@@ -96,10 +90,6 @@ public class ResourceServiceUnitTest {
           .resourceId(storageAccountId)
           .name(STORAGE_ACCOUNT_NAME)
           .applicationResource(applicationResource);
-
-  public void setup() throws InterruptedException {
-    MockitoAnnotations.initMocks(this);
-  }
 
   @Test
   public void testGrabBucket() throws Exception {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -129,15 +129,15 @@ public class SnapshotDaoTest {
   }
 
   @Test(expected = MissingRowCountsException.class)
-  public void testMissingRowCounts() throws Exception {
+  public void testMissingRowCounts() {
     Snapshot snapshot = snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequest);
     snapshot.projectResourceId(projectId);
     snapshotDao.updateSnapshotTableRowCounts(snapshot, Collections.emptyMap());
   }
 
   @Test
-  public void happyInOutTest() throws Exception {
-    snapshotRequest.name(snapshotRequest.getName() + UUID.randomUUID().toString());
+  public void happyInOutTest() {
+    snapshotRequest.name(snapshotRequest.getName() + UUID.randomUUID());
 
     String flightId = "happyInOutTest_flightId";
     Snapshot snapshot =
@@ -244,9 +244,9 @@ public class SnapshotDaoTest {
   }
 
   @Test
-  public void snapshotEnumerateTest() throws Exception {
+  public void snapshotEnumerateTest() {
     snapshotIdList = new ArrayList<>();
-    String snapshotName = snapshotRequest.getName() + UUID.randomUUID().toString();
+    String snapshotName = snapshotRequest.getName() + UUID.randomUUID();
 
     for (int i = 0; i < 6; i++) {
       snapshotRequest
@@ -254,7 +254,7 @@ public class SnapshotDaoTest {
           // set the description to a random string so we can verify the sorting is working
           // independently of the
           // dataset name or created_date. add a suffix to filter on for the even snapshots
-          .description(UUID.randomUUID().toString() + ((i % 2 == 0) ? "==foo==" : ""));
+          .description(UUID.randomUUID() + ((i % 2 == 0) ? "==foo==" : ""));
       String flightId = "snapshotEnumerateTest_flightId";
       UUID tempSnapshotId = UUID.randomUUID();
       Snapshot snapshot =
@@ -435,11 +435,11 @@ public class SnapshotDaoTest {
             datasetIds,
             snapshotIds);
     List<SnapshotSummary> summaryList = summaryEnum.getItems();
-    int index = (direction.equals(SqlSortDirection.ASC)) ? offset : snapshotIds.size() - offset - 1;
+    int index = direction.equals(SqlSortDirection.ASC) ? offset : snapshotIds.size() - offset - 1;
     for (SnapshotSummary summary : summaryList) {
       assertThat("correct id", snapshotIds.get(index), equalTo(summary.getId()));
       assertThat("correct name", makeName(snapshotName, index), equalTo(summary.getName()));
-      index += (direction.equals(SqlSortDirection.ASC)) ? 1 : -1;
+      index += direction.equals(SqlSortDirection.ASC) ? 1 : -1;
     }
   }
 
@@ -481,7 +481,7 @@ public class SnapshotDaoTest {
       assertThat(
           "correct snapshot name", makeName(snapshotName, index), equalTo(summary.getName()));
 
-      Map<CloudResource, StorageResource> storageMap =
+      Map<CloudResource, StorageResource<?, ?>> storageMap =
           summary.getStorage().stream()
               .collect(Collectors.toMap(StorageResource::getCloudResource, Function.identity()));
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotTest.java
@@ -64,7 +64,6 @@ public class SnapshotTest extends UsersBase {
   @Autowired private DataRepoFixtures dataRepoFixtures;
 
   @Autowired private AuthService authService;
-  @Autowired private BigQueryPdao bigQueryPdao;
 
   private static final Logger logger = LoggerFactory.getLogger(SnapshotTest.class);
   private UUID profileId;
@@ -73,6 +72,7 @@ public class SnapshotTest extends UsersBase {
   private final List<UUID> createdSnapshotIds = new ArrayList<>();
   private String stewardToken;
 
+  @Override
   @Before
   public void setup() throws Exception {
     super.setup();
@@ -273,8 +273,8 @@ public class SnapshotTest extends UsersBase {
     TimeUnit.SECONDS.sleep(10);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
-    assertEquals("all 5 relationships come through", snapshot.getRelationships().size(), 5);
+    assertEquals("new snapshot has been created", requestModel.getName(), snapshot.getName());
+    assertEquals("all 5 relationships come through", 5, snapshot.getRelationships().size());
   }
 
   @Test
@@ -332,8 +332,8 @@ public class SnapshotTest extends UsersBase {
         dataRepoFixtures.createSnapshotWithRequest(steward(), datasetName, profileId, requestModel);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
-    assertEquals("There should be 5 snapshot relationships", snapshot.getRelationships().size(), 5);
+    assertEquals("new snapshot has been created", requestModel.getName(), snapshot.getName());
+    assertEquals("There should be 5 snapshot relationships", 5, snapshot.getRelationships().size());
 
     // fetch Acls
     logger.info("---- Dataset Acls after snapshot create-----");
@@ -372,11 +372,13 @@ public class SnapshotTest extends UsersBase {
 
   enum AclCheck {
     GREATERTHAN {
+      @Override
       boolean compare(int snapshotCount, int aclCount) {
         return snapshotCount > aclCount;
       }
     },
     EQUALTO {
+      @Override
       boolean compare(int snapshotCount, int aclCount) {
         return snapshotCount == aclCount;
       }


### PR DESCRIPTION
ErrorProne is a java compiler that adds a number of checks, both stylistic and functional. https://errorprone.info/

This adds errorprone and "fixes" many cases that errorprone flagged as errors. Not sure if we'd want to use this as-is or tweak the settings for our code base. Most of the remaining errors can be fixed, and the rest can have annotations added to suppress them. Although it looks like by default if you have less than a certain number of errors it won't fail the build, we would probably want to change that too.

Most of the changes were one of these:
- unused fields / parameters
- missing `@Override` annotation
- unnecessary use of `LinkedList`
- incomplete javadoc
- unnecessary parentheses
- missing `final`