### PR TITLE
DR-2138 Support creating profiles, datasets and snapshots using a pet service account token

### DIFF
--- a/src/main/java/bio/terra/service/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/iam/IamProviderInterface.java
@@ -157,6 +157,17 @@ public interface IamProviderInterface {
       String userEmail)
       throws InterruptedException;
 
+  /**
+   * Return a Google access token for an arbitrary pet service account associated with the logged in
+   * user
+   *
+   * @param userReq authenticated user
+   * @param scopes List of scopes to request for the token
+   * @return A string access token
+   */
+  String getPetToken(AuthenticatedUserRequest userReq, List<String> scopes)
+      throws InterruptedException;
+
   UserStatusInfo getUserInfo(AuthenticatedUserRequest userReq);
 
   /**

--- a/src/main/java/bio/terra/service/iam/IamService.java
+++ b/src/main/java/bio/terra/service/iam/IamService.java
@@ -73,7 +73,7 @@ public class IamService {
           new AuthorizedCacheKey(userReqNoId, iamResourceType, resourceId, action);
       AuthorizedCacheValue authorizedCacheValue = authorizedMap.get(authorizedCacheKey);
       if (authorizedCacheValue != null) { // check if it's in the cache
-        // check if it's still in the alloted time
+        // check if it's still in the allotted time
         if (Instant.now().isBefore(authorizedCacheValue.getTimeout())) {
           logger.debug("Using the cache!");
           return authorizedCacheValue.isAuthorized();

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -506,7 +506,7 @@ public class SamIam implements IamProviderInterface {
     } catch (Exception ex) {
       String errorMsg = "Sam status check failed";
       logger.error(errorMsg, ex);
-      return new RepositoryStatusModelSystems().ok(false).message(errorMsg + ": " + ex.toString());
+      return new RepositoryStatusModelSystems().ok(false).message(errorMsg + ": " + ex);
     }
   }
 

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -59,7 +59,7 @@ public class ProfileService {
   }
 
   /**
-   * Create a new billing profile providing an valid google billing account We make the following
+   * Create a new billing profile providing a valid google billing account We make the following
    * checks:
    *
    * <ul>

--- a/src/test/java/bio/terra/common/auth/AuthService.java
+++ b/src/test/java/bio/terra/common/auth/AuthService.java
@@ -40,7 +40,6 @@ public class AuthService {
   private List<String> userLoginScopes =
       List.of(
           "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-billing.readonly");
-  private List<String> samUserLoginScopes = List.of("openid", "email", "profile");
   private List<String> directAccessScopes =
       List.of(
           "https://www.googleapis.com/auth/bigquery",
@@ -137,7 +136,7 @@ public class AuthService {
           .getPetToken(
               new AuthenticatedUserRequest()
                   .token(Optional.of(makeToken(userEmail).getAccessToken())),
-              samUserLoginScopes)
+              userLoginScopes)
           .replaceAll("\\.+$", "");
     } catch (InterruptedException e) {
       throw new RuntimeException(e);

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -66,7 +66,22 @@ public class DataRepoClient {
   public <T> DataRepoResponse<T> post(
       TestConfiguration.User user, String path, String json, Class<T> responseClass)
       throws Exception {
-    HttpEntity<String> entity = new HttpEntity<>(json, getHeaders(user));
+    return post(user, path, json, responseClass, false);
+  }
+
+  public <T> DataRepoResponse<T> post(
+      TestConfiguration.User user,
+      String path,
+      String json,
+      Class<T> responseClass,
+      boolean usePetAccount)
+      throws Exception {
+    HttpEntity<String> entity;
+    if (usePetAccount) {
+      entity = new HttpEntity<>(json, getHeadersForPet(user));
+    } else {
+      entity = new HttpEntity<>(json, getHeaders(user));
+    }
     return makeDataRepoRequest(path, HttpMethod.POST, entity, responseClass);
   }
 
@@ -249,6 +264,13 @@ public class DataRepoClient {
   private HttpHeaders getHeaders(TestConfiguration.User user) {
     HttpHeaders copy = new HttpHeaders(headers);
     copy.setBearerAuth(authService.getAuthToken(user.getEmail()));
+    copy.set("From", user.getEmail());
+    return copy;
+  }
+
+  private HttpHeaders getHeadersForPet(TestConfiguration.User user) {
+    HttpHeaders copy = new HttpHeaders(headers);
+    copy.setBearerAuth(authService.getPetAccountAuthToken(user.getEmail()));
     copy.set("From", user.getEmail());
     return copy;
   }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -154,7 +154,11 @@ public class DataRepoFixtures {
   // datasets
 
   private DataRepoResponse<JobModel> createDatasetRaw(
-      TestConfiguration.User user, UUID profileId, String filename, CloudPlatform cloudPlatform)
+      TestConfiguration.User user,
+      UUID profileId,
+      String filename,
+      CloudPlatform cloudPlatform,
+      boolean usePetAccount)
       throws Exception {
     DatasetRequestModel requestModel = jsonLoader.loadObject(filename, DatasetRequestModel.class);
     requestModel.setDefaultProfileId(profileId);
@@ -164,7 +168,8 @@ public class DataRepoFixtures {
     }
     String json = TestUtils.mapToJson(requestModel);
 
-    return dataRepoClient.post(user, "/api/repository/v1/datasets", json, JobModel.class);
+    return dataRepoClient.post(
+        user, "/api/repository/v1/datasets", json, JobModel.class, usePetAccount);
   }
 
   public DatasetSummaryModel createDataset(
@@ -175,8 +180,18 @@ public class DataRepoFixtures {
   public DatasetSummaryModel createDataset(
       TestConfiguration.User user, UUID profileId, String filename, CloudPlatform cloudPlatform)
       throws Exception {
+    return createDataset(user, profileId, filename, cloudPlatform, false);
+  }
+
+  public DatasetSummaryModel createDataset(
+      TestConfiguration.User user,
+      UUID profileId,
+      String filename,
+      CloudPlatform cloudPlatform,
+      boolean usePetAccount)
+      throws Exception {
     DataRepoResponse<JobModel> jobResponse =
-        createDatasetRaw(user, profileId, filename, cloudPlatform);
+        createDatasetRaw(user, profileId, filename, cloudPlatform, usePetAccount);
     assertTrue("dataset create launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
     assertTrue(
         "dataset create launch response is present", jobResponse.getResponseObject().isPresent());
@@ -204,7 +219,7 @@ public class DataRepoFixtures {
       CloudPlatform cloudPlatform)
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
-        createDatasetRaw(user, profileId, filename, cloudPlatform);
+        createDatasetRaw(user, profileId, filename, cloudPlatform, false);
     assertTrue("dataset create launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
     assertTrue(
         "dataset create launch response is present", jobResponse.getResponseObject().isPresent());
@@ -367,7 +382,8 @@ public class DataRepoFixtures {
       String datasetName,
       UUID profileId,
       SnapshotRequestModel requestModel,
-      boolean randomizeName)
+      boolean randomizeName,
+      boolean usePetAccount)
       throws Exception {
 
     if (randomizeName) {
@@ -377,7 +393,8 @@ public class DataRepoFixtures {
     requestModel.setProfileId(profileId);
     String json = TestUtils.mapToJson(requestModel);
 
-    return dataRepoClient.post(user, "/api/repository/v1/snapshots", json, JobModel.class);
+    return dataRepoClient.post(
+        user, "/api/repository/v1/snapshots", json, JobModel.class, usePetAccount);
   }
 
   public SnapshotSummaryModel createSnapshotWithRequest(
@@ -397,7 +414,21 @@ public class DataRepoFixtures {
       boolean randomizeName)
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
-        createSnapshotRaw(user, datasetName, profileId, snapshotRequest, randomizeName);
+        createSnapshotRaw(user, datasetName, profileId, snapshotRequest, randomizeName, false);
+    return finishCreateSnapshot(user, jobResponse);
+  }
+
+  public SnapshotSummaryModel createSnapshotWithRequest(
+      TestConfiguration.User user,
+      String datasetName,
+      UUID profileId,
+      SnapshotRequestModel snapshotRequest,
+      boolean randomizeName,
+      boolean usePetAccount)
+      throws Exception {
+    DataRepoResponse<JobModel> jobResponse =
+        createSnapshotRaw(
+            user, datasetName, profileId, snapshotRequest, randomizeName, usePetAccount);
     return finishCreateSnapshot(user, jobResponse);
   }
 
@@ -414,9 +445,20 @@ public class DataRepoFixtures {
       String filename,
       boolean randomizeName)
       throws Exception {
+    return createSnapshot(user, datasetName, profileId, filename, randomizeName, false);
+  }
+
+  public SnapshotSummaryModel createSnapshot(
+      TestConfiguration.User user,
+      String datasetName,
+      UUID profileId,
+      String filename,
+      boolean randomizeName,
+      boolean usePetAccount)
+      throws Exception {
     SnapshotRequestModel requestModel = jsonLoader.loadObject(filename, SnapshotRequestModel.class);
     DataRepoResponse<JobModel> jobResponse =
-        createSnapshotRaw(user, datasetName, profileId, requestModel, randomizeName);
+        createSnapshotRaw(user, datasetName, profileId, requestModel, randomizeName, usePetAccount);
     return finishCreateSnapshot(user, jobResponse);
   }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -20,6 +20,7 @@ import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.DataRepoResponse;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.AssetModel;
+import bio.terra.model.CloudPlatform;
 import bio.terra.model.DataDeletionGcsFileModel;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DataDeletionTableModel;
@@ -199,6 +200,25 @@ public class DatasetIntegrationTest extends UsersBase {
         "Custodian is authorized to enumerate datasets",
         enumDatasets.getStatusCode(),
         equalTo(HttpStatus.OK));
+  }
+
+  @Test
+  public void datasetHappyPathWithPet() throws Exception {
+    DatasetSummaryModel summaryModel =
+        dataRepoFixtures.createDataset(
+            steward(), profileId, "it-dataset-omop.json", CloudPlatform.GCP, true);
+    datasetId = summaryModel.getId();
+
+    logger.info("dataset id is " + summaryModel.getId());
+    assertThat(summaryModel.getName(), startsWith(omopDatasetName));
+    assertThat(summaryModel.getDescription(), equalTo(omopDatasetDesc));
+
+    // We just need to validate the steward is able to read back the dataset (e.g. the pet account
+    // resolved correctly)
+    DatasetModel datasetModel = dataRepoFixtures.getDataset(steward(), summaryModel.getId());
+
+    assertThat(datasetModel.getName(), startsWith(omopDatasetName));
+    assertThat(datasetModel.getDescription(), equalTo(omopDatasetDesc));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
@@ -177,12 +177,7 @@ public class SamIamTest {
   public void testGetUserInfo() throws ApiException {
     final String userSubjectId = "userid";
     final String userEmail = "a@a.com";
-    when(samUsersApi.getUserStatusInfo())
-        .thenReturn(
-            new org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo()
-                .userSubjectId(userSubjectId)
-                .userEmail(userEmail)
-                .enabled(true));
+    mockUserInfo(userSubjectId, userEmail);
 
     assertThat(samIam.getUserInfo(userReq))
         .isEqualTo(
@@ -247,6 +242,10 @@ public class SamIamTest {
 
   @Test
   public void testCreateDataset() throws InterruptedException, ApiException {
+    final String userSubjectId = "userid";
+    final String userEmail = "a@a.com";
+    mockUserInfo(userSubjectId, userEmail);
+
     final UUID datasetId = UUID.randomUUID();
     // Note: in our case, policies have a 1:1 relationship with roles
     final List<IamRole> allPolicies =
@@ -270,6 +269,10 @@ public class SamIamTest {
 
   @Test
   public void testCreateSnapshot() throws InterruptedException, ApiException {
+    final String userSubjectId = "userid";
+    final String userEmail = "a@a.com";
+    mockUserInfo(userSubjectId, userEmail);
+
     final UUID snapshotId = UUID.randomUUID();
     // Note: in our case, policies have a 1:1 relationship with roles
     final List<IamRole> allPolicies =
@@ -292,6 +295,10 @@ public class SamIamTest {
 
   @Test
   public void testCreateProfile() throws InterruptedException, ApiException {
+    final String userSubjectId = "userid";
+    final String userEmail = "a@a.com";
+    mockUserInfo(userSubjectId, userEmail);
+
     final UUID profileId = UUID.randomUUID();
     // Note: in our case, policies have a 1:1 relationship with roles
     final List<IamRole> allPolicies = List.of(IamRole.ADMIN, IamRole.OWNER, IamRole.USER);
@@ -351,5 +358,14 @@ public class SamIamTest {
             id.toString(),
             IamRole.OWNER.toString(),
             userEmail);
+  }
+
+  private void mockUserInfo(String userSubjectId, String userEmail) throws ApiException {
+    when(samUsersApi.getUserStatusInfo())
+        .thenReturn(
+            new org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo()
+                .userSubjectId(userSubjectId)
+                .userEmail(userEmail)
+                .enabled(true));
   }
 }


### PR DESCRIPTION
This PR makes it so that when we create one our 3 resources, we first lookup the user in Sam using the passed in credentials and then use that user email to set set the creating user as a Steward/Owner.

I didn't add an integration test for the billing profile since it's not a case I expect to see in the wild since it requires to have the Sam proxy user granted access to the billing account and not the actual Google user for it to work.