### PR TITLE
DR-2412 Make the data preview API for snapshot data visible in all environments

### DIFF
--- a/src/main/java/bio/terra/app/controller/SearchApiController.java
+++ b/src/main/java/bio/terra/app/controller/SearchApiController.java
@@ -11,7 +11,6 @@ import bio.terra.model.SearchMetadataModel;
 import bio.terra.model.SearchMetadataResponse;
 import bio.terra.model.SearchQueryRequest;
 import bio.terra.model.SearchQueryResultModel;
-import bio.terra.model.SnapshotPreviewModel;
 import bio.terra.service.iam.IamAction;
 import bio.terra.service.iam.IamResourceType;
 import bio.terra.service.iam.IamRole;
@@ -94,17 +93,6 @@ public class SearchApiController implements SearchApi {
 
   private AuthenticatedUserRequest getAuthenticatedInfo() {
     return authenticatedUserRequestFactory.from(request);
-  }
-
-  @Override
-  public ResponseEntity<SnapshotPreviewModel> lookupSnapshotPreviewById(
-      UUID id, String table, Integer offset, Integer limit) {
-    logger.info("Verifying user access");
-    iamService.verifyAuthorization(
-        getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id.toString(), IamAction.READ_DATA);
-    logger.info("Retrieving snapshot id {}", id);
-    SnapshotPreviewModel previewModel = snapshotService.retrievePreview(id, table, limit, offset);
-    return new ResponseEntity<>(previewModel, HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -16,6 +16,7 @@ import bio.terra.model.PolicyMemberRequest;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
 import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotPreviewModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRetrieveIncludeModel;
 import bio.terra.model.SqlSortDirection;
@@ -237,6 +238,17 @@ public class SnapshotsApiController implements SnapshotsApi {
     }
     FileModel fileModel = fileService.lookupSnapshotPath(id.toString(), path, depth);
     return new ResponseEntity<>(fileModel, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<SnapshotPreviewModel> lookupSnapshotPreviewById(
+      UUID id, String table, Integer offset, Integer limit) {
+    logger.info("Verifying user access");
+    iamService.verifyAuthorization(
+        getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id.toString(), IamAction.READ_DATA);
+    logger.info("Retrieving snapshot id {}", id);
+    SnapshotPreviewModel previewModel = snapshotService.retrievePreview(id, table, limit, offset);
+    return new ResponseEntity<>(previewModel, HttpStatus.OK);
   }
 
   // --snapshot policies --

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -690,8 +690,8 @@ paths:
   /api/repository/v1/snapshots/{id}/data/{table}:
     get:
       tags:
-        - search
         - snapshots
+        - search
         - repository
       description: Retrieve data for a table in a snapshot
       operationId: lookupSnapshotPreviewById


### PR DESCRIPTION
This is just making the preview API built by the data explorer team available in all envs.  Note1: we'll want a similar one (perhaps with sql capabilities for authoring) for datasets
Note2: we'll need to build the Azure versions of the endpoints too