### PR TITLE
[DR-2067] Add synapse functionality for snapshot creation

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -286,6 +286,10 @@ public final class IngestUtils {
     return "parquet/" + tableName + "/**";
   }
 
+  public static String formatSnapshotTableName(UUID snapshotId, String tableName) {
+    return snapshotId.toString().replaceAll("-", "") + "_" + tableName;
+  }
+
   public static String getIngestRequestDataSourceName(String flightId) {
     return SOURCE_DATA_SOURCE_PREFIX + flightId;
   }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -275,6 +275,17 @@ public final class IngestUtils {
     return "parquet/" + targetTableName + "/" + flightId + ".parquet";
   }
 
+  public static String getSnapshotParquetFilePath(UUID snapshotId, String targetTableName) {
+    return "parquet/" + snapshotId + "/" + targetTableName + ".parquet";
+  }
+
+  public static String getSourceDatasetParquetFilePath(String tableName, String datasetFlightId) {
+    if (datasetFlightId != null) {
+      return IngestUtils.getParquetFilePath(tableName, datasetFlightId);
+    }
+    return "parquet/" + tableName + "/**";
+  }
+
   public static String getIngestRequestDataSourceName(String flightId) {
     return SOURCE_DATA_SOURCE_PREFIX + flightId;
   }

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -238,11 +238,11 @@ public class AzureSynapsePdao {
     for (DatasetTable table : tables) {
       String datasetParquetFileName =
           IngestUtils.getSourceDatasetParquetFilePath(table.getName(), datasetFlightId);
-      ST sqlTableTemplate = new ST(getLiveViewTableTemplate);
-      sqlTableTemplate.add("tableId", table.getId().toString());
-      sqlTableTemplate.add("dataRepoRowId", PDAO_ROW_ID_COLUMN);
-      sqlTableTemplate.add("datasetParquetFileName", datasetParquetFileName);
-      sqlTableTemplate.add("datasetDataSourceName", datasetDataSourceName);
+      ST sqlTableTemplate = new ST(getLiveViewTableTemplate)
+        .add("tableId", table.getId().toString())
+        .add("dataRepoRowId", PDAO_ROW_ID_COLUMN)
+        .add("datasetParquetFileName", datasetParquetFileName)
+        .add("datasetDataSourceName", datasetDataSourceName);
       selectStatements.add(sqlTableTemplate.render());
     }
     ST sqlMergeTablesTemplate = new ST(mergeLiveViewTablesTemplate);

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -68,9 +68,7 @@ public class AzureSynapsePdao {
           + "}; separator=\",\n\">) AS rows;";
 
   private static final String createSnapshotRowIdTableTemplate =
-      "CREATE EXTERNAL TABLE "
-          + PDAO_ROW_ID_TABLE
-          + "\n"
+      "CREATE EXTERNAL TABLE [<tableName>]\n"
           + "WITH (\n"
           + "    LOCATION = '<destinationParquetFile>',\n"
           + "    DATA_SOURCE = [<destinationDataSourceName>],\n"
@@ -252,7 +250,9 @@ public class AzureSynapsePdao {
 
     // Create row id table
     ST sqlCreateRowIdTable = new ST(createSnapshotRowIdTableTemplate);
+    String rowIdTableName = IngestUtils.formatSnapshotTableName(snapshotId, PDAO_ROW_ID_TABLE);
     String rowIdParquetFile = IngestUtils.getSnapshotParquetFilePath(snapshotId, PDAO_ROW_ID_TABLE);
+    sqlCreateRowIdTable.add("tableName", rowIdTableName);
     sqlCreateRowIdTable.add("destinationParquetFile", rowIdParquetFile);
     sqlCreateRowIdTable.add("destinationDataSourceName", snapshotDataSourceName);
     sqlCreateRowIdTable.add(
@@ -277,8 +277,9 @@ public class AzureSynapsePdao {
           IngestUtils.getSourceDatasetParquetFilePath(table.getName(), datasetFlightId);
       String snapshotParquetFileName =
           IngestUtils.getSnapshotParquetFilePath(snapshotId, table.getName());
+      String tableName = IngestUtils.formatSnapshotTableName(snapshotId, table.getName());
 
-      sqlCreateSnapshotTableTemplate.add("tableName", table.getName());
+      sqlCreateSnapshotTableTemplate.add("tableName", tableName);
       sqlCreateSnapshotTableTemplate.add("destinationParquetFile", snapshotParquetFileName);
       sqlCreateSnapshotTableTemplate.add("destinationDataSourceName", snapshotDataSourceName);
       sqlCreateSnapshotTableTemplate.add(

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -238,26 +238,27 @@ public class AzureSynapsePdao {
     for (DatasetTable table : tables) {
       String datasetParquetFileName =
           IngestUtils.getSourceDatasetParquetFilePath(table.getName(), datasetFlightId);
-      ST sqlTableTemplate = new ST(getLiveViewTableTemplate)
-        .add("tableId", table.getId().toString())
-        .add("dataRepoRowId", PDAO_ROW_ID_COLUMN)
-        .add("datasetParquetFileName", datasetParquetFileName)
-        .add("datasetDataSourceName", datasetDataSourceName);
+      ST sqlTableTemplate =
+          new ST(getLiveViewTableTemplate)
+              .add("tableId", table.getId().toString())
+              .add("dataRepoRowId", PDAO_ROW_ID_COLUMN)
+              .add("datasetParquetFileName", datasetParquetFileName)
+              .add("datasetDataSourceName", datasetDataSourceName);
       selectStatements.add(sqlTableTemplate.render());
     }
-    ST sqlMergeTablesTemplate = new ST(mergeLiveViewTablesTemplate);
-    sqlMergeTablesTemplate.add("selectStatements", selectStatements);
+    ST sqlMergeTablesTemplate =
+        new ST(mergeLiveViewTablesTemplate).add("selectStatements", selectStatements);
 
     // Create row id table
-    ST sqlCreateRowIdTable = new ST(createSnapshotRowIdTableTemplate);
     String rowIdTableName = IngestUtils.formatSnapshotTableName(snapshotId, PDAO_ROW_ID_TABLE);
     String rowIdParquetFile = IngestUtils.getSnapshotParquetFilePath(snapshotId, PDAO_ROW_ID_TABLE);
-    sqlCreateRowIdTable.add("tableName", rowIdTableName);
-    sqlCreateRowIdTable.add("destinationParquetFile", rowIdParquetFile);
-    sqlCreateRowIdTable.add("destinationDataSourceName", snapshotDataSourceName);
-    sqlCreateRowIdTable.add(
-        "fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName());
-    sqlCreateRowIdTable.add("selectStatements", sqlMergeTablesTemplate.render());
+    ST sqlCreateRowIdTable =
+        new ST(createSnapshotRowIdTableTemplate)
+            .add("tableName", rowIdTableName)
+            .add("destinationParquetFile", rowIdParquetFile)
+            .add("destinationDataSourceName", snapshotDataSourceName)
+            .add("fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName())
+            .add("selectStatements", sqlMergeTablesTemplate.render());
     executeSynapseQuery(sqlCreateRowIdTable.render());
   }
 
@@ -270,7 +271,6 @@ public class AzureSynapsePdao {
       throws SQLException {
     for (DatasetTable table : tables) {
       // Create a copy of each dataset "table" (parquet file)
-      ST sqlCreateSnapshotTableTemplate = new ST(createSnapshotTableTemplate);
       List<SynapseColumn> columns =
           table.getColumns().stream().map(Column::toSynapseColumn).collect(Collectors.toList());
       String datasetParquetFileName =
@@ -279,14 +279,15 @@ public class AzureSynapsePdao {
           IngestUtils.getSnapshotParquetFilePath(snapshotId, table.getName());
       String tableName = IngestUtils.formatSnapshotTableName(snapshotId, table.getName());
 
-      sqlCreateSnapshotTableTemplate.add("tableName", tableName);
-      sqlCreateSnapshotTableTemplate.add("destinationParquetFile", snapshotParquetFileName);
-      sqlCreateSnapshotTableTemplate.add("destinationDataSourceName", snapshotDataSourceName);
-      sqlCreateSnapshotTableTemplate.add(
-          "fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName());
-      sqlCreateSnapshotTableTemplate.add("ingestFileName", datasetParquetFileName);
-      sqlCreateSnapshotTableTemplate.add("ingestFileDataSourceName", datasetDataSourceName);
-      sqlCreateSnapshotTableTemplate.add("columns", columns);
+      ST sqlCreateSnapshotTableTemplate =
+          new ST(createSnapshotTableTemplate)
+              .add("tableName", tableName)
+              .add("destinationParquetFile", snapshotParquetFileName)
+              .add("destinationDataSourceName", snapshotDataSourceName)
+              .add("fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName())
+              .add("ingestFileName", datasetParquetFileName)
+              .add("ingestFileDataSourceName", datasetDataSourceName)
+              .add("columns", columns);
       executeSynapseQuery(sqlCreateSnapshotTableTemplate.render());
     }
   }

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -1,9 +1,14 @@
 package bio.terra.service.filedata.azure;
 
+import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_COLUMN;
+import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_TABLE;
+import static bio.terra.common.PdaoConstant.PDAO_TABLE_ID_COLUMN;
+
 import bio.terra.common.Column;
 import bio.terra.common.SynapseColumn;
 import bio.terra.model.IngestRequestModel.FormatEnum;
 import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import bio.terra.service.resourcemanagement.exception.AzureResourceException;
 import com.azure.core.credential.AzureSasCredential;
@@ -17,6 +22,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
@@ -45,6 +51,42 @@ public class AzureSynapsePdao {
           + "    LOCATION = '<scheme>://<host>/<container>',\n"
           + "    CREDENTIAL = [<credential>]\n"
           + ");";
+
+  private static final String createSnapshotTableTemplate =
+      "CREATE EXTERNAL TABLE [<tableName>]\n"
+          + "WITH (\n"
+          + "    LOCATION = '<destinationParquetFile>',\n"
+          + "    DATA_SOURCE = [<destinationDataSourceName>],\n" // metadata container
+          + "    FILE_FORMAT = [<fileFormat>]\n"
+          + ") AS SELECT * FROM\n"
+          + "    OPENROWSET(\n"
+          + "       BULK '<ingestFileName>',\n"
+          + "       DATA_SOURCE = '<ingestFileDataSourceName>',\n"
+          + "       FORMAT = 'parquet') "
+          + "WITH (<columns:{c|<c.name> <c.synapseDataType>\n"
+          + " <if(c.requiresCollate)> COLLATE Latin1_General_100_CI_AI_SC_UTF8<endif>\n"
+          + "}; separator=\",\n\">) AS rows;";
+
+  private static final String createSnapshotRowIdTableTemplate =
+      "CREATE EXTERNAL TABLE "
+          + PDAO_ROW_ID_TABLE
+          + "\n"
+          + "WITH (\n"
+          + "    LOCATION = '<destinationParquetFile>',\n"
+          + "    DATA_SOURCE = [<destinationDataSourceName>],\n"
+          + "    FILE_FORMAT = [<fileFormat>]) AS  <selectStatements>";
+
+  private static final String getLiveViewTableTemplate =
+      "SELECT '<tableId>' as "
+          + PDAO_TABLE_ID_COLUMN
+          + ", <dataRepoRowId> FROM\n"
+          + "    OPENROWSET(\n"
+          + "       BULK '<datasetParquetFileName>',\n"
+          + "       DATA_SOURCE = '<datasetDataSourceName>',\n"
+          + "       FORMAT = 'parquet') AS rows;";
+
+  private static final String mergeLiveViewTablesTemplate =
+      "<selectStatements; separator=\" UNION ALL \">";
 
   private static final String createTableTemplate =
       "CREATE EXTERNAL TABLE [<tableName>]\n"
@@ -182,8 +224,70 @@ public class AzureSynapsePdao {
     sqlCreateTableTemplate.add("ingestFileName", ingestFileName);
     sqlCreateTableTemplate.add("controlFileDataSourceName", controlFileDataSourceName);
     sqlCreateTableTemplate.add("columns", columns);
-
     return executeSynapseQuery(sqlCreateTableTemplate.render());
+  }
+
+  public void createSnapshotRowIdsParquetFile(
+      List<DatasetTable> tables,
+      UUID snapshotId,
+      String datasetDataSourceName,
+      String snapshotDataSourceName,
+      String datasetFlightId)
+      throws SQLException {
+
+    // Get all row ids from the dataset
+    List<String> selectStatements = new ArrayList<>();
+    for (DatasetTable table : tables) {
+      String datasetParquetFileName =
+          IngestUtils.getSourceDatasetParquetFilePath(table.getName(), datasetFlightId);
+      ST sqlTableTemplate = new ST(getLiveViewTableTemplate);
+      sqlTableTemplate.add("tableId", table.getId().toString());
+      sqlTableTemplate.add("dataRepoRowId", PDAO_ROW_ID_COLUMN);
+      sqlTableTemplate.add("datasetParquetFileName", datasetParquetFileName);
+      sqlTableTemplate.add("datasetDataSourceName", datasetDataSourceName);
+      selectStatements.add(sqlTableTemplate.render());
+    }
+    ST sqlMergeTablesTemplate = new ST(mergeLiveViewTablesTemplate);
+    sqlMergeTablesTemplate.add("selectStatements", selectStatements);
+
+    // Create row id table
+    ST sqlCreateRowIdTable = new ST(createSnapshotRowIdTableTemplate);
+    String rowIdParquetFile = IngestUtils.getSnapshotParquetFilePath(snapshotId, PDAO_ROW_ID_TABLE);
+    sqlCreateRowIdTable.add("destinationParquetFile", rowIdParquetFile);
+    sqlCreateRowIdTable.add("destinationDataSourceName", snapshotDataSourceName);
+    sqlCreateRowIdTable.add(
+        "fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName());
+    sqlCreateRowIdTable.add("selectStatements", sqlMergeTablesTemplate.render());
+    executeSynapseQuery(sqlCreateRowIdTable.render());
+  }
+
+  public void createSnapshotParquetFiles(
+      List<DatasetTable> tables,
+      UUID snapshotId,
+      String datasetDataSourceName,
+      String snapshotDataSourceName,
+      String datasetFlightId)
+      throws SQLException {
+    for (DatasetTable table : tables) {
+      // Create a copy of each dataset "table" (parquet file)
+      ST sqlCreateSnapshotTableTemplate = new ST(createSnapshotTableTemplate);
+      List<SynapseColumn> columns =
+          table.getColumns().stream().map(Column::toSynapseColumn).collect(Collectors.toList());
+      String datasetParquetFileName =
+          IngestUtils.getSourceDatasetParquetFilePath(table.getName(), datasetFlightId);
+      String snapshotParquetFileName =
+          IngestUtils.getSnapshotParquetFilePath(snapshotId, table.getName());
+
+      sqlCreateSnapshotTableTemplate.add("tableName", table.getName());
+      sqlCreateSnapshotTableTemplate.add("destinationParquetFile", snapshotParquetFileName);
+      sqlCreateSnapshotTableTemplate.add("destinationDataSourceName", snapshotDataSourceName);
+      sqlCreateSnapshotTableTemplate.add(
+          "fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName());
+      sqlCreateSnapshotTableTemplate.add("ingestFileName", datasetParquetFileName);
+      sqlCreateSnapshotTableTemplate.add("ingestFileDataSourceName", datasetDataSourceName);
+      sqlCreateSnapshotTableTemplate.add("columns", columns);
+      executeSynapseQuery(sqlCreateSnapshotTableTemplate.render());
+    }
   }
 
   public void dropTables(List<String> tableNames) {

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -29,7 +29,6 @@ import com.azure.core.management.Region;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.storage.blob.BlobUrlParts;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -141,7 +140,7 @@ public class AzureSynapsePdaoConnectedTest {
     StorageAccount storageAccount =
         client
             .storageAccounts()
-            .define("ct" + Instant.now().toEpochMilli())
+            .define("ct" + UUID.randomUUID().toString())
             .withRegion(Region.US_CENTRAL)
             .withExistingResourceGroup(MANAGED_RESOURCE_GROUP_NAME)
             .create();
@@ -260,7 +259,7 @@ public class AzureSynapsePdaoConnectedTest {
     // where we'll write the resulting parquet files
     // We will build this parquetDestinationLocation according
     // to the associated storage account for the dataset
-    String parquetDestinationLocation = "https://tdrshiqauwlpzxavohmxxhfv.blob.core.windows.net";
+    String parquetDestinationLocation = IngestUtils.getParquetTargetLocationURL(storageAccountResource);
 
     BlobUrlParts destinationSignUrlBlob =
         azureBlobStorePdao.getOrSignUrlForTargetFactory(
@@ -296,8 +295,7 @@ public class AzureSynapsePdaoConnectedTest {
 
     // 5 - Create external data source for the snapshot
     // where we'll write the resulting parquet files
-    String parquetSnapshotLocation =
-        String.format("https://%s.blob.core.windows.net", snapshotStorageAccountResource.getName());
+    String parquetSnapshotLocation = IngestUtils.getParquetTargetLocationURL(snapshotStorageAccountResource);
     BlobUrlParts snapshotSignUrlBlob =
         azureSynapsePdao.getOrSignUrlForTargetFactory(
             parquetSnapshotLocation, billingProfile, snapshotStorageAccountResource);

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -299,7 +299,7 @@ public class AzureSynapsePdaoConnectedTest {
     String parquetSnapshotLocation =
         IngestUtils.getParquetTargetLocationURL(snapshotStorageAccountResource);
     BlobUrlParts snapshotSignUrlBlob =
-        azureSynapsePdao.getOrSignUrlForTargetFactory(
+        azureBlobStorePdao.getOrSignUrlForTargetFactory(
             parquetSnapshotLocation, billingProfile, snapshotStorageAccountResource);
     azureSynapsePdao.createExternalDataSource(
         snapshotSignUrlBlob, snapshotScopedCredentialName, snapshotDataSourceName);

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -29,6 +29,7 @@ import com.azure.core.management.Region;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.storage.blob.BlobUrlParts;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -140,7 +141,7 @@ public class AzureSynapsePdaoConnectedTest {
     StorageAccount storageAccount =
         client
             .storageAccounts()
-            .define("ct" + UUID.randomUUID().toString())
+            .define("ct" + Instant.now().toEpochMilli())
             .withRegion(Region.US_CENTRAL)
             .withExistingResourceGroup(MANAGED_RESOURCE_GROUP_NAME)
             .create();

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -320,7 +320,7 @@ public class AzureSynapsePdaoConnectedTest {
     assertThat(
         "List of names in snapshot should equal the dataset names",
         snapshotFirstNames,
-        equalTo(Arrays.asList("Bob", "Sally")));
+        equalTo(List.of("Bob", "Sally")));
 
     // 7 - Create snapshot row ids parquet file via external table
     azureSynapsePdao.createSnapshotRowIdsParquetFile(

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -174,7 +173,9 @@ public class AzureSynapsePdaoConnectedTest {
       logger.info("Unable to delete parquet files.");
     }
 
-    azureSynapsePdao.dropTables(List.of(tableName,
+    azureSynapsePdao.dropTables(
+        List.of(
+            tableName,
             IngestUtils.formatSnapshotTableName(snapshotId, "participant"),
             IngestUtils.formatSnapshotTableName(snapshotId, PDAO_ROW_ID_TABLE)));
     azureSynapsePdao.dropDataSources(
@@ -307,29 +308,29 @@ public class AzureSynapsePdaoConnectedTest {
     List<DatasetTable> datasetTables = List.of(destinationTable);
     azureSynapsePdao.createSnapshotParquetFiles(
         datasetTables,
-                snapshotId,
-                destinationDataSourceName,
-                snapshotDataSourceName,
-                randomFlightId);
+        snapshotId,
+        destinationDataSourceName,
+        snapshotDataSourceName,
+        randomFlightId);
     String snapshotParquetFileName =
-            IngestUtils.getSnapshotParquetFilePath(snapshotId, destinationTable.getName());
+        IngestUtils.getSnapshotParquetFilePath(snapshotId, destinationTable.getName());
     List<String> snapshotFirstNames =
-            synapseUtils.readParquetFileStringColumn(
-                    snapshotParquetFileName, snapshotDataSourceName, "first_name", true);
+        synapseUtils.readParquetFileStringColumn(
+            snapshotParquetFileName, snapshotDataSourceName, "first_name", true);
     assertThat(
-            "List of names in snapshot should equal the dataset names",
-            snapshotFirstNames,
-            equalTo(Arrays.asList("Bob", "Sally")));
+        "List of names in snapshot should equal the dataset names",
+        snapshotFirstNames,
+        equalTo(Arrays.asList("Bob", "Sally")));
 
     // 7 - Create snapshot row ids parquet file via external table
     azureSynapsePdao.createSnapshotRowIdsParquetFile(
-            datasetTables,
-            snapshotId,
-            destinationDataSourceName,
-            snapshotDataSourceName,
-            randomFlightId);
+        datasetTables,
+        snapshotId,
+        destinationDataSourceName,
+        snapshotDataSourceName,
+        randomFlightId);
     String snapshotRowIdsParquetFileName =
-            IngestUtils.getSnapshotParquetFilePath(snapshotId, PDAO_ROW_ID_TABLE);
+        IngestUtils.getSnapshotParquetFilePath(snapshotId, PDAO_ROW_ID_TABLE);
     List<String> snapshotRowIds =
         synapseUtils.readParquetFileStringColumn(
             snapshotRowIdsParquetFileName, snapshotDataSourceName, PDAO_ROW_ID_COLUMN, true);

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -178,8 +178,7 @@ public class AzureSynapsePdaoConnectedTest {
             IngestUtils.formatSnapshotTableName(snapshotId, "participant"),
             IngestUtils.formatSnapshotTableName(snapshotId, PDAO_ROW_ID_TABLE)));
     azureSynapsePdao.dropDataSources(
-        List.of(
-            snapshotDataSourceName, destinationDataSourceName, ingestRequestDataSourceName));
+        List.of(snapshotDataSourceName, destinationDataSourceName, ingestRequestDataSourceName));
     azureSynapsePdao.dropScopedCredentials(
         List.of(
             snapshotScopedCredentialName,
@@ -259,7 +258,8 @@ public class AzureSynapsePdaoConnectedTest {
     // where we'll write the resulting parquet files
     // We will build this parquetDestinationLocation according
     // to the associated storage account for the dataset
-    String parquetDestinationLocation = IngestUtils.getParquetTargetLocationURL(storageAccountResource);
+    String parquetDestinationLocation =
+        IngestUtils.getParquetTargetLocationURL(storageAccountResource);
 
     BlobUrlParts destinationSignUrlBlob =
         azureBlobStorePdao.getOrSignUrlForTargetFactory(
@@ -295,7 +295,8 @@ public class AzureSynapsePdaoConnectedTest {
 
     // 5 - Create external data source for the snapshot
     // where we'll write the resulting parquet files
-    String parquetSnapshotLocation = IngestUtils.getParquetTargetLocationURL(snapshotStorageAccountResource);
+    String parquetSnapshotLocation =
+        IngestUtils.getParquetTargetLocationURL(snapshotStorageAccountResource);
     BlobUrlParts snapshotSignUrlBlob =
         azureSynapsePdao.getOrSignUrlForTargetFactory(
             parquetSnapshotLocation, billingProfile, snapshotStorageAccountResource);

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -179,7 +179,7 @@ public class AzureSynapsePdaoConnectedTest {
             IngestUtils.formatSnapshotTableName(snapshotId, "participant"),
             IngestUtils.formatSnapshotTableName(snapshotId, PDAO_ROW_ID_TABLE)));
     azureSynapsePdao.dropDataSources(
-        Arrays.asList(
+        List.of(
             snapshotDataSourceName, destinationDataSourceName, ingestRequestDataSourceName));
     azureSynapsePdao.dropScopedCredentials(
         List.of(

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -182,7 +182,7 @@ public class AzureSynapsePdaoConnectedTest {
         Arrays.asList(
             snapshotDataSourceName, destinationDataSourceName, ingestRequestDataSourceName));
     azureSynapsePdao.dropScopedCredentials(
-        Arrays.asList(
+        List.of(
             snapshotScopedCredentialName,
             destinationScopedCredentialName,
             ingestRequestScopedCredentialName));


### PR DESCRIPTION
For full view snapshots, we need a parquet file containing all of the dataset's row ids as well as a parquet file for each dataset table containing a copy of all the ingested data.