### PR TITLE
DR-2066 DR-2223 DR-2230 DR-2226 Add SAS access to Snapshot Parquet and Wire up DRS Url for Azure snapshots

### DIFF
--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -153,7 +153,8 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
         new DRSServiceInfo()
             .version("0.0.1")
             .title("Terra Data Repository")
-            .description("Terra Data Repository (Jade) - a Broad/Verily open source project")
+            .description(
+                "Terra Data Repository (Jade) - a Broad/Verily/Microsoft open source project")
             .contact("cbernard@broadinstitute.org")
             .license("Apache 2.0");
     return new ResponseEntity<>(info, HttpStatus.OK);

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -142,10 +142,11 @@ public class DatasetsApiController implements DatasetsApi {
               required = false,
               defaultValue = RETRIEVE_INCLUDE_DEFAULT_VALUE)
           List<DatasetRequestAccessIncludeModel> include) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     iamService.verifyAuthorization(
-        getAuthenticatedInfo(), IamResourceType.DATASET, id.toString(), IamAction.READ_DATASET);
+        userRequest, IamResourceType.DATASET, id.toString(), IamAction.READ_DATASET);
     return new ResponseEntity<>(
-        datasetService.retrieveAvailableDatasetModel(id, include), HttpStatus.OK);
+        datasetService.retrieveAvailableDatasetModel(id, userRequest, include), HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -188,10 +188,12 @@ public class SnapshotsApiController implements SnapshotsApi {
               defaultValue = RETRIEVE_INCLUDE_DEFAULT_VALUE)
           List<SnapshotRequestAccessIncludeModel> include) {
     logger.info("Verifying user access");
+    AuthenticatedUserRequest authenticatedInfo = getAuthenticatedInfo();
     iamService.verifyAuthorization(
-        getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id.toString(), IamAction.READ_DATA);
+        authenticatedInfo, IamResourceType.DATASNAPSHOT, id.toString(), IamAction.READ_DATA);
     logger.info("Retrieving snapshot");
-    SnapshotModel snapshotModel = snapshotService.retrieveAvailableSnapshotModel(id, include);
+    SnapshotModel snapshotModel =
+        snapshotService.retrieveAvailableSnapshotModel(id, include, authenticatedInfo);
     return new ResponseEntity<>(snapshotModel, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/common/CollectionType.java
+++ b/src/main/java/bio/terra/common/CollectionType.java
@@ -1,0 +1,7 @@
+package bio.terra.common;
+
+/** Describes the types of collections supported by TDR */
+public enum CollectionType {
+  DATASET,
+  SNAPSHOT
+}

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -121,6 +121,7 @@ public class Dataset implements FSContainerInterface {
     return this;
   }
 
+  @Override
   public String getName() {
     return datasetSummary.getName();
   }

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -2,6 +2,7 @@ package bio.terra.service.dataset;
 
 import bio.terra.app.model.AzureCloudResource;
 import bio.terra.app.model.AzureRegion;
+import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.service.filedata.FSContainerInterface;
@@ -32,6 +33,11 @@ public class Dataset implements FSContainerInterface {
 
   public Dataset(DatasetSummary summary) {
     datasetSummary = summary;
+  }
+
+  @Override
+  public CollectionType getCollectionType() {
+    return CollectionType.DATASET;
   }
 
   public List<DatasetTable> getTables() {

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -19,6 +19,7 @@ import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.StorageResourceModel;
 import bio.terra.model.TableModel;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -91,7 +92,8 @@ public final class DatasetJsonConversion {
   public static DatasetModel populateDatasetModelFromDataset(
       Dataset dataset,
       List<DatasetRequestAccessIncludeModel> include,
-      MetadataDataAccessUtils metadataDataAccessUtils) {
+      MetadataDataAccessUtils metadataDataAccessUtils,
+      AuthenticatedUserRequest userRequest) {
     DatasetModel datasetModel =
         new DatasetModel()
             .id(dataset.getId())
@@ -120,7 +122,8 @@ public final class DatasetJsonConversion {
     }
 
     if (include.contains(DatasetRequestAccessIncludeModel.ACCESS_INFORMATION)) {
-      datasetModel.accessInformation(metadataDataAccessUtils.accessInfoFromDataset(dataset));
+      datasetModel.accessInformation(
+          metadataDataAccessUtils.accessInfoFromDataset(dataset, userRequest));
     }
     return datasetModel;
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -123,9 +123,11 @@ public class DatasetService {
    * @return a DatasetModel = API output-friendly representation of the Dataset
    */
   public DatasetModel retrieveAvailableDatasetModel(
-      UUID id, List<DatasetRequestAccessIncludeModel> include) {
+      UUID id,
+      AuthenticatedUserRequest userRequest,
+      List<DatasetRequestAccessIncludeModel> include) {
     Dataset dataset = retrieveAvailable(id);
-    return retrieveModel(dataset, include);
+    return retrieveModel(dataset, userRequest, include);
   }
 
   /**
@@ -133,16 +135,19 @@ public class DatasetService {
    * retrieve the dataset a second time if you already have it
    *
    * @param dataset the dataset being passed in
+   * @param userRequest the user making the request
    * @return a DatasetModel = API output-friendly representation of the Dataset
    */
-  public DatasetModel retrieveModel(Dataset dataset) {
-    return retrieveModel(dataset, getDefaultIncludes());
+  public DatasetModel retrieveModel(Dataset dataset, AuthenticatedUserRequest userRequest) {
+    return retrieveModel(dataset, userRequest, getDefaultIncludes());
   }
 
   public DatasetModel retrieveModel(
-      Dataset dataset, List<DatasetRequestAccessIncludeModel> include) {
+      Dataset dataset,
+      AuthenticatedUserRequest userRequest,
+      List<DatasetRequestAccessIncludeModel> include) {
     return DatasetJsonConversion.populateDatasetModelFromDataset(
-        dataset, include, metadataDataAccessUtils);
+        dataset, include, metadataDataAccessUtils, userRequest);
   }
 
   public EnumerateDatasetModel enumerate(

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
@@ -91,7 +91,8 @@ public class DatasetDeleteFlight extends Flight {
               datasetId,
               configService,
               resourceService,
-              profileDao),
+              profileDao,
+              userReq),
           primaryDataDeleteRetry);
       addStep(
           new DeleteDatasetDeleteStorageAccountsStep(resourceService, datasetService, datasetId));

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAuthzBqAclsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAuthzBqAclsStep.java
@@ -46,7 +46,7 @@ public class DeleteDatasetAuthzBqAclsStep implements Step {
     DatasetModel datasetModel;
     try {
       Dataset dataset = datasetService.retrieve(datasetId);
-      datasetModel = datasetService.retrieveModel(dataset);
+      datasetModel = datasetService.retrieveModel(dataset, userReq);
     } catch (DatasetNotFoundException | InvalidDatasetException e) {
       logger.warn("Dataset {} metadata was not found.  Ignoring explicit ACL clear.", datasetId);
       return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -179,8 +179,10 @@ public class DatasetIngestFlight extends Flight {
       addStep(new IngestInsertIntoDatasetTableStep(datasetService, bigQueryPdao));
       addStep(new IngestCleanupStep(datasetService, bigQueryPdao));
     } else if (cloudPlatform.isAzure()) {
-      addStep(new IngestCreateIngestRequestDataSourceStep(azureSynapsePdao, azureBlobStorePdao));
-      addStep(new IngestCreateTargetDataSourceStep(azureSynapsePdao, azureBlobStorePdao));
+      addStep(
+          new IngestCreateIngestRequestDataSourceStep(
+              azureSynapsePdao, azureBlobStorePdao, userReq));
+      addStep(new IngestCreateTargetDataSourceStep(azureSynapsePdao, azureBlobStorePdao, userReq));
       addStep(new IngestCreateParquetFilesStep(azureSynapsePdao, datasetService));
       addStep(
           new IngestValidateAzureRefsStep(
@@ -229,7 +231,7 @@ public class DatasetIngestFlight extends Flight {
     // Parse the JSON file and see if there's actually any files to load.
     // If there are no files to load, then SkippableSteps taking the `ingestSkipCondition`
     // will not be run.
-    addStep(new IngestJsonFileSetupGcpStep(gcsPdao, appConfig.objectMapper(), dataset));
+    addStep(new IngestJsonFileSetupGcpStep(gcsPdao, appConfig.objectMapper(), dataset, userReq));
 
     // Authorize the billing profile for use.
     addStep(
@@ -265,6 +267,7 @@ public class DatasetIngestFlight extends Flight {
             appConfig.objectMapper(),
             dataset,
             appConfig.getLoadFilePopulateBatchSize(),
+            userReq,
             isCombinedIngest));
 
     // Load the files!
@@ -295,7 +298,7 @@ public class DatasetIngestFlight extends Flight {
     // Build the scratch file using new file ids and store in new bucket.
     addStep(
         new IngestBuildAndWriteScratchLoadFileGcpStep(
-            appConfig.objectMapper(), gcsPdao, dataset, isCombinedIngest));
+            appConfig.objectMapper(), gcsPdao, dataset, userReq, isCombinedIngest));
 
     // Copy the load history into BigQuery.
     addStep(
@@ -346,7 +349,8 @@ public class DatasetIngestFlight extends Flight {
     // If there are no files to load, then SkippableSteps taking the `ingestSkipCondition`
     // will not be run.
     addStep(
-        new IngestJsonFileSetupAzureStep(appConfig.objectMapper(), azureBlobStorePdao, dataset));
+        new IngestJsonFileSetupAzureStep(
+            appConfig.objectMapper(), azureBlobStorePdao, dataset, userReq));
 
     // Lock the load.
     addStep(new LoadLockStep(loadService, isCombinedIngest));
@@ -366,6 +370,7 @@ public class DatasetIngestFlight extends Flight {
             appConfig.objectMapper(),
             dataset,
             appConfig.getLoadFilePopulateBatchSize(),
+            userReq,
             isCombinedIngest));
 
     // Load the files!
@@ -395,6 +400,7 @@ public class DatasetIngestFlight extends Flight {
             azureBlobStorePdao,
             azureContainerPdao,
             dataset,
+            userReq,
             isCombinedIngest));
 
     // Copy the load history to Azure Storage Tables.

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateIngestRequestDataSourceStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateIngestRequestDataSourceStep.java
@@ -7,6 +7,7 @@ import bio.terra.model.IngestRequestModel;
 import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.FlightContext;
@@ -19,13 +20,17 @@ import java.sql.SQLException;
 import java.util.Arrays;
 
 public class IngestCreateIngestRequestDataSourceStep implements Step {
-  private AzureSynapsePdao azureSynapsePdao;
-  private AzureBlobStorePdao azureBlobStorePdao;
+  private final AzureSynapsePdao azureSynapsePdao;
+  private final AzureBlobStorePdao azureBlobStorePdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public IngestCreateIngestRequestDataSourceStep(
-      AzureSynapsePdao azureSynapsePdao, AzureBlobStorePdao azureBlobStorePdao) {
+      AzureSynapsePdao azureSynapsePdao,
+      AzureBlobStorePdao azureBlobStorePdao,
+      AuthenticatedUserRequest userRequest) {
     this.azureSynapsePdao = azureSynapsePdao;
     this.azureBlobStorePdao = azureBlobStorePdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -44,11 +49,11 @@ public class IngestCreateIngestRequestDataSourceStep implements Step {
               CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
       signedBlobUrlParts =
           azureBlobStorePdao.getOrSignUrlForTargetFactory(
-              path, billingProfileModel, storageAccount, ContainerType.SCRATCH);
+              path, billingProfileModel, storageAccount, ContainerType.SCRATCH, userRequest);
     } else {
       signedBlobUrlParts =
           azureBlobStorePdao.getOrSignUrlForSourceFactory(
-              ingestRequestModel.getPath(), billingProfileModel.getTenantId());
+              ingestRequestModel.getPath(), billingProfileModel.getTenantId(), userRequest);
     }
 
     try {

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateTargetDataSourceStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateTargetDataSourceStep.java
@@ -6,6 +6,7 @@ import bio.terra.model.BillingProfileModel;
 import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.FlightContext;
@@ -18,13 +19,17 @@ import java.sql.SQLException;
 import java.util.Arrays;
 
 public class IngestCreateTargetDataSourceStep implements Step {
-  private AzureSynapsePdao azureSynapsePdao;
-  private AzureBlobStorePdao azureBlobStorePdao;
+  private final AzureSynapsePdao azureSynapsePdao;
+  private final AzureBlobStorePdao azureBlobStorePdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public IngestCreateTargetDataSourceStep(
-      AzureSynapsePdao azureSynapsePdao, AzureBlobStorePdao azureBlobStorePdao) {
+      AzureSynapsePdao azureSynapsePdao,
+      AzureBlobStorePdao azureBlobStorePdao,
+      AuthenticatedUserRequest userRequest) {
     this.azureSynapsePdao = azureSynapsePdao;
     this.azureBlobStorePdao = azureBlobStorePdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -45,7 +50,8 @@ public class IngestCreateTargetDataSourceStep implements Step {
             parquetDestinationLocation,
             billingProfile,
             storageAccountResource,
-            ContainerType.METADATA);
+            ContainerType.METADATA,
+            userRequest);
     try {
       azureSynapsePdao.createExternalDataSource(
           targetSignUrlBlob,

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupAzureStep.java
@@ -4,6 +4,7 @@ import bio.terra.common.Column;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 
@@ -11,12 +12,17 @@ public class IngestJsonFileSetupAzureStep extends IngestJsonFileSetupStep {
 
   private final ObjectMapper objectMapper;
   private final AzureBlobStorePdao azureBlobStorePdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public IngestJsonFileSetupAzureStep(
-      ObjectMapper objectMapper, AzureBlobStorePdao azureBlobStorePdao, Dataset dataset) {
+      ObjectMapper objectMapper,
+      AzureBlobStorePdao azureBlobStorePdao,
+      Dataset dataset,
+      AuthenticatedUserRequest userRequest) {
     super(dataset);
     this.objectMapper = objectMapper;
     this.azureBlobStorePdao = azureBlobStorePdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -27,6 +33,12 @@ public class IngestJsonFileSetupAzureStep extends IngestJsonFileSetupStep {
             .getTenantId()
             .toString();
     return IngestUtils.countBulkFileLoadModelsFromPath(
-        azureBlobStorePdao, objectMapper, ingestRequest, tenantId, fileRefColumns, errors);
+        azureBlobStorePdao,
+        objectMapper,
+        ingestRequest,
+        userRequest,
+        tenantId,
+        fileRefColumns,
+        errors);
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupGcpStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupGcpStep.java
@@ -4,6 +4,7 @@ import bio.terra.common.Column;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 
@@ -11,11 +12,17 @@ public class IngestJsonFileSetupGcpStep extends IngestJsonFileSetupStep {
 
   private final GcsPdao gcsPdao;
   private final ObjectMapper objectMapper;
+  private final AuthenticatedUserRequest userRequest;
 
-  public IngestJsonFileSetupGcpStep(GcsPdao gcsPdao, ObjectMapper objectMapper, Dataset dataset) {
+  public IngestJsonFileSetupGcpStep(
+      GcsPdao gcsPdao,
+      ObjectMapper objectMapper,
+      Dataset dataset,
+      AuthenticatedUserRequest userRequest) {
     super(dataset);
     this.gcsPdao = gcsPdao;
     this.objectMapper = objectMapper;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -25,6 +32,7 @@ public class IngestJsonFileSetupGcpStep extends IngestJsonFileSetupStep {
         gcsPdao,
         objectMapper,
         ingestRequest,
+        userRequest,
         dataset.getProjectResource().getGoogleProjectId(),
         fileRefColumns,
         errors);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestPopulateFileStateFromFlightMapAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestPopulateFileStateFromFlightMapAzureStep.java
@@ -6,6 +6,7 @@ import bio.terra.model.IngestRequestModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.load.LoadService;
 import bio.terra.stairway.FlightContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,6 +18,7 @@ public class IngestPopulateFileStateFromFlightMapAzureStep
     extends IngestPopulateFileStateFromFlightMapStep {
 
   private final AzureBlobStorePdao azureBlobStorePdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public IngestPopulateFileStateFromFlightMapAzureStep(
       LoadService loadService,
@@ -25,9 +27,11 @@ public class IngestPopulateFileStateFromFlightMapAzureStep
       ObjectMapper objectMapper,
       Dataset dataset,
       int batchSize,
+      AuthenticatedUserRequest userRequest,
       Predicate<FlightContext> doCondition) {
     super(loadService, fileService, objectMapper, dataset, batchSize, doCondition);
     this.azureBlobStorePdao = azureBlobStorePdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -38,6 +42,12 @@ public class IngestPopulateFileStateFromFlightMapAzureStep
             .getTenantId()
             .toString();
     return IngestUtils.getBulkFileLoadModelsStream(
-        azureBlobStorePdao, objectMapper, ingestRequest, tenantId, fileRefColumns, errors);
+        azureBlobStorePdao,
+        objectMapper,
+        ingestRequest,
+        userRequest,
+        tenantId,
+        fileRefColumns,
+        errors);
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestPopulateFileStateFromFlightMapGcpStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestPopulateFileStateFromFlightMapGcpStep.java
@@ -6,6 +6,7 @@ import bio.terra.model.IngestRequestModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.load.LoadService;
 import bio.terra.stairway.FlightContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,6 +18,7 @@ public class IngestPopulateFileStateFromFlightMapGcpStep
     extends IngestPopulateFileStateFromFlightMapStep {
 
   private final GcsPdao gcsPdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public IngestPopulateFileStateFromFlightMapGcpStep(
       LoadService loadService,
@@ -25,9 +27,11 @@ public class IngestPopulateFileStateFromFlightMapGcpStep
       ObjectMapper objectMapper,
       Dataset dataset,
       int batchSize,
+      AuthenticatedUserRequest userRequest,
       Predicate<FlightContext> doCondition) {
     super(loadService, fileService, objectMapper, dataset, batchSize, doCondition);
     this.gcsPdao = gcsPdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -37,6 +41,7 @@ public class IngestPopulateFileStateFromFlightMapGcpStep
         gcsPdao,
         objectMapper,
         ingestRequest,
+        userRequest,
         dataset.getProjectResource().getGoogleProjectId(),
         fileRefColumns,
         errors);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -14,6 +14,7 @@ import bio.terra.service.dataset.exception.InvalidIngestStrategyException;
 import bio.terra.service.dataset.exception.TableNotFoundException;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.filedata.CloudFileReader;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.FlightContext;
@@ -208,10 +209,11 @@ public final class IngestUtils {
       CloudFileReader cloudFileReader,
       ObjectMapper objectMapper,
       IngestRequestModel ingestRequest,
+      AuthenticatedUserRequest userRequest,
       String cloudEncapsulationId,
       List<String> errors) {
     return cloudFileReader
-        .getBlobsLinesStream(ingestRequest.getPath(), cloudEncapsulationId)
+        .getBlobsLinesStream(ingestRequest.getPath(), cloudEncapsulationId, userRequest)
         .map(
             content -> {
               try {
@@ -228,6 +230,7 @@ public final class IngestUtils {
       CloudFileReader cloudFileReader,
       ObjectMapper objectMapper,
       IngestRequestModel ingestRequest,
+      AuthenticatedUserRequest userRequest,
       String cloudEncapsulationId,
       List<Column> fileRefColumns,
       List<String> errors) {
@@ -236,6 +239,7 @@ public final class IngestUtils {
             cloudFileReader,
             objectMapper,
             ingestRequest,
+            userRequest,
             cloudEncapsulationId,
             fileRefColumns,
             errors)) {
@@ -247,11 +251,12 @@ public final class IngestUtils {
       CloudFileReader cloudFileReader,
       ObjectMapper objectMapper,
       IngestRequestModel ingestRequest,
+      AuthenticatedUserRequest userRequest,
       String cloudEncapsulationId,
       List<Column> fileRefColumns,
       List<String> errors) {
     return IngestUtils.getJsonNodesStreamFromFile(
-            cloudFileReader, objectMapper, ingestRequest, cloudEncapsulationId, errors)
+            cloudFileReader, objectMapper, ingestRequest, userRequest, cloudEncapsulationId, errors)
         .flatMap(
             node ->
                 fileRefColumns.stream()

--- a/src/main/java/bio/terra/service/filedata/CloudFileReader.java
+++ b/src/main/java/bio/terra/service/filedata/CloudFileReader.java
@@ -1,8 +1,10 @@
 package bio.terra.service.filedata;
 
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import java.util.stream.Stream;
 
 public interface CloudFileReader {
 
-  Stream<String> getBlobsLinesStream(String blobUrl, String cloudEncapsulationId);
+  Stream<String> getBlobsLinesStream(
+      String blobUrl, String cloudEncapsulationId, AuthenticatedUserRequest userRequest);
 }

--- a/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
+++ b/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
@@ -12,4 +12,6 @@ public interface FSContainerInterface {
   GoogleProjectResource getProjectResource();
 
   FireStoreProject firestoreConnection();
+
+  String getName();
 }

--- a/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
+++ b/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata;
 
+import bio.terra.common.CollectionType;
 import bio.terra.service.filedata.google.firestore.FireStoreProject;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import java.util.UUID;
@@ -14,4 +15,6 @@ public interface FSContainerInterface {
   FireStoreProject firestoreConnection();
 
   String getName();
+
+  CollectionType getCollectionType();
 }

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzurePrimaryDataStep.java
@@ -3,6 +3,7 @@ package bio.terra.service.filedata.flight.delete;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.flight.FileMapKeys;
 import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -15,9 +16,12 @@ public class DeleteFileAzurePrimaryDataStep implements Step {
       LoggerFactory.getLogger(DeleteFileAzurePrimaryDataStep.class);
 
   private final AzureBlobStorePdao azureBlobStorePdao;
+  private final AuthenticatedUserRequest userRequest;
 
-  public DeleteFileAzurePrimaryDataStep(AzureBlobStorePdao azureBlobStorePdao) {
+  public DeleteFileAzurePrimaryDataStep(
+      AzureBlobStorePdao azureBlobStorePdao, AuthenticatedUserRequest userRequest) {
     this.azureBlobStorePdao = azureBlobStorePdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -25,7 +29,7 @@ public class DeleteFileAzurePrimaryDataStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     FireStoreFile fireStoreFile = workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class);
     if (fireStoreFile != null) {
-      azureBlobStorePdao.deleteFile(fireStoreFile);
+      azureBlobStorePdao.deleteFile(fireStoreFile, userRequest);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/filedata/flight/delete/FileDeleteFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/FileDeleteFlight.java
@@ -15,6 +15,7 @@ import bio.terra.service.filedata.azure.tables.TableDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.ResourceService;
@@ -44,7 +45,8 @@ public class FileDeleteFlight extends Flight {
 
     String datasetId = inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class);
     String fileId = inputParameters.get(JobMapKeys.FILE_ID.getKeyName(), String.class);
-
+    AuthenticatedUserRequest userReq =
+        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
     // TODO: fix this
     //  Error handling within this constructor results in an obscure throw from
     //  Java (INVOCATION_EXCEPTION), instead of getting a good DATASET_NOT_FOUND error.
@@ -86,7 +88,7 @@ public class FileDeleteFlight extends Flight {
               tableDao, fileId, dataset, configService, resourceService, profileDao),
           fileSystemRetry);
       addStep(new DeleteFileAzureMetadataStep(tableDao, fileId, dataset), fileSystemRetry);
-      addStep(new DeleteFileAzurePrimaryDataStep(azureBlobStorePdao));
+      addStep(new DeleteFileAzurePrimaryDataStep(azureBlobStorePdao, userReq));
       addStep(new DeleteFileAzureDirectoryStep(tableDao, fileId, dataset), fileSystemRetry);
     }
     addStep(new UnlockDatasetStep(datasetDao, UUID.fromString(datasetId), true), lockDatasetRetry);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -180,7 +180,8 @@ public class FileIngestBulkFlight extends Flight {
                 appConfig.getMaxBadLoadFileLineErrorsReported(),
                 appConfig.getLoadFilePopulateBatchSize(),
                 azureBlobStorePdao,
-                bulkLoadObjectMapper));
+                bulkLoadObjectMapper,
+                userReq));
       }
     }
     addStep(

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -144,7 +144,7 @@ public class FileIngestFlight extends Flight {
           randomBackoffRetry);
       addStep(new ValidateIngestFileAzureDirectoryStep(azureTableDao, dataset));
       addStep(new IngestFileAzureDirectoryStep(azureTableDao, dataset), randomBackoffRetry);
-      addStep(new IngestFileAzurePrimaryDataStep(azureBlobStorePdao, configService));
+      addStep(new IngestFileAzurePrimaryDataStep(azureBlobStorePdao, configService, userReq));
       addStep(new IngestFileAzureFileStep(azureTableDao, fileService, dataset), randomBackoffRetry);
     }
     addStep(new LoadUnlockStep(loadService));

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestWorkerFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestWorkerFlight.java
@@ -85,7 +85,7 @@ public class FileIngestWorkerFlight extends Flight {
     } else if (platform.isAzure()) {
       addStep(new ValidateIngestFileAzureDirectoryStep(azureTableDao, dataset));
       addStep(new IngestFileAzureDirectoryStep(azureTableDao, dataset), fileSystemRetry);
-      addStep(new IngestFileAzurePrimaryDataStep(azureBlobStorePdao, configService));
+      addStep(new IngestFileAzurePrimaryDataStep(azureBlobStorePdao, configService, userReq));
       addStep(new IngestFileAzureFileStep(azureTableDao, fileService, dataset), fileSystemRetry);
     }
   }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileAzureStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileAzureStep.java
@@ -6,12 +6,15 @@ import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.filedata.azure.util.BlobSasTokenOptions;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.sas.BlobSasPermission;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
@@ -22,17 +25,20 @@ import java.util.stream.Stream;
 public class IngestBuildAndWriteScratchLoadFileAzureStep
     extends IngestBuildAndWriteScratchLoadFileStep {
   private final AzureBlobStorePdao azureBlobStorePdao;
-  AzureContainerPdao azureContainerPdao;
+  private final AzureContainerPdao azureContainerPdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public IngestBuildAndWriteScratchLoadFileAzureStep(
       ObjectMapper objectMapper,
       AzureBlobStorePdao azureBlobStorePdao,
       AzureContainerPdao azureContainerPdao,
       Dataset dataset,
+      AuthenticatedUserRequest userRequest,
       Predicate<FlightContext> doCondition) {
     super(objectMapper, dataset, doCondition);
     this.azureBlobStorePdao = azureBlobStorePdao;
     this.azureContainerPdao = azureContainerPdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -43,7 +49,7 @@ public class IngestBuildAndWriteScratchLoadFileAzureStep
             .getTenantId()
             .toString();
     return IngestUtils.getJsonNodesStreamFromFile(
-        azureBlobStorePdao, objectMapper, ingestRequest, tenantId, errors);
+        azureBlobStorePdao, objectMapper, ingestRequest, userRequest, tenantId, errors);
   }
 
   @Override
@@ -76,8 +82,10 @@ public class IngestBuildAndWriteScratchLoadFileAzureStep
             storageAccount,
             path,
             AzureStorageAccountResource.ContainerType.SCRATCH,
-            Duration.ofHours(1L),
-            billingProfile.getBiller());
+            new BlobSasTokenOptions(
+                Duration.ofHours(1),
+                new BlobSasPermission().setReadPermission(true).setWritePermission(true),
+                userRequest.getEmail()));
     azureBlobStorePdao.writeBlobLines(signedPath, lines);
   }
 }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileGcpStep.java
@@ -6,6 +6,7 @@ import bio.terra.service.common.gcs.GcsUriUtils;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.stairway.FlightContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -17,14 +18,17 @@ import java.util.stream.Stream;
 public class IngestBuildAndWriteScratchLoadFileGcpStep
     extends IngestBuildAndWriteScratchLoadFileStep {
   private final GcsPdao gcsPdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public IngestBuildAndWriteScratchLoadFileGcpStep(
       ObjectMapper objectMapper,
       GcsPdao gcsPdao,
       Dataset dataset,
+      AuthenticatedUserRequest userRequest,
       Predicate<FlightContext> doCondition) {
     super(objectMapper, dataset, doCondition);
     this.gcsPdao = gcsPdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -34,6 +38,7 @@ public class IngestBuildAndWriteScratchLoadFileGcpStep
         gcsPdao,
         objectMapper,
         ingestRequest,
+        userRequest,
         dataset.getProjectResource().getGoogleProjectId(),
         errors);
   }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata.flight.ingest;
 
+import bio.terra.common.CollectionType;
 import bio.terra.common.FlightUtils;
 import bio.terra.model.FileLoadModel;
 import bio.terra.service.common.CommonMapKeys;
@@ -62,7 +63,14 @@ public class IngestFileAzureFileStep implements Step {
       try {
         tableDao.createFileMetadata(newFile, storageAuthInfo);
         // Retrieve to build the complete FSItem
-        FSItem fsItem = tableDao.retrieveById(dataset.getId(), fileId, 1, storageAuthInfo);
+        FSItem fsItem =
+            tableDao.retrieveById(
+                CollectionType.DATASET,
+                dataset.getId(),
+                fileId,
+                1,
+                storageAuthInfo,
+                storageAuthInfo);
         workingMap.put(JobMapKeys.RESPONSE.getKeyName(), fileService.fileModelFromFSItem(fsItem));
       } catch (TableServiceException rex) {
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileAzureStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileAzureStep.java
@@ -6,6 +6,7 @@ import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.azure.util.AzureBlobStoreBufferedReader;
 import bio.terra.service.filedata.exception.BulkLoadControlFileException;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.load.LoadService;
 import bio.terra.service.profile.flight.ProfileMapKeys;
@@ -19,15 +20,18 @@ import java.io.IOException;
 // Populate the files to be loaded from the incoming array
 public class IngestPopulateFileStateFromFileAzureStep extends IngestPopulateFileStateFromFileStep {
   private final AzureBlobStorePdao azureBlobStorePdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public IngestPopulateFileStateFromFileAzureStep(
       LoadService loadService,
       int maxBadLines,
       int batchSize,
       AzureBlobStorePdao azureBlobStorePdao,
-      ObjectMapper bulkLoadObjectMapper) {
+      ObjectMapper bulkLoadObjectMapper,
+      AuthenticatedUserRequest userRequest) {
     super(loadService, maxBadLines, batchSize, bulkLoadObjectMapper);
     this.azureBlobStorePdao = azureBlobStorePdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -45,7 +49,7 @@ public class IngestPopulateFileStateFromFileAzureStep extends IngestPopulateFile
     IngestUtils.validateBlobAzureBlobFileURL(blobStoreUrl);
     String ingestRequestSignedUrl =
         azureBlobStorePdao.getOrSignUrlStringForSourceFactory(
-            blobStoreUrl, billingProfileModel.getTenantId());
+            blobStoreUrl, billingProfileModel.getTenantId(), userRequest);
 
     // Stream from control file and build list of files to be ingested
     try (BufferedReader reader = new AzureBlobStoreBufferedReader(ingestRequestSignedUrl)) {

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -123,10 +123,12 @@ public class GcsPdao implements CloudFileReader {
    * @param blobUrl blobUrl to files, or blobUrl including wildcard referring to many files
    * @param cloudEncapsulationId Project ID to use for storage service in case of requester pays
    *     bucket
+   * @param userRequest user making the request
    * @return All of the lines from all of the files matching the blobUrl, as a Stream
    */
   @Override
-  public Stream<String> getBlobsLinesStream(String blobUrl, String cloudEncapsulationId) {
+  public Stream<String> getBlobsLinesStream(
+      String blobUrl, String cloudEncapsulationId, AuthenticatedUserRequest userRequest) {
     Storage storage = gcsProjectFactory.getStorage(cloudEncapsulationId);
     return listGcsFiles(blobUrl, cloudEncapsulationId, storage)
         .flatMap(blob -> getBlobLinesStream(blob, cloudEncapsulationId, storage));

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -246,10 +246,18 @@ public class GcsPdao implements CloudFileReader {
           storageAsPet.testIamPermissions(bucket, List.of("storage.objects.get"));
 
       if (!permissions.equals(List.of(true))) {
+        String proxyGroup;
+        try {
+          proxyGroup = iamClient.getProxyGroup(user);
+        } catch (InterruptedException e) {
+          // Don't fail since this call is really to get more information on a previous error
+          logger.warn("Could not get proxy group for user {}", user.getEmail());
+          proxyGroup = "N/A";
+        }
         throw new BlobAccessNotAuthorizedException(
             String.format(
-                "Accessing bucket %s is not authorized. Please be sure to grant \"Storage Object Viewer\" permissions to the TDR service account and your Terra proxy user group",
-                bucket));
+                "Accessing bucket %s is not authorized for user %s. Please be sure to grant \"Storage Object Viewer\" permissions to the TDR service account and your Terra proxy user group (%s)",
+                bucket, user.getEmail(), proxyGroup));
       }
     }
   }

--- a/src/main/java/bio/terra/service/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/iam/IamProviderInterface.java
@@ -171,6 +171,14 @@ public interface IamProviderInterface {
   UserStatusInfo getUserInfo(AuthenticatedUserRequest userReq);
 
   /**
+   * Returns the proxy group of a user
+   *
+   * @param userReq authenticated user
+   * @return The google proxy group of a given user
+   */
+  String getProxyGroup(AuthenticatedUserRequest userReq) throws InterruptedException;
+
+  /**
    * Get Sam Status
    *
    * @return RepositoryStatusModelSystems model that includes status and message about sub-system

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -492,6 +492,15 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
+  public String getProxyGroup(AuthenticatedUserRequest userReq) throws InterruptedException {
+    return SamRetry.retry(configurationService, () -> getProxyGroupInner(userReq));
+  }
+
+  private String getProxyGroupInner(AuthenticatedUserRequest userReq) throws ApiException {
+    return samGoogleApi(userReq.getRequiredToken()).getProxyGroup(userReq.getEmail());
+  }
+
+  @Override
   public RepositoryStatusModelSystems samStatus() {
     try {
       return SamRetry.retry(

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -1,6 +1,7 @@
 package bio.terra.service.resourcemanagement;
 
 import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.common.CollectionType;
 import bio.terra.common.Table;
 import bio.terra.model.AccessInfoBigQueryModel;
 import bio.terra.model.AccessInfoBigQueryModelTable;
@@ -31,11 +32,6 @@ import org.stringtemplate.v4.ST;
 /** Utilities for building strings to access metadata */
 @Component
 public final class MetadataDataAccessUtils {
-
-  private enum CollectionType {
-    DATASET,
-    SNAPSHOT
-  }
 
   private static final Duration DEFAULT_SAS_TOKEN_EXPIRATION = Duration.ofMinutes(15);
   private static final String BIGQUERY_DATASET_LINK =
@@ -149,11 +145,11 @@ public final class MetadataDataAccessUtils {
 
     String blobName;
     BiFunction<FSContainerInterface, Table, String> tableBlobGenerator;
-    if (collection instanceof Dataset) {
+    if (collection.getCollectionType() == CollectionType.DATASET) {
       blobName = "parquet";
       tableBlobGenerator =
           (c, t) -> new ST(AZURE_BLOB_TEMPLATE_DATASET).add("table", t.getName()).render();
-    } else if (collection instanceof Snapshot) {
+    } else if (collection.getCollectionType() == CollectionType.SNAPSHOT) {
       blobName = "parquet/" + collection.getId();
       tableBlobGenerator =
           (c, t) ->

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -9,11 +9,16 @@ import bio.terra.model.AccessInfoParquetModel;
 import bio.terra.model.AccessInfoParquetModelTable;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.FSContainerInterface;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.filedata.azure.util.BlobSasTokenOptions;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
+import com.azure.storage.blob.sas.BlobSasPermission;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -21,11 +26,18 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.stringtemplate.v4.ST;
+import scala.Function2;
 
 /** Utilities for building strings to access metadata */
 @Component
 public final class MetadataDataAccessUtils {
 
+  private enum CollectionType {
+    DATASET,
+    SNAPSHOT
+  }
+
+  private static final Duration DEFAULT_SAS_TOKEN_EXPIRATION = Duration.ofMinutes(15);
   private static final String BIGQUERY_DATASET_LINK =
       "https://console.cloud.google.com/bigquery?project=<project>&"
           + "ws=!<dataset>&d=<dataset>&p=<project>&page=<page>";
@@ -37,7 +49,9 @@ public final class MetadataDataAccessUtils {
 
   private static final String AZURE_PARQUET_LINK =
       "https://<storageAccount>.blob.core.windows.net/metadata/<blob>";
-  private static final String AZURE_BLOB_TEMPLATE = "parquet/<table>";
+  private static final String AZURE_BLOB_TEMPLATE_DATASET = "parquet/<table>";
+  private static final String AZURE_BLOB_TEMPLATE_SNAPSHOT =
+      "parquet/<collectionId>/<table>.parquet";
   private static final String AZURE_DATASET_ID = "<storageAccount>.<dataset>";
 
   private static final String DEPLOYED_APPLICATION_RESOURCE_ID =
@@ -45,14 +59,18 @@ public final class MetadataDataAccessUtils {
           + "/<resource_group>/providers/Microsoft.Solutions/applications/<application_name>";
 
   private final ResourceService resourceService;
+  private final ProfileService profileService;
 
   private final AzureBlobStorePdao azureBlobStorePdao;
 
   @Autowired
   public MetadataDataAccessUtils(
-      ResourceService resourceService, AzureBlobStorePdao azureBlobStorePdao) {
+      ResourceService resourceService,
+      AzureBlobStorePdao azureBlobStorePdao,
+      ProfileService profileService) {
     this.resourceService = resourceService;
     this.azureBlobStorePdao = azureBlobStorePdao;
+    this.profileService = profileService;
   }
 
   /** Nature of the page to link to in the BigQuery UI */
@@ -67,15 +85,35 @@ public final class MetadataDataAccessUtils {
   }
 
   /** Generate an {@link AccessInfoModel} from a Snapshot */
-  public static AccessInfoModel accessInfoFromSnapshot(final Snapshot snapshot) {
-    return makeAccessInfoBigQuery(
-        snapshot.getName(),
-        snapshot.getProjectResource().getGoogleProjectId(),
-        snapshot.getTables());
+  public AccessInfoModel accessInfoFromSnapshot(
+      final Snapshot snapshot, final AuthenticatedUserRequest userRequest) {
+    CloudPlatformWrapper cloudPlatformWrapper =
+        CloudPlatformWrapper.of(
+            snapshot
+                .getFirstSnapshotSource()
+                .getDataset()
+                .getDatasetSummary()
+                .getStorageCloudPlatform());
+
+    if (cloudPlatformWrapper.isGcp()) {
+      return makeAccessInfoBigQuery(
+          snapshot.getName(),
+          snapshot.getProjectResource().getGoogleProjectId(),
+          snapshot.getTables());
+    } else if (cloudPlatformWrapper.isAzure()) {
+      BillingProfileModel profileModel =
+          profileService.getProfileByIdNoCheck(snapshot.getProfileId());
+      AzureStorageAccountResource storageAccountResource = snapshot.getStorageAccountResource();
+      return makeAccessInfoAzure(
+          snapshot, storageAccountResource, snapshot.getTables(), profileModel, userRequest);
+    } else {
+      throw new IllegalArgumentException("Unrecognized cloud platform");
+    }
   }
 
   /** Generate an {@link AccessInfoModel} from a Dataset */
-  public AccessInfoModel accessInfoFromDataset(final Dataset dataset) {
+  public AccessInfoModel accessInfoFromDataset(
+      final Dataset dataset, final AuthenticatedUserRequest userRequest) {
     CloudPlatformWrapper cloudPlatformWrapper =
         CloudPlatformWrapper.of(dataset.getDatasetSummary().getStorageCloudPlatform());
 
@@ -89,23 +127,49 @@ public final class MetadataDataAccessUtils {
       AzureStorageAccountResource storageAccountResource =
           resourceService.getDatasetStorageAccount(dataset, profileModel);
       return makeAccessInfoAzure(
-          dataset.getName(), storageAccountResource, dataset.getTables(), profileModel);
+          dataset, storageAccountResource, dataset.getTables(), profileModel, userRequest);
     } else {
       throw new IllegalArgumentException("Unrecognized cloud platform");
     }
   }
 
   private AccessInfoModel makeAccessInfoAzure(
-      final String datasetName,
+      final FSContainerInterface collection,
       final AzureStorageAccountResource storageAccountResource,
       final List<? extends Table> tables,
-      final BillingProfileModel profileModel) {
+      final BillingProfileModel profileModel,
+      final AuthenticatedUserRequest userRequest) {
     AccessInfoModel accessInfoModel = new AccessInfoModel();
+
+    BlobSasTokenOptions blobSasTokenOptions =
+        new BlobSasTokenOptions(
+            DEFAULT_SAS_TOKEN_EXPIRATION,
+            new BlobSasPermission().setReadPermission(true).setListPermission(true),
+            userRequest.getEmail());
+
+    String blobName;
+    Function2<FSContainerInterface, Table, String> tableBlobGenerator;
+    if (collection instanceof Dataset) {
+      blobName = "parquet";
+      tableBlobGenerator =
+          (c, t) -> new ST(AZURE_BLOB_TEMPLATE_DATASET).add("table", t.getName()).render();
+    } else if (collection instanceof Snapshot) {
+      blobName = "parquet/" + collection.getId();
+      tableBlobGenerator =
+          (c, t) ->
+              new ST(AZURE_BLOB_TEMPLATE_SNAPSHOT)
+                  .add("collectionId", c.getId())
+                  .add("table", t.getName())
+                  .render();
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Invalid collection type: %s", collection.getClass().getName()));
+    }
 
     String unsignedUrl =
         new ST(AZURE_PARQUET_LINK)
             .add("storageAccount", storageAccountResource.getName())
-            .add("blob", "parquet")
+            .add("blob", blobName)
             .render();
     String signedURL =
         azureBlobStorePdao.signFile(
@@ -113,25 +177,25 @@ public final class MetadataDataAccessUtils {
             storageAccountResource,
             unsignedUrl,
             ContainerType.METADATA,
-            Duration.ofMinutes(15),
-            profileModel.getBiller());
+            blobSasTokenOptions);
 
+    UrlParts urlParts = UrlParts.fromUrl(signedURL);
     accessInfoModel.parquet(
         new AccessInfoParquetModel()
-            .datasetName(datasetName)
+            .datasetName(collection.getName())
             .datasetId(
                 new ST(AZURE_DATASET_ID)
                     .add("storageAccount", storageAccountResource.getName())
-                    .add("dataset", datasetName)
+                    .add("dataset", collection.getName())
                     .render())
             .storageAccountId(storageAccountResource.getResourceId().toString())
-            .signedUrl(signedURL)
+            .url(urlParts.url)
+            .sasToken(urlParts.sasToken)
             .tables(
                 tables.stream()
                     .map(
                         t -> {
-                          String tableBlob =
-                              new ST(AZURE_BLOB_TEMPLATE).add("table", t.getName()).render();
+                          String tableBlob = tableBlobGenerator.apply(collection, t);
                           String unsignedTableUrl =
                               new ST(AZURE_PARQUET_LINK)
                                   .add("storageAccount", storageAccountResource.getName())
@@ -143,11 +207,12 @@ public final class MetadataDataAccessUtils {
                                   storageAccountResource,
                                   unsignedTableUrl,
                                   ContainerType.METADATA,
-                                  Duration.ofMinutes(15),
-                                  profileModel.getBiller());
+                                  blobSasTokenOptions);
+                          UrlParts tableUrlParts = UrlParts.fromUrl(tableUrl);
                           return new AccessInfoParquetModelTable()
                               .name(t.getName())
-                              .signedUrl(tableUrl);
+                              .url(tableUrlParts.url)
+                              .sasToken(tableUrlParts.sasToken);
                         })
                     .collect(Collectors.toList())));
 
@@ -243,5 +308,24 @@ public final class MetadataDataAccessUtils {
         .add("resource_group", resourceGroupName)
         .add("application_name", applicationDeploymentName)
         .render();
+  }
+
+  private static class UrlParts {
+    private final String url;
+    private final String sasToken;
+
+    public UrlParts(final String url, final String sasToken) {
+      this.url = url;
+      this.sasToken = sasToken;
+    }
+
+    public static UrlParts fromUrl(final String signedURL) {
+      String[] urlParts = signedURL.split("\\?");
+      if (urlParts.length != 2) {
+        throw new IllegalArgumentException(
+            String.format("Url %s does not appear to be properly formatted", signedURL));
+      }
+      return new UrlParts(urlParts[0], urlParts[1]);
+    }
   }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -22,11 +22,11 @@ import com.azure.storage.blob.sas.BlobSasPermission;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.stringtemplate.v4.ST;
-import scala.Function2;
 
 /** Utilities for building strings to access metadata */
 @Component
@@ -148,7 +148,7 @@ public final class MetadataDataAccessUtils {
             userRequest.getEmail());
 
     String blobName;
-    Function2<FSContainerInterface, Table, String> tableBlobGenerator;
+    BiFunction<FSContainerInterface, Table, String> tableBlobGenerator;
     if (collection instanceof Dataset) {
       blobName = "parquet";
       tableBlobGenerator =

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -40,6 +40,7 @@ public class Snapshot implements FSContainerInterface {
     return this;
   }
 
+  @Override
   public String getName() {
     return name;
   }
@@ -134,7 +135,7 @@ public class Snapshot implements FSContainerInterface {
     return storageAccountResource;
   }
 
-  public Snapshot setStorageAccountResource(AzureStorageAccountResource storageAccountResource) {
+  public Snapshot storageAccountResource(AzureStorageAccountResource storageAccountResource) {
     this.storageAccountResource = storageAccountResource;
     return this;
   }

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -1,6 +1,7 @@
 package bio.terra.service.snapshot;
 
 import bio.terra.app.model.AzureRegion;
+import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.service.filedata.FSContainerInterface;
@@ -30,6 +31,11 @@ public class Snapshot implements FSContainerInterface {
   private GoogleProjectResource projectResource;
   private AzureStorageAccountResource storageAccountResource;
   private List<Relationship> relationships = Collections.emptyList();
+
+  @Override
+  public CollectionType getCollectionType() {
+    return CollectionType.SNAPSHOT;
+  }
 
   public UUID getId() {
     return id;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -3,6 +3,7 @@ package bio.terra.service.snapshot;
 import bio.terra.common.DaoKeyHolder;
 import bio.terra.common.DaoUtils;
 import bio.terra.common.MetadataEnumeration;
+import bio.terra.model.CloudPlatform;
 import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.AssetSpecification;
@@ -311,7 +312,12 @@ public class SnapshotDao {
             + "        WHERE ss.dataset_id = d.id"
             + "        AND d.project_resource_id = p.id"
             + "        AND snapshot.id = ss.snapshot_id) ds)"
-            + "  AS dataset_sources "
+            + "  AS dataset_sources, "
+            // Detect the cloud provider of the snapshot
+            + "case "
+            + "when storage_account_resource_id is not null then 'azure' "
+            + "when project_resource_id is not null then 'gcp' "
+            + "end AS cloud_platform "
             + "FROM snapshot "
             + "JOIN project_resource ON snapshot.project_resource_id = project_resource.id "
             + "WHERE snapshot.id = :id";
@@ -377,7 +383,7 @@ public class SnapshotDao {
         // Retrieve the Azure Storage Account associated with the snapshot.
         resourceService
             .getSnapshotStorageAccount(snapshot.getId())
-            .ifPresent(snapshot::setStorageAccountResource);
+            .ifPresent(snapshot::storageAccountResource);
       }
       return snapshot;
     } catch (EmptyResultDataAccessException ex) {
@@ -405,6 +411,7 @@ public class SnapshotDao {
                     .name(rs.getString("name"))
                     .profileId(rs.getObject("profile_id", UUID.class))
                     .dataProject(rs.getString("google_project_id"))
+                    .cloudPlatform(CloudPlatform.fromValue(rs.getString("cloud_platform")))
                     .sourceDatasetProjects(datasetProjects);
               });
       return snapshotProject;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotProject.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotProject.java
@@ -1,5 +1,6 @@
 package bio.terra.service.snapshot;
 
+import bio.terra.model.CloudPlatform;
 import java.util.List;
 import java.util.UUID;
 
@@ -11,6 +12,7 @@ public class SnapshotProject {
       dataProject; // Project id of the snapshot data project--which is a string and feels like a
   // name
   private List<DatasetProject> sourceDatasetProjects;
+  private CloudPlatform cloudPlatform;
 
   public UUID getId() {
     return id;
@@ -58,6 +60,15 @@ public class SnapshotProject {
 
   public SnapshotProject sourceDatasetProjects(List<DatasetProject> sourceDatasetProjects) {
     this.sourceDatasetProjects = sourceDatasetProjects;
+    return this;
+  }
+
+  public CloudPlatform getCloudPlatform() {
+    return cloudPlatform;
+  }
+
+  public SnapshotProject cloudPlatform(CloudPlatform cloudPlatform) {
+    this.cloudPlatform = cloudPlatform;
     return this;
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -67,6 +67,7 @@ public class SnapshotService {
   private final FireStoreDependencyDao dependencyDao;
   private final BigQueryPdao bigQueryPdao;
   private final SnapshotDao snapshotDao;
+  private final MetadataDataAccessUtils metadataDataAccessUtils;
 
   @Autowired
   public SnapshotService(
@@ -74,12 +75,14 @@ public class SnapshotService {
       DatasetService datasetService,
       FireStoreDependencyDao dependencyDao,
       BigQueryPdao bigQueryPdao,
-      SnapshotDao snapshotDao) {
+      SnapshotDao snapshotDao,
+      MetadataDataAccessUtils metadataDataAccessUtils) {
     this.jobService = jobService;
     this.datasetService = datasetService;
     this.dependencyDao = dependencyDao;
     this.bigQueryPdao = bigQueryPdao;
     this.snapshotDao = snapshotDao;
+    this.metadataDataAccessUtils = metadataDataAccessUtils;
   }
 
   /**
@@ -176,10 +179,12 @@ public class SnapshotService {
    * require an exclusively locked snapshot to be returned (e.g. snapshot deletion).
    *
    * @param id in UUID format
+   * @param userRequest Authenticated user object
    * @return a SnapshotModel = API output-friendly representation of the Snapshot
    */
-  public SnapshotModel retrieveAvailableSnapshotModel(UUID id) {
-    return retrieveAvailableSnapshotModel(id, getDefaultIncludes());
+  public SnapshotModel retrieveAvailableSnapshotModel(
+      UUID id, AuthenticatedUserRequest userRequest) {
+    return retrieveAvailableSnapshotModel(id, getDefaultIncludes(), userRequest);
   }
 
   /**
@@ -195,12 +200,15 @@ public class SnapshotService {
    *
    * @param id in UUID format
    * @param include a list of what information to include
+   * @param userRequest Authenticated user object
    * @return an API output-friendly representation of the Snapshot
    */
   public SnapshotModel retrieveAvailableSnapshotModel(
-      UUID id, List<SnapshotRequestAccessIncludeModel> include) {
+      UUID id,
+      List<SnapshotRequestAccessIncludeModel> include,
+      AuthenticatedUserRequest userRequest) {
     Snapshot snapshot = retrieveAvailable(id);
-    return populateSnapshotModelFromSnapshot(snapshot, include);
+    return populateSnapshotModelFromSnapshot(snapshot, include, userRequest);
   }
 
   /**
@@ -340,8 +348,9 @@ public class SnapshotService {
         .collect(Collectors.toList());
   }
 
-  public List<UUID> getSourceDatasetIdsFromSnapshotId(UUID snapshotId) {
-    SnapshotModel snapshotModel = retrieveAvailableSnapshotModel(snapshotId);
+  public List<UUID> getSourceDatasetIdsFromSnapshotId(
+      UUID snapshotId, AuthenticatedUserRequest userRequest) {
+    SnapshotModel snapshotModel = retrieveAvailableSnapshotModel(snapshotId, userRequest);
     return snapshotModel.getSource().stream()
         .map(s -> s.getDataset().getId())
         .collect(Collectors.toList());
@@ -572,7 +581,9 @@ public class SnapshotService {
   }
 
   private SnapshotModel populateSnapshotModelFromSnapshot(
-      Snapshot snapshot, List<SnapshotRequestAccessIncludeModel> include) {
+      Snapshot snapshot,
+      List<SnapshotRequestAccessIncludeModel> include,
+      AuthenticatedUserRequest userRequest) {
     SnapshotModel snapshotModel =
         new SnapshotModel()
             .id(snapshot.getId())
@@ -610,7 +621,8 @@ public class SnapshotService {
       snapshotModel.dataProject(snapshot.getProjectResource().getGoogleProjectId());
     }
     if (include.contains(SnapshotRequestAccessIncludeModel.ACCESS_INFORMATION)) {
-      snapshotModel.accessInformation(MetadataDataAccessUtils.accessInfoFromSnapshot(snapshot));
+      snapshotModel.accessInformation(
+          metadataDataAccessUtils.accessInfoFromSnapshot(snapshot, userRequest));
     }
     return snapshotModel;
   }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotStorageAccountDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotStorageAccountDao.java
@@ -3,6 +3,7 @@ package bio.terra.service.snapshot;
 import static bio.terra.common.DaoUtils.retryQuery;
 
 import bio.terra.common.exception.RetryQueryException;
+import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
@@ -51,7 +52,11 @@ public class SnapshotStorageAccountDao {
             .addValue("storage_account_resource_id", storageAccountResourceId);
 
     try {
-      jdbcTemplate.update(sqlCreateLink, params);
+      int update = jdbcTemplate.update(sqlCreateLink, params);
+
+      if (update == 0) {
+        throw new CorruptMetadataException("Could not link storage account to snapshot");
+      }
     } catch (DataAccessException dataAccessException) {
       if (retryQuery(dataAccessException)) {
         logger.error("snapshotStorageAccount link operation failed with retryable exception.");

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPrimaryDataQueryStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPrimaryDataQueryStep.java
@@ -9,6 +9,7 @@ import bio.terra.model.SnapshotRequestQueryModel;
 import bio.terra.service.dataset.AssetSpecification;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
@@ -24,23 +25,26 @@ import java.util.Optional;
 
 public class CreateSnapshotPrimaryDataQueryStep implements Step {
 
-  private BigQueryPdao bigQueryPdao;
-  private DatasetService datasetService;
-  private SnapshotService snapshotService;
-  private SnapshotDao snapshotDao;
-  private SnapshotRequestModel snapshotReq;
+  private final BigQueryPdao bigQueryPdao;
+  private final DatasetService datasetService;
+  private final SnapshotService snapshotService;
+  private final SnapshotDao snapshotDao;
+  private final SnapshotRequestModel snapshotReq;
+  private final AuthenticatedUserRequest userRequest;
 
   public CreateSnapshotPrimaryDataQueryStep(
       BigQueryPdao bigQueryPdao,
       DatasetService datasetService,
       SnapshotService snapshotService,
       SnapshotDao snapshotDao,
-      SnapshotRequestModel snapshotReq) {
+      SnapshotRequestModel snapshotReq,
+      AuthenticatedUserRequest userRequest) {
     this.bigQueryPdao = bigQueryPdao;
     this.datasetService = datasetService;
     this.snapshotService = snapshotService;
     this.snapshotDao = snapshotDao;
     this.snapshotReq = snapshotReq;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -66,7 +70,7 @@ public class CreateSnapshotPrimaryDataQueryStep implements Step {
     String datasetName = datasetNames.get(0);
 
     Dataset dataset = datasetService.retrieveByName(datasetName);
-    DatasetModel datasetModel = datasetService.retrieveModel(dataset);
+    DatasetModel datasetModel = datasetService.retrieveModel(dataset, userRequest);
 
     // get asset out of dataset
     Optional<AssetSpecification> assetSpecOp =

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotSourceDatasetDataSourceAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotSourceDatasetDataSourceAzureStep.java
@@ -5,6 +5,7 @@ import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.FlightContext;
@@ -17,13 +18,17 @@ import java.sql.SQLException;
 import java.util.Arrays;
 
 public class CreateSnapshotSourceDatasetDataSourceAzureStep implements Step {
-  private AzureSynapsePdao azureSynapsePdao;
-  private AzureBlobStorePdao azureBlobStorePdao;
+  private final AzureSynapsePdao azureSynapsePdao;
+  private final AzureBlobStorePdao azureBlobStorePdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public CreateSnapshotSourceDatasetDataSourceAzureStep(
-      AzureSynapsePdao azureSynapsePdao, AzureBlobStorePdao azureBlobStorePdao) {
+      AzureSynapsePdao azureSynapsePdao,
+      AzureBlobStorePdao azureBlobStorePdao,
+      AuthenticatedUserRequest userRequest) {
     this.azureSynapsePdao = azureSynapsePdao;
     this.azureBlobStorePdao = azureBlobStorePdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -42,7 +47,8 @@ public class CreateSnapshotSourceDatasetDataSourceAzureStep implements Step {
             parquetDatasetSourceLocation,
             billingProfile,
             datasetAzureStorageAccountResource,
-            AzureStorageAccountResource.ContainerType.METADATA);
+            AzureStorageAccountResource.ContainerType.METADATA,
+            userRequest);
     try {
       azureSynapsePdao.createExternalDataSource(
           snapshotSignUrlBlob,

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotTargetDataSourceAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotTargetDataSourceAzureStep.java
@@ -5,6 +5,7 @@ import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.FlightContext;
@@ -18,13 +19,17 @@ import java.util.Arrays;
 
 // TODO - this is the exact same step as used for ingest - find way to share code
 public class CreateSnapshotTargetDataSourceAzureStep implements Step {
-  private AzureSynapsePdao azureSynapsePdao;
-  private AzureBlobStorePdao azureBlobStorePdao;
+  private final AzureSynapsePdao azureSynapsePdao;
+  private final AzureBlobStorePdao azureBlobStorePdao;
+  private final AuthenticatedUserRequest userRequest;
 
   public CreateSnapshotTargetDataSourceAzureStep(
-      AzureSynapsePdao azureSynapsePdao, AzureBlobStorePdao azureBlobStorePdao) {
+      AzureSynapsePdao azureSynapsePdao,
+      AzureBlobStorePdao azureBlobStorePdao,
+      AuthenticatedUserRequest userRequest) {
     this.azureSynapsePdao = azureSynapsePdao;
     this.azureBlobStorePdao = azureBlobStorePdao;
+    this.userRequest = userRequest;
   }
 
   @Override
@@ -43,7 +48,8 @@ public class CreateSnapshotTargetDataSourceAzureStep implements Step {
             snapshotParquetTargetLocation,
             billingProfile,
             snapshotAzureStorageAccountResource,
-            AzureStorageAccountResource.ContainerType.METADATA);
+            AzureStorageAccountResource.ContainerType.METADATA,
+            userRequest);
     try {
       azureSynapsePdao.createExternalDataSource(
           snapshotSignUrlBlob,

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
@@ -59,7 +59,8 @@ public class SnapshotDeleteFlight extends Flight {
     // TODO note that with multi-dataset snapshots this will need to change
     UUID datasetId;
     try {
-      List<UUID> sourceDatasetIds = snapshotService.getSourceDatasetIdsFromSnapshotId(snapshotId);
+      List<UUID> sourceDatasetIds =
+          snapshotService.getSourceDatasetIdsFromSnapshotId(snapshotId, userReq);
       datasetId = sourceDatasetIds.get(0);
     } catch (SnapshotNotFoundException notFoundEx) {
       datasetId = null;

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3680,7 +3680,8 @@ components:
         - datasetName
         - datasetId
         - storageAccountId
-        - signedUrl
+        - url
+        - sasToken
         - tables
       properties:
         datasetName:
@@ -3695,10 +3696,14 @@ components:
           type: string
           description: >
             Project id of the project where tabular data in Azure lives
-        signedUrl:
+        url:
           type: string
           description: >
-            The link to access the Azure dataset UI in Google Cloud console
+            The link to access all of the tabular data for this dataset or snapshot
+        sasToken:
+          type: string
+          description: >
+            A short lived SAS token to access all of the tabular data for this dataset
         tables:
           type: array
           description: >
@@ -3711,26 +3716,21 @@ components:
         Information on a snapshot or dataset table in a Azure dataset
       required:
         - name
-        - id
-        - signedUrl
-        - sampleQuery
+        - url
+        - sasToken
       properties:
         name:
           type: string
           description: >
             The name of the dataset table
-        id:
+        url:
           type: string
           description: >
-            The unique id of the dataset table
-        signedUrl:
+            The link to access the container that stores parquet files for this table
+        sasToken:
           type: string
           description: >
-            The link to access the container that stores parquet files
-        sampleQuery:
-          type: string
-          description: >
-            An example query that can be used to select data from this table
+            A short lived SAS token to access the parquet files for this table
     SnapshotSourceModel:
       required:
         - asset

--- a/src/test/java/bio/terra/common/SynapseUtils.java
+++ b/src/test/java/bio/terra/common/SynapseUtils.java
@@ -4,6 +4,7 @@ import bio.terra.model.BillingProfileModel;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.azure.util.BlobContainerClientFactory;
+import bio.terra.service.filedata.azure.util.BlobSasTokenOptions;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import java.sql.Connection;
@@ -55,10 +56,14 @@ public class SynapseUtils {
   public void deleteParquetFile(
       BillingProfileModel profileModel,
       AzureStorageAccountResource storageAccount,
-      String parquetFileName) {
+      String parquetFileName,
+      BlobSasTokenOptions blobSasTokenOptions) {
     BlobContainerClientFactory targetDataClientFactory =
         azureBlobStorePdao.getTargetDataClientFactory(
-            profileModel, storageAccount, AzureStorageAccountResource.ContainerType.METADATA, true);
+            profileModel,
+            storageAccount,
+            AzureStorageAccountResource.ContainerType.METADATA,
+            blobSasTokenOptions);
 
     var result =
         targetDataClientFactory

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -29,6 +29,7 @@ import bio.terra.model.ConfigModel;
 import bio.terra.model.DRSObject;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DatasetModel;
+import bio.terra.model.DatasetRequestAccessIncludeModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.DeleteResponseModel;
@@ -288,11 +289,31 @@ public class DataRepoFixtures {
 
   public DataRepoResponse<DatasetModel> getDatasetRaw(TestConfiguration.User user, UUID datasetId)
       throws Exception {
-    return dataRepoClient.get(user, "/api/repository/v1/datasets/" + datasetId, DatasetModel.class);
+    return getDatasetRaw(user, datasetId, null);
+  }
+
+  public DataRepoResponse<DatasetModel> getDatasetRaw(
+      TestConfiguration.User user, UUID datasetId, List<DatasetRequestAccessIncludeModel> include)
+      throws Exception {
+    String includeQuery;
+    if (include == null || include.isEmpty()) {
+      includeQuery = "";
+    } else {
+      includeQuery =
+          "?" + include.stream().map(i -> "include=" + i).collect(Collectors.joining("&"));
+    }
+    return dataRepoClient.get(
+        user, "/api/repository/v1/datasets/" + datasetId + includeQuery, DatasetModel.class);
   }
 
   public DatasetModel getDataset(TestConfiguration.User user, UUID datasetId) throws Exception {
-    DataRepoResponse<DatasetModel> response = getDatasetRaw(user, datasetId);
+    return getDataset(user, datasetId, null);
+  }
+
+  public DatasetModel getDataset(
+      TestConfiguration.User user, UUID datasetId, List<DatasetRequestAccessIncludeModel> include)
+      throws Exception {
+    DataRepoResponse<DatasetModel> response = getDatasetRaw(user, datasetId, include);
     assertThat(
         "dataset is successfully retrieved", response.getStatusCode(), equalTo(HttpStatus.OK));
     assertTrue("dataset get response is present", response.getResponseObject().isPresent());
@@ -501,8 +522,8 @@ public class DataRepoFixtures {
       throws Exception {
     DataRepoResponse<SnapshotModel> response = getSnapshotRaw(user, snapshotId, include);
     assertThat(
-        "dataset is successfully retrieved", response.getStatusCode(), equalTo(HttpStatus.OK));
-    assertTrue("dataset get response is present", response.getResponseObject().isPresent());
+        "snapshot is successfully retrieved", response.getStatusCode(), equalTo(HttpStatus.OK));
+    assertTrue("snapshot get response is present", response.getResponseObject().isPresent());
     return response.getResponseObject().get();
   }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -16,6 +16,7 @@ import bio.terra.model.DatasetRequestAccessIncludeModel;
 import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import java.io.IOException;
@@ -29,6 +30,8 @@ import org.junit.experimental.categories.Category;
 
 @Category(Unit.class)
 public class DatasetJsonConversionTest {
+  private AuthenticatedUserRequest testUser =
+      new AuthenticatedUserRequest().subjectId("DatasetUnit").email("dataset@unit.com");
 
   private static final UUID DATASET_PROFILE_ID = UUID.randomUUID();
   private static final String DATASET_NAME = "dataset_name";
@@ -137,7 +140,7 @@ public class DatasetJsonConversionTest {
                                 .follow(Collections.emptyList()))))
             .dataProject(DATASET_DATA_PROJECT);
 
-    metadataDataAccessUtils = new MetadataDataAccessUtils(null, null);
+    metadataDataAccessUtils = new MetadataDataAccessUtils(null, null, null);
   }
 
   @Test
@@ -149,7 +152,8 @@ public class DatasetJsonConversionTest {
                 DatasetRequestAccessIncludeModel.SCHEMA,
                 DatasetRequestAccessIncludeModel.PROFILE,
                 DatasetRequestAccessIncludeModel.DATA_PROJECT),
-            metadataDataAccessUtils),
+            metadataDataAccessUtils,
+            testUser),
         equalTo(datasetModel));
   }
 
@@ -160,7 +164,8 @@ public class DatasetJsonConversionTest {
             dataset,
             List.of(
                 DatasetRequestAccessIncludeModel.NONE, DatasetRequestAccessIncludeModel.PROFILE),
-            metadataDataAccessUtils),
+            metadataDataAccessUtils,
+            testUser),
         equalTo(datasetModel.dataProject(null).defaultProfileId(null).schema(null)));
   }
 
@@ -171,7 +176,8 @@ public class DatasetJsonConversionTest {
         DatasetJsonConversion.populateDatasetModelFromDataset(
             dataset,
             List.of(DatasetRequestAccessIncludeModel.ACCESS_INFORMATION),
-            metadataDataAccessUtils),
+            metadataDataAccessUtils,
+            testUser),
         equalTo(
             datasetModel
                 .dataProject(null)

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -481,10 +481,11 @@ public class DatasetServiceTest {
     Dataset dataset = datasetDao.retrieve(datasetId);
     assertThat(
         "dataset info defaults are expected",
-        datasetService.retrieveModel(dataset),
+        datasetService.retrieveModel(dataset, testUser),
         equalTo(
             datasetService.retrieveModel(
                 dataset,
+                testUser,
                 List.of(
                     DatasetRequestAccessIncludeModel.SCHEMA,
                     DatasetRequestAccessIncludeModel.PROFILE,

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -188,8 +188,7 @@ public class DrsServiceTest {
     when(fileService.lookupSnapshotFSItem(any(), any(), eq(1))).thenReturn(azureFsFile);
     when(resourceService.lookupStorageAccountMetadata(any())).thenReturn(storageAccountResource);
     String urlString = "https://blahblah.core.windows.com/data/file.json";
-    when(azureBlobStorePdao.signFile(any(), any(), any(), any(), any(), any()))
-        .thenReturn(urlString);
+    when(azureBlobStorePdao.signFile(any(), any(), any(), any(), any())).thenReturn(urlString);
 
     DRSAccessURL result =
         drsService.getAccessUrlForObjectId(authUser, azureDrsObjectId, "az-centralus");

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.AzureUtils;
+import bio.terra.common.CollectionType;
 import bio.terra.common.SynapseUtils;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
@@ -25,6 +26,7 @@ import bio.terra.service.filedata.azure.tables.TableDao;
 import bio.terra.service.filedata.azure.tables.TableDirectoryDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.resourcemanagement.azure.*;
 import com.azure.core.credential.AzureNamedKeyCredential;
@@ -52,6 +54,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 @Category(Connected.class)
 public class AzureIngestFileConnectedTest {
   private static final Logger logger = LoggerFactory.getLogger(AzureIngestFileConnectedTest.class);
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      new AuthenticatedUserRequest().subjectId("DatasetUnit").email("dataset@unit.com");
+
   private UUID datasetId;
   private String targetPath;
   private UUID homeTenantId;
@@ -198,7 +204,8 @@ public class AzureIngestFileConnectedTest {
 
     // 5 - IngestFileAzurePrimaryDataStep
     FSFileInfo fsFileInfo =
-        azureBlobStorePdao.copyFile(billingProfile, fileLoadModel, fileId, storageAccountResource);
+        azureBlobStorePdao.copyFile(
+            billingProfile, fileLoadModel, fileId, storageAccountResource, TEST_USER);
 
     // 6 - IngestFileAzureFileStep
     FireStoreFile newFile =
@@ -216,7 +223,9 @@ public class AzureIngestFileConnectedTest {
 
     tableDao.createFileMetadata(newFile, storageAuthInfo);
     // Retrieve to build the complete FSItem
-    FSItem fsItem = tableDao.retrieveById(datasetId, fileId, 1, storageAuthInfo);
+    FSItem fsItem =
+        tableDao.retrieveById(
+            CollectionType.DATASET, datasetId, fileId, 1, storageAuthInfo, storageAuthInfo);
     FileModel resultingFileModel = fileService.fileModelFromFSItem(fsItem);
     assertThat(
         "file model contains correct info.", resultingFileModel.getFileId(), equalTo(fileId));

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.equalTo;
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.category.Connected;
 import bio.terra.service.common.gcs.GcsUriUtils;
+import bio.terra.service.iam.AuthenticatedUserRequest;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -33,6 +34,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 public class GcsPdaoTest {
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      new AuthenticatedUserRequest().subjectId("DatasetUnit").email("dataset@unit.com");
+
   @Autowired private ConnectedTestConfiguration testConfig;
   @Autowired private GcsPdao gcsPdao;
 
@@ -136,7 +141,7 @@ public class GcsPdaoTest {
   }
 
   private List<String> getGcsFilesLines(String path, String projectId) {
-    try (var stream = gcsPdao.getBlobsLinesStream(path, projectId)) {
+    try (var stream = gcsPdao.getBlobsLinesStream(path, projectId, TEST_USER)) {
       return stream.collect(Collectors.toList());
     }
   }

--- a/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
@@ -1,5 +1,7 @@
 package bio.terra.service.resourcemanagement;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -14,13 +16,12 @@ import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetSummary;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
-import bio.terra.service.filedata.azure.util.BlobContainerClientFactory;
-import bio.terra.service.filedata.azure.util.BlobSasUrlFactory;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import java.util.List;
 import java.util.UUID;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,16 +33,15 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 @Category(Unit.class)
 public class MetadataDataAccessUtilsTest {
+  private static final AuthenticatedUserRequest TEST_USER =
+      new AuthenticatedUserRequest().subjectId("DatasetUnit").email("dataset@unit.com");
 
   @InjectMocks private MetadataDataAccessUtils metadataDataAccessUtils;
 
   @Mock private static ResourceService resourceService;
 
   @Mock private static AzureBlobStorePdao azureBlobStorePdao;
-
-  @Mock private BlobContainerClientFactory blobContainerClientFactory;
-
-  @Mock private BlobSasUrlFactory blobSasUrlFactory;
+  @Mock private static ProfileService profileService;
 
   private Dataset azureDataset;
   private DatasetSummary azureDatasetSummary;
@@ -67,7 +67,8 @@ public class MetadataDataAccessUtilsTest {
     azureDataset =
         new Dataset(azureDatasetSummary).tables(List.of(sampleTable)).name("test-dataset");
 
-    metadataDataAccessUtils = new MetadataDataAccessUtils(resourceService, azureBlobStorePdao);
+    metadataDataAccessUtils =
+        new MetadataDataAccessUtils(resourceService, azureBlobStorePdao, profileService);
   }
 
   @Test
@@ -81,29 +82,25 @@ public class MetadataDataAccessUtilsTest {
             any(),
             eq("https://michaelstorage.blob.core.windows.net/metadata/parquet"),
             eq(ContainerType.METADATA),
-            any(),
             any()))
-        .thenReturn("https://michaelstorage.blob.core.windows.net/metadata/parquet/signedUrl");
+        .thenReturn("https://michaelstorage.blob.core.windows.net/metadata/parquet/signedUrl?sast");
     when(azureBlobStorePdao.signFile(
             any(),
             any(),
             eq("https://michaelstorage.blob.core.windows.net/metadata/parquet/sample"),
             eq(ContainerType.METADATA),
-            any(),
             any()))
         .thenReturn(
-            "https://michaelstorage.blob.core.windows.net/metadata/parquet/sample/signedUrl");
+            "https://michaelstorage.blob.core.windows.net/metadata/parquet/sample/signedUrl?sast");
 
     AccessInfoParquetModel infoModel =
-        metadataDataAccessUtils.accessInfoFromDataset(azureDataset).getParquet();
+        metadataDataAccessUtils.accessInfoFromDataset(azureDataset, TEST_USER).getParquet();
 
-    Assert.assertEquals("test-dataset", infoModel.getDatasetName());
-    Assert.assertEquals("michaelstorage.test-dataset", infoModel.getDatasetId());
-    Assert.assertEquals(
-        "https://michaelstorage.blob.core.windows.net/metadata/parquet/signedUrl",
-        infoModel.getSignedUrl());
-    Assert.assertEquals(
-        "https://michaelstorage.blob.core.windows.net/metadata/parquet/sample/signedUrl",
-        infoModel.getTables().get(0).getSignedUrl());
+    assertThat(infoModel.getDatasetName(), equalTo("test-dataset"));
+    assertThat(infoModel.getDatasetId(), equalTo("michaelstorage.test-dataset"));
+    assertThat(
+        infoModel.getUrl(),
+        equalTo("https://michaelstorage.blob.core.windows.net/metadata/parquet/signedUrl"));
+    assertThat(infoModel.getSasToken(), equalTo("sast"));
   }
 }


### PR DESCRIPTION
This PR does a fair amount of things so I'll add the interesting bits here:
- Implemented the part of retrieveSnapshot that returns access info for parquet files
- Makes the object returned by retrieveDataset and retrieveSnapshot line up more with how users are likely to use them
- Made sure that the Drs lookup endpoints for Azure snapshots pull from the storage table daos
- Made sure that Sas tokens that we return to users encode the email address of the user
- Made sure that the Sas tokens that we return to users are read only
- Fixed a bug where storage account <-> snapshot links weren't getting recorded
- (GCP) Drive-by fixed an error message that gets returned to users when they haven't granted sufficient permissions to their source bucket