### PR TITLE
DR-2522 Upgrade Liquibase plugin so that dropAll command works again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 
 plugins {
     id "com.google.cloud.tools.jib" version "2.7.1"
-    id 'org.liquibase.gradle' version '2.0.1'
+    id 'org.liquibase.gradle' version '2.1.1'
     id "org.gradle.test-retry" version "1.2.0"
     id 'antlr'
     id 'com.github.spotbugs' version '4.7.1'


### PR DESCRIPTION
The gradle upgrade broke the liquibase `dropAll` command. This unbreaks it!

I reproduced the failure locally, and upgrading the plugin version fixed it.