### PR TITLE
DR-2335 Return bulk load result when max failed loads exceeded

### DIFF
--- a/src/main/java/bio/terra/service/common/gcs/CommonFlightKeys.java
+++ b/src/main/java/bio/terra/service/common/gcs/CommonFlightKeys.java
@@ -3,4 +3,5 @@ package bio.terra.service.common.gcs;
 public class CommonFlightKeys {
 
   public static final String SCRATCH_BUCKET_INFO = "scratchFileBucketInfo";
+  public static final String FLIGHT_HAS_WARNINGS = "flightHasWarnings";
 }

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -151,7 +151,6 @@ public class JobService {
 
   public static class JobResultWithStatus<T> {
     private T result;
-    private JobModel.JobStatusEnum jobStatus;
     private HttpStatus statusCode;
 
     public T getResult() {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3874,6 +3874,7 @@ components:
             - running
             - succeeded
             - failed
+            - succeeded_with_warnings
         status_code:
           type: integer
           description: HTTP code

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -244,8 +244,7 @@ public class DataRepoClient {
     URI uri = response.getHeaders().getLocation();
     drResponse.setLocationHeader((uri == null) ? Optional.empty() : Optional.of(uri.toString()));
 
-    if (response.getStatusCode().is2xxSuccessful()
-        || response.getStatusCode().equals(HttpStatus.UNPROCESSABLE_ENTITY)) {
+    if (response.getStatusCode().is2xxSuccessful()) {
       if (responseClass != null) {
         T responseObject = mapFromJson(response.getBody(), responseClass);
         drResponse.setResponseObject(Optional.of(responseObject));

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -244,7 +244,8 @@ public class DataRepoClient {
     URI uri = response.getHeaders().getLocation();
     drResponse.setLocationHeader((uri == null) ? Optional.empty() : Optional.of(uri.toString()));
 
-    if (response.getStatusCode().is2xxSuccessful()) {
+    if (response.getStatusCode().is2xxSuccessful()
+        || response.getStatusCode().equals(HttpStatus.UNPROCESSABLE_ENTITY)) {
       if (responseClass != null) {
         T responseObject = mapFromJson(response.getBody(), responseClass);
         drResponse.setResponseObject(Optional.of(responseObject));

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
@@ -101,7 +101,7 @@ public class IngestDriverStepTest extends TestCase {
     // Don't allow any file load errors.
     StepResult stepResult = runTest(0);
 
-    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, stepResult.getStepStatus());
+    assertEquals(StepStatus.STEP_RESULT_SUCCESS, stepResult.getStepStatus());
 
     // Verify that the step never started the candidate file.
     verify(loadService, never()).setLoadFileRunning(loadUuid, null, null);


### PR DESCRIPTION
We actually need to keep processing even if the max failed file loads is exceeded. I've added a `succeeded_with_warnings` Job Status that gets returned if this happens.