### PR TITLE
DR-2243 Cache the pet service account to avoid spamming Sam

### DIFF
--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -332,10 +332,14 @@ public class FileTest extends UsersBase {
     String gsPath = "gs://" + testConfiguration.getIngestbucket();
     String filePath = "/foo/bar";
     String gsFilePath = gsPath + "/files/file with space and #hash%percent+plus.txt";
+    dataRepoFixtures.addDatasetPolicyMember(
+        steward(), datasetId, IamRole.CUSTODIAN, reader().getEmail());
+    dataRepoFixtures.addPolicyMember(
+        steward(), profileId, IamRole.USER, reader().getEmail(), IamResourceType.SPEND_PROFILE);
     DataRepoResponse<JobModel> ingestJob =
         dataRepoFixtures.ingestFileLaunch(
-            // note: custodian's proxy group should not have access to the source bucket
-            custodian(), datasetId, profileId, gsFilePath, filePath);
+            // note: reader's proxy group should not have access to the source bucket
+            reader(), datasetId, profileId, gsFilePath, filePath);
     DataRepoResponse<FileModel> error =
         dataRepoClient.waitForResponse(steward(), ingestJob, FileModel.class);
 


### PR DESCRIPTION
Note: the cache is keyed on the current token of a user.  This should ensure-ish that the PSA tokens are always valid (since they should be valid longer than the user's actual token.  I added a 5 minute fuzz factor to avoid overlaps.  I say ensure-ish since tokens aren't always exactly an hour long