### PR TITLE
DR-1937 Follow-on: Clean up new connected tests

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
@@ -128,6 +128,11 @@ public class AzureStorageTablePdao {
         .collect(Collectors.toList());
   }
 
+  public void deleteLoadHistory(UUID datasetId, TableServiceClient serviceClient) {
+    var tableName = toLoadHistoryTableNameFromUUID(datasetId);
+    serviceClient.deleteTable(tableName);
+  }
+
   private static TableEntity bulkFileLoadModelToStorageTableEntity(
       StorageTableLoadHistoryEntity entity, String loadTag, Instant loadTime) {
     var model = entity.model;
@@ -187,7 +192,7 @@ public class AzureStorageTablePdao {
           .state(
               BulkLoadFileState.valueOf(
                   tableEntity.getProperty(LoadHistoryUtil.STATE_FIELD_NAME).toString()))
-          .fileId(tableEntity.getProperty(LoadHistoryUtil.FILE_ID_FIELD_NAME).toString())
+          .fileId((String) tableEntity.getProperty(LoadHistoryUtil.FILE_ID_FIELD_NAME))
           .checksumCRC((String) tableEntity.getProperty(LoadHistoryUtil.CHECKSUM_CRC32C_FIELD_NAME))
           .checksumMD5((String) tableEntity.getProperty(LoadHistoryUtil.CHECKSUM_MD5_FIELD_NAME))
           .error((String) tableEntity.getProperty(LoadHistoryUtil.ERROR_FIELD_NAME));

--- a/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
@@ -8,6 +8,7 @@ import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.models.ListEntitiesOptions;
 import com.azure.data.tables.models.TableEntity;
+import com.google.common.annotations.VisibleForTesting;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
@@ -128,11 +129,6 @@ public class AzureStorageTablePdao {
         .collect(Collectors.toList());
   }
 
-  public void deleteLoadHistory(UUID datasetId, TableServiceClient serviceClient) {
-    var tableName = toLoadHistoryTableNameFromUUID(datasetId);
-    serviceClient.deleteTable(tableName);
-  }
-
   private static TableEntity bulkFileLoadModelToStorageTableEntity(
       StorageTableLoadHistoryEntity entity, String loadTag, Instant loadTime) {
     var model = entity.model;
@@ -156,7 +152,8 @@ public class AzureStorageTablePdao {
    * @param datasetId The datasetId root of the table name
    * @return A valid azure storage table name with load history suffix.
    */
-  private static String toLoadHistoryTableNameFromUUID(UUID datasetId) {
+  @VisibleForTesting
+  public static String toLoadHistoryTableNameFromUUID(UUID datasetId) {
     return "datarepo" + datasetId.toString().replaceAll("-", "") + LOAD_HISTORY_TABLE_NAME_SUFFIX;
   }
 

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -52,6 +52,8 @@ import bio.terra.service.dataset.DatasetDaoUtils;
 import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamRole;
+import bio.terra.service.tabulardata.azure.AzureStorageTablePdao;
+import com.azure.data.tables.TableServiceClient;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
@@ -981,5 +983,10 @@ public class ConnectedOperations {
     createdProfileIds = new ArrayList<>();
     createdBuckets = new ArrayList<>();
     createdScratchFiles = new ArrayList<>();
+  }
+
+  public void deleteLoadHistory(UUID datasetId, TableServiceClient serviceClient) {
+    var tableName = AzureStorageTablePdao.toLoadHistoryTableNameFromUUID(datasetId);
+    serviceClient.deleteTable(tableName);
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -53,7 +53,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 public class AzureIngestFileConnectedTest {
-  private final Logger logger = LoggerFactory.getLogger(AzureIngestFileConnectedTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(AzureIngestFileConnectedTest.class);
   private UUID datasetId;
   private String targetPath;
   private UUID homeTenantId;
@@ -142,6 +142,8 @@ public class AzureIngestFileConnectedTest {
             .mimeType("application/json")
             .targetPath(targetPath)
             .loadTag(Names.randomizeName("loadTag"));
+
+    fileId = UUID.randomUUID().toString();
   }
 
   @After
@@ -158,8 +160,7 @@ public class AzureIngestFileConnectedTest {
 
   @Test
   public void testStorageTableMetadataDuringFileIngest() {
-    // 0 - IngestFileIdStep
-    fileId = UUID.randomUUID().toString();
+    // 0 - IngestFileIdStep - Done in test setup
     // 1 - IngestFileAzurePrimaryDataLocationStep
     // define storage account (this is already defined in the test setup)
     // 2 - IngestFileAzureMakeStorageAccountLinkStep

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -53,6 +53,7 @@ public class AzureIngestFileConnectedTest {
   private UUID datasetId;
   private String targetPath;
   private UUID homeTenantId;
+  private String fileId;
 
   private AzureStorageAccountResource storageAccountResource;
   private BillingProfileModel billingProfile;
@@ -141,6 +142,8 @@ public class AzureIngestFileConnectedTest {
 
   @After
   public void cleanup() throws Exception {
+    tableDao.deleteFileMetadata(fileId, billingProfile, storageAccountResource);
+    tableDirectoryDao.deleteDirectoryEntry(tableServiceClient, fileId);
     azureResourceConfiguration.getCredentials().setHomeTenantId(homeTenantId);
     connectedOperations.teardown();
   }
@@ -148,7 +151,7 @@ public class AzureIngestFileConnectedTest {
   @Test
   public void testStorageTableMetadataDuringFileIngest() {
     // 0 - IngestFileIdStep
-    String fileId = UUID.randomUUID().toString();
+    fileId = UUID.randomUUID().toString();
     // 1 - IngestFileAzurePrimaryDataLocationStep
     // define storage account (this is already defined in the test setup)
     // 2 - IngestFileAzureMakeStorageAccountLinkStep

--- a/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
@@ -89,7 +89,7 @@ public class LoadHistoryStorageTableConnectedTest {
     // ---- TEST FOUR STATES OF LOAD HISTORY TABLE ENTRIES ----
     // SUCCEEDED
     String checksum = Names.randomizeName("CRCSUM");
-    String successfulSourcePath = "/" + UUID.randomUUID().toString() + "/source/path.json";
+    String successfulSourcePath = "/" + UUID.randomUUID() + "/source/path.json";
     loadHistoryArray.add(
         new BulkLoadHistoryModel()
             .state(BulkLoadFileState.SUCCEEDED)
@@ -99,21 +99,21 @@ public class LoadHistoryStorageTableConnectedTest {
             .sourcePath(successfulSourcePath)
             .targetPath("/target/path.json"));
     // FAILED
-    String failedSourcePath = "/" + UUID.randomUUID().toString() + "/source/path.json";
+    String failedSourcePath = "/" + UUID.randomUUID() + "/source/path.json";
     loadHistoryArray.add(
         new BulkLoadHistoryModel()
             .state(BulkLoadFileState.FAILED)
             .sourcePath(failedSourcePath)
             .targetPath("/target/path.json"));
     // NOT_TRIED
-    String notTriedSourcePath = "/" + UUID.randomUUID().toString() + "/source/path.json";
+    String notTriedSourcePath = "/" + UUID.randomUUID() + "/source/path.json";
     loadHistoryArray.add(
         new BulkLoadHistoryModel()
             .state(BulkLoadFileState.NOT_TRIED)
             .sourcePath(notTriedSourcePath)
             .targetPath("/target2/path2.json"));
     // RUNNING
-    String runningSourcePath = "/" + UUID.randomUUID().toString() + "/source/path.json";
+    String runningSourcePath = "/" + UUID.randomUUID() + "/source/path.json";
     loadHistoryArray.add(
         new BulkLoadHistoryModel()
             .state(BulkLoadFileState.RUNNING)

--- a/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
@@ -79,7 +79,7 @@ public class LoadHistoryStorageTableConnectedTest {
 
   @After
   public void cleanup() throws Exception {
-    storageTableDao.deleteLoadHistory(datasetId, serviceClient);
+    connectedOperations.deleteLoadHistory(datasetId, serviceClient);
     connectedOperations.teardown();
   }
 

--- a/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
@@ -1,10 +1,14 @@
 package bio.terra.service.filedata.azure.tables;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.AzureUtils;
 import bio.terra.common.SynapseUtils;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
+import bio.terra.common.fixtures.Names;
 import bio.terra.model.BulkLoadFileState;
 import bio.terra.model.BulkLoadHistoryModel;
 import bio.terra.service.dataset.DatasetService;
@@ -75,38 +79,86 @@ public class LoadHistoryStorageTableConnectedTest {
 
   @After
   public void cleanup() throws Exception {
-    // TODO - clean up the load history table
+    storageTableDao.deleteLoadHistory(datasetId, serviceClient);
     connectedOperations.teardown();
   }
 
   @Test
   public void testStorageTableMetadataDuringFileIngest() {
-    String loadTag = UUID.randomUUID().toString();
     List<BulkLoadHistoryModel> loadHistoryArray = new ArrayList<>();
+    // ---- TEST FOUR STATES OF LOAD HISTORY TABLE ENTRIES ----
+    // SUCCEEDED
+    String checksum = Names.randomizeName("CRCSUM");
+    String successfulSourcePath = "/" + UUID.randomUUID().toString() + "/source/path.json";
     loadHistoryArray.add(
         new BulkLoadHistoryModel()
             .state(BulkLoadFileState.SUCCEEDED)
             .fileId(UUID.randomUUID().toString())
-            .checksumCRC("CRCTEST")
+            .checksumCRC(checksum)
             .checksumMD5("MD5TEST")
-            .sourcePath("/source/path.json")
+            .sourcePath(successfulSourcePath)
             .targetPath("/target/path.json"));
+    // FAILED
+    String failedSourcePath = "/" + UUID.randomUUID().toString() + "/source/path.json";
     loadHistoryArray.add(
         new BulkLoadHistoryModel()
             .state(BulkLoadFileState.FAILED)
-            .sourcePath("/source/path.json")
+            .sourcePath(failedSourcePath)
             .targetPath("/target/path.json"));
+    // NOT_TRIED
+    String notTriedSourcePath = "/" + UUID.randomUUID().toString() + "/source/path.json";
+    loadHistoryArray.add(
+        new BulkLoadHistoryModel()
+            .state(BulkLoadFileState.NOT_TRIED)
+            .sourcePath(notTriedSourcePath)
+            .targetPath("/target2/path2.json"));
+    // RUNNING
+    String runningSourcePath = "/" + UUID.randomUUID().toString() + "/source/path.json";
+    loadHistoryArray.add(
+        new BulkLoadHistoryModel()
+            .state(BulkLoadFileState.RUNNING)
+            .sourcePath(runningSourcePath)
+            .targetPath("/target3/path3.json"));
 
-    // TODO Test the other two states
-
+    // ---- ADD ENTRIES TO LOAD HISTORY TABLE ----
+    String loadTag = UUID.randomUUID().toString();
     storageTableDao.storeLoadHistory(
         serviceClient, datasetId, loadTag, Instant.now(), loadHistoryArray);
 
-    // TODO - confirm the results
+    // --- Confirm load history table has entries ---
+    List<BulkLoadHistoryModel> resultingLoadHistory =
+        storageTableDao.getLoadHistory(serviceClient, datasetId, loadTag, 0, 4);
 
-    //    List<BulkLoadHistoryModel> resultingLoadHistory =
-    // storageTableDao.getLoadHistory(serviceClient, datasetId, loadTag, 0, 2);
-    //    resultingLoadHistory.get(0
+    BulkLoadHistoryModel successfulEntry =
+        findEntryByState(resultingLoadHistory, BulkLoadFileState.SUCCEEDED);
+    assertThat(
+        "SUCCESSFUL entry is successful w/ right checksum",
+        successfulEntry.getChecksumCRC(),
+        equalTo(checksum));
+    BulkLoadHistoryModel failedEntry =
+        findEntryByState(resultingLoadHistory, BulkLoadFileState.FAILED);
+    assertThat(
+        "FAILED entry has correct source path",
+        failedEntry.getSourcePath(),
+        equalTo(failedSourcePath));
+
+    BulkLoadHistoryModel notTriedEntry =
+        findEntryByState(resultingLoadHistory, BulkLoadFileState.NOT_TRIED);
+    assertThat(
+        "NOTE_TRIED entry has correct source path",
+        notTriedEntry.getSourcePath(),
+        equalTo(notTriedSourcePath));
+    BulkLoadHistoryModel runningEntry =
+        findEntryByState(resultingLoadHistory, BulkLoadFileState.RUNNING);
+    assertThat(
+        "RUNNING entry has correct source path",
+        runningEntry.getSourcePath(),
+        equalTo(runningSourcePath));
+  }
+
+  private BulkLoadHistoryModel findEntryByState(
+      List<BulkLoadHistoryModel> resultingLoadHistory, BulkLoadFileState state) {
+    return resultingLoadHistory.stream().filter(s -> s.getState() == state).findFirst().get();
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
@@ -75,13 +75,9 @@ public class TableDirectoryDaoConnectedTest {
 
   @After
   public void cleanup() throws Exception {
-
     connectedOperations.teardown();
-    // TODO - clean out added entries from storage table
   }
 
-  // TODO - test other directory options:
-  // https://github.com/DataBiosphere/jade-data-repo/pull/1033/files#diff-65a4bf8d889dc4806c26c0a005ac19e9b8bbc24377583debc3689ff2679f55a8R62
   @Test
   public void testStorageTableMetadataDuringFileIngest() {
     // Test re-using same directory path, but for different files

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
@@ -83,13 +83,13 @@ public class TableDirectoryDaoConnectedTest {
 
   @After
   public void cleanup() throws Exception {
-    try {
-      var iter = directoryEntriesToCleanup.iterator();
-      while (iter.hasNext()) {
-        tableDirectoryDao.deleteDirectoryEntry(tableServiceClient, iter.next());
+    // Should already be deleted
+    for (String entry : directoryEntriesToCleanup) {
+      try {
+        tableDirectoryDao.deleteDirectoryEntry(tableServiceClient, entry);
+      } catch (Exception ex) {
+        logger.debug("Directory entry either already deleted or unable to delete {}", entry, ex);
       }
-    } catch (Exception ex) {
-      logger.error("Unable to delete table directory entry", ex);
     }
     if (tableName != null) {
       try {
@@ -127,7 +127,6 @@ public class TableDirectoryDaoConnectedTest {
     boolean deleteEntry =
         tableDirectoryDao.deleteDirectoryEntry(tableServiceClient, fileEntry1.getFileId());
     assertThat("Delete Entry 1", deleteEntry, equalTo(true));
-    directoryEntriesToCleanup.remove(fileEntry1.getFileId());
     FireStoreDirectoryEntry shouldbeNull =
         tableDirectoryDao.retrieveByPath(
             tableServiceClient, datasetId.toString(), sharedTargetPath + fileName1);
@@ -172,7 +171,6 @@ public class TableDirectoryDaoConnectedTest {
     boolean deleteEntry2 =
         tableDirectoryDao.deleteDirectoryEntry(tableServiceClient, fileEntry2.getFileId());
     assertThat("Delete Entry 2", deleteEntry2, equalTo(true));
-    directoryEntriesToCleanup.remove(fileEntry2.getFileId());
     FireStoreDirectoryEntry file2ShouldbeNull =
         tableDirectoryDao.retrieveByPath(
             tableServiceClient, datasetId.toString(), sharedTargetPath + fileName2);


### PR DESCRIPTION
Bonus Bug Fix:
* Fix NPE on getLoadHistory when fileId is null (This occurs when state of a given file load entry is not SUCCEEDED)

There were 3 connected tests added in the Storage Table PR, so those are the focus of this cleanup PR:
1. TableDirectoryDaoConnectedTest.java 
* Added additional cleanup
2. LoadHistoryStorageTableConnectedTest.java 
* Added cleanup
* Added more test cases
3. AzureIngestFileConnectedTest.java 
* Added cleanup
* More complete test of IngestFileAzureDirectoryStep