### PR TITLE
DR-2501 Make sure that we always at least sort by created_by > descending

### DIFF
--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -27,10 +27,18 @@ public final class DaoUtils {
 
   public static String orderByClause(
       EnumerateSortByParam sort, SqlSortDirection direction, String table) {
+    EnumerateSortByParam sortToUse;
+    SqlSortDirection directionToUse;
+
     if (sort == null || direction == null) {
-      return "";
+      sortToUse = EnumerateSortByParam.CREATED_DATE;
+      directionToUse = SqlSortDirection.DESC;
+    } else {
+      sortToUse = sort;
+      directionToUse = direction;
     }
-    return String.format(" ORDER BY %s.%s %s ", table, sort, direction);
+
+    return String.format(" ORDER BY %s.%s %s ", table, sortToUse, directionToUse);
   }
 
   public static void addFilterClause(

--- a/src/test/java/bio/terra/common/DaoUtilsTest.java
+++ b/src/test/java/bio/terra/common/DaoUtilsTest.java
@@ -1,0 +1,27 @@
+package bio.terra.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.EnumerateSortByParam;
+import bio.terra.model.SqlSortDirection;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Unit.class)
+public class DaoUtilsTest {
+
+  @Test
+  public void testOrderByClause() {
+    assertThat(
+        "order by clause looks correct",
+        DaoUtils.orderByClause(EnumerateSortByParam.NAME, SqlSortDirection.ASC, "foo"),
+        equalTo(" ORDER BY foo.name asc "));
+
+    assertThat(
+        "default order by clause looks correct",
+        DaoUtils.orderByClause(null, null, "foo"),
+        equalTo(" ORDER BY foo.created_date desc "));
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -44,6 +44,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.logging.v2.LifecycleState;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -173,6 +174,10 @@ public class SnapshotConnectedTest {
       SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
       snapshotList.add(summaryModel);
     }
+
+    // Reverse the order of the array since the order we return the snapshots in by default is
+    // descending order of creation
+    Collections.reverse(snapshotList);
 
     Map<UUID, Set<IamRole>> snapshotIds =
         snapshotList.stream()

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -420,7 +420,14 @@ public class SnapshotDaoTest {
 
     MetadataEnumeration<SnapshotSummary> summaryEnum =
         snapshotDao.retrieveSnapshots(
-            0, 2, null, null, "==foo==", null, datasetIds, snapshotIdList);
+            0,
+            2,
+            EnumerateSortByParam.CREATED_DATE,
+            SqlSortDirection.ASC,
+            "==foo==",
+            null,
+            datasetIds,
+            snapshotIdList);
     List<SnapshotSummary> summaryList = summaryEnum.getItems();
     assertThat("filtered and retrieved 2 snapshots", summaryList.size(), equalTo(2));
     assertThat("filtered total 3", summaryEnum.getFilteredTotal(), equalTo(3));


### PR DESCRIPTION
... when enumerating datasets and snapshots.

This will ensure a consistent order when retrieving the datasets and snapshots which has been identified as a problem