### PR TITLE
[DR-1937] Update ingest flight to use Azure storage tables

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
@@ -11,12 +11,14 @@ import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.flight.LockDatasetStep;
 import bio.terra.service.dataset.flight.UnlockDatasetStep;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.filedata.azure.tables.TableDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamService;
 import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
@@ -45,6 +47,8 @@ public class DatasetDeleteFlight extends Flight {
     DatasetService datasetService = appContext.getBean(DatasetService.class);
     ConfigurationService configService = appContext.getBean(ConfigurationService.class);
     ApplicationConfiguration appConfig = appContext.getBean(ApplicationConfiguration.class);
+    TableDao tableDao = appContext.getBean(TableDao.class);
+    ProfileDao profileDao = appContext.getBean(ProfileDao.class);
 
     // get data from inputs that steps need
     UUID datasetId =
@@ -68,7 +72,13 @@ public class DatasetDeleteFlight extends Flight {
     } else if (platform.isAzure()) {
       addStep(
           new DeleteDatasetAzurePrimaryDataStep(
-              azureBlobStorePdao, fileDao, datasetService, datasetId, configService),
+              azureBlobStorePdao,
+              tableDao,
+              datasetService,
+              datasetId,
+              configService,
+              resourceService,
+              profileDao),
           primaryDataDeleteRetry);
     }
     // Delete access control on objects that were explicitly added by data repo operations.  Do this

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
@@ -55,15 +55,20 @@ public class DatasetDeleteFlight extends Flight {
         UUID.fromString(inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class));
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
-    var platform =
-        CloudPlatformWrapper.of(
-            inputParameters.get(JobMapKeys.CLOUD_PLATFORM.getKeyName(), String.class));
+    //    // TODO - all we provide in the request is the dataset id. How would this cloud platform
+    // be set?
+    //    var platform =
+    //        CloudPlatformWrapper.of(
+    //            inputParameters.get(JobMapKeys.CLOUD_PLATFORM.getKeyName(), String.class));
     RetryRule lockDatasetRetry =
         getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
     RetryRule primaryDataDeleteRetry = getDefaultExponentialBackoffRetryRule();
 
     addStep(new LockDatasetStep(datasetDao, datasetId, false, true), lockDatasetRetry);
     addStep(new DeleteDatasetValidateStep(snapshotDao, dependencyDao, datasetService, datasetId));
+    var platform =
+        CloudPlatformWrapper.of(
+            datasetService.retrieve(datasetId).getDatasetSummary().getStorageCloudPlatform());
     if (platform.isGcp()) {
       addStep(
           new DeleteDatasetPrimaryDataStep(

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.jmx.export.metadata.InvalidMetadataException;
 
 public class DeleteDatasetAzurePrimaryDataStep implements Step {
 
@@ -58,14 +57,7 @@ public class DeleteDatasetAzurePrimaryDataStep implements Step {
     BillingProfileModel profileModel =
         profileDao.getBillingProfileById(dataset.getDefaultProfileId());
     AzureStorageAccountResource storageAccountResource =
-        resourceService
-            .getStorageAccount(dataset, profileModel)
-            .orElseThrow(
-                () ->
-                    new InvalidMetadataException(
-                        String.format(
-                            "Storage account does not exist for billing profile %s and dataset %s",
-                            profileModel.getId(), dataset.getId())));
+        resourceService.getStorageAccount(dataset, profileModel);
     tableDao.deleteFilesFromDataset(
         profileModel, storageAccountResource, azureBlobStorePdao::deleteFile);
 

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.jmx.export.metadata.InvalidMetadataException;
 
 public class DeleteDatasetAzurePrimaryDataStep implements Step {
 
@@ -57,7 +58,14 @@ public class DeleteDatasetAzurePrimaryDataStep implements Step {
     BillingProfileModel profileModel =
         profileDao.getBillingProfileById(dataset.getDefaultProfileId());
     AzureStorageAccountResource storageAccountResource =
-        resourceService.getOrCreateStorageAccount(dataset, profileModel, context.getFlightId());
+        resourceService
+            .getStorageAccount(dataset, profileModel)
+            .orElseThrow(
+                () ->
+                    new InvalidMetadataException(
+                        String.format(
+                            "Storage account does not exist for billing profile %s and dataset %s",
+                            profileModel.getId(), dataset.getId())));
     tableDao.deleteFilesFromDataset(
         profileModel, storageAccountResource, azureBlobStorePdao::deleteFile);
 

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
@@ -58,7 +58,8 @@ public class DeleteDatasetAzurePrimaryDataStep implements Step {
         profileDao.getBillingProfileById(dataset.getDefaultProfileId());
     AzureStorageAccountResource storageAccountResource =
         resourceService.getOrCreateStorageAccount(dataset, profileModel, context.getFlightId());
-    tableDao.deleteFilesFromDataset(storageAccountResource, azureBlobStorePdao::deleteFile);
+    tableDao.deleteFilesFromDataset(
+        profileModel, storageAccountResource, azureBlobStorePdao::deleteFile);
 
     // this fault is used by the DatasetConnectedTest > testOverlappingDeletes
     if (configService.testInsertFault(ConfigEnum.DATASET_DELETE_LOCK_CONFLICT_STOP_FAULT)) {

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -1,6 +1,7 @@
 package bio.terra.service.filedata;
 
 import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadRequestModel;
 import bio.terra.model.DRSChecksum;
@@ -203,8 +204,15 @@ public class FileService {
               .map(
                   storageAccountResource -> {
                     try {
+                      BillingProfileModel billingProfile =
+                          profileService.getProfileByIdNoCheck(
+                              storageAccountResource.getProfileId());
                       return tableDao.retrieveById(
-                          UUID.fromString(datasetId), fileId, depth, storageAccountResource);
+                          UUID.fromString(datasetId),
+                          fileId,
+                          depth,
+                          billingProfile,
+                          storageAccountResource);
                     } catch (FileNotFoundException ex) {
                       logger.debug("File not found in storage account: {}", storageAccountResource);
                     }

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -33,7 +33,6 @@ import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotProject;
 import bio.terra.service.snapshot.SnapshotService;
-import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -201,14 +200,7 @@ public class FileService {
       BillingProfileModel billingProfileModel =
           profileService.getProfileByIdNoCheck(dataset.getDefaultProfileId());
       AzureStorageAccountResource storageAccountResource =
-          resourceService
-              .getStorageAccount(dataset, billingProfileModel)
-              .orElseThrow(
-                  () ->
-                      new CorruptMetadataException(
-                          String.format(
-                              "No storage account resource for dataset %s and billing profile %s",
-                              datasetId, dataset.getDefaultProfileId())));
+          resourceService.getStorageAccount(dataset, billingProfileModel);
       return tableDao.retrieveById(
           UUID.fromString(datasetId), fileId, depth, billingProfileModel, storageAccountResource);
     }
@@ -229,14 +221,7 @@ public class FileService {
       BillingProfileModel billingProfileModel =
           profileService.getProfileByIdNoCheck(dataset.getDefaultProfileId());
       AzureStorageAccountResource storageAccountResource =
-          resourceService
-              .getStorageAccount(dataset, billingProfileModel)
-              .orElseThrow(
-                  () ->
-                      new CorruptMetadataException(
-                          String.format(
-                              "No storage account resource for dataset %s and billing profile %s",
-                              datasetId, dataset.getDefaultProfileId())));
+          resourceService.getStorageAccount(dataset, billingProfileModel);
       return tableDao.retrieveByPath(
           UUID.fromString(datasetId), path, depth, storageAccountResource);
     }

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -205,6 +205,7 @@ public class FileService {
               .flatMap(
                   storageAccountResource -> {
                     try {
+                      // TODO - should there be an auth check?
                       BillingProfileModel billingProfile =
                           profileService.getProfileByIdNoCheck(
                               storageAccountResource.getProfileId());

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -80,12 +80,10 @@ public class AzureBlobStorePdao {
   }
 
   public FSFileInfo copyFile(
+      BillingProfileModel profileModel,
       FileLoadModel fileLoadModel,
       String fileId,
       AzureStorageAccountResource storageAccountResource) {
-
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(fileLoadModel.getProfileId());
 
     BlobContainerClientFactory targetClientFactory =
         getTargetDataClientFactory(profileModel, storageAccountResource, ContainerType.DATA, false);

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -113,7 +113,7 @@ public class TableDao {
       logger.info("deleting files from dataset");
       fileDao.deleteFilesFromDataset(tableServiceClient, func);
     }
-    logger.info("deleting direcotry entries");
+    logger.info("deleting directory entries");
     directoryDao.deleteDirectoryEntriesFromCollection(tableServiceClient);
   }
 

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -1,6 +1,5 @@
 package bio.terra.service.filedata.azure.tables;
 
-import bio.terra.app.logging.PerformanceLogger;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
@@ -9,7 +8,6 @@ import bio.terra.service.filedata.*;
 import bio.terra.service.filedata.exception.FileNotFoundException;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import bio.terra.service.filedata.google.firestore.FireStoreFile;
-import bio.terra.service.filedata.google.firestore.FireStoreUtils;
 import bio.terra.service.filedata.google.firestore.InterruptibleConsumer;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
@@ -26,7 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 // Operations on a file often need to touch file and directory collections that is,
-// the FireStoreFileDao and the FireStoreDirectoryDao.
+// the Azure TableFileDao and the TableDirectoryDao.
 // The data to make an FSDir or FSFile is now spread between the file collection and the
 // directory collection, so a lookup needs to visit two places to generate a complete FSItem.
 // This class coordinates operations between the daos.
@@ -48,9 +46,7 @@ public class TableDao {
   private final ProfileDao profileDao;
   private final AzureAuthService azureAuthService;
   private final FileMetadataUtils fileMetadataUtils;
-  private final FireStoreUtils fireStoreUtils;
   private final ConfigurationService configurationService;
-  private final PerformanceLogger performanceLogger;
 
   @Autowired
   public TableDao(
@@ -59,17 +55,13 @@ public class TableDao {
       ProfileDao profileDao,
       AzureAuthService azureAuthService,
       FileMetadataUtils fileMetadataUtils,
-      FireStoreUtils fireStoreUtils,
-      ConfigurationService configurationService,
-      PerformanceLogger performanceLogger) {
+      ConfigurationService configurationService) {
     this.directoryDao = directoryDao;
     this.fileDao = fileDao;
     this.profileDao = profileDao;
     this.azureAuthService = azureAuthService;
     this.fileMetadataUtils = fileMetadataUtils;
-    this.fireStoreUtils = fireStoreUtils;
     this.configurationService = configurationService;
-    this.performanceLogger = performanceLogger;
   }
 
   public void createDirectoryEntry(
@@ -124,15 +116,6 @@ public class TableDao {
     logger.info("deleting direcotry entries");
     directoryDao.deleteDirectoryEntriesFromCollection(tableServiceClient);
   }
-
-  //      public FireStoreDirectoryEntry lookupDirectoryEntry(Dataset dataset, String fileId)
-  //              throws InterruptedException {
-  //          Firestore firestore =
-  //
-  //   FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
-  //          String datasetId = dataset.getId().toString();
-  //          return directoryDao.retrieveById(firestore, datasetId, fileId);
-  //      }
 
   public FireStoreDirectoryEntry lookupDirectoryEntryByPath(
       Dataset dataset,
@@ -217,87 +200,23 @@ public class TableDao {
         fileId);
   }
 
-  //    /**
-  //     * Retrieve a batch of FSFile by id
-  //     *
-  //     * @param container - dataset or snapshot containing file's directory entry
-  //     * @param fileIds - list of ids of file identifiers - directory identifiers will throw
-  //     * @return list of FSItem of retrieved files; throws on not found
-  //     */
-  //      public List<FSFile> batchRetrieveById(
-  //              FSContainerInterface container, List<String> fileIds, int enumerateDepth)
-  //              throws InterruptedException {
-  //
-  //          Firestore firestore =
-  // FireStoreProject.get(container.getProjectResource().getGoogleProjectId()).getFirestore();
-  //          String containerId = container.getId().toString();
-  //
-  //          List<FireStoreDirectoryEntry> directoryEntries =
-  //                  directoryDao.batchRetrieveById(firestore, containerId, fileIds);
-  //
-  //          // TODO: When we have more than one dataset in a snapshot then we will have to
-  //          //  split entries by underlying dataset. For now we know that they all come from one
-  // dataset.
-  //          List<FireStoreFile> files =
-  //                  fileDao.batchRetrieveFileMetadata(firestore, containerId, directoryEntries);
-  //
-  //          List<FSFile> resultList = new ArrayList<>();
-  //          if (directoryEntries.size() != files.size()) {
-  //              throw new FileSystemExecutionException("List sizes should be identical");
-  //          }
-  //
-  //          for (int i = 0; i < files.size(); i++) {
-  //              FireStoreFile file = files.get(i);
-  //              FireStoreDirectoryEntry entry = directoryEntries.get(i);
-  //
-  //              FSFile fsFile =
-  //                      new FSFile()
-  //                              .fileId(UUID.fromString(entry.getFileId()))
-  //                              .collectionId(UUID.fromString(entry.getDatasetId()))
-  //                              .datasetId(UUID.fromString(entry.getDatasetId()))
-  //                              .createdDate(Instant.parse(file.getFileCreatedDate()))
-  //                              .path(fileMetadataUtils.getFullPath(entry.getPath(),
-  // entry.getName()))
-  //                              .checksumCrc32c(file.getChecksumCrc32c())
-  //                              .checksumMd5(file.getChecksumMd5())
-  //                              .size(file.getSize())
-  //                              .description(file.getDescription())
-  //                              .gspath(file.getGspath())
-  //                              .mimeType(file.getMimeType())
-  //                              .bucketResourceId(file.getBucketResourceId())
-  //                              .loadTag(file.getLoadTag());
-  //
-  //              resultList.add(fsFile);
-  //          }
-  //
-  //          return resultList;
-  //      }
+  //   -- private methods --
 
-  //      public List<String> validateRefIds(Dataset dataset, List<String> refIdArray)
-  //              throws InterruptedException {
-  //          Firestore firestore =
-  // FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
-  //          String datasetId = dataset.getId().toString();
-  //          return directoryDao.validateRefIds(firestore, datasetId, refIdArray);
-  //      }
-
-  // -- private methods --
-  //
-  //      /**
-  //       * Retrieves an FSItem object
-  //       *
-  //       * @param tableServiceClient The client for the dataset or snapshot containing the
-  //       *                           virtual file system
-  //       * @param datasetTableServiceClient The client for the dataset (which contains the file
-  //       *     object metadata)
-  //       * @param collectionId The ID of the collection in the fsItemFirestore connection that
-  //       *                     contains the virtual file system objects
-  //       * @param enumerateDepth how far to enumerate the directory structure
-  //       * @param fireStoreDirectoryEntry The object to enumerate entries within
-  //       * @param context provides either the file id or the file path, for use in error messages.
-  //       * @return An {@link FSItem} representation of the passed in fireStoreDirectoryEntry with
-  // nested FSItems
-  //       */
+  /**
+   * Retrieves an FSItem object
+   *
+   * @param tableServiceClient The client for the dataset or snapshot containing the virtual file
+   *     system
+   * @param datasetTableServiceClient The client for the dataset (which contains the file object
+   *     metadata)
+   * @param collectionId The ID of the collection in the fsItemFirestore connection that contains
+   *     the virtual file system objects
+   * @param enumerateDepth how far to enumerate the directory structure
+   * @param fireStoreDirectoryEntry The object to enumerate entries within
+   * @param context provides either the file id or the file path, for use in error messages.
+   * @return An {@link FSItem} representation of the passed in fireStoreDirectoryEntry with nested
+   *     FSItems
+   */
   private FSItem retrieveWorker(
       TableServiceClient tableServiceClient,
       TableServiceClient datasetTableServiceClient,
@@ -327,22 +246,21 @@ public class TableDao {
         enumerateDepth,
         fireStoreDirectoryEntry);
   }
-  //
-  //      /**
-  //       * Create an FSItem object
-  //       *
-  //       * @param tableServiceClient The client for the dataset or snapshot containing the
-  //       *                           virtual file system
-  //       * @param datasetTableServiceClient The client for the dataset (which contains the file
-  //       *     object metadata)
-  //       * @param collectionId The ID of the collection in the fsItemFirestore connection that
-  // contains
-  //       *     the virtual file system objects
-  //       * @param level how far to enumerate the directory structure
-  //       * @param fireStoreDirectoryEntry The object to enumerate entries within
-  //       * @return An {@link FSItem} representation of the passed in fireStoreDirectoryEntry with
-  // nested FSItems
-  //       */
+
+  /**
+   * Create an FSItem object
+   *
+   * @param tableServiceClient The client for the dataset or snapshot containing the virtual file
+   *     system
+   * @param datasetTableServiceClient The client for the dataset (which contains the file object
+   *     metadata)
+   * @param collectionId The ID of the collection in the fsItemFirestore connection that contains
+   *     the virtual file system objects
+   * @param level how far to enumerate the directory structure
+   * @param fireStoreDirectoryEntry The object to enumerate entries within
+   * @return An {@link FSItem} representation of the passed in fireStoreDirectoryEntry with nested
+   *     FSItems
+   */
   private FSItem makeFSDir(
       TableServiceClient tableServiceClient,
       TableServiceClient datasetTableServiceClient,
@@ -430,127 +348,7 @@ public class TableDao {
 
     return fsFile;
   }
-  //
-  //    // Recursively compute the size and checksums of a directory
-  //    FireStoreDirectoryEntry computeDirectory(
-  //            Firestore snapshotFirestore,
-  //            Firestore datasetFirestore,
-  //            String snapshotId,
-  //            FireStoreDirectoryEntry dirEntry,
-  //            List<FireStoreDirectoryEntry> updateBatch)
-  //            throws InterruptedException {
-  //
-  //        String fullPath = fireStoreUtils.getFullPath(dirEntry.getPath(), dirEntry.getName());
-  //        List<FireStoreDirectoryEntry> enumDir =
-  //                directoryDao.enumerateDirectory(snapshotFirestore, snapshotId, fullPath);
-  //
-  //        List<FireStoreDirectoryEntry> enumComputed = new ArrayList<>();
-  //
-  //        // Recurse to compute results from underlying directories
-  //        try (Stream<FireStoreDirectoryEntry> stream = enumDir.stream()) {
-  //            enumComputed.addAll(
-  //                    stream
-  //                            .filter(f -> !f.getIsFileRef())
-  //                            .map(
-  //                                    f -> {
-  //                                        try {
-  //                                            return computeDirectory(
-  //                                                    snapshotFirestore, datasetFirestore,
-  // snapshotId, f, updateBatch);
-  //                                        } catch (InterruptedException e) {
-  //                                            throw new DirectoryMetadataComputeException(
-  //                                                    "Error computing directory metadata", e);
-  //                                        }
-  //                                    })
-  //                            .collect(Collectors.toList()));
-  //        }
-  //
-  //        // Collect metadata for file objects in the directory
-  //        try (Stream<FireStoreDirectoryEntry> stream = enumDir.stream()) {
-  //            // Group FireStoreDirectoryEntry objects by dataset Id to process one dataset at a
-  // time
-  //            final Map<String, List<FireStoreDirectoryEntry>> fileRefsByDatasetId =
-  //                    stream
-  //                            .filter(FireStoreDirectoryEntry::getIsFileRef)
-  //
-  // .collect(Collectors.groupingBy(FireStoreDirectoryEntry::getDatasetId));
-  //
-  //            for (Map.Entry<String, List<FireStoreDirectoryEntry>> entry :
-  //                    fileRefsByDatasetId.entrySet()) {
-  //                // Retrieve the file metadata from Firestore
-  //                final List<FireStoreFile> fireStoreFiles =
-  //                        fileDao.batchRetrieveFileMetadata(datasetFirestore, entry.getKey(),
-  // entry.getValue());
-  //
-  //                final AtomicInteger index = new AtomicInteger(0);
-  //                enumComputed.addAll(
-  //                        CollectionUtils.collect(
-  //                                entry.getValue(),
-  //                                dirItem -> {
-  //                                    final FireStoreFile file =
-  // fireStoreFiles.get(index.getAndIncrement());
-  //                                    if (file == null) {
-  //                                        throw new FileNotFoundException("File metadata was
-  // missing");
-  //                                    }
-  //                                    return dirItem
-  //                                            .size(file.getSize())
-  //                                            .checksumMd5(file.getChecksumMd5())
-  //                                            .checksumCrc32c(file.getChecksumCrc32c());
-  //                                }));
-  //            }
-  //        }
-  //
-  //        // Collect the ingredients for computing this directory's checksums and size
-  //        List<String> md5Collection = new ArrayList<>();
-  //        List<String> crc32cCollection = new ArrayList<>();
-  //        long totalSize = 0L;
-  //
-  //        for (FireStoreDirectoryEntry dirItem : enumComputed) {
-  //            totalSize = totalSize + dirItem.getSize();
-  //            if (!StringUtils.isEmpty(dirItem.getChecksumCrc32c())) {
-  //                crc32cCollection.add(dirItem.getChecksumCrc32c().toLowerCase());
-  //            }
-  //            if (!StringUtils.isEmpty(dirItem.getChecksumMd5())) {
-  //                md5Collection.add(dirItem.getChecksumMd5().toLowerCase());
-  //            }
-  //        }
-  //
-  //        // Compute checksums
-  //        // The spec is not 100% clear on the algorithm. I made specific choices on
-  //        // how to implement it:
-  //        // - set hex strings to lowercase before processing so we get consistent sort
-  //        //   order and digest results.
-  //        // - do not make leading zeros converting crc32 long to hex and it is returned
-  //        //   in lowercase. (Matches the semantics of toHexString).
-  //        Collections.sort(md5Collection);
-  //        String md5Concat = StringUtils.join(md5Collection, StringUtils.EMPTY);
-  //        String md5Checksum = fireStoreUtils.computeMd5(md5Concat);
-  //
-  //        Collections.sort(crc32cCollection);
-  //        String crc32cConcat = StringUtils.join(crc32cCollection, StringUtils.EMPTY);
-  //        String crc32cChecksum = fireStoreUtils.computeCrc32c(crc32cConcat);
-  //
-  //        // Update the directory in place
-  //        dirEntry.checksumCrc32c(crc32cChecksum).checksumMd5(md5Checksum).size(totalSize);
-  //        updateEntry(snapshotFirestore, snapshotId, dirEntry, updateBatch);
-  //
-  //        return dirEntry;
-  //    }
-  //
-  //    private void updateEntry(
-  //            Firestore firestore,
-  //            String snapshotId,
-  //            FireStoreDirectoryEntry entry,
-  //            List<FireStoreDirectoryEntry> updateBatch)
-  //            throws InterruptedException {
-  //
-  //        updateBatch.add(entry);
-  //        int batchSize = configurationService.getParameterValue(FIRESTORE_SNAPSHOT_BATCH_SIZE);
-  //        if (updateBatch.size() >= batchSize) {
-  //            logger.info("Snapshot compute updating batch of {} directory entries", batchSize);
-  //            directoryDao.batchStoreDirectoryEntry(firestore, snapshotId, updateBatch);
-  //            updateBatch.clear();
-  //        }
-  //    }
+
+  // TODO: Implement computeDirectory to recursively compute the size and checksums of a directory
+
 }

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -73,50 +73,49 @@ public class TableDao {
   }
 
   public void createDirectoryEntry(
-      FireStoreDirectoryEntry newEntry, AzureStorageAccountResource storageAccountResource) {
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+      FireStoreDirectoryEntry newEntry,
+      BillingProfileModel billingProfile,
+      AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
-        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
-    azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
+    azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     directoryDao.createDirectoryEntry(tableServiceClient, newEntry);
   }
 
   public boolean deleteDirectoryEntry(
-      String fileId, AzureStorageAccountResource storageAccountResource) {
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+      String fileId,
+      BillingProfileModel billingProfile,
+      AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
-        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
-    azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
+    azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     return directoryDao.deleteDirectoryEntry(tableServiceClient, fileId);
   }
 
   public void createFileMetadata(
-      FireStoreFile newFile, AzureStorageAccountResource storageAccountResource) {
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+      FireStoreFile newFile,
+      BillingProfileModel billingProfile,
+      AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
-        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     fileDao.createFileMetadata(tableServiceClient, newFile);
   }
 
   public boolean deleteFileMetadata(
-      String fileId, AzureStorageAccountResource storageAccountResource) {
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+      String fileId,
+      BillingProfileModel billingProfile,
+      AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
-        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     return fileDao.deleteFileMetadata(tableServiceClient, fileId);
   }
 
   public void deleteFilesFromDataset(
+      BillingProfileModel billingProfile,
       AzureStorageAccountResource storageAccountResource,
       InterruptibleConsumer<FireStoreFile> func) {
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
     TableServiceClient tableServiceClient =
-        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     if (configurationService.testInsertFault(ConfigEnum.LOAD_SKIP_FILE_LOAD)) {
       // If we didn't load files, don't try to delete them
       fileDao.deleteFilesFromDataset(tableServiceClient, f -> {});
@@ -136,23 +135,24 @@ public class TableDao {
   //      }
 
   public FireStoreDirectoryEntry lookupDirectoryEntryByPath(
-      Dataset dataset, String path, AzureStorageAccountResource storageAccountResource) {
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+      Dataset dataset,
+      String path,
+      BillingProfileModel billingProfile,
+      AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
-        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
-    azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
+    azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     String datasetId = dataset.getId().toString();
     return directoryDao.retrieveByPath(tableServiceClient, datasetId, path);
   }
 
-  public FireStoreFile lookupFile(String fileId, AzureStorageAccountResource storageAccountResource)
-      throws InterruptedException {
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+  public FireStoreFile lookupFile(
+      String fileId,
+      BillingProfileModel billingProfile,
+      AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
-        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
-    azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
+    azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     return fileDao.retrieveFileMetadata(tableServiceClient, fileId);
   }
 
@@ -172,10 +172,10 @@ public class TableDao {
       String fullPath,
       int enumerateDepth,
       AzureStorageAccountResource storageAccountResource) {
-    BillingProfileModel profileModel =
+    BillingProfileModel billingProfile =
         profileDao.getBillingProfileById(storageAccountResource.getProfileId());
     TableServiceClient tableServiceClient =
-        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
 
     FireStoreDirectoryEntry fireStoreDirectoryEntry =
         directoryDao.retrieveByPath(tableServiceClient, datasetId.toString(), fullPath);
@@ -203,11 +203,10 @@ public class TableDao {
       UUID datasetId,
       String fileId,
       int enumerateDepth,
+      BillingProfileModel billingProfile,
       AzureStorageAccountResource storageAccountResource) {
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
     TableServiceClient tableServiceClient =
-        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
 
     FireStoreDirectoryEntry fireStoreDirectoryEntry =
         directoryDao.retrieveById(tableServiceClient, fileId);

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -426,7 +426,7 @@ public class TableDao {
         .checksumMd5(fireStoreFile.getChecksumMd5())
         .size(fireStoreFile.getSize())
         .description(fireStoreFile.getDescription())
-        .gspath(fireStoreFile.getGspath())
+        .cloudPath(fireStoreFile.getGspath())
         .mimeType(fireStoreFile.getMimeType())
         .bucketResourceId(fireStoreFile.getBucketResourceId())
         .loadTag(fireStoreFile.getLoadTag());

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -411,9 +411,6 @@ public class TableDao {
     // snapshot directory
     // pointing to the files in one or more datasets.
     FireStoreFile fireStoreFile = fileDao.retrieveFileMetadata(datasetTableServiceClient, fileId);
-    if (fireStoreFile == null) {
-      return null;
-    }
 
     FSFile fsFile = new FSFile();
     fsFile

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -78,7 +78,6 @@ public class TableDao {
       AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
         azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
-    azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     directoryDao.createDirectoryEntry(tableServiceClient, newEntry);
   }
 
@@ -88,7 +87,6 @@ public class TableDao {
       AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
         azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
-    azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     return directoryDao.deleteDirectoryEntry(tableServiceClient, fileId);
   }
 
@@ -141,7 +139,6 @@ public class TableDao {
       AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
         azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
-    azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     String datasetId = dataset.getId().toString();
     return directoryDao.retrieveByPath(tableServiceClient, datasetId, path);
   }
@@ -152,7 +149,6 @@ public class TableDao {
       AzureStorageAccountResource storageAccountResource) {
     TableServiceClient tableServiceClient =
         azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
-    azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
     return fileDao.retrieveFileMetadata(tableServiceClient, fileId);
   }
 

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -118,8 +118,10 @@ public class TableDao {
       // If we didn't load files, don't try to delete them
       fileDao.deleteFilesFromDataset(tableServiceClient, f -> {});
     } else {
+      logger.info("deleting files from dataset");
       fileDao.deleteFilesFromDataset(tableServiceClient, func);
     }
+    logger.info("deleting direcotry entries");
     directoryDao.deleteDirectoryEntriesFromCollection(tableServiceClient);
   }
 

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -1,0 +1,558 @@
+package bio.terra.service.filedata.azure.tables;
+
+import bio.terra.app.logging.PerformanceLogger;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.*;
+import bio.terra.service.filedata.exception.FileNotFoundException;
+import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
+import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.filedata.google.firestore.FireStoreUtils;
+import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import com.azure.data.tables.TableServiceClient;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+// Operations on a file often need to touch file and directory collections that is,
+// the FireStoreFileDao and the FireStoreDirectoryDao.
+// The data to make an FSDir or FSFile is now spread between the file collection and the
+// directory collection, so a lookup needs to visit two places to generate a complete FSItem.
+// This class coordinates operations between the daos.
+//
+// The dependency collection is independent, so it is not included under this dao.
+// Perhaps it should be.
+//
+// There are several functions performed in this layer.
+//  1. Encapsulating the underlying daos
+//  2. Converting from dao objects into DR metadata objects
+//  3. Dealing with project, dataset, and snapshot objects, so the daos don't have to
+//
+@Component
+public class TableDao {
+  private final Logger logger = LoggerFactory.getLogger(TableDao.class);
+
+  private final TableDirectoryDao directoryDao;
+  private final TableFileDao fileDao;
+  private final ProfileDao profileDao;
+  private final AzureAuthService azureAuthService;
+  private final FileMetadataUtils fileMetadataUtils;
+  private final FireStoreUtils fireStoreUtils;
+  private final ConfigurationService configurationService;
+  private final PerformanceLogger performanceLogger;
+
+  @Autowired
+  public TableDao(
+      TableDirectoryDao directoryDao,
+      TableFileDao fileDao,
+      ProfileDao profileDao,
+      AzureAuthService azureAuthService,
+      FileMetadataUtils fileMetadataUtils,
+      FireStoreUtils fireStoreUtils,
+      ConfigurationService configurationService,
+      PerformanceLogger performanceLogger) {
+    this.directoryDao = directoryDao;
+    this.fileDao = fileDao;
+    this.profileDao = profileDao;
+    this.azureAuthService = azureAuthService;
+    this.fileMetadataUtils = fileMetadataUtils;
+    this.fireStoreUtils = fireStoreUtils;
+    this.configurationService = configurationService;
+    this.performanceLogger = performanceLogger;
+  }
+
+  public void createDirectoryEntry(
+      FireStoreDirectoryEntry newEntry, AzureStorageAccountResource storageAccountResource) {
+    BillingProfileModel profileModel =
+        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    directoryDao.createDirectoryEntry(tableServiceClient, newEntry);
+  }
+
+  public boolean deleteDirectoryEntry(
+      String fileId, AzureStorageAccountResource storageAccountResource) {
+    BillingProfileModel profileModel =
+        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    return directoryDao.deleteDirectoryEntry(tableServiceClient, fileId);
+  }
+
+  public void createFileMetadata(
+      FireStoreFile newFile, AzureStorageAccountResource storageAccountResource) {
+    BillingProfileModel profileModel =
+        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    fileDao.createFileMetadata(tableServiceClient, newFile);
+  }
+
+  public boolean deleteFileMetadata(
+      String fileId, AzureStorageAccountResource storageAccountResource) {
+    BillingProfileModel profileModel =
+        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    return fileDao.deleteFileMetadata(tableServiceClient, fileId);
+  }
+
+  //    public void deleteFilesFromDataset(Dataset dataset, InterruptibleConsumer<FireStoreFile>
+  // func)
+  //            throws InterruptedException {
+  //
+  //        Firestore firestore =
+  //
+  // FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
+  //        String datasetId = dataset.getId().toString();
+  //        if (configurationService.testInsertFault(ConfigEnum.LOAD_SKIP_FILE_LOAD)) {
+  //            // If we didn't load files, don't try to delete them
+  //            fileDao.deleteFilesFromDataset(firestore, datasetId, f -> {});
+  //        } else {
+  //            fileDao.deleteFilesFromDataset(firestore, datasetId, func);
+  //        }
+  //        directoryDao.deleteDirectoryEntriesFromCollection(firestore, datasetId);
+  //    }
+  //
+  //    public FireStoreDirectoryEntry lookupDirectoryEntry(Dataset dataset, String fileId)
+  //            throws InterruptedException {
+  //        Firestore firestore =
+  //
+  // FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
+  //        String datasetId = dataset.getId().toString();
+  //        return directoryDao.retrieveById(firestore, datasetId, fileId);
+  //    }
+  //
+  public FireStoreDirectoryEntry lookupDirectoryEntryByPath(
+      Dataset dataset, String path, AzureStorageAccountResource storageAccountResource) {
+    BillingProfileModel profileModel =
+        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    String datasetId = dataset.getId().toString();
+    return directoryDao.retrieveByPath(tableServiceClient, datasetId, path);
+  }
+
+  public FireStoreFile lookupFile(String fileId, AzureStorageAccountResource storageAccountResource)
+      throws InterruptedException {
+    BillingProfileModel profileModel =
+        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+    return fileDao.retrieveFileMetadata(tableServiceClient, fileId);
+  }
+
+  //    /**
+  //     * Retrieve an FSItem by path
+  //     *
+  //     * @param container - dataset or snapshot containing file's directory entry
+  //     * @param fullPath - path of the file in the directory
+  //     * @param enumerateDepth - how far to enumerate the directory structure; 0 means not at all;
+  // 1
+  //     *     means contents of this directory; 2 means this and its directories, etc. -1 means the
+  //     *     entire tree.
+  //     * @return FSFile or FSDir of retrieved file; can return null on not found
+  //  //     */
+  //      public FSItem retrieveByPath(FSContainerInterface container, String fullPath, int
+  // enumerateDepth)
+  //              throws InterruptedException {
+  //          Firestore fsItemFirestore =
+  // FireStoreProject.get(container.getProjectResource().getGoogleProjectId()).getFirestore();
+  //          Firestore metadataFirestore = container.firestoreConnection().getFirestore();
+  //          String containerId = container.getId().toString();
+  //
+  //          FireStoreDirectoryEntry fireStoreDirectoryEntry =
+  //                  directoryDao.retrieveByPath(fsItemFirestore, containerId, fullPath);
+  //          return retrieveWorker(
+  //                  fsItemFirestore,
+  //                  metadataFirestore,
+  //                  containerId,
+  //                  enumerateDepth,
+  //                  fireStoreDirectoryEntry,
+  //                  fullPath);
+  //      }
+
+  /**
+   * Retrieve an FSItem by id
+   *
+   * @param datasetId - dataset or snapshot containing file's directory entry
+   * @param fileId - id of the file or directory
+   * @param enumerateDepth - how far to enumerate the directory structure; 0 means not at all; 1
+   *     means contents of this directory; 2 means this and its directories, etc. -1 means the
+   *     entire tree.
+   * @return FSFile or FSDir of retrieved file; can return null on not found
+   */
+  public FSItem retrieveById(
+      UUID datasetId,
+      String fileId,
+      int enumerateDepth,
+      AzureStorageAccountResource storageAccountResource) {
+    BillingProfileModel profileModel =
+        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+
+    FireStoreDirectoryEntry fireStoreDirectoryEntry =
+        directoryDao.retrieveById(tableServiceClient, fileId);
+    return retrieveWorker(
+        tableServiceClient,
+        tableServiceClient,
+        datasetId.toString(),
+        enumerateDepth,
+        fireStoreDirectoryEntry,
+        fileId);
+  }
+
+  //    /**
+  //     * Retrieve a batch of FSFile by id
+  //     *
+  //     * @param container - dataset or snapshot containing file's directory entry
+  //     * @param fileIds - list of ids of file identifiers - directory identifiers will throw
+  //     * @return list of FSItem of retrieved files; throws on not found
+  //     */
+  //      public List<FSFile> batchRetrieveById(
+  //              FSContainerInterface container, List<String> fileIds, int enumerateDepth)
+  //              throws InterruptedException {
+  //
+  //          Firestore firestore =
+  // FireStoreProject.get(container.getProjectResource().getGoogleProjectId()).getFirestore();
+  //          String containerId = container.getId().toString();
+  //
+  //          List<FireStoreDirectoryEntry> directoryEntries =
+  //                  directoryDao.batchRetrieveById(firestore, containerId, fileIds);
+  //
+  //          // TODO: When we have more than one dataset in a snapshot then we will have to
+  //          //  split entries by underlying dataset. For now we know that they all come from one
+  // dataset.
+  //          List<FireStoreFile> files =
+  //                  fileDao.batchRetrieveFileMetadata(firestore, containerId, directoryEntries);
+  //
+  //          List<FSFile> resultList = new ArrayList<>();
+  //          if (directoryEntries.size() != files.size()) {
+  //              throw new FileSystemExecutionException("List sizes should be identical");
+  //          }
+  //
+  //          for (int i = 0; i < files.size(); i++) {
+  //              FireStoreFile file = files.get(i);
+  //              FireStoreDirectoryEntry entry = directoryEntries.get(i);
+  //
+  //              FSFile fsFile =
+  //                      new FSFile()
+  //                              .fileId(UUID.fromString(entry.getFileId()))
+  //                              .collectionId(UUID.fromString(entry.getDatasetId()))
+  //                              .datasetId(UUID.fromString(entry.getDatasetId()))
+  //                              .createdDate(Instant.parse(file.getFileCreatedDate()))
+  //                              .path(fileMetadataUtils.getFullPath(entry.getPath(),
+  // entry.getName()))
+  //                              .checksumCrc32c(file.getChecksumCrc32c())
+  //                              .checksumMd5(file.getChecksumMd5())
+  //                              .size(file.getSize())
+  //                              .description(file.getDescription())
+  //                              .gspath(file.getGspath())
+  //                              .mimeType(file.getMimeType())
+  //                              .bucketResourceId(file.getBucketResourceId())
+  //                              .loadTag(file.getLoadTag());
+  //
+  //              resultList.add(fsFile);
+  //          }
+  //
+  //          return resultList;
+  //      }
+
+  //      public List<String> validateRefIds(Dataset dataset, List<String> refIdArray)
+  //              throws InterruptedException {
+  //          Firestore firestore =
+  // FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
+  //          String datasetId = dataset.getId().toString();
+  //          return directoryDao.validateRefIds(firestore, datasetId, refIdArray);
+  //      }
+
+  // -- private methods --
+  //
+  //      /**
+  //       * Retrieves an FSItem object
+  //       *
+  //       * @param tableServiceClient The client for the dataset or snapshot containing the
+  //       *                           virtual file system
+  //       * @param datasetTableServiceClient The client for the dataset (which contains the file
+  //       *     object metadata)
+  //       * @param collectionId The ID of the collection in the fsItemFirestore connection that
+  //       *                     contains the virtual file system objects
+  //       * @param enumerateDepth how far to enumerate the directory structure
+  //       * @param fireStoreDirectoryEntry The object to enumerate entries within
+  //       * @param context provides either the file id or the file path, for use in error messages.
+  //       * @return An {@link FSItem} representation of the passed in fireStoreDirectoryEntry with
+  // nested FSItems
+  //       */
+  private FSItem retrieveWorker(
+      TableServiceClient tableServiceClient,
+      TableServiceClient datasetTableServiceClient,
+      String collectionId,
+      int enumerateDepth,
+      FireStoreDirectoryEntry fireStoreDirectoryEntry,
+      String context) {
+    if (fireStoreDirectoryEntry == null) {
+      throw new FileNotFoundException("File not found: " + context);
+    }
+
+    if (fireStoreDirectoryEntry.getIsFileRef()) {
+      FSItem fsFile = makeFSFile(datasetTableServiceClient, collectionId, fireStoreDirectoryEntry);
+      if (fsFile == null) {
+        // We found a file in the directory that is not done being created. We treat this
+        // as not found.
+        throw new FileNotFoundException(
+            "Found a file, but the directory is not done being created: " + context);
+      }
+      return fsFile;
+    }
+
+    return makeFSDir(
+        tableServiceClient,
+        datasetTableServiceClient,
+        collectionId,
+        enumerateDepth,
+        fireStoreDirectoryEntry);
+  }
+  //
+  //      /**
+  //       * Create an FSItem object
+  //       *
+  //       * @param tableServiceClient The client for the dataset or snapshot containing the
+  //       *                           virtual file system
+  //       * @param datasetTableServiceClient The client for the dataset (which contains the file
+  //       *     object metadata)
+  //       * @param collectionId The ID of the collection in the fsItemFirestore connection that
+  // contains
+  //       *     the virtual file system objects
+  //       * @param level how far to enumerate the directory structure
+  //       * @param fireStoreDirectoryEntry The object to enumerate entries within
+  //       * @return An {@link FSItem} representation of the passed in fireStoreDirectoryEntry with
+  // nested FSItems
+  //       */
+  private FSItem makeFSDir(
+      TableServiceClient tableServiceClient,
+      TableServiceClient datasetTableServiceClient,
+      String collectionId,
+      int level,
+      FireStoreDirectoryEntry fireStoreDirectoryEntry) {
+    if (fireStoreDirectoryEntry.getIsFileRef()) {
+      throw new IllegalStateException("Expected directory; got file!");
+    }
+
+    String fullPath =
+        fileMetadataUtils.getFullPath(
+            fireStoreDirectoryEntry.getPath(), fireStoreDirectoryEntry.getName());
+
+    FSDir fsDir = new FSDir();
+    fsDir
+        .fileId(UUID.fromString(fireStoreDirectoryEntry.getFileId()))
+        .collectionId(UUID.fromString(collectionId))
+        .createdDate(Instant.parse(fireStoreDirectoryEntry.getFileCreatedDate()))
+        .path(fullPath)
+        .checksumCrc32c(fireStoreDirectoryEntry.getChecksumCrc32c())
+        .checksumMd5(fireStoreDirectoryEntry.getChecksumMd5())
+        .size(fireStoreDirectoryEntry.getSize())
+        .description(StringUtils.EMPTY);
+
+    if (level != 0) {
+      List<FSItem> fsContents = new ArrayList<>();
+      List<FireStoreDirectoryEntry> dirContents =
+          directoryDao.enumerateDirectory(tableServiceClient, fullPath);
+      for (FireStoreDirectoryEntry fso : dirContents) {
+        if (fso.getIsFileRef()) {
+          // Files that are in the middle of being ingested can have a directory entry, but not yet
+          // have
+          // a file entry. We do not return files that do not yet have a file entry.
+          FSItem fsFile = makeFSFile(datasetTableServiceClient, collectionId, fso);
+          if (fsFile != null) {
+            fsContents.add(fsFile);
+          }
+        } else {
+          fsContents.add(
+              makeFSDir(
+                  tableServiceClient, datasetTableServiceClient, collectionId, level - 1, fso));
+        }
+      }
+      fsDir.contents(fsContents);
+    }
+
+    return fsDir;
+  }
+
+  // Handle files - the fireStoreDirectoryEntry is a reference to a file in a dataset.
+  private FSItem makeFSFile(
+      TableServiceClient datasetTableServiceClient,
+      String collectionId,
+      FireStoreDirectoryEntry fireStoreDirectoryEntry) {
+    if (!fireStoreDirectoryEntry.getIsFileRef()) {
+      throw new IllegalStateException("Expected file; got directory!");
+    }
+
+    String fullPath =
+        fileMetadataUtils.getFullPath(
+            fireStoreDirectoryEntry.getPath(), fireStoreDirectoryEntry.getName());
+    String fileId = fireStoreDirectoryEntry.getFileId();
+
+    // Lookup the file in its owning dataset, not in the collection. The collection may be a
+    // snapshot directory
+    // pointing to the files in one or more datasets.
+    FireStoreFile fireStoreFile = fileDao.retrieveFileMetadata(datasetTableServiceClient, fileId);
+    if (fireStoreFile == null) {
+      return null;
+    }
+
+    FSFile fsFile = new FSFile();
+    fsFile
+        .fileId(UUID.fromString(fileId))
+        .collectionId(UUID.fromString(collectionId))
+        .datasetId(UUID.fromString(fireStoreDirectoryEntry.getDatasetId()))
+        .createdDate(Instant.parse(fireStoreFile.getFileCreatedDate()))
+        .path(fullPath)
+        .checksumCrc32c(fireStoreFile.getChecksumCrc32c())
+        .checksumMd5(fireStoreFile.getChecksumMd5())
+        .size(fireStoreFile.getSize())
+        .description(fireStoreFile.getDescription())
+        .gspath(fireStoreFile.getGspath())
+        .mimeType(fireStoreFile.getMimeType())
+        .bucketResourceId(fireStoreFile.getBucketResourceId())
+        .loadTag(fireStoreFile.getLoadTag());
+
+    return fsFile;
+  }
+  //
+  //    // Recursively compute the size and checksums of a directory
+  //    FireStoreDirectoryEntry computeDirectory(
+  //            Firestore snapshotFirestore,
+  //            Firestore datasetFirestore,
+  //            String snapshotId,
+  //            FireStoreDirectoryEntry dirEntry,
+  //            List<FireStoreDirectoryEntry> updateBatch)
+  //            throws InterruptedException {
+  //
+  //        String fullPath = fireStoreUtils.getFullPath(dirEntry.getPath(), dirEntry.getName());
+  //        List<FireStoreDirectoryEntry> enumDir =
+  //                directoryDao.enumerateDirectory(snapshotFirestore, snapshotId, fullPath);
+  //
+  //        List<FireStoreDirectoryEntry> enumComputed = new ArrayList<>();
+  //
+  //        // Recurse to compute results from underlying directories
+  //        try (Stream<FireStoreDirectoryEntry> stream = enumDir.stream()) {
+  //            enumComputed.addAll(
+  //                    stream
+  //                            .filter(f -> !f.getIsFileRef())
+  //                            .map(
+  //                                    f -> {
+  //                                        try {
+  //                                            return computeDirectory(
+  //                                                    snapshotFirestore, datasetFirestore,
+  // snapshotId, f, updateBatch);
+  //                                        } catch (InterruptedException e) {
+  //                                            throw new DirectoryMetadataComputeException(
+  //                                                    "Error computing directory metadata", e);
+  //                                        }
+  //                                    })
+  //                            .collect(Collectors.toList()));
+  //        }
+  //
+  //        // Collect metadata for file objects in the directory
+  //        try (Stream<FireStoreDirectoryEntry> stream = enumDir.stream()) {
+  //            // Group FireStoreDirectoryEntry objects by dataset Id to process one dataset at a
+  // time
+  //            final Map<String, List<FireStoreDirectoryEntry>> fileRefsByDatasetId =
+  //                    stream
+  //                            .filter(FireStoreDirectoryEntry::getIsFileRef)
+  //
+  // .collect(Collectors.groupingBy(FireStoreDirectoryEntry::getDatasetId));
+  //
+  //            for (Map.Entry<String, List<FireStoreDirectoryEntry>> entry :
+  //                    fileRefsByDatasetId.entrySet()) {
+  //                // Retrieve the file metadata from Firestore
+  //                final List<FireStoreFile> fireStoreFiles =
+  //                        fileDao.batchRetrieveFileMetadata(datasetFirestore, entry.getKey(),
+  // entry.getValue());
+  //
+  //                final AtomicInteger index = new AtomicInteger(0);
+  //                enumComputed.addAll(
+  //                        CollectionUtils.collect(
+  //                                entry.getValue(),
+  //                                dirItem -> {
+  //                                    final FireStoreFile file =
+  // fireStoreFiles.get(index.getAndIncrement());
+  //                                    if (file == null) {
+  //                                        throw new FileNotFoundException("File metadata was
+  // missing");
+  //                                    }
+  //                                    return dirItem
+  //                                            .size(file.getSize())
+  //                                            .checksumMd5(file.getChecksumMd5())
+  //                                            .checksumCrc32c(file.getChecksumCrc32c());
+  //                                }));
+  //            }
+  //        }
+  //
+  //        // Collect the ingredients for computing this directory's checksums and size
+  //        List<String> md5Collection = new ArrayList<>();
+  //        List<String> crc32cCollection = new ArrayList<>();
+  //        long totalSize = 0L;
+  //
+  //        for (FireStoreDirectoryEntry dirItem : enumComputed) {
+  //            totalSize = totalSize + dirItem.getSize();
+  //            if (!StringUtils.isEmpty(dirItem.getChecksumCrc32c())) {
+  //                crc32cCollection.add(dirItem.getChecksumCrc32c().toLowerCase());
+  //            }
+  //            if (!StringUtils.isEmpty(dirItem.getChecksumMd5())) {
+  //                md5Collection.add(dirItem.getChecksumMd5().toLowerCase());
+  //            }
+  //        }
+  //
+  //        // Compute checksums
+  //        // The spec is not 100% clear on the algorithm. I made specific choices on
+  //        // how to implement it:
+  //        // - set hex strings to lowercase before processing so we get consistent sort
+  //        //   order and digest results.
+  //        // - do not make leading zeros converting crc32 long to hex and it is returned
+  //        //   in lowercase. (Matches the semantics of toHexString).
+  //        Collections.sort(md5Collection);
+  //        String md5Concat = StringUtils.join(md5Collection, StringUtils.EMPTY);
+  //        String md5Checksum = fireStoreUtils.computeMd5(md5Concat);
+  //
+  //        Collections.sort(crc32cCollection);
+  //        String crc32cConcat = StringUtils.join(crc32cCollection, StringUtils.EMPTY);
+  //        String crc32cChecksum = fireStoreUtils.computeCrc32c(crc32cConcat);
+  //
+  //        // Update the directory in place
+  //        dirEntry.checksumCrc32c(crc32cChecksum).checksumMd5(md5Checksum).size(totalSize);
+  //        updateEntry(snapshotFirestore, snapshotId, dirEntry, updateBatch);
+  //
+  //        return dirEntry;
+  //    }
+  //
+  //    private void updateEntry(
+  //            Firestore firestore,
+  //            String snapshotId,
+  //            FireStoreDirectoryEntry entry,
+  //            List<FireStoreDirectoryEntry> updateBatch)
+  //            throws InterruptedException {
+  //
+  //        updateBatch.add(entry);
+  //        int batchSize = configurationService.getParameterValue(FIRESTORE_SNAPSHOT_BATCH_SIZE);
+  //        if (updateBatch.size() >= batchSize) {
+  //            logger.info("Snapshot compute updating batch of {} directory entries", batchSize);
+  //            directoryDao.batchStoreDirectoryEntry(firestore, snapshotId, updateBatch);
+  //            updateBatch.clear();
+  //        }
+  //    }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -156,35 +156,37 @@ public class TableDao {
     return fileDao.retrieveFileMetadata(tableServiceClient, fileId);
   }
 
-  //    /**
-  //     * Retrieve an FSItem by path
-  //     *
-  //     * @param container - dataset or snapshot containing file's directory entry
-  //     * @param fullPath - path of the file in the directory
-  //     * @param enumerateDepth - how far to enumerate the directory structure; 0 means not at all;
-  // 1
-  //     *     means contents of this directory; 2 means this and its directories, etc. -1 means the
-  //     *     entire tree.
-  //     * @return FSFile or FSDir of retrieved file; can return null on not found
-  //  //     */
-  //      public FSItem retrieveByPath(FSContainerInterface container, String fullPath, int
-  // enumerateDepth)
-  //              throws InterruptedException {
-  //          Firestore fsItemFirestore =
-  // FireStoreProject.get(container.getProjectResource().getGoogleProjectId()).getFirestore();
-  //          Firestore metadataFirestore = container.firestoreConnection().getFirestore();
-  //          String containerId = container.getId().toString();
-  //
-  //          FireStoreDirectoryEntry fireStoreDirectoryEntry =
-  //                  directoryDao.retrieveByPath(fsItemFirestore, containerId, fullPath);
-  //          return retrieveWorker(
-  //                  fsItemFirestore,
-  //                  metadataFirestore,
-  //                  containerId,
-  //                  enumerateDepth,
-  //                  fireStoreDirectoryEntry,
-  //                  fullPath);
-  //      }
+  /**
+   * Retrieve an FSItem by path
+   *
+   * @param datasetId - dataset containing file's directory entry
+   * @param fullPath - path of the file in the directory
+   * @param enumerateDepth - how far to enumerate the directory structure; 0 means not at all; 1
+   *     means contents of this directory; 2 means this and its directories, etc. -1 means the
+   *     entire tree.
+   * @return FSFile or FSDir of retrieved file; can return null on not found //
+   */
+  // TODO - Azure snapshot: Support passing in snapshotID
+  public FSItem retrieveByPath(
+      UUID datasetId,
+      String fullPath,
+      int enumerateDepth,
+      AzureStorageAccountResource storageAccountResource) {
+    BillingProfileModel profileModel =
+        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(profileModel, storageAccountResource);
+
+    FireStoreDirectoryEntry fireStoreDirectoryEntry =
+        directoryDao.retrieveByPath(tableServiceClient, datasetId.toString(), fullPath);
+    return retrieveWorker(
+        tableServiceClient,
+        tableServiceClient,
+        datasetId.toString(),
+        enumerateDepth,
+        fireStoreDirectoryEntry,
+        fullPath);
+  }
 
   /**
    * Retrieve an FSItem by id
@@ -196,6 +198,7 @@ public class TableDao {
    *     entire tree.
    * @return FSFile or FSDir of retrieved file; can return null on not found
    */
+  // TODO - Azure snapshot: Support passing in snapshotID
   public FSItem retrieveById(
       UUID datasetId,
       String fileId,

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -211,9 +211,9 @@ public class TableDirectoryDao {
     String partitionKey = getPartitionKey(datasetId, lookupPath);
     String rowKey = encodePathAsAzureRowKey(lookupPath);
     try {
-        return tableClient.getEntity(partitionKey, rowKey);
+      return tableClient.getEntity(partitionKey, rowKey);
     } catch (TableServiceException ex) {
-        return null;
+      return null;
     }
   }
 

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -3,7 +3,6 @@ package bio.terra.service.filedata.azure.tables;
 import bio.terra.service.filedata.FileMetadataUtils;
 import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
-import bio.terra.service.filedata.google.firestore.FireStoreDirectoryDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.data.tables.TableClient;
@@ -55,7 +54,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class TableDirectoryDao {
-  private final Logger logger = LoggerFactory.getLogger(FireStoreDirectoryDao.class);
+  private final Logger logger = LoggerFactory.getLogger(TableDirectoryDao.class);
   private static final String TABLE_NAME = "dataset";
   private final FileMetadataUtils fileMetadataUtils;
 

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -211,9 +211,9 @@ public class TableDirectoryDao {
     String partitionKey = getPartitionKey(datasetId, lookupPath);
     String rowKey = encodePathAsAzureRowKey(lookupPath);
     try {
-      return tableClient.getEntity(partitionKey, rowKey);
+        return tableClient.getEntity(partitionKey, rowKey);
     } catch (TableServiceException ex) {
-      return null;
+        return null;
     }
   }
 

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -10,8 +10,6 @@ import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.models.ListEntitiesOptions;
 import com.azure.data.tables.models.TableEntity;
 import com.azure.data.tables.models.TableServiceException;
-import com.azure.data.tables.models.TableTransactionAction;
-import com.azure.data.tables.models.TableTransactionActionType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -124,10 +122,7 @@ public class TableDirectoryDao {
     if (leafEntity == null) {
       return false;
     }
-
-    TableTransactionAction t =
-        new TableTransactionAction(TableTransactionActionType.DELETE, leafEntity);
-    tableClient.submitTransaction(List.of(t));
+    tableClient.deleteEntity(leafEntity);
 
     FireStoreDirectoryEntry leafEntry = FireStoreDirectoryEntry.fromTableEntity(leafEntity);
     String datasetId = leafEntry.getDatasetId();
@@ -145,8 +140,9 @@ public class TableDirectoryDao {
         break;
       }
       TableEntity entity = lookupByFilePath(tableServiceClient, datasetId, lookupPath);
-      tableClient.submitTransaction(
-          List.of(new TableTransactionAction(TableTransactionActionType.DELETE, entity)));
+      if (entity != null) {
+        tableClient.deleteEntity(entity);
+      }
       lookupPath = fileMetadataUtils.getDirectoryPath(lookupPath);
     }
     return true;

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -139,6 +139,8 @@ public class TableDirectoryDao {
       String filterPath = fileMetadataUtils.makePathFromLookupPath(lookupPath);
       ListEntitiesOptions options =
           new ListEntitiesOptions().setFilter(String.format("path eq '%s'", filterPath));
+      // TODO - switch this back to checking for 1
+      // B/c we need to check if we can delete subdirectories too
       if (TableServiceClientUtils.tableHasEntries(tableServiceClient, TABLE_NAME, options)) {
         break;
       }

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -98,8 +98,11 @@ public class TableDirectoryDao {
       String partitionKey = getPartitionKey(datasetId, testPath);
       String rowKey = encodePathAsAzureRowKey(testPath);
       TableEntity entity = FireStoreDirectoryEntry.toTableEntity(partitionKey, rowKey, dirToCreate);
-      logger.info("Creating directory entry for {} in table {}", testPath, TABLE_NAME);
-      tableClient.createEntity(entity);
+      logger.info("Upserting directory entry for {} in table {}", testPath, TABLE_NAME);
+      // It's possible that another thread is trying to write the same directory entity at the same
+      // time
+      // upsert rather than create so that it does not fail if it already exists
+      tableClient.upsertEntity(entity);
     }
 
     String fullPath = fileMetadataUtils.getFullPath(createEntry.getPath(), createEntry.getName());

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
@@ -28,8 +28,6 @@ public class TableServiceClientUtils {
 
   public static boolean tableExists(TableServiceClient tableServiceClient, String tableName) {
     return tableServiceClient.listTables().stream()
-        .filter(table -> table.getName().matches(tableName))
-        .findAny()
-        .isPresent();
+        .anyMatch(table -> table.getName().matches(tableName));
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
@@ -1,0 +1,35 @@
+package bio.terra.service.filedata.azure.tables;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.data.tables.TableClient;
+import com.azure.data.tables.TableServiceClient;
+import com.azure.data.tables.models.ListEntitiesOptions;
+import com.azure.data.tables.models.TableEntity;
+
+public class TableServiceClientUtils {
+
+  public static boolean tableHasEntries(
+      TableServiceClient tableServiceClient, String tableName, ListEntitiesOptions options) {
+    if (tableExists(tableServiceClient, tableName)) {
+      TableClient tableClient = tableServiceClient.getTableClient(tableName);
+
+      PagedIterable<TableEntity> tableEntities = tableClient.listEntities(options, null, null);
+      if (tableEntities.iterator().hasNext()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static boolean tableHasEntries(TableServiceClient tableServiceClient, String tableName) {
+    ListEntitiesOptions options = new ListEntitiesOptions();
+    return tableHasEntries(tableServiceClient, tableName, options);
+  }
+
+  public static boolean tableExists(TableServiceClient tableServiceClient, String tableName) {
+    return tableServiceClient.listTables().stream()
+        .filter(table -> table.getName().matches(tableName))
+        .findAny()
+        .isPresent();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
@@ -4,7 +4,9 @@ import com.azure.core.http.rest.PagedIterable;
 import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.models.ListEntitiesOptions;
+import com.azure.data.tables.models.ListTablesOptions;
 import com.azure.data.tables.models.TableEntity;
+import com.azure.data.tables.models.TableItem;
 
 public class TableServiceClientUtils {
 
@@ -12,7 +14,7 @@ public class TableServiceClientUtils {
       TableServiceClient tableServiceClient, String tableName, ListEntitiesOptions options) {
     if (tableExists(tableServiceClient, tableName)) {
       TableClient tableClient = tableServiceClient.getTableClient(tableName);
-
+      options.setTop(1);
       PagedIterable<TableEntity> tableEntities = tableClient.listEntities(options, null, null);
       if (tableEntities.iterator().hasNext()) {
         return true;
@@ -27,7 +29,10 @@ public class TableServiceClientUtils {
   }
 
   public static boolean tableExists(TableServiceClient tableServiceClient, String tableName) {
-    return tableServiceClient.listTables().stream()
-        .anyMatch(table -> table.getName().matches(tableName));
+    ListTablesOptions options =
+        new ListTablesOptions().setFilter(String.format("TableName eq '%s'", tableName));
+    PagedIterable<TableItem> retrievedTableItems =
+        tableServiceClient.listTables(options, null, null);
+    return retrievedTableItems.iterator().hasNext();
   }
 }

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureDirectoryStep.java
@@ -1,0 +1,48 @@
+package bio.terra.service.filedata.flight.delete;
+
+import bio.terra.common.FlightUtils;
+import bio.terra.model.DeleteResponseModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.*;
+import org.springframework.http.HttpStatus;
+
+public class DeleteFileAzureDirectoryStep implements Step {
+  private final TableDao tableDao;
+  private final String fileId;
+  private final Dataset dataset;
+
+  public DeleteFileAzureDirectoryStep(TableDao tableDao, String fileId, Dataset dataset) {
+    this.tableDao = tableDao;
+    this.fileId = fileId;
+    this.dataset = dataset;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    AzureStorageAccountResource storageAccountResource =
+        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+    try {
+      boolean found = tableDao.deleteDirectoryEntry(fileId, storageAccountResource);
+      DeleteResponseModel.ObjectStateEnum stateEnum =
+          (found)
+              ? DeleteResponseModel.ObjectStateEnum.DELETED
+              : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
+      DeleteResponseModel deleteResponseModel = new DeleteResponseModel().objectState(stateEnum);
+      FlightUtils.setResponse(context, deleteResponseModel, HttpStatus.OK);
+    } catch (FileSystemAbortTransactionException rex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    // No undo is possible
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureDirectoryStep.java
@@ -33,11 +33,11 @@ public class DeleteFileAzureDirectoryStep implements Step {
     try {
       boolean found =
           tableDao.deleteDirectoryEntry(fileId, billingProfileModel, storageAccountResource);
-      DeleteResponseModel.ObjectStateEnum stateEnum =
+      DeleteResponseModel.ObjectStateEnum state =
           (found)
               ? DeleteResponseModel.ObjectStateEnum.DELETED
               : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
-      DeleteResponseModel deleteResponseModel = new DeleteResponseModel().objectState(stateEnum);
+      DeleteResponseModel deleteResponseModel = new DeleteResponseModel().objectState(state);
       FlightUtils.setResponse(context, deleteResponseModel, HttpStatus.OK);
     } catch (FileSystemAbortTransactionException rex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureDirectoryStep.java
@@ -1,11 +1,13 @@
 package bio.terra.service.filedata.flight.delete;
 
 import bio.terra.common.FlightUtils;
+import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DeleteResponseModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.azure.tables.TableDao;
 import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.*;
 import org.springframework.http.HttpStatus;
@@ -24,10 +26,13 @@ public class DeleteFileAzureDirectoryStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel billingProfileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     AzureStorageAccountResource storageAccountResource =
         workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
     try {
-      boolean found = tableDao.deleteDirectoryEntry(fileId, storageAccountResource);
+      boolean found =
+          tableDao.deleteDirectoryEntry(fileId, billingProfileModel, storageAccountResource);
       DeleteResponseModel.ObjectStateEnum stateEnum =
           (found)
               ? DeleteResponseModel.ObjectStateEnum.DELETED

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
@@ -1,0 +1,93 @@
+package bio.terra.service.filedata.flight.delete;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.*;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteFileAzureLookupStep implements Step {
+  private static Logger logger = LoggerFactory.getLogger(DeleteFileAzureLookupStep.class);
+
+  private final TableDao tableDao;
+  private final String fileId;
+  private final Dataset dataset;
+  private final ConfigurationService configService;
+  private final ResourceService resourceService;
+  private final ProfileDao profileDao;
+
+  public DeleteFileAzureLookupStep(
+      TableDao tableDao,
+      String fileId,
+      Dataset dataset,
+      ConfigurationService configService,
+      ResourceService resourceService,
+      ProfileDao profileDao) {
+    this.tableDao = tableDao;
+    this.fileId = fileId;
+    this.dataset = dataset;
+    this.configService = configService;
+    this.resourceService = resourceService;
+    this.profileDao = profileDao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    if (configService.testInsertFault(ConfigEnum.FILE_DELETE_LOCK_CONFLICT_STOP_FAULT)) {
+      logger.info("FILE_DELETE_LOCK_CONFLICT_STOP_FAULT");
+      while (!configService.testInsertFault(ConfigEnum.FILE_DELETE_LOCK_CONFLICT_CONTINUE_FAULT)) {
+        logger.info("Sleeping for CONTINUE FAULT");
+        TimeUnit.SECONDS.sleep(5);
+      }
+      logger.info("FILE_DELETE_LOCK_CONFLICT_CONTINUE_FAULT");
+    }
+
+    try {
+      // If we are restarting, we may have already retrieved and saved the file,
+      // so we check the working map before doing the lookup.
+      FlightMap workingMap = context.getWorkingMap();
+      FireStoreFile fireStoreFile = workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class);
+      BillingProfileModel billingProfile =
+          profileDao.getBillingProfileById(dataset.getDefaultProfileId());
+      AzureStorageAccountResource storageAccountResource =
+          resourceService.getOrCreateStorageAccount(dataset, billingProfile, context.getFlightId());
+      workingMap.put(FileMapKeys.STORAGE_ACCOUNT_INFO, storageAccountResource);
+
+      if (fireStoreFile == null) {
+        fireStoreFile = tableDao.lookupFile(fileId, storageAccountResource);
+        if (fireStoreFile != null) {
+          workingMap.put(FileMapKeys.FIRESTORE_FILE, fireStoreFile);
+        }
+      }
+      // TODO: Do this check when Azure snapshots are implemented
+      // We may not have found a fireStoreFile either way. We don't have a way to short-circuit
+      // running the rest of the steps, so we use the null stored in the working map to let other
+      // steps know there is no file. If there is a file, check dependencies here.
+      //      if (fireStoreFile != null) {
+      //        if (dependencyDao.fileHasSnapshotReference(dataset, fireStoreFile.getFileId())) {
+      //          throw new FileDependencyException(
+      //              "File is used by at least one snapshot and cannot be deleted");
+      //        }
+      //      }
+    } catch (FileSystemAbortTransactionException rex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
@@ -58,11 +58,9 @@ public class DeleteFileAzureLookupStep implements Step {
       // so we check the working map before doing the lookup.
       FlightMap workingMap = context.getWorkingMap();
       FireStoreFile fireStoreFile = workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class);
-      // TODO - wouldn't we need to check other associated billing profiles?
       BillingProfileModel billingProfile =
           profileDao.getBillingProfileById(dataset.getDefaultProfileId());
       workingMap.put(ProfileMapKeys.PROFILE_MODEL, billingProfile);
-      // TODO - why get or create? Why not just get?
       AzureStorageAccountResource storageAccountResource =
           resourceService.getOrCreateStorageAccount(dataset, billingProfile, context.getFlightId());
       workingMap.put(FileMapKeys.STORAGE_ACCOUNT_INFO, storageAccountResource);

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
@@ -9,6 +9,7 @@ import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.flight.FileMapKeys;
 import bio.terra.service.filedata.google.firestore.FireStoreFile;
 import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.*;
@@ -56,6 +57,7 @@ public class DeleteFileAzureLookupStep implements Step {
       // If we are restarting, we may have already retrieved and saved the file,
       // so we check the working map before doing the lookup.
       FlightMap workingMap = context.getWorkingMap();
+      workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
       FireStoreFile fireStoreFile = workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class);
       BillingProfileModel billingProfile =
           profileDao.getBillingProfileById(dataset.getDefaultProfileId());
@@ -64,7 +66,7 @@ public class DeleteFileAzureLookupStep implements Step {
       workingMap.put(FileMapKeys.STORAGE_ACCOUNT_INFO, storageAccountResource);
 
       if (fireStoreFile == null) {
-        fireStoreFile = tableDao.lookupFile(fileId, storageAccountResource);
+        fireStoreFile = tableDao.lookupFile(fileId, billingProfile, storageAccountResource);
         if (fireStoreFile != null) {
           workingMap.put(FileMapKeys.FIRESTORE_FILE, fireStoreFile);
         }

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
@@ -57,10 +57,10 @@ public class DeleteFileAzureLookupStep implements Step {
       // If we are restarting, we may have already retrieved and saved the file,
       // so we check the working map before doing the lookup.
       FlightMap workingMap = context.getWorkingMap();
-      workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
       FireStoreFile fireStoreFile = workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class);
       BillingProfileModel billingProfile =
           profileDao.getBillingProfileById(dataset.getDefaultProfileId());
+      workingMap.put(ProfileMapKeys.PROFILE_MODEL, billingProfile);
       AzureStorageAccountResource storageAccountResource =
           resourceService.getOrCreateStorageAccount(dataset, billingProfile, context.getFlightId());
       workingMap.put(FileMapKeys.STORAGE_ACCOUNT_INFO, storageAccountResource);

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
@@ -58,9 +58,11 @@ public class DeleteFileAzureLookupStep implements Step {
       // so we check the working map before doing the lookup.
       FlightMap workingMap = context.getWorkingMap();
       FireStoreFile fireStoreFile = workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class);
+      // TODO - wouldn't we need to check other associated billing profiles?
       BillingProfileModel billingProfile =
           profileDao.getBillingProfileById(dataset.getDefaultProfileId());
       workingMap.put(ProfileMapKeys.PROFILE_MODEL, billingProfile);
+      // TODO - why get or create? Why not just get?
       AzureStorageAccountResource storageAccountResource =
           resourceService.getOrCreateStorageAccount(dataset, billingProfile, context.getFlightId());
       workingMap.put(FileMapKeys.STORAGE_ACCOUNT_INFO, storageAccountResource);

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureMetadataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureMetadataStep.java
@@ -1,0 +1,39 @@
+package bio.terra.service.filedata.flight.delete;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.*;
+
+public class DeleteFileAzureMetadataStep implements Step {
+  private final TableDao tableDao;
+  private final String fileId;
+  private final Dataset dataset;
+
+  public DeleteFileAzureMetadataStep(TableDao tableDao, String fileId, Dataset dataset) {
+    this.tableDao = tableDao;
+    this.fileId = fileId;
+    this.dataset = dataset;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    AzureStorageAccountResource storageAccountResource =
+        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+    try {
+      tableDao.deleteFileMetadata(fileId, storageAccountResource);
+    } catch (FileSystemAbortTransactionException rex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    // No possible undo
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureMetadataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureMetadataStep.java
@@ -1,9 +1,11 @@
 package bio.terra.service.filedata.flight.delete;
 
+import bio.terra.model.BillingProfileModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.azure.tables.TableDao;
 import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.*;
 
@@ -21,10 +23,12 @@ public class DeleteFileAzureMetadataStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel billingProfileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     AzureStorageAccountResource storageAccountResource =
         workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
     try {
-      tableDao.deleteFileMetadata(fileId, storageAccountResource);
+      tableDao.deleteFileMetadata(fileId, billingProfileModel, storageAccountResource);
     } catch (FileSystemAbortTransactionException rex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
     }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -136,6 +136,7 @@ public class FileIngestBulkFlight extends Flight {
     //    locked tags
     // 10. Unlock the load tag
     addStep(new AuthorizeBillingProfileUseStep(profileService, profileId, userReq));
+    addStep(new IngestFileValidateCloudPlatformStep(dataset));
     addStep(new LockDatasetStep(datasetDao, datasetUuid, true), randomBackoffRetry);
     addStep(new LoadLockStep(loadService));
     if (platform.isGcp()) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -136,6 +136,10 @@ public class FileIngestBulkFlight extends Flight {
     //    locked tags
     // 10. Unlock the load tag
     addStep(new AuthorizeBillingProfileUseStep(profileService, profileId, userReq));
+    // For Azure datasets, the billing profile for file ingest must match the default
+    if (platform.isAzure()) {
+      addStep(new IngestFileValidateAzureBillingProfileStep(profileId, dataset));
+    }
     addStep(new IngestFileValidateCloudPlatformStep(dataset));
     addStep(new LockDatasetStep(datasetDao, datasetUuid, true), randomBackoffRetry);
     addStep(new LoadLockStep(loadService));

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -138,6 +138,7 @@ public class FileIngestBulkFlight extends Flight {
     addStep(new AuthorizeBillingProfileUseStep(profileService, profileId, userReq));
     addStep(new LockDatasetStep(datasetDao, datasetUuid, true), randomBackoffRetry);
     addStep(new LoadLockStep(loadService));
+    // TODO - Support Azure in this flight
     addStep(new IngestFileGetProjectStep(dataset, googleProjectService));
     addStep(new IngestFileGetOrCreateProject(resourceService, dataset), randomBackoffRetry);
     if (platform.isGcp()) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -138,10 +138,10 @@ public class FileIngestBulkFlight extends Flight {
     addStep(new AuthorizeBillingProfileUseStep(profileService, profileId, userReq));
     addStep(new LockDatasetStep(datasetDao, datasetUuid, true), randomBackoffRetry);
     addStep(new LoadLockStep(loadService));
-    // TODO - Support Azure in this flight
-    addStep(new IngestFileGetProjectStep(dataset, googleProjectService));
-    addStep(new IngestFileGetOrCreateProject(resourceService, dataset), randomBackoffRetry);
     if (platform.isGcp()) {
+      addStep(new IngestFileGetProjectStep(dataset, googleProjectService));
+      addStep(new IngestFileGetOrCreateProject(resourceService, dataset), randomBackoffRetry);
+
       addStep(new IngestFilePrimaryDataLocationStep(resourceService, dataset), randomBackoffRetry);
       addStep(new IngestFileMakeBucketLinkStep(datasetBucketDao, dataset), randomBackoffRetry);
     } else if (platform.isAzure()) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -119,6 +119,9 @@ public class FileIngestFlight extends Flight {
     // 9. Unlock the load tag
     // 10. Unlock the dataset
     addStep(new AuthorizeBillingProfileUseStep(profileService, profileId, userReq));
+    if (platform.isAzure()) {
+      addStep(new IngestFileValidateAzureBillingProfileStep(profileId, dataset));
+    }
     addStep(new IngestFileValidateCloudPlatformStep(dataset));
     addStep(new LockDatasetStep(datasetDao, datasetId, true), randomBackoffRetry);
     addStep(new LoadLockStep(loadService));

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -16,6 +16,7 @@ import bio.terra.service.dataset.flight.UnlockDatasetStep;
 import bio.terra.service.filedata.FileMetadataUtils;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.filedata.azure.tables.TableDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.iam.AuthenticatedUserRequest;
@@ -47,6 +48,7 @@ public class FileIngestFlight extends Flight {
     FileService fileService = appContext.getBean(FileService.class);
     GcsPdao gcsPdao = appContext.getBean(GcsPdao.class);
     AzureBlobStorePdao azureBlobStorePdao = appContext.getBean(AzureBlobStorePdao.class);
+    TableDao azureTableDao = appContext.getBean(TableDao.class);
     DatasetService datasetService = appContext.getBean(DatasetService.class);
     DatasetDao datasetDao = appContext.getBean(DatasetDao.class);
     ResourceService resourceService = appContext.getBean(ResourceService.class);
@@ -121,23 +123,29 @@ public class FileIngestFlight extends Flight {
     addStep(new LockDatasetStep(datasetDao, datasetId, true), randomBackoffRetry);
     addStep(new LoadLockStep(loadService));
     addStep(new IngestFileIdStep(configService));
-    addStep(new ValidateIngestFileDirectoryStep(fileDao, dataset));
-    addStep(new IngestFileDirectoryStep(fileDao, fileMetadataUtils, dataset), randomBackoffRetry);
-    addStep(new IngestFileGetProjectStep(dataset, googleProjectService));
-    addStep(new IngestFileGetOrCreateProject(resourceService, dataset), randomBackoffRetry);
+
     if (platform.isGcp()) {
+      addStep(new ValidateIngestFileDirectoryStep(fileDao, dataset));
+      addStep(new IngestFileDirectoryStep(fileDao, fileMetadataUtils, dataset), randomBackoffRetry);
+      addStep(new IngestFileGetProjectStep(dataset, googleProjectService));
+      addStep(new IngestFileGetOrCreateProject(resourceService, dataset), randomBackoffRetry);
       addStep(new IngestFilePrimaryDataLocationStep(resourceService, dataset), randomBackoffRetry);
       addStep(new IngestFileMakeBucketLinkStep(datasetBucketDao, dataset), randomBackoffRetry);
       addStep(new IngestFilePrimaryDataStep(dataset, gcsPdao, configService));
+      addStep(new IngestFileFileStep(fileDao, fileService, dataset), randomBackoffRetry);
     } else if (platform.isAzure()) {
       addStep(
           new IngestFileAzurePrimaryDataLocationStep(resourceService, dataset), randomBackoffRetry);
       addStep(
           new IngestFileAzureMakeStorageAccountLinkStep(datasetStorageAccountDao, dataset),
           randomBackoffRetry);
+      addStep(new ValidateIngestFileAzureDirectoryStep(azureTableDao, dataset));
+      addStep(
+          new IngestFileAzureDirectoryStep(azureTableDao, fileMetadataUtils, dataset),
+          randomBackoffRetry);
       addStep(new IngestFileAzurePrimaryDataStep(azureBlobStorePdao, configService));
+      addStep(new IngestFileAzureFileStep(azureTableDao, fileService, dataset), randomBackoffRetry);
     }
-    addStep(new IngestFileFileStep(fileDao, fileService, dataset), randomBackoffRetry);
     addStep(new LoadUnlockStep(loadService));
     addStep(new UnlockDatasetStep(datasetDao, datasetId, true), randomBackoffRetry);
   }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata.flight.ingest;
 
+import bio.terra.model.BillingProfileModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.FileLoadModel;
 import bio.terra.service.configuration.ConfigEnum;
@@ -14,6 +15,7 @@ import bio.terra.service.load.LoadCandidates;
 import bio.terra.service.load.LoadFile;
 import bio.terra.service.load.LoadService;
 import bio.terra.service.load.flight.LoadMapKeys;
+import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
@@ -117,7 +119,8 @@ public class IngestDriverStep extends SkippableStep {
 
     GoogleBucketResource bucketResource =
         workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
-
+    BillingProfileModel billingProfileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     AzureStorageAccountResource storageAccountResource =
         workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
 
@@ -163,6 +166,7 @@ public class IngestDriverStep extends SkippableStep {
               profileId,
               loadId,
               bucketResource,
+              billingProfileModel,
               storageAccountResource,
               platform);
 
@@ -306,6 +310,7 @@ public class IngestDriverStep extends SkippableStep {
       UUID profileId,
       UUID loadId,
       GoogleBucketResource bucketInfo,
+      BillingProfileModel billingProfileModel,
       AzureStorageAccountResource storageAccountResource,
       CloudPlatform platform)
       throws DatabaseOperationException, StairwayExecutionException, InterruptedException,
@@ -330,6 +335,7 @@ public class IngestDriverStep extends SkippableStep {
       inputParameters.put(FileMapKeys.DATASET_ID, datasetId);
       inputParameters.put(FileMapKeys.REQUEST, fileLoadModel);
       inputParameters.put(FileMapKeys.BUCKET_INFO, bucketInfo);
+      inputParameters.put(ProfileMapKeys.PROFILE_MODEL, billingProfileModel);
       inputParameters.put(FileMapKeys.STORAGE_ACCOUNT_INFO, storageAccountResource);
       inputParameters.put(JobMapKeys.CLOUD_PLATFORM.getKeyName(), platform.name());
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureDirectoryStep.java
@@ -88,8 +88,8 @@ public class IngestFileAzureDirectoryStep implements Step {
             new FireStoreDirectoryEntry()
                 .fileId(fileId)
                 .isFileRef(true)
-                .path(fileMetadataUtils.getDirectoryPath(loadModel.getTargetPath()))
-                .name(fileMetadataUtils.getName(loadModel.getTargetPath()))
+                .path(fileMetadataUtils.getDirectoryPath(targetPath))
+                .name(fileMetadataUtils.getName(targetPath))
                 .datasetId(datasetId)
                 .loadTag(loadModel.getLoadTag());
         tableDao.createDirectoryEntry(newEntry, billingProfileModel, storageAccountResource);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureDirectoryStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata.flight.ingest;
 
+import bio.terra.common.FlightUtils;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.FileLoadModel;
 import bio.terra.service.dataset.Dataset;
@@ -50,10 +51,13 @@ public class IngestFileAzureDirectoryStep implements Step {
     String targetPath = loadModel.getTargetPath();
 
     String ingestFileAction = workingMap.get(FileMapKeys.INGEST_FILE_ACTION, String.class);
-    AzureStorageAccountResource storageAccountResource =
-        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
     BillingProfileModel billingProfileModel =
-        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+        FlightUtils.getContextValue(
+            context, ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    AzureStorageAccountResource storageAccountResource =
+        FlightUtils.getContextValue(
+            context, FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+
     try {
       // The state logic goes like this:
       //  1. the directory entry doesn't exist. We need to create the directory entry for it.
@@ -116,9 +120,11 @@ public class IngestFileAzureDirectoryStep implements Step {
     String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
     String ingestFileAction = workingMap.get(FileMapKeys.INGEST_FILE_ACTION, String.class);
     BillingProfileModel billingProfileModel =
-        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+        FlightUtils.getContextValue(
+            context, ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     AzureStorageAccountResource storageAccountResource =
-        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+        FlightUtils.getContextValue(
+            context, FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
 
     if (ingestFileAction.equals(ValidateIngestFileDirectoryStep.CREATE_ENTRY_ACTION)) {
       try {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureDirectoryStep.java
@@ -1,0 +1,124 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.model.FileLoadModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.FileMetadataUtils;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
+import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.azure.data.tables.models.TableServiceException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IngestFileAzureDirectoryStep implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(IngestFileDirectoryStep.class);
+
+  private final TableDao tableDao;
+  private final FileMetadataUtils fileMetadataUtils;
+  private final Dataset dataset;
+
+  public IngestFileAzureDirectoryStep(
+      TableDao tableDao, FileMetadataUtils fileMetadataUtils, Dataset dataset) {
+    this.tableDao = tableDao;
+    this.fileMetadataUtils = fileMetadataUtils;
+    this.dataset = dataset;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap inputParameters = context.getInputParameters();
+    FileLoadModel loadModel =
+        inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
+
+    FlightMap workingMap = context.getWorkingMap();
+    String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
+    workingMap.put(FileMapKeys.LOAD_COMPLETED, false);
+
+    String datasetId = dataset.getId().toString();
+    String targetPath = loadModel.getTargetPath();
+
+    String ingestFileAction = workingMap.get(FileMapKeys.INGEST_FILE_ACTION, String.class);
+    AzureStorageAccountResource storageAccountResource =
+        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+    try {
+      // The state logic goes like this:
+      //  1. the directory entry doesn't exist. We need to create the directory entry for it.
+      //  2. the directory entry exists and the load tags match:
+      //      a. directory entry loadTag matches our loadTag AND entry fileId matches our fileId:
+      //         means we are recovering and need to complete the file creation work.
+      //      b. directory entry loadTag matches our loadTag AND entry fileId does NOT match our
+      // fileId
+      //         means this is a re-run of a load job. We update the fileId in the working map. We
+      // don't
+      //         know if we are recovering or already finished. We try to retrieve the file object
+      // for
+      //         the entry fileId:
+      //           i. If that is successful, then we already loaded this file. We store
+      // "completed=true"
+      //              in the working map, so other steps do nothing.
+      //          ii. If that fails, then we are recovering: we leave completed unset (=false) in
+      // the working map.
+      //
+      // Lookup the file - on a recovery, we may have already created it, but not
+      // finished. Or it might already exist, created by someone else.
+      FireStoreDirectoryEntry existingEntry =
+          tableDao.lookupDirectoryEntryByPath(dataset, targetPath, storageAccountResource);
+      if (ingestFileAction.equals(ValidateIngestFileDirectoryStep.CREATE_ENTRY_ACTION)) {
+        // (1) Not there - create it
+        FireStoreDirectoryEntry newEntry =
+            new FireStoreDirectoryEntry()
+                .fileId(fileId)
+                .isFileRef(true)
+                .path(fileMetadataUtils.getDirectoryPath(loadModel.getTargetPath()))
+                .name(fileMetadataUtils.getName(loadModel.getTargetPath()))
+                .datasetId(datasetId)
+                .loadTag(loadModel.getLoadTag());
+        tableDao.createDirectoryEntry(newEntry, storageAccountResource);
+      } else if (ingestFileAction.equals(ValidateIngestFileDirectoryStep.CHECK_ENTRY_ACTION)
+          && !StringUtils.equals(existingEntry.getFileId(), fileId)) {
+        // (b) We are in a re-run of a load job. Try to get the file entry.
+        fileId = existingEntry.getFileId();
+        workingMap.put(FileMapKeys.FILE_ID, fileId);
+        FireStoreFile fileEntry = tableDao.lookupFile(fileId, storageAccountResource);
+        if (fileEntry != null) {
+          // (b)(i) We successfully loaded this file already
+          workingMap.put(FileMapKeys.LOAD_COMPLETED, true);
+        }
+        // (b)(ii) We are recovering and should continue this load; leave load completed false/unset
+
+      }
+    } catch (FileSystemAbortTransactionException rex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
+    String ingestFileAction = workingMap.get(FileMapKeys.INGEST_FILE_ACTION, String.class);
+    AzureStorageAccountResource storageAccountResource =
+        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+
+    if (ingestFileAction.equals(ValidateIngestFileDirectoryStep.CREATE_ENTRY_ACTION)) {
+      try {
+        tableDao.deleteDirectoryEntry(fileId, storageAccountResource);
+      } catch (TableServiceException rex) {
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
@@ -74,11 +74,11 @@ public class IngestFileAzureFileStep implements Step {
     String itemId = workingMap.get(FileMapKeys.FILE_ID, String.class);
     AzureStorageAccountResource storageAccountResource =
         workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
-        try {
-          tableDao.deleteFileMetadata(itemId, storageAccountResource);
-        } catch (TableServiceException rex) {
-          return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
-        }
+    try {
+      tableDao.deleteFileMetadata(itemId, storageAccountResource);
+    } catch (TableServiceException rex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+    }
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
@@ -1,0 +1,84 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.model.FileLoadModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.FSFileInfo;
+import bio.terra.service.filedata.FSItem;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.azure.data.tables.models.TableServiceException;
+
+public class IngestFileAzureFileStep implements Step {
+  private final TableDao tableDao;
+  private final FileService fileService;
+  private final Dataset dataset;
+
+  public IngestFileAzureFileStep(TableDao tableDao, FileService fileService, Dataset dataset) {
+    this.tableDao = tableDao;
+    this.fileService = fileService;
+    this.dataset = dataset;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    AzureStorageAccountResource storageAccountResource =
+        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+    Boolean loadComplete = workingMap.get(FileMapKeys.LOAD_COMPLETED, Boolean.class);
+    if (loadComplete == null || !loadComplete) {
+      FlightMap inputParameters = context.getInputParameters();
+      FileLoadModel fileLoadModel =
+          inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
+
+      FSFileInfo fsFileInfo = workingMap.get(FileMapKeys.FILE_INFO, FSFileInfo.class);
+      String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
+
+      FireStoreFile newFile =
+          new FireStoreFile()
+              .fileId(fileId)
+              .mimeType(fileLoadModel.getMimeType())
+              .description(fileLoadModel.getDescription())
+              .bucketResourceId(fsFileInfo.getBucketResourceId())
+              .fileCreatedDate(fsFileInfo.getCreatedDate())
+              .gspath(fsFileInfo.getGspath())
+              .checksumCrc32c(fsFileInfo.getChecksumCrc32c())
+              .checksumMd5(fsFileInfo.getChecksumMd5())
+              .size(fsFileInfo.getSize())
+              .loadTag(fileLoadModel.getLoadTag());
+
+      try {
+        tableDao.createFileMetadata(newFile, storageAccountResource);
+        // Retrieve to build the complete FSItem
+        FSItem fsItem = tableDao.retrieveById(dataset.getId(), fileId, 1, storageAccountResource);
+        workingMap.put(JobMapKeys.RESPONSE.getKeyName(), fileService.fileModelFromFSItem(fsItem));
+      } catch (TableServiceException rex) {
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+      }
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    String itemId = workingMap.get(FileMapKeys.FILE_ID, String.class);
+    AzureStorageAccountResource storageAccountResource =
+        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+        try {
+          tableDao.deleteFileMetadata(itemId, storageAccountResource);
+        } catch (TableServiceException rex) {
+          return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+        }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata.flight.ingest;
 
+import bio.terra.common.FlightUtils;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.FileLoadModel;
 import bio.terra.service.dataset.Dataset;
@@ -34,9 +35,12 @@ public class IngestFileAzureFileStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
     BillingProfileModel billingProfileModel =
-        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+        FlightUtils.getContextValue(
+            context, ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     AzureStorageAccountResource storageAccountResource =
-        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+        FlightUtils.getContextValue(
+            context, FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+
     Boolean loadComplete = workingMap.get(FileMapKeys.LOAD_COMPLETED, Boolean.class);
     if (loadComplete == null || !loadComplete) {
       FlightMap inputParameters = context.getInputParameters();
@@ -80,9 +84,12 @@ public class IngestFileAzureFileStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     String itemId = workingMap.get(FileMapKeys.FILE_ID, String.class);
     BillingProfileModel billingProfileModel =
-        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+        FlightUtils.getContextValue(
+            context, ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     AzureStorageAccountResource storageAccountResource =
-        workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+        FlightUtils.getContextValue(
+            context, FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+
     try {
       tableDao.deleteFileMetadata(itemId, billingProfileModel, storageAccountResource);
     } catch (TableServiceException rex) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
@@ -49,7 +49,7 @@ public class IngestFileAzureFileStep implements Step {
               .description(fileLoadModel.getDescription())
               .bucketResourceId(fsFileInfo.getBucketResourceId())
               .fileCreatedDate(fsFileInfo.getCreatedDate())
-              .gspath(fsFileInfo.getGspath())
+              .gspath(fsFileInfo.getCloudPath())
               .checksumCrc32c(fsFileInfo.getChecksumCrc32c())
               .checksumMd5(fsFileInfo.getChecksumMd5())
               .size(fsFileInfo.getSize())

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
@@ -59,6 +59,7 @@ public class IngestFileAzureFileStep implements Step {
         tableDao.createFileMetadata(newFile, storageAccountResource);
         // Retrieve to build the complete FSItem
         FSItem fsItem = tableDao.retrieveById(dataset.getId(), fileId, 1, storageAccountResource);
+        // TODO - no longer read from fileService?
         workingMap.put(JobMapKeys.RESPONSE.getKeyName(), fileService.fileModelFromFSItem(fsItem));
       } catch (TableServiceException rex) {
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
@@ -69,7 +69,6 @@ public class IngestFileAzureFileStep implements Step {
         FSItem fsItem =
             tableDao.retrieveById(
                 dataset.getId(), fileId, 1, billingProfileModel, storageAccountResource);
-        // TODO - no longer read from fileService?
         workingMap.put(JobMapKeys.RESPONSE.getKeyName(), fileService.fileModelFromFSItem(fsItem));
       } catch (TableServiceException rex) {
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataStep.java
@@ -3,6 +3,7 @@ package bio.terra.service.filedata.flight.ingest;
 import static bio.terra.service.filedata.DrsService.getLastNameFromPath;
 
 import bio.terra.common.FlightUtils;
+import bio.terra.model.BillingProfileModel;
 import bio.terra.model.FileLoadModel;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
@@ -10,6 +11,7 @@ import bio.terra.service.filedata.FSFileInfo;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.flight.FileMapKeys;
 import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -37,6 +39,8 @@ public class IngestFileAzurePrimaryDataStep implements Step {
         context.getInputParameters().get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
 
     FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel billingProfileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
     Boolean loadComplete = workingMap.get(FileMapKeys.LOAD_COMPLETED, Boolean.class);
     if (loadComplete == null || !loadComplete) {
@@ -49,7 +53,9 @@ public class IngestFileAzurePrimaryDataStep implements Step {
         fsFileInfo =
             FSFileInfo.getTestInstance(fileId, storageAccountResource.getResourceId().toString());
       } else {
-        fsFileInfo = azureBlobStorePdao.copyFile(fileLoadModel, fileId, storageAccountResource);
+        fsFileInfo =
+            azureBlobStorePdao.copyFile(
+                billingProfileModel, fileLoadModel, fileId, storageAccountResource);
       }
       workingMap.put(FileMapKeys.FILE_INFO, fsFileInfo);
     }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataStep.java
@@ -39,11 +39,13 @@ public class IngestFileAzurePrimaryDataStep implements Step {
         context.getInputParameters().get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
 
     FlightMap workingMap = context.getWorkingMap();
-    BillingProfileModel billingProfileModel =
-        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+
     String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
     Boolean loadComplete = workingMap.get(FileMapKeys.LOAD_COMPLETED, Boolean.class);
     if (loadComplete == null || !loadComplete) {
+      BillingProfileModel billingProfileModel =
+          FlightUtils.getContextValue(
+              context, ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
       AzureStorageAccountResource storageAccountResource =
           FlightUtils.getContextValue(
               context, FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileValidateAzureBillingProfileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileValidateAzureBillingProfileStep.java
@@ -1,0 +1,53 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.model.CloudPlatform;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.exception.IngestFailureException;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+public class IngestFileValidateAzureBillingProfileStep implements Step {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(IngestFileValidateAzureBillingProfileStep.class);
+  private final UUID profileId;
+  private final Dataset dataset;
+
+  public IngestFileValidateAzureBillingProfileStep(UUID profileId,
+                                                   Dataset dataset) {
+    this.profileId = profileId;
+    this.dataset = dataset;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    var defaultBillingProfileId = dataset.getDefaultProfileId();
+    if (!defaultBillingProfileId.equals(profileId)) {
+      logger.warn(
+          "The billing profile in the ingest request ({}) does not match the default billing profile ({})",
+          profileId, defaultBillingProfileId);
+      IngestFailureException ex =
+          new IngestFailureException(
+              String.format(
+                  "Can't ingest files using a different billing profile %s than the Azure dataset %s.",
+                      profileId, defaultBillingProfileId));
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+    }
+
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // This step has no side effects
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileValidateAzureBillingProfileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileValidateAzureBillingProfileStep.java
@@ -1,17 +1,14 @@
 package bio.terra.service.filedata.flight.ingest;
 
-import bio.terra.common.CloudPlatformWrapper;
-import bio.terra.model.CloudPlatform;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.exception.IngestFailureException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.UUID;
 
 public class IngestFileValidateAzureBillingProfileStep implements Step {
 
@@ -20,8 +17,7 @@ public class IngestFileValidateAzureBillingProfileStep implements Step {
   private final UUID profileId;
   private final Dataset dataset;
 
-  public IngestFileValidateAzureBillingProfileStep(UUID profileId,
-                                                   Dataset dataset) {
+  public IngestFileValidateAzureBillingProfileStep(UUID profileId, Dataset dataset) {
     this.profileId = profileId;
     this.dataset = dataset;
   }
@@ -32,15 +28,15 @@ public class IngestFileValidateAzureBillingProfileStep implements Step {
     if (!defaultBillingProfileId.equals(profileId)) {
       logger.warn(
           "The billing profile in the ingest request ({}) does not match the default billing profile ({})",
-          profileId, defaultBillingProfileId);
+          profileId,
+          defaultBillingProfileId);
       IngestFailureException ex =
           new IngestFailureException(
               String.format(
                   "Can't ingest files using a different billing profile %s than the Azure dataset %s.",
-                      profileId, defaultBillingProfileId));
+                  profileId, defaultBillingProfileId));
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }
-
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/ValidateIngestFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/ValidateIngestFileAzureDirectoryStep.java
@@ -1,0 +1,70 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.model.FileLoadModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.exception.FileAlreadyExistsException;
+import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ValidateIngestFileAzureDirectoryStep implements Step {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ValidateIngestFileDirectoryStep.class);
+  public static final String CREATE_ENTRY_ACTION = "createEntry";
+  public static final String CHECK_ENTRY_ACTION = "checkEntry";
+
+  private final TableDao tableDao;
+  private final Dataset dataset;
+
+  public ValidateIngestFileAzureDirectoryStep(TableDao tableDao, Dataset dataset) {
+    this.tableDao = tableDao;
+    this.dataset = dataset;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap inputParameters = context.getInputParameters();
+    FileLoadModel loadModel =
+        inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
+
+    String targetPath = loadModel.getTargetPath();
+    FlightMap workingMap = context.getWorkingMap();
+
+    try {
+      //  1. If the directory entry does not exist, update INGEST_FILE_ACTION to createEntry
+      //  2. If the directory entry exists:
+      //      (a) If the loadTags do not match, then we throw FileAlreadyExistsException.
+      //      (b) Otherwise, update INGEST_FILE_ACTION to checkEntry
+      AzureStorageAccountResource storageAccountResource =
+          workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+      FireStoreDirectoryEntry existingEntry =
+          tableDao.lookupDirectoryEntryByPath(dataset, targetPath, storageAccountResource);
+      if (existingEntry == null) {
+        workingMap.put(FileMapKeys.INGEST_FILE_ACTION, CREATE_ENTRY_ACTION);
+      } else if (!existingEntry.getLoadTag().equals(loadModel.getLoadTag())) {
+        throw new FileAlreadyExistsException("Path already exists: " + targetPath);
+      } else {
+        workingMap.put(FileMapKeys.INGEST_FILE_ACTION, CHECK_ENTRY_ACTION);
+      }
+    } catch (FileSystemAbortTransactionException e) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/ValidateIngestFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/ValidateIngestFileAzureDirectoryStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata.flight.ingest;
 
+import bio.terra.common.FlightUtils;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.FileLoadModel;
 import bio.terra.service.dataset.Dataset;
@@ -44,9 +45,11 @@ public class ValidateIngestFileAzureDirectoryStep implements Step {
       //      (a) If the loadTags do not match, then we throw FileAlreadyExistsException.
       //      (b) Otherwise, update INGEST_FILE_ACTION to checkEntry
       BillingProfileModel billingProfileModel =
-          workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+          FlightUtils.getContextValue(
+              context, ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
       AzureStorageAccountResource storageAccountResource =
-          workingMap.get(FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
+          FlightUtils.getContextValue(
+              context, FileMapKeys.STORAGE_ACCOUNT_INFO, AzureStorageAccountResource.class);
       FireStoreDirectoryEntry existingEntry =
           tableDao.lookupDirectoryEntryByPath(
               dataset, targetPath, billingProfileModel, storageAccountResource);

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
@@ -509,7 +509,8 @@ public class FireStoreDirectoryDao {
             paths,
             path -> {
               DocumentReference docRef =
-                  datasetCollection.document(encodePathAsFirestoreDocumentName((String) path));
+                  datasetCollection.document(
+                          encodePathAsFirestoreDocumentName((String) path));
               return docRef.get();
             });
 

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
@@ -509,8 +509,7 @@ public class FireStoreDirectoryDao {
             paths,
             path -> {
               DocumentReference docRef =
-                  datasetCollection.document(
-                          encodePathAsFirestoreDocumentName((String) path));
+                  datasetCollection.document(encodePathAsFirestoreDocumentName((String) path));
               return docRef.get();
             });
 

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryEntry.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryEntry.java
@@ -210,10 +210,10 @@ public class FireStoreDirectoryEntry {
         .isFileRef((Boolean) entity.getProperty(IS_FILE_REF_FIELD_NAME))
         .path(entity.getProperty(PATH_FIELD_NAME).toString())
         .name(entity.getProperty(NAME_FIELD_NAME).toString())
-        .datasetId(entity.getProperty(DATASET_ID_FIELD_NAME).toString())
-        .fileCreatedDate(entity.getProperty(FILE_CREATED_DATE_FIELD_NAME).toString())
-        .checksumCrc32c(entity.getProperty(CHECKSUM_CRC32C_FIELD_NAME).toString())
-        .checksumMd5(entity.getProperty(CHECKSUM_MD5_FIELD_NAME).toString())
+        .datasetId((String) entity.getProperty(DATASET_ID_FIELD_NAME))
+        .fileCreatedDate((String) entity.getProperty(FILE_CREATED_DATE_FIELD_NAME))
+        .checksumCrc32c((String) entity.getProperty(CHECKSUM_CRC32C_FIELD_NAME))
+        .checksumMd5((String) entity.getProperty(CHECKSUM_MD5_FIELD_NAME))
         .size((Long) entity.getProperty(SIZE_FIELD_NAME));
   }
 

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFile.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFile.java
@@ -185,13 +185,13 @@ public class FireStoreFile {
     return new FireStoreFile()
         .fileId(entity.getProperty(FILE_ID_FIELD_NAME).toString())
         .mimeType(entity.getProperty(MIME_TYPE_FIELD_NAME).toString())
-        .description(entity.getProperty(DESCRIPTION_FIELD_NAME).toString())
+        .description((String) entity.getProperty(DESCRIPTION_FIELD_NAME))
         .bucketResourceId(entity.getProperty(BUCKET_RESOURCE_ID_FIELD_NAME).toString())
-        .loadTag(entity.getProperty(LOAD_TAG_FIELD_NAME).toString())
+        .loadTag((String) entity.getProperty(LOAD_TAG_FIELD_NAME))
         .fileCreatedDate(entity.getProperty(FILE_CREATED_DATE_FIELD_NAME).toString())
         .gspath(entity.getProperty(GS_PATH_FIELD_NAME).toString())
-        .checksumCrc32c(entity.getProperty(CHECKSUM_CRC32C_FIELD_NAME).toString())
-        .checksumMd5(entity.getProperty(CHECKSUM_MD5_FIELD_NAME).toString())
+        .checksumCrc32c((String) entity.getProperty(CHECKSUM_CRC32C_FIELD_NAME))
+        .checksumMd5((String) entity.getProperty(CHECKSUM_MD5_FIELD_NAME))
         .size((Long) entity.getProperty(SIZE_FIELD_NAME));
   }
 

--- a/src/main/java/bio/terra/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
+++ b/src/main/java/bio/terra/service/profile/flight/create/CreateProfileVerifyDeployedApplicationStep.java
@@ -6,12 +6,8 @@ import bio.terra.service.profile.ProfileService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CreateProfileVerifyDeployedApplicationStep implements Step {
-  private static final Logger logger =
-      LoggerFactory.getLogger(CreateProfileVerifyDeployedApplicationStep.class);
 
   private final ProfileService profileService;
   private final BillingProfileRequestModel request;

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -211,6 +211,20 @@ public class ResourceService {
   }
 
   /**
+   * Get all storage accounts for a dataset, regardless of billing profile
+   *
+   * @param dataset dataset to get storage account for
+   * @return Optional AzureStorageAccountResource
+   */
+  public List<AzureStorageAccountResource> getStorageAccountsForDataset(Dataset dataset) {
+    var storageAccountResourceIds =
+        datasetStorageAccountDao.getStorageAccountResourceIdForDatasetId(dataset.getId());
+    return storageAccountResourceIds.stream()
+        .map(this::lookupStorageAccount)
+        .collect(Collectors.toList());
+  }
+
+  /**
    * Delete the metadata and cloud storage account. Note: this will not check references and delete
    * the storage even if it contains data
    *

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -211,20 +211,6 @@ public class ResourceService {
   }
 
   /**
-   * Get all storage accounts for a dataset, regardless of billing profile
-   *
-   * @param dataset dataset to get storage account for
-   * @return Optional AzureStorageAccountResource
-   */
-  public List<AzureStorageAccountResource> getStorageAccountsForDataset(Dataset dataset) {
-    var storageAccountResourceIds =
-        datasetStorageAccountDao.getStorageAccountResourceIdForDatasetId(dataset.getId());
-    return storageAccountResourceIds.stream()
-        .map(this::lookupStorageAccount)
-        .collect(Collectors.toList());
-  }
-
-  /**
    * Delete the metadata and cloud storage account. Note: this will not check references and delete
    * the storage even if it contains data
    *

--- a/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
@@ -14,11 +14,13 @@ import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AzureStorageTablePdao {
-
+  private static final Logger logger = LoggerFactory.getLogger(AzureStorageTablePdao.class);
   private static final String LOAD_HISTORY_TABLE_NAME_SUFFIX = "LoadHistory";
 
   private static String computeInternalLoadTag(String loadTag) {
@@ -81,10 +83,10 @@ public class AzureStorageTablePdao {
     for (int i = 0; i < loadHistoryArray.size(); i++) {
       var isLast = i == loadHistoryArray.size() - 1;
       var thisIndex = i + indexToStartFrom;
+      BulkLoadHistoryModel historyEntry = loadHistoryArray.get(i);
       client.createEntity(
           bulkFileLoadModelToStorageTableEntity(
-              new StorageTableLoadHistoryEntity(
-                  loadHistoryArray.get(i), internalLoadTag, thisIndex, isLast),
+              new StorageTableLoadHistoryEntity(historyEntry, internalLoadTag, thisIndex, isLast),
               loadTag,
               loadTime));
     }
@@ -129,7 +131,7 @@ public class AzureStorageTablePdao {
   private static TableEntity bulkFileLoadModelToStorageTableEntity(
       StorageTableLoadHistoryEntity entity, String loadTag, Instant loadTime) {
     var model = entity.model;
-    return new TableEntity(entity.partitionKey, model.getFileId())
+    return new TableEntity(entity.partitionKey, UUID.randomUUID().toString())
         .addProperty(LoadHistoryUtil.LOAD_TAG_FIELD_NAME, loadTag)
         .addProperty(LoadHistoryUtil.LOAD_TIME_FIELD_NAME, loadTime)
         .addProperty(LoadHistoryUtil.SOURCE_NAME_FIELD_NAME, model.getSourcePath())

--- a/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class AzureStorageTablePdao {
   private static final Logger logger = LoggerFactory.getLogger(AzureStorageTablePdao.class);
-  private static final String LOAD_HISTORY_TABLE_NAME_SUFFIX = "LoadHistory";
+  private static final String LOAD_HISTORY_TABLE_NAME = "loadHistory";
 
   private static String computeInternalLoadTag(String loadTag) {
     return Base64.getEncoder().encodeToString(loadTag.getBytes(StandardCharsets.UTF_8));
@@ -31,8 +31,8 @@ public class AzureStorageTablePdao {
    * Store the results of a bulk file load in an Azure Storage Table
    *
    * <p>The table name will be the result of the dataset id passed through {@link
-   * AzureStorageTablePdao#toLoadHistoryTableNameFromUUID} Entities will be partitioned on the
-   * loadTag and their row keys will be the value of {@link BulkLoadHistoryModel#getFileId()}
+   * AzureStorageTablePdao#LOAD_HISTORY_TABLE_NAME} Entities will be partitioned on the loadTag and
+   * their row keys will be the value of {@link BulkLoadHistoryModel#getFileId()}
    *
    * @param serviceClient A service client for the dataset
    * @param datasetId the id of the dataset
@@ -49,11 +49,10 @@ public class AzureStorageTablePdao {
     if (loadHistoryArray.isEmpty()) {
       return;
     }
-    var tableName = toLoadHistoryTableNameFromUUID(datasetId);
-    TableClient client = serviceClient.createTableIfNotExists(tableName);
+    TableClient client = serviceClient.createTableIfNotExists(LOAD_HISTORY_TABLE_NAME);
     // if the table already exists, the returned client is null and we have to get it explicitly
     if (client == null) {
-      client = serviceClient.getTableClient(tableName);
+      client = serviceClient.getTableClient(LOAD_HISTORY_TABLE_NAME);
     }
 
     var internalLoadTag = computeInternalLoadTag(loadTag);
@@ -108,7 +107,7 @@ public class AzureStorageTablePdao {
       String loadTag,
       int offset,
       int limit) {
-    var tableClient = tableServiceClient.getTableClient(toLoadHistoryTableNameFromUUID(datasetId));
+    var tableClient = tableServiceClient.getTableClient(LOAD_HISTORY_TABLE_NAME);
     var internalLoadTag = computeInternalLoadTag(loadTag);
     ListEntitiesOptions options =
         new ListEntitiesOptions()
@@ -143,16 +142,6 @@ public class AzureStorageTablePdao {
         .addProperty(LoadHistoryUtil.ERROR_FIELD_NAME, model.getError())
         .addProperty(LoadHistoryUtil.INDEX_FIELD_NAME, entity.index)
         .addProperty(LoadHistoryUtil.IS_LAST_FIELD_NAME, entity.isLast);
-  }
-
-  /**
-   * Generate a Storage Table name from a UUID
-   *
-   * @param datasetId The datasetId root of the table name
-   * @return A valid azure storage table name with load history suffix.
-   */
-  private static String toLoadHistoryTableNameFromUUID(UUID datasetId) {
-    return "datarepo" + datasetId.toString().replaceAll("-", "") + LOAD_HISTORY_TABLE_NAME_SUFFIX;
   }
 
   private static class StorageTableLoadHistoryEntity {

--- a/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
@@ -31,8 +31,8 @@ public class AzureStorageTablePdao {
    * Store the results of a bulk file load in an Azure Storage Table
    *
    * <p>The table name will be the result of the dataset id passed through {@link
-   * AzureStorageTablePdao#toLoadHistoryTableNameFromUUID} Entities will be partitioned on the loadTag and
-   * their row keys will be the value of {@link BulkLoadHistoryModel#getFileId()}
+   * AzureStorageTablePdao#toLoadHistoryTableNameFromUUID} Entities will be partitioned on the
+   * loadTag and their row keys will be the value of {@link BulkLoadHistoryModel#getFileId()}
    *
    * @param serviceClient A service client for the dataset
    * @param datasetId the id of the dataset

--- a/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class StorageTableService {
-
   private final AzureStorageTablePdao storageTableDao;
   private final AzureAuthService azureAuthService;
   private final ResourceService resourceService;

--- a/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
@@ -4,7 +4,6 @@ import bio.terra.model.BulkLoadHistoryModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
-import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import com.azure.data.tables.TableServiceClient;
 import java.time.Instant;
 import java.util.List;
@@ -47,15 +46,7 @@ public class StorageTableService {
   public List<BulkLoadHistoryModel> getLoadHistory(
       Dataset dataset, String loadTag, int offset, int limit) {
     var billingProfile = dataset.getDatasetSummary().getDefaultBillingProfile();
-    var storageAccountResource =
-        resourceService
-            .getStorageAccount(dataset, billingProfile)
-            .orElseThrow(
-                () ->
-                    new CorruptMetadataException(
-                        String.format(
-                            "Expected storage account for Dataset/Billing Profile %s/%s",
-                            dataset.getId(), billingProfile.getId())));
+    var storageAccountResource = resourceService.getStorageAccount(dataset, billingProfile);
     TableServiceClient tableServiceClient =
         azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
 

--- a/src/test/java/bio/terra/common/AzureUtils.java
+++ b/src/test/java/bio/terra/common/AzureUtils.java
@@ -1,0 +1,39 @@
+package bio.terra.common;
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import com.azure.resourcemanager.AzureResourceManager;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AzureUtils {
+
+  @Autowired AzureResourceConfiguration azureResourceConfiguration;
+  @Autowired ConnectedTestConfiguration testConfiguration;
+
+  public String getSourceStorageAccountPrimarySharedKey(
+      UUID targetTenantId,
+      UUID targetSubscriptionId,
+      String targetResourceGroupName,
+      String sourceStorageAccountName) {
+    AzureResourceManager client =
+        azureResourceConfiguration.getClient(targetTenantId, targetSubscriptionId);
+    return client
+        .storageAccounts()
+        .getByResourceGroup(targetResourceGroupName, sourceStorageAccountName)
+        .getKeys()
+        .iterator()
+        .next()
+        .value();
+  }
+
+  public String getSourceStorageAccountPrimarySharedKey() {
+    return getSourceStorageAccountPrimarySharedKey(
+        testConfiguration.getTargetTenantId(),
+        testConfiguration.getTargetSubscriptionId(),
+        testConfiguration.getTargetResourceGroupName(),
+        testConfiguration.getSourceStorageAccountName());
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
@@ -214,7 +214,8 @@ public class DatasetAzureIntegrationTest extends UsersBase {
 
     // Create and delete a dataset and make sure that the profile still can't be deleted
     DatasetSummaryModel summaryModel2 =
-        dataRepoFixtures.createDataset(steward, profileId, "it-dataset-omop.json");
+        dataRepoFixtures.createDataset(
+            steward, profileId, "it-dataset-omop.json", CloudPlatform.AZURE);
     dataRepoFixtures.deleteDataset(steward, summaryModel2.getId());
     assertThat(
         "Original dataset is still there",

--- a/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
@@ -336,11 +336,17 @@ public class DatasetAzureIntegrationTest extends UsersBase {
 
     // Delete the file we just ingested
     String fileId = result.getLoadFileResults().get(0).getFileId();
+    String filePath = result.getLoadFileResults().get(0).getTargetPath();
     dataRepoFixtures.deleteFile(steward, datasetId, fileId);
 
     assertThat(
         "file is gone",
         dataRepoFixtures.getFileByIdRaw(steward, datasetId, fileId).getStatusCode(),
+        equalTo(HttpStatus.NOT_FOUND));
+
+    assertThat(
+        "file is gone",
+        dataRepoFixtures.getFileByNameRaw(steward, datasetId, filePath).getStatusCode(),
         equalTo(HttpStatus.NOT_FOUND));
 
     // Make sure that any failure in tearing down is presented as a test failure

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -1,0 +1,193 @@
+package bio.terra.service.filedata.azure;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.SynapseUtils;
+import bio.terra.common.category.Connected;
+import bio.terra.common.fixtures.ConnectedOperations;
+import bio.terra.common.fixtures.Names;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.FileLoadModel;
+import bio.terra.model.FileModel;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.FSFileInfo;
+import bio.terra.service.filedata.FSItem;
+import bio.terra.service.filedata.FileMetadataUtils;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.azure.tables.TableDirectoryDao;
+import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
+import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.iam.IamProviderInterface;
+import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
+import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import com.azure.data.tables.TableServiceClient;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Category(Connected.class)
+public class AzureIngestFileConnectedTest {
+  private static final String MANAGED_RESOURCE_GROUP_NAME = "mrg-tdr-dev-preview-20210802154510";
+  private static final String STORAGE_ACCOUNT_NAME = "tdrshiqauwlpzxavohmxxhfv";
+
+  private UUID applicationId;
+  private UUID storageAccountId;
+  private UUID datasetId;
+  private String targetPath;
+
+  private AzureApplicationDeploymentResource applicationResource;
+  private AzureStorageAccountResource storageAccountResource;
+  private BillingProfileModel billingProfile;
+  private FileLoadModel fileLoadModel;
+
+  @Autowired AzureSynapsePdao azureSynapsePdao;
+  @Autowired ConnectedOperations connectedOperations;
+  @Autowired private ConnectedTestConfiguration testConfig;
+  @Autowired DatasetService datasetService;
+  @MockBean private IamProviderInterface samService;
+  @Autowired SynapseUtils synapseUtils;
+  @Autowired AzureAuthService azureAuthService;
+  @Autowired TableDirectoryDao tableDirectoryDao;
+  @Autowired FileMetadataUtils fileMetadataUtils;
+  @Autowired TableDao tableDao;
+  @Autowired AzureBlobStorePdao azureBlobStorePdao;
+  @Autowired FileService fileService;
+
+  @Before
+  public void setup() throws Exception {
+    connectedOperations.stubOutSamCalls(samService);
+    applicationId = UUID.randomUUID();
+    storageAccountId = UUID.randomUUID();
+    datasetId = UUID.randomUUID();
+
+    billingProfile =
+        new BillingProfileModel()
+            .id(UUID.randomUUID())
+            .profileName(Names.randomizeName("somename"))
+            .biller("direct")
+            .billingAccountId(testConfig.getGoogleBillingAccountId())
+            .description("random description")
+            .cloudPlatform(CloudPlatform.AZURE)
+            .tenantId(testConfig.getTargetTenantId())
+            .subscriptionId(testConfig.getTargetSubscriptionId())
+            .resourceGroupName(testConfig.getTargetResourceGroupName())
+            .applicationDeploymentName(testConfig.getTargetApplicationName());
+
+    applicationResource =
+        new AzureApplicationDeploymentResource()
+            .id(applicationId)
+            .azureApplicationDeploymentName(testConfig.getTargetApplicationName())
+            .azureResourceGroupName(MANAGED_RESOURCE_GROUP_NAME)
+            .profileId(billingProfile.getId());
+    storageAccountResource =
+        new AzureStorageAccountResource()
+            .resourceId(storageAccountId)
+            .name(STORAGE_ACCOUNT_NAME)
+            .applicationResource(applicationResource)
+            .metadataContainer("metadata")
+            .dataContainer("data");
+
+    String exampleAzureFileToIngest =
+        synapseUtils.ingestRequestURL(
+            testConfig.getSourceStorageAccountName(),
+            testConfig.getIngestRequestContainer(),
+            "azure-simple-dataset-ingest-request.json");
+
+    targetPath = "/test/path/file.json";
+    fileLoadModel =
+        new FileLoadModel()
+            .sourcePath(exampleAzureFileToIngest)
+            .profileId(billingProfile.getId())
+            .description("test example file azure load")
+            .mimeType("application/json")
+            .targetPath(targetPath)
+            .loadTag(Names.randomizeName("loadTag"));
+  }
+
+  @After
+  public void cleanup() throws Exception {
+
+    connectedOperations.teardown();
+  }
+
+  @Test
+  public void testStorageTableMetadataDuringFileIngest() {
+    // 0 - IngestFileIdStep
+    String fileId = UUID.randomUUID().toString();
+    // 1 - IngestFileAzurePrimaryDataLocationStep
+    // define storage account (this is already defined in the test setup)
+    // 2 - IngestFileAzureMakeStorageAccountLinkStep
+    // make database entry to link storage account and storage account
+
+    // 3 - ValidateIngestFileAzureDirectoryStep
+    // Check if directory already exists - it should not yet
+
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
+    FireStoreDirectoryEntry de =
+        tableDirectoryDao.retrieveByPath(tableServiceClient, datasetId.toString(), targetPath);
+    assertThat("directory should not yet exist.", de, equalTo(null));
+
+    // 4 - IngestFileAzureDirectoryStep // TODO - test other cases
+    // Testing case 1 - Directory entry doesn't exist and needs to be created
+    // (1) Not there - create it
+    FireStoreDirectoryEntry newEntry =
+        new FireStoreDirectoryEntry()
+            .fileId(fileId)
+            .isFileRef(true)
+            .path(fileMetadataUtils.getDirectoryPath(targetPath))
+            .name(fileMetadataUtils.getName(targetPath))
+            .datasetId(datasetId.toString())
+            .loadTag(fileLoadModel.getLoadTag());
+    tableDao.createDirectoryEntry(newEntry, billingProfile, storageAccountResource);
+    // test that directory entry now exists
+    FireStoreDirectoryEntry de_after =
+        tableDirectoryDao.retrieveByPath(tableServiceClient, datasetId.toString(), targetPath);
+    assertThat("FireStoreDirectoryEntry should now exist", de_after, equalTo(newEntry));
+
+    // 5 - IngestFileAzurePrimaryDataStep
+    FSFileInfo fsFileInfo =
+        azureBlobStorePdao.copyFile(billingProfile, fileLoadModel, fileId, storageAccountResource);
+
+    // 6 - IngestFileAzureFileStep
+    FireStoreFile newFile =
+        new FireStoreFile()
+            .fileId(fileId)
+            .mimeType(fileLoadModel.getMimeType())
+            .description(fileLoadModel.getDescription())
+            .bucketResourceId(fsFileInfo.getBucketResourceId())
+            .fileCreatedDate(fsFileInfo.getCreatedDate())
+            .gspath(fsFileInfo.getCloudPath())
+            .checksumCrc32c(fsFileInfo.getChecksumCrc32c())
+            .checksumMd5(fsFileInfo.getChecksumMd5())
+            .size(fsFileInfo.getSize())
+            .loadTag(fileLoadModel.getLoadTag());
+
+    tableDao.createFileMetadata(newFile, billingProfile, storageAccountResource);
+    // Retrieve to build the complete FSItem
+    FSItem fsItem =
+        tableDao.retrieveById(datasetId, fileId, 1, billingProfile, storageAccountResource);
+    FileModel resultingFileModel = fileService.fileModelFromFSItem(fsItem);
+    assertThat(
+        "file model contains correct info.", resultingFileModel.getFileId(), equalTo(fileId));
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -132,7 +132,8 @@ public class AzureBlobStorePdaoTest {
     FSFileInfo expectedFileInfo = mockFileCopy(fileId);
 
     FSFileInfo fsFileInfo =
-        dao.copyFile(fileLoadModel, fileId.toString(), AZURE_STORAGE_ACCOUNT_RESOURCE);
+        dao.copyFile(
+            BILLING_PROFILE, fileLoadModel, fileId.toString(), AZURE_STORAGE_ACCOUNT_RESOURCE);
     assertThat("output is expected", fsFileInfo, samePropertyValuesAs(expectedFileInfo));
   }
 
@@ -147,7 +148,8 @@ public class AzureBlobStorePdaoTest {
     FSFileInfo expectedFileInfo = mockFileCopy(fileId);
 
     FSFileInfo fsFileInfo =
-        dao.copyFile(fileLoadModel, fileId.toString(), AZURE_STORAGE_ACCOUNT_RESOURCE);
+        dao.copyFile(
+            BILLING_PROFILE, fileLoadModel, fileId.toString(), AZURE_STORAGE_ACCOUNT_RESOURCE);
     assertThat("output is expected", fsFileInfo, samePropertyValuesAs(expectedFileInfo));
   }
 

--- a/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
@@ -1,0 +1,154 @@
+package bio.terra.service.filedata.azure.tables;
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.SynapseUtils;
+import bio.terra.common.category.Connected;
+import bio.terra.common.fixtures.ConnectedOperations;
+import bio.terra.common.fixtures.Names;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.BulkLoadFileState;
+import bio.terra.model.BulkLoadHistoryModel;
+import bio.terra.model.CloudPlatform;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.FileMetadataUtils;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.azure.AzureSynapsePdao;
+import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.iam.IamProviderInterface;
+import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
+import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.tabulardata.azure.AzureStorageTablePdao;
+import com.azure.data.tables.TableServiceClient;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Category(Connected.class)
+public class LoadHistoryStorageTableConnectedTest {
+  private static final String MANAGED_RESOURCE_GROUP_NAME = "mrg-tdr-dev-preview-20210802154510";
+  private static final String STORAGE_ACCOUNT_NAME = "tdrshiqauwlpzxavohmxxhfv";
+
+  private UUID applicationId;
+  private UUID storageAccountId;
+  private UUID datasetId;
+
+  private AzureApplicationDeploymentResource applicationResource;
+  private AzureStorageAccountResource storageAccountResource;
+  private BillingProfileModel billingProfile;
+
+  @Autowired AzureSynapsePdao azureSynapsePdao;
+  @Autowired ConnectedOperations connectedOperations;
+  @Autowired private ConnectedTestConfiguration testConfig;
+  @Autowired DatasetService datasetService;
+  @MockBean private IamProviderInterface samService;
+  @Autowired SynapseUtils synapseUtils;
+  @Autowired AzureAuthService azureAuthService;
+  @Autowired TableDirectoryDao tableDirectoryDao;
+  @Autowired FileMetadataUtils fileMetadataUtils;
+  @Autowired TableDao tableDao;
+  @Autowired AzureBlobStorePdao azureBlobStorePdao;
+  @Autowired FileService fileService;
+  @Autowired AzureStorageTablePdao storageTableDao;
+
+  @Before
+  public void setup() throws Exception {
+    connectedOperations.stubOutSamCalls(samService);
+    applicationId = UUID.randomUUID();
+    storageAccountId = UUID.randomUUID();
+    datasetId = UUID.randomUUID();
+
+    billingProfile =
+        new BillingProfileModel()
+            .id(UUID.randomUUID())
+            .profileName(Names.randomizeName("somename"))
+            .biller("direct")
+            .billingAccountId(testConfig.getGoogleBillingAccountId())
+            .description("random description")
+            .cloudPlatform(CloudPlatform.AZURE)
+            .tenantId(testConfig.getTargetTenantId())
+            .subscriptionId(testConfig.getTargetSubscriptionId())
+            .resourceGroupName(testConfig.getTargetResourceGroupName())
+            .applicationDeploymentName(testConfig.getTargetApplicationName());
+
+    applicationResource =
+        new AzureApplicationDeploymentResource()
+            .id(applicationId)
+            .azureApplicationDeploymentName(testConfig.getTargetApplicationName())
+            .azureResourceGroupName(MANAGED_RESOURCE_GROUP_NAME)
+            .profileId(billingProfile.getId());
+    storageAccountResource =
+        new AzureStorageAccountResource()
+            .resourceId(storageAccountId)
+            .name(STORAGE_ACCOUNT_NAME)
+            .applicationResource(applicationResource)
+            .metadataContainer("metadata")
+            .dataContainer("data");
+  }
+
+  @After
+  public void cleanup() throws Exception {
+
+    connectedOperations.teardown();
+  }
+
+  @Test
+  public void testStorageTableMetadataDuringFileIngest() {
+    String loadTag = UUID.randomUUID().toString();
+    TableServiceClient serviceClient =
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
+    List<BulkLoadHistoryModel> loadHistoryArray = new ArrayList<>();
+    loadHistoryArray.add(
+        new BulkLoadHistoryModel()
+            .state(BulkLoadFileState.SUCCEEDED)
+            .fileId(UUID.randomUUID().toString())
+            .checksumCRC("CRCTEST")
+            .checksumMD5("MD5TEST")
+            .sourcePath("/source/path.json")
+            .targetPath("/target/path.json"));
+    loadHistoryArray.add(
+        new BulkLoadHistoryModel()
+            .state(BulkLoadFileState.FAILED)
+            .sourcePath("/source/path.json")
+            .targetPath("/target/path.json"));
+
+    storageTableDao.storeLoadHistory(
+        serviceClient, datasetId, loadTag, Instant.now(), loadHistoryArray);
+
+    //    List<BulkLoadHistoryModel> resultingLoadHistory =
+    // storageTableDao.getLoadHistory(serviceClient, datasetId, loadTag, 0, 2);
+    //    resultingLoadHistory.get(0
+  }
+
+  @Test
+  public void testFailedFileIngestStorageTableMetadata() {
+    String loadTag = UUID.randomUUID().toString();
+    TableServiceClient serviceClient =
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
+    List<BulkLoadHistoryModel> loadHistoryArray = new ArrayList<>();
+    loadHistoryArray.add(
+        new BulkLoadHistoryModel()
+            .state(BulkLoadFileState.FAILED)
+            .sourcePath("/source/path.json")
+            .targetPath("/target/path.json"));
+
+    storageTableDao.storeLoadHistory(
+        serviceClient, datasetId, loadTag, Instant.now(), loadHistoryArray);
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
@@ -104,7 +104,7 @@ public class LoadHistoryStorageTableConnectedTest {
 
   @After
   public void cleanup() throws Exception {
-
+    // TODO - clean up the load history table
     connectedOperations.teardown();
   }
 
@@ -128,8 +128,12 @@ public class LoadHistoryStorageTableConnectedTest {
             .sourcePath("/source/path.json")
             .targetPath("/target/path.json"));
 
+    // TODO Test the other two states
+
     storageTableDao.storeLoadHistory(
         serviceClient, datasetId, loadTag, Instant.now(), loadHistoryArray);
+
+    // TODO - confirm the results
 
     //    List<BulkLoadHistoryModel> resultingLoadHistory =
     // storageTableDao.getLoadHistory(serviceClient, datasetId, loadTag, 0, 2);

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
@@ -1,0 +1,150 @@
+package bio.terra.service.filedata.azure.tables;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.SynapseUtils;
+import bio.terra.common.category.Connected;
+import bio.terra.common.fixtures.ConnectedOperations;
+import bio.terra.common.fixtures.Names;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.CloudPlatform;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.FileMetadataUtils;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.azure.AzureSynapsePdao;
+import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
+import bio.terra.service.iam.IamProviderInterface;
+import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
+import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import com.azure.data.tables.TableServiceClient;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Category(Connected.class)
+public class TableDirectoryDaoConnectedTest {
+  private static final String MANAGED_RESOURCE_GROUP_NAME = "mrg-tdr-dev-preview-20210802154510";
+  private static final String STORAGE_ACCOUNT_NAME = "tdrshiqauwlpzxavohmxxhfv";
+
+  private UUID applicationId;
+  private UUID storageAccountId;
+  private UUID datasetId;
+
+  private AzureApplicationDeploymentResource applicationResource;
+  private AzureStorageAccountResource storageAccountResource;
+  private BillingProfileModel billingProfile;
+  private TableServiceClient tableServiceClient;
+
+  @Autowired AzureSynapsePdao azureSynapsePdao;
+  @Autowired ConnectedOperations connectedOperations;
+  @Autowired private ConnectedTestConfiguration testConfig;
+  @Autowired DatasetService datasetService;
+  @MockBean private IamProviderInterface samService;
+  @Autowired SynapseUtils synapseUtils;
+  @Autowired AzureAuthService azureAuthService;
+  @Autowired TableDirectoryDao tableDirectoryDao;
+  @Autowired FileMetadataUtils fileMetadataUtils;
+  @Autowired TableDao tableDao;
+  @Autowired AzureBlobStorePdao azureBlobStorePdao;
+  @Autowired FileService fileService;
+
+  @Before
+  public void setup() throws Exception {
+    connectedOperations.stubOutSamCalls(samService);
+    applicationId = UUID.randomUUID();
+    storageAccountId = UUID.randomUUID();
+    datasetId = UUID.randomUUID();
+
+    billingProfile =
+        new BillingProfileModel()
+            .id(UUID.randomUUID())
+            .profileName(Names.randomizeName("somename"))
+            .biller("direct")
+            .billingAccountId(testConfig.getGoogleBillingAccountId())
+            .description("random description")
+            .cloudPlatform(CloudPlatform.AZURE)
+            .tenantId(testConfig.getTargetTenantId())
+            .subscriptionId(testConfig.getTargetSubscriptionId())
+            .resourceGroupName(testConfig.getTargetResourceGroupName())
+            .applicationDeploymentName(testConfig.getTargetApplicationName());
+
+    applicationResource =
+        new AzureApplicationDeploymentResource()
+            .id(applicationId)
+            .azureApplicationDeploymentName(testConfig.getTargetApplicationName())
+            .azureResourceGroupName(MANAGED_RESOURCE_GROUP_NAME)
+            .profileId(billingProfile.getId());
+    storageAccountResource =
+        new AzureStorageAccountResource()
+            .resourceId(storageAccountId)
+            .name(STORAGE_ACCOUNT_NAME)
+            .applicationResource(applicationResource)
+            .metadataContainer("metadata")
+            .dataContainer("data");
+
+    tableServiceClient =
+        azureAuthService.getTableServiceClient(billingProfile, storageAccountResource);
+  }
+
+  @After
+  public void cleanup() throws Exception {
+
+    connectedOperations.teardown();
+  }
+
+  @Test
+  public void testStorageTableMetadataDuringFileIngest() {
+    // Test re-using same directory path, but for different files
+    String sharedTargetPath = "/test/path/";
+    String fileName1 = "file1.json";
+    var fileEntry1 = createStorageTableEntrySharedBasePath(sharedTargetPath, fileName1);
+    String fileName2 = "file2.json";
+    var fileEntry2 = createStorageTableEntrySharedBasePath(sharedTargetPath, fileName2);
+
+    assertThat(
+        "FireStoreDirectoryEntry should now exist",
+        fileEntry1.getPath(),
+        equalTo(fileMetadataUtils.getDirectoryPath(sharedTargetPath + fileName1)));
+    assertThat(
+        "FireStoreDirectoryEntry should now exist",
+        fileEntry2.getPath(),
+        equalTo(fileMetadataUtils.getDirectoryPath(sharedTargetPath + fileName2)));
+  }
+
+  private FireStoreDirectoryEntry createStorageTableEntrySharedBasePath(
+      String sharedTargetPath, String fileName) {
+    UUID fileId = UUID.randomUUID();
+    String loadTag = Names.randomizeName("loadTag");
+
+    FireStoreDirectoryEntry newEntry =
+        new FireStoreDirectoryEntry()
+            .fileId(fileId.toString())
+            .isFileRef(true)
+            .path(fileMetadataUtils.getDirectoryPath(sharedTargetPath + fileName))
+            .name(fileMetadataUtils.getName(sharedTargetPath + fileName))
+            .datasetId(datasetId.toString())
+            .loadTag(loadTag);
+    tableDao.createDirectoryEntry(newEntry, billingProfile, storageAccountResource);
+
+    // test that directory entry now exists
+    return tableDirectoryDao.retrieveByPath(
+        tableServiceClient, datasetId.toString(), sharedTargetPath + fileName);
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
@@ -210,7 +210,6 @@ public class TableDirectoryDaoConnectedTest {
     String tableName = Names.randomizeName("testTable123").replaceAll("_", "");
     TableClient tableClient = tableServiceClient.getTableClient(tableName);
 
-    // Should throw TableServiceException
     boolean tableExists = TableServiceClientUtils.tableExists(tableServiceClient, tableName);
     assertThat("table should not exist", tableExists, equalTo(false));
 

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
@@ -15,6 +15,7 @@ import com.azure.core.http.rest.PagedIterable;
 import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.models.TableEntity;
+import com.azure.data.tables.models.TableItem;
 import com.azure.data.tables.models.TableServiceException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Iterator;
@@ -58,6 +59,14 @@ public class TableDirectoryDaoTest {
     dao = spy(dao);
     when(authService.getTableServiceClient(any(), any())).thenReturn(tableServiceClient);
     when(tableServiceClient.getTableClient(any())).thenReturn(tableClient);
+
+    // Mock table exists check
+    PagedIterable<TableItem> mockTablesIterable = mock(PagedIterable.class);
+    TableItem table = mock(TableItem.class);
+    when(table.getName()).thenReturn("dataset");
+    when(mockTablesIterable.stream()).thenReturn(Stream.of(table));
+    when(tableServiceClient.listTables()).thenReturn(mockTablesIterable);
+
     entity =
         new TableEntity(PARTITION_KEY, ROW_KEY)
             .addProperty(FireStoreDirectoryEntry.FILE_ID_FIELD_NAME, FILE_ID)
@@ -103,7 +112,6 @@ public class TableDirectoryDaoTest {
 
   @Test
   public void testRetrieveByFileIdNotFound() {
-    when(TableServiceClientUtils.tableExists(any(), any())).thenReturn(true);
     PagedIterable<TableEntity> mockPagedIterable = mock(PagedIterable.class);
     Iterator<TableEntity> mockIterator = mock(Iterator.class);
     when(mockIterator.hasNext()).thenReturn(false);

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
@@ -103,6 +103,7 @@ public class TableDirectoryDaoTest {
 
   @Test
   public void testRetrieveByFileIdNotFound() {
+    when(TableServiceClientUtils.tableExists(any(), any())).thenReturn(true);
     PagedIterable<TableEntity> mockPagedIterable = mock(PagedIterable.class);
     Iterator<TableEntity> mockIterator = mock(Iterator.class);
     when(mockIterator.hasNext()).thenReturn(false);

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
@@ -62,10 +62,10 @@ public class TableDirectoryDaoTest {
 
     // Mock table exists check
     PagedIterable<TableItem> mockTablesIterable = mock(PagedIterable.class);
-    TableItem table = mock(TableItem.class);
-    when(table.getName()).thenReturn("dataset");
-    when(mockTablesIterable.stream()).thenReturn(Stream.of(table));
-    when(tableServiceClient.listTables()).thenReturn(mockTablesIterable);
+    Iterator<TableItem> mockTableIterator = mock(Iterator.class);
+    when(mockTableIterator.hasNext()).thenReturn(true, false);
+    when(mockTablesIterable.iterator()).thenReturn(mockTableIterator);
+    when(tableServiceClient.listTables(any(), any(), any())).thenReturn(mockTablesIterable);
 
     entity =
         new TableEntity(PARTITION_KEY, ROW_KEY)

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
 import bio.terra.service.filedata.google.firestore.FireStoreFile;
-import bio.terra.service.resourcemanagement.azure.AzureAuthService;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.data.tables.TableServiceClient;
@@ -34,7 +33,6 @@ public class TableFileConnectedTest {
 
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;
   @Autowired private ConnectedTestConfiguration connectedTestConfiguration;
-  @Autowired private AzureAuthService azureAuthService;
   @Autowired private TableFileDao tableFileDao;
   private TableServiceClient tableServiceClient;
 

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.AzureUtils;
 import bio.terra.common.category.Connected;
 import bio.terra.service.filedata.google.firestore.FireStoreFile;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
@@ -12,7 +13,6 @@ import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.TableServiceClientBuilder;
 import com.azure.data.tables.models.TableEntity;
-import com.azure.resourcemanager.AzureResourceManager;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +34,7 @@ public class TableFileConnectedTest {
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;
   @Autowired private ConnectedTestConfiguration connectedTestConfiguration;
   @Autowired private TableFileDao tableFileDao;
+  @Autowired AzureUtils azureUtils;
   private TableServiceClient tableServiceClient;
 
   private static final String PARTITION_KEY = "partitionKey";
@@ -58,7 +59,7 @@ public class TableFileConnectedTest {
             .credential(
                 new AzureNamedKeyCredential(
                     connectedTestConfiguration.getSourceStorageAccountName(),
-                    getSourceStorageAccountPrimarySharedKey()))
+                    azureUtils.getSourceStorageAccountPrimarySharedKey()))
             .endpoint(
                 "https://"
                     + connectedTestConfiguration.getSourceStorageAccountName()
@@ -80,22 +81,5 @@ public class TableFileConnectedTest {
     // Try to delete the entry again
     boolean isNotDeleted = tableFileDao.deleteFileMetadata(tableServiceClient, FILE_ID);
     assertFalse("File record was already deleted", isNotDeleted);
-  }
-
-  private String getSourceStorageAccountPrimarySharedKey() {
-    AzureResourceManager client =
-        azureResourceConfiguration.getClient(
-            connectedTestConfiguration.getTargetTenantId(),
-            connectedTestConfiguration.getTargetSubscriptionId());
-
-    return client
-        .storageAccounts()
-        .getByResourceGroup(
-            connectedTestConfiguration.getTargetResourceGroupName(),
-            connectedTestConfiguration.getSourceStorageAccountName())
-        .getKeys()
-        .iterator()
-        .next()
-        .value();
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
@@ -120,15 +120,10 @@ public class AzureResourceConfigurationTest {
                 client.storageAccounts().getById(storageAccount.id());
               } catch (ManagementException e) {
                 logger.info("Expected error:", e);
-                assertThat(e.getValue().getCode(), equalTo("ResourceNotFound"));
                 assertThat(
                     "Deleted storage account isn't found",
                     e.getMessage(),
-                    containsString(
-                        String.format(
-                            "The Resource 'Microsoft.Storage/storageAccounts/%s' under resource "
-                                + "group '%s' was not found.",
-                            storageAccount.name(), storageAccount.resourceGroupName())));
+                    containsString("Status code 404"));
               }
             });
   }


### PR DESCRIPTION
Places to update:
- [x] File ingest flight
- [x] Dataset delete flight
- [x]  File delete flight
- [x] Endpoints that look up file metadata (right now the file ingest flight successfully writes the file metadata records in Azure, but the`fileService` still looks in Firestore)  [Q from Shelby: This is just to support lookupFileByPath() and lookupFileById() endpoints, right? The only fileservice method that appears to be used by the ingest flight is FIleService.fileModelFromFSItem(), which doesn't actually look anything up in firestore, right?]
- [x] File ingest bulk Flight
- [x] File Ingest Worker Flight

Load history table fix - It needs to be able to handle failed ingest files. When a file ingest fails, a file_id is not generated. So, we could only use the file id as the row key sometimes. I'm proposing the to use a random UUID as the row key instead. 
![image](https://user-images.githubusercontent.com/13254229/130499877-43b124f6-1b7d-4b33-87f1-54c881156dca.png)

Follow-on ticket:
- https://broadworkbench.atlassian.net/browse/DR-2051