### PR TITLE
DR-2405 User role endpoints for datasets and snapshots

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -343,6 +343,13 @@ public class DatasetsApiController implements DatasetsApi {
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
+  @Override
+  public ResponseEntity<List<String>> retrieveUserDatasetRoles(UUID id) {
+    List<String> roles =
+        iamService.retrieveUserRoles(getAuthenticatedInfo(), IamResourceType.DATASET, id);
+    return new ResponseEntity<>(roles, HttpStatus.OK);
+  }
+
   private void validateIngestParams(IngestRequestModel ingestRequestModel, UUID datasetId) {
     Dataset dataset = datasetService.retrieve(datasetId);
     CloudPlatformWrapper platform =

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -282,4 +282,11 @@ public class SnapshotsApiController implements SnapshotsApi {
     PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
+
+  @Override
+  public ResponseEntity<List<String>> retrieveUserSnapshotRoles(UUID id) {
+    List<String> roles =
+        iamService.retrieveUserRoles(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id);
+    return new ResponseEntity<>(roles, HttpStatus.OK);
+  }
 }

--- a/src/main/java/bio/terra/service/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/iam/IamProviderInterface.java
@@ -140,6 +140,10 @@ public interface IamProviderInterface {
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
       throws InterruptedException;
 
+  List<String> retrieveUserRoles(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
+      throws InterruptedException;
+
   Map<IamRole, String> retrievePolicyEmails(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
       throws InterruptedException;

--- a/src/main/java/bio/terra/service/iam/IamService.java
+++ b/src/main/java/bio/terra/service/iam/IamService.java
@@ -263,6 +263,11 @@ public class IamService {
         });
   }
 
+  public List<String> retrieveUserRoles(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId) {
+    return callProvider(() -> iamProvider.retrieveUserRoles(userReq, iamResourceType, resourceId));
+  }
+
   public UserStatusInfo getUserInfo(AuthenticatedUserRequest userReq) {
     return iamProvider.getUserInfo(userReq);
   }

--- a/src/main/java/bio/terra/service/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/iam/sam/SamIam.java
@@ -358,6 +358,22 @@ public class SamIam implements IamProviderInterface {
         configurationService, () -> retrievePoliciesInner(userReq, iamResourceType, resourceId));
   }
 
+  @Override
+  public List<String> retrieveUserRoles(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
+      throws InterruptedException {
+    return SamRetry.retry(
+        configurationService, () -> retrieveUserRolesInner(userReq, iamResourceType, resourceId));
+  }
+
+  private List<String> retrieveUserRolesInner(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
+      throws ApiException {
+    ResourcesApi samResourceApi = samResourcesApi(userReq.getToken());
+    return samResourceApi.resourceRoles(
+        iamResourceType.getSamResourceName(), resourceId.toString());
+  }
+
   private List<PolicyModel> retrievePoliciesInner(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
       throws ApiException {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1025,18 +1025,6 @@ paths:
                 type: array
                 items:
                   type: string
-        400:
-          description: Bad request - invalid id, badly formed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        403:
-          description: No permission to see policies
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
         404:
           description: Not found - snapshot id does not exist
           content:
@@ -1399,18 +1387,6 @@ paths:
                 type: array
                 items:
                   type: string
-        400:
-          description: Bad request - invalid id, badly formed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        403:
-          description: No permission to see policies
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
         404:
           description: Not found - dataset id does not exist
           content:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1007,6 +1007,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+  /api/repository/v1/snapshots/{id}/roles:
+    get:
+      tags:
+        - snapshots
+        - repository
+      description: Retrieve the roles the calling user has on the snapshot
+      operationId: retrieveUserSnapshotRoles
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: Policy
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        400:
+          description: Bad request - invalid id, badly formed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: No permission to see policies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: Not found - snapshot id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
   /api/repository/v1/datasets:
     get:
       tags:
@@ -1214,7 +1250,7 @@ paths:
       tags:
         - datasets
         - repository
-      description: Retrieve the read and discover policies for the snapshot
+      description: Retrieve the read and discover policies for the dataset
       operationId: retrieveDatasetPolicies
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -1238,7 +1274,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
         404:
-          description: Not found - snapshot id does not exist
+          description: Not found - dataset id does not exist
           content:
             application/json:
               schema:
@@ -1341,6 +1377,42 @@ paths:
                 $ref: '#/components/schemas/ErrorModel'
         404:
           description: Not found - snapshot id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+  /api/repository/v1/datasets/{id}/roles:
+    get:
+      tags:
+        - datasets
+        - repository
+      description: Retrieve the policies the calling user has on the dataset
+      operationId: retrieveUserDatasetRoles
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: Policy
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        400:
+          description: Bad request - invalid id, badly formed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: No permission to see policies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: Not found - dataset id does not exist
           content:
             application/json:
               schema:

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -397,6 +397,37 @@ public class DataRepoFixtures {
     addPolicyMember(user, datasetId, role, newMemberEmail, IamResourceType.DATASET);
   }
 
+  // getting a users roles on a resource
+  public DataRepoResponse<List> retrieveUserRolesRaw(
+      TestConfiguration.User user, UUID resourceId, IamResourceType iamResourceType)
+      throws Exception {
+    String pathPrefix;
+    switch (iamResourceType) {
+      case DATASET:
+        pathPrefix = "/api/repository/v1/datasets/";
+        break;
+      case DATASNAPSHOT:
+        pathPrefix = "/api/repository/v1/snapshots/";
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "No path prefix defined for IamResourceType " + iamResourceType);
+    }
+    String path = pathPrefix + resourceId + "/roles/";
+
+    return dataRepoClient.get(user, path, List.class);
+  }
+
+  public List<String> retrieveUserDatasetRoles(TestConfiguration.User user, UUID datasetId)
+      throws Exception {
+    DataRepoResponse<List> response =
+        retrieveUserRolesRaw(user, datasetId, IamResourceType.DATASET);
+    assertThat(
+        "getting dataset roles is successful", response.getStatusCode(), equalTo(HttpStatus.OK));
+    assertTrue("dataset roles get response is present", response.getResponseObject().isPresent());
+    return (List<String>) response.getResponseObject().get();
+  }
+
   // adding dataset asset
   public DataRepoResponse<JobModel> addDatasetAssetRaw(
       TestConfiguration.User user, UUID datasetId, AssetModel assetModel) throws Exception {
@@ -423,6 +454,16 @@ public class DataRepoFixtures {
       TestConfiguration.User user, UUID snapshotId, IamRole role, String newMemberEmail)
       throws Exception {
     addPolicyMember(user, snapshotId, role, newMemberEmail, IamResourceType.DATASNAPSHOT);
+  }
+
+  public List<String> retrieveUserSnapshotRoles(TestConfiguration.User user, UUID datasetId)
+      throws Exception {
+    DataRepoResponse<List> response =
+        retrieveUserRolesRaw(user, datasetId, IamResourceType.DATASNAPSHOT);
+    assertThat(
+        "getting snapshot roles is successful", response.getStatusCode(), equalTo(HttpStatus.OK));
+    assertTrue("snapshot roles get response is present", response.getResponseObject().isPresent());
+    return (List<String>) response.getResponseObject().get();
   }
 
   public DataRepoResponse<JobModel> createSnapshotRaw(

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -1,7 +1,9 @@
 package bio.terra.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -119,6 +121,9 @@ public class DatasetIntegrationTest extends UsersBase {
     assertThat(summaryModel.getName(), startsWith(omopDatasetName));
     assertThat(summaryModel.getDescription(), equalTo(omopDatasetDesc));
 
+    List<String> stewardRoles = dataRepoFixtures.retrieveUserDatasetRoles(steward(), datasetId);
+    assertThat("The Steward was given steward access", stewardRoles, hasItem("steward"));
+
     DatasetModel datasetModel = dataRepoFixtures.getDataset(steward(), summaryModel.getId());
 
     assertThat(datasetModel.getName(), startsWith(omopDatasetName));
@@ -200,6 +205,11 @@ public class DatasetIntegrationTest extends UsersBase {
         "Custodian is authorized to enumerate datasets",
         enumDatasets.getStatusCode(),
         equalTo(HttpStatus.OK));
+
+    List<String> custodianRoles = dataRepoFixtures.retrieveUserDatasetRoles(custodian(), datasetId);
+    assertThat("The Custodian was given custodian access", custodianRoles, hasItem("custodian"));
+    assertThat(
+        "The Custodian does not have Steward access", custodianRoles, not(hasItem("steward")));
 
     assertThat(
         "Default secure monitoring was applied to summary model",

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.snapshot;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
@@ -170,6 +171,10 @@ public class SnapshotIntegrationTest extends UsersBase {
         "The secure monitoring is propagated from the dataset",
         snapshot.getSource().get(0).getDataset().isSecureMonitoringEnabled(),
         is(false));
+
+    List<String> stewardRoles =
+        dataRepoFixtures.retrieveUserSnapshotRoles(steward(), snapshotSummary.getId());
+    assertThat("The Steward was given steward access", stewardRoles, hasItem("steward"));
   }
 
   @Test


### PR DESCRIPTION
In order to enable users to add/remove users from datasets/snapshots in the UI, we need to be able to determine the role of the logged in user. We can't just rely on the policies endpoint, because that only tells us emails, and if the user is part of a group that's added to  a dataset/snapshot, there's no way for the UI to tell what role they have. Adding a `roles` endpoint in the API is the easiest way to get this information to the UI, instead of making the UI talk to Sam as well as TDR. The TDR API already knows how to talk to Sam, so there's not all that much new code to enable this feature.