### PR TITLE
DR-2414 DR-2416 store and record column orders for datasets and snapshots

### DIFF
--- a/src/main/java/bio/terra/service/dataset/AssetDao.java
+++ b/src/main/java/bio/terra/service/dataset/AssetDao.java
@@ -156,7 +156,8 @@ public class AssetDao {
         "SELECT asset_column.id, asset_column.dataset_column_id, dataset_column.table_id "
             + "FROM asset_column "
             + "INNER JOIN dataset_column ON asset_column.dataset_column_id = dataset_column.id "
-            + "WHERE asset_id = :assetId";
+            + "WHERE asset_id = :assetId "
+            + "ORDER BY dataset_column.ordinal";
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("assetId", spec.getId());
     List<Map<String, Object>> results = jdbcTemplate.queryForList(sql, params);
     results.forEach(

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -37,7 +37,8 @@ public class DatasetTableDao {
           + "cast(:bigquery_partition_config AS jsonb))";
   private static final String sqlInsertColumn =
       "INSERT INTO dataset_column "
-          + "(table_id, name, type, array_of) VALUES (:table_id, :name, :type, :array_of)";
+          + "(table_id, name, type, array_of, ordinal) "
+          + "VALUES (:table_id, :name, :type, :array_of, :ordinal)";
   private static final String sqlSelectTable =
       "SELECT id, name, raw_table_name, soft_delete_table_name, row_metadata_table_name, primary_key, bigquery_partition_config::text, "
           + "(bigquery_partition_config->>'version')::bigint AS bigquery_partition_config_version "
@@ -99,10 +100,12 @@ public class DatasetTableDao {
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("table_id", tableId);
     DaoKeyHolder keyHolder = new DaoKeyHolder();
+    int ordinal = 0;
     for (Column column : columns) {
       params.addValue("name", column.getName());
       params.addValue("type", column.getType().toString());
       params.addValue("array_of", column.isArrayOf());
+      params.addValue("ordinal", ordinal++);
       jdbcTemplate.update(sqlInsertColumn, params, keyHolder);
       UUID columnId = keyHolder.getId();
       column.id(columnId);

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -43,7 +43,10 @@ public class DatasetTableDao {
           + "(bigquery_partition_config->>'version')::bigint AS bigquery_partition_config_version "
           + "FROM dataset_table WHERE dataset_id = :dataset_id";
   private static final String sqlSelectColumn =
-      "SELECT id, name, type, array_of FROM dataset_column " + "WHERE table_id = :table_id";
+      "SELECT id, name, type, array_of "
+          + "FROM dataset_column "
+          + "WHERE table_id = :table_id "
+          + "ORDER BY ordinal";
 
   private final DataSource jdbcDataSource;
   private final NamedParameterJdbcTemplate jdbcTemplate;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
@@ -19,7 +19,8 @@ public class SnapshotTableDao {
       "INSERT INTO snapshot_table " + "(name, parent_id) VALUES (:name, :parent_id)";
   private static final String sqlInsertColumn =
       "INSERT INTO snapshot_column "
-          + "(table_id, name, type, array_of) VALUES (:table_id, :name, :type, :array_of)";
+          + "(table_id, name, type, array_of, ordinal) "
+          + "VALUES (:table_id, :name, :type, :array_of, :ordinal)";
   private static final String sqlSelectTable =
       "SELECT id, name, row_count FROM snapshot_table WHERE parent_id = :parent_id";
   private static final String sqlSelectColumn =
@@ -53,10 +54,12 @@ public class SnapshotTableDao {
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("table_id", tableId);
     DaoKeyHolder keyHolder = new DaoKeyHolder();
+    int ordinal = 0;
     for (Column column : columns) {
       params.addValue("name", column.getName());
       params.addValue("type", column.getType().toString());
       params.addValue("array_of", column.isArrayOf());
+      params.addValue("ordinal", ordinal++);
       jdbcTemplate.update(sqlInsertColumn, params, keyHolder);
       UUID columnId = keyHolder.getId();
       column.id(columnId);

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
@@ -21,9 +21,12 @@ public class SnapshotTableDao {
       "INSERT INTO snapshot_column "
           + "(table_id, name, type, array_of) VALUES (:table_id, :name, :type, :array_of)";
   private static final String sqlSelectTable =
-      "SELECT id, name, row_count FROM snapshot_table " + "WHERE parent_id = :parent_id";
+      "SELECT id, name, row_count FROM snapshot_table WHERE parent_id = :parent_id";
   private static final String sqlSelectColumn =
-      "SELECT id, name, type, array_of FROM snapshot_column " + "WHERE table_id = :table_id";
+      "SELECT id, name, type, array_of "
+          + "FROM snapshot_column "
+          + "WHERE table_id = :table_id "
+          + "ORDER BY ordinal";
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -49,6 +49,7 @@
     <include file="changesets/20211206_datasetsecurityattributes.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20211209_datasetrequireslogging.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220112_addsnapshotcreatemode.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20220202_adddatasetandsnapshottablecolumnorder.yaml" relativeToChangelogFile="true" />
 
 
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20220202_adddatasetandsnapshottablecolumnorder.yaml
+++ b/src/main/resources/db/changesets/20220202_adddatasetandsnapshottablecolumnorder.yaml
@@ -1,0 +1,35 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_dataset_and_snapshot_table_column_order
+      author: nm
+      changes:
+        - addColumn:
+            tableName: dataset_column
+            columns:
+              name: ordinal
+              type: integer
+              defaultValue: 0
+        - sql:
+            comment: set the ordinal value to the order in which they were inserted for all existing dataset columns
+            sql: >
+              UPDATE dataset_column
+              SET ordinal = counter.ordinal
+              FROM (SELECT row_number() over (partition by table_id order by ctid) - 1 AS ordinal,
+                    id FROM dataset_column) AS counter
+              WHERE dataset_column.id = counter.id
+                AND dataset_column.ordinal IS NOT NULL
+        - addColumn:
+            tableName: snapshot_column
+            columns:
+              name: ordinal
+              type: integer
+              defaultValue: 0
+        - sql:
+            comment: set the ordinal value to the order in which they were inserted for all existing snapshot columns
+            sql: >
+              UPDATE snapshot_column
+              SET ordinal = counter.ordinal
+              FROM (SELECT row_number() over (partition by table_id order by ctid) - 1 AS ordinal,
+                    id FROM snapshot_column) AS counter
+              WHERE snapshot_column.id = counter.id
+                AND snapshot_column.ordinal IS NOT NULL

--- a/src/test/resources/snapshot-test-dataset-with-multi-columns.json
+++ b/src/test/resources/snapshot-test-dataset-with-multi-columns.json
@@ -1,0 +1,43 @@
+{
+  "name":        "snapshot_test_dataset",
+  "description": "Dataset to test building snapshots with",
+  "schema":      {
+    "tables":        [
+      {
+        "name":    "thetable",
+        "columns": [
+          {"name": "thecolumn1", "datatype": "string"},
+          {"name": "thecolumn2", "datatype": "string"},
+          {"name": "thecolumn3", "datatype": "string"}
+        ]
+      },
+      {
+        "name":    "anothertable",
+        "columns": [
+          {"name": "anothercolumn3", "datatype": "string"},
+          {"name": "anothercolumn2", "datatype": "string"},
+          {"name": "anothercolumn1", "datatype": "string"}
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "name": "the_relationship_with_a_very_very_very_very_very_very_very_very_very_very_very_very_very_long_name",
+        "from": {"table": "thetable", "column": "thecolumn1"},
+        "to":   {"table": "anothertable", "column": "anothercolumn1"}
+      }
+    ],
+    "assets":        [
+      {
+        "name":   "theasset",
+        "rootTable": "thetable",
+        "rootColumn": "thecolumn1",
+        "tables": [
+          {"name": "thetable", "columns": []},
+          {"name": "anothertable", "columns": []}
+        ],
+        "follow": ["the_relationship_with_a_very_very_very_very_very_very_very_very_very_very_very_very_very_long_name"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Turned out to be pretty easy to just do both tickets.  Note:

- While the ticket only asked for datasets, it seemed reasonable to also record order on snapshot columns
- I was able to figure out how to do the migration so that the initial values for the new `ordinal` column are actually correct
- The unit tests in the last commit end up exercising the migration, the insert into the table and the retrieval of columns