### PR TITLE
Fix issue where a job build failure doesn't fail the build step.

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Build
         id: build
         run: |
+          # Enable pipefail so a gradle build failure fails this step.
+          set -o pipeline
           # build sources and store the plain log without colors
           ./gradlew jibDockerBuild --console=plain \
             | perl -pe 's/\x1b\[[0-9;]*[mG]//g' | tee build.log

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,7 +30,7 @@ jobs:
         id: build
         run: |
           # Enable pipefail so a gradle build failure fails this step.
-          set -o pipeline
+          set -o pipefail
           # build sources and store the plain log without colors
           ./gradlew jibDockerBuild --console=plain \
             | perl -pe 's/\x1b\[[0-9;]*[mG]//g' | tee build.log


### PR DESCRIPTION
Because the jib build step pipes its output, an error result from `./gradlew` is ignored and doesn't cause the step to fail. Enabling the bash `pipefail` setting will generate a failure in the build step instead of a uninformative error in the trivy check step.