### PR TITLE
DR-2409 Add job sorting and filtering by flight class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,7 +408,7 @@ jar {
 jib {
     extraDirectories.paths = ['build/gen-expanded']
     from {
-        image = "gcr.io/distroless/java-debian10:11"
+        image = "gcr.io/distroless/java11-debian11"
     }
     to {
         image = "gcr.io/broad-jade-dev/jade-data-repo:" + (System.env.GCR_TAG ?: getGitHash())

--- a/build.gradle
+++ b/build.gradle
@@ -408,7 +408,7 @@ jar {
 jib {
     extraDirectories.paths = ['build/gen-expanded']
     from {
-        image = "gcr.io/distroless/java11-debian11"
+        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:11-distroless"
     }
     to {
         image = "gcr.io/broad-jade-dev/jade-data-repo:" + (System.env.GCR_TAG ?: getGitHash())

--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ dependencies {
         implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
         implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.1'
     } else {
-        implementation 'bio.terra:stairway:0.0.66-SNAPSHOT'
+        implementation 'bio.terra:stairway:0.0.69-SNAPSHOT'
     }
 
     // Similar development mode for pointing to terra common library

--- a/build.gradle
+++ b/build.gradle
@@ -408,7 +408,7 @@ jar {
 jib {
     extraDirectories.paths = ['build/gen-expanded']
     from {
-        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:11-distroless"
+        image = "gcr.io/distroless/java11-debian11"
     }
     to {
         image = "gcr.io/broad-jade-dev/jade-data-repo:" + (System.env.GCR_TAG ?: getGitHash())

--- a/src/main/java/bio/terra/app/controller/JobsApiController.java
+++ b/src/main/java/bio/terra/app/controller/JobsApiController.java
@@ -7,6 +7,7 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.controller.JobsApi;
 import bio.terra.model.JobModel;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.AssetModelValidator;
 import bio.terra.service.dataset.DatasetRequestValidator;
 import bio.terra.service.dataset.IngestRequestValidator;
@@ -94,9 +95,14 @@ public class JobsApiController implements JobsApi {
   @Override
   public ResponseEntity<List<JobModel>> enumerateJobs(
       @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
-      @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
+      @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit,
+      @RequestParam(value = "direction", required = false, defaultValue = "desc")
+          SqlSortDirection direction,
+      @RequestParam(value = "flightClass", required = false, defaultValue = "")
+          String flightClass) {
     validiateOffsetAndLimit(offset, limit);
-    List<JobModel> results = jobService.enumerateJobs(offset, limit, getAuthenticatedInfo());
+    List<JobModel> results =
+        jobService.enumerateJobs(offset, limit, getAuthenticatedInfo(), direction, flightClass);
     return new ResponseEntity<>(results, HttpStatus.OK);
   }
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2111,6 +2111,16 @@ paths:
           schema:
             type: integer
             default: 10
+        - name: direction
+          in: query
+          description: The direction to sort based on job creation time (default is descending).
+          schema:
+            $ref: '#/components/schemas/SqlSortDirection'
+        - name: className
+          in: query
+          description: Filter by the flight's class
+          schema:
+            type: string
       responses:
         200:
           description: List of jobs
@@ -3968,6 +3978,9 @@ components:
           type: string
           description: Timestamp when the flight was completed; not present if not
             complete
+        class_name:
+          type: string
+          description: Class name of the flight
       description: >
         Status of job
     ErrorModel:

--- a/src/test/java/bio/terra/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/service/job/JobServiceTest.java
@@ -18,7 +18,6 @@ import bio.terra.stairway.Flight;
 import bio.terra.stairway.exception.StairwayException;
 import java.util.ArrayList;
 import java.util.List;
-import org.broadinstitute.dsde.workbench.client.sam.model.ResourceAndAccessPolicy;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -58,7 +57,6 @@ public class JobServiceTest {
     // The fids list should be in exactly the same order as the database ordered by submit time.
 
     List<JobModel> expectedJobs = new ArrayList<>();
-    List<ResourceAndAccessPolicy> allowedIds = new ArrayList<>();
 
     for (int i = 0; i < 7; i++) {
       String jobId = runFlight(makeDescription(i), makeFlightClass(i));
@@ -69,7 +67,6 @@ public class JobServiceTest {
               .statusCode(HttpStatus.I_AM_A_TEAPOT.value())
               .description(makeDescription(i))
               .className(makeFlightClass(i).getName()));
-      allowedIds.add(new ResourceAndAccessPolicy().resourceId(jobId));
     }
 
     // Test single retrieval

--- a/src/test/java/bio/terra/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/service/job/JobServiceTest.java
@@ -2,18 +2,24 @@ package bio.terra.service.job;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.JobModel;
+import bio.terra.model.JobModel.JobStatusEnum;
+import bio.terra.model.SqlSortDirection;
+import bio.terra.stairway.Flight;
 import bio.terra.stairway.exception.StairwayException;
 import java.util.ArrayList;
 import java.util.List;
 import org.broadinstitute.dsde.workbench.client.sam.model.ResourceAndAccessPolicy;
-import org.junit.Assert;
-import org.junit.Ignore;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -46,76 +52,79 @@ public class JobServiceTest {
 
   @Autowired private ApplicationConfiguration appConfig;
 
-  // This test is unreliable. See https://broadworkbench.atlassian.net/browse/DR-1248
-  // todo - fix w/ DR-1255
-  @Ignore
   @Test
   public void retrieveTest() throws Exception {
-    // We perform 7 flights and then retrieve and enumerate them.
+    // We perform 7 flights of alternating classes and then retrieve and enumerate them.
     // The fids list should be in exactly the same order as the database ordered by submit time.
 
-    List<String> jobIds = new ArrayList<>();
+    List<JobModel> expectedJobs = new ArrayList<>();
     List<ResourceAndAccessPolicy> allowedIds = new ArrayList<>();
+
     for (int i = 0; i < 7; i++) {
-      String jobId = runFlight(makeDescription(i));
-      jobIds.add(jobId);
+      String jobId = runFlight(makeDescription(i), makeFlightClass(i));
+      expectedJobs.add(
+          new JobModel()
+              .id(jobId)
+              .jobStatus(JobStatusEnum.SUCCEEDED)
+              .statusCode(HttpStatus.I_AM_A_TEAPOT.value())
+              .description(makeDescription(i))
+              .className(makeFlightClass(i).getName()));
       allowedIds.add(new ResourceAndAccessPolicy().resourceId(jobId));
     }
 
     // Test single retrieval
-    testSingleRetrieval(jobIds);
+    testSingleRetrieval(expectedJobs.get(2));
 
     // Test result retrieval - the body should be the description string
-    testResultRetrieval(jobIds);
+    testResultRetrieval(expectedJobs.get(2));
 
     // Retrieve everything
-    testEnumRange(jobIds, 0, 100, allowedIds);
+    assertThat(
+        "retrieve everything",
+        jobService.enumerateJobs(0, 100, null, SqlSortDirection.ASC, ""),
+        contains(getJobMatchers(expectedJobs)));
 
     // Retrieve the middle 3; offset means skip 2 rows
-    testEnumRange(jobIds, 2, 3, allowedIds);
+    assertThat(
+        "retrieve the middle three",
+        jobService.enumerateJobs(2, 3, null, SqlSortDirection.ASC, ""),
+        contains(getJobMatchers(expectedJobs.subList(2, 5))));
+
+    // Retrieve in descending order and filtering to the even (JobServiceTestFlight) flights
+    assertThat(
+        "retrieve descending and alternating",
+        jobService.enumerateJobs(
+            0, 4, null, SqlSortDirection.DESC, JobServiceTestFlight.class.getName()),
+        contains(
+            getJobMatcher(expectedJobs.get(6)),
+            getJobMatcher(expectedJobs.get(4)),
+            getJobMatcher(expectedJobs.get(2)),
+            getJobMatcher(expectedJobs.get(0))));
 
     // Retrieve from the end; should only get the last one back
-    testEnumCount(1, 6, 3, allowedIds);
+    assertThat(
+        "retrieve from the end",
+        jobService.enumerateJobs(6, 3, null, SqlSortDirection.ASC, ""),
+        contains(getJobMatcher((expectedJobs.get(6)))));
 
     // Retrieve past the end; should get nothing
-    testEnumCount(0, 22, 3, allowedIds);
+    assertThat(
+        "retrieve from the end",
+        jobService.enumerateJobs(22, 3, null, SqlSortDirection.ASC, ""),
+        is(List.of()));
   }
 
-  private void testSingleRetrieval(List<String> fids) throws InterruptedException {
-    JobModel response = jobService.retrieveJob(fids.get(2), null);
-    Assert.assertNotNull(response);
-    validateJobModel(response, 2, fids);
+  private void testSingleRetrieval(JobModel job) throws InterruptedException {
+    JobModel response = jobService.retrieveJob(job.getId(), null);
+    assertThat(response, notNullValue());
+    assertThat(response, getJobMatcher(job));
   }
 
-  private void testResultRetrieval(List<String> fids) throws InterruptedException {
+  private void testResultRetrieval(JobModel job) throws InterruptedException {
     JobService.JobResultWithStatus<String> resultHolder =
-        jobService.retrieveJobResult(fids.get(2), String.class, null);
-    Assert.assertThat(resultHolder.getStatusCode(), is(equalTo(HttpStatus.I_AM_A_TEAPOT)));
-    Assert.assertThat(resultHolder.getResult(), is(equalTo(makeDescription(2))));
-  }
-
-  // Get some range and compare it with the fids
-  private void testEnumRange(
-      List<String> fids, int offset, int limit, List<ResourceAndAccessPolicy> resourceIds)
-      throws InterruptedException {
-
-    List<JobModel> jobList = jobService.enumerateJobs(offset, limit, null);
-    Assert.assertNotNull(jobList);
-    int index = offset;
-    for (JobModel job : jobList) {
-      validateJobModel(job, index, fids);
-      index++;
-    }
-  }
-
-  // Get some range and make sure we got the number we expected
-  private void testEnumCount(
-      int count, int offset, int length, List<ResourceAndAccessPolicy> resourceIds)
-      throws InterruptedException {
-
-    List<JobModel> jobList = jobService.enumerateJobs(offset, length, null);
-    Assert.assertNotNull(jobList);
-    Assert.assertThat(jobList.size(), is(count));
+        jobService.retrieveJobResult(job.getId(), String.class, null);
+    assertThat(resultHolder.getStatusCode(), is(equalTo(HttpStatus.I_AM_A_TEAPOT)));
+    assertThat(resultHolder.getResult(), is(equalTo(job.getDescription())));
   }
 
   @Test(expected = StairwayException.class)
@@ -128,22 +137,27 @@ public class JobServiceTest {
     jobService.retrieveJobResult("abcdef", Object.class, null);
   }
 
-  private void validateJobModel(JobModel jm, int index, List<String> fids) {
-    Assert.assertThat(jm.getDescription(), is(equalTo(makeDescription(index))));
-    Assert.assertThat(jm.getId(), is(equalTo(fids.get(index))));
-    Assert.assertThat(jm.getJobStatus(), is(JobModel.JobStatusEnum.SUCCEEDED));
-    Assert.assertThat(jm.getStatusCode(), is(HttpStatus.I_AM_A_TEAPOT.value()));
+  private Matcher<JobModel> getJobMatcher(JobModel jobModel) {
+    return samePropertyValuesAs(jobModel, "submitted", "completed");
+  }
+
+  @SuppressWarnings("unchecked")
+  private Matcher<JobModel>[] getJobMatchers(List<JobModel> jobModels) {
+    return jobModels.stream().map(this::getJobMatcher).toArray(Matcher[]::new);
   }
 
   // Submit a flight; wait for it to finish; return the flight id
-  private String runFlight(String description) throws InterruptedException {
-    String jobId =
-        jobService.newJob(description, JobServiceTestFlight.class, null, testUser).submit();
+  private String runFlight(String description, Class<? extends Flight> clazz) {
+    String jobId = jobService.newJob(description, clazz, null, testUser).submit();
     jobService.waitForJob(jobId);
     return jobId;
   }
 
   private String makeDescription(int ii) {
     return String.format("flight%d", ii);
+  }
+
+  private Class<? extends Flight> makeFlightClass(int ii) {
+    return ii % 2 == 0 ? JobServiceTestFlight.class : JobServiceTestFlightAlt.class;
   }
 }

--- a/src/test/java/bio/terra/service/job/JobServiceTestFlightAlt.java
+++ b/src/test/java/bio/terra/service/job/JobServiceTestFlightAlt.java
@@ -1,0 +1,17 @@
+package bio.terra.service.job;
+
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+
+public class JobServiceTestFlightAlt extends Flight {
+
+  public JobServiceTestFlightAlt(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+    // Pull out our parameters and feed them in to the step classes.
+    String description = inputParameters.get("description", String.class);
+
+    // Just one step for this test
+    addStep(new JobServiceTestStep(description));
+  }
+}


### PR DESCRIPTION
...Also return the class name of a flight.

After this PR, flights will return flights that look like:
```
{
  "id": "sd6PPr6WTFi_pdIz6GC9pQ",
  "description": "Create snapshot newcol2",
  "job_status": "succeeded",
  "status_code": 201,
  "submitted": "2022-02-11T14:47:21.525819Z",
  "completed": "2022-02-11T14:49:10.613542Z",
  "class_name": "bio.terra.service.snapshot.flight.create.SnapshotCreateFlight"
}
```

(note the last field)

This has the added benefit of creating an index on the submit_time field which should speed up the list jobs api pretty significantly (it currently takes about a minute in dev)

Of note, the submit_time is what the user can sort on (today we sort ascending, this gives the user a choice to do descending...which is more useful)

If folks are interested in trying, I've got this change up in:
https://jade-nm.datarepo-dev.broadinstitute.org/swagger-ui.html#/jobs/enumerateJobs

