### PR TITLE
DR-2006 Job result endpoint returns an empty 202 when the job is still running

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2149,6 +2149,10 @@ paths:
             application/json:
               schema:
                 type: object
+        202:
+          description: The job is currently running
+          content:
+            application/json: {}
   /api/repository/v1/configs/{name}:
     get:
       tags:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2152,7 +2152,9 @@ paths:
         202:
           description: The job is currently running
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: object
   /api/repository/v1/configs/{name}:
     get:
       tags:


### PR DESCRIPTION
Like it says on the tin. Stop throwing a 500 when attempting to retrieve results from a running job