### PR TITLE
Remove sibling $ref elements as they are ignored

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2602,10 +2602,8 @@ components:
           $ref: '#/components/schemas/CloudPlatform'
         tenantId:
           $ref: '#/components/schemas/UniqueIdProperty'
-          description: An optional tenant id for Azure
         subscriptionId:
           $ref: '#/components/schemas/UniqueIdProperty'
-          description: an optional subscription id for Azure
         resourceGroupName:
           type: string
           description: an optional resource group name for Azure
@@ -2649,10 +2647,8 @@ components:
           $ref: '#/components/schemas/CloudPlatform'
         tenantId:
           $ref: '#/components/schemas/UniqueIdProperty'
-          description: An optional tenant id for Azure
         subscriptionId:
           $ref: '#/components/schemas/UniqueIdProperty'
-          description: an optional subscription id for Azure
         resourceGroupName:
           type: string
           description: an optional resource group name for Azure


### PR DESCRIPTION
I noticed that some of our `$ref` elements have sibling elements. These are ignored and show up in intellij as warnings, so I removed them. See https://swagger.io/docs/specification/using-ref/