### PR TITLE
DR-2461 Snapshot export primary keys unique

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -159,12 +159,13 @@ public class SnapshotsApiController implements SnapshotsApi {
 
   @Override
   public ResponseEntity<JobModel> exportSnapshot(
-      @PathVariable("id") UUID id, Boolean exportGsPaths) {
+      @PathVariable("id") UUID id, Boolean exportGsPaths, Boolean validatePrimaryKeyUniqueness) {
     logger.info("Verifying user access");
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     iamService.verifyAuthorization(
         userReq, IamResourceType.DATASNAPSHOT, id.toString(), IamAction.READ_DATA);
-    String jobId = snapshotService.exportSnapshot(id, userReq, exportGsPaths);
+    String jobId =
+        snapshotService.exportSnapshot(id, userReq, exportGsPaths, validatePrimaryKeyUniqueness);
     // we can retrieve the job we just created
     return jobToResponse(jobService.retrieveJob(jobId, userReq));
   }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStep.java
@@ -29,7 +29,7 @@ public class IngestValidateIngestRowsStep implements Step {
     String stagingTableName = IngestUtils.getStagingTableName(context);
 
     if (targetTable.getPrimaryKey() != null && !targetTable.getPrimaryKey().isEmpty()) {
-      if (bigQueryPdao.selectHasDuplicateStagingIds(
+      if (bigQueryPdao.hasDuplicatePrimaryKeys(
           dataset, targetTable.getPrimaryKey(), stagingTableName)) {
         throw new InvalidIngestDuplicatesException(
             "Duplicate primary key values identified.",

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -14,11 +14,9 @@ public enum JobMapKeys {
   // parameters for specific flight types
   DATASET_ID("datasetId"),
   SNAPSHOT_ID("snapshotId"),
-  EXPORT_GSPATHS("exportGsPaths"),
   FILE_ID("fileId"),
   ASSET_ID("assetId"),
-  TRANSACTION_ID("transactionId"),
-  EXPORT_VALIDATE_PK_UNIQUENESS("exportValidatePkUniqueness");
+  TRANSACTION_ID("transactionId");
 
   private String keyName;
 

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -17,7 +17,8 @@ public enum JobMapKeys {
   EXPORT_GSPATHS("exportGsPaths"),
   FILE_ID("fileId"),
   ASSET_ID("assetId"),
-  TRANSACTION_ID("transactionId");
+  TRANSACTION_ID("transactionId"),
+  EXPORT_VALIDATE_PK_UNIQUENESS("exportValidatePkUniqueness");
 
   private String keyName;
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -130,13 +130,18 @@ public class SnapshotService {
         .submit();
   }
 
-  public String exportSnapshot(UUID id, AuthenticatedUserRequest userReq, Boolean exportGsPaths) {
+  public String exportSnapshot(
+      UUID id,
+      AuthenticatedUserRequest userReq,
+      Boolean exportGsPaths,
+      Boolean validatePrimaryKeyUniqueness) {
     String description = "Export snapshot " + id;
     return jobService
         .newJob(description, SnapshotExportFlight.class, null, userReq)
         .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), id.toString())
         .addParameter(JobMapKeys.EXPORT_GSPATHS.getKeyName(), exportGsPaths)
-        .addParameter(JobMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS.getKeyName(), false)
+        .addParameter(
+            JobMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS.getKeyName(), validatePrimaryKeyUniqueness)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -45,6 +45,7 @@ import bio.terra.service.snapshot.exception.InvalidSnapshotException;
 import bio.terra.service.snapshot.exception.SnapshotPreviewException;
 import bio.terra.service.snapshot.flight.create.SnapshotCreateFlight;
 import bio.terra.service.snapshot.flight.delete.SnapshotDeleteFlight;
+import bio.terra.service.snapshot.flight.export.ExportMapKeys;
 import bio.terra.service.snapshot.flight.export.SnapshotExportFlight;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import java.util.ArrayList;
@@ -139,9 +140,8 @@ public class SnapshotService {
     return jobService
         .newJob(description, SnapshotExportFlight.class, null, userReq)
         .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), id.toString())
-        .addParameter(JobMapKeys.EXPORT_GSPATHS.getKeyName(), exportGsPaths)
-        .addParameter(
-            JobMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS.getKeyName(), validatePrimaryKeyUniqueness)
+        .addParameter(ExportMapKeys.EXPORT_GSPATHS, exportGsPaths)
+        .addParameter(ExportMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS, validatePrimaryKeyUniqueness)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -136,6 +136,7 @@ public class SnapshotService {
         .newJob(description, SnapshotExportFlight.class, null, userReq)
         .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), id.toString())
         .addParameter(JobMapKeys.EXPORT_GSPATHS.getKeyName(), exportGsPaths)
+        .addParameter(JobMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS.getKeyName(), false)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -134,8 +134,8 @@ public class SnapshotService {
   public String exportSnapshot(
       UUID id,
       AuthenticatedUserRequest userReq,
-      Boolean exportGsPaths,
-      Boolean validatePrimaryKeyUniqueness) {
+      boolean exportGsPaths,
+      boolean validatePrimaryKeyUniqueness) {
     String description = "Export snapshot " + id;
     return jobService
         .newJob(description, SnapshotExportFlight.class, null, userReq)

--- a/src/main/java/bio/terra/service/snapshot/exception/SnapshotExportException.java
+++ b/src/main/java/bio/terra/service/snapshot/exception/SnapshotExportException.java
@@ -1,0 +1,10 @@
+package bio.terra.service.snapshot.exception;
+
+import bio.terra.common.exception.BadRequestException;
+import java.util.List;
+
+public class SnapshotExportException extends BadRequestException {
+  public SnapshotExportException(String message, List<String> causes) {
+    super(message, causes);
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/export/ExportMapKeys.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/ExportMapKeys.java
@@ -1,0 +1,7 @@
+package bio.terra.service.snapshot.flight.export;
+
+public final class ExportMapKeys {
+
+  public static final String EXPORT_VALIDATE_PK_UNIQUENESS = "exportValidatePkUniqueness";
+  public static final String EXPORT_GSPATHS = "exportGsPaths";
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
@@ -60,7 +60,12 @@ public class SnapshotExportFlight extends Flight {
             bigQueryPdao, gcsPdao, snapshotService, snapshotId, exportGsPaths));
     addStep(
         new SnapshotExportWriteManifestStep(
-            snapshotId, snapshotService, gcsPdao, objectMapper, userReq));
+            snapshotId,
+            snapshotService,
+            gcsPdao,
+            objectMapper,
+            userReq,
+            validatePrimaryKeyUniqueness));
     addStep(new SnapshotExportGrantPermissionsStep(gcsPdao, userReq));
     if (exportGsPaths) {
       addStep(new CleanUpExportGsPathsStep(bigQueryPdao, gcsPdao, snapshotService, snapshotId));

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
@@ -36,19 +36,17 @@ public class SnapshotExportFlight extends Flight {
 
     boolean validatePrimaryKeyUniqueness =
         Objects.requireNonNullElse(
-            inputParameters.get(
-                JobMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS.getKeyName(), Boolean.class),
-            true);
+            inputParameters.get(ExportMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS, Boolean.class), true);
 
     if (validatePrimaryKeyUniqueness) {
-      addStep(new SnapshotExportValidateStep(bigQueryPdao, snapshotService, snapshotId));
+      addStep(new SnapshotExportValidatePrimaryKeysStep(bigQueryPdao, snapshotService, snapshotId));
     }
 
     addStep(new SnapshotExportCreateBucketStep(resourceService, snapshotService, snapshotId));
 
     boolean exportGsPaths =
         Objects.requireNonNullElse(
-            inputParameters.get(JobMapKeys.EXPORT_GSPATHS.getKeyName(), Boolean.class), false);
+            inputParameters.get(ExportMapKeys.EXPORT_GSPATHS, Boolean.class), false);
     if (exportGsPaths) {
       addStep(
           new SnapshotExportDumpFirestoreStep(

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
@@ -34,6 +34,16 @@ public class SnapshotExportFlight extends Flight {
     UUID snapshotId =
         UUID.fromString(inputParameters.get(JobMapKeys.SNAPSHOT_ID.getKeyName(), String.class));
 
+    boolean validatePrimaryKeyUniqueness =
+        Objects.requireNonNullElse(
+            inputParameters.get(
+                JobMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS.getKeyName(), Boolean.class),
+            true);
+
+    if (validatePrimaryKeyUniqueness) {
+      addStep(new SnapshotExportValidateStep(bigQueryPdao, snapshotService, snapshotId));
+    }
+
     addStep(new SnapshotExportCreateBucketStep(resourceService, snapshotService, snapshotId));
 
     boolean exportGsPaths =

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportValidatePrimaryKeysStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportValidatePrimaryKeysStep.java
@@ -8,25 +8,24 @@ import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.SnapshotTable;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
+import bio.terra.service.snapshot.exception.SnapshotExportException;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class SnapshotExportValidateStep implements Step {
+public class SnapshotExportValidatePrimaryKeysStep implements Step {
   private final BigQueryPdao bigQueryPdao;
   private final SnapshotService snapshotService;
   private final UUID snapshotId;
 
-  public SnapshotExportValidateStep(
+  public SnapshotExportValidatePrimaryKeysStep(
       BigQueryPdao bigQueryPdao, SnapshotService snapshotService, UUID snapshotId) {
     this.bigQueryPdao = bigQueryPdao;
     this.snapshotService = snapshotService;
@@ -38,22 +37,22 @@ public class SnapshotExportValidateStep implements Step {
     Snapshot snapshot = snapshotService.retrieve(snapshotId);
     Dataset dataset = snapshot.getFirstSnapshotSource().getDataset();
     List<SnapshotTable> tables = snapshot.getTables();
-    List<String> tablesWithoutPrimaryKeys = new ArrayList<>();
     List<String> tablesWithDuplicates =
         tables.stream()
             .map(
                 table -> {
                   String tableName = table.getName();
-                  Optional<DatasetTable> datasetTable = dataset.getTableByName(tableName);
-                  if (datasetTable.isEmpty()) {
-                    throw new CorruptMetadataException(
-                        String.format(
-                            "Could not find '%s' table in the snapshot's dataset", tableName));
-                  }
-                  DatasetTable realDatasetTable = datasetTable.get();
-                  List<Column> primaryKeyColumns = realDatasetTable.getPrimaryKey();
+                  DatasetTable datasetTable =
+                      dataset
+                          .getTableByName(tableName)
+                          .orElseThrow(
+                              () ->
+                                  new CorruptMetadataException(
+                                      String.format(
+                                          "Could not find '%s' table in the snapshot's dataset",
+                                          tableName)));
+                  List<Column> primaryKeyColumns = datasetTable.getPrimaryKey();
                   if (primaryKeyColumns.isEmpty()) {
-                    tablesWithoutPrimaryKeys.add(table.getName());
                     return null;
                   }
 
@@ -77,29 +76,19 @@ public class SnapshotExportValidateStep implements Step {
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
 
-    if (tablesWithDuplicates.isEmpty() && tablesWithoutPrimaryKeys.isEmpty()) {
+    if (tablesWithDuplicates.isEmpty()) {
       return StepResult.getStepResultSuccess();
     } else {
-      StringBuilder sb = new StringBuilder();
-      sb.append("Validating snapshot for export failed. ");
-      if (!tablesWithDuplicates.isEmpty()) {
-        int numTables = tablesWithDuplicates.size();
-        String tableNames = String.join(", ", tablesWithDuplicates);
-        sb.append(
-            String.format(
-                "%d table(s) had rows with duplicate primary keys [%s]. ", numTables, tableNames));
-        sb.append(
-            "To export, please create a new snapshot, ensuring there are rows with duplicate primary keys. ");
-      }
-      if (!tablesWithoutPrimaryKeys.isEmpty()) {
-        int numTables = tablesWithoutPrimaryKeys.size();
-        String tableNames = String.join(", ", tablesWithoutPrimaryKeys);
-        sb.append(String.format("%d table(s) had no primary keys [%s]. ", numTables, tableNames));
-        sb.append("To export, please ensure every table being exported has a primary key. ");
-      }
-
+      String message = "Validating snapshot primary keys for export failed.";
+      int numTables = tablesWithDuplicates.size();
+      String tableNames = String.join(", ", tablesWithDuplicates);
+      List<String> details =
+          List.of(
+              String.format(
+                  "%d table(s) had rows with duplicate primary keys [%s]. ", numTables, tableNames),
+              "To export, please create a new snapshot, ensuring there are no rows with duplicate primary keys.");
       return new StepResult(
-          StepStatus.STEP_RESULT_FAILURE_FATAL, new UnsupportedOperationException(sb.toString()));
+          StepStatus.STEP_RESULT_FAILURE_FATAL, new SnapshotExportException(message, details));
     }
   }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportValidateStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportValidateStep.java
@@ -1,0 +1,90 @@
+package bio.terra.service.snapshot.flight.export;
+
+import bio.terra.common.Column;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.resourcemanagement.exception.GoogleResourceException;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.SnapshotTable;
+import bio.terra.service.snapshot.exception.CorruptMetadataException;
+import bio.terra.service.tabulardata.google.BigQueryPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class SnapshotExportValidateStep implements Step {
+  private final BigQueryPdao bigQueryPdao;
+  private final SnapshotService snapshotService;
+  private final UUID snapshotId;
+
+  public SnapshotExportValidateStep(
+      BigQueryPdao bigQueryPdao, SnapshotService snapshotService, UUID snapshotId) {
+    this.bigQueryPdao = bigQueryPdao;
+    this.snapshotService = snapshotService;
+    this.snapshotId = snapshotId;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Snapshot snapshot = snapshotService.retrieve(snapshotId);
+    Dataset dataset = snapshot.getFirstSnapshotSource().getDataset();
+    List<SnapshotTable> tables = snapshot.getTables();
+    List<String> tablesWithDuplicates =
+        tables.stream()
+            .map(
+                table -> {
+                  String tableName = table.getName();
+                  Optional<DatasetTable> datasetTable = dataset.getTableByName(tableName);
+                  if (datasetTable.isEmpty()) {
+                    throw new CorruptMetadataException(
+                        String.format(
+                            "Could not find '%s' table in the snapshot's dataset", tableName));
+                  }
+                  DatasetTable realDatasetTable = datasetTable.get();
+                  List<Column> primaryKeyColumns = realDatasetTable.getPrimaryKey();
+                  boolean hasDuplicates;
+                  try {
+                    hasDuplicates =
+                        bigQueryPdao.hasDuplicatePrimaryKeys(
+                            snapshot, primaryKeyColumns, tableName);
+                  } catch (InterruptedException e) {
+                    throw new GoogleResourceException(
+                        String.format(
+                            "Failed to query BigQuery for duplicate rows in snapshot table '%s'",
+                            tableName));
+                  }
+                  if (hasDuplicates) {
+                    return table.getName();
+                  } else {
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+
+    if (tablesWithDuplicates.isEmpty()) {
+      return StepResult.getStepResultSuccess();
+    } else {
+      String message =
+          String.format(
+              "%d tables had rows with duplicate primary keys [%s]."
+                  + " To export a dataset, please create a new dataset, ensuring there are rows with duplicate primary keys.",
+              tablesWithDuplicates.size(), String.join(", ", tablesWithDuplicates));
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL, new UnsupportedOperationException(message));
+    }
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestStep.java
@@ -35,18 +35,21 @@ public class SnapshotExportWriteManifestStep extends DefaultUndoStep {
   private final GcsPdao gcsPdao;
   private final ObjectMapper objectMapper;
   private final AuthenticatedUserRequest userReq;
+  private final boolean validatePrimaryKeyUniqueness;
 
   public SnapshotExportWriteManifestStep(
       UUID snapshotId,
       SnapshotService snapshotService,
       GcsPdao gcsPdao,
       ObjectMapper objectMapper,
-      AuthenticatedUserRequest userReq) {
+      AuthenticatedUserRequest userReq,
+      boolean validatePrimaryKeyUniqueness) {
     this.snapshotId = snapshotId;
     this.snapshotService = snapshotService;
     this.gcsPdao = gcsPdao;
     this.objectMapper = objectMapper;
     this.userReq = userReq;
+    this.validatePrimaryKeyUniqueness = validatePrimaryKeyUniqueness;
   }
 
   @Override
@@ -99,6 +102,7 @@ public class SnapshotExportWriteManifestStep extends DefaultUndoStep {
     }
 
     workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_EXPORT_MANIFEST_PATH, exportManifestPath);
+    responseModel.validatedPrimaryKeys(validatePrimaryKeyUniqueness);
     context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), responseModel);
 
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -1435,23 +1435,25 @@ public class BigQueryPdao {
 
   private static final String selectHasDuplicateStagingIdsTemplate =
       "SELECT <pkColumns:{c|<c.name>}; separator=\",\">,COUNT(*) "
-          + "FROM `<project>.<dataset>.<stagingTable>` "
+          + "FROM `<project>.<dataset>.<tableName>` "
           + "GROUP BY <pkColumns:{c|<c.name>}; separator=\",\"> "
           + "HAVING COUNT(*) > 1";
 
   /**
-   * Returns true is any duplicate IDs are present in the staging table TODO: add support for
+   * Returns true is any duplicate IDs are present in a BigQuery table TODO: add support for
    * returning top few instances
    */
-  public boolean selectHasDuplicateStagingIds(
-      Dataset dataset, List<Column> pkColumns, String stagingTableName)
+  public boolean hasDuplicatePrimaryKeys(
+      FSContainerInterface container, List<Column> pkColumns, String tableName)
       throws InterruptedException {
-    BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
+    BigQueryProject bigQueryProject = BigQueryProject.from(container);
+
+    String bqDatasetName = prefixContainerName(container);
 
     ST sqlTemplate = new ST(selectHasDuplicateStagingIdsTemplate);
     sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", prefixName(dataset.getName()));
-    sqlTemplate.add("stagingTable", stagingTableName);
+    sqlTemplate.add("dataset", bqDatasetName);
+    sqlTemplate.add("tableName", tableName);
     sqlTemplate.add("pkColumns", pkColumns);
 
     TableResult result = bigQueryProject.query(sqlTemplate.render());
@@ -2489,14 +2491,17 @@ public class BigQueryPdao {
       FSContainerInterface container, String tableName, String suffix) {
 
     BigQueryProject bigQueryProject = BigQueryProject.from(container);
-    final String bqDatasetName;
-    if (container.getCollectionType() == CollectionType.DATASET) {
-      bqDatasetName = prefixName(container.getName());
-    } else {
-      bqDatasetName = container.getName();
-    }
+    String bqDatasetName = prefixContainerName(container);
     String extTableName = externalTableName(tableName, suffix);
     return bigQueryProject.deleteTable(bqDatasetName, extTableName);
+  }
+
+  private String prefixContainerName(FSContainerInterface container) {
+    if (container.getCollectionType() == CollectionType.DATASET) {
+      return prefixName(container.getName());
+    } else {
+      return container.getName();
+    }
   }
 
   private static final String insertSoftDeleteTemplate =

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -712,6 +712,14 @@ paths:
             default: false
             required: true
           description: Convert DRS urls to GS paths in the output parquet file. Note, GS paths could change over time.
+        - in: query
+          name: validatePrimaryKeyUniqueness
+          schema:
+            type: boolean
+            default: true
+            required: false
+          description: Verify that primary keys are unique in all exported tables.
+            Required for proper Terra workspace integration
       responses:
         202:
           description: Job status of snapshot export job & url for polling in the

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4041,6 +4041,8 @@ components:
       properties:
         snapshot:
           $ref: '#/components/schemas/SnapshotModel'
+        validatedPrimaryKeys:
+          type: boolean
         format:
           type: object
           properties:

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -681,7 +681,11 @@ public class DataRepoFixtures {
   }
 
   public DataRepoResponse<SnapshotExportResponseModel> exportSnapshotLog(
-      TestConfiguration.User user, UUID snapshotId, boolean resolveGsPaths, boolean validatePkUniqueness) throws Exception {
+      TestConfiguration.User user,
+      UUID snapshotId,
+      boolean resolveGsPaths,
+      boolean validatePkUniqueness)
+      throws Exception {
     DataRepoResponse<JobModel> jobResponse =
         exportSnapshot(user, snapshotId, resolveGsPaths, validatePkUniqueness);
     assertTrue("snapshot export launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
@@ -691,10 +695,18 @@ public class DataRepoFixtures {
     return dataRepoClient.waitForResponseLog(user, jobResponse, SnapshotExportResponseModel.class);
   }
 
-  public DataRepoResponse<JobModel> exportSnapshot(TestConfiguration.User user, UUID snapshotId, boolean resolveGsPaths, boolean validatePkUniqueness)
+  public DataRepoResponse<JobModel> exportSnapshot(
+      TestConfiguration.User user,
+      UUID snapshotId,
+      boolean resolveGsPaths,
+      boolean validatePkUniqueness)
       throws Exception {
     return dataRepoClient.get(
-        user, String.format("/api/repository/v1/snapshots/%s/export?exportGsPaths=%s&validatePrimaryKeyUniqueness=%s", snapshotId, resolveGsPaths, validatePkUniqueness), JobModel.class);
+        user,
+        String.format(
+            "/api/repository/v1/snapshots/%s/export?exportGsPaths=%s&validatePrimaryKeyUniqueness=%s",
+            snapshotId, resolveGsPaths, validatePkUniqueness),
+        JobModel.class);
   }
 
   public DataRepoResponse<JobModel> exportSnapshotResolveGsPaths(

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -681,13 +681,9 @@ public class DataRepoFixtures {
   }
 
   public DataRepoResponse<SnapshotExportResponseModel> exportSnapshotLog(
-      TestConfiguration.User user, UUID snapshotId, boolean resolveGsPaths) throws Exception {
-    DataRepoResponse<JobModel> jobResponse;
-    if (resolveGsPaths) {
-      jobResponse = exportSnapshotResolveGsPaths(user, snapshotId);
-    } else {
-      jobResponse = exportSnapshot(user, snapshotId);
-    }
+      TestConfiguration.User user, UUID snapshotId, boolean resolveGsPaths, boolean validatePkUniqueness) throws Exception {
+    DataRepoResponse<JobModel> jobResponse =
+        exportSnapshot(user, snapshotId, resolveGsPaths, validatePkUniqueness);
     assertTrue("snapshot export launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
     assertTrue(
         "snapshot export launch response is present", jobResponse.getResponseObject().isPresent());
@@ -695,10 +691,10 @@ public class DataRepoFixtures {
     return dataRepoClient.waitForResponseLog(user, jobResponse, SnapshotExportResponseModel.class);
   }
 
-  public DataRepoResponse<JobModel> exportSnapshot(TestConfiguration.User user, UUID snapshotId)
+  public DataRepoResponse<JobModel> exportSnapshot(TestConfiguration.User user, UUID snapshotId, boolean resolveGsPaths, boolean validatePkUniqueness)
       throws Exception {
     return dataRepoClient.get(
-        user, String.format("/api/repository/v1/snapshots/%s/export?", snapshotId), JobModel.class);
+        user, String.format("/api/repository/v1/snapshots/%s/export?exportGsPaths=%s&validatePrimaryKeyUniqueness=%s", snapshotId, resolveGsPaths, validatePkUniqueness), JobModel.class);
   }
 
   public DataRepoResponse<JobModel> exportSnapshotResolveGsPaths(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -4,9 +4,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -328,16 +330,15 @@ public class SnapshotExportIntegrationTest extends UsersBase {
 
     ErrorModel errorModel = exportResponse.getErrorObject().get();
 
-    String message = errorModel.getMessage();
     assertThat(
-        "The error message says there are duplicate primary keys",
-        message,
-        containsString("1 table(s) had rows with duplicate primary keys"));
+        "The error says it the export failed validation",
+        errorModel.getMessage(),
+        not(emptyOrNullString()));
 
     assertThat(
-        "The error message says there are tables with no primary keys",
-        message,
-        containsString("1 table(s) had no primary keys"));
+        "The error detail says there are duplicate primary keys",
+        errorModel.getErrorDetail().get(0),
+        containsString("1 table(s) had rows with duplicate primary keys"));
   }
 
   private static void isGsPath(String path) {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -145,6 +146,12 @@ public class SnapshotExportIntegrationTest extends UsersBase {
         dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, false, true);
 
     SnapshotExportResponseModel exportModel = exportResponse.getResponseObject().get();
+
+    assertThat(
+        "The export had it's primary keys validated",
+        exportModel.isValidatedPrimaryKeys(),
+        is(true));
+
     SnapshotExportResponseModelFormatParquet parquet = exportModel.getFormat().getParquet();
     SnapshotModel snapshot = exportModel.getSnapshot();
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -137,7 +137,7 @@ public class SnapshotExportIntegrationTest extends UsersBase {
     UUID snapshotId = snapshotSummary.getId();
     createdSnapshotIds.add(snapshotId);
     DataRepoResponse<SnapshotExportResponseModel> exportResponse =
-        dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, false);
+        dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, false, false);
 
     SnapshotExportResponseModel exportModel = exportResponse.getResponseObject().get();
     SnapshotExportResponseModelFormatParquet parquet = exportModel.getFormat().getParquet();
@@ -254,7 +254,7 @@ public class SnapshotExportIntegrationTest extends UsersBase {
     UUID snapshotId = snapshotSummary.getId();
     createdSnapshotIds.add(snapshotId);
     DataRepoResponse<SnapshotExportResponseModel> exportResponse =
-        dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, true);
+        dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, true, false);
 
     SnapshotExportResponseModel exportModel = exportResponse.getResponseObject().get();
     SnapshotExportResponseModelFormatParquet parquet = exportModel.getFormat().getParquet();

--- a/src/test/resources/ingest-test-dataset.json
+++ b/src/test/resources/ingest-test-dataset.json
@@ -93,6 +93,21 @@
           "participant_children",
           "participant_files"
         ]
+      },
+      {
+        "name":   "no_file",
+        "rootTable": "sample",
+        "rootColumn": "id",
+        "tables": [
+          {"name": "sample", "columns": []},
+          {"name": "participant", "columns": []}
+        ],
+        "follow": [
+          "sample_derived_from",
+          "participant_samples",
+          "sample_participants",
+          "participant_children"
+        ]
       }
     ]
   }

--- a/src/test/resources/ingest-test-snapshot-no-file.json
+++ b/src/test/resources/ingest-test-snapshot-no-file.json
@@ -1,0 +1,17 @@
+{
+  "name":"demo",
+  "description":"desc",
+  "contents":[
+    {
+      "datasetName": "IngestTest",
+      "mode": "byAsset",
+      "assetSpec": {
+        "assetName": "no_file",
+        "rootValues": [
+          "sample1",
+          "sample2"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
In order to export to workspaces, we need to make sure that primary keys both exist and are unique for a snapshot. This PR adds a validation step to the `SnapshotExportFlight` which does this check. It can be turned off, but the default behavior is that validation will happen. Because it can be turned off, a `validatedPrimaryKeys` field is added to tell Terra whether or not it needs to make its own primary keys.