### PR TITLE
DR-1905 Ensure users are not given blank error messages

### DIFF
--- a/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
+++ b/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
@@ -6,6 +6,7 @@ import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.iam.exception.IamUnauthorizedException;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -48,7 +49,8 @@ public class ValidateBucketAccessStep implements Step {
       throw new IllegalArgumentException("Invalid request type");
     }
     gcsPdao.validateUserCanRead(sourcePath, userRequest);
-    return StepResult.getStepResultSuccess();
+    throw new IamUnauthorizedException("This message thrown from the step.");
+    //    return StepResult.getStepResultSuccess();
   }
 
   @Override

--- a/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
+++ b/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
@@ -6,7 +6,6 @@ import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
-import bio.terra.service.iam.exception.IamUnauthorizedException;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -49,8 +48,7 @@ public class ValidateBucketAccessStep implements Step {
       throw new IllegalArgumentException("Invalid request type");
     }
     gcsPdao.validateUserCanRead(sourcePath, userRequest);
-    throw new IamUnauthorizedException("This message thrown from the step.");
-    //    return StepResult.getStepResultSuccess();
+    return StepResult.getStepResultSuccess();
   }
 
   @Override

--- a/src/main/java/bio/terra/common/exception/PdaoException.java
+++ b/src/main/java/bio/terra/common/exception/PdaoException.java
@@ -1,5 +1,7 @@
 package bio.terra.common.exception;
 
+import java.util.List;
+
 public class PdaoException extends InternalServerErrorException {
   public PdaoException(String message) {
     super(message);
@@ -11,5 +13,9 @@ public class PdaoException extends InternalServerErrorException {
 
   public PdaoException(Throwable cause) {
     super(cause);
+  }
+
+  public PdaoException(String message, List<String> causes) {
+    super(message, causes);
   }
 }

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -24,6 +24,7 @@ import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.filedata.google.firestore.FireStoreFile;
 import bio.terra.service.iam.IamProviderInterface;
 import bio.terra.service.iam.IamRole;
+import bio.terra.service.iam.exception.IamUnauthorizedException;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.exception.GoogleResourceException;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
@@ -232,6 +233,13 @@ public class GcsPdao implements CloudFileReader {
                 return iamClient.getPetToken(user, GCS_VERIFICATION_SCOPES);
               } catch (InterruptedException e) {
                 throw new PdaoException("Error obtaining a pet service account token");
+              } catch (IamUnauthorizedException e) {
+                throw new PdaoException(
+                    "Could not get pet service account token while validating user can read paths",
+                    List.of(
+                        "If this error occurs as part of a very large ingest job, "
+                            + "the user request token may have timed out. "
+                            + "Try splitting very large ingests into multiple, smaller ingests."));
               }
             });
 

--- a/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
@@ -63,14 +63,11 @@ public class StairwayExceptionFieldsFactory {
   }
 
   private static List<String> getJobExceptionDetails(Exception exception) {
-    if (ErrorReportException.class.isAssignableFrom(exception.getClass())) {
-      ErrorReportException errorReportException = (ErrorReportException) exception;
-      return errorReportException.getCauses();
+    List<String> errorReportCauses = getErrorReportExceptionCauses(exception);
+    if (errorReportCauses != null) {
+      return errorReportCauses;
     }
-    List<String> details = new ArrayList<>();
-    details.add("The job failed, but not while running a step");
-    details.add(CONTACT_TEAM_MESSAGE);
-    return details;
+    return List.of("The job failed, but not while running a step", CONTACT_TEAM_MESSAGE);
   }
 
   private static String getStepExceptionMessage(String stepName, Exception exception) {
@@ -82,13 +79,21 @@ public class StairwayExceptionFieldsFactory {
   }
 
   private static List<String> getStepExceptionDetails(Exception exception) {
-    if (ErrorReportException.class.isAssignableFrom(exception.getClass())) {
-      ErrorReportException errorReportException = (ErrorReportException) exception;
-      return errorReportException.getCauses();
+    List<String> errorReportCauses = getErrorReportExceptionCauses(exception);
+    if (errorReportCauses != null) {
+      return errorReportCauses;
     }
-    List<String> details = new ArrayList<>();
-    details.add("The step failed for an unknown reason.");
-    details.add(CONTACT_TEAM_MESSAGE);
-    return details;
+    return List.of("The step failed for an unknown reason.", CONTACT_TEAM_MESSAGE);
+  }
+
+  private static List<String> getErrorReportExceptionCauses(Exception exception) {
+    if (ErrorReportException.class.isAssignableFrom(exception.getClass())) {
+      // Java 17 will make casting unnecessary
+      ErrorReportException errorReportException = (ErrorReportException) exception;
+      if (!errorReportException.getCauses().isEmpty()) {
+        return errorReportException.getCauses();
+      }
+    }
+    return null;
   }
 }

--- a/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
@@ -1,0 +1,96 @@
+package bio.terra.service.job;
+
+import bio.terra.common.exception.ErrorReportException;
+import bio.terra.service.job.exception.ExceptionSerializerException;
+import bio.terra.service.job.exception.JobExecutionException;
+import bio.terra.service.job.exception.StepExecutionException;
+import bio.terra.stairway.Step;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+
+public class StairwayExceptionFieldsFactory {
+
+  private static String CONTACT_TEAM_MESSAGE = "Please contact the TDR team for help.";
+
+  public static StairwayExceptionFields fieldsFromException(Exception ex) {
+    Optional<String> stepName = getStepNameFromStairwayException(ex);
+
+    if (stepName.isEmpty()) {
+      return new StairwayExceptionFields()
+          .setClassName(JobExecutionException.class.getName())
+          .setDataRepoException(true)
+          .setMessage(getJobExceptionMessage(ex))
+          .setErrorDetails(getJobExceptionDetails(ex));
+    }
+
+    return new StairwayExceptionFields()
+        .setClassName(StepExecutionException.class.getName())
+        .setDataRepoException(true)
+        .setMessage(getStepExceptionMessage(stepName.get(), ex))
+        .setErrorDetails(getStepExceptionDetails(stepName.get(), ex));
+  }
+
+  private static Optional<String> getStepNameFromStairwayException(Exception ex) {
+    Class<? extends Step> failedStep = null;
+    for (StackTraceElement ste : ex.getStackTrace()) {
+      try {
+        Class<?> cls = Class.forName(ste.getClassName());
+        if (Step.class.isAssignableFrom(cls)) {
+          // Java 17 will make this casting unnecessary
+          failedStep = (Class<? extends Step>) cls;
+          break;
+        }
+      } catch (ClassNotFoundException e) {
+        throw new ExceptionSerializerException(
+            "All steps in a stacktrace should be able to be found", e);
+      }
+    }
+    return Optional.ofNullable(failedStep.getSimpleName());
+  }
+
+  private static String getJobExceptionMessage(Exception exception) {
+    return String.format(
+        "Encountered a %s while running the job", exception.getClass().getSimpleName());
+  }
+
+  private static List<String> getJobExceptionDetails(Exception exception) {
+    List<String> details = new ArrayList<>();
+    details.add("The job failed, but not while running a step");
+    if (StringUtils.isNotBlank(exception.getMessage())) {
+      details.add("The job reported the following message: " + exception.getMessage());
+    }
+    if (ErrorReportException.class.isAssignableFrom(exception.getClass())) {
+      ErrorReportException errorReportException = (ErrorReportException) exception;
+      details.addAll(errorReportException.getCauses());
+    }
+    return details;
+  }
+
+  private static String getStepExceptionMessage(String stepName, Exception exception) {
+    return String.format(
+        "Encountered %s while running %s. Check error details for more information and possible fixes",
+        exception.getClass().getSimpleName(), stepName);
+  }
+
+  private static List<String> getStepExceptionDetails(String stepName, Exception exception) {
+    List<String> details = new ArrayList<>();
+    if (StringUtils.isNotBlank(exception.getMessage())) {
+      details.add("The step reported the following message: " + exception.getMessage());
+    }
+    if ("IamUnauthorizedException".equals(exception.getClass().getSimpleName())) {
+      details.add(
+          "If this is a long-running job, the user token may have timed out. "
+              + "Consider breaking the job into smaller jobs if possible.");
+      details.add(
+          "There may be a problem with bucket access. "
+              + "Has the user (or PET) account been granted access to all necessary files?");
+    }
+    if (ErrorReportException.class.isAssignableFrom(exception.getClass())) {
+      ErrorReportException errorReportException = (ErrorReportException) exception;
+      details.addAll(errorReportException.getCauses());
+    }
+    return details;
+  }
+}

--- a/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
@@ -17,29 +17,34 @@ public class StairwayExceptionFieldsFactory {
   public static StairwayExceptionFields fieldsFromException(Exception ex) {
     Optional<String> stepName = getStepNameFromStairwayException(ex);
 
+    Optional<String> fieldExceptionClassName = Optional.empty();
+    if (ErrorReportException.class.isAssignableFrom(ex.getClass())) {
+      fieldExceptionClassName = Optional.of(ex.getClass().getName());
+    }
+
     if (stepName.isEmpty()) {
       return new StairwayExceptionFields()
-          .setClassName(JobExecutionException.class.getName())
+          .setClassName(fieldExceptionClassName.orElse(JobExecutionException.class.getName()))
           .setDataRepoException(true)
           .setMessage(getJobExceptionMessage(ex))
           .setErrorDetails(getJobExceptionDetails(ex));
     }
 
     return new StairwayExceptionFields()
-        .setClassName(StepExecutionException.class.getName())
+        .setClassName(fieldExceptionClassName.orElse(StepExecutionException.class.getName()))
         .setDataRepoException(true)
         .setMessage(getStepExceptionMessage(stepName.get(), ex))
-        .setErrorDetails(getStepExceptionDetails(stepName.get(), ex));
+        .setErrorDetails(getStepExceptionDetails(ex));
   }
 
   private static Optional<String> getStepNameFromStairwayException(Exception ex) {
-    Class<? extends Step> failedStep = null;
+    String failedStepName = null;
     for (StackTraceElement ste : ex.getStackTrace()) {
       try {
         Class<?> cls = Class.forName(ste.getClassName());
         if (Step.class.isAssignableFrom(cls)) {
           // Java 17 will make this casting unnecessary
-          failedStep = (Class<? extends Step>) cls;
+          failedStepName = cls.getSimpleName();
           break;
         }
       } catch (ClassNotFoundException e) {
@@ -47,50 +52,52 @@ public class StairwayExceptionFieldsFactory {
             "All steps in a stacktrace should be able to be found", e);
       }
     }
-    return Optional.ofNullable(failedStep.getSimpleName());
+    return Optional.ofNullable(failedStepName);
   }
 
   private static String getJobExceptionMessage(Exception exception) {
+    if (StringUtils.isNotBlank(exception.getMessage())) {
+      return exception.getMessage();
+    }
     return String.format(
         "Encountered a %s while running the job", exception.getClass().getSimpleName());
   }
 
   private static List<String> getJobExceptionDetails(Exception exception) {
-    List<String> details = new ArrayList<>();
-    details.add("The job failed, but not while running a step");
-    if (StringUtils.isNotBlank(exception.getMessage())) {
-      details.add("The job reported the following message: " + exception.getMessage());
-    }
     if (ErrorReportException.class.isAssignableFrom(exception.getClass())) {
       ErrorReportException errorReportException = (ErrorReportException) exception;
-      details.addAll(errorReportException.getCauses());
+      return errorReportException.getCauses();
+    } else {
+      List<String> details = new ArrayList<>();
+      details.add("The job failed, but not while running a step");
+      details.add(CONTACT_TEAM_MESSAGE);
+      return details;
     }
-    return details;
   }
 
   private static String getStepExceptionMessage(String stepName, Exception exception) {
+    if (StringUtils.isNotBlank(exception.getMessage())) {
+      return exception.getMessage();
+    }
     return String.format(
-        "Encountered %s while running %s. Check error details for more information and possible fixes",
-        exception.getClass().getSimpleName(), stepName);
+        "Encountered %s while running %s.", exception.getClass().getSimpleName(), stepName);
   }
 
-  private static List<String> getStepExceptionDetails(String stepName, Exception exception) {
-    List<String> details = new ArrayList<>();
-    if (StringUtils.isNotBlank(exception.getMessage())) {
-      details.add("The step reported the following message: " + exception.getMessage());
-    }
-    if ("IamUnauthorizedException".equals(exception.getClass().getSimpleName())) {
-      details.add(
-          "If this is a long-running job, the user token may have timed out. "
-              + "Consider breaking the job into smaller jobs if possible.");
-      details.add(
-          "There may be a problem with bucket access. "
-              + "Has the user (or PET) account been granted access to all necessary files?");
-    }
+  private static List<String> getStepExceptionDetails(Exception exception) {
     if (ErrorReportException.class.isAssignableFrom(exception.getClass())) {
       ErrorReportException errorReportException = (ErrorReportException) exception;
-      details.addAll(errorReportException.getCauses());
+      return errorReportException.getCauses();
+    } else {
+      List<String> details = new ArrayList<>();
+      if ("IamUnauthorizedException".equals(exception.getClass().getSimpleName())) {
+        details.add(
+            "If this is a long-running job, the user token may have timed out. "
+                + "Consider breaking the job into smaller jobs if possible.");
+        details.add(
+            "There may be a problem with bucket access. "
+                + "Has the user (or PET) account been granted access to all necessary files?");
+      }
+      return details;
     }
-    return details;
   }
 }

--- a/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
@@ -5,7 +5,6 @@ import bio.terra.service.job.exception.ExceptionSerializerException;
 import bio.terra.service.job.exception.JobExecutionException;
 import bio.terra.service.job.exception.StepExecutionException;
 import bio.terra.stairway.Step;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/bio/terra/service/job/StairwayExceptionSerializer.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionSerializer.java
@@ -1,6 +1,5 @@
 package bio.terra.service.job;
 
-import bio.terra.common.exception.ErrorReportException;
 import bio.terra.service.job.exception.ExceptionSerializerException;
 import bio.terra.service.job.exception.JobResponseException;
 import bio.terra.stairway.ExceptionSerializer;
@@ -30,18 +29,8 @@ public class StairwayExceptionSerializer implements ExceptionSerializer {
       exception = new JobResponseException(exception.getMessage(), exception);
     }
 
-    StairwayExceptionFields fields =
-        new StairwayExceptionFields()
-            .setClassName(exception.getClass().getName())
-            .setMessage(exception.getMessage());
-
-    if (exception instanceof ErrorReportException) {
-      fields
-          .setDataRepoException(true)
-          .setErrorDetails(((ErrorReportException) exception).getCauses());
-    } else {
-      fields.setDataRepoException(false);
-    }
+    final StairwayExceptionFields fields =
+        StairwayExceptionFieldsFactory.fieldsFromException(exception);
 
     try {
       return objectMapper.writeValueAsString(fields);

--- a/src/main/java/bio/terra/service/job/StairwayExceptionSerializer.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionSerializer.java
@@ -29,8 +29,7 @@ public class StairwayExceptionSerializer implements ExceptionSerializer {
       exception = new JobResponseException(exception.getMessage(), exception);
     }
 
-    final StairwayExceptionFields fields =
-        StairwayExceptionFieldsFactory.fieldsFromException(exception);
+    final StairwayExceptionFields fields = StairwayExceptionFieldsFactory.fromException(exception);
 
     try {
       return objectMapper.writeValueAsString(fields);

--- a/src/main/java/bio/terra/service/job/exception/JobExecutionException.java
+++ b/src/main/java/bio/terra/service/job/exception/JobExecutionException.java
@@ -1,0 +1,22 @@
+package bio.terra.service.job.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+import java.util.List;
+
+public class JobExecutionException extends InternalServerErrorException {
+  public JobExecutionException(String message) {
+    super(message);
+  }
+
+  public JobExecutionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public JobExecutionException(Throwable cause) {
+    super(cause);
+  }
+
+  public JobExecutionException(String message, List<String> causes) {
+    super(message, causes);
+  }
+}

--- a/src/main/java/bio/terra/service/job/exception/StepExecutionException.java
+++ b/src/main/java/bio/terra/service/job/exception/StepExecutionException.java
@@ -1,0 +1,22 @@
+package bio.terra.service.job.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+import java.util.List;
+
+public class StepExecutionException extends InternalServerErrorException {
+  public StepExecutionException(String message) {
+    super(message);
+  }
+
+  public StepExecutionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public StepExecutionException(Throwable cause) {
+    super(cause);
+  }
+
+  public StepExecutionException(String message, List<String> causes) {
+    super(message, causes);
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/exception/InaccessibleBillingAccountException.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/exception/InaccessibleBillingAccountException.java
@@ -2,6 +2,8 @@ package bio.terra.service.resourcemanagement.exception;
 
 import bio.terra.common.exception.BadRequestException;
 
+import java.util.List;
+
 public class InaccessibleBillingAccountException extends BadRequestException {
   public InaccessibleBillingAccountException(String message) {
     super(message);
@@ -13,5 +15,9 @@ public class InaccessibleBillingAccountException extends BadRequestException {
 
   public InaccessibleBillingAccountException(Throwable cause) {
     super(cause);
+  }
+
+  public InaccessibleBillingAccountException(String message, List<String> causes) {
+    super(message, causes);
   }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/exception/InaccessibleBillingAccountException.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/exception/InaccessibleBillingAccountException.java
@@ -1,7 +1,6 @@
 package bio.terra.service.resourcemanagement.exception;
 
 import bio.terra.common.exception.BadRequestException;
-
 import java.util.List;
 
 public class InaccessibleBillingAccountException extends BadRequestException {


### PR DESCRIPTION
The way we handle exceptions in flights is... interesting. Instead of completely re-doing it, a quick fix is to make sure that all exceptions->error serializations have contents, and take some steps to be more specific about a failure if we can.

I've written code that will fill in error fields if none are provided by the caught exception in `StairwayExceptionSerializer`. This way, when the exception is de-serialized, There is actual content to return to the user. I think this approach works pretty well and could at least provide non-empty messages to the user.

There's more code which tries to be intelligent about errors it returns. Currently, it looks for an `IamUnauthorizedException` and provides some possible mitigations to the user. I'm not in love with how this works. String matching on exception type names is brittle, and tweaking error messages requires an entire re-deployment. I'm not sure the best data structure to handle these types of messages. I think some sort of external config would go well here. The current code is just a representation of what the end result could look like.