### PR TITLE
DR-2371 Run file checks in batches of parallel threads

### DIFF
--- a/src/main/java/bio/terra/common/ErrorCollector.java
+++ b/src/main/java/bio/terra/common/ErrorCollector.java
@@ -20,14 +20,16 @@ public class ErrorCollector {
   }
 
   public void record(String lineErrorMsgFormat, Object... lineErrorMsgArgs) {
-    if (errors.size() < maxErrorsReported) {
-      errors.add(String.format(lineErrorMsgFormat, lineErrorMsgArgs));
-    } else if (errors.size() == maxErrorsReported) {
-      errors.add(
-          "Error details truncated. [MaxBadLoadFileLineErrorsReported = "
-              + maxErrorsReported
-              + "]");
-      throw getFormattedException();
+    synchronized (errors) {
+      if (errors.size() < maxErrorsReported) {
+        errors.add(String.format(lineErrorMsgFormat, lineErrorMsgArgs));
+      } else if (errors.size() == maxErrorsReported) {
+        errors.add(
+            "Error details truncated. [MaxBadLoadFileLineErrorsReported = "
+                + maxErrorsReported
+                + "]");
+        throw getFormattedException();
+      }
     }
   }
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -37,6 +37,7 @@ import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.RetryRuleExponentialBackoff;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import org.springframework.context.ApplicationContext;
 
 /*
@@ -72,6 +73,7 @@ public class FileIngestBulkFlight extends Flight {
     GoogleBillingService googleBillingService = appContext.getBean(GoogleBillingService.class);
     StorageTableService storageTableService = appContext.getBean(StorageTableService.class);
     AzureBlobStorePdao azureBlobStorePdao = appContext.getBean(AzureBlobStorePdao.class);
+    ExecutorService executor = appContext.getBean("performanceThreadpool", ExecutorService.class);
     ObjectMapper bulkLoadObjectMapper = appConfig.bulkLoadObjectMapper();
 
     // Common input parameters
@@ -175,6 +177,7 @@ public class FileIngestBulkFlight extends Flight {
                 appConfig.getLoadFilePopulateBatchSize(),
                 gcsPdao,
                 bulkLoadObjectMapper,
+                executor,
                 userReq));
       } else {
         addStep(
@@ -184,6 +187,7 @@ public class FileIngestBulkFlight extends Flight {
                 appConfig.getLoadFilePopulateBatchSize(),
                 azureBlobStorePdao,
                 bulkLoadObjectMapper,
+                executor,
                 userReq));
       }
     }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileAzureStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileAzureStep.java
@@ -16,6 +16,7 @@ import bio.terra.stairway.StepResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 // Populate the files to be loaded from the incoming array
 public class IngestPopulateFileStateFromFileAzureStep extends IngestPopulateFileStateFromFileStep {
@@ -28,6 +29,7 @@ public class IngestPopulateFileStateFromFileAzureStep extends IngestPopulateFile
       int batchSize,
       AzureBlobStorePdao azureBlobStorePdao,
       ObjectMapper bulkLoadObjectMapper,
+      ExecutorService executor,
       AuthenticatedUserRequest userRequest) {
     super(
         loadService,
@@ -35,6 +37,7 @@ public class IngestPopulateFileStateFromFileAzureStep extends IngestPopulateFile
         batchSize,
         bulkLoadObjectMapper,
         azureBlobStorePdao,
+        executor,
         userRequest);
     this.azureBlobStorePdao = azureBlobStorePdao;
     this.userRequest = userRequest;

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileGcpStep.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.storage.Storage;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 // Populate the files to be loaded from the incoming array
 public class IngestPopulateFileStateFromFileGcpStep extends IngestPopulateFileStateFromFileStep {
@@ -28,8 +29,10 @@ public class IngestPopulateFileStateFromFileGcpStep extends IngestPopulateFileSt
       int batchSize,
       GcsPdao gcsPdao,
       ObjectMapper bulkLoadObjectMapper,
+      ExecutorService executor,
       AuthenticatedUserRequest userRequest) {
-    super(loadService, maxBadLines, batchSize, bulkLoadObjectMapper, gcsPdao, userRequest);
+    super(
+        loadService, maxBadLines, batchSize, bulkLoadObjectMapper, gcsPdao, executor, userRequest);
     this.gcsPdao = gcsPdao;
   }
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileStep.java
@@ -1,6 +1,7 @@
 package bio.terra.service.filedata.flight.ingest;
 
 import bio.terra.common.ErrorCollector;
+import bio.terra.common.FutureUtils;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BulkLoadFileModel;
@@ -18,7 +19,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 public abstract class IngestPopulateFileStateFromFileStep implements Step {
   private final LoadService loadService;
@@ -26,6 +32,7 @@ public abstract class IngestPopulateFileStateFromFileStep implements Step {
   private final int batchSize;
   private final ObjectMapper bulkLoadObjectMapper;
   private final CloudFileReader cloudFileReader;
+  private final ExecutorService executor;
   private final AuthenticatedUserRequest userRequest;
 
   public IngestPopulateFileStateFromFileStep(
@@ -34,12 +41,14 @@ public abstract class IngestPopulateFileStateFromFileStep implements Step {
       int batchSize,
       ObjectMapper bulkLoadObjectMapper,
       CloudFileReader cloudFileReader,
+      ExecutorService executor,
       AuthenticatedUserRequest userRequest) {
     this.loadService = loadService;
     this.maxBadLoadFileLineErrorsReported = maxBadLoadFileLineErrorsReported;
     this.batchSize = batchSize;
     this.bulkLoadObjectMapper = bulkLoadObjectMapper;
     this.cloudFileReader = cloudFileReader;
+    this.executor = executor;
     this.userRequest = userRequest;
   }
 
@@ -51,26 +60,40 @@ public abstract class IngestPopulateFileStateFromFileStep implements Step {
         new ErrorCollector(
             maxBadLoadFileLineErrorsReported,
             "Invalid lines in the control file. [All lines in control file must be valid in order to proceed - 'maxFailedFileLoads' not applicable here.]");
-    long lineCount = 0;
-    List<BulkLoadFileModel> fileList = new ArrayList<>();
+    List<Future<BulkLoadFileModel>> futures = new ArrayList<>();
 
+    // Value used in a lambda so needs to be effectively final
+    final AtomicLong lineCount = new AtomicLong(0);
     String line;
     while ((line = reader.readLine()) != null) {
-      lineCount++;
+      final String lineCopy = line;
+      lineCount.incrementAndGet();
 
-      try {
-        BulkLoadFileModel loadFile = bulkLoadObjectMapper.readValue(line, BulkLoadFileModel.class);
-        IngestUtils.validateBulkLoadFileModel(loadFile);
-        cloudFileReader.validateUserCanRead(List.of(loadFile.getSourcePath()), userRequest);
-        fileList.add(loadFile);
-      } catch (IOException | BlobAccessNotAuthorizedException | BadRequestException ex) {
-        errorCollector.record("Error at line %d: %s", lineCount, ex.getMessage());
-      }
+      // Run batches in parallel
+      futures.add(
+          executor.submit(
+              () -> {
+                try {
+                  BulkLoadFileModel loadFile =
+                      bulkLoadObjectMapper.readValue(lineCopy, BulkLoadFileModel.class);
+                  IngestUtils.validateBulkLoadFileModel(loadFile);
+                  cloudFileReader.validateUserCanRead(
+                      List.of(loadFile.getSourcePath()), userRequest);
+                  return loadFile;
+                } catch (IOException | BlobAccessNotAuthorizedException | BadRequestException ex) {
+                  errorCollector.record("Error at line %d: %s", lineCount.get(), ex.getMessage());
+                  return null;
+                }
+              }));
 
       // Keep this check and load out of the inner try; it should only catch objectMapper failures
-      if (fileList.size() > batchSize) {
+      if (futures.size() > batchSize) {
+        List<BulkLoadFileModel> fileList =
+            FutureUtils.waitFor(futures).stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
         loadService.populateFiles(loadId, fileList);
-        fileList.clear();
+        futures.clear();
       }
     }
 
@@ -79,7 +102,11 @@ public abstract class IngestPopulateFileStateFromFileStep implements Step {
       throw errorCollector.getFormattedException();
     }
 
-    if (fileList.size() > 0) {
+    if (futures.size() > 0) {
+      List<BulkLoadFileModel> fileList =
+          FutureUtils.waitFor(futures).stream()
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
       loadService.populateFiles(loadId, fileList);
     }
   }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileStep.java
@@ -97,17 +97,17 @@ public abstract class IngestPopulateFileStateFromFileStep implements Step {
       }
     }
 
-    // If there are errors in the load file, don't do the load
-    if (errorCollector.anyErrorsCollected()) {
-      throw errorCollector.getFormattedException();
-    }
-
     if (futures.size() > 0) {
       List<BulkLoadFileModel> fileList =
           FutureUtils.waitFor(futures).stream()
               .filter(Objects::nonNull)
               .collect(Collectors.toList());
       loadService.populateFiles(loadId, fileList);
+    }
+
+    // If there are errors in the load file, don't do the load
+    if (errorCollector.anyErrorsCollected()) {
+      throw errorCollector.getFormattedException();
     }
   }
 


### PR DESCRIPTION
This is a mitigation against tokens out of time during very large file loads.

Testing locally with ~2K files ingesting, I saw the step that checks permissions go from 120 seconds down to 45 seconds so that's not bad.  I'm unsure if this will be enough but it should make it less likely to run into the issue