### PR TITLE
DR-2262 DR-2259 DR-2121 DR-2274 Azure Snapshot fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,6 +242,31 @@ dependencies {
     implementation 'com.azure:azure-storage-file-datalake:12.5.1'
     implementation 'com.azure:azure-data-tables:12.1.0'
 
+    testImplementation "org.apache.parquet:parquet-common:1.12.0"
+    testImplementation "org.apache.parquet:parquet-hadoop:1.12.0"
+    testImplementation "org.apache.parquet:parquet-hadoop-bundle:1.12.0"
+    testImplementation "org.apache.parquet:parquet-encoding:1.12.0"
+    testImplementation "org.apache.parquet:parquet-column:1.12.0"
+    testImplementation ('org.apache.hadoop:hadoop-common:3.3.1')  {
+        exclude group: 'com.sun.jersey', module: 'jersey-core'
+        exclude group: 'com.sun.jersey', module: 'jersey-servlet'
+        exclude group: 'com.sun.jersey', module: 'jersey-json'
+        exclude group: 'com.sun.jersey', module: 'jersey-server'
+    }
+    testImplementation ('org.apache.hadoop:hadoop-azure:3.3.1') {
+        exclude group: 'com.sun.jersey', module: 'jersey-core'
+        exclude group: 'com.sun.jersey', module: 'jersey-servlet'
+        exclude group: 'com.sun.jersey', module: 'jersey-json'
+        exclude group: 'com.sun.jersey', module: 'jersey-server'
+    }
+    testImplementation('org.apache.hadoop:hadoop-mapreduce-client-core:3.3.1') {
+        exclude group: 'com.sun.jersey', module: 'jersey-core'
+        exclude group: 'com.sun.jersey', module: 'jersey-servlet'
+        exclude group: 'com.sun.jersey', module: 'jersey-json'
+        exclude group: 'com.sun.jersey', module: 'jersey-server'
+    }
+
+
     antlr "org.antlr:antlr4:4.8"
     spotbugs 'com.github.spotbugs:spotbugs:4.2.2'
 

--- a/src/main/java/bio/terra/common/CloudPlatformWrapper.java
+++ b/src/main/java/bio/terra/common/CloudPlatformWrapper.java
@@ -85,9 +85,6 @@ public abstract class CloudPlatformWrapper {
         .createStorageResourceValues(datasetRequestModel);
   }
 
-  public abstract GoogleRegion getGoogleRegionFromDatasetRequestModel(
-      DatasetRequestModel datasetRequestModel);
-
   static class GcpPlatform extends CloudPlatformWrapper {
     static final GcpPlatform INSTANCE = new GcpPlatform();
 
@@ -109,7 +106,7 @@ public abstract class CloudPlatformWrapper {
     @Override
     public List<? extends StorageResource<?, ?>> createStorageResourceValues(
         DatasetRequestModel datasetRequest) {
-      final GoogleRegion region = getGoogleRegionFromDatasetRequestModel(datasetRequest);
+      final GoogleRegion region = GoogleRegion.fromValueWithDefault(datasetRequest.getRegion());
       return Arrays.stream(GoogleCloudResource.values())
           .map(
               resource -> {
@@ -127,12 +124,6 @@ public abstract class CloudPlatformWrapper {
                 return new GoogleStorageResource(null, resource, finalRegion);
               })
           .collect(Collectors.toList());
-    }
-
-    @Override
-    public GoogleRegion getGoogleRegionFromDatasetRequestModel(
-        DatasetRequestModel datasetRequestModel) {
-      return GoogleRegion.fromValueWithDefault(datasetRequestModel.getRegion());
     }
   }
 
@@ -165,12 +156,6 @@ public abstract class CloudPlatformWrapper {
                   .map(resource -> new AzureStorageResource(null, resource, region)),
               CloudPlatformWrapper.getGoogleResourcesForAzure(datasetRequest).stream())
           .collect(Collectors.toList());
-    }
-
-    @Override
-    public GoogleRegion getGoogleRegionFromDatasetRequestModel(
-        DatasetRequestModel datasetRequestModel) {
-      return GoogleRegion.fromValueWithDefault(datasetRequestModel.getGcpRegion());
     }
   }
 }

--- a/src/main/java/bio/terra/common/SynapseColumn.java
+++ b/src/main/java/bio/terra/common/SynapseColumn.java
@@ -1,9 +1,12 @@
 package bio.terra.common;
 
 import bio.terra.model.TableDataType;
+import java.util.Set;
 import javax.ws.rs.NotSupportedException;
 
 public class SynapseColumn extends Column {
+  private static final Set<TableDataType> FILE_TYPES =
+      Set.of(TableDataType.FILEREF, TableDataType.DIRREF);
   private String synapseDataType;
   private boolean requiresCollate;
   private boolean requiresJSONCast;
@@ -41,6 +44,10 @@ public class SynapseColumn extends Column {
   public SynapseColumn requiresJSONCast(boolean requiresJSONCast) {
     this.requiresJSONCast = requiresJSONCast;
     return this;
+  }
+
+  public boolean getIsFileType() {
+    return FILE_TYPES.contains(getType());
   }
 
   static String translateDataType(TableDataType datatype, boolean isArrayOf) {

--- a/src/main/java/bio/terra/common/exception/InvalidCloudPlatformException.java
+++ b/src/main/java/bio/terra/common/exception/InvalidCloudPlatformException.java
@@ -1,0 +1,16 @@
+package bio.terra.common.exception;
+
+public class InvalidCloudPlatformException extends ApiException {
+
+  public InvalidCloudPlatformException() {
+    this("Unrecognized cloud platform");
+  }
+
+  public InvalidCloudPlatformException(String message) {
+    super(message);
+  }
+
+  public InvalidCloudPlatformException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -5,7 +5,6 @@ import bio.terra.common.PdaoConstant;
 import bio.terra.common.ValidationUtils;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
-import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSpecificationModel;
@@ -427,11 +426,6 @@ public class DatasetRequestValidator implements Validator {
         CloudPlatformWrapper cloudWrapper =
             CloudPlatformWrapper.of(datasetRequest.getCloudPlatform());
         cloudWrapper.ensureValidRegion(datasetRequest.getRegion(), errors);
-
-        if (cloudWrapper.isAzure()) {
-          CloudPlatformWrapper.of(CloudPlatform.GCP)
-              .ensureValidRegion(datasetRequest.getGcpRegion(), errors);
-        }
       }
     }
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -3,6 +3,7 @@ package bio.terra.service.dataset;
 import bio.terra.app.controller.DatasetsApiController;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.MetadataEnumeration;
+import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.model.AssetModel;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BulkLoadHistoryModel;
@@ -261,7 +262,7 @@ public class DatasetService {
     } else if (platformWrapper.isGcp()) {
       return bigQueryPdao.getLoadHistory(dataset, loadTag, offset, limit);
     } else {
-      throw new IllegalArgumentException("Unrecognized cloud platform");
+      throw new InvalidCloudPlatformException();
     }
   }
 

--- a/src/main/java/bio/terra/service/dataset/StorageResourceDao.java
+++ b/src/main/java/bio/terra/service/dataset/StorageResourceDao.java
@@ -6,6 +6,7 @@ import bio.terra.app.model.AzureRegion;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.DaoKeyHolder;
+import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.model.CloudPlatform;
 import bio.terra.service.dataset.exception.InvalidStorageException;
 import bio.terra.service.dataset.exception.StorageResourceNotFoundException;
@@ -86,7 +87,7 @@ public class StorageResourceDao {
               AzureCloudResource.valueOf(rs.getString("cloud_resource")),
               AzureRegion.valueOf(rs.getString("region")));
         default:
-          throw new IllegalArgumentException("Unrecognized cloud platform");
+          throw new InvalidCloudPlatformException();
       }
     }
   }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateAzureRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateAzureRefsStep.java
@@ -54,7 +54,8 @@ public class IngestValidateAzureRefsStep extends IngestValidateRefsStep {
             .filter(Column::isFileOrDirRef)
             .flatMap(
                 column -> {
-                  List<String> refIdArray = azureSynapsePdao.getRefIds(tableName, column);
+                  List<String> refIdArray =
+                      azureSynapsePdao.getRefIds(tableName, column, dataset.getCollectionType());
                   return tableDirectoryDao.validateRefIds(tableServiceClient, refIdArray).stream()
                       .map(id -> new InvalidRefId(id, column.getName()));
                 })

--- a/src/main/java/bio/terra/service/filedata/DrsIdService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsIdService.java
@@ -43,12 +43,12 @@ public class DrsIdService {
         .build();
   }
 
-  public static DrsId fromUri(String drsuri) {
-    URI uri = URI.create(drsuri);
+  public static DrsId fromUri(String drsUri) {
+    URI uri = URI.create(drsUri);
     if (!StringUtils.equals(uri.getScheme(), "drs")
         || uri.getAuthority() == null
         || !StringUtils.startsWith(uri.getPath(), "/")) {
-      throw new InvalidDrsIdException("Invalid DRS URI '" + drsuri + "'");
+      throw new InvalidDrsIdException("Invalid DRS URI '" + drsUri + "'");
     }
     String datarepoDnsName = uri.getAuthority();
     String objectId = StringUtils.remove(uri.getPath(), '/');

--- a/src/main/java/bio/terra/service/filedata/DrsIdService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsIdService.java
@@ -43,16 +43,16 @@ public class DrsIdService {
         .build();
   }
 
-  public DrsId fromUri(String drsuri) {
+  public static DrsId fromUri(String drsuri) {
     URI uri = URI.create(drsuri);
     if (!StringUtils.equals(uri.getScheme(), "drs")
         || uri.getAuthority() == null
         || !StringUtils.startsWith(uri.getPath(), "/")) {
       throw new InvalidDrsIdException("Invalid DRS URI '" + drsuri + "'");
     }
-
+    String datarepoDnsName = uri.getAuthority();
     String objectId = StringUtils.remove(uri.getPath(), '/');
-    return parseObjectId(objectId).dnsname(uri.getAuthority()).build();
+    return parseObjectId(datarepoDnsName, objectId).dnsname(uri.getAuthority()).build();
   }
 
   public DrsId fromObjectId(String drsObjectId) {
@@ -60,6 +60,10 @@ public class DrsIdService {
   }
 
   private DrsId.Builder parseObjectId(String objectId) {
+    return parseObjectId(datarepoDnsName, objectId);
+  }
+
+  private static DrsId.Builder parseObjectId(String datarepoDnsName, String objectId) {
     // The format is v1_<snapshotid>_<fsobjectid>
     String[] idParts = StringUtils.split(objectId, '_');
     if (idParts.length != 3 || !StringUtils.equals(idParts[0], "v1")) {

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -5,6 +5,7 @@ import bio.terra.app.logging.PerformanceLogger;
 import bio.terra.app.model.AzureRegion;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.common.exception.NotImplementedException;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DRSAccessMethod;
@@ -157,6 +158,7 @@ public class DrsService {
       } catch (IllegalArgumentException ex) {
         throw new InvalidDrsIdException("Invalid object id format '" + drsObjectId + "'", ex);
       } catch (SnapshotNotFoundException ex) {
+        logger.error("No snapshot found for DRS object id '" + drsObjectId + "'", ex);
         throw new DrsObjectNotFoundException(
             "No snapshot found for DRS object id '" + drsObjectId + "'", ex);
       }
@@ -301,12 +303,13 @@ public class DrsService {
     } else if (platform.isAzure()) {
       accessMethods = getDrsAccessMethodsOnAzure(fsFile);
     } else {
-      throw new IllegalArgumentException("Unrecognized cloud platform");
+      throw new InvalidCloudPlatformException();
     }
 
     fileObject
         .mimeType(fsFile.getMimeType())
         .checksums(fileService.makeChecksums(fsFile))
+        .selfUri(drsIdService.makeDrsId(fsFile, snapshotId).toDrsUri())
         .accessMethods(accessMethods);
 
     return fileObject;

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -158,7 +158,6 @@ public class DrsService {
       } catch (IllegalArgumentException ex) {
         throw new InvalidDrsIdException("Invalid object id format '" + drsObjectId + "'", ex);
       } catch (SnapshotNotFoundException ex) {
-        logger.error("No snapshot found for DRS object id '" + drsObjectId + "'", ex);
         throw new DrsObjectNotFoundException(
             "No snapshot found for DRS object id '" + drsObjectId + "'", ex);
       }

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -73,7 +73,7 @@ public class AzureSynapsePdao {
           + "    FILE_FORMAT = [<fileFormat>]\n"
           + ") AS SELECT datarepo_row_id,<columns:{c|"
           + "          <if(c.isFileType)>"
-          + "             'drs://<hostname>/v1_<snapshotId>_' + <c.name> AS [<c.name>]"
+          + "             'drs://<hostname>/v1_<snapshotId>_' + [<c.name>] AS [<c.name>]"
           + "          <else>"
           + "             <c.name> AS [<c.name>]"
           + "          <endif>\n"

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -34,10 +34,10 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -126,7 +126,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
             String.format(
                 "%s/%s",
                 targetClientFactory.getBlobContainerClient().getBlobContainerUrl(), blobName))
-        .checksumMd5(Base64.getEncoder().encodeToString((blobProperties.getContentMd5())))
+        .checksumMd5(Hex.encodeHexString(blobProperties.getContentMd5()))
         .size(blobProperties.getBlobSize())
         .bucketResourceId(storageAccountResource.getResourceId().toString());
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -3,6 +3,7 @@ package bio.terra.service.resourcemanagement;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.CollectionType;
 import bio.terra.common.Table;
+import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.model.AccessInfoBigQueryModel;
 import bio.terra.model.AccessInfoBigQueryModelTable;
 import bio.terra.model.AccessInfoModel;
@@ -125,7 +126,7 @@ public final class MetadataDataAccessUtils {
       return makeAccessInfoAzure(
           dataset, storageAccountResource, dataset.getTables(), profileModel, userRequest);
     } else {
-      throw new IllegalArgumentException("Unrecognized cloud platform");
+      throw new InvalidCloudPlatformException();
     }
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -357,17 +357,23 @@ public class ResourceService {
    * Create a new project for a snapshot, if none exists already.
    *
    * @param billingProfile authorized billing profile to pay for the project
-   * @param region the region to create the Firestore in
    * @return project resource id
    */
   public UUID initializeSnapshotProject(
       BillingProfileModel billingProfile,
       String projectId,
-      GoogleRegion region,
       List<Dataset> sourceDatasets,
       String snapshotName,
       UUID snapshotId)
       throws InterruptedException {
+
+    GoogleRegion region =
+        (GoogleRegion)
+            sourceDatasets
+                .iterator()
+                .next()
+                .getDatasetSummary()
+                .getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
 
     String datasetNames =
         sourceDatasets.stream().map(Dataset::getName).collect(Collectors.joining(","));

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -404,18 +404,13 @@ public class ResourceService {
       String projectId,
       GoogleRegion region,
       String datasetName,
-      UUID datasetId,
-      Boolean isAzure)
+      UUID datasetId)
       throws InterruptedException {
 
     Map<String, String> labels = new HashMap<>();
     labels.put("dataset-name", datasetName);
     labels.put("dataset-id", datasetId.toString());
     labels.put("project-usage", "dataset");
-
-    if (isAzure) {
-      labels.put("is-azure", "true");
-    }
 
     GoogleProjectResource googleProjectResource =
         projectService.initializeGoogleProject(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -621,7 +621,9 @@ public class SnapshotService {
       snapshotModel.profileId(snapshot.getProfileId());
     }
     if (include.contains(SnapshotRequestAccessIncludeModel.DATA_PROJECT)) {
-      snapshotModel.dataProject(snapshot.getProjectResource().getGoogleProjectId());
+      if (snapshot.getProjectResource() != null) {
+        snapshotModel.dataProject(snapshot.getProjectResource().getGoogleProjectId());
+      }
     }
     if (include.contains(SnapshotRequestAccessIncludeModel.ACCESS_INFORMATION)) {
       snapshotModel.accessInformation(

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotInitializeProjectStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotInitializeProjectStep.java
@@ -1,6 +1,5 @@
 package bio.terra.service.snapshot.flight.create;
 
-import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.profile.flight.ProfileMapKeys;
@@ -17,17 +16,12 @@ import java.util.UUID;
 
 public class CreateSnapshotInitializeProjectStep implements Step {
   private final ResourceService resourceService;
-  private final GoogleRegion region;
   private final List<Dataset> sourceDatasets;
   private final String snapshotName;
 
   public CreateSnapshotInitializeProjectStep(
-      ResourceService resourceService,
-      GoogleRegion region,
-      List<Dataset> sourceDatasets,
-      String snapshotName) {
+      ResourceService resourceService, List<Dataset> sourceDatasets, String snapshotName) {
     this.resourceService = resourceService;
-    this.region = region;
     this.sourceDatasets = sourceDatasets;
     this.snapshotName = snapshotName;
   }
@@ -47,7 +41,7 @@ public class CreateSnapshotInitializeProjectStep implements Step {
     try {
       projectResourceId =
           resourceService.initializeSnapshotProject(
-              profileModel, projectId, region, sourceDatasets, snapshotName, snapshotId);
+              profileModel, projectId, sourceDatasets, snapshotName, snapshotId);
     } catch (GoogleResourceException e) {
       if (e.getCause().getMessage().contains("500 Internal Server Error")) {
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -3,8 +3,6 @@ package bio.terra.service.snapshot.flight.create;
 import static bio.terra.common.FlightUtils.getDefaultExponentialBackoffRetryRule;
 
 import bio.terra.app.logging.PerformanceLogger;
-import bio.terra.app.model.GoogleCloudResource;
-import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.GetResourceBufferProjectStep;
 import bio.terra.common.exception.NotImplementedException;
@@ -99,15 +97,8 @@ public class SnapshotCreateFlight extends Flight {
       addStep(new GetResourceBufferProjectStep(bufferService));
 
       // Get or initialize the project where the snapshot resources will be created
-      GoogleRegion firestoreRegion =
-          (GoogleRegion)
-              sourceDataset
-                  .getDatasetSummary()
-                  .getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
-
       addStep(
-          new CreateSnapshotInitializeProjectStep(
-              resourceService, firestoreRegion, sourceDatasets, snapshotName),
+          new CreateSnapshotInitializeProjectStep(resourceService, sourceDatasets, snapshotName),
           getDefaultExponentialBackoffRetryRule());
     }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -84,11 +84,6 @@ public class SnapshotCreateFlight extends Flight {
 
     var platform =
         CloudPlatformWrapper.of(sourceDataset.getDatasetSummary().getStorageCloudPlatform());
-    GoogleRegion firestoreRegion =
-        (GoogleRegion)
-            sourceDataset
-                .getDatasetSummary()
-                .getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
 
     // Make sure this user is authorized to use the billing profile in SAM
     addStep(
@@ -103,14 +98,20 @@ public class SnapshotCreateFlight extends Flight {
       // Get a new google project from RBS and store it in the working map
       addStep(new GetResourceBufferProjectStep(bufferService));
 
-      // create the snapshot metadata object in postgres and lock it
-
       // Get or initialize the project where the snapshot resources will be created
+      GoogleRegion firestoreRegion =
+          (GoogleRegion)
+              sourceDataset
+                  .getDatasetSummary()
+                  .getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
+
       addStep(
           new CreateSnapshotInitializeProjectStep(
               resourceService, firestoreRegion, sourceDatasets, snapshotName),
           getDefaultExponentialBackoffRetryRule());
     }
+
+    // create the snapshot metadata object in postgres and lock it
     addStep(
         new CreateSnapshotMetadataStep(snapshotDao, snapshotService, snapshotReq),
         getDefaultExponentialBackoffRetryRule());

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2833,10 +2833,6 @@ components:
           $ref: '#/components/schemas/DatasetSpecificationModel'
         region:
           type: string
-        gcpRegion:
-          type: string
-          description: >
-            This is a temporary parameter until GCP and Azure resources are no longer entwined.  This parameter will disappear shortly
         cloudPlatform:
           $ref: '#/components/schemas/CloudPlatform'
       description: >

--- a/src/test/java/bio/terra/common/ParquetUtils.java
+++ b/src/test/java/bio/terra/common/ParquetUtils.java
@@ -1,0 +1,72 @@
+package bio.terra.common;
+
+import com.azure.storage.blob.BlobUrlParts;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+
+/** Helper test methods for working directly with parquet files */
+public class ParquetUtils {
+
+  /**
+   * Given a signed Azure URL, this method will read through the parquet data specified as list of
+   * maps that are keyed on column name and whose values are string representations of the parquet
+   * field values
+   *
+   * @param url The Azure URL to read from with a sas token included
+   * @return A java representation of the parquet record data
+   */
+  public static List<Map<String, String>> readParquetRecords(final String url) {
+    BlobUrlParts blobUrlParts = BlobUrlParts.parse(url);
+    Configuration config = new Configuration();
+    config.set("fs.azure", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
+    config.set(
+        "fs.azure.sas."
+            + blobUrlParts.getBlobContainerName()
+            + "."
+            + blobUrlParts.getAccountName()
+            + ".blob.core.windows.net",
+        blobUrlParts.getCommonSasQueryParameters().encode());
+
+    List<Map<String, String>> results = new ArrayList<>();
+
+    URI uri;
+    try {
+      uri =
+          new URI(
+              "wasbs://"
+                  + blobUrlParts.getBlobContainerName()
+                  + "@"
+                  + blobUrlParts.getAccountName()
+                  + ".blob.core.windows.net/"
+                  + blobUrlParts.getBlobName());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    try (ParquetReader<Group> pReader =
+        ParquetReader.builder(new GroupReadSupport(), new Path(uri)).withConf(config).build()) {
+      Group record;
+      while ((record = pReader.read()) != null) {
+        final Group r = record;
+        results.add(
+            IntStream.range(0, r.getType().getFields().size())
+                .mapToObj(i -> Pair.of(r.getType().getFieldName(i), r.getValueToString(i, 0)))
+                .collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
+      }
+    } catch (IOException ex) {
+      throw new RuntimeException("Error reading parquet data data", ex);
+    }
+    return results;
+  }
+}

--- a/src/test/java/bio/terra/common/SynapseUtils.java
+++ b/src/test/java/bio/terra/common/SynapseUtils.java
@@ -22,8 +22,8 @@ import org.stringtemplate.v4.ST;
 @Component
 public class SynapseUtils {
   private static final Logger logger = LoggerFactory.getLogger(SynapseUtils.class);
-  private static final String readFromParquetFile =
-      "SELECT *\n"
+  private static final String READ_FROM_PARQUET_FILE =
+      "SELECT [<columnName>] AS [<columnName>]\n"
           + "FROM OPENROWSET(\n"
           + "    BULK '<parquetFilePath>',\n"
           + "    DATA_SOURCE = '<dataSourceName>',\n"
@@ -34,9 +34,10 @@ public class SynapseUtils {
 
   public List<String> readParquetFileStringColumn(
       String parquetFilePath, String dataSourceName, String columnName, boolean expectSuccess) {
-    ST sqlReadTemplate = new ST(readFromParquetFile);
+    ST sqlReadTemplate = new ST(READ_FROM_PARQUET_FILE);
     sqlReadTemplate.add("parquetFilePath", parquetFilePath);
     sqlReadTemplate.add("dataSourceName", dataSourceName);
+    sqlReadTemplate.add("columnName", columnName);
     SQLServerDataSource ds = azureSynapsePdao.getDatasource();
     List<String> resultList = new ArrayList<>();
     try (Connection connection = ds.getConnection();

--- a/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
@@ -468,18 +468,16 @@ public class DatasetAzureIntegrationTest extends UsersBase {
         // TODO: once we have an endpoint to expose parquet data, we should use that mechanism here
         if (table.getName().equals("vocabulary")) {
           List<Map<String, String>> records = ParquetUtils.readParquetRecords(tableUrl);
-          assertThat("2 rows are present", records.size(), equalTo(2));
+          assertThat("2 rows are present", records, hasSize(2));
+
           // Extract the DRS Ids
-          drsIds.addAll(
-              records.stream()
-                  .map(r -> r.get("vocabulary_reference"))
-                  .collect(Collectors.toList()));
+          records.stream().map(r -> r.get("vocabulary_reference")).forEach(drsIds::add);
         }
       }
     }
 
     // Assert that 2 drs ids were loaded
-    assertThat("2 drs ids are present", drsIds.size(), equalTo(2));
+    assertThat("2 drs ids are present", drsIds, hasSize(2));
     // Ensure that all DRS can be parsed
     List<String> drsObjectIds =
         drsIds.stream()
@@ -492,10 +490,9 @@ public class DatasetAzureIntegrationTest extends UsersBase {
 
     // Do a Drs lookup
     String drsId = String.format("v1_%s_%s", snapshotId, fileId);
-    assertThat("Expected Drs object Id exists", drsObjectIds.contains(drsId), equalTo(true));
+    assertThat("Expected Drs object Id exists", drsObjectIds.contains(drsId));
     DRSObject drsObject = dataRepoFixtures.drsGetObject(steward(), drsId);
-    assertThat(
-        "DRS object has single access method", drsObject.getAccessMethods().size(), equalTo(1));
+    assertThat("DRS object has single access method", drsObject.getAccessMethods(), hasSize(1));
     assertThat(
         "DRS object has HTTPS",
         drsObject.getAccessMethods().get(0).getType(),

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -75,8 +75,8 @@ public class AzureBlobStorePdaoTest {
   private static final OffsetDateTime BLOB_CREATION_TIME = OffsetDateTime.now();
   private static final long BLOB_SIZE = 1234567890L;
   private static final byte[] BLOB_CONTENT_MD5 = "FOOBAR".getBytes(StandardCharsets.UTF_8);
-  // This is the base64 encoding of FOOBAR
-  private static final String BLOB_CONTENT_MD5_B64 = "Rk9PQkFS";
+  // This is bytes of the FOOBAR string in Hex
+  private static final String BLOB_CONTENT_MD5_B64 = "464f4f424152";
   private static final String LOAD_TAG = "tag";
   private static final String MIME_TYPE = "txt/plain";
 

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -76,7 +76,7 @@ public class AzureBlobStorePdaoTest {
   private static final long BLOB_SIZE = 1234567890L;
   private static final byte[] BLOB_CONTENT_MD5 = "FOOBAR".getBytes(StandardCharsets.UTF_8);
   // This is bytes of the FOOBAR string in Hex
-  private static final String BLOB_CONTENT_MD5_B64 = "464f4f424152";
+  private static final String BLOB_CONTENT_MD5_HEX = "464f4f424152";
   private static final String LOAD_TAG = "tag";
   private static final String MIME_TYPE = "txt/plain";
 
@@ -284,7 +284,7 @@ public class AzureBlobStorePdaoTest {
         .fileId(fileId.toString())
         .createdDate(BLOB_CREATION_TIME.toInstant().toString())
         .cloudPath(targetContainerUrl + "/" + targetBlobName)
-        .checksumMd5(BLOB_CONTENT_MD5_B64)
+        .checksumMd5(BLOB_CONTENT_MD5_HEX)
         .size(BLOB_SIZE)
         .bucketResourceId(RESOURCE_ID.toString());
   }

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -13,7 +13,6 @@ import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.buffer.model.ResourceInfo;
-import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.PdaoConstant;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Connected;
@@ -662,9 +661,7 @@ public class BigQueryPdaoTest {
     DatasetRequestModel datasetRequest =
         jsonLoader.loadObject(requestFile, DatasetRequestModel.class);
     datasetRequest.defaultProfileId(profileModel.getId()).name(datasetName);
-    GoogleRegion region =
-        CloudPlatformWrapper.of(datasetRequest.getCloudPlatform())
-            .getGoogleRegionFromDatasetRequestModel(datasetRequest);
+    GoogleRegion region = GoogleRegion.fromValueWithDefault(datasetRequest.getRegion());
     Dataset dataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
     dataset.id(UUID.randomUUID());
     ResourceInfo resource = bufferService.handoutResource();
@@ -672,7 +669,7 @@ public class BigQueryPdaoTest {
     projectService.addLabelsToProject(googleProjectId, Map.of("test-name", "bigquery-pdao-test"));
     UUID projectId =
         resourceService.getOrCreateDatasetProject(
-            profileModel, googleProjectId, region, dataset.getName(), dataset.getId(), false);
+            profileModel, googleProjectId, region, dataset.getName(), dataset.getId());
     dataset
         .projectResourceId(projectId)
         .projectResource(resourceService.getProjectResource(projectId));


### PR DESCRIPTION
This PR addresses a couple of straggler issues that I noticed when prepping for the demo:
- Snapshots in Azure now create a DRS URI
- Added a way to read parquet files directly sans-Synapse for tests (and use that to verify that filerefs are properly converted to drs uris)
- Make sure we return the selfuri field in the DRS object (the Python SDK fails when we don't have this)
- Removed the gcpRegion field from the dataset creation request body
- MD5s for Azure files are now stored as hex strings
- Fixed an NPE where we were checking for Firestore info in Azure snapshots
- Made the invalid cloud specification an error class

Going through commit-by-commit should be easier