### PR TITLE
DR-2335 Allow flights to throw exceptions without failing the flight

### DIFF
--- a/src/main/java/bio/terra/service/common/CommonMapKeys.java
+++ b/src/main/java/bio/terra/service/common/CommonMapKeys.java
@@ -11,4 +11,7 @@ public final class CommonMapKeys {
       PREFIX + "datasetStorageAccountResource";
   public static final String SNAPSHOT_STORAGE_ACCOUNT_RESOURCE =
       PREFIX + "snapshotStorageAccountResource";
+
+  public static final String COMPLETION_TO_FAILURE_EXCEPTION =
+      PREFIX + "completionToFailureException";
 }

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
@@ -101,7 +101,7 @@ public class IngestDriverStepTest extends TestCase {
     // Don't allow any file load errors.
     StepResult stepResult = runTest(0);
 
-    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, stepResult.getStepStatus());
+    assertEquals(StepStatus.STEP_RESULT_SUCCESS, stepResult.getStepStatus());
 
     // Verify that the step never started the candidate file.
     verify(loadService, never()).setLoadFileRunning(loadUuid, null, null);


### PR DESCRIPTION
Specifically, the bulk ingest flights need to be able to process the successful files after `maxBadRecords` is reached, but still return a failure at the end of the flight. This is done here by using `JobService` as a translation layer between the flight state and job result. Stairway will still think the flight was successful, but the sentinel `COMPLETION_TO_FAILURE_EXCEPTION` is used to tell `JobService` that the user should be given a failure with the stored exception.

This should probably be a first-class feature of Stairway, but this workaround will suffice in the meantime.