### PR TITLE
DR-2373 Make the directory calculation step retry for up to 30 minutes

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreComputeStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreComputeStep.java
@@ -1,12 +1,14 @@
 package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.model.SnapshotRequestModel;
+import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
 
 public class CreateSnapshotFireStoreComputeStep implements Step {
 
@@ -24,7 +26,11 @@ public class CreateSnapshotFireStoreComputeStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Snapshot snapshot = snapshotService.retrieveByName(snapshotReq.getName());
-    fileDao.snapshotCompute(snapshot);
+    try {
+      fileDao.snapshotCompute(snapshot);
+    } catch (FileSystemAbortTransactionException rex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+    }
     return StepResult.getStepResultSuccess();
   }
 


### PR DESCRIPTION
This will make the step that calculates size/MD5 hashes aggregation for files on snapshot creation retry.  There's a better way to do this longer term probably but this will unblock HCA work for now