### PR TITLE
DR-2031 Handle field delimiter and quote characters for CSV

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -36,6 +36,7 @@ import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamService;
 import bio.terra.service.job.JobService;
+import bio.terra.service.job.exception.InvalidJobParameterException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import java.util.Collections;
@@ -178,6 +179,11 @@ public class DatasetsApiController implements DatasetsApi {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     iamService.verifyAuthorization(
         userReq, IamResourceType.DATASET, id.toString(), IamAction.INGEST_DATA);
+    List<String> ingestParameterErrors = ingestRequestValidator.validateIngestParams(ingest, id);
+    if (!ingestParameterErrors.isEmpty()) {
+      throw new InvalidJobParameterException(
+          "Invalid ingest parameters detected", ingestParameterErrors);
+    }
     String jobId = datasetService.ingestDataset(id.toString(), ingest, userReq);
     return jobToResponse(jobService.retrieveJob(jobId, userReq));
   }

--- a/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
@@ -1,28 +1,15 @@
 package bio.terra.service.dataset;
 
-import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.IngestRequestModel;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 import javax.validation.constraints.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 @Component
 public class IngestRequestValidator implements Validator {
-
-  private final DatasetService datasetService;
-
-  @Autowired
-  IngestRequestValidator(DatasetService datasetService) {
-    this.datasetService = datasetService;
-  }
 
   @Override
   public boolean supports(Class<?> clazz) {
@@ -33,36 +20,6 @@ public class IngestRequestValidator implements Validator {
     if (name == null) {
       errors.rejectValue("name", "TableNameMissing", "Ingest requires a table name");
     }
-  }
-
-  public List<String> validateIngestParams(IngestRequestModel ingestRequestModel, UUID datasetId) {
-    Dataset dataset = datasetService.retrieve(datasetId);
-    CloudPlatformWrapper platform =
-        CloudPlatformWrapper.of(dataset.getDatasetSummary().getStorageCloudPlatform());
-
-    if (platform.isAzure()) {
-      return validateAzureIngestParams(ingestRequestModel);
-    }
-    return Collections.emptyList();
-  }
-
-  private List<String> validateAzureIngestParams(IngestRequestModel ingestRequest) {
-    List<String> errors = new ArrayList<>();
-    if (ingestRequest.getFormat() == IngestRequestModel.FormatEnum.CSV) {
-      // validate CSV parameters
-      if (ingestRequest.getCsvSkipLeadingRows() == null) {
-        errors.add("For CSV ingests, 'csvSkipLeadingRows' must be defined.");
-      }
-      if (ingestRequest.isCsvAllowQuotedNewlines() != null) {
-        errors.add(
-            "Azure CSV ingests do not support 'csvAllowQuotedNewlines', which should be left undefined.");
-      }
-      if (ingestRequest.getCsvNullMarker() != null) {
-        errors.add(
-            "Azure CSV ingest do not support 'csvNullMarker', which should be left undefined.");
-      }
-    }
-    return errors;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStep.java
@@ -15,7 +15,6 @@ import bio.terra.stairway.StepStatus;
 import com.azure.storage.blob.BlobUrlParts;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.Optional;
 
 public class IngestCreateParquetFilesStep implements Step {
 
@@ -48,7 +47,9 @@ public class IngestCreateParquetFilesStep implements Step {
               IngestUtils.getTargetDataSourceName(context.getFlightId()),
               IngestUtils.getIngestRequestDataSourceName(context.getFlightId()),
               IngestUtils.getSynapseTableName(context.getFlightId()),
-              Optional.ofNullable(ingestRequestModel.getCsvSkipLeadingRows()));
+              ingestRequestModel.getCsvSkipLeadingRows(),
+              ingestRequestModel.getCsvFieldDelimiter(),
+              ingestRequestModel.getCsvQuote());
 
     } catch (SQLException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -8,7 +8,6 @@ import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.azure.util.BlobContainerClientFactory;
 import bio.terra.service.filedata.azure.util.BlobSasTokenOptions;
-import bio.terra.service.job.exception.InvalidJobParameterException;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
@@ -203,10 +202,6 @@ public class AzureSynapsePdao {
     sqlCreateTableTemplate.add("isCSV", isCSV);
     if (isCSV) {
       sqlCreateTableTemplate.add("parserVersion", PARSER_VERSION);
-      if (csvSkipLeadingRows == null) {
-        throw new InvalidJobParameterException(
-            "For CSV ingests, 'csvSkipLeadingRows' must be defined.");
-      }
       sqlCreateTableTemplate.add("firstRow", csvSkipLeadingRows);
       sqlCreateTableTemplate.add(
           "fieldTerminator",

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -22,7 +22,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
@@ -40,6 +40,9 @@ public class AzureSynapsePdao {
   private final AzureBlobStorePdao azureBlobStorePdao;
   private static final String PARSER_VERSION = "2.0";
   private static final Duration DEFAULT_SAS_TOKEN_EXPIRATION = Duration.ofHours(24);
+  private static final String DEFAULT_CSV_FIELD_TERMINATOR = ",";
+  private static final String DEFAULT_CSV_QUOTE = "\"";
+
   private static final String scopedCredentialCreateTemplate =
       "CREATE DATABASE SCOPED CREDENTIAL [<scopedCredentialName>]\n"
           + "WITH IDENTITY = 'SHARED ACCESS SIGNATURE',\n"
@@ -77,10 +80,12 @@ public class AzureSynapsePdao {
           + "       FORMAT = 'CSV',\n"
           + "<if(isCSV)>"
           + "       PARSER_VERSION = '<parserVersion>',\n"
-          + "       FIRSTROW = <firstRow>\n"
+          + "       FIRSTROW = <firstRow>,\n"
+          + "       FIELDTERMINATOR = '<fieldTerminator>',\n"
+          + "       FIELDQUOTE = '<csvQuote>'\n"
           + "<else>"
-          + "       fieldterminator ='0x0b',\n"
-          + "       fieldquote = '0x0b'\n"
+          + "       FIELDTERMINATOR ='0x0b',\n"
+          + "       FIELDQUOTE = '0x0b'\n"
           + "<endif>"
           + "    ) WITH (\n"
           + "      <if(isCSV)>"
@@ -183,7 +188,9 @@ public class AzureSynapsePdao {
       String destinationDataSourceName,
       String controlFileDataSourceName,
       String ingestTableName,
-      Optional<Integer> csvSkipLeadingRows)
+      Integer csvSkipLeadingRows,
+      String csvFieldTerminator,
+      String csvStringDelimiter)
       throws SQLException {
 
     List<SynapseColumn> columns =
@@ -196,11 +203,16 @@ public class AzureSynapsePdao {
     sqlCreateTableTemplate.add("isCSV", isCSV);
     if (isCSV) {
       sqlCreateTableTemplate.add("parserVersion", PARSER_VERSION);
-      if (csvSkipLeadingRows.isEmpty()) {
+      if (csvSkipLeadingRows == null) {
         throw new InvalidJobParameterException(
             "For CSV ingests, 'csvSkipLeadingRows' must be defined.");
       }
-      sqlCreateTableTemplate.add("firstRow", csvSkipLeadingRows.get());
+      sqlCreateTableTemplate.add("firstRow", csvSkipLeadingRows);
+      sqlCreateTableTemplate.add(
+          "fieldTerminator",
+          Objects.requireNonNullElse(csvFieldTerminator, DEFAULT_CSV_FIELD_TERMINATOR));
+      sqlCreateTableTemplate.add(
+          "csvQuote", Objects.requireNonNullElse(csvStringDelimiter, DEFAULT_CSV_QUOTE));
     }
     sqlCreateTableTemplate.add("tableName", ingestTableName);
     sqlCreateTableTemplate.add("destinationParquetFile", destinationParquetFile);

--- a/src/main/java/bio/terra/service/job/exception/InvalidJobParameterException.java
+++ b/src/main/java/bio/terra/service/job/exception/InvalidJobParameterException.java
@@ -1,6 +1,7 @@
 package bio.terra.service.job.exception;
 
 import bio.terra.common.exception.BadRequestException;
+import java.util.List;
 
 public class InvalidJobParameterException extends BadRequestException {
   public InvalidJobParameterException(String message) {
@@ -13,5 +14,9 @@ public class InvalidJobParameterException extends BadRequestException {
 
   public InvalidJobParameterException(Throwable cause) {
     super(cause);
+  }
+
+  public InvalidJobParameterException(String message, List<String> errorDetails) {
+    super(message, errorDetails);
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -133,7 +133,7 @@ public class AzureSynapsePdaoConnectedTest {
       logger.info("Unable to delete parquet files.");
     }
 
-    azureSynapsePdao.dropTables(Arrays.asList(tableName));
+    azureSynapsePdao.dropTables(List.of(tableName));
     azureSynapsePdao.dropDataSources(
         Arrays.asList(destinationDataSourceName, ingestRequestDataSourceName));
     azureSynapsePdao.dropScopedCredentials(
@@ -173,9 +173,7 @@ public class AzureSynapsePdaoConnectedTest {
         synapseUtils.readParquetFileStringColumn(
             destinationParquetFile, destinationDataSourceName, "textCol", true);
     assertThat(
-        "The text columns should be properly quoted",
-        textCols,
-        equalTo(Arrays.asList("Dao!", "Jones!")));
+        "The text columns should be properly quoted", textCols, equalTo(List.of("Dao!", "Jones!")));
   }
 
   @Test
@@ -244,7 +242,7 @@ public class AzureSynapsePdaoConnectedTest {
         synapseUtils.readParquetFileStringColumn(
             destinationParquetFile, destinationDataSourceName, "first_name", true);
     assertThat(
-        "List of names should equal the input", firstNames, equalTo(Arrays.asList("Bob", "Sally")));
+        "List of names should equal the input", firstNames, equalTo(List.of("Bob", "Sally")));
 
     // 4 - clean out synapse
     // we'll do this in the test cleanup method, but it will be a step in the normal flight


### PR DESCRIPTION
It looks like Azure Synapse doesn't support null characters and doesn't care about quoted newlines, so we won't be implementing those. Instead, we'll return a 400 and say that these features aren't supported on Azure.

This PR implements the field delimiter and quote character for Azure Synapse. 