### PR TITLE
Fix issue where snapshot metadata search result was a string

### DIFF
--- a/src/main/java/bio/terra/app/controller/SearchApiController.java
+++ b/src/main/java/bio/terra/app/controller/SearchApiController.java
@@ -19,7 +19,6 @@ import bio.terra.service.search.SearchService;
 import bio.terra.service.search.SnapshotSearchMetadataDao;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
-import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/bio/terra/app/controller/SearchApiController.java
+++ b/src/main/java/bio/terra/app/controller/SearchApiController.java
@@ -18,8 +18,6 @@ import bio.terra.service.search.SearchService;
 import bio.terra.service.search.SnapshotSearchMetadataDao;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import java.util.HashSet;
@@ -91,26 +89,9 @@ public class SearchApiController implements SearchApi {
     List<UUID> ids =
         iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT);
     Map<UUID, String> metadata = snapshotSearchMetadataDao.getMetadata(ids);
-    //    var response = new SearchMetadataResponse();
-    //    response.setResult(new ArrayList<>());
-    // There's no easy way to tell openapi to map a field as @JsonRawValue mapping, so
-    // instead we translate the json text from Postgres back to a JsonNode, which Jackson
-    // will convert back to text in the response.
     // Create the JSON result "by hand" to avoid having to round trip the data to JsonNode.
-    var jsonResponseTemplate = "{ \"result\": [ %s ] }";
-    //    metadata.values().stream().map(this::toJsonNode).forEach(response.getResult()::add);
-    return ResponseEntity.ok(
-        String.format(jsonResponseTemplate, String.join(",", metadata.values())));
-  }
-
-  private JsonNode toJsonNode(String json) {
-    try {
-      return objectMapper.readValue(json, JsonNode.class);
-    } catch (JsonProcessingException e) {
-      // This shouldn't occur, as the data stored in postgres must be valid JSON, because it's
-      // stored as JSONB.
-      throw new RuntimeException(e);
-    }
+    String response = String.format("{ \"result\": [ %s ] }", String.join(",", metadata.values()));
+    return ResponseEntity.ok(response);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/search/SearchService.java
+++ b/src/main/java/bio/terra/service/search/SearchService.java
@@ -46,20 +46,15 @@ import org.springframework.stereotype.Component;
 public class SearchService {
 
   private final BigQueryPdao bigQueryPdao;
-  private final SnapshotSearchMetadataDao snapshotSearchMetadataDao;
   private final RestHighLevelClient client;
 
   @Value("${elasticsearch.numShards}")
   private int NUM_SHARDS;
 
   @Autowired
-  public SearchService(
-      BigQueryPdao bigQueryPdao,
-      SnapshotSearchMetadataDao snapshotSearchMetadataDao,
-      RestHighLevelClient client) {
+  public SearchService(BigQueryPdao bigQueryPdao, RestHighLevelClient client) {
     this.bigQueryPdao = bigQueryPdao;
     this.client = client;
-    this.snapshotSearchMetadataDao = snapshotSearchMetadataDao;
   }
 
   private void validateSnapshotDataNotEmpty(List<Map<String, Object>> values) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2282,7 +2282,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/SearchMetadataResponse'
 
   /api/repository/v1/search/{id}/index:
     post:
@@ -4142,6 +4142,15 @@ components:
           description: Results that match the search criteria
       description: >
         The available search results that match the filter criteria
+
+    SearchMetadataResponse:
+      type: object
+      properties:
+        result:
+          type: array
+          items:
+            type: object
+      description: List of snapshot metadata
 
     ##############################################################################
     ## DRS STANDARD MODELS

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4143,15 +4143,6 @@ components:
       description: >
         The available search results that match the filter criteria
 
-    SearchMetadataResponse:
-      type: object
-      properties:
-        result:
-          type: array
-          items:
-            type: object
-      description: List of snapshot metadata
-
     ##############################################################################
     ## DRS STANDARD MODELS
     ##############################################################################

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2282,7 +2282,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SearchMetadataResponse'
+                type: string
 
   /api/repository/v1/search/{id}/index:
     post:

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -35,6 +35,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = "features.search.api=enabled")
@@ -93,9 +94,10 @@ public class SearchApiControllerTest {
     when(iamService.listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT)))
         .thenReturn(uuids);
     when(snapshotMetadataDao.getMetadata(uuids)).thenReturn(Map.of(uuid, json));
-    mvc.perform(get(endpoint))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.result[0].test").value("data"));
+    final ResultActions data =
+        mvc.perform(get(endpoint))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result[0].test").value("data"));
     verify(iamService).listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT));
     verify(snapshotMetadataDao).getMetadata(uuids);
   }

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -35,7 +35,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = "features.search.api=enabled")
@@ -94,10 +93,9 @@ public class SearchApiControllerTest {
     when(iamService.listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT)))
         .thenReturn(uuids);
     when(snapshotMetadataDao.getMetadata(uuids)).thenReturn(Map.of(uuid, json));
-    final ResultActions data =
-        mvc.perform(get(endpoint))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.result[0].test").value("data"));
+    mvc.perform(get(endpoint))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result[0].test").value("data"));
     verify(iamService).listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT));
     verify(snapshotMetadataDao).getMetadata(uuids);
   }

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -22,7 +22,6 @@ import bio.terra.service.search.SearchService;
 import bio.terra.service.search.SnapshotSearchMetadataDao;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -22,7 +22,9 @@ import bio.terra.service.search.SearchService;
 import bio.terra.service.search.SnapshotSearchMetadataDao;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -86,12 +88,17 @@ public class SearchApiControllerTest {
   @Test
   public void testEnumerateSnapshotSearch() throws Exception {
     var endpoint = "/api/repository/v1/search/metadata";
-    List<UUID> uuids = List.of(UUID.randomUUID());
+    var json = "{\"test\":\"data\"}";
+    UUID uuid = UUID.randomUUID();
+    List<UUID> uuids = List.of(uuid);
     when(iamService.listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT)))
         .thenReturn(uuids);
-    mvc.perform(get(endpoint)).andExpect(status().isOk());
+    when(snapshotMetadataDao.getMetadata(uuids)).thenReturn(Map.of(uuid, json));
+    mvc.perform(get(endpoint))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result[0].test").value("data"));
     verify(iamService).listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT));
-    verify(snapshotMetadataDao).getMetadata(eq(uuids));
+    verify(snapshotMetadataDao).getMetadata(uuids);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/search/SearchServiceTest.java
+++ b/src/test/java/bio/terra/service/search/SearchServiceTest.java
@@ -76,7 +76,7 @@ public class SearchServiceTest {
 
   @Before
   public void setup() throws Exception {
-    service = new SearchService(bigQueryPdao, snapshotSearchMetadataDao, client);
+    service = new SearchService(bigQueryPdao, client);
 
     searchIndexRequest = getSearchIndexRequest();
     snapshot = getSnapshot();


### PR DESCRIPTION
Alternate approach to fix; instead of round trip to `JsonNode`, leave data as `String` by creating JSON result using string formatting. Alternate to https://github.com/DataBiosphere/jade-data-repo/pull/1071