### PR TITLE
DR-2200 Extra verification that user can read bucket

### DIFF
--- a/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
+++ b/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
@@ -1,0 +1,58 @@
+package bio.terra.common;
+
+import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.model.DataDeletionRequest;
+import bio.terra.model.FileLoadModel;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ValidateBucketAccessStep implements Step {
+  private final GcsPdao gcsPdao;
+  private final AuthenticatedUserRequest userRequest;
+
+  public ValidateBucketAccessStep(GcsPdao gcsPdao, AuthenticatedUserRequest userRequest) {
+    this.gcsPdao = gcsPdao;
+    this.userRequest = userRequest;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap inputParameters = context.getInputParameters();
+    List<String> sourcePath;
+    Object loadModel = inputParameters.get(JobMapKeys.REQUEST.getKeyName(), Object.class);
+    if (loadModel instanceof FileLoadModel) {
+      // Single file ingest
+      sourcePath = List.of(((FileLoadModel) loadModel).getSourcePath());
+    } else if (loadModel instanceof BulkLoadRequestModel) {
+      // Bulk file ingest
+      sourcePath = List.of(((BulkLoadRequestModel) loadModel).getLoadControlFile());
+    } else if (loadModel instanceof IngestRequestModel) {
+      // Metadata ingests
+      sourcePath = List.of(((IngestRequestModel) loadModel).getPath());
+    } else if (loadModel instanceof DataDeletionRequest) {
+      // Soft deletes
+      sourcePath =
+          ((DataDeletionRequest) loadModel)
+              .getTables().stream()
+                  .map(t -> t.getGcsFileSpec().getPath())
+                  .collect(Collectors.toList());
+    } else {
+      throw new IllegalArgumentException("Invalid request type");
+    }
+    gcsPdao.validateUserCanRead(sourcePath, userRequest);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/common/gcs/GcsUriUtils.java
+++ b/src/main/java/bio/terra/service/common/gcs/GcsUriUtils.java
@@ -80,12 +80,6 @@ public final class GcsUriUtils {
     return "gs://" + bucket + "/" + name;
   }
 
-  public static String makeBucketHttpsFromGs(String gspath) {
-    BlobId locator = GcsUriUtils.parseBlobUri(gspath);
-    String gsBucket = locator.getBucket();
-    return String.format("https://www.googleapis.com/storage/v1/b/%s/o", gsBucket);
-  }
-
   public static String makeHttpsFromGs(String gspath) {
     try {
       BlobId locator = GcsUriUtils.parseBlobUri(gspath);

--- a/src/main/java/bio/terra/service/common/gcs/GcsUriUtils.java
+++ b/src/main/java/bio/terra/service/common/gcs/GcsUriUtils.java
@@ -1,7 +1,11 @@
 package bio.terra.service.common.gcs;
 
+import bio.terra.service.filedata.exception.InvalidDrsIdException;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 public final class GcsUriUtils {
@@ -74,5 +78,29 @@ public final class GcsUriUtils {
 
   public static String getGsPathFromComponents(String bucket, String name) {
     return "gs://" + bucket + "/" + name;
+  }
+
+  public static String makeBucketHttpsFromGs(String gspath) {
+    BlobId locator = GcsUriUtils.parseBlobUri(gspath);
+    String gsBucket = locator.getBucket();
+    return String.format("https://www.googleapis.com/storage/v1/b/%s/o", gsBucket);
+  }
+
+  public static String makeHttpsFromGs(String gspath) {
+    try {
+      BlobId locator = GcsUriUtils.parseBlobUri(gspath);
+      String gsBucket = locator.getBucket();
+      String gsPath = locator.getName();
+      String encodedPath =
+          URLEncoder.encode(gsPath, StandardCharsets.UTF_8.toString())
+              // Google does not recognize the + characters that are produced from spaces by the
+              // URLEncoder.encode
+              // method. As a result, these must be converted to %2B.
+              .replaceAll("\\+", "%20");
+      return String.format(
+          "https://www.googleapis.com/storage/v1/b/%s/o/%s?alt=media", gsBucket, encodedPath);
+    } catch (UnsupportedEncodingException ex) {
+      throw new InvalidDrsIdException("Failed to urlencode file path", ex);
+    }
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
@@ -3,11 +3,14 @@ package bio.terra.service.dataset.flight.datadelete;
 import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.ValidateBucketAccessStep;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.flight.LockDatasetStep;
 import bio.terra.service.dataset.flight.UnlockDatasetStep;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.iam.IamResourceType;
@@ -33,9 +36,13 @@ public class DatasetDataDeleteFlight extends Flight {
     IamProviderInterface iamClient = appContext.getBean("iamProvider", IamProviderInterface.class);
     ConfigurationService configService = appContext.getBean(ConfigurationService.class);
     ApplicationConfiguration appConfig = appContext.getBean(ApplicationConfiguration.class);
+    GcsPdao gcsPdao = appContext.getBean(GcsPdao.class);
 
     // get data from inputs that steps need
     String datasetId = inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class);
+
+    AuthenticatedUserRequest userReq =
+        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
     RetryRule lockDatasetRetry =
         getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
@@ -43,6 +50,8 @@ public class DatasetDataDeleteFlight extends Flight {
     addStep(
         new VerifyAuthorizationStep(
             iamClient, IamResourceType.DATASET, datasetId, IamAction.SOFT_DELETE));
+
+    addStep(new ValidateBucketAccessStep(gcsPdao, userReq));
 
     // need to lock, need dataset name and flight id
     addStep(new LockDatasetStep(datasetDao, UUID.fromString(datasetId), true), lockDatasetRetry);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -4,6 +4,7 @@ import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.common.ValidateBucketAccessStep;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.service.configuration.ConfigEnum;
@@ -150,6 +151,7 @@ public class DatasetIngestFlight extends Flight {
             configService,
             fileService,
             ingestRequestModel,
+            userReq,
             dataset,
             profileId,
             randomBackoffRetry,
@@ -211,6 +213,9 @@ public class DatasetIngestFlight extends Flight {
 
     var platform = CloudPlatform.GCP;
 
+    // Verify that the user is allowed to access the bucket where the control file lives
+    addStep(new ValidateBucketAccessStep(gcsPdao, userReq));
+
     // Parse the JSON file and see if there's actually any files to load.
     // If there are no files to load, then SkippableSteps taking the `ingestSkipCondition`
     // will not be run.
@@ -265,7 +270,8 @@ public class DatasetIngestFlight extends Flight {
             driverWaitSeconds,
             profileId,
             platform,
-            ingestSkipCondition),
+            ingestSkipCondition,
+            userReq),
         driverRetry);
 
     // Create the job result with the results of the bulk file load.
@@ -309,6 +315,7 @@ public class DatasetIngestFlight extends Flight {
       ConfigurationService configService,
       FileService fileService,
       IngestRequestModel ingestRequest,
+      AuthenticatedUserRequest userReq,
       Dataset dataset,
       UUID profileId,
       RetryRule randomBackoffRetry,
@@ -364,7 +371,8 @@ public class DatasetIngestFlight extends Flight {
             driverWaitSeconds,
             profileId,
             platform,
-            ingestSkipCondition),
+            ingestSkipCondition,
+            userReq),
         driverRetry);
 
     // Create the job result with the results of the bulk file load.

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -38,10 +38,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -326,7 +323,7 @@ public class DrsService {
 
     DRSAccessURL httpsAccessURL =
         new DRSAccessURL()
-            .url(makeHttpsFromGs(fsFile.getCloudPath()))
+            .url(GcsUriUtils.makeHttpsFromGs(fsFile.getCloudPath()))
             .headers(makeAuthHeader(authUser));
 
     DRSAccessMethod httpsAccessMethod =
@@ -413,24 +410,6 @@ public class DrsService {
     }
 
     return contentsObject;
-  }
-
-  private String makeHttpsFromGs(String gspath) {
-    try {
-      BlobId locator = GcsUriUtils.parseBlobUri(gspath);
-      String gsBucket = locator.getBucket();
-      String gsPath = locator.getName();
-      String encodedPath =
-          URLEncoder.encode(gsPath, StandardCharsets.UTF_8.toString())
-              // Google does not recognize the + characters that are produced from spaces by the
-              // URLEncoder.encode
-              // method. As a result, these must be converted to %2B.
-              .replaceAll("\\+", "%20");
-      return String.format(
-          "https://www.googleapis.com/storage/v1/b/%s/o/%s?alt=media", gsBucket, encodedPath);
-    } catch (UnsupportedEncodingException ex) {
-      throw new InvalidDrsIdException("Failed to urlencode file path", ex);
-    }
   }
 
   private List<String> makeAuthHeader(AuthenticatedUserRequest authUser) {

--- a/src/main/java/bio/terra/service/filedata/exception/BlobAccessNotAuthorizedException.java
+++ b/src/main/java/bio/terra/service/filedata/exception/BlobAccessNotAuthorizedException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.filedata.exception;
+
+import bio.terra.common.exception.UnauthorizedException;
+
+public class BlobAccessNotAuthorizedException extends UnauthorizedException {
+  public BlobAccessNotAuthorizedException(String message) {
+    super(message);
+  }
+
+  public BlobAccessNotAuthorizedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public BlobAccessNotAuthorizedException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -4,6 +4,7 @@ import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.common.ValidateBucketAccessStep;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadRequestModel;
 import bio.terra.service.configuration.ConfigurationService;
@@ -164,6 +165,7 @@ public class FileIngestBulkFlight extends Flight {
       addStep(new IngestPopulateFileStateFromArrayStep(loadService));
     } else {
       if (platform.isGcp()) {
+        addStep(new ValidateBucketAccessStep(gcsPdao, userReq));
         addStep(
             new IngestPopulateFileStateFromFileGcpStep(
                 loadService,
@@ -191,7 +193,8 @@ public class FileIngestBulkFlight extends Flight {
             maxFailedFileLoads,
             driverWaitSeconds,
             profileId,
-            platform.getCloudPlatform()),
+            platform.getCloudPlatform(),
+            userReq),
         driverRetry);
 
     if (isArray) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -4,6 +4,7 @@ import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.common.ValidateBucketAccessStep;
 import bio.terra.model.FileLoadModel;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
@@ -126,6 +127,7 @@ public class FileIngestFlight extends Flight {
     addStep(new IngestFileIdStep(configService));
 
     if (platform.isGcp()) {
+      addStep(new ValidateBucketAccessStep(gcsPdao, userReq));
       addStep(new ValidateIngestFileDirectoryStep(fileDao, dataset));
       addStep(new IngestFileDirectoryStep(fileDao, dataset), randomBackoffRetry);
       addStep(new IngestFileGetProjectStep(dataset, googleProjectService));

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
@@ -62,7 +62,8 @@ public class IngestDriverStepTest extends TestCase {
             maxFailedFileLoads,
             0,
             null,
-            CloudPlatform.GCP);
+            CloudPlatform.GCP,
+            null);
 
     FlightContext flightContext = new FlightContext(new FlightMap(), "", Collections.emptyList());
     flightContext.getWorkingMap().put(LoadMapKeys.LOAD_ID, loadUuid.toString());


### PR DESCRIPTION
This PR tightens security around what buckets the TDR service account can access.

This introduces a new constraint where users that wish to:
- ingest files
- ingest metadata
- delete rows

must grant `Storage Object Viewer` permission to their Terra Proxy user group in addition to the TDR Service Account to the source bucket