### PR TITLE
Patch using recommended strategy

### DIFF
--- a/src/main/java/bio/terra/Main.java
+++ b/src/main/java/bio/terra/Main.java
@@ -1,5 +1,9 @@
 package bio.terra;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -14,12 +18,6 @@ import org.springframework.web.method.annotation.InitBinderDataBinderFactory;
 import org.springframework.web.method.support.InvocableHandlerMethod;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.mvc.method.annotation.ServletRequestDataBinderFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Stream;
 
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class Main implements CommandLineRunner {
@@ -48,7 +46,8 @@ public class Main implements CommandLineRunner {
     }
   }
 
-  // Mitigation for Spring Core Bug: https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement
+  // Mitigation for Spring Core Bug:
+  // https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement
   @Bean
   public WebMvcRegistrations mvcRegistrations() {
     return new WebMvcRegistrations() {
@@ -59,11 +58,11 @@ public class Main implements CommandLineRunner {
     };
   }
 
-
   private static class ExtendedRequestMappingHandlerAdapter extends RequestMappingHandlerAdapter {
 
     @Override
-    protected InitBinderDataBinderFactory createDataBinderFactory(List<InvocableHandlerMethod> methods) {
+    protected InitBinderDataBinderFactory createDataBinderFactory(
+        List<InvocableHandlerMethod> methods) {
 
       return new ServletRequestDataBinderFactory(methods, getWebBindingInitializer()) {
 
@@ -73,7 +72,8 @@ public class Main implements CommandLineRunner {
 
           ServletRequestDataBinder binder = super.createBinderInstance(target, name, request);
           String[] fields = binder.getDisallowedFields();
-          List<String> fieldList = new ArrayList<>(fields != null ? Arrays.asList(fields) : Collections.emptyList());
+          List<String> fieldList =
+              new ArrayList<>(fields != null ? Arrays.asList(fields) : Collections.emptyList());
           fieldList.addAll(Arrays.asList("class.*", "Class.*", "*.class.*", "*.Class.*"));
           binder.setDisallowedFields(fieldList.toArray(new String[] {}));
           return binder;

--- a/src/main/java/bio/terra/Main.java
+++ b/src/main/java/bio/terra/Main.java
@@ -5,6 +5,21 @@ import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
+import org.springframework.context.annotation.Bean;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.ServletRequestDataBinder;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.annotation.InitBinderDataBinderFactory;
+import org.springframework.web.method.support.InvocableHandlerMethod;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
+import org.springframework.web.servlet.mvc.method.annotation.ServletRequestDataBinderFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
 
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class Main implements CommandLineRunner {
@@ -30,6 +45,40 @@ public class Main implements CommandLineRunner {
     @Override
     public int getExitCode() {
       return 10;
+    }
+  }
+
+  // Mitigation for Spring Core Bug: https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement
+  @Bean
+  public WebMvcRegistrations mvcRegistrations() {
+    return new WebMvcRegistrations() {
+      @Override
+      public RequestMappingHandlerAdapter getRequestMappingHandlerAdapter() {
+        return new ExtendedRequestMappingHandlerAdapter();
+      }
+    };
+  }
+
+
+  private static class ExtendedRequestMappingHandlerAdapter extends RequestMappingHandlerAdapter {
+
+    @Override
+    protected InitBinderDataBinderFactory createDataBinderFactory(List<InvocableHandlerMethod> methods) {
+
+      return new ServletRequestDataBinderFactory(methods, getWebBindingInitializer()) {
+
+        @Override
+        protected ServletRequestDataBinder createBinderInstance(
+            @Nullable Object target, String name, NativeWebRequest request) throws Exception {
+
+          ServletRequestDataBinder binder = super.createBinderInstance(target, name, request);
+          String[] fields = binder.getDisallowedFields();
+          List<String> fieldList = new ArrayList<>(fields != null ? Arrays.asList(fields) : Collections.emptyList());
+          fieldList.addAll(Arrays.asList("class.*", "Class.*", "*.class.*", "*.Class.*"));
+          binder.setDisallowedFields(fieldList.toArray(new String[] {}));
+          return binder;
+        }
+      };
     }
   }
 }

--- a/src/main/java/bio/terra/Main.java
+++ b/src/main/java/bio/terra/Main.java
@@ -71,11 +71,12 @@ public class Main implements CommandLineRunner {
             @Nullable Object target, String name, NativeWebRequest request) throws Exception {
 
           ServletRequestDataBinder binder = super.createBinderInstance(target, name, request);
+          List<String> fieldList = new ArrayList<>(List.of("class.*", "Class.*", "*.class.*", "*.Class.*"));
           String[] fields = binder.getDisallowedFields();
-          List<String> fieldList =
-              new ArrayList<>(fields != null ? Arrays.asList(fields) : Collections.emptyList());
-          fieldList.addAll(Arrays.asList("class.*", "Class.*", "*.class.*", "*.Class.*"));
-          binder.setDisallowedFields(fieldList.toArray(new String[] {}));
+          if (fields != null) {
+            fieldList.addAll(List.of(fields));
+          }
+          binder.setDisallowedFields(fieldList.toArray());
           return binder;
         }
       };


### PR DESCRIPTION
According to https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement, patching the spring core bug using Controller Advice may still leave vulnerabilities, as well as make it easier to introduce vulnerabilities through omission of a `binder.setDisallowedFields` call in a new controller. The recommended method is to "extend RequestMappingHandlerAdapter to update the WebDataBinder at the end after all other initialization". 