### PR TITLE
DR-2193 soft delete without scratch file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,6 +283,7 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testCompile group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
+    testCompile 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testCompile "org.springframework.boot:spring-boot-starter-test"
     testCompile 'org.postgresql:postgresql:42.2.8'
     testCompile 'com.google.code.findbugs:annotations:3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,6 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testCompile group: 'org.hamcrest', name: 'hamcrest', version: '2.1'
-    testCompile 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testCompile "org.springframework.boot:spring-boot-starter-test"
     testCompile 'org.postgresql:postgresql:42.2.8'
     testCompile 'com.google.code.findbugs:annotations:3.0.1'

--- a/src/main/java/bio/terra/service/dataset/DataDeletionRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DataDeletionRequestValidator.java
@@ -1,9 +1,11 @@
 package bio.terra.service.dataset;
 
 import bio.terra.model.DataDeletionGcsFileModel;
+import bio.terra.model.DataDeletionJsonArrayModel;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DataDeletionTableModel;
 import bio.terra.service.common.gcs.GcsUriUtils;
+import java.util.List;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
@@ -18,20 +20,81 @@ public class DataDeletionRequestValidator implements Validator {
     return true;
   }
 
-  private void validateFileSpec(DataDeletionTableModel fileSpec, Errors errors) {
-    String tableName = fileSpec.getTableName();
-    if (StringUtils.isEmpty(tableName)) {
-      errors.rejectValue("tables.tableName", "TableNameMissing", "Requires a table name");
-    }
-
-    DataDeletionGcsFileModel gcsFileSpec = fileSpec.getGcsFileSpec();
+  private void validateFileSpec(DataDeletionTableModel table, int index, Errors errors) {
+    DataDeletionGcsFileModel gcsFileSpec = table.getGcsFileSpec();
+    DataDeletionJsonArrayModel jsonArraySpec = table.getJsonArraySpec();
     if (gcsFileSpec == null) {
-      errors.rejectValue("tables.gcsFileSpec", "FileSpecMissing", "Requires a file spec");
+      if (jsonArraySpec != null) {
+        errors.rejectValue(
+            String.format("tables[%d].jsonArraySpec", index),
+            "dataDeletion.specType.mismatch",
+            "JsonArray table specs provided when GcsFileSpec chosen");
+      } else {
+        errors.rejectValue(
+            String.format("tables[%d].gcsFileSpec", index),
+            "dataDeletion.tables.gcsFileSpec.missing",
+            "GcsFileSpec table spec missing when GcsFileSpec chosen");
+      }
     } else {
       try {
-        GcsUriUtils.validateBlobUri(gcsFileSpec.getPath());
+        if (gcsFileSpec.getPath() != null) {
+          GcsUriUtils.validateBlobUri(gcsFileSpec.getPath());
+        }
       } catch (IllegalArgumentException ex) {
-        errors.rejectValue("tables.gcsFileSpec.path", "InvalidGsUri", ex.getMessage());
+        errors.rejectValue(
+            String.format("tables[%d].gcsFileSpec.path", index),
+            "dataDeletion.tables.gcsFileSpec.path.invalid",
+            ex.getMessage());
+      }
+    }
+  }
+
+  private void validateJsonArraySpec(DataDeletionTableModel table, int index, Errors errors) {
+    DataDeletionGcsFileModel gcsFileSpec = table.getGcsFileSpec();
+    DataDeletionJsonArrayModel jsonArraySpec = table.getJsonArraySpec();
+
+    if (jsonArraySpec == null) {
+      if (gcsFileSpec != null) {
+        errors.rejectValue(
+            String.format("tables[%d].gcsFileSpec", index),
+            "dataDeletion.specType.mismatch",
+            "GcsFile table spec provided when JsonArraySpec chosen.");
+      } else {
+        errors.rejectValue(
+            String.format("tables[%d].jsonArraySpec", index),
+            "dataDeletion.tables.jsonArraySpec.missing",
+            "JsonArraySpec table spec missing when JsonArraySpec chosen");
+      }
+    }
+  }
+
+  private void validateDataDeletionRequest(DataDeletionRequest dataDeletionRequest, Errors errors) {
+    DataDeletionRequest.SpecTypeEnum specType = dataDeletionRequest.getSpecType();
+    if (specType == null) {
+      return;
+    }
+
+    List<DataDeletionTableModel> tables = dataDeletionRequest.getTables();
+    // Check the table names
+    for (int i = 0; i < tables.size(); i++) {
+      DataDeletionTableModel table = tables.get(i);
+
+      if (StringUtils.isEmpty(table.getTableName())) {
+        errors.rejectValue(
+            String.format("tables[%d].tableName", i),
+            "dataDeletionRequest.tables.name.empty",
+            "Must provide a table name");
+      }
+
+      switch (dataDeletionRequest.getSpecType()) {
+        case GCSFILE:
+          validateFileSpec(table, i, errors);
+          break;
+        case JSONARRAY:
+          validateJsonArraySpec(table, i, errors);
+          break;
+        default:
+          errors.rejectValue("specType", "specType.invalid", "Invalid spec type provided");
       }
     }
   }
@@ -40,7 +103,7 @@ public class DataDeletionRequestValidator implements Validator {
   public void validate(@NotNull Object target, Errors errors) {
     if (target instanceof DataDeletionRequest) {
       DataDeletionRequest dataDeletionRequest = (DataDeletionRequest) target;
-      dataDeletionRequest.getTables().forEach(table -> validateFileSpec(table, errors));
+      validateDataDeletionRequest(dataDeletionRequest, errors);
     }
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/CreateExternalTablesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/CreateExternalTablesStep.java
@@ -52,6 +52,7 @@ public class CreateExternalTablesStep implements Step {
 
     validateTablesExistInDataset(tables, dataset);
 
+    // At this point, all table models have a GcsFileSpec
     for (DataDeletionTableModel table : tables) {
       String path = table.getGcsFileSpec().getPath();
       // let any exception here trigger an undo, no use trying to continue

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DataDeletionCopyFilesToBigQueryScratchBucketStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DataDeletionCopyFilesToBigQueryScratchBucketStep.java
@@ -43,14 +43,20 @@ public class DataDeletionCopyFilesToBigQueryScratchBucketStep implements Step {
     DataDeletionRequest dataDeletionRequest = getRequest(context);
     GoogleBucketResource bucketResource =
         FlightUtils.getTyped(workingMap, CommonFlightKeys.SCRATCH_BUCKET_INFO);
-    List<DataDeletionTableModel> tables;
-    if (dataDeletionRequest.getSpecType() == DataDeletionRequest.SpecTypeEnum.GCSFILE) {
-      tables = copyGcsFileSpecPaths(context, dataDeletionRequest, projectId, bucketResource);
-    } else {
-      tables = writeJsonArraysToFile(context, dataDeletionRequest, projectId, bucketResource);
-    }
-    workingMap.put(DataDeletionMapKeys.TABLES, tables);
 
+    List<DataDeletionTableModel> tables;
+    switch (dataDeletionRequest.getSpecType()) {
+      case GCSFILE:
+        tables = copyGcsFileSpecPaths(context, dataDeletionRequest, projectId, bucketResource);
+        break;
+      case JSONARRAY:
+        tables = writeJsonArraysToFile(context, dataDeletionRequest, projectId, bucketResource);
+        break;
+      default:
+        throw new IllegalStateException("Unexpected value: " + dataDeletionRequest.getSpecType());
+    }
+
+    workingMap.put(DataDeletionMapKeys.TABLES, tables);
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -197,11 +197,15 @@ public class GcsPdao implements CloudFileReader {
    * @return the Blob of the created file
    */
   public Blob createGcsFile(String path, String projectId) {
-    Storage storage = gcsProjectFactory.getStorage(projectId);
-    logger.info("Creating GCS file at {}", path);
     BlobId locator = GcsUriUtils.parseBlobUri(path);
+    return createGcsFile(locator, projectId);
+  }
+
+  public Blob createGcsFile(BlobId blobId, String projectId) {
+    Storage storage = gcsProjectFactory.getStorage(projectId);
+    logger.info("Creating GCS file at {}", blobId.getName());
     return storage.create(
-        BlobInfo.newBuilder(locator).build(), Storage.BlobTargetOption.userProject(projectId));
+        BlobInfo.newBuilder(blobId).build(), Storage.BlobTargetOption.userProject(projectId));
   }
 
   /**

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3950,6 +3950,7 @@ components:
           type: string
           enum:
             - gcsFile
+            - jsonArray
         tables:
           type: array
           items:
@@ -3966,6 +3967,8 @@ components:
           description: the name of a table in the dataset
         gcsFileSpec:
           $ref: '#/components/schemas/DataDeletionGcsFileModel'
+        jsonArraySpec:
+          $ref: '#/components/schemas/DataDeletionJsonArrayModel'
       description: >
         a specification for how to delete tabular data in one table
     DataDeletionGcsFileModel:
@@ -3983,6 +3986,18 @@ components:
           description: a gs://path/to/a/file that can include a wildcard (*)
       description: >
         a specification of a gcs file containing row ids to delete
+    DataDeletionJsonArrayModel:
+      required:
+        - rowIds
+      type: object
+      properties:
+        rowIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+      description: >
+        a specification of row ids to delete
     UserStatusInfo:
       required:
         - enabled

--- a/src/test/java/bio/terra/common/VariableArgumentsProvider.java
+++ b/src/test/java/bio/terra/common/VariableArgumentsProvider.java
@@ -1,0 +1,46 @@
+package bio.terra.common;
+
+import java.lang.reflect.Field;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+
+class VariableArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<VariableSource> {
+
+  private String variableName;
+
+  @Override
+  public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+    return context
+        .getTestClass()
+        .map(this::getField)
+        .map(this::getValue)
+        .orElseThrow(() -> new IllegalArgumentException("Failed to load test arguments"));
+  }
+
+  @Override
+  public void accept(VariableSource variableSource) {
+    variableName = variableSource.value();
+  }
+
+  private Field getField(Class<?> clazz) {
+    try {
+      return clazz.getDeclaredField(variableName);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Stream<Arguments> getValue(Field field) {
+    Object value = null;
+    try {
+      value = field.get(null);
+    } catch (Exception ignored) {
+    }
+
+    return value == null ? null : (Stream<Arguments>) value;
+  }
+}

--- a/src/test/java/bio/terra/common/VariableSource.java
+++ b/src/test/java/bio/terra/common/VariableSource.java
@@ -1,0 +1,18 @@
+package bio.terra.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ArgumentsSource(VariableArgumentsProvider.class)
+public @interface VariableSource {
+
+  /** The name of the static variable */
+  String value();
+}

--- a/src/test/java/bio/terra/service/dataset/DataDeletionRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DataDeletionRequestValidatorTest.java
@@ -1,0 +1,205 @@
+package bio.terra.service.dataset;
+
+import static bio.terra.model.DataDeletionRequest.SpecTypeEnum.GCSFILE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.common.TestUtils;
+import bio.terra.common.category.Unit;
+import bio.terra.model.DataDeletionGcsFileModel;
+import bio.terra.model.DataDeletionJsonArrayModel;
+import bio.terra.model.DataDeletionRequest;
+import bio.terra.model.DataDeletionTableModel;
+import bio.terra.model.ErrorModel;
+import bio.terra.model.JobModel;
+import bio.terra.service.job.JobService;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+@AutoConfigureMockMvc
+public class DataDeletionRequestValidatorTest {
+
+  @Autowired private MockMvc mvc;
+  @MockBean private DatasetService datasetService;
+  @MockBean private JobService jobService;
+
+  private DataDeletionRequest goodGcsRequest;
+  private DataDeletionRequest goodJsonArrayRequest;
+
+  @Before
+  public void setup() throws Exception {
+    when(datasetService.deleteTabularData(any(), any(), any())).thenReturn("mock-job-id");
+    when(jobService.retrieveJob(any(), any()))
+        .thenReturn(new JobModel().id("mock-job-id").jobStatus(JobModel.JobStatusEnum.RUNNING));
+    goodGcsRequest =
+        new DataDeletionRequest()
+            .specType(GCSFILE)
+            .deleteType(DataDeletionRequest.DeleteTypeEnum.SOFT)
+            .tables(
+                List.of(
+                    new DataDeletionTableModel()
+                        .tableName("my-gcs-table")
+                        .gcsFileSpec(
+                            new DataDeletionGcsFileModel()
+                                .path("gs://my-bucket/my-folder/my-file.json")
+                                .fileType(DataDeletionGcsFileModel.FileTypeEnum.CSV))));
+
+    goodJsonArrayRequest =
+        new DataDeletionRequest()
+            .specType(DataDeletionRequest.SpecTypeEnum.JSONARRAY)
+            .deleteType(DataDeletionRequest.DeleteTypeEnum.SOFT)
+            .tables(
+                List.of(
+                    new DataDeletionTableModel()
+                        .tableName("my-json-table")
+                        .jsonArraySpec(
+                            new DataDeletionJsonArrayModel().rowIds(List.of(UUID.randomUUID())))));
+  }
+
+  @Test
+  public void goodGcsFileSpecTest() throws Exception {
+    mvc.perform(
+            post("/api/repository/v1/datasets/{id}/deletes", UUID.randomUUID())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(goodGcsRequest)))
+        .andExpect(status().is2xxSuccessful())
+        .andReturn();
+  }
+
+  public void goodJsonArraySpecTest() throws Exception {
+    mvc.perform(
+            post("/api/repository/v1/datasets/{id}/deletes", UUID.randomUUID())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(goodJsonArrayRequest)))
+        .andExpect(status().is2xxSuccessful())
+        .andReturn();
+  }
+
+  @Test
+  public void badGcsFileSpecTest() throws Exception {
+    DataDeletionRequest badGcsRequest =
+        goodGcsRequest.tables(
+            List.of(
+                new DataDeletionTableModel()
+                    .tableName("badPathTable")
+                    .gcsFileSpec(
+                        new DataDeletionGcsFileModel()
+                            .fileType(DataDeletionGcsFileModel.FileTypeEnum.CSV)
+                            .path("invalidpath")),
+                new DataDeletionTableModel()
+                    .tableName("")
+                    .gcsFileSpec(new DataDeletionGcsFileModel().fileType(null).path(null)),
+                new DataDeletionTableModel()
+                    .tableName("invalidSpecTable")
+                    .jsonArraySpec(
+                        new DataDeletionJsonArrayModel().rowIds(List.of(UUID.randomUUID()))),
+                new DataDeletionTableModel().tableName("noSpecTable")));
+    MvcResult result =
+        mvc.perform(
+                post("/api/repository/v1/datasets/{id}/deletes", UUID.randomUUID())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(badGcsRequest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+    var response = result.getResponse();
+
+    ErrorModel errorModel = TestUtils.mapFromJson(response.getContentAsString(), ErrorModel.class);
+
+    Set<String> expectedErrors =
+        Set.of(
+            "tables[0].gcsFileSpec.path: 'dataDeletion.tables.gcsFileSpec.path.invalid'",
+            "tables[1].tableName: 'dataDeletionRequest.tables.name.empty'",
+            "tables[1].gcsFileSpec.path: 'NotNull'",
+            "tables[1].gcsFileSpec.fileType: 'NotNull'",
+            "tables[2].jsonArraySpec: 'dataDeletion.specType.mismatch'",
+            "tables[3].gcsFileSpec: 'dataDeletion.tables.gcsFileSpec.missing'");
+
+    assertThat(
+        "The invalid GcsFileSpec request has the right errors",
+        getErrors(errorModel),
+        equalTo(expectedErrors));
+  }
+
+  @Test
+  public void badJsonArraySpecTest() throws Exception {
+    DataDeletionRequest badJsonRequest =
+        goodJsonArrayRequest.tables(
+            List.of(
+                new DataDeletionTableModel()
+                    .tableName("badPathTable")
+                    .jsonArraySpec(new DataDeletionJsonArrayModel().rowIds(null)),
+                new DataDeletionTableModel()
+                    .tableName("invalidSpecTable")
+                    .gcsFileSpec(
+                        new DataDeletionGcsFileModel()
+                            .path("gs://not/the/right/spec.csv")
+                            .fileType(DataDeletionGcsFileModel.FileTypeEnum.CSV)),
+                new DataDeletionTableModel().tableName("noSpecTable")));
+    MvcResult result =
+        mvc.perform(
+                post("/api/repository/v1/datasets/{id}/deletes", UUID.randomUUID())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(badJsonRequest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+    var response = result.getResponse();
+
+    ErrorModel errorModel = TestUtils.mapFromJson(response.getContentAsString(), ErrorModel.class);
+    Set<String> expectedErrors =
+        Set.of(
+            "tables[0].jsonArraySpec.rowIds: 'NotNull'",
+            "tables[1].gcsFileSpec: 'dataDeletion.specType.mismatch'",
+            "tables[2].jsonArraySpec: 'dataDeletion.tables.jsonArraySpec.missing'");
+    assertThat(
+        "The invalid GcsFileSpec request has the right errors",
+        getErrors(errorModel),
+        equalTo(expectedErrors));
+  }
+
+  @Test
+  public void testBadRequest() throws Exception {
+    DataDeletionRequest badRequest = new DataDeletionRequest().addTablesItem(null);
+    MvcResult result =
+        mvc.perform(
+                post("/api/repository/v1/datasets/{id}/deletes", UUID.randomUUID())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(badRequest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+    var response = result.getResponse();
+
+    ErrorModel errorModel = TestUtils.mapFromJson(response.getContentAsString(), ErrorModel.class);
+    Set<String> expectedErrors = Set.of("specType: 'NotNull'", "deleteType: 'NotNull'");
+    assertThat(
+        "The invalid request has the right errors", getErrors(errorModel), equalTo(expectedErrors));
+  }
+
+  private Set<String> getErrors(ErrorModel errorModel) {
+    return errorModel.getErrorDetail().stream()
+        .map(d -> d.replaceAll("\\(.*\\)", "").trim())
+        .collect(Collectors.toSet());
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -21,6 +21,7 @@ import bio.terra.integration.UsersBase;
 import bio.terra.model.AssetModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.DataDeletionGcsFileModel;
+import bio.terra.model.DataDeletionJsonArrayModel;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DataDeletionTableModel;
 import bio.terra.model.DatasetModel;
@@ -330,6 +331,12 @@ public class DatasetIntegrationTest extends UsersBase {
             .fileType(DataDeletionGcsFileModel.FileTypeEnum.CSV)
             .path(path);
     return new DataDeletionTableModel().tableName(tableName).gcsFileSpec(deletionGcsFileModel);
+  }
+
+  static DataDeletionTableModel deletionTableJson(String tableName, List<UUID> rowIds) {
+    DataDeletionJsonArrayModel deletionJsonArrayModel =
+        new DataDeletionJsonArrayModel().rowIds(rowIds);
+    return new DataDeletionTableModel().tableName(tableName).jsonArraySpec(deletionJsonArrayModel);
   }
 
   static DataDeletionRequest dataDeletionRequest() {


### PR DESCRIPTION
Adding the ability to provide a List of UUIDs to the data deletion endpoint. This enables users to simply send a request to TDR for soft-deletes, instead of needing to stage a file with the rowIds to be deleted.