### PR TITLE
DR-2317 Update datarepo-client in clienttests

### DIFF
--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -38,7 +38,7 @@ dependencies {
         swaggerAnnotations = "2.1.5"
         jersey = "2.30.1"
 
-        datarepoClient = "1.129.0-SNAPSHOT"
+        datarepoClient = "1.251.0-SNAPSHOT"
         samClient = "0.1-9435410-SNAP"
     }
 


### PR DESCRIPTION
I'm tired of seeing the red squiggly lines for datarepo-clienttests in IntelliJ due to outdated models in datarepo-client. 