### PR TITLE
DR-2165: Add support for including roles in the catalog snapshot response.

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -169,8 +169,10 @@ public class DatasetsApiController implements DatasetsApi {
       @Valid @RequestParam(value = "filter", required = false) String filter,
       @Valid @RequestParam(value = "region", required = false) String region) {
     ControllerUtils.validateEnumerateParams(offset, limit);
-    List<UUID> resources =
-        iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASET);
+    var resources =
+        iamService
+            .listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASET)
+            .keySet();
     EnumerateDatasetModel esm =
         datasetService.enumerate(offset, limit, sort, direction, filter, region, resources);
     return new ResponseEntity<>(esm, HttpStatus.OK);

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -169,7 +170,7 @@ public class DatasetsApiController implements DatasetsApi {
       @Valid @RequestParam(value = "filter", required = false) String filter,
       @Valid @RequestParam(value = "region", required = false) String region) {
     ControllerUtils.validateEnumerateParams(offset, limit);
-    var resources =
+    Set<UUID> resources =
         iamService
             .listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASET)
             .keySet();

--- a/src/main/java/bio/terra/app/controller/SearchApiController.java
+++ b/src/main/java/bio/terra/app/controller/SearchApiController.java
@@ -171,7 +171,7 @@ public class SearchApiController implements SearchApi {
   public ResponseEntity<SearchQueryResultModel> querySearchIndices(
       SearchQueryRequest searchQueryRequest, Integer offset, Integer limit) {
 
-    var accessibleIds =
+    Set<UUID> accessibleIds =
         iamService
             .listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT)
             .keySet();

--- a/src/main/java/bio/terra/app/controller/SearchApiController.java
+++ b/src/main/java/bio/terra/app/controller/SearchApiController.java
@@ -93,7 +93,7 @@ public class SearchApiController implements SearchApi {
 
   @Override
   public ResponseEntity<SearchMetadataResponse> enumerateSnapshotSearch() {
-    var idsAndRoles =
+    Map<UUID, Set<IamRole>> idsAndRoles =
         iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT);
     Map<UUID, String> metadata = snapshotSearchMetadataDao.getMetadata(idsAndRoles.keySet());
     var response = new SearchMetadataResponse();

--- a/src/main/java/bio/terra/app/controller/SearchApiController.java
+++ b/src/main/java/bio/terra/app/controller/SearchApiController.java
@@ -6,20 +6,28 @@ import bio.terra.controller.SearchApi;
 import bio.terra.model.SearchIndexModel;
 import bio.terra.model.SearchIndexRequest;
 import bio.terra.model.SearchMetadataModel;
+import bio.terra.model.SearchMetadataResponse;
 import bio.terra.model.SearchQueryRequest;
 import bio.terra.model.SearchQueryResultModel;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.AuthenticatedUserRequestFactory;
 import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamResourceType;
+import bio.terra.service.iam.IamRole;
 import bio.terra.service.iam.IamService;
 import bio.terra.service.iam.exception.IamForbiddenException;
 import bio.terra.service.search.SearchService;
 import bio.terra.service.search.SnapshotSearchMetadataDao;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.swagger.annotations.Api;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -85,13 +93,34 @@ public class SearchApiController implements SearchApi {
   }
 
   @Override
-  public ResponseEntity<String> enumerateSnapshotSearch() {
-    List<UUID> ids =
-        iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT);
-    Map<UUID, String> metadata = snapshotSearchMetadataDao.getMetadata(ids);
-    // Create the JSON result "by hand" to avoid having to round trip the data to JsonNode.
-    String response = String.format("{ \"result\": [ %s ] }", String.join(",", metadata.values()));
+  public ResponseEntity<SearchMetadataResponse> enumerateSnapshotSearch() {
+    var idsAndRoles =
+        iamService.listAuthorizedResourcesAndRoles(
+            getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT);
+    Map<UUID, String> metadata = snapshotSearchMetadataDao.getMetadata(idsAndRoles.keySet());
+    var response = new SearchMetadataResponse();
+    response.setResult(new ArrayList<>());
+    metadata.forEach(
+        (uuid, data) -> {
+          JsonNode node = toJsonNode(data);
+          ArrayNode roles = objectMapper.createArrayNode();
+          for (IamRole iamRole : idsAndRoles.get(uuid)) {
+            roles.add(TextNode.valueOf(iamRole.toString()));
+          }
+          ((ObjectNode) node).set("roles", roles);
+          response.getResult().add(node);
+        });
     return ResponseEntity.ok(response);
+  }
+
+  private JsonNode toJsonNode(String json) {
+    try {
+      return objectMapper.readValue(json, JsonNode.class);
+    } catch (JsonProcessingException e) {
+      // This shouldn't occur, as the data stored in postgres must be valid JSON, because it's
+      // stored as JSONB.
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -166,8 +166,10 @@ public class SnapshotsApiController implements SnapshotsApi {
       @Valid @RequestParam(value = "region", required = false) String region,
       @Valid @RequestParam(value = "datasetIds", required = false) List<String> datasetIds) {
     ControllerUtils.validateEnumerateParams(offset, limit);
-    List<UUID> resources =
-        iamService.listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT);
+    var resources =
+        iamService
+            .listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT)
+            .keySet();
     List<UUID> datasetUUIDs =
         ListUtils.emptyIfNull(datasetIds).stream()
             .map(UUID::fromString)

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -34,6 +34,7 @@ import io.swagger.annotations.Api;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
@@ -166,7 +167,7 @@ public class SnapshotsApiController implements SnapshotsApi {
       @Valid @RequestParam(value = "region", required = false) String region,
       @Valid @RequestParam(value = "datasetIds", required = false) List<String> datasetIds) {
     ControllerUtils.validateEnumerateParams(offset, limit);
-    var resources =
+    Set<UUID> resources =
         iamService
             .listAuthorizedResources(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT)
             .keySet();

--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -7,7 +7,7 @@ import java.sql.Array;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
@@ -25,12 +25,7 @@ public final class DaoUtils {
     if (sort == null || direction == null) {
       return "";
     }
-    return new StringBuilder(" ORDER BY ")
-        .append(sort)
-        .append(" ")
-        .append(direction)
-        .append(" ")
-        .toString();
+    return " ORDER BY " + sort + " " + direction + " ";
   }
 
   public static void addFilterClause(
@@ -57,13 +52,13 @@ public final class DaoUtils {
   }
 
   public static void addAuthzIdsClause(
-      List<UUID> authzIds, MapSqlParameterSource params, List<String> clauses) {
+      Collection<UUID> authzIds, MapSqlParameterSource params, List<String> clauses) {
     params.addValue("idlist", authzIds);
     clauses.add(" dataset.id in (:idlist) ");
   }
 
   public static void addAuthzSnapshotIdsClause(
-      List<UUID> authzIds, MapSqlParameterSource params, List<String> clauses) {
+      Collection<UUID> authzIds, MapSqlParameterSource params, List<String> clauses) {
     params.addValue("idlist", authzIds);
     clauses.add(" snapshot.id in (:idlist) ");
   }
@@ -79,44 +74,22 @@ public final class DaoUtils {
     return builder.append('%').toString();
   }
 
-  public static Array createSqlUUIDArray(Connection connection, List<UUID> list)
-      throws SQLException {
-    if (list == null) {
-      return null;
-    }
-    return connection.createArrayOf("UUID", list.toArray());
-  }
-
   public static Array createSqlStringArray(Connection connection, List<String> list)
       throws SQLException {
-    if (list == null) {
-      return null;
-    }
     return connection.createArrayOf("text", list.toArray());
-  }
-
-  public static List<UUID> getUUIDList(ResultSet rs, String column) throws SQLException {
-    Array sqlArray = rs.getArray(column);
-    if (sqlArray == null) {
-      return null;
-    }
-    return Arrays.asList((UUID[]) sqlArray.getArray());
   }
 
   public static List<String> getStringList(ResultSet rs, String column) throws SQLException {
     Array sqlArray = rs.getArray(column);
     if (sqlArray == null) {
-      return null;
+      return List.of();
     }
-    return Arrays.asList((String[]) sqlArray.getArray());
+    return List.of((String[]) sqlArray.getArray());
   }
 
   // Based on Exception returned, determine if we should attempt to retry an operation/stairway step
   public static boolean retryQuery(DataAccessException dataAccessException) {
-    if (ExceptionUtils.hasCause(dataAccessException, RecoverableDataAccessException.class)
-        || ExceptionUtils.hasCause(dataAccessException, TransientDataAccessException.class)) {
-      return true;
-    }
-    return false;
+    return ExceptionUtils.hasCause(dataAccessException, RecoverableDataAccessException.class)
+        || ExceptionUtils.hasCause(dataAccessException, TransientDataAccessException.class);
   }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -25,6 +25,7 @@ import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
@@ -584,7 +585,7 @@ public class DatasetDao {
       SqlSortDirection direction,
       String filter,
       String region,
-      List<UUID> accessibleDatasetIds) {
+      Collection<UUID> accessibleDatasetIds) {
     MapSqlParameterSource params = new MapSqlParameterSource();
     List<String> whereClauses = new ArrayList<>();
     DaoUtils.addAuthzIdsClause(accessibleDatasetIds, params, whereClauses);

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -35,6 +35,7 @@ import bio.terra.service.snapshot.exception.AssetNotFoundException;
 import bio.terra.service.tabulardata.azure.StorageTableService;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -152,7 +153,7 @@ public class DatasetService {
       SqlSortDirection direction,
       String filter,
       String region,
-      List<UUID> resources) {
+      Collection<UUID> resources) {
     if (resources.isEmpty()) {
       return new EnumerateDatasetModel().total(0).items(Collections.emptyList());
     }

--- a/src/main/java/bio/terra/service/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/iam/IamProviderInterface.java
@@ -6,6 +6,7 @@ import bio.terra.model.UserStatusInfo;
 import bio.terra.service.iam.exception.IamUnauthorizedException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -55,6 +56,18 @@ public interface IamProviderInterface {
    * @return List of ids in UUID form
    */
   List<UUID> listAuthorizedResources(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType)
+      throws InterruptedException;
+
+  /**
+   * Return the ids of resources of type iamResourceType that the user has access to, along with the
+   * roles the user has on the resource.
+   *
+   * @param userReq authenticated user
+   * @param iamResourceType resource type; e.g. dataset
+   * @return Map of ids in UUID form to set of roles
+   */
+  Map<UUID, Set<IamRole>> listAuthorizedResourcesAndRoles(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType)
       throws InterruptedException;
 

--- a/src/main/java/bio/terra/service/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/iam/IamProviderInterface.java
@@ -49,17 +49,6 @@ public interface IamProviderInterface {
   }
 
   /**
-   * List of the ids of the resources of iamResourceType that the user has any access to.
-   *
-   * @param userReq authenticated user
-   * @param iamResourceType resource type; e.g. dataset
-   * @return List of ids in UUID form
-   */
-  List<UUID> listAuthorizedResources(
-      AuthenticatedUserRequest userReq, IamResourceType iamResourceType)
-      throws InterruptedException;
-
-  /**
    * Return the ids of resources of type iamResourceType that the user has access to, along with the
    * roles the user has on the resource.
    *
@@ -67,7 +56,7 @@ public interface IamProviderInterface {
    * @param iamResourceType resource type; e.g. dataset
    * @return Map of ids in UUID form to set of roles
    */
-  Map<UUID, Set<IamRole>> listAuthorizedResourcesAndRoles(
+  Map<UUID, Set<IamRole>> listAuthorizedResources(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType)
       throws InterruptedException;
 

--- a/src/main/java/bio/terra/service/iam/IamService.java
+++ b/src/main/java/bio/terra/service/iam/IamService.java
@@ -142,7 +142,7 @@ public class IamService {
    * @param iamResourceType resource type; e.g. dataset
    * @return List of ids in UUID form
    */
-  public List<UUID> listAuthorizedResources(
+  public Map<UUID, Set<IamRole>> listAuthorizedResources(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType) {
     return callProvider(() -> iamProvider.listAuthorizedResources(userReq, iamResourceType));
   }
@@ -265,11 +265,5 @@ public class IamService {
 
   public UserStatusInfo getUserInfo(AuthenticatedUserRequest userReq) {
     return iamProvider.getUserInfo(userReq);
-  }
-
-  public Map<UUID, Set<IamRole>> listAuthorizedResourcesAndRoles(
-      AuthenticatedUserRequest userReq, IamResourceType iamResourceType) {
-    return callProvider(
-        () -> iamProvider.listAuthorizedResourcesAndRoles(userReq, iamResourceType));
   }
 }

--- a/src/main/java/bio/terra/service/iam/IamService.java
+++ b/src/main/java/bio/terra/service/iam/IamService.java
@@ -13,7 +13,8 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.collections4.map.LRUMap;
 import org.slf4j.Logger;
@@ -38,22 +39,45 @@ import org.springframework.stereotype.Component;
 public class IamService {
   private final Logger logger = LoggerFactory.getLogger(IamService.class);
 
-  private final int AUTH_CACHE_SIZE_DEFAULT = 100;
+  private static final int AUTH_CACHE_SIZE_DEFAULT = 100;
 
   private final IamProviderInterface iamProvider;
   private final ConfigurationService configurationService;
   private final Map<AuthorizedCacheKey, AuthorizedCacheValue> authorizedMap;
-  private int cacheSize;
 
   @Autowired
   public IamService(IamProviderInterface iamProvider, ConfigurationService configurationService) {
     this.iamProvider = iamProvider;
     this.configurationService = configurationService;
-    cacheSize =
-        Optional.<Integer>ofNullable(configurationService.getParameterValue(AUTH_CACHE_SIZE))
-            .orElse(AUTH_CACHE_SIZE_DEFAULT);
+    int cacheSize =
+        Objects.requireNonNullElse(
+            configurationService.getParameterValue(AUTH_CACHE_SIZE), AUTH_CACHE_SIZE_DEFAULT);
     // wrap the cache map with a synchronized map to safely share the cache across threads
     authorizedMap = Collections.synchronizedMap(new LRUMap<>(cacheSize));
+  }
+
+  private interface Call<T> {
+    T get() throws InterruptedException;
+  }
+
+  private interface VoidCall {
+    void get() throws InterruptedException;
+  }
+
+  private <T> T callProvider(Call<T> call) {
+    try {
+      return call.get();
+    } catch (InterruptedException e) {
+      throw new IamUnavailableException("service unavailable", e);
+    }
+  }
+
+  private void callProvider(VoidCall call) {
+    callProvider(
+        () -> {
+          call.get();
+          return null;
+        });
   }
 
   /**
@@ -66,31 +90,30 @@ public class IamService {
       IamResourceType iamResourceType,
       String resourceId,
       IamAction action) {
-    try {
-      int timeoutSeconds = configurationService.getParameterValue(AUTH_CACHE_TIMEOUT_SECONDS);
-      AuthenticatedUserRequest userReqNoId = userReq.reqId(null);
-      AuthorizedCacheKey authorizedCacheKey =
-          new AuthorizedCacheKey(userReqNoId, iamResourceType, resourceId, action);
-      AuthorizedCacheValue authorizedCacheValue = authorizedMap.get(authorizedCacheKey);
-      if (authorizedCacheValue != null) { // check if it's in the cache
-        // check if it's still in the allotted time
-        if (Instant.now().isBefore(authorizedCacheValue.getTimeout())) {
-          logger.debug("Using the cache!");
-          return authorizedCacheValue.isAuthorized();
-        }
-        authorizedMap.remove(authorizedCacheKey); // if timed out, remove it
-      }
-      boolean authorizedLookup =
-          iamProvider.isAuthorized(userReq, iamResourceType, resourceId, action);
-      Instant newTimeout = Instant.now().plusSeconds(timeoutSeconds);
-      AuthorizedCacheValue newAuthorizedCacheValue =
-          new AuthorizedCacheValue(newTimeout, authorizedLookup);
-      authorizedMap.put(authorizedCacheKey, newAuthorizedCacheValue);
-      // finally return the authorization
-      return authorizedLookup;
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    return callProvider(
+        () -> {
+          int timeoutSeconds = configurationService.getParameterValue(AUTH_CACHE_TIMEOUT_SECONDS);
+          AuthenticatedUserRequest userReqNoId = userReq.reqId(null);
+          AuthorizedCacheKey authorizedCacheKey =
+              new AuthorizedCacheKey(userReqNoId, iamResourceType, resourceId, action);
+          AuthorizedCacheValue authorizedCacheValue = authorizedMap.get(authorizedCacheKey);
+          if (authorizedCacheValue != null) { // check if it's in the cache
+            // check if it's still in the allotted time
+            if (Instant.now().isBefore(authorizedCacheValue.getTimeout())) {
+              logger.debug("Using the cache!");
+              return authorizedCacheValue.isAuthorized();
+            }
+            authorizedMap.remove(authorizedCacheKey); // if timed out, remove it
+          }
+          boolean authorizedLookup =
+              iamProvider.isAuthorized(userReq, iamResourceType, resourceId, action);
+          Instant newTimeout = Instant.now().plusSeconds(timeoutSeconds);
+          AuthorizedCacheValue newAuthorizedCacheValue =
+              new AuthorizedCacheValue(newTimeout, authorizedLookup);
+          authorizedMap.put(authorizedCacheKey, newAuthorizedCacheValue);
+          // finally return the authorization
+          return authorizedLookup;
+        });
   }
 
   /**
@@ -121,11 +144,7 @@ public class IamService {
    */
   public List<UUID> listAuthorizedResources(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType) {
-    try {
-      return iamProvider.listAuthorizedResources(userReq, iamResourceType);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    return callProvider(() -> iamProvider.listAuthorizedResources(userReq, iamResourceType));
   }
 
   /**
@@ -139,11 +158,7 @@ public class IamService {
    */
   public boolean hasActions(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId) {
-    try {
-      return iamProvider.hasActions(userReq, iamResourceType, resourceId);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    return callProvider(() -> iamProvider.hasActions(userReq, iamResourceType, resourceId));
   }
 
   /**
@@ -153,11 +168,7 @@ public class IamService {
    * @param datasetId dataset to delete
    */
   public void deleteDatasetResource(AuthenticatedUserRequest userReq, UUID datasetId) {
-    try {
-      iamProvider.deleteDatasetResource(userReq, datasetId);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    callProvider(() -> iamProvider.deleteDatasetResource(userReq, datasetId));
   }
 
   /**
@@ -167,11 +178,7 @@ public class IamService {
    * @param snapshotId snapshot to delete
    */
   public void deleteSnapshotResource(AuthenticatedUserRequest userReq, UUID snapshotId) {
-    try {
-      iamProvider.deleteSnapshotResource(userReq, snapshotId);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    callProvider(() -> iamProvider.deleteSnapshotResource(userReq, snapshotId));
   }
 
   /**
@@ -183,11 +190,7 @@ public class IamService {
    */
   public Map<IamRole, String> createDatasetResource(
       AuthenticatedUserRequest userReq, UUID datasetId) {
-    try {
-      return iamProvider.createDatasetResource(userReq, datasetId);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    return callProvider(() -> iamProvider.createDatasetResource(userReq, datasetId));
   }
 
   /**
@@ -200,49 +203,30 @@ public class IamService {
    */
   public Map<IamRole, String> createSnapshotResource(
       AuthenticatedUserRequest userReq, UUID snapshotId, List<String> readersList) {
-    try {
-      return iamProvider.createSnapshotResource(userReq, snapshotId, readersList);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    return callProvider(() -> iamProvider.createSnapshotResource(userReq, snapshotId, readersList));
   }
 
   // -- billing profile resource support --
 
   public void createProfileResource(AuthenticatedUserRequest userReq, String profileId) {
-    try {
-      iamProvider.createProfileResource(userReq, profileId);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    callProvider(() -> iamProvider.createProfileResource(userReq, profileId));
   }
 
   public void deleteProfileResource(AuthenticatedUserRequest userReq, String profileId) {
-    try {
-      iamProvider.deleteProfileResource(userReq, profileId);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    callProvider(() -> iamProvider.deleteProfileResource(userReq, profileId));
   }
 
   // -- policy membership support --
 
   public List<PolicyModel> retrievePolicies(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId) {
-    try {
-      return iamProvider.retrievePolicies(userReq, iamResourceType, resourceId);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    return callProvider(() -> iamProvider.retrievePolicies(userReq, iamResourceType, resourceId));
   }
 
   public Map<IamRole, String> retrievePolicyEmails(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId) {
-    try {
-      return iamProvider.retrievePolicyEmails(userReq, iamResourceType, resourceId);
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    return callProvider(
+        () -> iamProvider.retrievePolicyEmails(userReq, iamResourceType, resourceId));
   }
 
   public PolicyModel addPolicyMember(
@@ -251,15 +235,15 @@ public class IamService {
       UUID resourceId,
       String policyName,
       String userEmail) {
-    try {
-      PolicyModel policy =
-          iamProvider.addPolicyMember(userReq, iamResourceType, resourceId, policyName, userEmail);
-      // Invalidate the cache
-      authorizedMap.clear();
-      return policy;
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    return callProvider(
+        () -> {
+          PolicyModel policy =
+              iamProvider.addPolicyMember(
+                  userReq, iamResourceType, resourceId, policyName, userEmail);
+          // Invalidate the cache
+          authorizedMap.clear();
+          return policy;
+        });
   }
 
   public PolicyModel deletePolicyMember(
@@ -268,19 +252,24 @@ public class IamService {
       UUID resourceId,
       String policyName,
       String userEmail) {
-    try {
-      PolicyModel policy =
-          iamProvider.deletePolicyMember(
-              userReq, iamResourceType, resourceId, policyName, userEmail);
-      // Invalidate the cache
-      authorizedMap.clear();
-      return policy;
-    } catch (InterruptedException ex) {
-      throw new IamUnavailableException("service unavailable");
-    }
+    return callProvider(
+        () -> {
+          PolicyModel policy =
+              iamProvider.deletePolicyMember(
+                  userReq, iamResourceType, resourceId, policyName, userEmail);
+          // Invalidate the cache
+          authorizedMap.clear();
+          return policy;
+        });
   }
 
   public UserStatusInfo getUserInfo(AuthenticatedUserRequest userReq) {
     return iamProvider.getUserInfo(userReq);
+  }
+
+  public Map<UUID, Set<IamRole>> listAuthorizedResourcesAndRoles(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType) {
+    return callProvider(
+        () -> iamProvider.listAuthorizedResourcesAndRoles(userReq, iamResourceType));
   }
 }

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -147,13 +146,11 @@ public class SamIam implements IamProviderInterface {
     return samResourceApi.listResourcesAndPolicies(iamResourceType.getSamResourceName()).stream()
         .filter(resource -> ValidationUtils.isValidUuid(resource.getResourceId()))
         .collect(
-            Collectors.toMap(
+            Collectors.groupingBy(
                 resource -> UUID.fromString(resource.getResourceId()),
-                resource ->
-                    resource.getAuthDomainGroups().stream()
-                        .map(IamRole::fromValue)
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toSet())));
+                Collectors.mapping(
+                    resource -> IamRole.fromValue(resource.getAccessPolicyName()),
+                    Collectors.toSet())));
   }
 
   @Override

--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -11,6 +11,7 @@ import bio.terra.service.profile.exception.ProfileNotFoundException;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -146,7 +147,7 @@ public class ProfileDao {
 
   @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
   public EnumerateBillingProfileModel enumerateBillingProfiles(
-      int offset, int limit, List<UUID> accessibleProfileId) {
+      int offset, int limit, Collection<UUID> accessibleProfileId) {
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -26,7 +26,6 @@ import bio.terra.service.profile.flight.update.ProfileUpdateFlight;
 import bio.terra.service.profile.google.GoogleBillingService;
 import bio.terra.service.resourcemanagement.exception.InaccessibleApplicationDeploymentException;
 import bio.terra.service.resourcemanagement.exception.InaccessibleBillingAccountException;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -158,9 +157,10 @@ public class ProfileService {
    */
   public EnumerateBillingProfileModel enumerateProfiles(
       Integer offset, Integer limit, AuthenticatedUserRequest user) {
-    List<UUID> resources = iamService.listAuthorizedResources(user, IamResourceType.SPEND_PROFILE);
+    var resources =
+        iamService.listAuthorizedResources(user, IamResourceType.SPEND_PROFILE).keySet();
     if (resources.isEmpty()) {
-      return new EnumerateBillingProfileModel().total(0).items(Collections.emptyList());
+      return new EnumerateBillingProfileModel().total(0).items(List.of());
     }
     return profileDao.enumerateBillingProfiles(offset, limit, resources);
   }

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -27,6 +27,7 @@ import bio.terra.service.profile.google.GoogleBillingService;
 import bio.terra.service.resourcemanagement.exception.InaccessibleApplicationDeploymentException;
 import bio.terra.service.resourcemanagement.exception.InaccessibleBillingAccountException;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,7 +158,7 @@ public class ProfileService {
    */
   public EnumerateBillingProfileModel enumerateProfiles(
       Integer offset, Integer limit, AuthenticatedUserRequest user) {
-    var resources =
+    Set<UUID> resources =
         iamService.listAuthorizedResources(user, IamResourceType.SPEND_PROFILE).keySet();
     if (resources.isEmpty()) {
       return new EnumerateBillingProfileModel().total(0).items(List.of());

--- a/src/main/java/bio/terra/service/search/SnapshotSearchMetadataDao.java
+++ b/src/main/java/bio/terra/service/search/SnapshotSearchMetadataDao.java
@@ -1,8 +1,8 @@
 package bio.terra.service.search;
 
 import java.sql.Types;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +55,7 @@ public class SnapshotSearchMetadataDao {
       propagation = Propagation.REQUIRED,
       isolation = Isolation.SERIALIZABLE,
       readOnly = true)
-  public Map<UUID, String> getMetadata(List<UUID> snapshotIds) {
+  public Map<UUID, String> getMetadata(Collection<UUID> snapshotIds) {
     var params = new MapSqlParameterSource().addValue("snapshot_ids", snapshotIds);
     Map<UUID, String> result = new HashMap<>();
     jdbcTemplate.query(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -490,7 +491,7 @@ public class SnapshotDao {
       String filter,
       String region,
       List<UUID> datasetIds,
-      List<UUID> accessibleSnapshotIds) {
+      Collection<UUID> accessibleSnapshotIds) {
     logger.debug(
         "retrieve snapshots offset: "
             + offset

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -45,6 +45,7 @@ import bio.terra.service.snapshot.flight.delete.SnapshotDeleteFlight;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -137,16 +138,16 @@ public class SnapshotService {
       String filter,
       String region,
       List<UUID> datasetIds,
-      List<UUID> resources) {
+      Collection<UUID> resources) {
     if (resources.isEmpty()) {
-      return new EnumerateSnapshotModel().total(0).items(Collections.emptyList());
+      return new EnumerateSnapshotModel().total(0).items(List.of());
     }
     MetadataEnumeration<SnapshotSummary> enumeration =
         snapshotDao.retrieveSnapshots(
             offset, limit, sort, direction, filter, region, datasetIds, resources);
     List<SnapshotSummaryModel> models =
         enumeration.getItems().stream()
-            .map(this::makeSummaryModelFromSummary)
+            .map(SnapshotService::makeSummaryModelFromSummary)
             .collect(Collectors.toList());
     return new EnumerateSnapshotModel()
         .items(models)
@@ -542,7 +543,7 @@ public class SnapshotService {
     snapshotSource.snapshotMapTables(mapTableList);
   }
 
-  public SnapshotSummaryModel makeSummaryModelFromSummary(SnapshotSummary snapshotSummary) {
+  private static SnapshotSummaryModel makeSummaryModelFromSummary(SnapshotSummary snapshotSummary) {
     SnapshotSummaryModel summaryModel =
         new SnapshotSummaryModel()
             .id(snapshotSummary.getId())

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -6,7 +6,6 @@ import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
-import bio.terra.service.snapshot.SnapshotSummary;
 import bio.terra.service.snapshot.exception.InvalidSnapshotException;
 import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
@@ -49,8 +48,7 @@ public class CreateSnapshotMetadataStep implements Step {
               .projectResourceId(projectResourceId);
       snapshotDao.createAndLock(snapshot, context.getFlightId());
 
-      SnapshotSummary snapshotSummary = snapshotDao.retrieveSummaryById(snapshotId);
-      SnapshotSummaryModel response = snapshotService.makeSummaryModelFromSummary(snapshotSummary);
+      SnapshotSummaryModel response = snapshotService.retrieveSnapshotSummary(snapshotId);
 
       FlightUtils.setResponse(context, response, HttpStatus.CREATED);
       return StepResult.getStepResultSuccess();

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2282,7 +2282,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/SearchMetadataResponse'
 
   /api/repository/v1/search/{id}/index:
     post:
@@ -4152,6 +4152,14 @@ components:
           description: Results that match the search criteria
       description: >
         The available search results that match the filter criteria
+    SearchMetadataResponse:
+      type: object
+      properties:
+        result:
+          type: array
+          items:
+            type: object
+      description: List of snapshot metadata
 
     ##############################################################################
     ## DRS STANDARD MODELS

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -92,13 +92,13 @@ public class SearchApiControllerTest {
     UUID uuid = UUID.randomUUID();
     Set<UUID> uuids = Set.of(uuid);
     Map<UUID, Set<IamRole>> resourcesAndRoles = Map.of(uuid, Set.of(IamRole.DISCOVERER));
-    when(iamService.listAuthorizedResourcesAndRoles(any(), eq(IamResourceType.DATASNAPSHOT)))
+    when(iamService.listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT)))
         .thenReturn(resourcesAndRoles);
     when(snapshotMetadataDao.getMetadata(uuids)).thenReturn(Map.of(uuid, json));
     mvc.perform(get(endpoint))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.result[0].test").value("data"));
-    verify(iamService).listAuthorizedResourcesAndRoles(any(), eq(IamResourceType.DATASNAPSHOT));
+    verify(iamService).listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT));
     verify(snapshotMetadataDao).getMetadata(uuids);
   }
 
@@ -109,13 +109,13 @@ public class SearchApiControllerTest {
     UUID uuid = UUID.randomUUID();
     Set<UUID> uuids = Set.of(uuid);
     Map<UUID, Set<IamRole>> resourcesAndRoles = Map.of(uuid, Set.of(IamRole.DISCOVERER));
-    when(iamService.listAuthorizedResourcesAndRoles(any(), eq(IamResourceType.DATASNAPSHOT)))
+    when(iamService.listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT)))
         .thenReturn(resourcesAndRoles);
     when(snapshotMetadataDao.getMetadata(uuids)).thenReturn(Map.of(uuid, json));
     mvc.perform(get(endpoint))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.result[0].roles").value("discoverer"));
-    verify(iamService).listAuthorizedResourcesAndRoles(any(), eq(IamResourceType.DATASNAPSHOT));
+    verify(iamService).listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT));
     verify(snapshotMetadataDao).getMetadata(uuids);
   }
 

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -17,13 +17,14 @@ import bio.terra.common.category.Unit;
 import bio.terra.model.SearchIndexRequest;
 import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamResourceType;
+import bio.terra.service.iam.IamRole;
 import bio.terra.service.iam.IamService;
 import bio.terra.service.search.SearchService;
 import bio.terra.service.search.SnapshotSearchMetadataDao;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -89,14 +90,32 @@ public class SearchApiControllerTest {
     var endpoint = "/api/repository/v1/search/metadata";
     var json = "{\"test\":\"data\"}";
     UUID uuid = UUID.randomUUID();
-    List<UUID> uuids = List.of(uuid);
-    when(iamService.listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT)))
-        .thenReturn(uuids);
+    Set<UUID> uuids = Set.of(uuid);
+    Map<UUID, Set<IamRole>> resourcesAndRoles = Map.of(uuid, Set.of(IamRole.DISCOVERER));
+    when(iamService.listAuthorizedResourcesAndRoles(any(), eq(IamResourceType.DATASNAPSHOT)))
+        .thenReturn(resourcesAndRoles);
     when(snapshotMetadataDao.getMetadata(uuids)).thenReturn(Map.of(uuid, json));
     mvc.perform(get(endpoint))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.result[0].test").value("data"));
-    verify(iamService).listAuthorizedResources(any(), eq(IamResourceType.DATASNAPSHOT));
+    verify(iamService).listAuthorizedResourcesAndRoles(any(), eq(IamResourceType.DATASNAPSHOT));
+    verify(snapshotMetadataDao).getMetadata(uuids);
+  }
+
+  @Test
+  public void testEnumerateSnapshotSearchPermission() throws Exception {
+    var endpoint = "/api/repository/v1/search/metadata";
+    var json = "{}";
+    UUID uuid = UUID.randomUUID();
+    Set<UUID> uuids = Set.of(uuid);
+    Map<UUID, Set<IamRole>> resourcesAndRoles = Map.of(uuid, Set.of(IamRole.DISCOVERER));
+    when(iamService.listAuthorizedResourcesAndRoles(any(), eq(IamResourceType.DATASNAPSHOT)))
+        .thenReturn(resourcesAndRoles);
+    when(snapshotMetadataDao.getMetadata(uuids)).thenReturn(Map.of(uuid, json));
+    mvc.perform(get(endpoint))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result[0].roles").value("discoverer"));
+    verify(iamService).listAuthorizedResourcesAndRoles(any(), eq(IamResourceType.DATASNAPSHOT));
     verify(snapshotMetadataDao).getMetadata(uuids);
   }
 

--- a/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
@@ -1,6 +1,10 @@
 package bio.terra.service.iam.sam;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -19,9 +23,9 @@ import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamRole;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
@@ -81,7 +85,7 @@ public class SamIamTest {
   public void testExtractErrorMessageSimple() {
     ErrorReport errorReport = new ErrorReport().message("FOO").source("sam");
 
-    assertThat(SamIam.extractErrorMessage(errorReport)).isEqualTo("FOO");
+    assertThat(SamIam.extractErrorMessage(errorReport), is("FOO"));
   }
 
   @Test
@@ -92,7 +96,7 @@ public class SamIamTest {
             .source("sam")
             .addCausesItem(new ErrorReport().message("BAR").source("sam"));
 
-    assertThat(SamIam.extractErrorMessage(errorReport)).isEqualTo("FOO: BAR");
+    assertThat(SamIam.extractErrorMessage(errorReport), is("FOO: BAR"));
   }
 
   @Test
@@ -112,7 +116,7 @@ public class SamIamTest {
                             .source("sam")
                             .addCausesItem(new ErrorReport().message("QUX").source("sam"))));
 
-    assertThat(SamIam.extractErrorMessage(errorReport)).isEqualTo("FOO: BAR: (BAZ1, BAZ2: QUX)");
+    assertThat(SamIam.extractErrorMessage(errorReport), is("FOO: BAR: (BAZ1, BAZ2: QUX)"));
   }
 
   @Test
@@ -127,7 +131,7 @@ public class SamIamTest {
                 new ResourceAndAccessPolicy().resourceId(badId)));
 
     var uuids = samIam.listAuthorizedResources(userReq, IamResourceType.SPEND_PROFILE).keySet();
-    assertThat(uuids).containsExactly(goodId);
+    assertThat(uuids, contains(goodId));
   }
 
   @Test
@@ -142,14 +146,11 @@ public class SamIamTest {
             "my-id",
             IamAction.ALTER_POLICIES.toString()))
         .thenReturn(false);
-    assertThat(
-            samIam.isAuthorized(
-                userReq, IamResourceType.SPEND_PROFILE, "my-id", IamAction.READ_DATA))
-        .isTrue();
-    assertThat(
-            samIam.isAuthorized(
-                userReq, IamResourceType.SPEND_PROFILE, "my-id", IamAction.ALTER_POLICIES))
-        .isFalse();
+    assertTrue(
+        samIam.isAuthorized(userReq, IamResourceType.SPEND_PROFILE, "my-id", IamAction.READ_DATA));
+    assertFalse(
+        samIam.isAuthorized(
+            userReq, IamResourceType.SPEND_PROFILE, "my-id", IamAction.ALTER_POLICIES));
   }
 
   @Test
@@ -157,20 +158,22 @@ public class SamIamTest {
     when(samStatusApi.getSystemStatus())
         .thenReturn(
             new SystemStatus().ok(true).systems(Map.of("GooglePubSub", Map.of("ok", true))));
-    assertThat(samIam.samStatus())
-        .isEqualTo(new RepositoryStatusModelSystems().ok(true).message("{GooglePubSub={ok=true}}"));
+    assertThat(
+        samIam.samStatus(),
+        is(new RepositoryStatusModelSystems().ok(true).message("{GooglePubSub={ok=true}}")));
   }
 
   @Test
   public void testGetStatusException() throws ApiException {
     when(samStatusApi.getSystemStatus()).thenThrow(new ApiException("BOOM!"));
-    assertThat(samIam.samStatus())
-        .isEqualTo(
+    assertThat(
+        samIam.samStatus(),
+        is(
             new RepositoryStatusModelSystems()
                 .ok(false)
                 .message(
                     "Sam status check failed: bio.terra.service.iam.exception.IamInternalServerErrorException: "
-                        + "BOOM!"));
+                        + "BOOM!")));
   }
 
   @Test
@@ -179,21 +182,21 @@ public class SamIamTest {
     final String userEmail = "a@a.com";
     mockUserInfo(userSubjectId, userEmail);
 
-    assertThat(samIam.getUserInfo(userReq))
-        .isEqualTo(
-            new UserStatusInfo().userSubjectId(userSubjectId).userEmail(userEmail).enabled(true));
+    assertThat(
+        samIam.getUserInfo(userReq),
+        is(new UserStatusInfo().userSubjectId(userSubjectId).userEmail(userEmail).enabled(true)));
   }
 
   @Test
   public void testHasActions() throws ApiException, InterruptedException {
     when(samResourceApi.resourceActions(
             IamResourceType.SPEND_PROFILE.getSamResourceName(), "my-id-1"))
-        .thenReturn(Collections.singletonList(IamAction.READ_DATA.toString()));
+        .thenReturn(List.of(IamAction.READ_DATA.toString()));
     when(samResourceApi.resourceActions(
             IamResourceType.SPEND_PROFILE.getSamResourceName(), "my-id-2"))
-        .thenReturn(Collections.emptyList());
-    assertThat(samIam.hasActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-1")).isTrue();
-    assertThat(samIam.hasActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-2")).isFalse();
+        .thenReturn(List.of());
+    assertTrue(samIam.hasActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-1"));
+    assertFalse(samIam.hasActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-2"));
   }
 
   @Test
@@ -225,19 +228,21 @@ public class SamIamTest {
     when(samResourceApi.listResourcePolicies(
             IamResourceType.SPEND_PROFILE.getSamResourceName(), id.toString()))
         .thenReturn(
-            Collections.singletonList(
+            List.of(
                 new AccessPolicyResponseEntry()
                     .policyName(IamRole.CUSTODIAN.toString())
                     .email(policyEmail)
                     .policy(new AccessPolicyMembership().addMemberEmailsItem(memberEmail))));
 
-    assertThat(samIam.retrievePolicies(userReq, IamResourceType.SPEND_PROFILE, id))
-        .isEqualTo(
-            Collections.singletonList(
-                new PolicyModel().name(IamRole.CUSTODIAN.toString()).addMembersItem(memberEmail)));
+    assertThat(
+        samIam.retrievePolicies(userReq, IamResourceType.SPEND_PROFILE, id),
+        is(
+            List.of(
+                new PolicyModel().name(IamRole.CUSTODIAN.toString()).addMembersItem(memberEmail))));
 
-    assertThat(samIam.retrievePolicyEmails(userReq, IamResourceType.SPEND_PROFILE, id))
-        .isEqualTo(Map.of(IamRole.CUSTODIAN, policyEmail));
+    assertThat(
+        samIam.retrievePolicyEmails(userReq, IamResourceType.SPEND_PROFILE, id),
+        is(Map.of(IamRole.CUSTODIAN, policyEmail)));
   }
 
   @Test
@@ -258,13 +263,14 @@ public class SamIamTest {
               IamResourceType.DATASET.getSamResourceName(),
               datasetId.toString(),
               policy.toString()))
-          .thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
+          .thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", List.of()));
     }
 
-    assertThat(samIam.createDatasetResource(userReq, datasetId))
-        .isEqualTo(
+    assertThat(
+        samIam.createDatasetResource(userReq, datasetId),
+        is(
             syncedPolicies.stream()
-                .collect(Collectors.toMap(p -> p, p -> "policygroup-" + p + "@firecloud.org")));
+                .collect(Collectors.toMap(p -> p, p -> "policygroup-" + p + "@firecloud.org"))));
   }
 
   @Test
@@ -284,13 +290,14 @@ public class SamIamTest {
               IamResourceType.DATASNAPSHOT.getSamResourceName(),
               snapshotId.toString(),
               policy.toString()))
-          .thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
+          .thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", List.of()));
     }
 
-    assertThat(samIam.createSnapshotResource(userReq, snapshotId, Collections.emptyList()))
-        .isEqualTo(
+    assertThat(
+        samIam.createSnapshotResource(userReq, snapshotId, List.of()),
+        is(
             syncedPolicies.stream()
-                .collect(Collectors.toMap(p -> p, p -> "policygroup-" + p + "@firecloud.org")));
+                .collect(Collectors.toMap(p -> p, p -> "policygroup-" + p + "@firecloud.org"))));
   }
 
   @Test
@@ -308,7 +315,7 @@ public class SamIamTest {
               IamResourceType.DATASNAPSHOT.getSamResourceName(),
               profileId.toString(),
               policy.toString()))
-          .thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", Collections.emptyList()));
+          .thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", List.of()));
     }
 
     samIam.createProfileResource(userReq, profileId.toString());
@@ -322,13 +329,13 @@ public class SamIamTest {
             IamResourceType.SPEND_PROFILE.getSamResourceName(),
             id.toString(),
             IamRole.OWNER.toString()))
-        .thenReturn(
-            new AccessPolicyMembership().memberEmails(Collections.singletonList(userEmail)));
+        .thenReturn(new AccessPolicyMembership().memberEmails(List.of(userEmail)));
     final PolicyModel policyModel =
         samIam.addPolicyMember(
             userReq, IamResourceType.SPEND_PROFILE, id, IamRole.OWNER.toString(), userEmail);
-    assertThat(policyModel)
-        .isEqualTo(new PolicyModel().name(IamRole.OWNER.toString()).addMembersItem(userEmail));
+    assertThat(
+        policyModel,
+        is(new PolicyModel().name(IamRole.OWNER.toString()).addMembersItem(userEmail)));
     verify(samResourceApi, times(1))
         .addUserToPolicy(
             IamResourceType.SPEND_PROFILE.getSamResourceName(),
@@ -345,13 +352,12 @@ public class SamIamTest {
             IamResourceType.SPEND_PROFILE.getSamResourceName(),
             id.toString(),
             IamRole.OWNER.toString()))
-        .thenReturn(new AccessPolicyMembership().memberEmails(Collections.emptyList()));
+        .thenReturn(new AccessPolicyMembership().memberEmails(List.of()));
     final PolicyModel policyModel =
         samIam.deletePolicyMember(
             userReq, IamResourceType.SPEND_PROFILE, id, IamRole.OWNER.toString(), userEmail);
-    assertThat(policyModel)
-        .isEqualTo(
-            new PolicyModel().name(IamRole.OWNER.toString()).members(Collections.emptyList()));
+    assertThat(
+        policyModel, is(new PolicyModel().name(IamRole.OWNER.toString()).members(List.of())));
     verify(samResourceApi, times(1))
         .removeUserFromPolicy(
             IamResourceType.SPEND_PROFILE.getSamResourceName(),
@@ -367,5 +373,22 @@ public class SamIamTest {
                 .userSubjectId(userSubjectId)
                 .userEmail(userEmail)
                 .enabled(true));
+  }
+
+  @Test
+  public void listAuthorizedResourcesTest() throws Exception {
+    UUID id = UUID.randomUUID();
+    when(samResourceApi.listResourcesAndPolicies(IamResourceType.DATASNAPSHOT.getSamResourceName()))
+        .thenReturn(
+            List.of(
+                new ResourceAndAccessPolicy()
+                    .resourceId(id.toString())
+                    .accessPolicyName(IamRole.OWNER.toString()),
+                new ResourceAndAccessPolicy()
+                    .resourceId(id.toString())
+                    .accessPolicyName(IamRole.READER.toString())));
+    Map<UUID, Set<IamRole>> uuidSetMap =
+        samIam.listAuthorizedResources(userReq, IamResourceType.DATASNAPSHOT);
+    assertThat(uuidSetMap, is((Map.of(id, Set.of(IamRole.OWNER, IamRole.READER)))));
   }
 }

--- a/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
@@ -117,17 +117,17 @@ public class SamIamTest {
 
   @Test
   public void testIgnoresNonUUIDResourceName() throws ApiException, InterruptedException {
-    final String goodId = UUID.randomUUID().toString();
+    final UUID goodId = UUID.randomUUID();
     final String badId = "badUUID";
     when(samResourceApi.listResourcesAndPolicies(
             IamResourceType.SPEND_PROFILE.getSamResourceName()))
         .thenReturn(
             List.of(
-                new ResourceAndAccessPolicy().resourceId(goodId),
+                new ResourceAndAccessPolicy().resourceId(goodId.toString()),
                 new ResourceAndAccessPolicy().resourceId(badId)));
 
-    List<UUID> uuids = samIam.listAuthorizedResources(userReq, IamResourceType.SPEND_PROFILE);
-    assertThat(uuids).containsExactly(UUID.fromString(goodId));
+    var uuids = samIam.listAuthorizedResources(userReq, IamResourceType.SPEND_PROFILE).keySet();
+    assertThat(uuids).containsExactly(goodId);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/iam/sam/SamIamTest.java
@@ -130,7 +130,8 @@ public class SamIamTest {
                 new ResourceAndAccessPolicy().resourceId(goodId.toString()),
                 new ResourceAndAccessPolicy().resourceId(badId)));
 
-    var uuids = samIam.listAuthorizedResources(userReq, IamResourceType.SPEND_PROFILE).keySet();
+    Set<UUID> uuids =
+        samIam.listAuthorizedResources(userReq, IamResourceType.SPEND_PROFILE).keySet();
     assertThat(uuids, contains(goodId));
   }
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -45,6 +45,7 @@ import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.filedata.DrsId;
 import bio.terra.service.filedata.DrsIdService;
 import bio.terra.service.iam.IamProviderInterface;
+import bio.terra.service.iam.IamRole;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
@@ -62,9 +63,12 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -298,8 +302,10 @@ public class SnapshotConnectedTest {
       snapshotList.add(summaryModel);
     }
 
-    List<UUID> snapshotIds =
-        snapshotList.stream().map(snapshot -> snapshot.getId()).collect(Collectors.toList());
+    Map<UUID, Set<IamRole>> snapshotIds =
+        snapshotList.stream()
+            .map(SnapshotSummaryModel::getId)
+            .collect(Collectors.toMap(Function.identity(), x -> Set.of(IamRole.READER)));
 
     when(samService.listAuthorizedResources(any(), any())).thenReturn(snapshotIds);
     EnumerateSnapshotModel enumResponse = enumerateTestSnapshots();


### PR DESCRIPTION
Each snapshot's metadata now has a property `roles` which contains an array of the user's roles on a snapshot. A user must have at least one role on the snapshot in order for it to be returned, so this array will never be empty.

If a snapshot is publicly readable, then every user will have `reader` role on it. If it's private but publicly discoverable, it will have the `discoverer` role on it. Since all roles are returned, a user who's been granted read access to a private snapshot will have both `reader` and `discoverer` set at the same time.