### PR TITLE
Use an array result for `TerraDCAT_ap:hasDataUsePermission` since it can contain multiple values.

### DIFF
--- a/ops/search/create-hca-collection.py
+++ b/ops/search/create-hca-collection.py
@@ -174,7 +174,7 @@ for hit in projects[0]["hits"]:
         "dct:issued": project["submissionDate"],
         "dct:modified": project["updateDate"],
         "dcat:accessURL": access_url(snapshot),
-        "TerraDCAT_ap:hasDataUsePermission": "TerraCore:NoRestriction",
+        "TerraDCAT_ap:hasDataUsePermission": [ "TerraCore:NoRestriction" ],
         "TerraDCAT_ap:hasOriginalPublication": get_publications(project),
         "TerraDCAT_ap:hasDataCollection": [
             {

--- a/ops/search/create-hca-collection.py
+++ b/ops/search/create-hca-collection.py
@@ -174,7 +174,7 @@ for hit in projects[0]["hits"]:
         "dct:issued": project["submissionDate"],
         "dct:modified": project["updateDate"],
         "dcat:accessURL": access_url(snapshot),
-        "TerraDCAT_ap:hasDataUsePermission": [ "TerraCore:NoRestriction" ],
+        "TerraDCAT_ap:hasDataUsePermission": ["TerraCore:NoRestriction"],
         "TerraDCAT_ap:hasOriginalPublication": get_publications(project),
         "TerraDCAT_ap:hasDataCollection": [
             {

--- a/ops/search/ingest-hca-collection.py
+++ b/ops/search/ingest-hca-collection.py
@@ -44,7 +44,7 @@ def upsert(snapshot):
 with open("hca-collection.json", "r") as f:
     collection = json.load(f)
 
-#TODO: remove steward policy after upsert?
+# TODO: remove steward policy after upsert?
 for snapshot in tqdm(collection["data"]):
     policy(snapshot)
     upsert(snapshot)


### PR DESCRIPTION
Once this is approved, I'll regenerate the HCA catalog metadata in dev, and fix the 1000 genomes and ENCODE metadata too if necessary.