### PR TITLE
DR-2386 Default to non-empty load tag if none provided

### DIFF
--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -132,7 +132,7 @@ public class FileService {
 
   public String ingestBulkFileArray(
       String datasetId, BulkLoadArrayRequestModel loadArray, AuthenticatedUserRequest userReq) {
-    String loadTag = loadService.computeLoadTag(loadArray.getLoadTag());;
+    String loadTag = loadService.computeLoadTag(loadArray.getLoadTag());
     loadArray.setLoadTag(loadTag);
     String description =
         "Bulk ingest from array of "

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -105,7 +105,7 @@ public class FileService {
 
   public String ingestBulkFile(
       String datasetId, BulkLoadRequestModel loadModel, AuthenticatedUserRequest userReq) {
-    String loadTag = loadModel.getLoadTag();
+    String loadTag = loadService.computeLoadTag(loadModel.getLoadTag());
     loadModel.setLoadTag(loadTag);
     String description =
         "Bulk ingest from control file: "
@@ -132,7 +132,7 @@ public class FileService {
 
   public String ingestBulkFileArray(
       String datasetId, BulkLoadArrayRequestModel loadArray, AuthenticatedUserRequest userReq) {
-    String loadTag = loadArray.getLoadTag();
+    String loadTag = loadService.computeLoadTag(loadArray.getLoadTag());;
     loadArray.setLoadTag(loadTag);
     String description =
         "Bulk ingest from array of "


### PR DESCRIPTION
Load tags for bulk load operations will now default to a non-empty load tag if one is not provided.