### PR TITLE
DR-2281 Only register LocalAuthenticatedUserRequestFactory if the local profile is selected

### DIFF
--- a/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Primary
 @Component
-@Profile({"local", "connectedtest"})
+@Profile({"local", "connectedtest", "unittest"})
 public class LocalAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
   private Logger logger = LoggerFactory.getLogger(LocalAuthenticatedUserRequestFactory.class);
 

--- a/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Primary
 @Component
-@Profile({"local"})
+@Profile({"local", "connected-test", "unit-test"})
 public class LocalAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
   private Logger logger = LoggerFactory.getLogger(LocalAuthenticatedUserRequestFactory.class);
 

--- a/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Primary
 @Component
-@Profile({"!terra", "!dev", "!integration"})
+@Profile({"local"})
 public class LocalAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
   private Logger logger = LoggerFactory.getLogger(LocalAuthenticatedUserRequestFactory.class);
 

--- a/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Primary
 @Component
-@Profile({"local", "connected-test", "unit-test"})
+@Profile({"local", "connectedtest", "unittest"})
 public class LocalAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
   private Logger logger = LoggerFactory.getLogger(LocalAuthenticatedUserRequestFactory.class);
 

--- a/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/iam/LocalAuthenticatedUserRequestFactory.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Primary
 @Component
-@Profile({"local", "connectedtest", "unittest"})
+@Profile({"local", "connectedtest"})
 public class LocalAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
   private Logger logger = LoggerFactory.getLogger(LocalAuthenticatedUserRequestFactory.class);
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
@@ -1,9 +1,9 @@
 package bio.terra.service.snapshot;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 
 import bio.terra.common.auth.AuthService;
@@ -160,7 +160,7 @@ public class SnapshotPermissionsIntegrationTest extends UsersBase {
     assertThat(
         "Retrieve the dataSnapshot by dataset when no dataset is passed in",
         enumSnapByNoDatasetId.getItems(),
-        contains(enumSnapByDatasetId.getItems().get(0)));
+        hasItem(enumSnapByDatasetId.getItems().get(0)));
 
     EnumerateSnapshotModel enumSnapByBadDatasetId =
         dataRepoFixtures.enumerateSnapshotsByDatasetIds(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
@@ -1,6 +1,7 @@
 package bio.terra.service.snapshot;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
@@ -156,13 +157,17 @@ public class SnapshotPermissionsIntegrationTest extends UsersBase {
     EnumerateSnapshotModel enumSnapByNoDatasetId =
         dataRepoFixtures.enumerateSnapshotsByDatasetIds(steward(), Collections.emptyList());
 
-    assertThat("Dataset filters to dataSnapshots", enumSnapByNoDatasetId.getTotal(), equalTo(1));
+    assertThat(
+        "Retrieve the dataSnapshot by dataset when no dataset is passed in",
+        enumSnapByNoDatasetId.getItems(),
+        contains(enumSnapByDatasetId.getItems().get(0)));
 
     EnumerateSnapshotModel enumSnapByBadDatasetId =
         dataRepoFixtures.enumerateSnapshotsByDatasetIds(
             steward(), Collections.singletonList(UUID.randomUUID()));
 
-    assertThat("Dataset filters to dataSnapshots", enumSnapByBadDatasetId.getTotal(), equalTo(0));
+    assertThat(
+        "Invalid dataset filters out dataSnapshots", enumSnapByBadDatasetId.getTotal(), equalTo(0));
 
     // Delete snapshot as custodian for this test since teardown uses steward
     dataRepoFixtures.deleteSnapshot(custodian(), snapshotSummary.getId());

--- a/src/test/resources/application-connectedtest.properties
+++ b/src/test/resources/application-connectedtest.properties
@@ -1,5 +1,7 @@
 datarepo.testWithEmbeddedDatabase=true
 
+spring.profiles.active=connected-test
+
 # ct for connected test
 ct.ingestBucket=jade-testdata
 ct.nonDefaultRegionIngestBucket=jade-testdata-useastregion

--- a/src/test/resources/application-connectedtest.properties
+++ b/src/test/resources/application-connectedtest.properties
@@ -1,6 +1,6 @@
 datarepo.testWithEmbeddedDatabase=true
 
-spring.profiles.active=connected-test
+spring.profiles.active=connectedtest
 
 # ct for connected test
 ct.ingestBucket=jade-testdata

--- a/src/test/resources/application-connectedtest.properties
+++ b/src/test/resources/application-connectedtest.properties
@@ -1,7 +1,5 @@
 datarepo.testWithEmbeddedDatabase=true
 
-spring.profiles.active=connectedtest
-
 # ct for connected test
 ct.ingestBucket=jade-testdata
 ct.nonDefaultRegionIngestBucket=jade-testdata-useastregion

--- a/src/test/resources/application-unittest.properties
+++ b/src/test/resources/application-unittest.properties
@@ -1,3 +1,1 @@
 datarepo.testWithEmbeddedDatabase=true
-
-spring.profiles.active=unit-test

--- a/src/test/resources/application-unittest.properties
+++ b/src/test/resources/application-unittest.properties
@@ -1,1 +1,3 @@
 datarepo.testWithEmbeddedDatabase=true
+
+spring.profiles.active=unit-test


### PR DESCRIPTION
This will require adding a `local` profile when running TDR locally

I tested on a personal deployment and it seems to work