### PR TITLE
DR-2266: Backfill row metadata tables

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -1084,7 +1084,8 @@ public class BigQueryPdao {
     return PDAO_PREFIX + name;
   }
 
-  private Schema buildRowMetadataSchema() {
+  // TODO- make private after reverting upgrade flight
+  public Schema buildRowMetadataSchema() {
     List<Field> fieldList =
         List.of(
             Field.newBuilder(PDAO_ROW_ID_COLUMN, LegacySQLTypeName.STRING)

--- a/src/main/java/bio/terra/service/upgrade/UpgradeService.java
+++ b/src/main/java/bio/terra/service/upgrade/UpgradeService.java
@@ -21,7 +21,6 @@ public class UpgradeService {
     PLACEHOLDER(null),
     ROW_METADATA_UPDATE(RowMetadataUpdateFlight.class);
 
-
     private final Class<? extends Flight> flightClass;
 
     CustomFlight(Class<? extends Flight> flightClass) {

--- a/src/main/java/bio/terra/service/upgrade/UpgradeService.java
+++ b/src/main/java/bio/terra/service/upgrade/UpgradeService.java
@@ -9,6 +9,7 @@ import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamService;
 import bio.terra.service.job.JobService;
 import bio.terra.service.upgrade.exception.InvalidCustomNameException;
+import bio.terra.service.upgrade.flight.RowMetadataUpdateFlight;
 import bio.terra.stairway.Flight;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -17,7 +18,9 @@ import org.springframework.stereotype.Component;
 public class UpgradeService {
 
   private enum CustomFlight {
-    PLACEHOLDER(null);
+    PLACEHOLDER(null),
+    ROW_METADATA_UPDATE(RowMetadataUpdateFlight.class);
+
 
     private final Class<? extends Flight> flightClass;
 

--- a/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
@@ -101,6 +101,8 @@ public class BackfillRowMetadataTablesStep implements Step {
                   logger.error(
                       "Unable to add row metadata tables for dataset {}", dataset.getId(), ex);
                 }
+              } else {
+                logger.info("SKIPPING AZURE DATASET - [{}]", dataset.getId());
               }
             });
     logger.info("DONE - Total datasets updated: {}", totalDatasetCount);

--- a/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 public class BackfillRowMetadataTablesStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(BackfillRowMetadataTablesStep.class);
   private UpgradeModel request;
+
   BackfillRowMetadataTablesStep(UpgradeModel request) {
     this.request = request;
   }
@@ -20,11 +21,11 @@ public class BackfillRowMetadataTablesStep implements Step {
     logger.info("HELLO FROM BackfillRowMetadataTablesStep");
     // enumerate datasets
     // for each dataset:
-      // connect to big query for dataset's data project
-      // for each table:
-            // retrieve the row metadata table name from the database
-            // check if row metadata table already exists in big query
-            // if doesn't exist, create row metadata table
+    // connect to big query for dataset's data project
+    // for each table:
+    // retrieve the row metadata table name from the database
+    // check if row metadata table already exists in big query
+    // if doesn't exist, create row metadata table
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
@@ -1,0 +1,35 @@
+package bio.terra.service.upgrade.flight;
+
+import bio.terra.model.UpgradeModel;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BackfillRowMetadataTablesStep implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(BackfillRowMetadataTablesStep.class);
+  private UpgradeModel request;
+  BackfillRowMetadataTablesStep(UpgradeModel request) {
+    this.request = request;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    logger.info("HELLO FROM BackfillRowMetadataTablesStep");
+    // enumerate datasets
+    // for each dataset:
+      // connect to big query for dataset's data project
+      // for each table:
+            // retrieve the row metadata table name from the database
+            // check if row metadata table already exists in big query
+            // if doesn't exist, create row metadata table
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
@@ -45,7 +45,6 @@ public class BackfillRowMetadataTablesStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    logger.info("HELLO FROM BackfillRowMetadataTablesStep");
     // enumerate datasets
     // Appears the max in an environment is 188 in dev
     int limit = 1000;

--- a/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/BackfillRowMetadataTablesStep.java
@@ -1,31 +1,107 @@
 package bio.terra.service.upgrade.flight;
 
+import bio.terra.model.EnumerateDatasetModel;
+import bio.terra.model.EnumerateSortByParam;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.model.UpgradeModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.iam.IamResourceType;
+import bio.terra.service.iam.IamService;
+import bio.terra.service.tabulardata.google.BigQueryProject;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
+import java.util.Set;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BackfillRowMetadataTablesStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(BackfillRowMetadataTablesStep.class);
-  private UpgradeModel request;
+  private final UpgradeModel request;
+  private final DatasetService datasetService;
+  private final IamService iamService;
+  private final AuthenticatedUserRequest userReq;
 
-  BackfillRowMetadataTablesStep(UpgradeModel request) {
+  BackfillRowMetadataTablesStep(
+      UpgradeModel request,
+      DatasetService datasetService,
+      IamService iamService,
+      AuthenticatedUserRequest userReq) {
     this.request = request;
+    this.datasetService = datasetService;
+    this.iamService = iamService;
+    this.userReq = userReq;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     logger.info("HELLO FROM BackfillRowMetadataTablesStep");
     // enumerate datasets
-    // for each dataset:
-    // connect to big query for dataset's data project
-    // for each table:
-    // retrieve the row metadata table name from the database
-    // check if row metadata table already exists in big query
-    // if doesn't exist, create row metadata table
+    int chunkSize = 100;
+    int currentChunk = 0;
+    int totalDatasetCount = 0;
+    while (true) {
+      Set<UUID> resources =
+          iamService.listAuthorizedResources(userReq, IamResourceType.DATASET).keySet();
+      EnumerateDatasetModel enumerateDatasetModel =
+          datasetService.enumerate(
+              currentChunk,
+              chunkSize,
+              EnumerateSortByParam.NAME,
+              SqlSortDirection.ASC,
+              null,
+              null,
+              resources);
+      // kill forever loop when no more datasets
+      int chunkDatasetCount = enumerateDatasetModel.getFilteredTotal();
+      totalDatasetCount += chunkDatasetCount;
+      if (chunkDatasetCount == 0) {
+        logger.info("DONE - Total datasets updated: {}", totalDatasetCount);
+        break;
+      }
+      // update chunk parameters
+      currentChunk += chunkSize;
+
+      // for each dataset:
+      enumerateDatasetModel.getItems().stream()
+          .forEach(
+              datasetSummaryModel -> {
+                // connect to big query for dataset's data project
+                Dataset dataset = datasetService.retrieve(datasetSummaryModel.getId());
+                BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
+                dataset
+                    .getTables()
+                    .forEach(
+                        table -> {
+                          // for each table:
+                          // retrieve the row metadata table name from the database
+                          String rowMetadataTableName = table.getRowMetadataTableName();
+                          // check if row metadata table already exists in big query
+                          boolean rowMetadataTableExists =
+                              bigQueryProject.tableExists(dataset.getName(), rowMetadataTableName);
+                          // TODO - Remove - Sanity check: Does this check find the soft delete
+                          // table name?
+                          boolean softDeleteTableExists =
+                              bigQueryProject.tableExists(
+                                  dataset.getName(), table.getSoftDeleteTableName());
+                          logger.info(
+                              "For dataset {}, table: {}, Found metadata table {}: {}, Found soft delete table {}: {}",
+                              dataset.getName(),
+                              table.getName(),
+                              rowMetadataTableName,
+                              rowMetadataTableExists,
+                              table.getSoftDeleteTableName(),
+                              softDeleteTableExists);
+                          // if doesn't exist, create row metadata table
+
+                        });
+              });
+    }
+
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/upgrade/flight/RowMetadataUpdateFlight.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/RowMetadataUpdateFlight.java
@@ -1,6 +1,9 @@
 package bio.terra.service.upgrade.flight;
 
 import bio.terra.model.UpgradeModel;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.iam.IamService;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -11,10 +14,13 @@ public class RowMetadataUpdateFlight extends Flight {
     super(inputParameters, applicationContext);
 
     ApplicationContext appContext = (ApplicationContext) applicationContext;
-    // ProfileService profileService = (ProfileService) appContext.getBean("profileService");
+    DatasetService datasetService = (DatasetService) appContext.getBean("datasetService");
+    IamService iamService = (IamService) appContext.getBean("iamService");
 
     UpgradeModel request = inputParameters.get(JobMapKeys.REQUEST.getKeyName(), UpgradeModel.class);
+    AuthenticatedUserRequest userReq =
+        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
-    addStep(new BackfillRowMetadataTablesStep(request));
+    addStep(new BackfillRowMetadataTablesStep(request, datasetService, iamService, userReq));
   }
 }

--- a/src/main/java/bio/terra/service/upgrade/flight/RowMetadataUpdateFlight.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/RowMetadataUpdateFlight.java
@@ -1,0 +1,22 @@
+package bio.terra.service.upgrade.flight;
+
+import bio.terra.model.UpgradeModel;
+import bio.terra.service.iam.AuthenticatedUserRequest;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import org.springframework.context.ApplicationContext;
+
+public class RowMetadataUpdateFlight extends Flight {
+  public RowMetadataUpdateFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+    //ProfileService profileService = (ProfileService) appContext.getBean("profileService");
+
+    UpgradeModel request =
+        inputParameters.get(JobMapKeys.REQUEST.getKeyName(), UpgradeModel.class);
+
+    addStep(new BackfillRowMetadataTablesStep(request));
+  }
+}

--- a/src/main/java/bio/terra/service/upgrade/flight/RowMetadataUpdateFlight.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/RowMetadataUpdateFlight.java
@@ -1,7 +1,6 @@
 package bio.terra.service.upgrade.flight;
 
 import bio.terra.model.UpgradeModel;
-import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -12,10 +11,9 @@ public class RowMetadataUpdateFlight extends Flight {
     super(inputParameters, applicationContext);
 
     ApplicationContext appContext = (ApplicationContext) applicationContext;
-    //ProfileService profileService = (ProfileService) appContext.getBean("profileService");
+    // ProfileService profileService = (ProfileService) appContext.getBean("profileService");
 
-    UpgradeModel request =
-        inputParameters.get(JobMapKeys.REQUEST.getKeyName(), UpgradeModel.class);
+    UpgradeModel request = inputParameters.get(JobMapKeys.REQUEST.getKeyName(), UpgradeModel.class);
 
     addStep(new BackfillRowMetadataTablesStep(request));
   }

--- a/src/main/java/bio/terra/service/upgrade/flight/RowMetadataUpdateFlight.java
+++ b/src/main/java/bio/terra/service/upgrade/flight/RowMetadataUpdateFlight.java
@@ -5,6 +5,7 @@ import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.iam.AuthenticatedUserRequest;
 import bio.terra.service.iam.IamService;
 import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import org.springframework.context.ApplicationContext;
@@ -16,11 +17,14 @@ public class RowMetadataUpdateFlight extends Flight {
     ApplicationContext appContext = (ApplicationContext) applicationContext;
     DatasetService datasetService = (DatasetService) appContext.getBean("datasetService");
     IamService iamService = (IamService) appContext.getBean("iamService");
+    BigQueryPdao bigQueryPdao = (BigQueryPdao) appContext.getBean("bigQueryPdao");
 
     UpgradeModel request = inputParameters.get(JobMapKeys.REQUEST.getKeyName(), UpgradeModel.class);
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
-    addStep(new BackfillRowMetadataTablesStep(request, datasetService, iamService, userReq));
+    addStep(
+        new BackfillRowMetadataTablesStep(
+            request, datasetService, iamService, bigQueryPdao, userReq));
   }
 }


### PR DESCRIPTION
- Run via the upgrade endpoint with the following JSON request:
`{"customArgs": [],"customName": "ROW_METADATA_UPDATE","upgradeName": "row_metadata_update", "upgradeType": "custom"}`
- Can be re-run multiple times and will only backfill the BQ table if it is not found
- Assumption: Fewer than 1k datasets on a given environment