### PR TITLE
DR-2460: Perf tests - Wire through test users in order to refresh tokens on long running jobs

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/BillingProfileInUseTest.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/BillingProfileInUseTest.java
@@ -155,7 +155,7 @@ public class BillingProfileInUseTest extends BillingProfileUsers {
 
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(dataset.getId(), fileLoadModelArray);
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
+    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, userUser);
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);
@@ -192,7 +192,7 @@ public class BillingProfileInUseTest extends BillingProfileUsers {
         repositoryApi.ingestDataset(dataset.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, userUser);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/BillingProfileInUseTest.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/BillingProfileInUseTest.java
@@ -155,7 +155,8 @@ public class BillingProfileInUseTest extends BillingProfileUsers {
 
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(dataset.getId(), fileLoadModelArray);
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, userUser);
+    ingestFileJobResponse =
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, userUser);
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/BuildSnapshotWithFiles.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/BuildSnapshotWithFiles.java
@@ -66,7 +66,7 @@ public class BuildSnapshotWithFiles extends SimpleDataset {
 
     // wait for the job to complete
     bulkLoadArrayJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, bulkLoadArrayJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, bulkLoadArrayJobResponse, testUser);
     BulkLoadArrayResultModel result =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, bulkLoadArrayJobResponse, BulkLoadArrayResultModel.class);
@@ -91,7 +91,7 @@ public class BuildSnapshotWithFiles extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, testUser);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
@@ -118,14 +118,15 @@ public class BuildSnapshotWithFiles extends SimpleDataset {
 
   @Override
   public void cleanup(List<TestUserSpecification> testUsers) throws Exception {
-    ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUsers.get(0), server);
+    TestUserSpecification testUser = testUsers.get(0);
+    ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
     RepositoryApi repositoryApi = new RepositoryApi(apiClient);
 
     for (SnapshotSummaryModel snapshotSummaryModel : snapshotSummaryModels) {
       JobModel deleteSnapshotJobResponse =
           repositoryApi.deleteSnapshot(snapshotSummaryModel.getId());
       deleteSnapshotJobResponse =
-          DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse);
+          DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse, testUser);
       DataRepoUtils.expectJobSuccess(
           repositoryApi, deleteSnapshotJobResponse, DeleteResponseModel.class);
       logger.info("Successfully deleted snapshot: {}", snapshotSummaryModel.getName());

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/BuildSnapshotWithFiles.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/BuildSnapshotWithFiles.java
@@ -105,7 +105,7 @@ public class BuildSnapshotWithFiles extends SimpleDataset {
       for (int i = 0; i < snapshotsToCreate; i++) {
         JobModel createSnapshotJobResponse =
             DataRepoUtils.createSnapshot(
-                repositoryApi, datasetSummaryModel, "snapshot-simple.json", true);
+                repositoryApi, datasetSummaryModel, "snapshot-simple.json", testUser, true);
 
         SnapshotSummaryModel snapshotSummaryModel =
             DataRepoUtils.expectJobSuccess(

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/BulkLoad.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/BulkLoad.java
@@ -49,7 +49,7 @@ public class BulkLoad extends SimpleDataset {
 
     // wait for the job to complete and print out results to debug log level
     BulkLoadResultModel loadSummary =
-        BulkLoadUtils.getAndDisplayResults(repositoryApi, bulkLoadArrayJobResponse);
+        BulkLoadUtils.getAndDisplayResults(repositoryApi, bulkLoadArrayJobResponse, testUser);
 
     assertThat(
         "Number of successful files loaded should equal total files.",

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
@@ -137,7 +137,8 @@ public class CreateSnapshot extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
+        DataRepoUtils.waitForJobToFinish(
+            repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
@@ -167,7 +168,7 @@ public class CreateSnapshot extends SimpleDataset {
       // make the create snapshot request and wait for the job to finish
       JobModel createSnapshotJobResponse =
           DataRepoUtils.createSnapshot(
-              repositoryApi, datasetSummaryModel, "snapshot-simple.json", true);
+              repositoryApi, datasetSummaryModel, "snapshot-simple.json", testUser, true);
 
       logger.info("Snapshot job is done");
       if (createSnapshotJobResponse.getJobStatus() == JobModel.JobStatusEnum.FAILED) {
@@ -200,7 +201,8 @@ public class CreateSnapshot extends SimpleDataset {
     if (snapshotModel != null) {
       JobModel deleteSnapshotJobResponse = repositoryApi.deleteSnapshot(snapshotModel.getId());
       deleteSnapshotJobResponse =
-          DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse, datasetCreator);
+          DataRepoUtils.waitForJobToFinish(
+              repositoryApi, deleteSnapshotJobResponse, datasetCreator);
       DataRepoUtils.expectJobSuccess(
           repositoryApi, deleteSnapshotJobResponse, DeleteResponseModel.class);
       logger.info("Successfully deleted snapshot: {}", snapshotModel.getName());

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CreateSnapshot.java
@@ -137,7 +137,7 @@ public class CreateSnapshot extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
@@ -200,7 +200,7 @@ public class CreateSnapshot extends SimpleDataset {
     if (snapshotModel != null) {
       JobModel deleteSnapshotJobResponse = repositoryApi.deleteSnapshot(snapshotModel.getId());
       deleteSnapshotJobResponse =
-          DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse);
+          DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse, datasetCreator);
       DataRepoUtils.expectJobSuccess(
           repositoryApi, deleteSnapshotJobResponse, DeleteResponseModel.class);
       logger.info("Successfully deleted snapshot: {}", snapshotModel.getName());

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
@@ -90,7 +90,7 @@ public class DRSLookup extends SimpleDataset {
 
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
+    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, datasetCreator);
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);
@@ -126,7 +126,7 @@ public class DRSLookup extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
@@ -204,7 +204,7 @@ public class DRSLookup extends SimpleDataset {
     // make the delete request and wait for the job to finish
     JobModel deleteSnapshotJobResponse = repositoryApi.deleteSnapshot(snapshotModel.getId());
     deleteSnapshotJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse, datasetCreator);
     DataRepoUtils.expectJobSuccess(
         repositoryApi, deleteSnapshotJobResponse, DeleteResponseModel.class);
     logger.info("Successfully deleted snapshot: {}", snapshotModel.getName());

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
@@ -135,7 +135,7 @@ public class DRSLookup extends SimpleDataset {
     // make the create snapshot request and wait for the job to finish
     JobModel createSnapshotJobResponse =
         DataRepoUtils.createSnapshot(
-            repositoryApi, datasetSummaryModel, "snapshot-simple.json", true);
+            repositoryApi, datasetSummaryModel, "snapshot-simple.json", datasetCreator, true);
 
     // save a reference to the snapshot summary model so we can delete it in cleanup()
     SnapshotSummaryModel snapshotSummaryModel =

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/DRSLookup.java
@@ -90,7 +90,8 @@ public class DRSLookup extends SimpleDataset {
 
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, datasetCreator);
+    ingestFileJobResponse =
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, datasetCreator);
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);
@@ -126,7 +127,8 @@ public class DRSLookup extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
+        DataRepoUtils.waitForJobToFinish(
+            repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/IngestFile.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/IngestFile.java
@@ -64,7 +64,8 @@ public class IngestFile extends SimpleDataset {
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
 
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, testUser);
+    ingestFileJobResponse =
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, testUser);
 
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/IngestFile.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/IngestFile.java
@@ -64,7 +64,7 @@ public class IngestFile extends SimpleDataset {
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
 
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
+    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, testUser);
 
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/PodDeleteDuringBulkLoad.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/PodDeleteDuringBulkLoad.java
@@ -65,7 +65,7 @@ public class PodDeleteDuringBulkLoad extends SimpleDataset {
 
     // wait for the job to complete and print out results to debug log level
     BulkLoadResultModel loadSummary =
-        BulkLoadUtils.getAndDisplayResults(repositoryApi, bulkLoadArrayJobResponse);
+        BulkLoadUtils.getAndDisplayResults(repositoryApi, bulkLoadArrayJobResponse, testUser);
 
     assertThat(
         "Number of successful files loaded should equal total files.",

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -103,7 +103,7 @@ public class RetrieveSnapshot extends SimpleDataset {
 
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
+    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, datasetCreator);
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);
@@ -139,7 +139,7 @@ public class RetrieveSnapshot extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
@@ -192,7 +192,7 @@ public class RetrieveSnapshot extends SimpleDataset {
     // make the delete request and wait for the job to finish
     JobModel deleteSnapshotJobResponse = repositoryApi.deleteSnapshot(snapshotSummaryModel.getId());
     deleteSnapshotJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse, datasetCreator);
     DataRepoUtils.expectJobSuccess(
         repositoryApi, deleteSnapshotJobResponse, DeleteResponseModel.class);
     logger.info("Successfully deleted snapshot: {}", snapshotSummaryModel.getName());

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -103,7 +103,8 @@ public class RetrieveSnapshot extends SimpleDataset {
 
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, datasetCreator);
+    ingestFileJobResponse =
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, datasetCreator);
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);
@@ -139,7 +140,8 @@ public class RetrieveSnapshot extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
+        DataRepoUtils.waitForJobToFinish(
+            repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveSnapshot.java
@@ -148,7 +148,7 @@ public class RetrieveSnapshot extends SimpleDataset {
     // make the create snapshot request and wait for the job to finish
     JobModel createSnapshotJobResponse =
         DataRepoUtils.createSnapshot(
-            repositoryApi, datasetSummaryModel, "snapshot-simple.json", true);
+            repositoryApi, datasetSummaryModel, "snapshot-simple.json", datasetCreator, true);
 
     // save a reference to the snapshot summary model so we can delete it in cleanup()
     snapshotSummaryModel =

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/ScalePodsToZero.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/ScalePodsToZero.java
@@ -97,7 +97,7 @@ public class ScalePodsToZero extends SimpleDataset {
 
     // wait for the job to complete and print out results to debug log level
     BulkLoadResultModel loadSummary =
-        BulkLoadUtils.getAndDisplayResults(repositoryApi, bulkLoadArrayJobResponse);
+        BulkLoadUtils.getAndDisplayResults(repositoryApi, bulkLoadArrayJobResponse, testUser);
 
     assertThat(
         "Number of successful files loaded should equal total files.",

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/ScalePodsUpDown.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/ScalePodsUpDown.java
@@ -72,7 +72,7 @@ public class ScalePodsUpDown extends SimpleDataset {
 
     // wait for the job to complete and print out results to debug log level
     BulkLoadResultModel loadSummary =
-        BulkLoadUtils.getAndDisplayResults(repositoryApi, bulkLoadArrayJobResponse);
+        BulkLoadUtils.getAndDisplayResults(repositoryApi, bulkLoadArrayJobResponse, testUser);
 
     assertThat(
         "Number of successful files loaded should equal total files.",

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/SnapshotScaleCreate.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/SnapshotScaleCreate.java
@@ -83,7 +83,7 @@ public class SnapshotScaleCreate extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
@@ -123,7 +123,7 @@ public class SnapshotScaleCreate extends SimpleDataset {
     for (int i = 0; i < numSnapshots; i++) {
       JobModel createSnapshotJobResponse = createSnapshotJobResponses.get(i);
       JobModel createSnapshotJobResult =
-          DataRepoUtils.waitForJobToFinish(repositoryApi, createSnapshotJobResponse);
+          DataRepoUtils.waitForJobToFinish(repositoryApi, createSnapshotJobResponse, datasetCreator);
       SnapshotSummaryModel snapshotSummaryModel =
           DataRepoUtils.expectJobSuccess(
               repositoryApi, createSnapshotJobResult, SnapshotSummaryModel.class);
@@ -138,7 +138,7 @@ public class SnapshotScaleCreate extends SimpleDataset {
       JobModel deleteSnapshotJobResponse =
           repositoryApi.deleteSnapshot(snapshotSummaryModel.getId());
       JobModel deleteSnapshotJobResult =
-          DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse);
+          DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse, datasetCreator);
       //  ^ Shelby makes the great point that this wait is v artificial
       DataRepoUtils.expectJobSuccess(
           repositoryApi, deleteSnapshotJobResult, DeleteResponseModel.class);
@@ -167,7 +167,7 @@ public class SnapshotScaleCreate extends SimpleDataset {
         JobModel deleteSnapshotJobResponse =
             repositoryApi.deleteSnapshot(snapshotList.get(i).getId());
         deleteSnapshotJobResponse =
-            DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse);
+            DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse, datasetCreator);
         DataRepoUtils.expectJobSuccess(
             repositoryApi, deleteSnapshotJobResponse, DeleteResponseModel.class);
         logger.info("Successfully cleaned up snapshot: {}", snapshotList.get(i).getName());

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/SnapshotScaleCreate.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/SnapshotScaleCreate.java
@@ -83,7 +83,8 @@ public class SnapshotScaleCreate extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
+        DataRepoUtils.waitForJobToFinish(
+            repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
@@ -123,7 +124,8 @@ public class SnapshotScaleCreate extends SimpleDataset {
     for (int i = 0; i < numSnapshots; i++) {
       JobModel createSnapshotJobResponse = createSnapshotJobResponses.get(i);
       JobModel createSnapshotJobResult =
-          DataRepoUtils.waitForJobToFinish(repositoryApi, createSnapshotJobResponse, datasetCreator);
+          DataRepoUtils.waitForJobToFinish(
+              repositoryApi, createSnapshotJobResponse, datasetCreator);
       SnapshotSummaryModel snapshotSummaryModel =
           DataRepoUtils.expectJobSuccess(
               repositoryApi, createSnapshotJobResult, SnapshotSummaryModel.class);
@@ -138,7 +140,8 @@ public class SnapshotScaleCreate extends SimpleDataset {
       JobModel deleteSnapshotJobResponse =
           repositoryApi.deleteSnapshot(snapshotSummaryModel.getId());
       JobModel deleteSnapshotJobResult =
-          DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse, datasetCreator);
+          DataRepoUtils.waitForJobToFinish(
+              repositoryApi, deleteSnapshotJobResponse, datasetCreator);
       //  ^ Shelby makes the great point that this wait is v artificial
       DataRepoUtils.expectJobSuccess(
           repositoryApi, deleteSnapshotJobResult, DeleteResponseModel.class);
@@ -167,7 +170,8 @@ public class SnapshotScaleCreate extends SimpleDataset {
         JobModel deleteSnapshotJobResponse =
             repositoryApi.deleteSnapshot(snapshotList.get(i).getId());
         deleteSnapshotJobResponse =
-            DataRepoUtils.waitForJobToFinish(repositoryApi, deleteSnapshotJobResponse, datasetCreator);
+            DataRepoUtils.waitForJobToFinish(
+                repositoryApi, deleteSnapshotJobResponse, datasetCreator);
         DataRepoUtils.expectJobSuccess(
             repositoryApi, deleteSnapshotJobResponse, DeleteResponseModel.class);
         logger.info("Successfully cleaned up snapshot: {}", snapshotList.get(i).getName());

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/SoftDeleteDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/SoftDeleteDataset.java
@@ -77,7 +77,8 @@ public class SoftDeleteDataset extends SimpleDataset {
 
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, datasetCreator);
+    ingestFileJobResponse =
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, datasetCreator);
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);
@@ -101,7 +102,8 @@ public class SoftDeleteDataset extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
+        DataRepoUtils.waitForJobToFinish(
+            repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
@@ -172,7 +174,8 @@ public class SoftDeleteDataset extends SimpleDataset {
     // send off the soft delete request
     JobModel softDeleteJobResponse =
         repositoryApi.applyDatasetDataDeletion(datasetSummaryModel.getId(), dataDeletionRequest);
-    softDeleteJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, softDeleteJobResponse, datasetCreator);
+    softDeleteJobResponse =
+        DataRepoUtils.waitForJobToFinish(repositoryApi, softDeleteJobResponse, datasetCreator);
     DeleteResponseModel deleteResponseModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, softDeleteJobResponse, DeleteResponseModel.class);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/SoftDeleteDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/SoftDeleteDataset.java
@@ -77,7 +77,7 @@ public class SoftDeleteDataset extends SimpleDataset {
 
     JobModel ingestFileJobResponse =
         repositoryApi.bulkFileLoadArray(datasetSummaryModel.getId(), fileLoadModelArray);
-    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse);
+    ingestFileJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, ingestFileJobResponse, datasetCreator);
     BulkLoadArrayResultModel bulkLoadArrayResultModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestFileJobResponse, BulkLoadArrayResultModel.class);
@@ -101,7 +101,7 @@ public class SoftDeleteDataset extends SimpleDataset {
         repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
 
     ingestTabularDataJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, ingestTabularDataJobResponse, datasetCreator);
     IngestResponseModel ingestResponse =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, ingestTabularDataJobResponse, IngestResponseModel.class);
@@ -172,7 +172,7 @@ public class SoftDeleteDataset extends SimpleDataset {
     // send off the soft delete request
     JobModel softDeleteJobResponse =
         repositoryApi.applyDatasetDataDeletion(datasetSummaryModel.getId(), dataDeletionRequest);
-    softDeleteJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, softDeleteJobResponse);
+    softDeleteJobResponse = DataRepoUtils.waitForJobToFinish(repositoryApi, softDeleteJobResponse, datasetCreator);
     DeleteResponseModel deleteResponseModel =
         DataRepoUtils.expectJobSuccess(
             repositoryApi, softDeleteJobResponse, DeleteResponseModel.class);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
@@ -51,7 +51,7 @@ public class SimpleDataset extends runner.TestScript {
       if (cloudPlatform.equals(CloudPlatform.GCP)) {
         billingProfileModel =
             DataRepoUtils.createProfile(
-                resourcesApi, repositoryApi, billingAccount, "profile-simple", true);
+                resourcesApi, repositoryApi, billingAccount, "profile-simple", datasetCreator, true);
       } else if (cloudPlatform.equals(CloudPlatform.AZURE)) {
         billingProfileModel =
             DataRepoUtils.createAzureProfile(
@@ -63,6 +63,7 @@ public class SimpleDataset extends runner.TestScript {
                 applicationDeploymentName,
                 "azure-profile-simple",
                 billingAccount,
+                datasetCreator,
                 true);
       } else {
         throw new RuntimeException("Unsupported cloud platform");
@@ -75,7 +76,7 @@ public class SimpleDataset extends runner.TestScript {
     // make the create dataset request and wait for the job to finish
     JobModel createDatasetJobResponse =
         DataRepoUtils.createDataset(
-            repositoryApi, billingProfileModel.getId(), cloudPlatform, "dataset-simple.json", true);
+            repositoryApi, billingProfileModel.getId(), cloudPlatform, "dataset-simple.json", datasetCreator, true);
 
     // save a reference to the dataset summary model so we can delete it in cleanup()
     datasetSummaryModel =
@@ -113,7 +114,7 @@ public class SimpleDataset extends runner.TestScript {
     // make the delete dataset request and wait for the job to finish
     JobModel deleteDatasetJobResponse = repositoryApi.deleteDataset(datasetSummaryModel.getId());
     deleteDatasetJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, deleteDatasetJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, deleteDatasetJobResponse, datasetCreator);
     DataRepoUtils.expectJobSuccess(
         repositoryApi, deleteDatasetJobResponse, DeleteResponseModel.class);
     logger.info("Successfully deleted dataset: {}", datasetSummaryModel.getName());

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
@@ -51,7 +51,12 @@ public class SimpleDataset extends runner.TestScript {
       if (cloudPlatform.equals(CloudPlatform.GCP)) {
         billingProfileModel =
             DataRepoUtils.createProfile(
-                resourcesApi, repositoryApi, billingAccount, "profile-simple", datasetCreator, true);
+                resourcesApi,
+                repositoryApi,
+                billingAccount,
+                "profile-simple",
+                datasetCreator,
+                true);
       } else if (cloudPlatform.equals(CloudPlatform.AZURE)) {
         billingProfileModel =
             DataRepoUtils.createAzureProfile(
@@ -76,7 +81,12 @@ public class SimpleDataset extends runner.TestScript {
     // make the create dataset request and wait for the job to finish
     JobModel createDatasetJobResponse =
         DataRepoUtils.createDataset(
-            repositoryApi, billingProfileModel.getId(), cloudPlatform, "dataset-simple.json", datasetCreator, true);
+            repositoryApi,
+            billingProfileModel.getId(),
+            cloudPlatform,
+            "dataset-simple.json",
+            datasetCreator,
+            true);
 
     // save a reference to the dataset summary model so we can delete it in cleanup()
     datasetSummaryModel =

--- a/datarepo-clienttests/src/main/java/scripts/utils/BulkLoadUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/BulkLoadUtils.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import runner.config.ServiceAccountSpecification;
+import runner.config.TestUserSpecification;
 
 public class BulkLoadUtils {
   private static final Logger logger = LoggerFactory.getLogger(BulkLoadUtils.class);
@@ -133,7 +134,10 @@ public class BulkLoadUtils {
   }
 
   public static BulkLoadResultModel getAndDisplayResults(
-      RepositoryApi repositoryApi, JobModel bulkLoadArrayJobResponse, TestUserSpecification testUser) throws Exception {
+      RepositoryApi repositoryApi,
+      JobModel bulkLoadArrayJobResponse,
+      TestUserSpecification testUser)
+      throws Exception {
     bulkLoadArrayJobResponse =
         DataRepoUtils.waitForJobToFinish(repositoryApi, bulkLoadArrayJobResponse, testUser);
 

--- a/datarepo-clienttests/src/main/java/scripts/utils/BulkLoadUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/BulkLoadUtils.java
@@ -133,9 +133,9 @@ public class BulkLoadUtils {
   }
 
   public static BulkLoadResultModel getAndDisplayResults(
-      RepositoryApi repositoryApi, JobModel bulkLoadArrayJobResponse) throws Exception {
+      RepositoryApi repositoryApi, JobModel bulkLoadArrayJobResponse, TestUserSpecification testUser) throws Exception {
     bulkLoadArrayJobResponse =
-        DataRepoUtils.waitForJobToFinish(repositoryApi, bulkLoadArrayJobResponse);
+        DataRepoUtils.waitForJobToFinish(repositoryApi, bulkLoadArrayJobResponse, testUser);
 
     BulkLoadArrayResultModel result =
         DataRepoUtils.expectJobSuccess(

--- a/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
@@ -250,6 +250,7 @@ public final class DataRepoUtils {
    * @param profileId the billing profile id
    * @param apipayloadFilename the name of the create dataset payload file in the apipayloads
    *     resources directory
+   * @param testUser - user specification used to refresh credentials on long running job
    * @param randomizeName true to append a random number at the end of the dataset name, false
    *     otherwise
    * @return the completed job model
@@ -259,6 +260,7 @@ public final class DataRepoUtils {
       UUID profileId,
       CloudPlatform cloudPlatform,
       String apipayloadFilename,
+      TestUserSpecification testUser,
       boolean randomizeName)
       throws Exception {
     logger.debug("Creating a dataset");
@@ -277,7 +279,7 @@ public final class DataRepoUtils {
 
     // make the create request and wait for the job to finish
     JobModel createDatasetJobResponse = repositoryApi.createDataset(createDatasetRequest);
-    return DataRepoUtils.waitForJobToFinish(repositoryApi, createDatasetJobResponse);
+    return DataRepoUtils.waitForJobToFinish(repositoryApi, createDatasetJobResponse, testUser);
   }
 
   /**
@@ -337,6 +339,7 @@ public final class DataRepoUtils {
    * @param resourcesApi the api object to use
    * @param billingAccount the Google billing account id
    * @param profileName the name of the new profile
+   * @param testUser a TestUserSpecification to refresh the token for long-running jobs
    * @param randomizeName true to append a random number at the end of the profile name, false
    *     otherwise
    * @return the created billing profile model
@@ -346,6 +349,7 @@ public final class DataRepoUtils {
       RepositoryApi repositoryApi,
       String billingAccount,
       String profileName,
+      TestUserSpecification testUser,
       boolean randomizeName)
       throws Exception {
     logger.debug("Creating a billing profile");
@@ -364,7 +368,7 @@ public final class DataRepoUtils {
 
     // make the create request and wait for the job to finish
     JobModel jobModel = resourcesApi.createProfile(createProfileRequest);
-    jobModel = DataRepoUtils.waitForJobToFinish(repositoryApi, jobModel);
+    jobModel = DataRepoUtils.waitForJobToFinish(repositoryApi, jobModel, testUser);
 
     BillingProfileModel billingProfile =
         DataRepoUtils.expectJobSuccess(repositoryApi, jobModel, BillingProfileModel.class);
@@ -381,6 +385,7 @@ public final class DataRepoUtils {
       String applicationDeploymentName,
       String profileName,
       String billingAccount,
+      TestUserSpecification testUser,
       boolean randomizeName)
       throws Exception {
     logger.debug("Creating a billing profile");
@@ -403,7 +408,7 @@ public final class DataRepoUtils {
 
     // make the create request and wait for the job to finish
     JobModel jobModel = resourcesApi.createProfile(createProfileRequest);
-    jobModel = DataRepoUtils.waitForJobToFinish(repositoryApi, jobModel);
+    jobModel = DataRepoUtils.waitForJobToFinish(repositoryApi, jobModel, testUser);
 
     BillingProfileModel billingProfile =
         DataRepoUtils.expectJobSuccess(repositoryApi, jobModel, BillingProfileModel.class);

--- a/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
@@ -287,6 +287,7 @@ public final class DataRepoUtils {
    * @param datasetSummaryModel the summary of the dataset used by the snapshot
    * @param apipayloadFilename the name of the create snapshot payload file in the apipayloads
    *     resources directory
+   * @param testUser - user specification used to refresh credentials on long running job
    * @param randomizeName true to append a random number at the end of the snapshot name, false
    *     otherwise
    * @return the completed job model
@@ -295,6 +296,7 @@ public final class DataRepoUtils {
       RepositoryApi repositoryApi,
       DatasetSummaryModel datasetSummaryModel,
       String apipayloadFilename,
+      TestUserSpecification testUser,
       boolean randomizeName)
       throws Exception {
 
@@ -302,7 +304,7 @@ public final class DataRepoUtils {
     JobModel createSnapshotJobResponse =
         createSnapshotWithoutWaiting(
             repositoryApi, datasetSummaryModel, apipayloadFilename, randomizeName);
-    return DataRepoUtils.waitForJobToFinish(repositoryApi, createSnapshotJobResponse);
+    return DataRepoUtils.waitForJobToFinish(repositoryApi, createSnapshotJobResponse, testUser);
   }
 
   public static JobModel createSnapshotWithoutWaiting(

--- a/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
@@ -114,27 +114,6 @@ public final class DataRepoUtils {
   }
 
   /**
-   * Wait until the job finishes, either successfully or not. Times out after {@link
-   * DataRepoUtils#maximumSecondsToWaitForJob} seconds. Polls in intervals of {@link
-   * DataRepoUtils#secondsIntervalToPollJob} seconds.
-   *
-   * @param repositoryApi the api object to use
-   * @param job the job model to poll
-   */
-  public static JobModel waitForJobToFinish(RepositoryApi repositoryApi, JobModel job)
-      throws Exception {
-    logger.debug("Waiting for Data Repo job to finish");
-    job = pollForRunningJob(repositoryApi, job, maximumSecondsToWaitForJob, null);
-
-    if (job.getJobStatus().equals(JobModel.JobStatusEnum.RUNNING)) {
-      throw new RuntimeException(
-          "Timed out waiting for job to finish. (jobid=" + job.getId() + ")");
-    }
-
-    return job;
-  }
-
-  /**
    * Poll for running job. Polls for designated time.
    *
    * @param repositoryApi the api object to use


### PR DESCRIPTION
The fix:
The pollForRunningJob method only updates the credentials if a test user is provided. https://github.com/DataBiosphere/jade-data-repo/blob/develop/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java#L181

Note for reviewers: I think the main thing to look out for is to check that I'm passing through the correct test user for the particular job.