### PR TITLE
DR-2525: Use git-blame-ignore-revs to ignore reformatting commit when running `git blame`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# To configure git to use this file when using `git blame`:
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# DR-1850: Replace checkstyle with spotless
+c6a70ff75f408fcb8dc36cda777e91b7a27be535


### PR DESCRIPTION
`git blame` supports a feature that can exclude commits when annotating a source file. Using this, a commit that reformats the code base can be ignored when showing blame, making it easier to find the "real" commit behind a line of code.

This filename is recognized by GitHub and will be used in Github's blame view. To use it locally, you must either specify it on the command line or configure git to use it by default. To configure git, run this command in the the checked out repo:
```sh
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

This configuration will be honored by IDEs that internally use `git` to produce their blame view, such as Intellij.