### PR TITLE
DR-2061 Limit dataset ingest on number of files not numebr of lines

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestParseJsonFileStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestParseJsonFileStep.java
@@ -47,8 +47,6 @@ public class IngestParseJsonFileStep implements Step {
     List<String> gcsFileLines =
         gcsPdao.getGcsFilesLines(
             ingestRequest.getPath(), dataset.getProjectResource().getGoogleProjectId());
-    IngestUtils.checkForLargeIngestRequests(
-        gcsFileLines.size(), applicationConfiguration.getMaxDatasetIngest());
     List<String> fileRefColumnNames =
         dataset.getTableByName(ingestRequest.getTable()).orElseThrow().getColumns().stream()
             .filter(c -> c.getType() == TableDataType.FILEREF)
@@ -97,6 +95,9 @@ public class IngestParseJsonFileStep implements Step {
                             })
                         .filter(Objects::nonNull))
             .collect(Collectors.toSet());
+
+    IngestUtils.checkForLargeIngestRequests(
+        bulkLoadFileModels.size(), applicationConfiguration.getMaxDatasetIngest());
 
     workingMap.put(IngestMapKeys.BULK_LOAD_FILE_MODELS, bulkLoadFileModels);
 


### PR DESCRIPTION
We made a small error in limiting dataset combined ingest on the number of lines in the ingest control file. We wanted to limit on the number of actual file ingests specified in the control file. 