### PR TITLE
Fix Row Key in Azure Storage Tables Load History

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
@@ -21,8 +21,8 @@ public class AzureStorageTablePdao {
 
   private static final String LOAD_HISTORY_TABLE_NAME_SUFFIX = "LoadHistory";
 
-  private static String computeInternalLoadTag(String loadTag) {
-    return Base64.getEncoder().encodeToString(loadTag.getBytes(StandardCharsets.UTF_8));
+  private static String computeSafeKey(String unsafeString) {
+    return Base64.getEncoder().encodeToString(unsafeString.getBytes(StandardCharsets.UTF_8));
   }
 
   /**
@@ -54,7 +54,7 @@ public class AzureStorageTablePdao {
       client = serviceClient.getTableClient(tableName);
     }
 
-    var internalLoadTag = computeInternalLoadTag(loadTag);
+    var internalLoadTag = computeSafeKey(loadTag);
 
     ListEntitiesOptions options =
         new ListEntitiesOptions()
@@ -107,7 +107,7 @@ public class AzureStorageTablePdao {
       int offset,
       int limit) {
     var tableClient = tableServiceClient.getTableClient(toLoadHistoryTableNameFromUUID(datasetId));
-    var internalLoadTag = computeInternalLoadTag(loadTag);
+    var internalLoadTag = computeSafeKey(loadTag);
     ListEntitiesOptions options =
         new ListEntitiesOptions()
             .setTop(limit)
@@ -129,7 +129,7 @@ public class AzureStorageTablePdao {
   private static TableEntity bulkFileLoadModelToStorageTableEntity(
       StorageTableLoadHistoryEntity entity, String loadTag, Instant loadTime) {
     var model = entity.model;
-    return new TableEntity(entity.partitionKey, model.getFileId())
+    return new TableEntity(entity.partitionKey, computeSafeKey(model.getTargetPath()))
         .addProperty(LoadHistoryUtil.LOAD_TAG_FIELD_NAME, loadTag)
         .addProperty(LoadHistoryUtil.LOAD_TIME_FIELD_NAME, loadTime)
         .addProperty(LoadHistoryUtil.SOURCE_NAME_FIELD_NAME, model.getSourcePath())

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -301,7 +301,9 @@ public class BigQueryPdao {
       "SELECT * "
           + "FROM `<project>.<dataset>.<loadTable>` L "
           + "WHERE L.load_tag = @loadTag "
-          + String.format("ORDER BY %s ASC ", LoadHistoryUtil.FILE_ID_FIELD_NAME)
+          + String.format(
+              "ORDER BY TO_BASE64(CAST('%s' as BYTES)) ASC ",
+              LoadHistoryUtil.TARGET_PATH_FIELD_NAME)
           + "LIMIT <limit> "
           + "OFFSET <offset> ";
 


### PR DESCRIPTION
The previously-used `fileId` can be null if a load fails, so we need to use something that always exists for the `RowKey`. A Base64-encoded target path means the order will always be consistent, and its reproducible across GCP and Azure. The user will never see the bas64 encoded target path.