### PR TITLE
DR-2458 Send authenticated API requests to bard to tracking

### DIFF
--- a/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
@@ -1,0 +1,64 @@
+package bio.terra.app.configuration;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "usermetrics")
+public class UserMetricsConfiguration {
+
+  private String appId;
+  private String bardBasePath;
+  private Integer metricsReportingPoolSize;
+  private List<String> ignorePaths;
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public void setAppId(String appId) {
+    this.appId = appId;
+  }
+
+  public String getBardBasePath() {
+    return bardBasePath;
+  }
+
+  public void setBardBasePath(String bardBasePath) {
+    this.bardBasePath = bardBasePath;
+  }
+
+  public Integer getMetricsReportingPoolSize() {
+    return metricsReportingPoolSize;
+  }
+
+  public void setMetricsReportingPoolSize(Integer metricsReportingPoolSize) {
+    this.metricsReportingPoolSize = metricsReportingPoolSize;
+  }
+
+  public List<String> getIgnorePaths() {
+    return ignorePaths;
+  }
+
+  public void setIgnorePaths(List<String> ignorePaths) {
+    this.ignorePaths = ignorePaths;
+  }
+
+  @Bean("metricsReportingThreadpool")
+  public ExecutorService metricsPerformanceThreadpool() {
+    return new ThreadPoolExecutor(
+        metricsReportingPoolSize,
+        metricsReportingPoolSize,
+        0,
+        TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<>(metricsReportingPoolSize));
+  }
+}

--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -1,6 +1,7 @@
 package bio.terra.app.configuration;
 
 import bio.terra.app.logging.LoggerInterceptor;
+import bio.terra.app.usermetrics.UserMetricsInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -9,16 +10,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Component
 public class WebConfig implements WebMvcConfigurer {
-  private final LoggerInterceptor loggerInterceptor;
-
-  @Autowired
-  public WebConfig(LoggerInterceptor loggerInterceptor) {
-    this.loggerInterceptor = loggerInterceptor;
-  }
+  @Autowired private LoggerInterceptor loggerInterceptor;
+  @Autowired private UserMetricsInterceptor metricsInterceptor;
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(loggerInterceptor);
+    registry.addInterceptor(metricsInterceptor);
   }
 
   @Override

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -1,0 +1,59 @@
+package bio.terra.app.usermetrics;
+
+import bio.terra.app.configuration.UserMetricsConfiguration;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/** Wraps HTTP calls to communicate with the Bard Http service */
+@Component
+public class BardClient {
+
+  private static final Logger logger = LoggerFactory.getLogger(BardClient.class);
+
+  private final UserMetricsConfiguration metricsConfig;
+
+  private final RestTemplate restTemplate;
+  private final HttpHeaders headers;
+
+  @Autowired
+  public BardClient(UserMetricsConfiguration metricsConfig) {
+    this.restTemplate = new RestTemplate();
+    restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+    this.headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON));
+
+    this.metricsConfig = metricsConfig;
+  }
+
+  public void logEvent(AuthenticatedUserRequest userReq, BardEvent event) {
+    HttpHeaders authedHeaders = new HttpHeaders(headers);
+    authedHeaders.setBearerAuth(userReq.getToken());
+    try {
+      ResponseEntity<Void> eventCall =
+          restTemplate.exchange(
+              metricsConfig.getBardBasePath() + "/api/event",
+              HttpMethod.POST,
+              new HttpEntity<>(event, authedHeaders),
+              Void.class);
+      if (!eventCall.getStatusCode().is2xxSuccessful()) {
+        logger.warn(
+            "Error logging event {}%n{}",
+            event.getEvent(), eventCall.getStatusCode().getReasonPhrase());
+      }
+    } catch (Exception e) {
+      logger.warn("Error logging event {}", event.getEvent(), e);
+    }
+  }
+}

--- a/src/main/java/bio/terra/app/usermetrics/BardEvent.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardEvent.java
@@ -1,0 +1,56 @@
+package bio.terra.app.usermetrics;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/** Payload that gets sent to bard to log a user events */
+public class BardEvent {
+  private static final String APP_ID_FIELD = "appId";
+  private static final String HOSTNAME_FIELD = "hostname";
+  private final String event;
+  private final Map<String, Object> properties;
+
+  public BardEvent(String event, Map<String, Object> properties, String appId, String hostName) {
+    this.event = event;
+    this.properties = new HashMap<>();
+    this.properties.putAll(properties);
+    this.properties.put(APP_ID_FIELD, appId);
+    this.properties.put(HOSTNAME_FIELD, hostName);
+  }
+
+  public String getEvent() {
+    return event;
+  }
+
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BardEvent bardEvent = (BardEvent) o;
+    return Objects.equals(event, bardEvent.event)
+        && Objects.equals(properties, bardEvent.properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(event, properties);
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+        .append("event", event)
+        .append("properties", properties)
+        .toString();
+  }
+}

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -1,0 +1,80 @@
+package bio.terra.app.usermetrics;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.app.configuration.UserMetricsConfiguration;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import liquibase.util.StringUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class UserMetricsInterceptor implements HandlerInterceptor {
+  static final String API_EVENT_NAME = "tdr:api";
+  static final String METHOD_FIELD_NAME = "method";
+  static final String PATH_FIELD_NAME = "path";
+
+  private final BardClient bardClient;
+  private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  private final ApplicationConfiguration applicationConfiguration;
+  private final UserMetricsConfiguration metricsConfig;
+  private final ExecutorService metricsPerformanceThreadpool;
+
+  @Autowired
+  public UserMetricsInterceptor(
+      BardClient bardClient,
+      AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
+      ApplicationConfiguration applicationConfiguration,
+      UserMetricsConfiguration metricsConfig,
+      @Qualifier("metricsReportingThreadpool") ExecutorService metricsPerformanceThreadpool) {
+    this.bardClient = bardClient;
+    this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
+    this.applicationConfiguration = applicationConfiguration;
+    this.metricsConfig = metricsConfig;
+    this.metricsPerformanceThreadpool = metricsPerformanceThreadpool;
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+      throws Exception {
+    String method = request.getMethod().toUpperCase();
+    String path = request.getRequestURI();
+    AuthenticatedUserRequest userRequest = authenticatedUserRequestFactory.from(request);
+    System.err.println("Start client " + bardClient);
+    // Don't log metrics if bard isn't configured, the path is part of the ignore list or the
+    // request is unauthorized
+    if (StringUtils.isEmpty(metricsConfig.getBardBasePath())
+        || ignoreEventForPath(path)
+        || StringUtils.isEmpty(userRequest.getToken())) {
+      System.err.println("exit");
+      return;
+    }
+
+    // Spawn a thread so that sending the metric doesn't slow down the initial request
+    metricsPerformanceThreadpool.submit(
+        () ->
+            bardClient.logEvent(
+                userRequest,
+                new BardEvent(
+                    API_EVENT_NAME,
+                    Map.of(
+                        METHOD_FIELD_NAME, method,
+                        PATH_FIELD_NAME, path),
+                    metricsConfig.getAppId(),
+                    applicationConfiguration.getDnsName())));
+  }
+
+  /** Should we actually ignore sending a tracking event for this path */
+  private boolean ignoreEventForPath(String path) {
+    return metricsConfig.getIgnorePaths().stream()
+        .anyMatch(p -> FilenameUtils.wildcardMatch(path, p));
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -106,3 +106,7 @@ rbs.enabled=false
 rbs.poolId=datarepo_v1
 rbs.instanceUrl=https://buffer.tools.integ.envs.broadinstitute.org
 rbs.clientCredentialFilePath=/tmp/buffer-client-sa-account.json
+usermetrics.appId=datarepo
+usermetrics.bardBasePath=
+usermetrics.metricsReportingPoolSize=10
+usermetrics.ignorePaths=/api/repository/v1/jobs/*,/api/repository/v1/configs*,/api/repository/v1/upgrade,/actuator/*,/configuration,/status

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -1,0 +1,125 @@
+package bio.terra.app.usermetrics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.app.configuration.UserMetricsConfiguration;
+import bio.terra.common.category.Unit;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class UserMetricsInterceptorTest {
+  @MockBean private BardClient bardClient;
+  @Autowired private UserMetricsConfiguration metricsConfig;
+  @Captor private ArgumentCaptor<AuthenticatedUserRequest> authCaptor;
+  @Autowired private UserMetricsInterceptor metricsInterceptor;
+
+  @Before
+  public void setUp() throws Exception {
+    metricsConfig.setIgnorePaths(List.of());
+  }
+
+  @Test
+  public void testSendEvent() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(request.getMethod()).thenReturn("post");
+    when(request.getRequestURI()).thenReturn("/foo/bar");
+    mockRequestAuth(request);
+
+    runAnWait(request, response);
+
+    verify(bardClient, times(1))
+        .logEvent(
+            authCaptor.capture(),
+            eq(
+                new BardEvent(
+                    UserMetricsInterceptor.API_EVENT_NAME,
+                    Map.of(
+                        UserMetricsInterceptor.METHOD_FIELD_NAME, "POST",
+                        UserMetricsInterceptor.PATH_FIELD_NAME, "/foo/bar"),
+                    "testapp",
+                    "some.dnsname.org")));
+
+    assertThat("token is correct", authCaptor.getValue().getToken(), equalTo("footoken"));
+  }
+
+  @Test
+  public void testSendEventNotFiredWithNoToken() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(request.getMethod()).thenReturn("post");
+    when(request.getRequestURI()).thenReturn("/foo/bar");
+
+    runAnWait(request, response);
+
+    verify(bardClient, times(0)).logEvent(any(), any());
+  }
+
+  @Test
+  public void testSendEventNotFiredWithIgnoredUrl() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(request.getMethod()).thenReturn("post");
+    when(request.getRequestURI()).thenReturn("/foo/bar");
+    metricsConfig.setIgnorePaths(List.of("/foo/bar"));
+    mockRequestAuth(request);
+
+    runAnWait(request, response);
+
+    verify(bardClient, times(0)).logEvent(any(), any());
+  }
+
+  @Test
+  public void testSendEventNotFiredWithIgnoredWildcardUrl() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(request.getMethod()).thenReturn("post");
+    when(request.getRequestURI()).thenReturn("/foo/bar");
+    metricsConfig.setIgnorePaths(List.of("/foo/*"));
+    mockRequestAuth(request);
+
+    runAnWait(request, response);
+
+    verify(bardClient, times(0)).logEvent(any(), any());
+  }
+
+  private void mockRequestAuth(HttpServletRequest request) {
+    when(request.getHeader("Authorization")).thenReturn("Bearer footoken");
+    when(request.getHeader("From")).thenReturn("me@me.me");
+  }
+
+  private void runAnWait(HttpServletRequest request, HttpServletResponse response)
+      throws Exception {
+    metricsInterceptor.afterCompletion(request, response, null, null);
+    // This waits for the threadpool to wrap up so that we can examine the results
+    metricsConfig.metricsPerformanceThreadpool().awaitTermination(100, TimeUnit.MILLISECONDS);
+  }
+}

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -118,7 +118,7 @@ public class UserMetricsInterceptorTest {
 
   private void runAnWait(HttpServletRequest request, HttpServletResponse response)
       throws Exception {
-    metricsInterceptor.afterCompletion(request, response, null, null);
+    metricsInterceptor.afterCompletion(request, response, new Object(), null);
     // This waits for the threadpool to wrap up so that we can examine the results
     metricsConfig.metricsPerformanceThreadpool().awaitTermination(100, TimeUnit.MILLISECONDS);
   }

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableFileDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableFileDaoTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -57,7 +58,11 @@ public class TableFileDaoTest {
   @MockBean private TableServiceClient tableServiceClient;
   @MockBean private TableClient tableClient;
   @MockBean private FireStoreUtils fireStoreUtils;
-  @MockBean private ExecutorService executor;
+
+  @MockBean
+  @Qualifier("performanceThreadpool")
+  private ExecutorService executor;
+
   @Autowired private TableFileDao dao;
 
   @Before

--- a/src/test/resources/application-unittest.properties
+++ b/src/test/resources/application-unittest.properties
@@ -1,1 +1,5 @@
 datarepo.testWithEmbeddedDatabase=true
+
+usermetrics.appId=testapp
+usermetrics.bardBasePath=https://bard.com
+usermetrics.metricsReportingPoolSize=10


### PR DESCRIPTION
This adds a `HandlerInterceptor` (similar to how we do request logging) to the TDR app which sends authenticated requests to Bard, a service that Terra operates which communicates with MixPanel.  The events that get sent end up looking like:
![image](https://user-images.githubusercontent.com/5633787/156664191-84774934-aae3-4421-a639-822569cc4715.png)

Namely: the name of each event is `tdr:api` with an appId of `datarepo`.  Currently, we track method and endpoint as well as user id

I added new properties to configure metrics collection:
`usermetrics.appId`: Identifier of the TDR to be able to filter in MixPanel (default: `datarepo`)
`usermetrics.bardBasePath`: The base path to access Bard.  If it's empty, no metrics are collected
`usermetrics.metricsReportingPoolSize`: The pool size to sending requests to Bard (default `10`)
`usermetrics.ignorePaths`: Comma separated list of paths (that support wildcard) that should be ignored (e.g. not tracked) (Default is: `/api/repository/v1/jobs/*,/api/repository/v1/configs*,/api/repository/v1/upgrade,/actuator/*,/configuration,/status`)

