### PR TITLE
DR-2531 Cache snapshot retrieve in Drs Service

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -161,6 +161,7 @@ jobs:
           retention-days: 10
       - name: "Archive junit test reports"
         uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: junit-test-report
           path: build/reports

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -76,6 +76,13 @@ jobs:
           test_to_run: 'testConnected'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
+      - name: "Archive connected junit test reports"
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: junit-test-report-connected
+          path: build/reports
+          retention-days: 10
   deploy_test_integration:
     timeout-minutes: 180
     strategy:

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -53,7 +53,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-
 import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -239,9 +238,7 @@ public class DrsService {
       try {
         FSItem fsItem =
             fileService.lookupSnapshotFSItem(
-                getSnapshotProject(snapshotId),
-                drsId.getFsObjectId(),
-                1);
+                getSnapshotProject(snapshotId), drsId.getFsObjectId(), 1);
         return signAzureUrl(billingProfileModel, fsItem, authUser);
       } catch (InterruptedException e) {
         throw new IllegalArgumentException(e);
@@ -280,10 +277,7 @@ public class DrsService {
 
   private DRSAccessURL signGoogleUrl(String googleProjectId, DRSAccessMethod accessMethod) {
     Storage storage =
-        StorageOptions.newBuilder()
-            .setProjectId(googleProjectId)
-            .build()
-            .getService();
+        StorageOptions.newBuilder().setProjectId(googleProjectId).build().getService();
     String gsPath = accessMethod.getAccessUrl().getUrl();
     BlobId locator = GcsUriUtils.parseBlobUri(gsPath);
 
@@ -330,8 +324,7 @@ public class DrsService {
 
     final GoogleRegion region;
     if (cachedSnapshot.isSelfHosted) {
-      Storage storage =
-          gcsProjectFactory.getStorage(cachedSnapshot.googleProjectId);
+      Storage storage = gcsProjectFactory.getStorage(cachedSnapshot.googleProjectId);
       Bucket bucket = storage.get(GcsUriUtils.parseBlobUri(fsFile.getCloudPath()).getBucket());
       region = GoogleRegion.fromValue(bucket.getLocation());
     } else {
@@ -457,18 +450,23 @@ public class DrsService {
   }
 
   private void verifyAuthorization(String snapshotId, AuthenticatedUserRequest authUser) {
-    samAuthorizations.computeIfAbsent(snapshotId, id -> {
-      samService.verifyAuthorization(authUser, IamResourceType.DATASNAPSHOT, id, IamAction.READ_DATA);
-      return id;
-    });
+    samAuthorizations.computeIfAbsent(
+        snapshotId,
+        id -> {
+          samService.verifyAuthorization(
+              authUser, IamResourceType.DATASNAPSHOT, id, IamAction.READ_DATA);
+          return id;
+        });
   }
 
   private SnapshotProject getSnapshotProject(UUID snapshotId) {
-    return snapshotProjects.computeIfAbsent(snapshotId, snapshotService::retrieveAvailableSnapshotProject);
+    return snapshotProjects.computeIfAbsent(
+        snapshotId, snapshotService::retrieveAvailableSnapshotProject);
   }
 
   private SnapshotCacheResult getSnapshot(UUID snapshotId) {
-    return snapshotCache.computeIfAbsent(snapshotId, id -> new SnapshotCacheResult(snapshotService.retrieve(id)));
+    return snapshotCache.computeIfAbsent(
+        snapshotId, id -> new SnapshotCacheResult(snapshotService.retrieve(id)));
   }
 
   private static class SnapshotCacheResult {
@@ -479,10 +477,12 @@ public class DrsService {
     public SnapshotCacheResult(Snapshot snapshot) {
       this.googleProjectId = snapshot.getProjectResource().getGoogleProjectId();
       this.isSelfHosted = snapshot.isSelfHosted();
-      this.billingProfileModel = snapshot.getFirstSnapshotSource().getDataset().getDatasetSummary().getDefaultBillingProfile();
+      this.billingProfileModel =
+          snapshot
+              .getFirstSnapshotSource()
+              .getDataset()
+              .getDatasetSummary()
+              .getDefaultBillingProfile();
     }
   }
-
-
-
 }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -472,21 +472,17 @@ public class DrsService {
   private static class SnapshotCacheResult {
     private final Boolean isSelfHosted;
     private final BillingProfileModel billingProfileModel;
-    private String googleProjectId;
+    private final String googleProjectId;
 
     public SnapshotCacheResult(Snapshot snapshot) {
       this.isSelfHosted = snapshot.isSelfHosted();
       this.billingProfileModel =
-          snapshot
-              .getFirstSnapshotSource()
-              .getDataset()
-              .getDatasetSummary()
-              .getDefaultBillingProfile();
-
-      CloudPlatformWrapper platform =
-          CloudPlatformWrapper.of(billingProfileModel.getCloudPlatform());
-      if (platform.isGcp()) {
-        this.googleProjectId = snapshot.getProjectResource().getGoogleProjectId();
+          snapshot.getSourceDataset().getDatasetSummary().getDefaultBillingProfile();
+      var projectResource = snapshot.getProjectResource();
+      if (projectResource != null) {
+        this.googleProjectId = projectResource.getGoogleProjectId();
+      } else {
+        this.googleProjectId = null;
       }
     }
   }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -470,12 +470,11 @@ public class DrsService {
   }
 
   private static class SnapshotCacheResult {
-    private final String googleProjectId;
     private final Boolean isSelfHosted;
     private final BillingProfileModel billingProfileModel;
+    private String googleProjectId;
 
     public SnapshotCacheResult(Snapshot snapshot) {
-      this.googleProjectId = snapshot.getProjectResource().getGoogleProjectId();
       this.isSelfHosted = snapshot.isSelfHosted();
       this.billingProfileModel =
           snapshot
@@ -483,6 +482,12 @@ public class DrsService {
               .getDataset()
               .getDatasetSummary()
               .getDefaultBillingProfile();
+
+      CloudPlatformWrapper platform =
+          CloudPlatformWrapper.of(billingProfileModel.getCloudPlatform());
+      if (platform.isGcp()) {
+        this.googleProjectId = snapshot.getProjectResource().getGoogleProjectId();
+      }
     }
   }
 }

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -33,6 +33,7 @@ import bio.terra.service.job.JobService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotProject;
 import bio.terra.service.snapshot.SnapshotService;
@@ -86,6 +87,7 @@ public class DrsServiceTest {
 
   @Before
   public void before() throws Exception {
+    UUID defaultProfileModelId = UUID.randomUUID();
     drsService =
         new DrsService(
             snapshotService,
@@ -109,10 +111,20 @@ public class DrsServiceTest {
         .thenReturn(
             new Snapshot()
                 .id(snapshotId)
+                .projectResource(new GoogleProjectResource().googleProjectId("google-project"))
                 .snapshotSources(
                     List.of(
                         new SnapshotSource()
-                            .dataset(new Dataset(new DatasetSummary().selfHosted(false))))));
+                            .dataset(
+                                new Dataset(
+                                    new DatasetSummary()
+                                        .selfHosted(false)
+                                        .defaultProfileId(defaultProfileModelId)
+                                        .billingProfiles(
+                                            List.of(
+                                                new BillingProfileModel()
+                                                    .id(defaultProfileModelId)
+                                                    .cloudPlatform(CloudPlatform.GCP))))))));
 
     String bucketResourceId = UUID.randomUUID().toString();
     String storageAccountResourceId = UUID.randomUUID().toString();


### PR DESCRIPTION
Caching snapshot retrieve calls in DrsService should take a lot of load off of the database for object lookups. We don't actually use most of the result, so I've only cached the fields that we use.

I'm also throwing in a cache in front of SAM authorizations. This is risky, since it means someone could get access to a file even after being revoked. The cache is only for 1 minute, so I'm not too concerned, since signed urls are good for 15 minutes. Still, I'd love some security input on this, and can take it out if we think it'll be too much hassle.