### PR TITLE
DR-2155 Get Snapshot Azure Storage Account

### DIFF
--- a/src/main/java/bio/terra/service/dataset/AzureStorageAccountComponent.java
+++ b/src/main/java/bio/terra/service/dataset/AzureStorageAccountComponent.java
@@ -1,3 +1,0 @@
-package bio.terra.service.dataset;
-
-public interface AzureStorageAccountComponent {}

--- a/src/main/java/bio/terra/service/dataset/AzureStorageAccountComponent.java
+++ b/src/main/java/bio/terra/service/dataset/AzureStorageAccountComponent.java
@@ -1,0 +1,3 @@
+package bio.terra.service.dataset;
+
+public interface AzureStorageAccountComponent {}

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -1,5 +1,7 @@
 package bio.terra.service.dataset;
 
+import bio.terra.app.model.AzureCloudResource;
+import bio.terra.app.model.AzureRegion;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.service.filedata.FSContainerInterface;
@@ -204,5 +206,10 @@ public class Dataset implements FSContainerInterface {
       AzureApplicationDeploymentResource applicationDeploymentResource) {
     this.applicationDeploymentResource = applicationDeploymentResource;
     return this;
+  }
+
+  public AzureRegion getStorageAccountRegion() {
+    return (AzureRegion)
+        datasetSummary.getStorageResourceRegion(AzureCloudResource.STORAGE_ACCOUNT);
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
@@ -41,7 +41,7 @@ public class CreateDatasetGetOrCreateContainerStep implements Step {
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
 
     AzureStorageAccountResource storageAccount =
-        resourceService.getOrCreateStorageAccount(
+        resourceService.getOrCreateDatasetStorageAccount(
             DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel),
             profileModel,
             context.getFlightId());

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateStorageAccountStep.java
@@ -39,7 +39,7 @@ public class CreateDatasetGetOrCreateStorageAccountStep implements Step {
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
 
     AzureStorageAccountResource storageAccount =
-        resourceService.getOrCreateStorageAccount(
+        resourceService.getOrCreateDatasetStorageAccount(
             DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel),
             profileModel,
             context.getFlightId());

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
@@ -58,7 +58,7 @@ public class DeleteDatasetAzurePrimaryDataStep implements Step {
     BillingProfileModel profileModel =
         profileDao.getBillingProfileById(dataset.getDefaultProfileId());
     AzureStorageAccountResource storageAccountResource =
-        resourceService.getStorageAccount(dataset, profileModel);
+        resourceService.getDatasetStorageAccount(dataset, profileModel);
     AzureStorageAuthInfo storageAuthInfo =
         AzureStorageAuthInfo.azureStorageAuthInfoBuilder(profileModel, storageAccountResource);
     tableDao.deleteFilesFromDataset(storageAuthInfo, azureBlobStorePdao::deleteFile);

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -203,7 +203,7 @@ public class FileService {
       BillingProfileModel billingProfileModel =
           profileService.getProfileByIdNoCheck(dataset.getDefaultProfileId());
       AzureStorageAccountResource storageAccountResource =
-          resourceService.getStorageAccount(dataset, billingProfileModel);
+          resourceService.getDatasetStorageAccount(dataset, billingProfileModel);
       AzureStorageAuthInfo storageAuthInfo =
           AzureStorageAuthInfo.azureStorageAuthInfoBuilder(
               billingProfileModel, storageAccountResource);
@@ -227,7 +227,7 @@ public class FileService {
       BillingProfileModel billingProfileModel =
           profileService.getProfileByIdNoCheck(dataset.getDefaultProfileId());
       AzureStorageAccountResource storageAccountResource =
-          resourceService.getStorageAccount(dataset, billingProfileModel);
+          resourceService.getDatasetStorageAccount(dataset, billingProfileModel);
       AzureStorageAuthInfo storageAuthInfo =
           AzureStorageAuthInfo.azureStorageAuthInfoBuilder(
               billingProfileModel, storageAccountResource);
@@ -250,7 +250,7 @@ public class FileService {
       BillingProfileModel billingProfileModel =
           profileService.getProfileByIdNoCheck(dataset.getDefaultProfileId());
       AzureStorageAccountResource storageAccountResource =
-          resourceService.getStorageAccount(dataset, billingProfileModel);
+          resourceService.getDatasetStorageAccount(dataset, billingProfileModel);
       AzureStorageAuthInfo storageAuthInfo =
           AzureStorageAuthInfo.azureStorageAuthInfoBuilder(
               billingProfileModel, storageAccountResource);

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
@@ -61,7 +61,8 @@ public class DeleteFileAzureLookupStep implements Step {
       BillingProfileModel billingProfile =
           profileDao.getBillingProfileById(dataset.getDefaultProfileId());
       AzureStorageAccountResource storageAccountResource =
-          resourceService.getOrCreateStorageAccount(dataset, billingProfile, context.getFlightId());
+          resourceService.getOrCreateDatasetStorageAccount(
+              dataset, billingProfile, context.getFlightId());
 
       AzureStorageAuthInfo storageAuthInfo =
           AzureStorageAuthInfo.azureStorageAuthInfoBuilder(billingProfile, storageAccountResource);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCreateAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCreateAzureStorageAccountStep.java
@@ -35,7 +35,7 @@ public class IngestCreateAzureStorageAccountStep implements Step {
     Dataset dataset = IngestUtils.getDataset(context, datasetService);
 
     AzureStorageAccountResource storageAccountResource =
-        resourceService.getOrCreateStorageAccount(dataset, billingProfile, flightId);
+        resourceService.getOrCreateDatasetStorageAccount(dataset, billingProfile, flightId);
     workingMap.put(FileMapKeys.STORAGE_ACCOUNT_INFO, storageAccountResource);
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataLocationStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataLocationStep.java
@@ -43,7 +43,7 @@ public class IngestFileAzurePrimaryDataLocationStep extends SkippableStep {
 
       try {
         AzureStorageAccountResource storageAccountResource =
-            resourceService.getOrCreateStorageAccount(
+            resourceService.getOrCreateDatasetStorageAccount(
                 dataset, billingProfile, context.getFlightId());
         workingMap.put(FileMapKeys.STORAGE_ACCOUNT_INFO, storageAccountResource);
         AzureStorageAuthInfo storageAuthInfo =

--- a/src/main/java/bio/terra/service/resourcemanagement/AzureDataLocationSelector.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/AzureDataLocationSelector.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class AzureDataLocationSelector {
 
-  public String storageAccountNameForDataset(
+  public String createStorageAccountName(
       String prefix, String datasetName, BillingProfileModel billingProfile) {
     int maxStorageAccountNameLength = 24;
     int randomLength = maxStorageAccountNameLength - prefix.length();

--- a/src/main/java/bio/terra/service/resourcemanagement/AzureDataLocationSelector.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/AzureDataLocationSelector.java
@@ -13,10 +13,10 @@ import org.springframework.stereotype.Component;
 public class AzureDataLocationSelector {
 
   public String createStorageAccountName(
-      String prefix, String datasetName, BillingProfileModel billingProfile) {
+      String prefix, String collectionName, BillingProfileModel billingProfile) {
     int maxStorageAccountNameLength = 24;
     int randomLength = maxStorageAccountNameLength - prefix.length();
-    return prefix + armUniqueString(datasetName + billingProfile.toString(), randomLength);
+    return prefix + armUniqueString(collectionName + billingProfile.toString(), randomLength);
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -87,7 +87,7 @@ public final class MetadataDataAccessUtils {
     } else if (cloudPlatformWrapper.isAzure()) {
       BillingProfileModel profileModel = dataset.getDatasetSummary().getDefaultBillingProfile();
       AzureStorageAccountResource storageAccountResource =
-          resourceService.getStorageAccount(dataset, profileModel);
+          resourceService.getDatasetStorageAccount(dataset, profileModel);
       return makeAccessInfoAzure(
           dataset.getName(), storageAccountResource, dataset.getTables(), profileModel);
     } else {

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -203,6 +203,7 @@ public class ResourceService {
     final AzureStorageAccountResource storageAccountResource;
 
     // Maybe the storage account exists in the db, but the in-memory object hasn't been updated
+    // I don't think this case exists, but I'm programming defensively here.
     if (storageAccountResourceId.isPresent()) {
       storageAccountResource =
           storageAccountService.getStorageAccountResourceById(

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -1,5 +1,6 @@
 package bio.terra.service.snapshot;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.service.filedata.FSContainerInterface;
@@ -163,5 +164,9 @@ public class Snapshot implements FSContainerInterface {
     String datasetProjectId =
         getFirstSnapshotSource().getDataset().getProjectResource().getGoogleProjectId();
     return FireStoreProject.get(datasetProjectId);
+  }
+
+  public AzureRegion getStorageAccountRegion() {
+    return getFirstSnapshotSource().getDataset().getStorageAccountRegion();
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -4,6 +4,7 @@ import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.service.filedata.FSContainerInterface;
 import bio.terra.service.filedata.google.firestore.FireStoreProject;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import java.time.Instant;
@@ -26,6 +27,7 @@ public class Snapshot implements FSContainerInterface {
   private UUID profileId;
   private UUID projectResourceId;
   private GoogleProjectResource projectResource;
+  private AzureStorageAccountResource storageAccountResource;
   private List<Relationship> relationships = Collections.emptyList();
 
   public UUID getId() {
@@ -124,6 +126,15 @@ public class Snapshot implements FSContainerInterface {
 
   public Snapshot projectResource(GoogleProjectResource projectResource) {
     this.projectResource = projectResource;
+    return this;
+  }
+
+  public AzureStorageAccountResource getStorageAccountResource() {
+    return storageAccountResource;
+  }
+
+  public Snapshot setStorageAccountResource(AzureStorageAccountResource storageAccountResource) {
+    this.storageAccountResource = storageAccountResource;
     return this;
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -373,6 +373,11 @@ public class SnapshotDao {
         // It seemed like the cleanest thing to me at the time.
         snapshot.projectResource(
             resourceService.getProjectResource(snapshot.getProjectResourceId()));
+
+        // Retrieve the Azure Storage Account associated with the snapshot.
+        resourceService
+            .getSnapshotStorageAccount(snapshot.getId())
+            .ifPresent(snapshot::setStorageAccountResource);
       }
       return snapshot;
     } catch (EmptyResultDataAccessException ex) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotStorageAccountDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotStorageAccountDao.java
@@ -1,10 +1,18 @@
 package bio.terra.service.snapshot;
 
+import static bio.terra.common.DaoUtils.retryQuery;
+
 import bio.terra.common.exception.RetryQueryException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -12,28 +20,21 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
-
-import static bio.terra.common.DaoUtils.retryQuery;
-
 @Component
 public class SnapshotStorageAccountDao {
   private static final Logger logger = LoggerFactory.getLogger(SnapshotStorageAccountDao.class);
 
-  private static final String whereClause =
-      " WHERE id = :snapshot_id";
+  private static final String whereClause = " WHERE id = :snapshot_id";
 
   private static final String sqlCreateLink =
       "UPDATE snapshot "
           + " SET storage_account_resource_id = :storage_account_resource_id"
           + whereClause;
 
-  private static final String sqlExistsLink =
-      "SELECT storage_account_resource_id FROM snapshot" + whereClause;
-
   private static final String sqlGetStorageAccountResourceId =
-      "SELECT storage_account_resource_id FROM snapshot" +
-      whereClause;
+      "SELECT storage_account_resource_id FROM snapshot"
+          + whereClause
+          + " AND storage_account_resource-id IS NOT NULL";
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -61,18 +62,29 @@ public class SnapshotStorageAccountDao {
     }
   }
 
-  boolean snapshotStorageAccountLinkExists(UUID snapshotId, UUID storageAccountResourceId) {
-    MapSqlParameterSource params =
-        new MapSqlParameterSource()
-            .addValue("snapshot_id", snapshotId)
-            .addValue("storage_account_resource_id", storageAccountResourceId);
-    String id = jdbcTemplate.queryForObject(sqlExistsLink, params, String.class);
-    return id != null;
-  }
-
-  public UUID getStorageAccountResourceIdForSnapshotId(UUID snapshotId) {
+  public Optional<UUID> getStorageAccountResourceIdForSnapshotId(UUID snapshotId) {
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("snapshot_id", snapshotId);
-    return jdbcTemplate.queryForObject(sqlGetStorageAccountResourceId, params, UUID.class);
+
+    List<UUID> storageAccountResourceIds =
+        jdbcTemplate.query(
+            sqlGetStorageAccountResourceId, params, new UuidMapper("storage_account_resource_id"));
+
+    if (!storageAccountResourceIds.isEmpty()) {
+      return Optional.of(storageAccountResourceIds.get(0));
+    } else {
+      return Optional.empty();
+    }
   }
 
+  private static class UuidMapper implements RowMapper<UUID> {
+    private String columnLabel;
+
+    UuidMapper(String columnLabel) {
+      this.columnLabel = columnLabel;
+    }
+
+    public UUID mapRow(ResultSet rs, int rowNum) throws SQLException {
+      return rs.getObject(this.columnLabel, UUID.class);
+    }
+  }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotStorageAccountDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotStorageAccountDao.java
@@ -34,7 +34,7 @@ public class SnapshotStorageAccountDao {
   private static final String sqlGetStorageAccountResourceId =
       "SELECT storage_account_resource_id FROM snapshot"
           + whereClause
-          + " AND storage_account_resource-id IS NOT NULL";
+          + " AND storage_account_resource_id IS NOT NULL";
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotStorageAccountDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotStorageAccountDao.java
@@ -1,0 +1,78 @@
+package bio.terra.service.snapshot;
+
+import bio.terra.common.exception.RetryQueryException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static bio.terra.common.DaoUtils.retryQuery;
+
+@Component
+public class SnapshotStorageAccountDao {
+  private static final Logger logger = LoggerFactory.getLogger(SnapshotStorageAccountDao.class);
+
+  private static final String whereClause =
+      " WHERE id = :snapshot_id";
+
+  private static final String sqlCreateLink =
+      "UPDATE snapshot "
+          + " SET storage_account_resource_id = :storage_account_resource_id"
+          + whereClause;
+
+  private static final String sqlExistsLink =
+      "SELECT storage_account_resource_id FROM snapshot" + whereClause;
+
+  private static final String sqlGetStorageAccountResourceId =
+      "SELECT storage_account_resource_id FROM snapshot" +
+      whereClause;
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  @Autowired
+  public SnapshotStorageAccountDao(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public void createSnapshotStorageAccountLink(UUID snapshotId, UUID storageAccountResourceId) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("snapshot_id", snapshotId)
+            .addValue("storage_account_resource_id", storageAccountResourceId);
+
+    try {
+      jdbcTemplate.update(sqlCreateLink, params);
+    } catch (DataAccessException dataAccessException) {
+      if (retryQuery(dataAccessException)) {
+        logger.error("snapshotStorageAccount link operation failed with retryable exception.");
+        throw new RetryQueryException("Retry", dataAccessException);
+      }
+      logger.error("snapshotStorageAccount link operation failed with fatal exception.");
+      throw dataAccessException;
+    }
+  }
+
+  boolean snapshotStorageAccountLinkExists(UUID snapshotId, UUID storageAccountResourceId) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("snapshot_id", snapshotId)
+            .addValue("storage_account_resource_id", storageAccountResourceId);
+    String id = jdbcTemplate.queryForObject(sqlExistsLink, params, String.class);
+    return id != null;
+  }
+
+  public UUID getStorageAccountResourceIdForSnapshotId(UUID snapshotId) {
+    MapSqlParameterSource params = new MapSqlParameterSource().addValue("snapshot_id", snapshotId);
+    return jdbcTemplate.queryForObject(sqlGetStorageAccountResourceId, params, UUID.class);
+  }
+
+}

--- a/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
@@ -49,7 +49,7 @@ public class StorageTableService {
   public List<BulkLoadHistoryModel> getLoadHistory(
       Dataset dataset, String loadTag, int offset, int limit) {
     var billingProfile = dataset.getDatasetSummary().getDefaultBillingProfile();
-    var storageAccountResource = resourceService.getStorageAccount(dataset, billingProfile);
+    var storageAccountResource = resourceService.getDatasetStorageAccount(dataset, billingProfile);
     TableServiceClient tableServiceClient =
         azureAuthService.getTableServiceClient(
             billingProfile.getSubscriptionId(),

--- a/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
@@ -35,7 +35,7 @@ public class StorageTableService {
       throws InterruptedException {
     var billingProfile = dataset.getDatasetSummary().getDefaultBillingProfile();
     var storageAccountResource =
-        resourceService.getOrCreateStorageAccount(dataset, billingProfile, flightId);
+        resourceService.getOrCreateDatasetStorageAccount(dataset, billingProfile, flightId);
     TableServiceClient serviceClient =
         azureAuthService.getTableServiceClient(
             billingProfile.getSubscriptionId(),

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -43,4 +43,5 @@
     <include file="changesets/20210615_azureappdeploymentinfo.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210616_azurestorage.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20210902_snapshotmetadata.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20211007_snapshot_storage_account.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20211007_snapshot_storage_account.yaml
+++ b/src/main/resources/db/changesets/20211007_snapshot_storage_account.yaml
@@ -12,5 +12,5 @@ databaseChangeLog:
                   constraints:
                     nullable: true
                     foreignKeyName: fk_snapshot_storage_acct
-                    references: storage_acccount_resource(id)
+                    references: storage_account_resource(id)
                     deleteCascade: true

--- a/src/main/resources/db/changesets/20211007_snapshot_storage_account.yaml
+++ b/src/main/resources/db/changesets/20211007_snapshot_storage_account.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: azure_snapshot_storage_account
+      author: tlangs
+      changes:
+        - addColumn:
+            tableName: snapshot
+            columns:
+              - column:
+                  name: storage_account_resource_id
+                  type: ${uuid_type}
+                  constraints:
+                    nullable: true
+                    foreignKeyName: fk_snapshot_storage_acct
+                    references: storage_acccount_resource(id)
+                    deleteCascade: true

--- a/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
@@ -74,7 +74,7 @@ public class MetadataDataAccessUtilsTest {
   public void testAzureAccessInfo() {
     AzureStorageAccountResource storageAccountResource =
         new AzureStorageAccountResource().resourceId(UUID.randomUUID()).name("michaelstorage");
-    when(resourceService.getStorageAccount(any(), any())).thenReturn(storageAccountResource);
+    when(resourceService.getDatasetStorageAccount(any(), any())).thenReturn(storageAccountResource);
 
     when(azureBlobStorePdao.signFile(
             any(),

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
@@ -121,7 +121,7 @@ public class ResourceServiceUnitTest {
     when(datasetStorageAccountDao.getStorageAccountResourceIdForDatasetId(dataset.getId()))
         .thenReturn(List.of(storageAccountId));
     AzureStorageAccountResource createdStorageAccount =
-        resourceService.getOrCreateStorageAccount(dataset, profileModel, "flightId");
+        resourceService.getOrCreateDatasetStorageAccount(dataset, profileModel, "flightId");
     Assert.assertEquals(storageAccountResource, createdStorageAccount);
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotStorageAccountDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotStorageAccountDaoTest.java
@@ -1,0 +1,99 @@
+package bio.terra.service.snapshot;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.when;
+
+import bio.terra.app.model.AzureCloudResource;
+import bio.terra.app.model.AzureRegion;
+import bio.terra.common.category.Unit;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.dataset.AzureStorageResource;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetSummary;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
+import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Category(Unit.class)
+public class SnapshotStorageAccountDaoTest {
+
+  @MockBean private SnapshotStorageAccountDao snapshotStorageAccountDao;
+  @MockBean private AzureStorageAccountService storageAccountService;
+  @MockBean private AzureApplicationDeploymentService applicationDeploymentService;
+  @Autowired private ResourceService resourceService;
+
+  @Test
+  public void testCreateSnapshotAccountLink() throws Exception {
+    String flightId = UUID.randomUUID().toString();
+    UUID billingProfileId = UUID.randomUUID();
+    UUID datasetId = UUID.randomUUID();
+    UUID snapshotId = UUID.randomUUID();
+    UUID azureStorageAccountResourceId = UUID.randomUUID();
+    UUID azureApplicationDeploymentResourceId = UUID.randomUUID();
+    BillingProfileModel billingProfile =
+        new BillingProfileModel().profileName("profileName").id(billingProfileId);
+    DatasetSummary summary =
+        new DatasetSummary()
+            .storage(
+                List.of(
+                    new AzureStorageResource(
+                        datasetId,
+                        AzureCloudResource.STORAGE_ACCOUNT,
+                        AzureRegion.DEFAULT_AZURE_REGION)));
+    Snapshot snapshot =
+        new Snapshot()
+            .id(snapshotId)
+            .profileId(billingProfileId)
+            .name("snapshotName")
+            .snapshotSources(
+                List.of(new SnapshotSource().dataset(new Dataset(summary).id(datasetId))));
+    when(snapshotStorageAccountDao.getStorageAccountResourceIdForSnapshotId(snapshotId))
+        .thenReturn(Optional.of(azureStorageAccountResourceId));
+    when(storageAccountService.getStorageAccountResourceById(any(), anyBoolean()))
+        .thenReturn(
+            new AzureStorageAccountResource()
+                .name("azureStorageAccount")
+                .resourceId(azureStorageAccountResourceId)
+                .profileId(billingProfileId)
+                .region(AzureRegion.DEFAULT_AZURE_REGION));
+    when(applicationDeploymentService.getOrRegisterApplicationDeployment(any()))
+        .thenReturn(
+            new AzureApplicationDeploymentResource()
+                .id(azureApplicationDeploymentResourceId)
+                .profileId(billingProfileId)
+                .storageAccountPrefix("tdr"));
+    when(storageAccountService.getOrCreateStorageAccount(any(), any(), any(), any()))
+        .thenReturn(
+            new AzureStorageAccountResource()
+                .region(AzureRegion.DEFAULT_AZURE_REGION)
+                .name("name")
+                .profileId(billingProfileId)
+                .resourceId(azureStorageAccountResourceId));
+
+    resourceService.createSnapshotStorageAccount(snapshot, billingProfile, flightId);
+
+    assertThat(
+        "Snapshot has an Azure Storage Account Resource after creating the Storage Account",
+        snapshot.getStorageAccountResource(),
+        notNullValue());
+  }
+}


### PR DESCRIPTION
Because a Snapshot will only ever have 1 Azure Storage Account, it seems redundant to make an entirely new table to support the link, so I just added another column to the `snapshot` table in the DB. This causes some weirdness in the storage account creation process for snapshots, as we store Snapshots in-memory as composite objects over multiple tables. 

As a result, I've implemented `createSnapshotStorageAccount` as a method that mutates the provided `Snapshot` object. After calling this method, the `Snapshot` object will always have a storage account, and the method handles the cases where one already exists. 