### PR TITLE
DR-2054: store per-snapshot catalog metadata

### DIFF
--- a/src/main/java/bio/terra/service/search/SnapshotSearchMetadataDao.java
+++ b/src/main/java/bio/terra/service/search/SnapshotSearchMetadataDao.java
@@ -1,15 +1,12 @@
 package bio.terra.service.search;
 
 import bio.terra.service.snapshot.Snapshot;
-import java.util.Collections;
+import java.sql.Types;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -21,17 +18,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class SnapshotSearchMetadataDao {
 
   private static final String PUT_METADATA =
-      "INSERT INTO snapshot_search_metadata(snapshot_id, metadata) " +
-          "VALUES(:snapshot_id, :metadata) " +
-          "ON CONFLICT ON CONSTRAINT unique_snapshot_metadata_id " +
-          "DO UPDATE SET metadata = :metadata";
+      "INSERT INTO snapshot_search_metadata(snapshot_id, metadata) "
+          + "VALUES(:snapshot_id, :metadata) "
+          + "ON CONFLICT ON CONSTRAINT pkey_snapshot_search_metadata "
+          + "DO UPDATE SET metadata = :metadata";
 
   private static final String DELETE_METADATA =
       "DELETE FROM snapshot_search_metadata where snapshot_id = :snapshot_id";
 
   private static final String GET_METADATA =
-      "SELECT (snapshot_id, metadata) FROM snapshot_search_metadata " +
-          "WHERE snapshot_id IN (:snapshot_ids)";
+      "SELECT snapshot_id, metadata FROM snapshot_search_metadata "
+          + "WHERE snapshot_id IN (:snapshot_ids)";
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -42,16 +39,16 @@ public class SnapshotSearchMetadataDao {
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public void putMetadata(Snapshot snapshot, String jsonData) {
-    var params = new MapSqlParameterSource()
-        .addValue("snapshot_id", snapshot.getId())
-        .addValue("metadata", jsonData);
+    var params =
+        new MapSqlParameterSource()
+            .addValue("snapshot_id", snapshot.getId())
+            .addValue("metadata", jsonData, Types.OTHER);
     jdbcTemplate.update(PUT_METADATA, params);
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public void deleteMetadata(Snapshot snapshot) {
-    var params = new MapSqlParameterSource()
-        .addValue("snapshot_id", snapshot.getId());
+    var params = new MapSqlParameterSource().addValue("snapshot_id", snapshot.getId());
     jdbcTemplate.update(DELETE_METADATA, params);
   }
 
@@ -60,12 +57,14 @@ public class SnapshotSearchMetadataDao {
       isolation = Isolation.SERIALIZABLE,
       readOnly = true)
   public Map<UUID, String> getMetadata(List<UUID> snapshotIds) {
-    var params = new MapSqlParameterSource()
-        .addValue("snapshot_ids", snapshotIds);
+    var params = new MapSqlParameterSource().addValue("snapshot_ids", snapshotIds);
     Map<UUID, String> result = new HashMap<>();
-    jdbcTemplate.query(GET_METADATA, params, rs -> {
-        result.put(UUID.fromString(rs.getString(0)), rs.getString(1));
-    });
+    jdbcTemplate.query(
+        GET_METADATA,
+        params,
+        rs -> {
+          result.put(UUID.fromString(rs.getString(1)), rs.getString(2));
+        });
     return result;
   }
 }

--- a/src/main/java/bio/terra/service/search/SnapshotSearchMetadataDao.java
+++ b/src/main/java/bio/terra/service/search/SnapshotSearchMetadataDao.java
@@ -1,6 +1,5 @@
 package bio.terra.service.search;
 
-import bio.terra.service.snapshot.Snapshot;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.List;
@@ -38,17 +37,17 @@ public class SnapshotSearchMetadataDao {
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public void putMetadata(Snapshot snapshot, String jsonData) {
+  public void putMetadata(UUID snapshotId, String jsonData) {
     var params =
         new MapSqlParameterSource()
-            .addValue("snapshot_id", snapshot.getId())
+            .addValue("snapshot_id", snapshotId)
             .addValue("metadata", jsonData, Types.OTHER);
     jdbcTemplate.update(PUT_METADATA, params);
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public void deleteMetadata(Snapshot snapshot) {
-    var params = new MapSqlParameterSource().addValue("snapshot_id", snapshot.getId());
+  public void deleteMetadata(UUID snapshotId) {
+    var params = new MapSqlParameterSource().addValue("snapshot_id", snapshotId);
     jdbcTemplate.update(DELETE_METADATA, params);
   }
 

--- a/src/main/java/bio/terra/service/search/SnapshotSearchMetadataDao.java
+++ b/src/main/java/bio/terra/service/search/SnapshotSearchMetadataDao.java
@@ -1,0 +1,71 @@
+package bio.terra.service.search;
+
+import bio.terra.service.snapshot.Snapshot;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.RowCallbackHandler;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class SnapshotSearchMetadataDao {
+
+  private static final String PUT_METADATA =
+      "INSERT INTO snapshot_search_metadata(snapshot_id, metadata) " +
+          "VALUES(:snapshot_id, :metadata) " +
+          "ON CONFLICT ON CONSTRAINT unique_snapshot_metadata_id " +
+          "DO UPDATE SET metadata = :metadata";
+
+  private static final String DELETE_METADATA =
+      "DELETE FROM snapshot_search_metadata where snapshot_id = :snapshot_id";
+
+  private static final String GET_METADATA =
+      "SELECT (snapshot_id, metadata) FROM snapshot_search_metadata " +
+          "WHERE snapshot_id IN (:snapshot_ids)";
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired
+  public SnapshotSearchMetadataDao(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public void putMetadata(Snapshot snapshot, String jsonData) {
+    var params = new MapSqlParameterSource()
+        .addValue("snapshot_id", snapshot.getId())
+        .addValue("metadata", jsonData);
+    jdbcTemplate.update(PUT_METADATA, params);
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public void deleteMetadata(Snapshot snapshot) {
+    var params = new MapSqlParameterSource()
+        .addValue("snapshot_id", snapshot.getId());
+    jdbcTemplate.update(DELETE_METADATA, params);
+  }
+
+  @Transactional(
+      propagation = Propagation.REQUIRED,
+      isolation = Isolation.SERIALIZABLE,
+      readOnly = true)
+  public Map<UUID, String> getMetadata(List<UUID> snapshotIds) {
+    var params = new MapSqlParameterSource()
+        .addValue("snapshot_ids", snapshotIds);
+    Map<UUID, String> result = new HashMap<>();
+    jdbcTemplate.query(GET_METADATA, params, rs -> {
+        result.put(UUID.fromString(rs.getString(0)), rs.getString(1));
+    });
+    return result;
+  }
+}

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -42,4 +42,5 @@
     <include file="changesets/20210517_azurebillinginformation.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210615_azureappdeploymentinfo.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210616_azurestorage.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20210902_snapshotmetadata.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20210902_snapshotmetadata.yaml
+++ b/src/main/resources/db/changesets/20210902_snapshotmetadata.yaml
@@ -12,11 +12,10 @@ databaseChangeLog:
                   constraints:
                     nullable: false
                     foreignKeyName: fk_snapshot_metadata_snapshot_id
-                    references: snapshot_column(id)
+                    references: snapshot(id)
                     deleteCascade: true
                     primaryKey: true
-                    unique: true
-                    uniqueConstraintName: unique_snapshot_metadata_id
+                    primaryKeyName: pkey_snapshot_search_metadata
               - column:
                   name: metadata
                   type: jsonb

--- a/src/main/resources/db/changesets/20210902_snapshotmetadata.yaml
+++ b/src/main/resources/db/changesets/20210902_snapshotmetadata.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: snapshotmetadata
+      author: ps
+      changes:
+        - createTable:
+            tableName: snapshot_search_metadata
+            columns:
+              - column:
+                  name: snapshot_id
+                  type: ${uuid_type}
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_snapshot_metadata_snapshot_id
+                    references: snapshot_column(id)
+                    deleteCascade: true
+                    primaryKey: true
+                    unique: true
+                    uniqueConstraintName: unique_snapshot_metadata_id
+              - column:
+                  name: metadata
+                  type: jsonb

--- a/src/test/java/bio/terra/service/search/SnapshotSearchMetadataDaoTest.java
+++ b/src/test/java/bio/terra/service/search/SnapshotSearchMetadataDaoTest.java
@@ -1,0 +1,76 @@
+package bio.terra.service.search;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.ProfileFixtures;
+import bio.terra.common.fixtures.ResourceFixtures;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetUtils;
+import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
+import bio.terra.service.snapshot.Snapshot;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Category(Unit.class)
+class SnapshotSearchMetadataDaoTest {
+
+  @Autowired
+  private GoogleResourceDao resourceDao;
+
+  @Autowired
+  private ProfileDao profileDao;
+
+  private UUID profileId;
+  private UUID projectId;
+  private Dataset dataset;
+  private Snapshot snapshot;
+
+  @Before
+  public void before() throws Exception {
+    BillingProfileModel billingProfile =
+        profileDao.createBillingProfile(ProfileFixtures.randomBillingProfileRequest(), "hi@hi.hi");
+    profileId = billingProfile.getId();
+
+    GoogleProjectResource projectResource = ResourceFixtures.randomProjectResource(billingProfile);
+    var projectId = resourceDao.createProject(projectResource);
+
+    DatasetRequestModel datasetRequest =
+        jsonLoader.loadObject("snapshot-test-dataset.json", DatasetRequestModel.class);
+    datasetRequest
+        .name(datasetRequest.getName() + UUID.randomUUID())
+        .defaultProfileId(profileId)
+        .cloudPlatform(CloudPlatform.GCP);
+
+    dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
+    dataset.projectResourceId(projectId);
+
+    String createFlightId = UUID.randomUUID().toString();
+    datasetId = UUID.randomUUID();
+    dataset.id(datasetId);
+    datasetDao.createAndLock(dataset, createFlightId);
+    datasetDao.unlockExclusive(dataset.getId(), createFlightId);
+    dataset = datasetDao.retrieve(datasetId);
+
+  }
+
+  @After
+  public void after() throws Exception {
+
+  }
+
+  public void testPutGetDelete() {
+
+  }
+}

--- a/src/test/java/bio/terra/service/search/SnapshotSearchMetadataDaoTest.java
+++ b/src/test/java/bio/terra/service/search/SnapshotSearchMetadataDaoTest.java
@@ -1,41 +1,53 @@
 package bio.terra.service.search;
 
-import bio.terra.common.category.Unit;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+
+import bio.terra.common.category.Connected;
+import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.common.fixtures.ResourceFixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.DatasetRequestModel;
-import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetUtils;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
 import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotDao;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@Category(Unit.class)
-class SnapshotSearchMetadataDaoTest {
+@AutoConfigureMockMvc
+@Category(Connected.class)
+public class SnapshotSearchMetadataDaoTest {
 
-  @Autowired
-  private GoogleResourceDao resourceDao;
-
-  @Autowired
-  private ProfileDao profileDao;
+  @Autowired private GoogleResourceDao resourceDao;
+  @Autowired private ProfileDao profileDao;
+  @Autowired private JsonLoader jsonLoader;
+  @Autowired private SnapshotDao snapshotDao;
+  @Autowired private SnapshotSearchMetadataDao snapshotSearchDao;
 
   private UUID profileId;
   private UUID projectId;
-  private Dataset dataset;
-  private Snapshot snapshot;
+  private List<UUID> snapshotIds;
 
   @Before
   public void before() throws Exception {
@@ -44,7 +56,7 @@ class SnapshotSearchMetadataDaoTest {
     profileId = billingProfile.getId();
 
     GoogleProjectResource projectResource = ResourceFixtures.randomProjectResource(billingProfile);
-    var projectId = resourceDao.createProject(projectResource);
+    projectId = resourceDao.createProject(projectResource);
 
     DatasetRequestModel datasetRequest =
         jsonLoader.loadObject("snapshot-test-dataset.json", DatasetRequestModel.class);
@@ -53,24 +65,67 @@ class SnapshotSearchMetadataDaoTest {
         .defaultProfileId(profileId)
         .cloudPlatform(CloudPlatform.GCP);
 
-    dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
+    var dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
     dataset.projectResourceId(projectId);
 
-    String createFlightId = UUID.randomUUID().toString();
-    datasetId = UUID.randomUUID();
-    dataset.id(datasetId);
-    datasetDao.createAndLock(dataset, createFlightId);
-    datasetDao.unlockExclusive(dataset.getId(), createFlightId);
-    dataset = datasetDao.retrieve(datasetId);
+    String flightId = UUID.randomUUID().toString();
 
+    snapshotIds =
+        Stream.generate(UUID::randomUUID)
+            .limit(3)
+            .peek(
+                uuid -> {
+                  var snapshot =
+                      new Snapshot()
+                          .id(uuid)
+                          .name("snap-" + uuid)
+                          .profileId(profileId)
+                          .projectResourceId(projectId);
+                  snapshotDao.createAndLock(snapshot, flightId);
+                })
+            .collect(Collectors.toList());
   }
 
   @After
   public void after() throws Exception {
-
+    snapshotIds.forEach(snapshotDao::delete);
+    resourceDao.deleteProject(projectId);
+    profileDao.deleteBillingProfileById(profileId);
   }
 
+  // Test invalid foreign key constraint on snapshot ID.
+  @Test(expected = DataIntegrityViolationException.class)
+  public void testInvalidSnapshotId() {
+    snapshotSearchDao.putMetadata(new Snapshot().id(UUID.randomUUID()), "{}");
+  }
+
+  // Test invalid JSON data.
+  @Test(expected = DataIntegrityViolationException.class)
+  public void testInvalidJsonData() {
+    snapshotSearchDao.putMetadata(new Snapshot().id(snapshotIds.get(0)), "not json!");
+  }
+
+  @Test
   public void testPutGetDelete() {
 
+    // Test get with no data.
+    assertThat(snapshotSearchDao.getMetadata(snapshotIds), is(anEmptyMap()));
+
+    // Test put/get with data.
+    var snapshotId = snapshotIds.get(0);
+    var snapshot = new Snapshot().id(snapshotId);
+    // The whitespace here is important as JSONB will reformat the JSON data.
+    var data = "{\"name\": \"test\"}";
+    snapshotSearchDao.putMetadata(snapshot, data);
+    assertThat(snapshotSearchDao.getMetadata(snapshotIds), is(Map.of(snapshotId, data)));
+
+    // Test data update.
+    var data2 = "{\"another\": \"something\"}";
+    snapshotSearchDao.putMetadata(snapshot, data2);
+    assertThat(snapshotSearchDao.getMetadata(snapshotIds), is(Map.of(snapshotId, data2)));
+
+    // Test delete.
+    snapshotSearchDao.deleteMetadata(snapshot);
+    assertThat(snapshotSearchDao.getMetadata(snapshotIds), is(anEmptyMap()));
   }
 }

--- a/src/test/java/bio/terra/service/search/SnapshotSearchMetadataDaoTest.java
+++ b/src/test/java/bio/terra/service/search/SnapshotSearchMetadataDaoTest.java
@@ -5,13 +5,9 @@ import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
 
 import bio.terra.common.category.Connected;
-import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.common.fixtures.ResourceFixtures;
 import bio.terra.model.BillingProfileModel;
-import bio.terra.model.CloudPlatform;
-import bio.terra.model.DatasetRequestModel;
-import bio.terra.service.dataset.DatasetUtils;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
@@ -41,7 +37,6 @@ public class SnapshotSearchMetadataDaoTest {
 
   @Autowired private GoogleResourceDao resourceDao;
   @Autowired private ProfileDao profileDao;
-  @Autowired private JsonLoader jsonLoader;
   @Autowired private SnapshotDao snapshotDao;
   @Autowired private SnapshotSearchMetadataDao snapshotSearchDao;
 
@@ -57,16 +52,6 @@ public class SnapshotSearchMetadataDaoTest {
 
     GoogleProjectResource projectResource = ResourceFixtures.randomProjectResource(billingProfile);
     projectId = resourceDao.createProject(projectResource);
-
-    DatasetRequestModel datasetRequest =
-        jsonLoader.loadObject("snapshot-test-dataset.json", DatasetRequestModel.class);
-    datasetRequest
-        .name(datasetRequest.getName() + UUID.randomUUID())
-        .defaultProfileId(profileId)
-        .cloudPlatform(CloudPlatform.GCP);
-
-    var dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
-    dataset.projectResourceId(projectId);
 
     String flightId = UUID.randomUUID().toString();
 
@@ -107,7 +92,6 @@ public class SnapshotSearchMetadataDaoTest {
 
   @Test
   public void testPutGetDelete() {
-
     // Test get with no data.
     assertThat(snapshotSearchDao.getMetadata(snapshotIds), is(anEmptyMap()));
 


### PR DESCRIPTION
Add a new database object with its own DAO to store a json metadata blob that's linked to a snapshot.