### PR TITLE
DR-2459 Ingest metadata from the api

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -187,7 +187,7 @@ public class DatasetsApiController implements DatasetsApi {
   public ResponseEntity<JobModel> ingestDataset(
       @PathVariable("id") UUID id, @Valid @RequestBody IngestRequestModel ingest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    // Set default strategy to by append
+    // Set default strategy to append
     if (ingest.getUpdateStrategy() == null) {
       ingest.updateStrategy(UpdateStrategyEnum.APPEND);
     }

--- a/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
+++ b/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
@@ -5,6 +5,7 @@ import bio.terra.model.BulkLoadRequestModel;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.IngestRequestModel;
+import bio.terra.model.IngestRequestModel.FormatEnum;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -36,7 +37,12 @@ public class ValidateBucketAccessStep implements Step {
       sourcePath = List.of(((BulkLoadRequestModel) loadModel).getLoadControlFile());
     } else if (loadModel instanceof IngestRequestModel) {
       // Metadata ingests
-      sourcePath = List.of(((IngestRequestModel) loadModel).getPath());
+      // Don't validate if we are ingesting as a payload object
+      if (((IngestRequestModel) loadModel).getFormat().equals(FormatEnum.ARRAY)) {
+        sourcePath = List.of();
+      } else {
+        sourcePath = List.of(((IngestRequestModel) loadModel).getPath());
+      }
     } else if (loadModel instanceof DataDeletionRequest) {
       // Soft deletes
       sourcePath =

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -272,8 +272,7 @@ public class DatasetService {
       String pathToUse;
       if (cloudPlatform.isGcp()) {
         pathToUse =
-            writeIngestRowsToGcpBucket(
-                dataset, tempFilePath, ingestRequestModel.getJsonArraySpec());
+            writeIngestRowsToGcpBucket(dataset, tempFilePath, ingestRequestModel.getRecords());
       } else if (cloudPlatform.isAzure()) {
         pathToUse =
             writeIngestRowsToAzureStorageAccount(
@@ -281,13 +280,13 @@ public class DatasetService {
                 ingestRequestModel.getProfileId(),
                 dataset,
                 tempFilePath,
-                ingestRequestModel.getJsonArraySpec());
+                ingestRequestModel.getRecords());
       } else {
         throw new IllegalArgumentException("Cloud not recognized");
       }
       ingestRequestModel.setPath(pathToUse);
       // Clear the json object so that it doesn't get written to the flight db
-      ingestRequestModel.getJsonArraySpec().clear();
+      ingestRequestModel.getRecords().clear();
       description = "Ingest tabular data to " + ingestRequestModel.getTable() + " in dataset " + id;
     } else {
       description =

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -257,7 +257,7 @@ public class DatasetService {
       ingestRequestModel.setProfileId(
           Optional.ofNullable(ingestRequestModel.getProfileId())
               .orElse(dataset.getDefaultProfileId()));
-      // Create staging area if needed and get the path where the temo file will live
+      // Create staging area if needed and get the path where the temp file will live
       String tempFilePath =
           jobService
               .newJob(
@@ -287,15 +287,14 @@ public class DatasetService {
       ingestRequestModel.setPath(pathToUse);
       // Clear the json object so that it doesn't get written to the flight db
       ingestRequestModel.getRecords().clear();
-      description = "Ingest tabular data to " + ingestRequestModel.getTable() + " in dataset " + id;
+      description =
+          String.format(
+              "Ingest tabular data to %s in dataset id %s", ingestRequestModel.getTable(), id);
     } else {
       description =
-          "Ingest from "
-              + ingestRequestModel.getPath()
-              + " to "
-              + ingestRequestModel.getTable()
-              + " in dataset id "
-              + id;
+          String.format(
+              "Ingest from %s to %s in dataset id %s",
+              ingestRequestModel.getPath(), ingestRequestModel.getTable(), id);
     }
 
     return jobService
@@ -492,7 +491,7 @@ public class DatasetService {
         .map(
             r -> {
               try {
-                // We could eventually do more up front validation but at this point but for
+                // We could eventually do more up front validation at this point but for
                 // now depend on the ingest-into-temp-table step to fail
                 return objectMapper.writeValueAsString(r);
               } catch (JsonProcessingException e) {

--- a/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
@@ -45,20 +45,18 @@ public class IngestRequestValidator implements Validator {
             "path", "PathIsPresent", "Path should not be specified when ingesting from an array");
       }
 
-      if (ListUtils.emptyIfNull(ingestRequest.getJsonArraySpec()).isEmpty()
+      if (ListUtils.emptyIfNull(ingestRequest.getRecords()).isEmpty()
           && ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY)) {
         errors.rejectValue(
-            "jsonArraySpec",
-            "DataPayloadIsMissing",
-            "JsonArraySpec is required when ingesting as an array");
+            "records", "DataPayloadIsMissing", "Records is required when ingesting as an array");
       }
 
-      if (!ListUtils.emptyIfNull(ingestRequest.getJsonArraySpec()).isEmpty()
+      if (!ListUtils.emptyIfNull(ingestRequest.getRecords()).isEmpty()
           && !ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY)) {
         errors.rejectValue(
-            "jsonArraySpec",
+            "records",
             "DataPayloadIsPresent",
-            "JsonArraySpec should not be specified when ingesting from a path");
+            "Records should not be specified when ingesting from a path");
       }
     } else if (target instanceof FileLoadModel) {
       FileLoadModel fileLoadModel = (FileLoadModel) target;

--- a/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
@@ -32,27 +32,24 @@ public class IngestRequestValidator implements Validator {
     if (target instanceof IngestRequestModel) {
       IngestRequestModel ingestRequest = (IngestRequestModel) target;
       validateTableName(ingestRequest.getTable(), errors);
-
-      if (StringUtils.isEmpty(ingestRequest.getPath())
-          && !ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY)) {
+      boolean isPayloadIngest =
+          ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY);
+      if (StringUtils.isEmpty(ingestRequest.getPath()) && !isPayloadIngest) {
         errors.rejectValue(
             "path", "PathIsMissing", "Path is required when ingesting from a cloud object");
       }
 
-      if (!StringUtils.isEmpty(ingestRequest.getPath())
-          && ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY)) {
+      if (!StringUtils.isEmpty(ingestRequest.getPath()) && isPayloadIngest) {
         errors.rejectValue(
             "path", "PathIsPresent", "Path should not be specified when ingesting from an array");
       }
 
-      if (ListUtils.emptyIfNull(ingestRequest.getRecords()).isEmpty()
-          && ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY)) {
+      if (ListUtils.emptyIfNull(ingestRequest.getRecords()).isEmpty() && isPayloadIngest) {
         errors.rejectValue(
             "records", "DataPayloadIsMissing", "Records is required when ingesting as an array");
       }
 
-      if (!ListUtils.emptyIfNull(ingestRequest.getRecords()).isEmpty()
-          && !ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY)) {
+      if (!ListUtils.emptyIfNull(ingestRequest.getRecords()).isEmpty() && !isPayloadIngest) {
         errors.rejectValue(
             "records",
             "DataPayloadIsPresent",

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -143,8 +143,7 @@ public class DatasetIngestFlight extends Flight {
 
     addStep(new IngestSetupStep(datasetService, configService, cloudPlatform));
 
-    if (ingestRequestModel.getFormat() == IngestRequestModel.FormatEnum.JSON
-        || ingestRequestModel.getFormat() == IngestRequestModel.FormatEnum.ARRAY) {
+    if (IngestUtils.isJsonTypeIngest(inputParameters)) {
       int driverWaitSeconds = configService.getParameterValue(ConfigEnum.LOAD_DRIVER_WAIT_SECONDS);
       int loadHistoryWaitSeconds =
           configService.getParameterValue(ConfigEnum.LOAD_HISTORY_WAIT_SECONDS);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStep.java
@@ -85,6 +85,11 @@ public class IngestCreateParquetFilesStep implements Step {
       ingestResponse.loadResult(fileLoadResults);
     }
 
+    // If loading from a payload, there is no path to report to the user
+    if (IngestUtils.isIngestFromPayload(context.getInputParameters())) {
+      ingestResponse.setPath(null);
+    }
+
     context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), ingestResponse);
 
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestInsertIntoDatasetTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestInsertIntoDatasetTableStep.java
@@ -69,6 +69,11 @@ public class IngestInsertIntoDatasetTableStep implements Step {
       ingestResponse.rowCount(ingestResponse.getRowCount() + failedRowCount);
     }
 
+    // If loading from a payload, there is no path to report to the user
+    if (IngestUtils.isIngestFromPayload(context.getInputParameters())) {
+      ingestResponse.setPath(null);
+    }
+
     workingMap.put(JobMapKeys.RESPONSE.getKeyName(), ingestResponse);
 
     UUID transactionId = TransactionUtils.getTransactionId(context);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLandingFileDeleteAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLandingFileDeleteAzureStep.java
@@ -13,6 +13,7 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobUrlParts;
 
 public class IngestLandingFileDeleteAzureStep implements Step {
 
@@ -58,7 +59,8 @@ public class IngestLandingFileDeleteAzureStep implements Step {
         azureContainerPdao.getOrCreateContainer(
             profile, storageAccount, AzureStorageAccountResource.ContainerType.SCRATCH);
 
-    containerClient.getBlobClient(pathToLandingFile).delete();
+    String blobName = BlobUrlParts.parse(pathToLandingFile).getBlobName();
+    containerClient.getBlobClient(blobName).delete();
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLandingFileDeleteAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLandingFileDeleteAzureStep.java
@@ -1,0 +1,65 @@
+package bio.terra.service.dataset.flight.ingest;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import com.azure.storage.blob.BlobContainerClient;
+
+public class IngestLandingFileDeleteAzureStep implements Step {
+
+  private final boolean performInUndoPhase;
+  private final AzureContainerPdao azureContainerPdao;
+
+  public IngestLandingFileDeleteAzureStep(
+      boolean performInUndoPhase, AzureContainerPdao azureContainerPdao) {
+    this.performInUndoPhase = performInUndoPhase;
+    this.azureContainerPdao = azureContainerPdao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    if (!performInUndoPhase) {
+      return performDelete(context);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    if (performInUndoPhase) {
+      return performDelete(context);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  private StepResult performDelete(FlightContext context)
+      throws InterruptedException, RetryException {
+    // Clean up the file where data was staged to ingest
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profile =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    AzureStorageAccountResource storageAccount =
+        workingMap.get(
+            CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
+    IngestRequestModel ingestRequestModel =
+        context.getInputParameters().get(JobMapKeys.REQUEST.getKeyName(), IngestRequestModel.class);
+    String pathToLandingFile = ingestRequestModel.getPath();
+
+    BlobContainerClient containerClient =
+        azureContainerPdao.getOrCreateContainer(
+            profile, storageAccount, AzureStorageAccountResource.ContainerType.SCRATCH);
+
+    containerClient.getBlobClient(pathToLandingFile).delete();
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLandingFileDeleteGcpStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLandingFileDeleteGcpStep.java
@@ -1,0 +1,36 @@
+package bio.terra.service.dataset.flight.ingest;
+
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+
+public class IngestLandingFileDeleteGcpStep implements Step {
+
+  private final boolean performInUndoPhase;
+  private final GcsPdao gcsPdao;
+
+  public IngestLandingFileDeleteGcpStep(boolean performInUndoPhase, GcsPdao gcsPdao) {
+    this.performInUndoPhase = performInUndoPhase;
+    this.gcsPdao = gcsPdao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    if (!performInUndoPhase) {
+      IngestUtils.deleteLandingFile(context, gcsPdao);
+      return StepResult.getStepResultSuccess();
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    if (performInUndoPhase) {
+      IngestUtils.deleteLandingFile(context, gcsPdao);
+      return StepResult.getStepResultSuccess();
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestMapKeys.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestMapKeys.java
@@ -14,4 +14,5 @@ public final class IngestMapKeys {
   public static final String PARQUET_FILE_PATH = PREFIX + "parquetFilePath";
   public static final String COMBINED_FAILED_ROW_COUNT = PREFIX + "combinedFailedRowCount";
   public static final String COMBINED_EXISTING_FILES = PREFIX + "existingFileModels";
+  public static final String TABLE_NAME = PREFIX + "tableName";
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestSetupStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestSetupStep.java
@@ -75,7 +75,10 @@ public class IngestSetupStep implements Step {
       String sgName = DatasetUtils.generateAuxTableName(targetTable, "st");
       IngestUtils.putStagingTableName(context, sgName);
     } else if (cloudPlatform.isAzure()) {
-      IngestUtils.validateBlobAzureBlobFileURL(ingestRequestModel.getPath());
+      // Don't validate if we are ingesting as a payload object
+      if (!IngestUtils.isIngestFromPayload(context.getInputParameters())) {
+        IngestUtils.validateBlobAzureBlobFileURL(ingestRequestModel.getPath());
+      }
       workingMap.put(
           IngestMapKeys.PARQUET_FILE_PATH,
           IngestUtils.getParquetFilePath(targetTable.getName(), context.getFlightId()));

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -210,6 +210,13 @@ public final class IngestUtils {
     return ingestRequestModel.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY);
   }
 
+  public static boolean isJsonTypeIngest(FlightMap inputParameters) {
+    IngestRequestModel ingestRequestModel =
+        inputParameters.get(JobMapKeys.REQUEST.getKeyName(), IngestRequestModel.class);
+    return ingestRequestModel.getFormat() == IngestRequestModel.FormatEnum.JSON
+        || ingestRequestModel.getFormat() == IngestRequestModel.FormatEnum.ARRAY;
+  }
+
   public static Stream<JsonNode> getJsonNodesStreamFromFile(
       CloudFileReader cloudFileReader,
       ObjectMapper objectMapper,

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -204,6 +204,12 @@ public final class IngestUtils {
     return numFiles != 0;
   }
 
+  public static boolean isIngestFromPayload(FlightMap inputParameters) {
+    IngestRequestModel ingestRequestModel =
+        inputParameters.get(JobMapKeys.REQUEST.getKeyName(), IngestRequestModel.class);
+    return ingestRequestModel.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY);
+  }
+
   public static Stream<JsonNode> getJsonNodesStreamFromFile(
       CloudFileReader cloudFileReader,
       ObjectMapper objectMapper,
@@ -393,6 +399,16 @@ public final class IngestUtils {
         FlightUtils.getTyped(workingMap, CommonFlightKeys.SCRATCH_BUCKET_INFO);
     String pathToIngestFile = workingMap.get(IngestMapKeys.INGEST_CONTROL_FILE_PATH, String.class);
     gcsPdao.deleteFileByGspath(pathToIngestFile, bucketResource.projectIdForBucket());
+  }
+
+  public static void deleteLandingFile(FlightContext context, GcsPdao gcsPdao) {
+    FlightMap workingMap = context.getWorkingMap();
+    GoogleBucketResource bucketResource =
+        FlightUtils.getTyped(workingMap, CommonFlightKeys.SCRATCH_BUCKET_INFO);
+    IngestRequestModel ingestRequestModel =
+        context.getInputParameters().get(JobMapKeys.REQUEST.getKeyName(), IngestRequestModel.class);
+    String pathToLandingFile = ingestRequestModel.getPath();
+    gcsPdao.deleteFileByGspath(pathToLandingFile, bucketResource.projectIdForBucket());
   }
 
   public static void validateBulkLoadFileModel(BulkLoadFileModel loadFile) {

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/PerformPayloadIngestStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/PerformPayloadIngestStep.java
@@ -1,0 +1,16 @@
+package bio.terra.service.dataset.flight.ingest;
+
+import bio.terra.service.job.OptionalStep;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+
+public class PerformPayloadIngestStep extends OptionalStep {
+  public PerformPayloadIngestStep(Step step) {
+    super(step);
+  }
+
+  @Override
+  public boolean isEnabled(FlightContext context) {
+    return IngestUtils.isIngestFromPayload(context.getInputParameters());
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
@@ -1,0 +1,50 @@
+package bio.terra.service.dataset.flight.ingest.scratch;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.dataset.flight.ingest.IngestMapKeys;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import com.azure.storage.blob.BlobContainerClient;
+
+public class CreateScratchFileForAzureStep extends DefaultUndoStep {
+
+  private final AzureContainerPdao azureContainerPdao;
+
+  public CreateScratchFileForAzureStep(AzureContainerPdao azureContainerPdao) {
+    this.azureContainerPdao = azureContainerPdao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    String tableName = context.getInputParameters().get(IngestMapKeys.TABLE_NAME, String.class);
+    BillingProfileModel billingProfile =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    AzureStorageAccountResource storageAccount =
+        workingMap.get(
+            CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
+    BlobContainerClient containerClient =
+        azureContainerPdao.getOrCreateContainer(
+            billingProfile, storageAccount, AzureStorageAccountResource.ContainerType.SCRATCH);
+
+    String path =
+        containerClient
+            .getBlobClient(context.getFlightId() + "/ingest-scratch/" + tableName + ".json")
+            .getBlobUrl();
+
+    context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), path);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForGCPStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForGCPStep.java
@@ -23,7 +23,8 @@ public class CreateScratchFileForGCPStep extends DefaultUndoStep {
     GoogleBucketResource bucket =
         workingMap.get(CommonFlightKeys.SCRATCH_BUCKET_INFO, GoogleBucketResource.class);
     BlobId scratchFilePath =
-        GcsUriUtils.getBlobForFlight(bucket.getName(), tableName, context.getFlightId());
+        GcsUriUtils.getBlobForFlight(
+            bucket.getName(), "ingest-scratch/" + tableName, context.getFlightId());
 
     String path = GcsUriUtils.getGsPathFromBlob(scratchFilePath);
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForGCPStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForGCPStep.java
@@ -1,0 +1,38 @@
+package bio.terra.service.dataset.flight.ingest.scratch;
+
+import static bio.terra.service.dataset.flight.ingest.IngestMapKeys.TABLE_NAME;
+
+import bio.terra.service.common.gcs.CommonFlightKeys;
+import bio.terra.service.common.gcs.GcsUriUtils;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import com.google.cloud.storage.BlobId;
+
+public class CreateScratchFileForGCPStep extends DefaultUndoStep {
+
+  public CreateScratchFileForGCPStep() {}
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    String tableName = context.getInputParameters().get(TABLE_NAME, String.class);
+    GoogleBucketResource bucket =
+        workingMap.get(CommonFlightKeys.SCRATCH_BUCKET_INFO, GoogleBucketResource.class);
+    BlobId scratchFilePath =
+        GcsUriUtils.getBlobForFlight(bucket.getName(), tableName, context.getFlightId());
+
+    String path = GcsUriUtils.getGsPathFromBlob(scratchFilePath);
+
+    context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), path);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/DatasetScratchFilePrepareFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/DatasetScratchFilePrepareFlight.java
@@ -1,0 +1,63 @@
+package bio.terra.service.dataset.flight.ingest.scratch;
+
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.flight.ingest.CreateBucketForBigQueryScratchStep;
+import bio.terra.service.filedata.flight.ingest.IngestCreateAzureStorageAccountStep;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.ProfileService;
+import bio.terra.service.profile.flight.AuthorizeBillingProfileUseStep;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import java.util.UUID;
+import org.springframework.context.ApplicationContext;
+
+/** Create the scratch bucket/storage account to use when ingesting data from a payload */
+public class DatasetScratchFilePrepareFlight extends Flight {
+
+  public DatasetScratchFilePrepareFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+    // get the required daos to pass into the steps
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+
+    ApplicationConfiguration appConfig = appContext.getBean(ApplicationConfiguration.class);
+    DatasetService datasetService = appContext.getBean(DatasetService.class);
+    ResourceService resourceService = appContext.getBean(ResourceService.class);
+    ProfileService profileService = appContext.getBean(ProfileService.class);
+    AzureContainerPdao azureContainerPdao = appContext.getBean(AzureContainerPdao.class);
+
+    AuthenticatedUserRequest userReq =
+        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+
+    Dataset dataset =
+        datasetService.retrieve(
+            UUID.fromString(inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class)));
+
+    UUID profileId =
+        UUID.fromString(inputParameters.get(JobMapKeys.BILLING_ID.getKeyName(), String.class));
+
+    CloudPlatformWrapper cloudPlatform =
+        CloudPlatformWrapper.of(dataset.getDatasetSummary().getStorageCloudPlatform());
+
+    if (cloudPlatform.isGcp()) {
+      addStep(
+          new CreateBucketForBigQueryScratchStep(resourceService, datasetService),
+          getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads()));
+      addStep(new CreateScratchFileForGCPStep());
+    } else if (cloudPlatform.isAzure()) {
+      addStep(new AuthorizeBillingProfileUseStep(profileService, profileId, userReq));
+      addStep(new IngestCreateAzureStorageAccountStep(resourceService, dataset));
+      addStep(
+          new CreateScratchFileForAzureStep(azureContainerPdao),
+          getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads()));
+    }
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -159,6 +159,12 @@ public class AzureBlobStorePdao implements CloudFileReader {
     // between gcp and azure [See CloudFileReader]
   }
 
+  public void writeBlobLines(String signedPath, List<String> lines) {
+    try (Stream<String> stream = lines.stream()) {
+      writeBlobLines(signedPath, stream);
+    }
+  }
+
   public void writeBlobLines(String signedPath, Stream<String> lines) {
     var newLine = "\n";
     try (AzureBlobStoreBufferedWriter writer = new AzureBlobStoreBufferedWriter(signedPath)) {

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -169,7 +169,19 @@ public class GcsPdao implements CloudFileReader {
   }
 
   /**
-   * Write String to a GCS file
+   * Write {@link List} of {@link String} objects to a GCS file separated by newlines
+   *
+   * @param path gs path to write the lines to
+   * @param contentsToWrite contents to write to file
+   * @param projectId project for billing
+   */
+  public void writeListToCloudFile(String path, List<String> contentsToWrite, String projectId) {
+    try (Stream<String> stream = contentsToWrite.stream()) {
+      writeStreamToCloudFile(path, stream, projectId);
+    }
+  }
+  /**
+   * Write a {@link Stream} to a GCS file separated by newlines
    *
    * @param path gs path to write the lines to
    * @param contentsToWrite contents to write to file

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -12,6 +12,7 @@ public enum JobMapKeys {
   CLOUD_PLATFORM("cloudPlatform"),
 
   // parameters for specific flight types
+  BILLING_ID("billingId"),
   DATASET_ID("datasetId"),
   SNAPSHOT_ID("snapshotId"),
   FILE_ID("fileId"),

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -103,7 +103,7 @@ public final class MetadataDataAccessUtils {
       return makeAccessInfoAzure(
           snapshot, storageAccountResource, snapshot.getTables(), profileModel, userRequest);
     } else {
-      throw new IllegalArgumentException();
+      throw new InvalidCloudPlatformException();
     }
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -103,7 +103,7 @@ public final class MetadataDataAccessUtils {
       return makeAccessInfoAzure(
           snapshot, storageAccountResource, snapshot.getTables(), profileModel, userRequest);
     } else {
-      throw new IllegalArgumentException("Unrecognized cloud platform");
+      throw new IllegalArgumentException();
     }
   }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryPdao.java
@@ -1614,6 +1614,7 @@ public class BigQueryPdao {
         break;
 
       case JSON:
+      case ARRAY:
         options = FormatOptions.json();
         break;
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3386,7 +3386,6 @@ components:
     IngestRequestModel:
       required:
         - format
-        - path
         - table
       type: object
       properties:
@@ -3394,12 +3393,23 @@ components:
           $ref: '#/components/schemas/ObjectNameProperty'
         path:
           type: string
-          description: gs path to a file in a bucket accessible to data repo
+          description: >
+            cloud path path to a file in a bucket accessible to data repo (e.g. gs path for GCP
+            datasets or https path for Azure datasets).  Required if the format is csv or json
+        json_array_spec:
+          type: array
+          items:
+            type: object
+            description: >
+              a representation of a record to ingest in the form of `{"sColumn":"string value", "nColumn":123, "lValue":["a","b"]...}`
+          description: >
+            an array of json metadata records to ingest
         format:
           type: string
           enum:
             - csv
             - json
+            - array
         load_tag:
           $ref: '#/components/schemas/LoadTagModel'
         profile_id:
@@ -3407,14 +3417,14 @@ components:
         max_bad_records:
           type: integer
           default: 0
-          description: max number of bad records to skip; applies to JSON and CSV
+          description: max number of bad records to skip; applies to all ingest formats
         max_failed_file_loads:
           type: integer
           default: 0
           description: max number of failed file loads before stopping; if -1, allow any number of errors
         ignore_unknown_values:
           type: boolean
-          description: skip extra data; applies to JSON and CSV
+          description: skip extra data; applies to all ingest formats
           default: true
         csv_field_delimiter:
           type: string

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3394,8 +3394,9 @@ components:
         path:
           type: string
           description: >
-            cloud path path to a file in a bucket accessible to data repo (e.g. gs path for GCP
-            datasets or https path for Azure datasets).  Required if the format is csv or json
+            cloud path to a file in a bucket accessible to data repo (e.g. gs path for GCP
+            datasets or https path for Azure datasets).  Required if the format is `csv` or `json`.
+            Do not specify if the ingest format is `array`
         records:
           type: array
           items:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3396,7 +3396,7 @@ components:
           description: >
             cloud path path to a file in a bucket accessible to data repo (e.g. gs path for GCP
             datasets or https path for Azure datasets).  Required if the format is csv or json
-        json_array_spec:
+        records:
           type: array
           items:
             type: object

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -989,7 +989,7 @@ public class DataRepoFixtures {
         .ignoreUnknownValues(false)
         .maxBadRecords(0)
         .table(table)
-        .jsonArraySpec(Arrays.asList(data.toArray()));
+        .records(Arrays.asList(data.toArray()));
   }
 
   // Transaction methods

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -65,7 +65,9 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -978,6 +980,16 @@ public class DataRepoFixtures {
         .maxBadRecords(0)
         .table(table)
         .path(gsPath);
+  }
+
+  public IngestRequestModel buildSimpleIngest(String table, List<Map<String, Object>> data)
+      throws Exception {
+    return new IngestRequestModel()
+        .format(IngestRequestModel.FormatEnum.ARRAY)
+        .ignoreUnknownValues(false)
+        .maxBadRecords(0)
+        .table(table)
+        .jsonArraySpec(Arrays.asList(data.toArray()));
   }
 
   // Transaction methods

--- a/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
@@ -1063,7 +1063,7 @@ public class DatasetAzureIntegrationTest extends UsersBase {
               .map(j -> jsonLoader.loadJson(j, new TypeReference<Map<String, Object>>() {}))
               .collect(Collectors.toList());
       ingestRequest
-          .jsonArraySpec(Arrays.asList(data.toArray()))
+          .records(Arrays.asList(data.toArray()))
           .format(IngestRequestModel.FormatEnum.ARRAY);
     }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetAzureIntegrationTest.java
@@ -1029,7 +1029,7 @@ public class DatasetAzureIntegrationTest extends UsersBase {
 
   @Test
   public void testDatasetCombinedIngestFromApi() throws Exception {
-    testDatasetCombinedIngest(true);
+    testDatasetCombinedIngest(false);
   }
 
   public void testDatasetCombinedIngest(boolean ingestFromFile) throws Exception {

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -745,6 +746,78 @@ public class DatasetRequestValidatorTest {
         "Validator catches invalid 'csvQuote'",
         csvQuoteError,
         containsString("'csvQuote' must be a single character, was 'toolong'."));
+  }
+
+  @Test
+  public void testInvalidIngestByArray() throws Exception {
+    var invalidIngest =
+        new IngestRequestModel()
+            .path("foo/bar")
+            .table("myTable")
+            .format(IngestRequestModel.FormatEnum.ARRAY);
+
+    var invalidResult =
+        mvc.perform(
+                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(invalidIngest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
+    String invalidResponseBody = invalidResponse.getContentAsString();
+    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
+    assertThat(
+        "Validation catches all invalid parameters",
+        invalidErrorModel.getErrorDetail(),
+        hasSize(2));
+    var pathIsPresentError = invalidErrorModel.getErrorDetail().get(0);
+    var payloadIsMissingError = invalidErrorModel.getErrorDetail().get(1);
+
+    assertThat(
+        "Validator catches invalid 'path' and 'format' combo",
+        pathIsPresentError,
+        containsString("Path should not be specified when ingesting from an array"));
+    assertThat(
+        "Validator catches invalid 'format' and 'json_array_spec' combo",
+        payloadIsMissingError,
+        containsString("JsonArraySpec is required when ingesting as an array"));
+  }
+
+  @Test
+  public void testInvalidIngestByPath() throws Exception {
+    var invalidIngest =
+        new IngestRequestModel()
+            .table("myTable")
+            .format(IngestRequestModel.FormatEnum.JSON)
+            .addJsonArraySpecItem(Map.of("foo", "bar"));
+
+    var invalidResult =
+        mvc.perform(
+                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(invalidIngest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
+    String invalidResponseBody = invalidResponse.getContentAsString();
+    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
+    assertThat(
+        "Validation catches all invalid parameters",
+        invalidErrorModel.getErrorDetail(),
+        hasSize(2));
+    var pathIsMissingError = invalidErrorModel.getErrorDetail().get(0);
+    var payloadIsPresentError = invalidErrorModel.getErrorDetail().get(1);
+
+    assertThat(
+        "Validator catches invalid 'path' and 'format' combo",
+        pathIsMissingError,
+        containsString("Path is required when ingesting from a cloud object"));
+    assertThat(
+        "Validator catches invalid 'json_array_spec' and 'format' combo",
+        payloadIsPresentError,
+        containsString("JsonArraySpec should not be specified when ingesting from a path"));
   }
 
   private void checkValidationErrorModel(ErrorModel errorModel, String[] messageCodes) {

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -779,9 +779,9 @@ public class DatasetRequestValidatorTest {
         pathIsPresentError,
         containsString("Path should not be specified when ingesting from an array"));
     assertThat(
-        "Validator catches invalid 'format' and 'json_array_spec' combo",
+        "Validator catches invalid 'format' and 'records' combo",
         payloadIsMissingError,
-        containsString("JsonArraySpec is required when ingesting as an array"));
+        containsString("Records is required when ingesting as an array"));
   }
 
   @Test
@@ -790,7 +790,7 @@ public class DatasetRequestValidatorTest {
         new IngestRequestModel()
             .table("myTable")
             .format(IngestRequestModel.FormatEnum.JSON)
-            .addJsonArraySpecItem(Map.of("foo", "bar"));
+            .addRecordsItem(Map.of("foo", "bar"));
 
     var invalidResult =
         mvc.perform(
@@ -815,9 +815,9 @@ public class DatasetRequestValidatorTest {
         pathIsMissingError,
         containsString("Path is required when ingesting from a cloud object"));
     assertThat(
-        "Validator catches invalid 'json_array_spec' and 'format' combo",
+        "Validator catches invalid 'records' and 'format' combo",
         payloadIsPresentError,
-        containsString("JsonArraySpec should not be specified when ingesting from a path"));
+        containsString("Records should not be specified when ingesting from a path"));
   }
 
   private void checkValidationErrorModel(ErrorModel errorModel, String[] messageCodes) {

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -551,9 +551,9 @@ public class DatasetServiceTest {
             .format(FormatEnum.ARRAY)
             .updateStrategy(UpdateStrategyEnum.APPEND)
             .table("participant")
-            .addJsonArraySpecItem(Map.of("id", "1", "age", 12, "gender", "F"))
-            .addJsonArraySpecItem(Map.of("id", "2", "age", 24, "gender", "N"))
-            .addJsonArraySpecItem(Map.of("id", "3", "age", 36, "gender", "M"));
+            .addRecordsItem(Map.of("id", "1", "age", 12, "gender", "F"))
+            .addRecordsItem(Map.of("id", "2", "age", 24, "gender", "N"))
+            .addRecordsItem(Map.of("id", "3", "age", 36, "gender", "M"));
 
     datasetService.ingestDataset(datasetId.toString(), ingestRequestModel, testUser);
 
@@ -571,7 +571,7 @@ public class DatasetServiceTest {
         .newJob(any(), eq(DatasetScratchFilePrepareFlight.class), any(), any());
     verify(jobService, times(1))
         .newJob(any(), eq(DatasetIngestFlight.class), requestCaptor.capture(), any());
-    assertThat("payload is stripped out", requestCaptor.getValue().getJsonArraySpec(), empty());
+    assertThat("payload is stripped out", requestCaptor.getValue().getRecords(), empty());
   }
 
   @Test
@@ -606,9 +606,9 @@ public class DatasetServiceTest {
             .format(FormatEnum.ARRAY)
             .updateStrategy(UpdateStrategyEnum.APPEND)
             .table("participant")
-            .addJsonArraySpecItem(Map.of("id", "1", "age", 12, "gender", "F"))
-            .addJsonArraySpecItem(Map.of("id", "2", "age", 24, "gender", "N"))
-            .addJsonArraySpecItem(Map.of("id", "3", "age", 36, "gender", "M"));
+            .addRecordsItem(Map.of("id", "1", "age", 12, "gender", "F"))
+            .addRecordsItem(Map.of("id", "2", "age", 24, "gender", "N"))
+            .addRecordsItem(Map.of("id", "3", "age", 36, "gender", "M"));
 
     datasetService.ingestDataset(datasetId.toString(), ingestRequestModel, testUser);
 
@@ -626,6 +626,6 @@ public class DatasetServiceTest {
         .newJob(any(), eq(DatasetScratchFilePrepareFlight.class), any(), any());
     verify(jobService, times(1))
         .newJob(any(), eq(DatasetIngestFlight.class), requestCaptor.capture(), any());
-    assertThat("payload is stripped out", requestCaptor.getValue().getJsonArraySpec(), empty());
+    assertThat("payload is stripped out", requestCaptor.getValue().getRecords(), empty());
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -10,13 +10,18 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.category.Unit;
+import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.iam.IamRole;
 import bio.terra.service.job.JobService;
 import bio.terra.service.load.LoadService;
 import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
+import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.tabulardata.azure.StorageTableService;
 import bio.terra.service.tabulardata.google.BigQueryPdao;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +52,11 @@ public class DatasetServiceUnitTest {
   @MockBean private StorageTableService storageTableService;
   @MockBean private BigQueryPdao bigQueryPdao;
   @MockBean private MetadataDataAccessUtils metadataDataAccessUtils;
+  @MockBean private ResourceService resourceService;
+  @MockBean private GcsPdao gcsPdao;
+  @MockBean private ObjectMapper objectMapper;
+  @MockBean private AzureBlobStorePdao azureBlobStorePdao;
+  @MockBean private ProfileService profileService;
 
   @Test
   public void enumerate() {


### PR DESCRIPTION
This PR implements the proposal here:
https://docs.google.com/document/d/16Yu9Q43V1jmmszIkz2NrC7GZmum_-RyOaZn0Wyn12Iw

Namely, this introduces changes to the ingest request payload:
- adds a new format `ARRAY` which indicates that the ingest data should come from a new:
- `json_array_spec` field which is a list of record map objects

E.g. an ingest payload may now look like:
```{
  "format": "array",
  "table": "test_data",
  "json_array_spec": [
    {"id":1,"first_name":"Al","last_name":"Johnson","email":"al.johnson@broadinstitute.org"},
    {"id":2,"first_name":"Alice","last_name":"McGee","email":"alicm@broadinstitute.org"}
  ]
}
```

An interesting nuance to this PR is that it streams the `json_array_spec` contents to the scratch bucket/storage account _before_ starting the flight then strips it from the request in order to avoid writing the data to the flight db.
