### PR TITLE
PF-934 Bump Stairway to 0.0.62 to pick up the serdes change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ dependencies {
         implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
         implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.1'
     } else {
-        implementation 'bio.terra:stairway:0.0.52-SNAPSHOT'
+        implementation 'bio.terra:stairway:0.0.62-SNAPSHOT'
     }
 
     // Similar development mode for pointing to terra common library

--- a/build.gradle
+++ b/build.gradle
@@ -229,13 +229,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus:latest.release'
 
-    // Forcing this due to vulnerability issues
-    compile ('com.fasterxml.jackson.core:jackson-databind:2.11.0.rc1') {
-        force = true
-    }
-    compile ('com.fasterxml.jackson.core:jackson-core:2.10.2') {
-        force = true
-    }
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.4'
 
     // Azure related dependencies
     implementation 'com.azure:azure-identity:1.2.5'

--- a/src/main/java/bio/terra/service/dataset/AzureStorageResource.java
+++ b/src/main/java/bio/terra/service/dataset/AzureStorageResource.java
@@ -3,14 +3,19 @@ package bio.terra.service.dataset;
 import bio.terra.app.model.AzureCloudResource;
 import bio.terra.app.model.AzureRegion;
 import bio.terra.model.CloudPlatform;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.UUID;
 
 @JsonTypeName("azure")
 public class AzureStorageResource extends StorageResource<AzureCloudResource, AzureRegion> {
 
+  @JsonCreator
   public AzureStorageResource(
-      UUID datasetId, AzureCloudResource cloudResource, AzureRegion region) {
+      @JsonProperty("datasetId") UUID datasetId,
+      @JsonProperty("cloudResource") AzureCloudResource cloudResource,
+      @JsonProperty("region") AzureRegion region) {
     super(datasetId, cloudResource, region);
   }
 

--- a/src/main/java/bio/terra/service/dataset/GoogleStorageResource.java
+++ b/src/main/java/bio/terra/service/dataset/GoogleStorageResource.java
@@ -3,14 +3,19 @@ package bio.terra.service.dataset;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.CloudPlatform;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.UUID;
 
 @JsonTypeName("gcp")
 public class GoogleStorageResource extends StorageResource<GoogleCloudResource, GoogleRegion> {
 
+  @JsonCreator
   public GoogleStorageResource(
-      UUID datasetId, GoogleCloudResource cloudResource, GoogleRegion region) {
+      @JsonProperty("datasetId") UUID datasetId,
+      @JsonProperty("cloudResource") GoogleCloudResource cloudResource,
+      @JsonProperty("region") GoogleRegion region) {
     super(datasetId, cloudResource, region);
   }
 

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzBqJobUserStep.java
@@ -9,6 +9,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -31,7 +32,8 @@ public class CreateDatasetAuthzBqJobUserStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
     UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
-    Map<IamRole, String> policies = workingMap.get(DatasetWorkingMapKeys.POLICY_EMAILS, Map.class);
+    Map<IamRole, String> policies =
+        workingMap.get(DatasetWorkingMapKeys.POLICY_EMAILS, new TypeReference<>() {});
     Dataset dataset = datasetService.retrieve(datasetId);
     resourceService.grantPoliciesBqJobUser(
         dataset.getProjectResource().getGoogleProjectId(), policies.values());

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzPrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzPrimaryDataStep.java
@@ -15,6 +15,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ public class CreateDatasetAuthzPrimaryDataStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
     Map<IamRole, String> policyEmails =
-        workingMap.get(DatasetWorkingMapKeys.POLICY_EMAILS, Map.class);
+        workingMap.get(DatasetWorkingMapKeys.POLICY_EMAILS, new TypeReference<>() {});
     Dataset dataset = datasetService.retrieve(datasetId);
     try {
       if (configService.testInsertFault(DATASET_GRANT_ACCESS_FAULT)) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -9,6 +9,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Collections;
 import java.util.Map;
 
@@ -27,7 +28,8 @@ public class SnapshotAuthzBqJobUserStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
-    Map<IamRole, String> policyMap = workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, Map.class);
+    Map<IamRole, String> policyMap =
+        workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, new TypeReference<>() {});
 
     Snapshot snapshot = snapshotService.retrieveByName(snapshotName);
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzFileAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzFileAclStep.java
@@ -18,6 +18,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.cloud.storage.StorageException;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,8 @@ public class SnapshotAuthzFileAclStep implements Step {
     UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
     Snapshot snapshot = snapshotService.retrieve(snapshotId);
 
-    Map<IamRole, String> policies = workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, Map.class);
+    Map<IamRole, String> policies =
+        workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, new TypeReference<>() {});
 
     // TODO: when we support multiple datasets, we can generate more than one copy of this
     //  step: one for each dataset. That is because each dataset keeps its file dependencies
@@ -111,7 +113,8 @@ public class SnapshotAuthzFileAclStep implements Step {
     UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
     Snapshot snapshot = snapshotService.retrieve(snapshotId);
 
-    Map<IamRole, String> policies = workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, Map.class);
+    Map<IamRole, String> policies =
+        workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, new TypeReference<>() {});
 
     // TODO: when we support multiple datasets, we can generate more than one copy of this
     //  step: one for each dataset. That is because each dataset keeps its file dependencies

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -15,6 +15,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
 import java.util.ArrayList;
@@ -45,7 +46,8 @@ public class SnapshotAuthzTabularAclStep implements Step {
     UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
     Snapshot snapshot = snapshotService.retrieve(snapshotId);
 
-    Map<IamRole, String> policies = workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, Map.class);
+    Map<IamRole, String> policies =
+        workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, new TypeReference<>() {});
     // Build the list of the policy emails that should have read access to the big query dataset
     List<String> emails = new ArrayList<>();
     emails.add(policies.get(IamRole.STEWARD));


### PR DESCRIPTION
This PR picks up the latest Stairway version that moves serialization/deserialization to the get/put. This is serdes [Phase 2 as described in this document](https://docs.google.com/document/d/1b1VckTBb_V1pCMhoN2GgHnGDR2f8MV2HuwIgDqFc_9M/edit#heading=h.49331srrvaui)

I will leave it to the Jade Core team to decide when the time is right to merge this.

