### PR TITLE
[DR-2015] SAS URLs factories for blobs.

### DIFF
--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -2,12 +2,10 @@ package bio.terra.common;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 
 public final class ValidationUtils {
 
@@ -53,13 +51,11 @@ public final class ValidationUtils {
     }
   }
 
-  public static void requiresNotBlankInList(List<Pair<String, String>> listToValidate) {
-    listToValidate.forEach(
-        (item) -> {
-          if (StringUtils.isBlank(item.getLeft())) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "The %s is either null or empty", item.getRight()));
-          }
-        });
+  public static String requiresNotBlank(String value, String errorMsg) {
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalArgumentException(errorMsg);
+    }
+
+    return value;
   }
 }

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -51,7 +51,7 @@ public final class ValidationUtils {
     }
   }
 
-  public static String requiresNotBlank(String value, String errorMsg) {
+  public static String requireNotBlank(String value, String errorMsg) {
     if (StringUtils.isBlank(value)) {
       throw new IllegalArgumentException(errorMsg);
     }

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -2,9 +2,12 @@ package bio.terra.common;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 public final class ValidationUtils {
 
@@ -48,5 +51,15 @@ public final class ValidationUtils {
     } catch (IllegalArgumentException e) {
       return Optional.empty();
     }
+  }
+
+  public static void requiresNotBlankInList(List<Pair<String, String>> listToValidate) {
+    listToValidate.forEach(
+        (item) -> {
+          if (StringUtils.isBlank(item.getLeft())) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "The %s is either null or empty", item.getRight()));
+          }
+        });
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -1,6 +1,6 @@
 package bio.terra.service.filedata.azure.util;
 
-import static bio.terra.common.ValidationUtils.requiresNotBlankInList;
+import static bio.terra.common.ValidationUtils.requiresNotBlank;
 
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
@@ -12,10 +12,8 @@ import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.BlobUrlParts;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import java.time.Duration;
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
  * A class that wraps the SDK container client and facilities the creation of SAS Urls for blobs by
@@ -36,31 +34,25 @@ public class BlobContainerClientFactory {
 
   public BlobContainerClientFactory(String accountName, String accountKey, String containerName) {
 
-    requiresNotBlankInList(
-        List.of(
-            new ImmutablePair<>(accountName, "account account"),
-            new ImmutablePair<>(accountKey, "account key"),
-            new ImmutablePair<>(containerName, "container name")));
-
     blobContainerClient =
-        createBlobServiceClientUsingSharedKey(accountName, accountKey)
-            .getBlobContainerClient(containerName);
+        createBlobServiceClientUsingSharedKey(
+                requiresNotBlank(accountName, "Account name is null or empty"),
+                requiresNotBlank(accountKey, "Account key is null or empty"))
+            .getBlobContainerClient(
+                requiresNotBlank(containerName, "Container name is null or empty"));
     blobSasUrlFactory = new SharedAccountKeySasUrlFactory(blobContainerClient);
   }
 
   public BlobContainerClientFactory(
       String accountName, TokenCredential azureCredential, String containerName) {
 
-    requiresNotBlankInList(
-        List.of(
-            new ImmutablePair<>(accountName, "account account"),
-            new ImmutablePair<>(containerName, "container name")));
-
     var blobServiceClient =
         createBlobServiceClientUsingTokenCredentials(
-            accountName,
+            requiresNotBlank(accountName, "Account name is null or empty"),
             Objects.requireNonNull(azureCredential, "Azure token credentials are null."));
-    blobContainerClient = blobServiceClient.getBlobContainerClient(containerName);
+    blobContainerClient =
+        blobServiceClient.getBlobContainerClient(
+            requiresNotBlank(containerName, "Container name is null or empty"));
 
     // The delegated key expiration is set to a constant.
     // There is little benefit for the caller to adjust this value.

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -1,7 +1,6 @@
 package bio.terra.service.filedata.azure.util;
 
-import static bio.terra.common.ValidationUtils.requiresNotBlank;
-
+import bio.terra.common.ValidationUtils;
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.HttpClient;
@@ -36,10 +35,10 @@ public class BlobContainerClientFactory {
 
     blobContainerClient =
         createBlobServiceClientUsingSharedKey(
-                requiresNotBlank(accountName, "Account name is null or empty"),
-                requiresNotBlank(accountKey, "Account key is null or empty"))
+                ValidationUtils.requiresNotBlank(accountName, "Account name is null or empty"),
+                ValidationUtils.requiresNotBlank(accountKey, "Account key is null or empty"))
             .getBlobContainerClient(
-                requiresNotBlank(containerName, "Container name is null or empty"));
+                ValidationUtils.requiresNotBlank(containerName, "Container name is null or empty"));
     blobSasUrlFactory = new SharedAccountKeySasUrlFactory(blobContainerClient);
   }
 
@@ -48,11 +47,11 @@ public class BlobContainerClientFactory {
 
     var blobServiceClient =
         createBlobServiceClientUsingTokenCredentials(
-            requiresNotBlank(accountName, "Account name is null or empty"),
+            ValidationUtils.requiresNotBlank(accountName, "Account name is null or empty"),
             Objects.requireNonNull(azureCredential, "Azure token credentials are null."));
     blobContainerClient =
         blobServiceClient.getBlobContainerClient(
-            requiresNotBlank(containerName, "Container name is null or empty"));
+            ValidationUtils.requiresNotBlank(containerName, "Container name is null or empty"));
 
     // The delegated key expiration is set to a constant.
     // There is little benefit for the caller to adjust this value.

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -35,10 +35,10 @@ public class BlobContainerClientFactory {
 
     blobContainerClient =
         createBlobServiceClientUsingSharedKey(
-                ValidationUtils.requiresNotBlank(accountName, "Account name is null or empty"),
-                ValidationUtils.requiresNotBlank(accountKey, "Account key is null or empty"))
+                ValidationUtils.requireNotBlank(accountName, "Account name is null or empty"),
+                ValidationUtils.requireNotBlank(accountKey, "Account key is null or empty"))
             .getBlobContainerClient(
-                ValidationUtils.requiresNotBlank(containerName, "Container name is null or empty"));
+                ValidationUtils.requireNotBlank(containerName, "Container name is null or empty"));
     blobSasUrlFactory = new SharedAccountKeySasUrlFactory(blobContainerClient);
   }
 
@@ -47,11 +47,11 @@ public class BlobContainerClientFactory {
 
     var blobServiceClient =
         createBlobServiceClientUsingTokenCredentials(
-            ValidationUtils.requiresNotBlank(accountName, "Account name is null or empty"),
+            ValidationUtils.requireNotBlank(accountName, "Account name is null or empty"),
             Objects.requireNonNull(azureCredential, "Azure token credentials are null."));
     blobContainerClient =
         blobServiceClient.getBlobContainerClient(
-            ValidationUtils.requiresNotBlank(containerName, "Container name is null or empty"));
+            ValidationUtils.requireNotBlank(containerName, "Container name is null or empty"));
 
     // The delegated key expiration is set to a constant.
     // There is little benefit for the caller to adjust this value.

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -20,7 +20,7 @@ import java.util.Objects;
  */
 public class BlobContainerClientFactory {
 
-  public static final Duration DELEGATED_KEY_EXPIRATION = Duration.ofHours(24);
+  public static final Duration DELEGATED_KEY_DURATION = Duration.ofHours(24);
   private final HttpClient httpClient = HttpClient.createDefault();
 
   private final BlobContainerClient blobContainerClient;
@@ -57,8 +57,7 @@ public class BlobContainerClientFactory {
     // There is little benefit for the caller to adjust this value.
     // A long duration minimizes the number of calls to get it and noise in audits logs.
     blobSasUrlFactory =
-        new UserDelegatedKeySasUrlFactory(
-            blobServiceClient, containerName, DELEGATED_KEY_EXPIRATION);
+        new UserDelegatedKeySasUrlFactory(blobServiceClient, containerName, DELEGATED_KEY_DURATION);
   }
 
   public BlobContainerClientFactory(String containerURLWithSasToken) {

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -1,24 +1,21 @@
 package bio.terra.service.filedata.azure.util;
 
+import static bio.terra.common.ValidationUtils.requiresNotBlankInList;
+
 import com.azure.core.credential.AzureSasCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.HttpClient;
-import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.BlobUrlParts;
-import com.azure.storage.blob.models.UserDelegationKey;
-import com.azure.storage.blob.sas.BlobSasPermission;
-import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.StorageSharedKeyCredential;
-import com.azure.storage.common.sas.SasProtocol;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.Duration;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
  * A class that wraps the SDK container client and facilities the creation of SAS Urls for blobs by
@@ -26,65 +23,56 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class BlobContainerClientFactory {
 
-  public static final int EXPIRATION_DAYS = 7;
+  public static final Duration DELEGATED_KEY_EXPIRATION = Duration.ofHours(24);
   private final HttpClient httpClient = HttpClient.createDefault();
 
   private final BlobContainerClient blobContainerClient;
 
-  private final SasTokenGeneratorStrategy sasTokenGeneratorStrategy;
-  private final AzureSasCredential blobContainerSasTokenCreds;
-  private final BlobServiceClient blobServiceClient;
-  private UserDelegationKey delegationKey;
+  public BlobSasUrlFactory getBlobSasUrlFactory() {
+    return blobSasUrlFactory;
+  }
+
+  private final BlobSasUrlFactory blobSasUrlFactory;
 
   public BlobContainerClientFactory(String accountName, String accountKey, String containerName) {
 
-    if (StringUtils.isBlank(accountName)) {
-      throw new IllegalArgumentException("The account name is either null or empty.");
-    }
-
-    if (StringUtils.isBlank(accountKey)) {
-      throw new IllegalArgumentException("The account key is either null or empty.");
-    }
-
-    if (StringUtils.isBlank(containerName)) {
-      throw new IllegalArgumentException("The container name is either null or empty.");
-    }
+    requiresNotBlankInList(
+        List.of(
+            new ImmutablePair<>(accountName, "account account"),
+            new ImmutablePair<>(accountKey, "account key"),
+            new ImmutablePair<>(containerName, "container name")));
 
     blobContainerClient =
         createBlobServiceClientUsingSharedKey(accountName, accountKey)
             .getBlobContainerClient(containerName);
-    sasTokenGeneratorStrategy = SasTokenGeneratorStrategy.SHARED_KEY;
-    blobContainerSasTokenCreds = null;
-    blobServiceClient = null;
+    blobSasUrlFactory = new SharedAccountKeySasUrlFactory(blobContainerClient);
   }
 
   public BlobContainerClientFactory(
       String accountName, TokenCredential azureCredential, String containerName) {
 
-    if (StringUtils.isBlank(accountName)) {
-      throw new IllegalArgumentException("The account name is either null or empty.");
-    }
+    requiresNotBlankInList(
+        List.of(
+            new ImmutablePair<>(accountName, "account account"),
+            new ImmutablePair<>(containerName, "container name")));
 
-    if (StringUtils.isBlank(containerName)) {
-      throw new IllegalArgumentException("The container name is either null or empty.");
-    }
-
-    blobServiceClient =
+    var blobServiceClient =
         createBlobServiceClientUsingTokenCredentials(
             accountName,
             Objects.requireNonNull(azureCredential, "Azure token credentials are null."));
     blobContainerClient = blobServiceClient.getBlobContainerClient(containerName);
 
-    sasTokenGeneratorStrategy = SasTokenGeneratorStrategy.USER_DELEGATED_KEY;
-    blobContainerSasTokenCreds = null;
+    // The delegated key expiration is set to a constant.
+    // A long duration minimizes the number of calls to get it and noise in audits logs.
+    blobSasUrlFactory =
+        new UserDelegatedKeySasUrlFactory(
+            blobServiceClient, containerName, DELEGATED_KEY_EXPIRATION);
   }
 
   public BlobContainerClientFactory(String containerURLWithSasToken) {
 
     BlobUrlParts blobUrl = BlobUrlParts.parse(containerURLWithSasToken);
 
-    blobContainerSasTokenCreds =
-        new AzureSasCredential(blobUrl.getCommonSasQueryParameters().encode());
     blobContainerClient =
         new BlobContainerClientBuilder()
             .httpClient(httpClient)
@@ -94,90 +82,14 @@ public class BlobContainerClientFactory {
                     "https://%s/%s",
                     blobUrl.getHost(),
                     blobUrl.getBlobContainerName()))
-            .credential(blobContainerSasTokenCreds)
+            .credential(new AzureSasCredential(blobUrl.getCommonSasQueryParameters().encode()))
             .buildClient();
 
-    sasTokenGeneratorStrategy = SasTokenGeneratorStrategy.CONTAINER_SAS_TOKEN;
-    blobServiceClient = null;
+    blobSasUrlFactory = new ContainerSasTokenSasUrlFactory(blobUrl);
   }
 
   public BlobContainerClient getBlobContainerClient() {
     return blobContainerClient;
-  }
-
-  public String createReadOnlySasUrlForBlob(String blobName) {
-    if (sasTokenGeneratorStrategy.equals(SasTokenGeneratorStrategy.SHARED_KEY)) {
-      return createReadOnlySasUrlForBlobUsingClient(blobName);
-    }
-
-    if (sasTokenGeneratorStrategy.equals(SasTokenGeneratorStrategy.CONTAINER_SAS_TOKEN)) {
-      return createReadOnlySasUrlForBlobUsingContainerSas(blobName);
-    }
-
-    if (sasTokenGeneratorStrategy.equals(SasTokenGeneratorStrategy.USER_DELEGATED_KEY)) {
-      return createReadOnlySasUrlForBlobUsingUserDelegatedSas(blobName);
-    }
-
-    throw new RuntimeException("Failed to generate SAS token for blob. Invalid strategy set.");
-  }
-
-  private String createReadOnlySasUrlForBlobUsingUserDelegatedSas(String blobName) {
-
-    UserDelegationKey userDelegationKey = getUserDelegationKey();
-
-    BlobServiceSasSignatureValues sasSignatureValues = createSasSignatureValues();
-
-    BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
-    String sasToken = blobClient.generateUserDelegationSas(sasSignatureValues, userDelegationKey);
-
-    return String.format(
-        "%s/%s?%s", blobContainerClient.getBlobContainerUrl(), blobClient.getBlobName(), sasToken);
-  }
-
-  /**
-   * Gets a UserDelegationKey of the authenticated users. The key is cached to minimize the
-   * performance impact of multiple calls to obtain it and reduce the noise if the operation is
-   * logged for security reasons.
-   *
-   * @return User delegation key.
-   */
-  private synchronized UserDelegationKey getUserDelegationKey() {
-    if (delegationKey == null
-        || delegationKey.getSignedExpiry().isBefore(OffsetDateTime.now(ZoneOffset.UTC))) {
-      OffsetDateTime keyExpiry = OffsetDateTime.now(ZoneOffset.UTC).plusDays(EXPIRATION_DAYS);
-      delegationKey = blobServiceClient.getUserDelegationKey(null, keyExpiry);
-    }
-    return delegationKey;
-  }
-
-  private String createReadOnlySasUrlForBlobUsingContainerSas(String blobName) {
-    return String.format(
-        "%s/%s?%s",
-        blobContainerClient.getBlobContainerUrl(),
-        blobName,
-        blobContainerSasTokenCreds.getSignature());
-  }
-
-  private String createReadOnlySasUrlForBlobUsingClient(String blobName) {
-
-    BlobServiceSasSignatureValues sasSignatureValues = createSasSignatureValues();
-
-    BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
-    String sasToken = blobClient.generateSas(sasSignatureValues);
-
-    return String.format(
-        "%s/%s?%s", blobContainerClient.getBlobContainerUrl(), blobClient.getBlobName(), sasToken);
-  }
-
-  private BlobServiceSasSignatureValues createSasSignatureValues() {
-
-    BlobSasPermission permissions = new BlobSasPermission().setReadPermission(true);
-
-    OffsetDateTime expiryTime = OffsetDateTime.now().plusDays(1);
-    SasProtocol sasProtocol = SasProtocol.HTTPS_ONLY;
-
-    // build the token
-    return new BlobServiceSasSignatureValues(expiryTime, permissions).setProtocol(sasProtocol);
   }
 
   private BlobServiceClient createBlobServiceClientUsingSharedKey(
@@ -196,11 +108,5 @@ public class BlobContainerClientFactory {
         .httpClient(httpClient)
         .endpoint(String.format(Locale.ROOT, "https://%s.blob.core.windows.net", accountName))
         .buildClient();
-  }
-
-  public enum SasTokenGeneratorStrategy {
-    SHARED_KEY,
-    CONTAINER_SAS_TOKEN,
-    USER_DELEGATED_KEY
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactory.java
@@ -63,6 +63,7 @@ public class BlobContainerClientFactory {
     blobContainerClient = blobServiceClient.getBlobContainerClient(containerName);
 
     // The delegated key expiration is set to a constant.
+    // There is little benefit for the caller to adjust this value.
     // A long duration minimizes the number of calls to get it and noise in audits logs.
     blobSasUrlFactory =
         new UserDelegatedKeySasUrlFactory(

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopier.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopier.java
@@ -203,7 +203,7 @@ public class BlobContainerCopier {
             new BlobSasPermission().setReadPermission(true),
             BlobContainerCopier.class.getName());
 
-    return this.sourceClientFactory
+    return sourceClientFactory
         .getBlobSasUrlFactory()
         .createSasUrlForBlob(blobName, blobSasTokenOptions);
   }

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopier.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobContainerCopier.java
@@ -19,7 +19,7 @@ public class BlobContainerCopier {
 
   private static final int MIN_LIST_OPERATION_TIMEOUT_IN_SECONDS = 10;
   private static final int MIN_POLLING_INTERVAL_IN_SECONDS = 2;
-  private static final Logger LOGGER = LoggerFactory.getLogger(BlobContainerCopier.class);
+  private static final Logger logger = LoggerFactory.getLogger(BlobContainerCopier.class);
   private static final Duration DEFAULT_SAS_TOKEN_EXPIRATION = Duration.ofHours(24);
   private final BlobContainerClientFactory destinationClientFactory;
 
@@ -51,12 +51,12 @@ public class BlobContainerCopier {
   public BlobContainerCopySyncPoller beginCopyOperation() {
 
     if (sourceClientFactory != null) {
-      LOGGER.info("Starting copy operation using a container as a source");
+      logger.info("Starting copy operation using a container as a source");
       return beginCopyOperationUsingSourceBlobContainerClient();
     }
 
     if (StringUtils.isNotBlank(sourceBlobUrl)) {
-      LOGGER.info("Starting copy operation using a signed blob URL as the source");
+      logger.info("Starting copy operation using a signed blob URL as the source");
       return beginCopyOperationUsingBlobSignedUrl();
     }
 
@@ -133,7 +133,7 @@ public class BlobContainerCopier {
 
   private BlobContainerCopySyncPoller beginCopyOperationUsingSourceBlobContainerClient() {
     if (sourceDestinationPairs != null) {
-      LOGGER.info("Copy operation using source and destination pairs.");
+      logger.info("Copy operation using source and destination pairs.");
       return beginCopyOperationUsingDestinationPairs(sourceDestinationPairs);
     }
 
@@ -158,7 +158,7 @@ public class BlobContainerCopier {
       String blobPrefix) {
 
     ListBlobsOptions options = createListBlobsOptions(blobPrefix);
-    LOGGER.info("List operation from the source using the prefix: '{}'", blobSourcePrefix);
+    logger.info("List operation from the source using the prefix: '{}'", blobSourcePrefix);
 
     return this.sourceClientFactory
         .getBlobContainerClient()
@@ -187,7 +187,7 @@ public class BlobContainerCopier {
 
     // Azure blob copy does not support empty files.
     if (isSourceBlobEmpty(sourceBlobName)) {
-      LOGGER.warn("Blob {} is empty. Copy operation is not allowed", sourceBlobName);
+      logger.warn("Blob {} is empty. Copy operation is not allowed", sourceBlobName);
       return null;
     }
 
@@ -211,7 +211,7 @@ public class BlobContainerCopier {
   private SyncPoller<BlobCopyInfo, Void> beginBlobCopyFromSasUrl(
       String sourceName, String sourceSasUrl, String destinationBlobName) {
     if (StringUtils.isBlank(destinationBlobName)) {
-      LOGGER.debug(
+      logger.debug(
           "Destination blob name is blank. The source name: {}, will be used.", sourceName);
       destinationBlobName = sourceName;
     }

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -126,6 +126,16 @@ public class BlobCrl {
         .getProperties();
   }
 
+  /**
+   * Creates a URLs with SAS tokens for a given blob.
+   * @param blobName blob name.
+   * @param options sas token creation options.
+   * @return Blob URL with a SAS token
+   */
+  public String createSasTokenUrlForBlob(String blobName, BlobSasTokenOptions options) {
+    return blobContainerClientFactory.getBlobSasUrlFactory().createSasUrlForBlob(blobName, options);
+  }
+
   /** Creates a the container in the storage account if it does not exist. */
   public void createContainerNameIfNotExists() {
 

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -128,6 +128,7 @@ public class BlobCrl {
 
   /**
    * Creates a URLs with SAS tokens for a given blob.
+   *
    * @param blobName blob name.
    * @param options sas token creation options.
    * @return Blob URL with a SAS token

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -127,7 +127,7 @@ public class BlobCrl {
   }
 
   /**
-   * Creates a URLs with SAS tokens for a given blob.
+   * Creates a URLa with a SAS tokens for a given blob.
    *
    * @param blobName blob name.
    * @param options sas token creation options.

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -127,7 +127,7 @@ public class BlobCrl {
   }
 
   /**
-   * Creates a URLa with a SAS tokens for a given blob.
+   * Creates a URL with a SAS tokens for a given blob.
    *
    * @param blobName blob name.
    * @param options sas token creation options.

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobCrl.java
@@ -127,7 +127,7 @@ public class BlobCrl {
   }
 
   /**
-   * Creates a URL with a SAS tokens for a given blob.
+   * Creates a URL with a SAS token for a given blob.
    *
    * @param blobName blob name.
    * @param options sas token creation options.

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobSasTokenOptions.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobSasTokenOptions.java
@@ -6,20 +6,20 @@ import java.util.Objects;
 
 public class BlobSasTokenOptions {
 
-  private final Duration expiration;
+  private final Duration duration;
   private final BlobSasPermission sasPermissions;
   private final String contentDisposition;
 
   public BlobSasTokenOptions(
-      Duration expiration, BlobSasPermission sasPermissions, String contentDisposition) {
+      Duration duration, BlobSasPermission sasPermissions, String contentDisposition) {
 
-    this.expiration = Objects.requireNonNull(expiration, "Expiration is required.");
+    this.duration = Objects.requireNonNull(duration, "Duration is required.");
     this.sasPermissions = Objects.requireNonNull(sasPermissions, "SAS permissions are required");
     this.contentDisposition = contentDisposition;
   }
 
-  public Duration getExpiration() {
-    return expiration;
+  public Duration getDuration() {
+    return duration;
   }
 
   public BlobSasPermission getSasPermissions() {

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobSasTokenOptions.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobSasTokenOptions.java
@@ -1,0 +1,32 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.storage.blob.sas.BlobSasPermission;
+import java.time.Duration;
+import java.util.Objects;
+
+public class BlobSasTokenOptions {
+
+  private final Duration expiration;
+  private final BlobSasPermission sasPermissions;
+  private final String contentDisposition;
+
+  public BlobSasTokenOptions(
+      Duration expiration, BlobSasPermission sasPermissions, String contentDisposition) {
+
+    this.expiration = Objects.requireNonNull(expiration, "Expiration is required.");
+    this.sasPermissions = Objects.requireNonNull(sasPermissions, "SAS permissions are required");
+    this.contentDisposition = contentDisposition;
+  }
+
+  public Duration getExpiration() {
+    return expiration;
+  }
+
+  public BlobSasPermission getSasPermissions() {
+    return sasPermissions;
+  }
+
+  public String getContentDisposition() {
+    return contentDisposition;
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/BlobSasUrlFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/BlobSasUrlFactory.java
@@ -1,0 +1,5 @@
+package bio.terra.service.filedata.azure.util;
+
+public interface BlobSasUrlFactory {
+  String createSasUrlForBlob(String blobName, BlobSasTokenOptions options);
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/ContainerSasTokenSasUrlFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/ContainerSasTokenSasUrlFactory.java
@@ -1,0 +1,41 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.core.credential.AzureSasCredential;
+import com.azure.storage.blob.BlobUrlParts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Creates SAS URLs for blobs from a Container URl with a SAS token. */
+public class ContainerSasTokenSasUrlFactory implements BlobSasUrlFactory {
+  private final BlobUrlParts blobContainerUrlParts;
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ContainerSasTokenSasUrlFactory.class);
+
+  public ContainerSasTokenSasUrlFactory(BlobUrlParts blobContainerUrlParts) {
+    this.blobContainerUrlParts = blobContainerUrlParts;
+  }
+
+  @Override
+  public String createSasUrlForBlob(String blobName, BlobSasTokenOptions options) {
+
+    // The SAS token of the blob is the same as the container
+    // therefore the token options are ignored.
+    // A potential future enhancement is to compare the BlobSasTokenOptions and the container SAS
+    // token, confirm they match and throw an exception if not.
+    LOGGER.warn(
+        "Using the container SAS token for blob:{}. BlobSasTokenOptions options were ignored.",
+        blobName);
+
+    return String.format(
+        "https://%s/%s/%s?%s",
+        blobContainerUrlParts.getHost(),
+        blobContainerUrlParts.getBlobContainerName(),
+        blobName,
+        getSignature());
+  }
+
+  private String getSignature() {
+    return new AzureSasCredential(blobContainerUrlParts.getCommonSasQueryParameters().encode())
+        .getSignature();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/ContainerSasTokenSasUrlFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/ContainerSasTokenSasUrlFactory.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 /** Creates SAS URLs for blobs from a Container URl with a SAS token. */
 public class ContainerSasTokenSasUrlFactory implements BlobSasUrlFactory {
   private final BlobUrlParts blobContainerUrlParts;
-  private static final Logger LOGGER =
+  private static final Logger logger =
       LoggerFactory.getLogger(ContainerSasTokenSasUrlFactory.class);
 
   public ContainerSasTokenSasUrlFactory(BlobUrlParts blobContainerUrlParts) {
@@ -22,7 +22,7 @@ public class ContainerSasTokenSasUrlFactory implements BlobSasUrlFactory {
     // therefore the token options are ignored.
     // A potential future enhancement is to compare the BlobSasTokenOptions and the container SAS
     // token, confirm they match and throw an exception if not.
-    LOGGER.warn(
+    logger.warn(
         "Using the container SAS token for blob:{}. BlobSasTokenOptions options were ignored.",
         blobName);
 

--- a/src/main/java/bio/terra/service/filedata/azure/util/KeySasUrlFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/KeySasUrlFactory.java
@@ -1,0 +1,50 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.azure.storage.common.sas.SasProtocol;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.apache.commons.lang3.StringUtils;
+
+/** Base class for factories that generate SAS URLs for blobs using tokens from keys. */
+public abstract class KeySasUrlFactory implements BlobSasUrlFactory {
+  private final BlobContainerClient blobContainerClient;
+
+  public KeySasUrlFactory(BlobContainerClient blobContainerClient) {
+    this.blobContainerClient = blobContainerClient;
+  }
+
+  abstract String generateSasToken(
+      BlobServiceSasSignatureValues sasSignatureValues, BlobClient blobClient);
+
+  @Override
+  public String createSasUrlForBlob(String blobName, BlobSasTokenOptions options) {
+
+    BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
+    String sasToken = generateSasToken(createSasSignatureValues(options), blobClient);
+
+    return String.format(
+        "%s/%s?%s", blobContainerClient.getBlobContainerUrl(), blobClient.getBlobName(), sasToken);
+  }
+
+  private BlobServiceSasSignatureValues createSasSignatureValues(
+      BlobSasTokenOptions blobSasTokenOptions) {
+
+    OffsetDateTime expiryTime =
+        OffsetDateTime.now(ZoneOffset.UTC).plus(blobSasTokenOptions.getExpiration());
+    SasProtocol sasProtocol = SasProtocol.HTTPS_ONLY;
+
+    // build the token
+    BlobServiceSasSignatureValues values =
+        new BlobServiceSasSignatureValues(expiryTime, blobSasTokenOptions.getSasPermissions())
+            .setProtocol(sasProtocol);
+
+    if (StringUtils.isNotBlank(blobSasTokenOptions.getContentDisposition())) {
+      values.setContentDisposition(blobSasTokenOptions.getContentDisposition());
+    }
+
+    return values;
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/KeySasUrlFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/KeySasUrlFactory.java
@@ -33,7 +33,7 @@ public abstract class KeySasUrlFactory implements BlobSasUrlFactory {
       BlobSasTokenOptions blobSasTokenOptions) {
 
     OffsetDateTime expiryTime =
-        OffsetDateTime.now(ZoneOffset.UTC).plus(blobSasTokenOptions.getExpiration());
+        OffsetDateTime.now(ZoneOffset.UTC).plus(blobSasTokenOptions.getDuration());
     SasProtocol sasProtocol = SasProtocol.HTTPS_ONLY;
 
     // build the token

--- a/src/main/java/bio/terra/service/filedata/azure/util/SharedAccountKeySasUrlFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/SharedAccountKeySasUrlFactory.java
@@ -1,0 +1,18 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+
+/** Generates a SAS token using the Shared Account Key from a storage account. */
+public class SharedAccountKeySasUrlFactory extends KeySasUrlFactory {
+
+  SharedAccountKeySasUrlFactory(BlobContainerClient blobContainerClient) {
+    super(blobContainerClient);
+  }
+
+  @Override
+  String generateSasToken(BlobServiceSasSignatureValues sasSignatureValues, BlobClient blobClient) {
+    return blobClient.generateSas(sasSignatureValues);
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/util/UserDelegatedKeySasUrlFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/UserDelegatedKeySasUrlFactory.java
@@ -11,13 +11,13 @@ import java.time.ZoneOffset;
 /** Generates a SAS token using a User delegated key. */
 public class UserDelegatedKeySasUrlFactory extends KeySasUrlFactory {
   private final BlobServiceClient blobServiceClient;
-  private final Duration delegatedKeyExpiration;
+  private final Duration delegatedKeyDuration;
   private UserDelegationKey delegationKey;
 
   UserDelegatedKeySasUrlFactory(
-      BlobServiceClient blobServiceClient, String containerName, Duration delegatedKeyExpiration) {
+      BlobServiceClient blobServiceClient, String containerName, Duration delegatedKeyDuration) {
     super(blobServiceClient.getBlobContainerClient(containerName));
-    this.delegatedKeyExpiration = delegatedKeyExpiration;
+    this.delegatedKeyDuration = delegatedKeyDuration;
     this.blobServiceClient = blobServiceClient;
   }
 
@@ -31,7 +31,7 @@ public class UserDelegatedKeySasUrlFactory extends KeySasUrlFactory {
   private synchronized UserDelegationKey getUserDelegationKey() {
     if (delegationKey == null
         || delegationKey.getSignedExpiry().isBefore(OffsetDateTime.now(ZoneOffset.UTC))) {
-      OffsetDateTime keyExpiry = OffsetDateTime.now(ZoneOffset.UTC).plus(delegatedKeyExpiration);
+      OffsetDateTime keyExpiry = OffsetDateTime.now(ZoneOffset.UTC).plus(delegatedKeyDuration);
       delegationKey = blobServiceClient.getUserDelegationKey(null, keyExpiry);
     }
     return delegationKey;

--- a/src/main/java/bio/terra/service/filedata/azure/util/UserDelegatedKeySasUrlFactory.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/UserDelegatedKeySasUrlFactory.java
@@ -1,0 +1,39 @@
+package bio.terra.service.filedata.azure.util;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.UserDelegationKey;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/** Generates a SAS token using a User delegated key. */
+public class UserDelegatedKeySasUrlFactory extends KeySasUrlFactory {
+  private final BlobServiceClient blobServiceClient;
+  private final Duration delegatedKeyExpiration;
+  private UserDelegationKey delegationKey;
+
+  UserDelegatedKeySasUrlFactory(
+      BlobServiceClient blobServiceClient, String containerName, Duration delegatedKeyExpiration) {
+    super(blobServiceClient.getBlobContainerClient(containerName));
+    this.delegatedKeyExpiration = delegatedKeyExpiration;
+    this.blobServiceClient = blobServiceClient;
+  }
+
+  @Override
+  String generateSasToken(BlobServiceSasSignatureValues sasSignatureValues, BlobClient blobClient) {
+    UserDelegationKey userDelegationKey = getUserDelegationKey();
+
+    return blobClient.generateUserDelegationSas(sasSignatureValues, userDelegationKey);
+  }
+
+  private synchronized UserDelegationKey getUserDelegationKey() {
+    if (delegationKey == null
+        || delegationKey.getSignedExpiry().isBefore(OffsetDateTime.now(ZoneOffset.UTC))) {
+      OffsetDateTime keyExpiry = OffsetDateTime.now(ZoneOffset.UTC).plus(delegatedKeyExpiration);
+      delegationKey = blobServiceClient.getUserDelegationKey(null, keyExpiry);
+    }
+    return delegationKey;
+  }
+}

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -6,9 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import bio.terra.common.category.Unit;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import liquibase.util.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -61,28 +59,19 @@ public class ValidationUtilsTest {
   }
 
   @Test
-  public void testValidationOfEmptyBlankAndNullStringsList() {
+  public void testValidationOfEmptyBlankAndNullStrings() {
 
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
-            () ->
-                ValidationUtils.requiresNotBlankInList(List.of(new ImmutablePair<>("", "param"))));
+        .isThrownBy(() -> ValidationUtils.requiresNotBlank("", "empty arg"));
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
-            () ->
-                ValidationUtils.requiresNotBlankInList(
-                    List.of(new ImmutablePair<>(null, "param"))));
+        .isThrownBy(() -> ValidationUtils.requiresNotBlank(null, "null arg"));
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
-            () ->
-                ValidationUtils.requiresNotBlankInList(
-                    List.of(new ImmutablePair<>("  ", "param"))));
+        .isThrownBy(() -> ValidationUtils.requiresNotBlank("  ", "param"));
   }
 
   @Test
-  public void testValidationOfValidInputStringlist() {
+  public void testValidationOfValidInputString() {
     // no exception is thrown
-    ValidationUtils.requiresNotBlankInList(
-        List.of(new ImmutablePair<>("abc", "param"), new ImmutablePair<>("123", "param")));
+    ValidationUtils.requiresNotBlank("abc", "error msg");
   }
 }

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -1,11 +1,14 @@
 package bio.terra.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import bio.terra.common.category.Unit;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import liquibase.util.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -55,5 +58,31 @@ public class ValidationUtilsTest {
     assertThat(ValidationUtils.convertToUuid("2c297e7c-b303-4243-af6a-76cd9d3b0ca8")).isPresent();
     assertThat(ValidationUtils.isValidUuid("not a uuid")).isFalse();
     assertThat(ValidationUtils.convertToUuid("not a uuid")).isEmpty();
+  }
+
+  @Test
+  public void testValidationOfEmptyBlankAndNullStringsList() {
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                ValidationUtils.requiresNotBlankInList(List.of(new ImmutablePair<>("", "param"))));
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                ValidationUtils.requiresNotBlankInList(
+                    List.of(new ImmutablePair<>(null, "param"))));
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                ValidationUtils.requiresNotBlankInList(
+                    List.of(new ImmutablePair<>("  ", "param"))));
+  }
+
+  @Test
+  public void testValidationOfValidInputStringlist() {
+    // no exception is thrown
+    ValidationUtils.requiresNotBlankInList(
+        List.of(new ImmutablePair<>("abc", "param"), new ImmutablePair<>("123", "param")));
   }
 }

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -62,16 +62,16 @@ public class ValidationUtilsTest {
   public void testValidationOfEmptyBlankAndNullStrings() {
 
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> ValidationUtils.requiresNotBlank("", "empty arg"));
+        .isThrownBy(() -> ValidationUtils.requireNotBlank("", "empty arg"));
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> ValidationUtils.requiresNotBlank(null, "null arg"));
+        .isThrownBy(() -> ValidationUtils.requireNotBlank(null, "null arg"));
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> ValidationUtils.requiresNotBlank("  ", "param"));
+        .isThrownBy(() -> ValidationUtils.requireNotBlank("  ", "param"));
   }
 
   @Test
   public void testValidationOfValidInputString() {
     // no exception is thrown
-    ValidationUtils.requiresNotBlank("abc", "error msg");
+    ValidationUtils.requireNotBlank("abc", "error msg");
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -75,7 +75,11 @@ public class BlobContainerClientFactoryTest {
     BlobContainerClientFactory factory =
         new BlobContainerClientFactory(accountName, tokenCredential, containerName);
 
-    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySasUrlForBlob(blobName));
+    BlobClient blobClient =
+        getBlobClientFromUrl(
+            factory
+                .getBlobSasUrlFactory()
+                .createSasUrlForBlob(blobName, blobIOTestUtility.createReadOnlyTokenOptions()));
 
     assertThat(blobClient.exists(), is(true));
   }
@@ -88,7 +92,11 @@ public class BlobContainerClientFactoryTest {
             blobIOTestUtility.generateSourceContainerUrlWithSasReadAndListPermissions(
                 getSourceStorageAccountPrimarySharedKey()));
 
-    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySasUrlForBlob(blobName));
+    BlobClient blobClient =
+        getBlobClientFromUrl(
+            factory
+                .getBlobSasUrlFactory()
+                .createSasUrlForBlob(blobName, blobIOTestUtility.createReadOnlyTokenOptions()));
 
     assertThat(blobClient.exists(), is(true));
   }
@@ -100,7 +108,11 @@ public class BlobContainerClientFactoryTest {
         new BlobContainerClientFactory(
             accountName, getSourceStorageAccountPrimarySharedKey(), containerName);
 
-    BlobClient blobClient = getBlobClientFromUrl(factory.createReadOnlySasUrlForBlob(blobName));
+    BlobClient blobClient =
+        getBlobClientFromUrl(
+            factory
+                .getBlobSasUrlFactory()
+                .createSasUrlForBlob(blobName, blobIOTestUtility.createReadOnlyTokenOptions()));
 
     assertThat(blobClient.exists(), is(true));
   }

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -163,7 +163,10 @@ public class BlobContainerCopierTest {
 
     BlobContainerCopier copier =
         new BlobContainerCopier(blobIOTestUtility.createDestinationClientFactory());
-    copier.setSourceBlobUrl(sourceFactory.createReadOnlySasUrlForBlob(blobName));
+    copier.setSourceBlobUrl(
+        sourceFactory
+            .getBlobSasUrlFactory()
+            .createSasUrlForBlob(blobName, blobIOTestUtility.createReadOnlyTokenOptions()));
 
     copier.beginCopyOperation().waitForCompletion();
 
@@ -180,7 +183,10 @@ public class BlobContainerCopierTest {
 
     BlobContainerCopier copier =
         new BlobContainerCopier(blobIOTestUtility.createDestinationClientFactory());
-    copier.setSourceBlobUrl(sourceFactory.createReadOnlySasUrlForBlob(blobName));
+    copier.setSourceBlobUrl(
+        sourceFactory
+            .getBlobSasUrlFactory()
+            .createSasUrlForBlob(blobName, blobIOTestUtility.createReadOnlyTokenOptions()));
     copier.setDestinationBlobName(destinationBlobName);
     copier.beginCopyOperation().waitForCompletion();
 

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopyInfoTest.java
@@ -24,7 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BlobContainerCopyInfoTest {
-  private BlobContainerCopyInfo blobContainerCopyInfo;
 
   @Mock private SyncPoller<BlobCopyInfo, Void> poller;
 
@@ -45,7 +44,8 @@ class BlobContainerCopyInfoTest {
   @MethodSource("getCopyStatusScenario")
   void getCopyStatus_ScenarioIsProvided_ExpectedStatusIsReturned(
       LongRunningOperationStatus expectedStatus, CopyStatusType... statuses) {
-    blobContainerCopyInfo = new BlobContainerCopyInfo(createPollResponses(statuses));
+    BlobContainerCopyInfo blobContainerCopyInfo =
+        new BlobContainerCopyInfo(createPollResponses(statuses));
 
     assertThat(blobContainerCopyInfo.getCopyStatus(), equalTo(expectedStatus));
   }

--- a/src/test/java/bio/terra/service/filedata/azure/util/ContainerSasTokenSasUrlFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/ContainerSasTokenSasUrlFactoryTest.java
@@ -1,0 +1,63 @@
+package bio.terra.service.filedata.azure.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.common.category.Unit;
+import com.azure.storage.blob.BlobUrlParts;
+import java.util.Locale;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+@Category(Unit.class)
+public class ContainerSasTokenSasUrlFactoryTest {
+
+  private ContainerSasTokenSasUrlFactory sasUrlFactory;
+  private static final String SIGNATURE_VALUE = "123";
+  private static final String PERMISSIONS_VALUE = "r";
+  private static final String EXPIRY_VALUE = "2015-07-02T08:49Z";
+
+  @Before
+  public void setUp() {
+    BlobUrlParts containerUrl =
+        BlobUrlParts.parse(
+            String.format(
+                Locale.ROOT,
+                "https://mydata.blob.core.windows.net/cont/?sig=%s&sp=%s&se=%s",
+                SIGNATURE_VALUE,
+                PERMISSIONS_VALUE,
+                EXPIRY_VALUE));
+    sasUrlFactory = new ContainerSasTokenSasUrlFactory(containerUrl);
+  }
+
+  @Test
+  public void testBlobSasTokenContainsSignatureFromContainerUrl() {
+
+    String sasToken = sasUrlFactory.createSasUrlForBlob("myblob", null);
+    assertThat(
+        BlobUrlParts.parse(sasToken).getCommonSasQueryParameters().getSignature(),
+        equalTo(SIGNATURE_VALUE));
+  }
+
+  @Test
+  public void testBlobSasTokenContainsPermissionsFromContainerUrl() {
+
+    String sasToken = sasUrlFactory.createSasUrlForBlob("myblob", null);
+    assertThat(
+        BlobUrlParts.parse(sasToken).getCommonSasQueryParameters().getPermissions(),
+        equalTo(PERMISSIONS_VALUE));
+  }
+
+  @Test
+  public void testBlobSasTokenContainsExpirationFromContainerUrl() {
+
+    String sasToken = sasUrlFactory.createSasUrlForBlob("myblob", null);
+    assertThat(
+        BlobUrlParts.parse(sasToken).getCommonSasQueryParameters().getExpiryTime().toString(),
+        equalTo(EXPIRY_VALUE));
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/util/KeySasUrlFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/KeySasUrlFactoryTest.java
@@ -1,0 +1,88 @@
+package bio.terra.service.filedata.azure.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+@Category(Unit.class)
+public class KeySasUrlFactoryTest {
+  private static final String SAS_TOKEN = "sig=123&sv=2020-06-10&sp=crwl";
+  private static final String CONTENT_DISPOSITION = "myuser@xyz.org";
+  private BlobSasTokenOptions sasTokenOptions;
+  private BlobSasPermission permissions;
+
+  @Mock private BlobContainerClient blobContainerClient;
+
+  @Mock private BlobClient blobClient;
+
+  private KeySasUrlFactory keySasUrlFactory;
+
+  @Captor ArgumentCaptor<BlobServiceSasSignatureValues> signatureValuesArgumentCaptor;
+
+  @Before
+  public void setUp() {
+    when(blobContainerClient.getBlobClient(any())).thenReturn(blobClient);
+
+    keySasUrlFactory =
+        mock(
+            KeySasUrlFactory.class,
+            Mockito.withSettings()
+                .useConstructor(blobContainerClient)
+                .defaultAnswer(CALLS_REAL_METHODS));
+
+    when(keySasUrlFactory.generateSasToken(signatureValuesArgumentCaptor.capture(), any()))
+        .thenReturn(SAS_TOKEN);
+    Duration expiration = Duration.ofMinutes(15);
+    permissions = new BlobSasPermission().setReadPermission(true);
+    sasTokenOptions = new BlobSasTokenOptions(expiration, permissions, CONTENT_DISPOSITION);
+  }
+
+  @Test
+  public void testContentDispositionWhenSetInOptions() {
+    keySasUrlFactory.createSasUrlForBlob("myblob", sasTokenOptions);
+
+    assertThat(
+        signatureValuesArgumentCaptor.getValue().getContentDisposition(),
+        equalTo(CONTENT_DISPOSITION));
+  }
+
+  @Test
+  public void testPermissionsWhenSetInOptions() {
+    keySasUrlFactory.createSasUrlForBlob("myblob", sasTokenOptions);
+
+    assertThat(
+        signatureValuesArgumentCaptor.getValue().getPermissions(), equalTo(permissions.toString()));
+  }
+
+  @Test
+  public void testExpirationWhenSetInOptions() {
+    keySasUrlFactory.createSasUrlForBlob("myblob", sasTokenOptions);
+
+    assertThat(
+        signatureValuesArgumentCaptor.getValue().getExpiryTime(),
+        greaterThan(OffsetDateTime.now(ZoneOffset.UTC)));
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
@@ -14,7 +14,6 @@ import com.azure.storage.blob.BlobClientBuilder;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
-import com.azure.storage.blob.BlobUrlParts;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import java.time.Duration;
@@ -150,8 +149,7 @@ public class SasUrlFactoriesTest {
   }
 
   private BlobClient createBlobClientUsingSasToken(String sasUrl) {
-    String sasToken = BlobUrlParts.parse(sasUrl).getCommonSasQueryParameters().encode();
-    return new BlobClientBuilder().endpoint(getBlobEndpoint()).sasToken(sasToken).buildClient();
+    return new BlobClientBuilder().endpoint(sasUrl).buildClient();
   }
 
   private BlobContainerClient createBlobContainerClientUsingSharedKeyCredentials() {

--- a/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
@@ -1,0 +1,199 @@
+package bio.terra.service.filedata.azure.util;
+
+import static bio.terra.service.filedata.azure.util.BlobIOTestUtility.MIB;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.category.Connected;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import com.azure.core.util.BinaryData;
+import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.BlobUrlParts;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Category(Connected.class)
+public class SasUrlFactoriesTest {
+  @Autowired private AzureResourceConfiguration azureResourceConfiguration;
+
+  @Autowired private ConnectedTestConfiguration connectedTestConfiguration;
+
+  private BlobIOTestUtility blobIOTestUtility;
+  private String accountName;
+  private String containerName;
+  private String blobName;
+  private List<BlobSasUrlFactory> sasUrlFactories;
+
+  @Before
+  public void setUp() {
+
+    blobIOTestUtility =
+        new BlobIOTestUtility(
+            azureResourceConfiguration.getAppToken(connectedTestConfiguration.getTargetTenantId()),
+            connectedTestConfiguration.getSourceStorageAccountName(),
+            connectedTestConfiguration.getDestinationStorageAccountName());
+
+    accountName = connectedTestConfiguration.getSourceStorageAccountName();
+    containerName = blobIOTestUtility.getSourceBlobContainerClient().getBlobContainerName();
+    BlobSasUrlFactory sharedKeyFactory =
+        new SharedAccountKeySasUrlFactory(createBlobContainerClientUsingSharedKeyCredentials());
+    BlobSasUrlFactory userDelegatedKeyFactory =
+        new UserDelegatedKeySasUrlFactory(
+            createBlobServiceClientUsingTokenCredentials(), containerName, Duration.ofHours(1));
+    sasUrlFactories = List.of(sharedKeyFactory, userDelegatedKeyFactory);
+  }
+
+  @After
+  public void tearDown() {
+    blobIOTestUtility.deleteContainers();
+  }
+
+  @Test
+  public void testCreateSasTokenGeneratedWithReadPermission() {
+    sasUrlFactories.forEach(this::testCreateSasTokenGeneratedWithReadPermission);
+  }
+
+  @Test
+  public void testCreateSasTokenGeneratedWithCreatePermissions() {
+    sasUrlFactories.forEach(this::testCreateSasTokenGeneratedWithCreatePermissions);
+  }
+
+  @Test
+  public void testCreateSasTokenGeneratedWithDeletePermissions() {
+    sasUrlFactories.forEach(this::testCreateSasTokenGeneratedWithDeletePermissions);
+  }
+
+  public void testCreateSasTokenGeneratedWithReadPermission(BlobSasUrlFactory factory) {
+    blobName = blobIOTestUtility.uploadSourceFiles(1, MIB / 10).iterator().next();
+    BlobSasPermission permission = new BlobSasPermission().setReadPermission(true);
+
+    String sasUrl = factory.createSasUrlForBlob(blobName, createBlobSasTokenOptions(permission));
+
+    BlobClient blobClient = createBlobClientUsingSasToken(sasUrl);
+
+    assertThat(blobClient.getProperties().getBlobSize(), equalTo(MIB / 10));
+  }
+
+  public void testCreateSasTokenGeneratedWithWritePermissions(BlobSasUrlFactory factory) {
+    blobName = blobIOTestUtility.uploadSourceFiles(1, MIB / 10).iterator().next();
+    BlobSasPermission permission = new BlobSasPermission().setWritePermission(true);
+
+    String sasUrl = factory.createSasUrlForBlob(blobName, createBlobSasTokenOptions(permission));
+
+    // write permissions allow overwrite.
+    String contentData = uploadContentDataToBlobUsingSasUrl(sasUrl, true);
+
+    assertThat(
+        getBlobClientWithFullAccess().getProperties().getBlobSize(),
+        equalTo((long) contentData.length()));
+  }
+
+  public void testCreateSasTokenGeneratedWithCreatePermissions(BlobSasUrlFactory factory) {
+    blobName = "myCreateTestBlob" + UUID.randomUUID(); // create does not allow overwrite
+    BlobSasPermission permission = new BlobSasPermission().setCreatePermission(true);
+
+    String sasUrl = factory.createSasUrlForBlob(blobName, createBlobSasTokenOptions(permission));
+    // create does not allow overwrite
+    String contentData = uploadContentDataToBlobUsingSasUrl(sasUrl, false);
+
+    assertThat(
+        getBlobClientWithFullAccess().getProperties().getBlobSize(),
+        equalTo((long) contentData.length()));
+  }
+
+  public void testCreateSasTokenGeneratedWithDeletePermissions(BlobSasUrlFactory factory) {
+    blobName = blobIOTestUtility.uploadSourceFiles(1, MIB / 10).iterator().next();
+    BlobSasPermission permission = new BlobSasPermission().setDeletePermission(true);
+
+    String sasUrl = factory.createSasUrlForBlob(blobName, createBlobSasTokenOptions(permission));
+
+    BlobClient blobClient = createBlobClientUsingSasToken(sasUrl);
+    blobClient.delete();
+
+    assertThat(getBlobClientWithFullAccess().exists(), equalTo(false));
+  }
+
+  private String uploadContentDataToBlobUsingSasUrl(String sasUrl, Boolean overwrite) {
+    BlobClient blobClient = createBlobClientUsingSasToken(sasUrl);
+    String contentData = "0123456789";
+    BinaryData data = BinaryData.fromString(contentData);
+    blobClient.upload(data, overwrite);
+    return contentData;
+  }
+
+  private BlobSasTokenOptions createBlobSasTokenOptions(BlobSasPermission permission) {
+    return new BlobSasTokenOptions(Duration.ofHours(1), permission, "");
+  }
+
+  private BlobClient createBlobClientUsingSasToken(String sasUrl) {
+    String sasToken = BlobUrlParts.parse(sasUrl).getCommonSasQueryParameters().encode();
+    return new BlobClientBuilder().endpoint(getBlobEndpoint()).sasToken(sasToken).buildClient();
+  }
+
+  private BlobContainerClient createBlobContainerClientUsingSharedKeyCredentials() {
+    AzureResourceManager client =
+        azureResourceConfiguration.getClient(
+            connectedTestConfiguration.getTargetTenantId(),
+            connectedTestConfiguration.getTargetSubscriptionId());
+
+    String sharedKey =
+        blobIOTestUtility.getSourceStorageAccountPrimarySharedKey(
+            client, connectedTestConfiguration.getTargetResourceGroupName(), accountName);
+
+    return new BlobServiceClientBuilder()
+        .credential(new StorageSharedKeyCredential(accountName, sharedKey))
+        .endpoint(getAccountEndpoint())
+        .buildClient()
+        .getBlobContainerClient(containerName);
+  }
+
+  private BlobClient getBlobClientWithFullAccess() {
+    return blobIOTestUtility.getSourceBlobContainerClient().getBlobClient(blobName);
+  }
+
+  private BlobServiceClient createBlobServiceClientUsingTokenCredentials() {
+
+    return new BlobServiceClientBuilder()
+        .endpoint(getAccountEndpoint())
+        .credential(
+            azureResourceConfiguration.getAppToken(connectedTestConfiguration.getTargetTenantId()))
+        .buildClient();
+  }
+
+  private String getAccountEndpoint() {
+    return String.format(Locale.ROOT, "https://%s.blob.core.windows.net", accountName);
+  }
+
+  private String getBlobEndpoint() {
+    return String.format(
+        Locale.ROOT,
+        "https://%s.blob.core.windows.net/%s/%s",
+        accountName,
+        containerName,
+        blobName);
+  }
+}


### PR DESCRIPTION
This PR includes the capability to create SAS URLs for blobs via `BlobCrl`:
 - SAS Tokens can be set with any permissions.
 - Content disposition and expiration time can be set.

