### PR TITLE
DR-2430 load firestore json into bq

### DIFF
--- a/src/main/java/bio/terra/service/common/gcs/BigQueryUtils.java
+++ b/src/main/java/bio/terra/service/common/gcs/BigQueryUtils.java
@@ -1,0 +1,15 @@
+package bio.terra.service.common.gcs;
+
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.stairway.FlightContext;
+
+public class BigQueryUtils {
+
+  public static String getSuffix(FlightContext context) {
+    return context.getFlightId().replace('-', '_');
+  }
+
+  public static String firestoreDumpTableName(Snapshot snapshot) {
+    return snapshot.getName() + "_gspath_mapping";
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/CreateExternalTablesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/CreateExternalTablesStep.java
@@ -2,10 +2,10 @@ package bio.terra.service.dataset.flight.datadelete;
 
 import static bio.terra.service.dataset.flight.datadelete.DataDeletionUtils.getDataset;
 import static bio.terra.service.dataset.flight.datadelete.DataDeletionUtils.getRequest;
-import static bio.terra.service.dataset.flight.datadelete.DataDeletionUtils.getSuffix;
 
 import bio.terra.common.FlightUtils;
 import bio.terra.model.DataDeletionTableModel;
+import bio.terra.service.common.gcs.BigQueryUtils;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.exception.TableNotFoundException;
@@ -46,7 +46,7 @@ public class CreateExternalTablesStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Dataset dataset = getDataset(context, datasetService);
-    String suffix = getSuffix(context);
+    String suffix = BigQueryUtils.getSuffix(context);
     List<DataDeletionTableModel> tables =
         FlightUtils.getTyped(context.getWorkingMap(), DataDeletionMapKeys.TABLES);
 
@@ -65,11 +65,11 @@ public class CreateExternalTablesStep implements Step {
   @Override
   public StepResult undoStep(FlightContext context) {
     Dataset dataset = getDataset(context, datasetService);
-    String suffix = getSuffix(context);
+    String suffix = BigQueryUtils.getSuffix(context);
 
     for (DataDeletionTableModel table : getRequest(context).getTables()) {
       try {
-        bigQueryPdao.deleteSoftDeleteExternalTable(dataset, table.getTableName(), suffix);
+        bigQueryPdao.deleteExternalTable(dataset, table.getTableName(), suffix);
       } catch (Exception ex) {
         // catch any exception and get it into the log, make a
         String msg =

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DataDeletionStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DataDeletionStep.java
@@ -2,12 +2,12 @@ package bio.terra.service.dataset.flight.datadelete;
 
 import static bio.terra.service.dataset.flight.datadelete.DataDeletionUtils.getDataset;
 import static bio.terra.service.dataset.flight.datadelete.DataDeletionUtils.getRequest;
-import static bio.terra.service.dataset.flight.datadelete.DataDeletionUtils.getSuffix;
 
 import bio.terra.common.FlightUtils;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DataDeletionTableModel;
 import bio.terra.model.DeleteResponseModel;
+import bio.terra.service.common.gcs.BigQueryUtils;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
@@ -43,7 +43,7 @@ public class DataDeletionStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Dataset dataset = getDataset(context, datasetService);
-    String suffix = getSuffix(context);
+    String suffix = BigQueryUtils.getSuffix(context);
     DataDeletionRequest dataDeletionRequest = getRequest(context);
     List<String> tableNames =
         dataDeletionRequest.getTables().stream()

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DataDeletionUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DataDeletionUtils.java
@@ -18,10 +18,6 @@ public final class DataDeletionUtils {
 
   private DataDeletionUtils() {}
 
-  public static String getSuffix(FlightContext context) {
-    return context.getFlightId().replace('-', '_');
-  }
-
   public static DataDeletionRequest getRequest(FlightContext context) {
     return context
         .getInputParameters()

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DropExternalTablesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DropExternalTablesStep.java
@@ -2,10 +2,10 @@ package bio.terra.service.dataset.flight.datadelete;
 
 import static bio.terra.service.dataset.flight.datadelete.DataDeletionUtils.getDataset;
 import static bio.terra.service.dataset.flight.datadelete.DataDeletionUtils.getRequest;
-import static bio.terra.service.dataset.flight.datadelete.DataDeletionUtils.getSuffix;
 
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DataDeletionTableModel;
+import bio.terra.service.common.gcs.BigQueryUtils;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
@@ -30,11 +30,11 @@ public class DropExternalTablesStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Dataset dataset = getDataset(context, datasetService);
-    String suffix = getSuffix(context);
+    String suffix = BigQueryUtils.getSuffix(context);
     DataDeletionRequest dataDeletionRequest = getRequest(context);
 
     for (DataDeletionTableModel table : dataDeletionRequest.getTables()) {
-      bigQueryPdao.deleteSoftDeleteExternalTable(dataset, table.getTableName(), suffix);
+      bigQueryPdao.deleteExternalTable(dataset, table.getTableName(), suffix);
     }
 
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
@@ -19,4 +19,6 @@ public final class SnapshotWorkingMapKeys extends ProjectCreatingFlightKeys {
   public static final String SNAPSHOT_EXPORT_BUCKET = "snapshotExportBucket";
   public static final String SNAPSHOT_EXPORT_PARQUET_PATHS = "snapshotExportParquetPaths";
   public static final String SNAPSHOT_EXPORT_MANIFEST_PATH = "snapshotExportManifestPath";
+  public static final String SNAPSHOT_EXPORT_FIRESTORE_DUMP_PATH =
+      "snapshotExportFirestoreDumpPath";
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteMappingTable.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteMappingTable.java
@@ -1,0 +1,48 @@
+package bio.terra.service.snapshot.flight.export;
+
+import bio.terra.service.common.gcs.BigQueryUtils;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.service.tabulardata.google.BigQueryPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+
+public class SnapshotExportWriteMappingTable implements Step {
+
+  private final UUID snapshotId;
+  private final SnapshotService snapshotService;
+  private final BigQueryPdao bigQueryPdao;
+
+  public SnapshotExportWriteMappingTable(
+      UUID snapshotId, SnapshotService snapshotService, BigQueryPdao bigQueryPdao) {
+    this.snapshotId = snapshotId;
+    this.snapshotService = snapshotService;
+    this.bigQueryPdao = bigQueryPdao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Snapshot snapshot = snapshotService.retrieve(snapshotId);
+    FlightMap workingMap = context.getWorkingMap();
+    String firestoreDumpPath =
+        workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_EXPORT_FIRESTORE_DUMP_PATH, String.class);
+    String tableName = BigQueryUtils.firestoreDumpTableName(snapshot);
+    String suffix = BigQueryUtils.getSuffix(context);
+    bigQueryPdao.createFirestoreGsPathExternalTable(snapshot, firestoreDumpPath, tableName, suffix);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    Snapshot snapshot = snapshotService.retrieve(snapshotId);
+    String tableName = BigQueryUtils.firestoreDumpTableName(snapshot);
+    String suffix = BigQueryUtils.getSuffix(context);
+    bigQueryPdao.deleteExternalTable(snapshot, tableName, suffix);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -5,7 +5,7 @@ import bio.terra.common.AclUtils;
 import bio.terra.common.exception.PdaoException;
 import bio.terra.model.SnapshotModel;
 import bio.terra.service.dataset.BigQueryPartitionConfigV1;
-import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.filedata.FSContainerInterface;
 import com.google.cloud.bigquery.Acl;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
@@ -51,16 +51,12 @@ public final class BigQueryProject {
     PROJECT_CACHE.put(bigQueryProject.getProjectId(), bigQueryProject);
   }
 
-  public static BigQueryProject from(bio.terra.service.dataset.Dataset dataset) {
-    return get(dataset.getProjectResource().getGoogleProjectId());
-  }
-
-  public static BigQueryProject from(Snapshot snapshot) {
-    return get(snapshot.getProjectResource().getGoogleProjectId());
-  }
-
   public static BigQueryProject from(SnapshotModel snapshotModel) {
     return get(snapshotModel.getDataProject());
+  }
+
+  public static BigQueryProject from(FSContainerInterface fsContainerInterface) {
+    return get(fsContainerInterface.getProjectResource().getGoogleProjectId());
   }
 
   public String getProjectId() {


### PR DESCRIPTION
Load the JSON file dumped from firestore into the bucket into a temporary table in BigQuery. This is still a WIP, and will change based on changes in https://github.com/DataBiosphere/jade-data-repo/pull/1209.