### PR TITLE
DR-2329 Log Json POST body, but only in StackDriver

### DIFF
--- a/src/main/java/bio/terra/app/logging/LoggerInterceptor.java
+++ b/src/main/java/bio/terra/app/logging/LoggerInterceptor.java
@@ -7,7 +7,6 @@ import com.google.gson.Gson;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/bio/terra/app/logging/LoggerInterceptor.java
+++ b/src/main/java/bio/terra/app/logging/LoggerInterceptor.java
@@ -100,8 +100,11 @@ public class LoggerInterceptor implements HandlerInterceptor {
       }
       // The warning here can be ignored, as StackDriver logging will interpret the extra arg
       // and insert it into the `jsonPayload`. It is ignored when running locally.
-      // This copies the Terra Commons logging.
+      // This copies the Terra Commons logging, which relies on the GoogleJsonLayout.
       // See bio.terra.common.logging.RequestLoggingFilter.doFilter:92 for another example.
+      // Also see
+      // https://github.com/DataBiosphere/terra-common-lib/blob/develop/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java
+      // for the layout implementation.
       logger.info(
           "userId: {}, email: {}, institute: {}, url: {}, method: {}, params: {}, status: {}, duration: {}",
           userId,


### PR DESCRIPTION
We log GET request params in our logs, but not POST bodies. This makes it hard to help users when things go wrong, often requiring them to send us their requests over Slack. If they've lost the request, we can sometimes get it from the Stairway database, but if not, we're out of luck.

Json POST bodies can get pretty noisy, so we should make sure they're added to the StackDriver jsonPayload only. Adding them locally would probably slow down connected tests and make our local deployments pretty chatty. 

There may be some security concerns about this logging, especially if POST bodies might contain PHI. We should talk about this in 2022 before merging this.