### PR TITLE
[DR-2219] Create the billing profile id by default

### DIFF
--- a/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
+++ b/src/main/java/bio/terra/service/profile/ProfileRequestValidator.java
@@ -27,9 +27,6 @@ public class ProfileRequestValidator implements Validator {
   public void validate(@NotNull Object target, Errors errors) {
     if (target != null && target instanceof BillingProfileRequestModel) {
       BillingProfileRequestModel billingProfileRequestModel = (BillingProfileRequestModel) target;
-      if (billingProfileRequestModel.getId() == null) {
-        errors.rejectValue("id", "The billing profile id must be specified");
-      }
       isValidCloudPlatform(billingProfileRequestModel, errors);
     }
   }

--- a/src/main/java/bio/terra/service/profile/flight/create/GetOrCreateProfileIdStep.java
+++ b/src/main/java/bio/terra/service/profile/flight/create/GetOrCreateProfileIdStep.java
@@ -1,0 +1,29 @@
+package bio.terra.service.profile.flight.create;
+
+import bio.terra.model.BillingProfileRequestModel;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import java.util.UUID;
+
+public class GetOrCreateProfileIdStep implements Step {
+  private final BillingProfileRequestModel request;
+
+  public GetOrCreateProfileIdStep(BillingProfileRequestModel request) {
+    this.request = request;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    UUID profileId = request.getId();
+    if (profileId == null) {
+      request.setId(UUID.randomUUID());
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/profile/flight/create/ProfileCreateFlight.java
+++ b/src/main/java/bio/terra/service/profile/flight/create/ProfileCreateFlight.java
@@ -25,6 +25,7 @@ public class ProfileCreateFlight extends Flight {
 
     CloudPlatformWrapper platform = CloudPlatformWrapper.of(request.getCloudPlatform());
 
+    addStep(new GetOrCreateProfileIdStep(request));
     addStep(new CreateProfileMetadataStep(profileService, request, user));
     if (platform.isGcp()) {
       addStep(new CreateProfileVerifyAccountStep(profileService, request, user));

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2730,7 +2730,6 @@ components:
     BillingProfileRequestModel:
       required:
         - biller
-        - id
         - profileName
       type: object
       properties:

--- a/src/test/java/bio/terra/flight/ProfileCreateFlightTest.java
+++ b/src/test/java/bio/terra/flight/ProfileCreateFlightTest.java
@@ -44,6 +44,7 @@ public class ProfileCreateFlightTest {
         steps,
         is(
             List.of(
+                "GetOrCreateProfileIdStep",
                 "CreateProfileMetadataStep",
                 "CreateProfileVerifyDeployedApplicationStep",
                 "CreateProfileAuthzIamStep")));
@@ -59,17 +60,17 @@ public class ProfileCreateFlightTest {
 
     var flight = new ProfileCreateFlight(inputParameters, context);
 
-    var packageName = "bio.terra.service.profile.flight.create";
     var steps =
         flight.getSteps().stream()
-            .map(step -> step.getClass().getName())
+            .map(step -> step.getClass().getSimpleName())
             .collect(Collectors.toList());
     assertThat(
         steps,
         is(
             List.of(
-                packageName + ".CreateProfileMetadataStep",
-                packageName + ".CreateProfileVerifyAccountStep",
-                packageName + ".CreateProfileAuthzIamStep")));
+                "GetOrCreateProfileIdStep",
+                "CreateProfileMetadataStep",
+                "CreateProfileVerifyAccountStep",
+                "CreateProfileAuthzIamStep")));
   }
 }


### PR DESCRIPTION
When a user creates a billing profile via the API, the id field is now optional. If it is not specified in the request, we will generate the uuid.