### PR TITLE
DR-2304 Flagging sensitive data in datasets and snapshots

### DIFF
--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -21,18 +21,20 @@ public final class DaoUtils {
 
   private DaoUtils() {}
 
-  public static String orderByClause(EnumerateSortByParam sort, SqlSortDirection direction) {
+  public static String orderByClause(
+      EnumerateSortByParam sort, SqlSortDirection direction, String table) {
     if (sort == null || direction == null) {
       return "";
     }
-    return " ORDER BY " + sort + " " + direction + " ";
+    return String.format(" ORDER BY %s.%s %s ", table, sort, direction);
   }
 
   public static void addFilterClause(
-      String filter, MapSqlParameterSource params, List<String> clauses) {
+      String filter, MapSqlParameterSource params, List<String> clauses, String table) {
     if (!StringUtils.isEmpty(filter)) {
       params.addValue("filter", DaoUtils.escapeFilter(filter));
-      clauses.add(" (name ILIKE :filter OR description ILIKE :filter) ");
+      clauses.add(
+          String.format(" (%s.name ILIKE :filter OR %s.description ILIKE :filter) ", table, table));
     }
   }
 

--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -52,15 +52,9 @@ public final class DaoUtils {
   }
 
   public static void addAuthzIdsClause(
-      Collection<UUID> authzIds, MapSqlParameterSource params, List<String> clauses) {
+      Collection<UUID> authzIds, MapSqlParameterSource params, List<String> clauses, String table) {
     params.addValue("idlist", authzIds);
-    clauses.add(" dataset.id in (:idlist) ");
-  }
-
-  public static void addAuthzSnapshotIdsClause(
-      Collection<UUID> authzIds, MapSqlParameterSource params, List<String> clauses) {
-    params.addValue("idlist", authzIds);
-    clauses.add(" snapshot.id in (:idlist) ");
+    clauses.add(String.format(" %s.id in (:idlist) ", table));
   }
 
   public static String escapeFilter(String filter) {

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -5,6 +5,7 @@ import bio.terra.app.model.AzureRegion;
 import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
+import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.service.filedata.FSContainerInterface;
 import bio.terra.service.filedata.google.firestore.FireStoreProject;
 import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
@@ -218,5 +219,9 @@ public class Dataset implements FSContainerInterface {
   public AzureRegion getStorageAccountRegion() {
     return (AzureRegion)
         datasetSummary.getStorageResourceRegion(AzureCloudResource.STORAGE_ACCOUNT);
+  }
+
+  public DatasetSecurityClassification getSecurityClassification() {
+    return datasetSummary.getSecurityClassification();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -5,7 +5,6 @@ import bio.terra.app.model.AzureRegion;
 import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
-import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.service.filedata.FSContainerInterface;
 import bio.terra.service.filedata.google.firestore.FireStoreProject;
 import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
@@ -221,7 +220,7 @@ public class Dataset implements FSContainerInterface {
         datasetSummary.getStorageResourceRegion(AzureCloudResource.STORAGE_ACCOUNT);
   }
 
-  public DatasetSecurityClassification getSecurityClassification() {
-    return datasetSummary.getSecurityClassification();
+  public boolean isSecureMonitoringEnabled() {
+    return datasetSummary.isSecureMonitoringEnabled();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -593,7 +593,7 @@ public class DatasetDao {
       Collection<UUID> accessibleDatasetIds) {
     MapSqlParameterSource params = new MapSqlParameterSource();
     List<String> whereClauses = new ArrayList<>();
-    DaoUtils.addAuthzIdsClause(accessibleDatasetIds, params, whereClauses);
+    DaoUtils.addAuthzIdsClause(accessibleDatasetIds, params, whereClauses, "dataset");
     whereClauses.add(" flightid IS NULL"); // exclude datasets that are exclusively locked
 
     // get total count of objects

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -605,7 +605,7 @@ public class DatasetDao {
     }
 
     // add the filters to the clause to get the actual items
-    DaoUtils.addFilterClause(filter, params, whereClauses);
+    DaoUtils.addFilterClause(filter, params, whereClauses, "dataset");
     DaoUtils.addRegionFilterClause(region, params, whereClauses, "dataset.id");
 
     String whereSql = "";
@@ -629,7 +629,7 @@ public class DatasetDao {
             + billingProfileQuery
             + "FROM dataset "
             + whereSql
-            + DaoUtils.orderByClause(sort, direction)
+            + DaoUtils.orderByClause(sort, direction, "dataset")
             + " OFFSET :offset LIMIT :limit";
     params.addValue("offset", offset).addValue("limit", limit);
     List<DatasetSummary> summaries = jdbcTemplate.query(sql, params, new DatasetSummaryMapper());

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -12,7 +12,6 @@ import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestAccessIncludeModel;
 import bio.terra.model.DatasetRequestModel;
-import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.DatePartitionOptionsModel;
@@ -69,9 +68,8 @@ public final class DatasetJsonConversion {
     final List<? extends StorageResource<?, ?>> storageResources =
         cloudPlatform.createStorageResourceValues(datasetRequest);
 
-    DatasetSecurityClassification securityClassification =
-        Objects.requireNonNullElse(
-            datasetRequest.getSecurityClassification(), DatasetSecurityClassification.NONE);
+    boolean secureMonitoringEnabled =
+        Objects.requireNonNullElse(datasetRequest.isSecureMonitoringEnabled(), false);
 
     return new Dataset(
             new DatasetSummary()
@@ -79,7 +77,7 @@ public final class DatasetJsonConversion {
                 .description(datasetRequest.getDescription())
                 .storage(storageResources)
                 .defaultProfileId(defaultProfileId)
-                .securityClassification(securityClassification))
+                .secureMonitoringEnabled(secureMonitoringEnabled))
         .tables(new ArrayList<>(tablesMap.values()))
         .relationships(new ArrayList<>(relationshipsMap.values()))
         .assetSpecifications(assetSpecifications);
@@ -94,7 +92,7 @@ public final class DatasetJsonConversion {
         .createdDate(datasetSummary.getCreatedDate().toString())
         .defaultProfileId(datasetSummary.getDefaultProfileId())
         .storage(storageResourceModelFromDatasetSummary(datasetSummary))
-        .securityClassification(datasetSummary.getSecurityClassification());
+        .secureMonitoringEnabled(datasetSummary.isSecureMonitoringEnabled());
   }
 
   public static DatasetModel populateDatasetModelFromDataset(
@@ -108,7 +106,7 @@ public final class DatasetJsonConversion {
             .name(dataset.getName())
             .description(dataset.getDescription())
             .createdDate(dataset.getCreatedDate().toString())
-            .securityClassification(dataset.getSecurityClassification());
+            .secureMonitoringEnabled(dataset.isSecureMonitoringEnabled());
 
     if (include.contains(DatasetRequestAccessIncludeModel.NONE)) {
       return datasetModel;

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -12,6 +12,7 @@ import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestAccessIncludeModel;
 import bio.terra.model.DatasetRequestModel;
+import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.DatePartitionOptionsModel;
@@ -68,12 +69,17 @@ public final class DatasetJsonConversion {
     final List<? extends StorageResource<?, ?>> storageResources =
         cloudPlatform.createStorageResourceValues(datasetRequest);
 
+    DatasetSecurityClassification securityClassification =
+        Objects.requireNonNullElse(
+            datasetRequest.getSecurityClassification(), DatasetSecurityClassification.NONE);
+
     return new Dataset(
             new DatasetSummary()
                 .name(datasetRequest.getName())
                 .description(datasetRequest.getDescription())
                 .storage(storageResources)
-                .defaultProfileId(defaultProfileId))
+                .defaultProfileId(defaultProfileId)
+                .securityClassification(securityClassification))
         .tables(new ArrayList<>(tablesMap.values()))
         .relationships(new ArrayList<>(relationshipsMap.values()))
         .assetSpecifications(assetSpecifications);
@@ -87,7 +93,8 @@ public final class DatasetJsonConversion {
         .description(datasetSummary.getDescription())
         .createdDate(datasetSummary.getCreatedDate().toString())
         .defaultProfileId(datasetSummary.getDefaultProfileId())
-        .storage(storageResourceModelFromDatasetSummary(datasetSummary));
+        .storage(storageResourceModelFromDatasetSummary(datasetSummary))
+        .securityClassification(datasetSummary.getSecurityClassification());
   }
 
   public static DatasetModel populateDatasetModelFromDataset(
@@ -100,7 +107,8 @@ public final class DatasetJsonConversion {
             .id(dataset.getId())
             .name(dataset.getName())
             .description(dataset.getDescription())
-            .createdDate(dataset.getCreatedDate().toString());
+            .createdDate(dataset.getCreatedDate().toString())
+            .securityClassification(dataset.getSecurityClassification());
 
     if (include.contains(DatasetRequestAccessIncludeModel.NONE)) {
       return datasetModel;

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -7,7 +7,6 @@ import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.CloudPlatform;
-import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.service.dataset.exception.StorageResourceNotFoundException;
 import java.time.Instant;
 import java.util.List;
@@ -24,7 +23,7 @@ public class DatasetSummary {
   private Instant createdDate;
   private List<BillingProfileModel> billingProfiles;
   private List<? extends StorageResource<?, ?>> storage;
-  private DatasetSecurityClassification securityClassification;
+  private boolean secureMonitoringEnabled;
 
   public UUID getId() {
     return id;
@@ -151,13 +150,12 @@ public class DatasetSummary {
                         "%s could not be found for dataset %s", cloudResource.name(), id)));
   }
 
-  public DatasetSecurityClassification getSecurityClassification() {
-    return securityClassification;
+  public boolean isSecureMonitoringEnabled() {
+    return secureMonitoringEnabled;
   }
 
-  public DatasetSummary securityClassification(
-      DatasetSecurityClassification securityClassification) {
-    this.securityClassification = securityClassification;
+  public DatasetSummary secureMonitoringEnabled(boolean secureMonitoringEnabled) {
+    this.secureMonitoringEnabled = secureMonitoringEnabled;
     return this;
   }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -7,6 +7,7 @@ import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.service.dataset.exception.StorageResourceNotFoundException;
 import java.time.Instant;
 import java.util.List;
@@ -23,6 +24,7 @@ public class DatasetSummary {
   private Instant createdDate;
   private List<BillingProfileModel> billingProfiles;
   private List<? extends StorageResource<?, ?>> storage;
+  private DatasetSecurityClassification securityClassification;
 
   public UUID getId() {
     return id;
@@ -147,5 +149,15 @@ public class DatasetSummary {
                 new StorageResourceNotFoundException(
                     String.format(
                         "%s could not be found for dataset %s", cloudResource.name(), id)));
+  }
+
+  public DatasetSecurityClassification getSecurityClassification() {
+    return securityClassification;
+  }
+
+  public DatasetSummary securityClassification(
+      DatasetSecurityClassification securityClassification) {
+    this.securityClassification = securityClassification;
+    return this;
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -4,7 +4,6 @@ import bio.terra.app.model.AzureRegion;
 import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
-import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.service.filedata.FSContainerInterface;
 import bio.terra.service.filedata.google.firestore.FireStoreProject;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
@@ -178,7 +177,7 @@ public class Snapshot implements FSContainerInterface {
     return getFirstSnapshotSource().getDataset().getStorageAccountRegion();
   }
 
-  public DatasetSecurityClassification getSecurityClassification() {
-    return getFirstSnapshotSource().getDataset().getSecurityClassification();
+  public boolean isSecureMonitoringEnabled() {
+    return getFirstSnapshotSource().getDataset().isSecureMonitoringEnabled();
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -4,6 +4,7 @@ import bio.terra.app.model.AzureRegion;
 import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
+import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.service.filedata.FSContainerInterface;
 import bio.terra.service.filedata.google.firestore.FireStoreProject;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
@@ -175,5 +176,9 @@ public class Snapshot implements FSContainerInterface {
 
   public AzureRegion getStorageAccountRegion() {
     return getFirstSnapshotSource().getDataset().getStorageAccountRegion();
+  }
+
+  public DatasetSecurityClassification getSecurityClassification() {
+    return getFirstSnapshotSource().getDataset().getSecurityClassification();
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -531,7 +531,7 @@ public class SnapshotDao {
 
     // get filtered total count of objects
     String countSql =
-        "SELECT count(s.id) AS total FROM snapshot s"
+        "SELECT count(s.id) AS total FROM snapshot s "
             + joinSql
             + " WHERE "
             + StringUtils.join(whereClauses, " AND ");
@@ -548,7 +548,7 @@ public class SnapshotDao {
 
     // get filtered total count of objects
     String filteredCountSql =
-        "SELECT count(s.id) AS total FROM snapshot s"
+        "SELECT count(s.id) AS total FROM snapshot s "
             + joinSql
             + " WHERE "
             + StringUtils.join(whereClauses, " AND ");
@@ -561,7 +561,7 @@ public class SnapshotDao {
         "SELECT s.id, s.name, s.description, s.created_date, s.profile_id, "
             + "snapshot_source.id, d.security_classification, "
             + snapshotSourceStorageQuery
-            + "FROM snapshot s"
+            + "FROM snapshot s "
             + joinSql
             + whereSql
             + DaoUtils.orderByClause(sort, direction)
@@ -607,7 +607,7 @@ public class SnapshotDao {
           "SELECT s.id, s.name, s.description, s.created_date, s.profile_id, "
               + "d.security_classification, "
               + snapshotSourceStorageQuery
-              + "FROM snapshot s"
+              + "FROM snapshot s "
               + "JOIN snapshot_source ON s.id = snapshot_source.snapshot_id "
               + "JOIN dataset d ON d.id = snapshot_source.dataset_id "
               + "WHERE snapshot_source.dataset_id = :datasetId";

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -541,7 +541,7 @@ public class SnapshotDao {
     }
 
     // add the filter to the clause to get the actual items
-    DaoUtils.addFilterClause(filter, params, whereClauses);
+    DaoUtils.addFilterClause(filter, params, whereClauses, "s");
     DaoUtils.addRegionFilterClause(region, params, whereClauses, "snapshot_source.dataset_id");
 
     String whereSql = " WHERE " + StringUtils.join(whereClauses, " AND ");
@@ -564,7 +564,7 @@ public class SnapshotDao {
             + "FROM snapshot s "
             + joinSql
             + whereSql
-            + DaoUtils.orderByClause(sort, direction)
+            + DaoUtils.orderByClause(sort, direction, "s")
             + " OFFSET :offset LIMIT :limit";
 
     params.addValue("offset", offset).addValue("limit", limit);

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -608,7 +608,7 @@ public class SnapshotService {
             .createdDate(snapshotSummary.getCreatedDate().toString())
             .profileId(snapshotSummary.getProfileId())
             .storage(storageResourceModelFromSnapshotSummary(snapshotSummary))
-            .securityClassification(snapshotSummary.getSecurityClassification());
+            .secureMonitoringEnabled(snapshotSummary.isSecureMonitoringEnabled());
     return summaryModel;
   }
 
@@ -629,7 +629,7 @@ public class SnapshotService {
             .name(snapshot.getName())
             .description(snapshot.getDescription())
             .createdDate(snapshot.getCreatedDate().toString())
-            .securityClassification(snapshot.getSecurityClassification());
+            .secureMonitoringEnabled(snapshot.isSecureMonitoringEnabled());
 
     // In case NONE is specified, this should supersede any other value being passed in
     if (include.contains(SnapshotRequestAccessIncludeModel.NONE)) {
@@ -695,7 +695,7 @@ public class SnapshotService {
                 dataset.getDatasetSummary().getStorage().stream()
                     .map(StorageResource::toModel)
                     .collect(Collectors.toList()))
-            .securityClassification(dataset.getSecurityClassification());
+            .secureMonitoringEnabled(dataset.isSecureMonitoringEnabled());
 
     SnapshotSourceModel sourceModel = new SnapshotSourceModel().dataset(summaryModel);
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -628,8 +628,7 @@ public class SnapshotService {
             .id(snapshot.getId())
             .name(snapshot.getName())
             .description(snapshot.getDescription())
-            .createdDate(snapshot.getCreatedDate().toString())
-            .secureMonitoringEnabled(snapshot.isSecureMonitoringEnabled());
+            .createdDate(snapshot.getCreatedDate().toString());
 
     // In case NONE is specified, this should supersede any other value being passed in
     if (include.contains(SnapshotRequestAccessIncludeModel.NONE)) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -607,7 +607,8 @@ public class SnapshotService {
             .description(snapshotSummary.getDescription())
             .createdDate(snapshotSummary.getCreatedDate().toString())
             .profileId(snapshotSummary.getProfileId())
-            .storage(storageResourceModelFromSnapshotSummary(snapshotSummary));
+            .storage(storageResourceModelFromSnapshotSummary(snapshotSummary))
+            .securityClassification(snapshotSummary.getSecurityClassification());
     return summaryModel;
   }
 
@@ -627,7 +628,8 @@ public class SnapshotService {
             .id(snapshot.getId())
             .name(snapshot.getName())
             .description(snapshot.getDescription())
-            .createdDate(snapshot.getCreatedDate().toString());
+            .createdDate(snapshot.getCreatedDate().toString())
+            .securityClassification(snapshot.getSecurityClassification());
 
     // In case NONE is specified, this should supersede any other value being passed in
     if (include.contains(SnapshotRequestAccessIncludeModel.NONE)) {
@@ -692,7 +694,8 @@ public class SnapshotService {
             .storage(
                 dataset.getDatasetSummary().getStorage().stream()
                     .map(StorageResource::toModel)
-                    .collect(Collectors.toList()));
+                    .collect(Collectors.toList()))
+            .securityClassification(dataset.getSecurityClassification());
 
     SnapshotSourceModel sourceModel = new SnapshotSourceModel().dataset(summaryModel);
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -1,6 +1,5 @@
 package bio.terra.service.snapshot;
 
-import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.service.dataset.StorageResource;
 import java.time.Instant;
 import java.util.List;
@@ -13,7 +12,7 @@ public class SnapshotSummary {
   private Instant createdDate;
   private UUID profileId;
   private List<StorageResource> storage;
-  private DatasetSecurityClassification securityClassification;
+  private boolean secureMonitoringEnabled;
 
   public UUID getId() {
     return id;
@@ -69,13 +68,12 @@ public class SnapshotSummary {
     return this;
   }
 
-  public DatasetSecurityClassification getSecurityClassification() {
-    return securityClassification;
+  public boolean isSecureMonitoringEnabled() {
+    return secureMonitoringEnabled;
   }
 
-  public SnapshotSummary securityClassification(
-      DatasetSecurityClassification securityClassification) {
-    this.securityClassification = securityClassification;
+  public SnapshotSummary secureMonitoringEnabled(boolean secureMonitoringEnabled) {
+    this.secureMonitoringEnabled = secureMonitoringEnabled;
     return this;
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -1,5 +1,6 @@
 package bio.terra.service.snapshot;
 
+import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.service.dataset.StorageResource;
 import java.time.Instant;
 import java.util.List;
@@ -12,6 +13,7 @@ public class SnapshotSummary {
   private Instant createdDate;
   private UUID profileId;
   private List<StorageResource> storage;
+  private DatasetSecurityClassification securityClassification;
 
   public UUID getId() {
     return id;
@@ -64,6 +66,16 @@ public class SnapshotSummary {
 
   public SnapshotSummary storage(List<StorageResource> storage) {
     this.storage = storage;
+    return this;
+  }
+
+  public DatasetSecurityClassification getSecurityClassification() {
+    return securityClassification;
+  }
+
+  public SnapshotSummary securityClassification(
+      DatasetSecurityClassification securityClassification) {
+    this.securityClassification = securityClassification;
     return this;
   }
 }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3676,9 +3676,6 @@ components:
           description: Project id of the snapshot data project
         accessInformation:
           $ref: '#/components/schemas/AccessInfoModel'
-        secureMonitoringEnabled:
-          type: boolean
-          default: false
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
     SnapshotExportResponseModel:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2851,6 +2851,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageResourceModel'
+        securityClassification:
+          $ref: '#/components/schemas/DatasetSecurityClassification'
         accessInformation:
           $ref: '#/components/schemas/AccessInfoModel'
       description: >
@@ -2874,6 +2876,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageResourceModel'
+        securityClassification:
+          $ref: '#/components/schemas/DatasetSecurityClassification'
       description: >
         Summary of a dataset.
     DatasetRequestModel:
@@ -2896,6 +2900,8 @@ components:
           type: string
         cloudPlatform:
           $ref: '#/components/schemas/CloudPlatform'
+        securityClassification:
+          $ref: '#/components/schemas/DatasetSecurityClassification'
       description: >
         Complete definition of a dataset without the id (used to create a dataset)
     DatasetRequestAccessIncludeModel:
@@ -3218,6 +3224,12 @@ components:
         dataset bucket.
         Eventually, this will include attributes of the storage including
         billing, temperature, geography, etc. But for now...
+    DatasetSecurityClassification:
+      type: string
+      enum:
+        - none
+        - sensitive
+        - contains_phi
     SnapshotPreviewModel:
       type: object
       properties:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3627,6 +3627,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageResourceModel'
+        securityClassification:
+          $ref: '#/components/schemas/DatasetSecurityClassification'
       description: >
         summary of snapshot
     EnumerateSnapshotModel:
@@ -3676,6 +3678,8 @@ components:
           description: Project id of the snapshot data project
         accessInformation:
           $ref: '#/components/schemas/AccessInfoModel'
+        securityClassification:
+          $ref: '#/components/schemas/DatasetSecurityClassification'
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
     SnapshotExportResponseModel:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2851,8 +2851,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageResourceModel'
-        securityClassification:
-          $ref: '#/components/schemas/DatasetSecurityClassification'
+        secureMonitoringEnabled:
+          type: boolean
+          default: false
         accessInformation:
           $ref: '#/components/schemas/AccessInfoModel'
       description: >
@@ -2876,8 +2877,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageResourceModel'
-        securityClassification:
-          $ref: '#/components/schemas/DatasetSecurityClassification'
+        secureMonitoringEnabled:
+          type: boolean
+          default: false
       description: >
         Summary of a dataset.
     DatasetRequestModel:
@@ -2900,8 +2902,9 @@ components:
           type: string
         cloudPlatform:
           $ref: '#/components/schemas/CloudPlatform'
-        securityClassification:
-          $ref: '#/components/schemas/DatasetSecurityClassification'
+        secureMonitoringEnabled:
+          type: boolean
+          default: false
       description: >
         Complete definition of a dataset without the id (used to create a dataset)
     DatasetRequestAccessIncludeModel:
@@ -3224,12 +3227,6 @@ components:
         dataset bucket.
         Eventually, this will include attributes of the storage including
         billing, temperature, geography, etc. But for now...
-    DatasetSecurityClassification:
-      type: string
-      enum:
-        - none
-        - sensitive
-        - contains_phi
     SnapshotPreviewModel:
       type: object
       properties:
@@ -3627,8 +3624,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageResourceModel'
-        securityClassification:
-          $ref: '#/components/schemas/DatasetSecurityClassification'
+        secureMonitoringEnabled:
+          type: boolean
+          default: false
       description: >
         summary of snapshot
     EnumerateSnapshotModel:
@@ -3678,8 +3676,9 @@ components:
           description: Project id of the snapshot data project
         accessInformation:
           $ref: '#/components/schemas/AccessInfoModel'
-        securityClassification:
-          $ref: '#/components/schemas/DatasetSecurityClassification'
+        secureMonitoringEnabled:
+          type: boolean
+          default: false
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
     SnapshotExportResponseModel:

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -47,5 +47,6 @@
     <include file="changesets/20211015_allownullbillingaccountandprojectresourceid.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20211112_rowmetadatatable.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20211206_datasetsecurityattributes.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20211209_datasetrequireslogging.yaml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -46,5 +46,6 @@
     <include file="changesets/20211007_snapshot_storage_account.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20211015_allownullbillingaccountandprojectresourceid.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20211112_rowmetadatatable.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20211206_datasetsecurityattributes.yaml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20211206_datasetsecurityattributes.yaml
+++ b/src/main/resources/db/changesets/20211206_datasetsecurityattributes.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: datasetSecurity
+      author: tlangs
+      changes:
+        - addColumn:
+            tableName: dataset
+            columns:
+              name: security_classification
+              type: ${identifier_type}
+              defaultValue: "NONE"
+              constraints:
+                nullable: false
+
+

--- a/src/main/resources/db/changesets/20211209_datasetrequireslogging.yaml
+++ b/src/main/resources/db/changesets/20211209_datasetrequireslogging.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: datasetSecurity
+      author: tlangs
+      changes:
+        - dropColumn:
+            tableName: dataset
+            columnName: security_classification
+        - addColumn:
+            tableName: dataset
+            columns:
+              name: secure_monitoring
+              type: boolean
+              defaultValue: false
+              constraints:
+                nullable: false
+
+

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -187,6 +187,16 @@ public class DataRepoFixtures {
   }
 
   public DatasetSummaryModel createDataset(
+      TestConfiguration.User user, DatasetRequestModel requestModel, boolean usePetAccount)
+      throws Exception {
+    String json = TestUtils.mapToJson(requestModel);
+    DataRepoResponse<JobModel> post =
+        dataRepoClient.post(
+            user, "/api/repository/v1/datasets", json, JobModel.class, usePetAccount);
+    return waitForDatasetCreate(user, post);
+  }
+
+  public DatasetSummaryModel createDataset(
       TestConfiguration.User user,
       UUID profileId,
       String filename,
@@ -195,6 +205,11 @@ public class DataRepoFixtures {
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
         createDatasetRaw(user, profileId, filename, cloudPlatform, usePetAccount);
+    return waitForDatasetCreate(user, jobResponse);
+  }
+
+  private DatasetSummaryModel waitForDatasetCreate(
+      TestConfiguration.User user, DataRepoResponse<JobModel> jobResponse) throws Exception {
     assertTrue("dataset create launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
     assertTrue(
         "dataset create launch response is present", jobResponse.getResponseObject().isPresent());

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -24,6 +24,7 @@ import bio.terra.model.DataDeletionGcsFileModel;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DataDeletionTableModel;
 import bio.terra.model.DatasetModel;
+import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateDatasetModel;
@@ -187,6 +188,16 @@ public class DatasetIntegrationTest extends UsersBase {
         "Custodian is authorized to enumerate datasets",
         enumDatasets.getStatusCode(),
         equalTo(HttpStatus.OK));
+
+    assertThat(
+        "Default security classification was applied to summary model",
+        summaryModel.getSecurityClassification(),
+        equalTo(DatasetSecurityClassification.NONE));
+
+    assertThat(
+        "Default security classification was propagated to model",
+        datasetModel.getSecurityClassification(),
+        equalTo(DatasetSecurityClassification.NONE));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertTrue;
 
@@ -24,7 +25,6 @@ import bio.terra.model.DataDeletionGcsFileModel;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DataDeletionTableModel;
 import bio.terra.model.DatasetModel;
-import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateDatasetModel;
@@ -190,14 +190,14 @@ public class DatasetIntegrationTest extends UsersBase {
         equalTo(HttpStatus.OK));
 
     assertThat(
-        "Default security classification was applied to summary model",
-        summaryModel.getSecurityClassification(),
-        equalTo(DatasetSecurityClassification.NONE));
+        "Default secure monitoring was applied to summary model",
+        summaryModel.isSecureMonitoringEnabled(),
+        is(false));
 
     assertThat(
         "Default security classification was propagated to model",
-        datasetModel.getSecurityClassification(),
-        equalTo(DatasetSecurityClassification.NONE));
+        datasetModel.isSecureMonitoringEnabled(),
+        is(false));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
@@ -111,7 +111,7 @@ public class SecureMonitoringIntegrationTest extends UsersBase {
 
     assertThat(
         "Snapshot model denotes secure monitoring enabled",
-        snapshot.isSecureMonitoringEnabled(),
+        snapshot.getSource().get(0).getDataset().isSecureMonitoringEnabled(),
         is(true));
 
     Optional<SnapshotSummaryModel> enumeratedModel =

--- a/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
@@ -40,10 +40,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "integrationtest"})
 @AutoConfigureMockMvc
 @Category(Integration.class)
-public class SecurityClassificationsIntegrationTest extends UsersBase {
+public class SecureMonitoringIntegrationTest extends UsersBase {
 
-  private static Logger logger =
-      LoggerFactory.getLogger(SecurityClassificationsIntegrationTest.class);
+  private static Logger logger = LoggerFactory.getLogger(SecureMonitoringIntegrationTest.class);
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private AuthService authService;

--- a/src/test/java/bio/terra/service/dataset/SecurityClassificationsIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SecurityClassificationsIntegrationTest.java
@@ -14,7 +14,14 @@ import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.model.SnapshotSummaryModel;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +51,7 @@ public class SecurityClassificationsIntegrationTest extends UsersBase {
   @Autowired private JsonLoader jsonLoader;
 
   private UUID datasetId;
+  private UUID snapshotId;
   private UUID profileId;
 
   @Before
@@ -62,6 +70,10 @@ public class SecurityClassificationsIntegrationTest extends UsersBase {
       dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
     }
 
+    if (snapshotId != null) {
+      dataRepoFixtures.deleteSnapshotLog(steward(), snapshotId);
+    }
+
     if (profileId != null) {
       dataRepoFixtures.deleteProfileLog(steward(), profileId);
     }
@@ -75,21 +87,72 @@ public class SecurityClassificationsIntegrationTest extends UsersBase {
 
     assertThat(
         String.format(
-            "'%s' security classification was applied to summary model", classification.name()),
+            "'%s' security classification was applied to the dataset summary model",
+            classification.name()),
         summary.getSecurityClassification(),
         equalTo(classification));
 
     assertThat(
         String.format(
-            "'%s' security classification was propagated to model", classification.name()),
+            "'%s' security classification was propagated to the dataset model",
+            classification.name()),
         dataset.getSecurityClassification(),
+        equalTo(classification));
+
+    String datasetName = dataset.getName();
+    SnapshotRequestModel requestModel =
+        jsonLoader.loadObject("ingest-test-snapshot-fullviews.json", SnapshotRequestModel.class);
+    // swap in the correct dataset name (with the id at the end)
+    requestModel.getContents().get(0).setDatasetName(datasetName);
+    SnapshotSummaryModel snapshotSummary =
+        dataRepoFixtures.createSnapshotWithRequest(steward(), datasetName, profileId, requestModel);
+    TimeUnit.SECONDS.sleep(10);
+    snapshotId = snapshotSummary.getId();
+
+    assertThat(
+        String.format(
+            "Snapshot summary has the '%s' security classification", classification.name()),
+        snapshotSummary.getSecurityClassification(),
+        equalTo(classification));
+
+    SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotId, List.of());
+
+    assertThat(
+        String.format("Snapshot model has the '%s' security classification", classification.name()),
+        snapshot.getSecurityClassification(),
+        equalTo(classification));
+
+    Optional<SnapshotSummaryModel> enumeratedModel =
+        dataRepoFixtures.enumerateSnapshots(steward()).getItems().stream()
+            .filter(s -> s.getId().equals(snapshotId))
+            .findFirst();
+
+    assertThat(
+        String.format(
+            "Enumerated snapshot model has '%s' security classification", classification.name()),
+        enumeratedModel.get().getSecurityClassification(),
+        equalTo(classification));
+
+    Optional<SnapshotSummaryModel> enumeratedByDatasetModel =
+        dataRepoFixtures
+            .enumerateSnapshotsByDatasetIds(steward(), List.of(datasetId))
+            .getItems()
+            .stream()
+            .filter(s -> s.getId().equals(snapshotId))
+            .findFirst();
+
+    assertThat(
+        String.format(
+            "Enumerated by dataset id snapshot model has '%s' security classification",
+            classification.name()),
+        enumeratedByDatasetModel.get().getSecurityClassification(),
         equalTo(classification));
   }
 
   private DatasetSummaryModel datasetWithSecurityClassification(
       DatasetSecurityClassification securityClassification) throws Exception {
     DatasetRequestModel requestModel =
-        jsonLoader.loadObject("it-dataset-omop.json", DatasetRequestModel.class);
+        jsonLoader.loadObject("ingest-test-dataset.json", DatasetRequestModel.class);
     requestModel.setDefaultProfileId(profileId);
     requestModel.setName(Names.randomizeName(requestModel.getName()));
     requestModel.setCloudPlatform(CloudPlatform.GCP);
@@ -97,6 +160,13 @@ public class SecurityClassificationsIntegrationTest extends UsersBase {
     DatasetSummaryModel summaryModel =
         dataRepoFixtures.createDataset(steward(), requestModel, false);
     datasetId = summaryModel.getId();
+
+    IngestRequestModel request =
+        dataRepoFixtures.buildSimpleIngest(
+            "participant", "ingest-test/ingest-test-participant.json");
+    dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
+    request = dataRepoFixtures.buildSimpleIngest("sample", "ingest-test/ingest-test-sample.json");
+    dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
     return summaryModel;
   }
 }

--- a/src/test/java/bio/terra/service/dataset/SecurityClassificationsIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SecurityClassificationsIntegrationTest.java
@@ -1,0 +1,102 @@
+package bio.terra.service.dataset;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.common.auth.AuthService;
+import bio.terra.common.category.Integration;
+import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.common.fixtures.Names;
+import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.UsersBase;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetModel;
+import bio.terra.model.DatasetRequestModel;
+import bio.terra.model.DatasetSecurityClassification;
+import bio.terra.model.DatasetSummaryModel;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+// TODO move me to integration dir
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles({"google", "integrationtest"})
+@AutoConfigureMockMvc
+@Category(Integration.class)
+public class SecurityClassificationsIntegrationTest extends UsersBase {
+
+  private static Logger logger =
+      LoggerFactory.getLogger(SecurityClassificationsIntegrationTest.class);
+
+  @Autowired private DataRepoFixtures dataRepoFixtures;
+  @Autowired private AuthService authService;
+  @Autowired private JsonLoader jsonLoader;
+
+  private UUID datasetId;
+  private UUID profileId;
+
+  @Before
+  public void setup() throws Exception {
+    super.setup();
+    dataRepoFixtures.resetConfig(steward());
+    profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
+    datasetId = null;
+  }
+
+  @After
+  public void teardown() throws Exception {
+    dataRepoFixtures.resetConfig(steward());
+
+    if (datasetId != null) {
+      dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
+    }
+
+    if (profileId != null) {
+      dataRepoFixtures.deleteProfileLog(steward(), profileId);
+    }
+  }
+
+  @Test
+  public void testDatasetSecurityClassifications() throws Exception {
+    DatasetSecurityClassification classification = DatasetSecurityClassification.CONTAINS_PHI;
+    DatasetSummaryModel summary = datasetWithSecurityClassification(classification);
+    DatasetModel dataset = dataRepoFixtures.getDataset(steward(), summary.getId());
+
+    assertThat(
+        String.format(
+            "'%s' security classification was applied to summary model", classification.name()),
+        summary.getSecurityClassification(),
+        equalTo(classification));
+
+    assertThat(
+        String.format(
+            "'%s' security classification was propagated to model", classification.name()),
+        dataset.getSecurityClassification(),
+        equalTo(classification));
+  }
+
+  private DatasetSummaryModel datasetWithSecurityClassification(
+      DatasetSecurityClassification securityClassification) throws Exception {
+    DatasetRequestModel requestModel =
+        jsonLoader.loadObject("it-dataset-omop.json", DatasetRequestModel.class);
+    requestModel.setDefaultProfileId(profileId);
+    requestModel.setName(Names.randomizeName(requestModel.getName()));
+    requestModel.setCloudPlatform(CloudPlatform.GCP);
+    requestModel.setSecurityClassification(securityClassification);
+    DatasetSummaryModel summaryModel =
+        dataRepoFixtures.createDataset(steward(), requestModel, false);
+    datasetId = summaryModel.getId();
+    return summaryModel;
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -168,7 +168,7 @@ public class SnapshotIntegrationTest extends UsersBase {
 
     assertThat(
         "The secure monitoring is propagated from the dataset",
-        snapshot.isSecureMonitoringEnabled(),
+        snapshot.getSource().get(0).getDataset().isSecureMonitoringEnabled(),
         is(false));
   }
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -13,6 +13,7 @@ import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.DatasetModel;
+import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.SnapshotModel;
@@ -164,6 +165,11 @@ public class SnapshotIntegrationTest extends UsersBase {
         "the right relationship comes through",
         snapshot.getRelationships().get(0).getName(),
         equalTo("sample_participants"));
+
+    assertThat(
+        "The security classification is propagated from the dataset",
+        snapshot.getSecurityClassification(),
+        equalTo(DatasetSecurityClassification.NONE));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.snapshot;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 import bio.terra.common.PdaoConstant;
@@ -13,7 +14,6 @@ import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.DatasetModel;
-import bio.terra.model.DatasetSecurityClassification;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.SnapshotModel;
@@ -167,9 +167,9 @@ public class SnapshotIntegrationTest extends UsersBase {
         equalTo("sample_participants"));
 
     assertThat(
-        "The security classification is propagated from the dataset",
-        snapshot.getSecurityClassification(),
-        equalTo(DatasetSecurityClassification.NONE));
+        "The secure monitoring is propagated from the dataset",
+        snapshot.isSecureMonitoringEnabled(),
+        is(false));
   }
 
   @Test


### PR DESCRIPTION
~This PR adds a flag to datasets to indicate whether the dataset contains sensitive information. Valid options are `NONE`, `SENSITIVE`, and `CONTAINS_PHI`. If a dataset's "security classification" (I'm not married to the name, let me know if you have a better idea please) is not `NONE`, https://broadworkbench.atlassian.net/browse/DR-2306 will use this information to put the dataset's projects into a special Google folder with additional monitoring and security features.~

~The "security classification" of a dataset is inherited by any snapshots created from that dataset, and the same project-moving logic will apply.~

"security classification" turned out to be a bit too confusing and ambiguous, so instead, this PR will add a `enableSecureMonitoring` boolean to the `DatasetRequestModel` and a `secureMonitoringEnabled` boolean to dataset and snapshot response models. This will default to `false` for all existing datasets, and dataset requests that don't specify a value will also default to `false`.  A dataset with a `true` value will have that value propagated to any snapshots created from that dataset.