### PR TITLE
DR-2185 Better invalid refId error messages

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateAzureRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateAzureRefsStep.java
@@ -55,14 +55,15 @@ public class IngestValidateAzureRefsStep extends IngestValidateRefsStep {
     // Then probe the file system to validate that the file exists and is part
     // of this dataset. We check all ids and return one complete error.
 
-    Set<String> invalidRefIds =
+    Set<InvalidRefId> invalidRefIds =
         table.getColumns().stream()
             .map(Column::toSynapseColumn)
             .filter(Column::isFileOrDirRef)
             .flatMap(
                 column -> {
                   List<String> refIdArray = azureSynapsePdao.getRefIds(tableName, column);
-                  return tableDirectoryDao.validateRefIds(tableServiceClient, refIdArray).stream();
+                  return tableDirectoryDao.validateRefIds(tableServiceClient, refIdArray).stream()
+                      .map(id -> new InvalidRefId(id, column.getName()));
                 })
             .collect(Collectors.toSet());
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateGcpRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateGcpRefsStep.java
@@ -11,7 +11,6 @@ import bio.terra.stairway.StepResult;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class IngestValidateGcpRefsStep extends IngestValidateRefsStep {
 
@@ -41,12 +40,7 @@ public class IngestValidateGcpRefsStep extends IngestValidateRefsStep {
       if (column.isFileOrDirRef()) {
         List<String> refIdArray = bigQueryPdao.getRefIds(dataset, stagingTableName, column);
         List<String> badRefIds = fileDao.validateRefIds(dataset, refIdArray);
-        if (badRefIds != null) {
-          invalidRefIds.addAll(
-              badRefIds.stream()
-                  .map(id -> new InvalidRefId(id, column.getName()))
-                  .collect(Collectors.toList()));
-        }
+        badRefIds.forEach(id -> invalidRefIds.add(new InvalidRefId(id, column.getName())));
       }
     }
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
@@ -42,8 +42,8 @@ public abstract class IngestValidateRefsStep implements Step {
   }
 
   public static class InvalidRefId {
-    public String refId;
-    public String columnName;
+    public final String refId;
+    public final String columnName;
 
     public InvalidRefId(String refId, String columnName) {
       this.refId = refId;

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
@@ -6,12 +6,13 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public abstract class IngestValidateRefsStep implements Step {
   private static final int MAX_ERROR_REF_IDS = 20;
 
-  public StepResult handleInvalidRefs(Set<String> invalidRefIds) {
+  public StepResult handleInvalidRefs(Set<InvalidRefId> invalidRefIds) {
     int invalidIdCount = invalidRefIds.size();
     if (invalidIdCount != 0) {
       // Made a string buffer to appease findbugs; it saw + in the loop and said "bad!"
@@ -19,8 +20,8 @@ public abstract class IngestValidateRefsStep implements Step {
 
       List<String> errorDetails = new ArrayList<>();
       int count = 0;
-      for (String badId : invalidRefIds) {
-        errorDetails.add(badId);
+      for (InvalidRefId badId : invalidRefIds) {
+        errorDetails.add(badId.toString());
         count++;
         if (count > MAX_ERROR_REF_IDS) {
           errorMessage.append(MAX_ERROR_REF_IDS + "out of ");
@@ -38,5 +39,40 @@ public abstract class IngestValidateRefsStep implements Step {
   public StepResult undoStep(FlightContext context) {
     // The update will update row ids that are null, so it can be restarted on failure.
     return StepResult.getStepResultSuccess();
+  }
+
+  public static class InvalidRefId {
+    public String refId;
+    public String columnName;
+
+    public InvalidRefId(String refId, String columnName) {
+      this.refId = refId;
+      this.columnName = columnName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      InvalidRefId that = (InvalidRefId) o;
+      return Objects.equals(refId, that.refId) && Objects.equals(columnName, that.columnName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(refId, columnName);
+    }
+
+    @Override
+    public String toString() {
+      return "InvalidRefId{"
+          + "refId='"
+          + refId
+          + '\''
+          + ", columnName='"
+          + columnName
+          + '\''
+          + '}';
+    }
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
@@ -65,14 +65,7 @@ public abstract class IngestValidateRefsStep implements Step {
 
     @Override
     public String toString() {
-      return "InvalidRefId{"
-          + "refId='"
-          + refId
-          + '\''
-          + ", columnName='"
-          + columnName
-          + '\''
-          + '}';
+      return "{" + "refId: " + refId + ", " + "columnName: " + columnName + "}";
     }
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
@@ -1,7 +1,6 @@
 package bio.terra.service.filedata.google.firestore;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFileTest.java
@@ -344,7 +344,7 @@ public class EncodeFileTest {
 
     List<String> errorDetails = ingestError.getErrorDetail();
     assertNotNull("Error details were returned", errorDetails);
-    assertThat("Bad id was returned in details", errorDetails.get(0), endsWith(ID_GARBAGE));
+    assertThat("Bad id was returned in details", errorDetails.get(0), containsString(ID_GARBAGE));
 
     // Delete the scratch blob
     Blob scratchBlob = storage.get(BlobId.of(testConfig.getIngestbucket(), targetPath));


### PR DESCRIPTION
Ingests that fail with invalidRefIds will now include the column name in the output message rather than just the failing refId. This will help users diagnose their own schema and ingest issues by removing ambiguity and giving starting place for users to start debugging.