### PR TITLE
[DR-2180] Increase retry timeout in BigQuery tests

### DIFF
--- a/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
+++ b/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
@@ -39,14 +39,14 @@ public final class BigQueryUtils {
 
     RetrySettings retrySettings =
         RetrySettings.newBuilder()
-                .setInitialRetryDelay(Duration.ofMillis(1000L))
-                .setMaxRetryDelay(Duration.ofMillis(32_000L))
-                .setRetryDelayMultiplier(2.0)
-                .setTotalTimeout(Duration.ofMinutes(7))
-                .setInitialRpcTimeout(Duration.ofMillis(50_000L))
-                .setRpcTimeoutMultiplier(1.0)
-                .setMaxRpcTimeout(Duration.ofMillis(50_000L))
-                .build();
+            .setInitialRetryDelay(Duration.ofMillis(1000L))
+            .setMaxRetryDelay(Duration.ofMillis(32_000L))
+            .setRetryDelayMultiplier(2.0)
+            .setTotalTimeout(Duration.ofMinutes(7))
+            .setInitialRpcTimeout(Duration.ofMillis(50_000L))
+            .setRpcTimeoutMultiplier(1.0)
+            .setMaxRpcTimeout(Duration.ofMillis(50_000L))
+            .build();
 
     GoogleCredentials userCredential = AuthenticationUtils.getDelegatedUserCredential(testUser);
     BigQuery bigQuery =

--- a/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
+++ b/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
@@ -40,7 +40,8 @@ public final class BigQueryUtils {
     RetrySettings retrySettings =
         RetrySettings.newBuilder()
             .setInitialRetryDelay(Duration.ofMillis(1000L))
-            .setMaxRetryDelay(Duration.ofMillis(32_000L))
+            .setInitialRetryDelay(Duration.ofSeconds(1))
+            .setMaxRetryDelay(Duration.ofSeconds(32))
             .setRetryDelayMultiplier(2.0)
             .setTotalTimeout(Duration.ofMinutes(7))
             .setInitialRpcTimeout(Duration.ofMillis(50_000L))

--- a/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
+++ b/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
@@ -46,7 +46,7 @@ public final class BigQueryUtils {
             .setTotalTimeout(Duration.ofMinutes(7))
             .setInitialRpcTimeout(Duration.ofMillis(50_000L))
             .setRpcTimeoutMultiplier(1.0)
-            .setMaxRpcTimeout(Duration.ofMillis(50_000L))
+            .setMaxRpcTimeout(Duration.ofSeconds(50))
             .build();
 
     GoogleCredentials userCredential = AuthenticationUtils.getDelegatedUserCredential(testUser);

--- a/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
+++ b/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
@@ -44,7 +44,7 @@ public final class BigQueryUtils {
             .setMaxRetryDelay(Duration.ofSeconds(32))
             .setRetryDelayMultiplier(2.0)
             .setTotalTimeout(Duration.ofMinutes(7))
-            .setInitialRpcTimeout(Duration.ofMillis(50_000L))
+            .setInitialRpcTimeout(Duration.ofSeconds(50))
             .setRpcTimeoutMultiplier(1.0)
             .setMaxRpcTimeout(Duration.ofSeconds(50))
             .build();

--- a/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
+++ b/datarepo-clienttests/src/main/java/common/utils/BigQueryUtils.java
@@ -39,7 +39,6 @@ public final class BigQueryUtils {
 
     RetrySettings retrySettings =
         RetrySettings.newBuilder()
-            .setInitialRetryDelay(Duration.ofMillis(1000L))
             .setInitialRetryDelay(Duration.ofSeconds(1))
             .setMaxRetryDelay(Duration.ofSeconds(32))
             .setRetryDelayMultiplier(2.0)

--- a/src/test/java/bio/terra/integration/BigQueryFixtures.java
+++ b/src/test/java/bio/terra/integration/BigQueryFixtures.java
@@ -10,6 +10,7 @@ import bio.terra.common.PdaoConstant;
 import bio.terra.common.TestUtils;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.SnapshotModel;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -27,6 +28,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.threeten.bp.Duration;
 
 public final class BigQueryFixtures {
   private static final Logger logger = LoggerFactory.getLogger(BigQueryFixtures.class);
@@ -35,9 +37,21 @@ public final class BigQueryFixtures {
   private BigQueryFixtures() {}
 
   public static BigQuery getBigQuery(String projectId, Credentials credentials) {
+    RetrySettings retrySettings =
+        RetrySettings.newBuilder()
+            .setInitialRetryDelay(Duration.ofMillis(1000L))
+            .setMaxRetryDelay(Duration.ofMillis(32_000L))
+            .setRetryDelayMultiplier(2.0)
+            .setTotalTimeout(Duration.ofMinutes(7))
+            .setInitialRpcTimeout(Duration.ofMillis(50_000L))
+            .setRpcTimeoutMultiplier(1.0)
+            .setMaxRpcTimeout(Duration.ofMillis(50_000L))
+            .build();
+
     return BigQueryOptions.newBuilder()
         .setProjectId(projectId)
         .setCredentials(credentials)
+        .setRetrySettings(retrySettings)
         .build()
         .getService();
   }

--- a/src/test/java/bio/terra/integration/BigQueryFixtures.java
+++ b/src/test/java/bio/terra/integration/BigQueryFixtures.java
@@ -39,13 +39,13 @@ public final class BigQueryFixtures {
   public static BigQuery getBigQuery(String projectId, Credentials credentials) {
     RetrySettings retrySettings =
         RetrySettings.newBuilder()
-            .setInitialRetryDelay(Duration.ofMillis(1000L))
-            .setMaxRetryDelay(Duration.ofMillis(32_000L))
+            .setInitialRetryDelay(Duration.ofSeconds(1))
+            .setMaxRetryDelay(Duration.ofSeconds(32))
             .setRetryDelayMultiplier(2.0)
             .setTotalTimeout(Duration.ofMinutes(7))
-            .setInitialRpcTimeout(Duration.ofMillis(50_000L))
+            .setInitialRpcTimeout(Duration.ofSeconds(50))
             .setRpcTimeoutMultiplier(1.0)
-            .setMaxRpcTimeout(Duration.ofMillis(50_000L))
+            .setMaxRpcTimeout(Duration.ofSeconds(50))
             .build();
 
     return BigQueryOptions.newBuilder()


### PR DESCRIPTION
All of the settings are the same as the default retrySettings except for the total timeout of 7 minutes, which is how long it can take for permissions to propagate.