### PR TITLE
DR-2322 - Allow marking dataset columns as required

### DIFF
--- a/src/main/java/bio/terra/common/Column.java
+++ b/src/main/java/bio/terra/common/Column.java
@@ -10,6 +10,7 @@ public class Column {
   private String name;
   private TableDataType type;
   private boolean arrayOf;
+  private boolean required;
 
   public Column() {}
 
@@ -19,13 +20,15 @@ public class Column {
     this.name = fromColumn.name;
     this.type = fromColumn.type;
     this.arrayOf = fromColumn.arrayOf;
+    this.required = fromColumn.required;
   }
 
   public static Column toSnapshotColumn(Column datasetColumn) {
     return new Column()
         .name(datasetColumn.getName())
         .type(datasetColumn.getType())
-        .arrayOf(datasetColumn.isArrayOf());
+        .arrayOf(datasetColumn.isArrayOf())
+        .required(datasetColumn.isRequired());
   }
 
   public static SynapseColumn toSynapseColumn(Column datasetColumn) {
@@ -41,7 +44,8 @@ public class Column {
                     datasetColumn.getType(), datasetColumn.isArrayOf()))
             .name(datasetColumn.getName())
             .type(datasetColumn.getType())
-            .arrayOf(datasetColumn.isArrayOf());
+            .arrayOf(datasetColumn.isArrayOf())
+            .required(datasetColumn.isRequired());
   }
 
   public UUID getId() {
@@ -89,8 +93,17 @@ public class Column {
     return this;
   }
 
+  public boolean isRequired() {
+    return required;
+  }
+
+  public Column required(boolean required) {
+    this.required = required;
+    return this;
+  }
+
   public ColumnModel toColumnModel() {
-    return new ColumnModel().name(name).datatype(type).arrayOf(arrayOf);
+    return new ColumnModel().name(name).datatype(type).arrayOf(arrayOf).required(required);
   }
 
   public boolean isFileOrDirRef() {

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -230,7 +230,7 @@ public final class DatasetJsonConversion {
   public static Column columnModelToDatasetColumn(
       ColumnModel columnModel, List<String> primaryKeys) {
     boolean required =
-        primaryKeys.contains(columnModel.getName())
+        (Objects.nonNull(primaryKeys) && primaryKeys.contains(columnModel.getName()))
             || Boolean.TRUE.equals(columnModel.isRequired());
     return new Column()
         .name(columnModel.getName())

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -147,18 +147,17 @@ public final class DatasetJsonConversion {
     Map<String, Column> columnMap = new HashMap<>();
     List<Column> columns = new ArrayList<>();
     DatasetTable datasetTable = new DatasetTable().name(tableModel.getName());
+    List<String> primaryKeys =
+        Optional.ofNullable(tableModel.getPrimaryKey()).orElse(Collections.emptyList());
 
     for (ColumnModel columnModel : tableModel.getColumns()) {
-      Column column =
-          columnModelToDatasetColumn(columnModel, tableModel.getPrimaryKey()).table(datasetTable);
+      Column column = columnModelToDatasetColumn(columnModel, primaryKeys).table(datasetTable);
       columnMap.put(column.getName(), column);
       columns.add(column);
     }
 
     List<Column> primaryKeyColumns =
-        Optional.ofNullable(tableModel.getPrimaryKey()).orElse(Collections.emptyList()).stream()
-            .map(columnMap::get)
-            .collect(Collectors.toList());
+        primaryKeys.stream().map(columnMap::get).collect(Collectors.toList());
     datasetTable.primaryKey(primaryKeyColumns);
 
     BigQueryPartitionConfigV1 partitionConfig;
@@ -230,7 +229,7 @@ public final class DatasetJsonConversion {
   public static Column columnModelToDatasetColumn(
       ColumnModel columnModel, List<String> primaryKeys) {
     boolean required =
-        (Objects.nonNull(primaryKeys) && primaryKeys.contains(columnModel.getName()))
+        primaryKeys.contains(columnModel.getName())
             || Boolean.TRUE.equals(columnModel.isRequired());
     return new Column()
         .name(columnModel.getName())

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -230,7 +230,8 @@ public final class DatasetJsonConversion {
     return new Column()
         .name(columnModel.getName())
         .type(columnModel.getDatatype())
-        .arrayOf(columnModel.isArrayOf());
+        .arrayOf(columnModel.isArrayOf())
+        .required(columnModel.isRequired());
   }
 
   public static Relationship relationshipModelToDatasetRelationship(

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -149,7 +149,8 @@ public final class DatasetJsonConversion {
     DatasetTable datasetTable = new DatasetTable().name(tableModel.getName());
 
     for (ColumnModel columnModel : tableModel.getColumns()) {
-      Column column = columnModelToDatasetColumn(columnModel).table(datasetTable);
+      Column column =
+          columnModelToDatasetColumn(columnModel, tableModel.getPrimaryKey()).table(datasetTable);
       columnMap.put(column.getName(), column);
       columns.add(column);
     }
@@ -226,12 +227,16 @@ public final class DatasetJsonConversion {
                 .collect(Collectors.toList()));
   }
 
-  public static Column columnModelToDatasetColumn(ColumnModel columnModel) {
+  public static Column columnModelToDatasetColumn(
+      ColumnModel columnModel, List<String> primaryKeys) {
+    boolean required =
+        primaryKeys.contains(columnModel.getName())
+            || Boolean.TRUE.equals(columnModel.isRequired());
     return new Column()
         .name(columnModel.getName())
         .type(columnModel.getDatatype())
         .arrayOf(columnModel.isArrayOf())
-        .required(columnModel.isRequired());
+        .required(required);
   }
 
   public static Relationship relationshipModelToDatasetRelationship(

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -272,6 +272,12 @@ public class DatasetRequestValidator implements Validator {
     if (invalidTypes.contains(columnModel.getDatatype())) {
       rejectKey(errors, keyType, columnModel.getName(), columnModel.getDatatype().toString());
     }
+    if (PRIMARY_KEY.equals(keyType) && Boolean.FALSE.equals(columnModel.isRequired())) {
+      errors.rejectValue(
+          "schema",
+          "OptionalPrimaryKeyColumn",
+          String.format("A %s column cannot be marked as not required", PRIMARY_KEY));
+    }
   }
 
   private void rejectKey(Errors errors, String keyType, String columnName, String type) {

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -37,14 +37,14 @@ public class DatasetTableDao {
           + "cast(:bigquery_partition_config AS jsonb))";
   private static final String sqlInsertColumn =
       "INSERT INTO dataset_column "
-          + "(table_id, name, type, array_of, ordinal) "
-          + "VALUES (:table_id, :name, :type, :array_of, :ordinal)";
+          + "(table_id, name, type, array_of, required, ordinal) "
+          + "VALUES (:table_id, :name, :type, :array_of, :required, :ordinal)";
   private static final String sqlSelectTable =
       "SELECT id, name, raw_table_name, soft_delete_table_name, row_metadata_table_name, primary_key, bigquery_partition_config::text, "
           + "(bigquery_partition_config->>'version')::bigint AS bigquery_partition_config_version "
           + "FROM dataset_table WHERE dataset_id = :dataset_id";
   private static final String sqlSelectColumn =
-      "SELECT id, name, type, array_of "
+      "SELECT id, name, type, array_of, required "
           + "FROM dataset_column "
           + "WHERE table_id = :table_id "
           + "ORDER BY ordinal";
@@ -105,6 +105,7 @@ public class DatasetTableDao {
       params.addValue("name", column.getName());
       params.addValue("type", column.getType().toString());
       params.addValue("array_of", column.isArrayOf());
+      params.addValue("required", column.isRequired());
       params.addValue("ordinal", ordinal++);
       jdbcTemplate.update(sqlInsertColumn, params, keyHolder);
       UUID columnId = keyHolder.getId();
@@ -165,6 +166,7 @@ public class DatasetTableDao {
                 .table(table)
                 .name(rs.getString("name"))
                 .type(TableDataType.fromValue(rs.getString("type")))
-                .arrayOf(rs.getBoolean("array_of")));
+                .arrayOf(rs.getBoolean("array_of"))
+                .required(rs.getBoolean("required")));
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
@@ -32,12 +32,12 @@ public class SnapshotTableDao {
           + "VALUES (:name, :parent_id, :primary_key)";
   private static final String sqlInsertColumn =
       "INSERT INTO snapshot_column "
-          + "(table_id, name, type, array_of, ordinal) "
-          + "VALUES (:table_id, :name, :type, :array_of, :ordinal)";
+          + "(table_id, name, type, array_of, required, ordinal) "
+          + "VALUES (:table_id, :name, :type, :array_of, :required, :ordinal)";
   private static final String sqlSelectTable =
       "SELECT id, name, row_count, primary_key FROM snapshot_table WHERE parent_id = :parent_id";
   private static final String sqlSelectColumn =
-      "SELECT id, name, type, array_of "
+      "SELECT id, name, type, array_of, required "
           + "FROM snapshot_column "
           + "WHERE table_id = :table_id "
           + "ORDER BY ordinal";
@@ -84,6 +84,7 @@ public class SnapshotTableDao {
       params.addValue("name", column.getName());
       params.addValue("type", column.getType().toString());
       params.addValue("array_of", column.isArrayOf());
+      params.addValue("required", column.isRequired());
       params.addValue("ordinal", ordinal++);
       jdbcTemplate.update(sqlInsertColumn, params, keyHolder);
       UUID columnId = keyHolder.getId();
@@ -127,6 +128,7 @@ public class SnapshotTableDao {
                 .table(table)
                 .name(rs.getString("name"))
                 .type(TableDataType.fromValue(rs.getString("type")))
-                .arrayOf(rs.getBoolean("array_of")));
+                .arrayOf(rs.getBoolean("array_of"))
+                .required(rs.getBoolean("required")));
   }
 }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -894,7 +894,7 @@ public class BigQueryDatasetPdao {
 
     for (Column column : table.getColumns()) {
       Field.Mode mode;
-      if (primaryKeys.contains(column.getName())) {
+      if (primaryKeys.contains(column.getName()) || column.isRequired()) {
         mode = Field.Mode.REQUIRED;
       } else if (column.isArrayOf()) {
         mode = Field.Mode.REPEATED;

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3249,6 +3249,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ObjectNameProperty'
+          description: >
+            Primary key columns names. Any columns listed as a primary key will be marked as required by default.
         partitionMode:
           type: string
           default: none

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3229,6 +3229,10 @@ components:
           type: boolean
           description: if true, make this column an array of type datatype.
           default: false
+        required:
+          type: boolean
+          description: if false, mark this column as non-nullable
+          default: false
       description: one column of a table
     TableModel:
       required:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3231,8 +3231,7 @@ components:
           default: false
         required:
           type: boolean
-          description: if false, mark this column as non-nullable
-          default: false
+          description: if true, mark this column as required
       description: one column of a table
     TableModel:
       required:

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -53,5 +53,6 @@
     <include file="changesets/20220217_addphsidandconsentcodecolumns.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220324_addsnapshottablepkfield.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220325_selfhosteddatasets.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20220411_requiredcolumns.yaml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20220411_requiredcolumns.yaml
+++ b/src/main/resources/db/changesets/20220411_requiredcolumns.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: self_hosted_datasets
+      author: tlangs
+      changes:
+        - addColumn:
+            tableName: dataset_column
+            columns:
+              name: required
+              type: boolean
+              defaultValue: false
+              constraints:
+                nullable: false
+        - addColumn:
+            tableName: snapshot_column
+            columns:
+              name: required
+              type: boolean
+              defaultValue: false
+              constraints:
+                nullable: false

--- a/src/main/resources/db/changesets/20220411_requiredcolumns.yaml
+++ b/src/main/resources/db/changesets/20220411_requiredcolumns.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      id: self_hosted_datasets
+      id: required_columns
       author: tlangs
       changes:
         - addColumn:

--- a/src/main/resources/db/changesets/20220411_requiredcolumns.yaml
+++ b/src/main/resources/db/changesets/20220411_requiredcolumns.yaml
@@ -11,6 +11,16 @@ databaseChangeLog:
               defaultValue: false
               constraints:
                 nullable: false
+        - sql:
+            comment: Backfill dataset PK columns
+            sql: >
+              update dataset_column
+              set required = true
+              where id in (
+                select dc.id
+                from dataset_table dt
+              	  left join dataset_column dc
+              		on dc.name = ANY(dt.primary_key) and dc.table_id = dt.id)
         - addColumn:
             tableName: snapshot_column
             columns:
@@ -19,3 +29,13 @@ databaseChangeLog:
               defaultValue: false
               constraints:
                 nullable: false
+        - sql:
+            comment: Backfill snapshot PK columns
+            sql: >
+              update snapshot_column
+              set required = true
+              where id in (
+                select sc.id
+                from snapshot_table st
+              	  left join snapshot_column sc
+              		on sc.name = ANY(st.primary_key) and sc.table_id = st.id)

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -67,7 +67,8 @@ public class DatasetJsonConversionTest {
             .id(DATASET_COLUMN_ID)
             .name(DATASET_COLUMN_NAME)
             .arrayOf(false)
-            .type(DATASET_COLUMN_TYPE);
+            .type(DATASET_COLUMN_TYPE)
+            .required(true);
     DatasetTable datasetTable =
         new DatasetTable()
             .id(DATASET_TABLE_ID)
@@ -79,7 +80,8 @@ public class DatasetJsonConversionTest {
                     new Column()
                         .id(DATASET_COLUMN_ID)
                         .name(DATASET_COLUMN_NAME)
-                        .type(DATASET_COLUMN_TYPE)))
+                        .type(DATASET_COLUMN_TYPE)
+                        .required(true)))
             .bigQueryPartitionConfig(BigQueryPartitionConfigV1.none());
 
     AssetColumn assetColumn =
@@ -134,7 +136,8 @@ public class DatasetJsonConversionTest {
                                 new ColumnModel()
                                     .name(DATASET_COLUMN_NAME)
                                     .datatype(DATASET_COLUMN_TYPE)
-                                    .arrayOf(false)))
+                                    .arrayOf(false)
+                                    .required(true)))
                     .relationships(Collections.emptyList())
                     .assets(
                         List.of(

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
@@ -11,9 +12,11 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.AccessInfoModel;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
+import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestAccessIncludeModel;
+import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
@@ -241,5 +244,50 @@ public class DatasetJsonConversionTest {
                                                     + "."
                                                     + DATASET_TABLE_NAME
                                                     + "` LIMIT 1000")))))));
+  }
+
+  @Test
+  public void testRequiredColumns() throws Exception {
+    var defaultColumnName = "NOT_PRIMARY_KEY_COLUMN";
+    var requiredColumnName = "REQUIRED_COLUMN";
+    DatasetRequestModel datasetRequestModel =
+        new DatasetRequestModel()
+            .name(DATASET_NAME)
+            .defaultProfileId(DATASET_PROFILE_ID)
+            .description(DATASET_DESCRIPTION)
+            .cloudPlatform(CloudPlatform.GCP)
+            .region(GoogleRegion.DEFAULT_GOOGLE_REGION.name())
+            .schema(
+                new DatasetSpecificationModel()
+                    .tables(
+                        List.of(
+                            new TableModel()
+                                .name(DATASET_TABLE_NAME)
+                                .primaryKey(List.of(DATASET_COLUMN_NAME))
+                                .columns(
+                                    List.of(
+                                        new ColumnModel()
+                                            .name(DATASET_COLUMN_NAME)
+                                            .datatype(DATASET_COLUMN_TYPE)
+                                            .arrayOf(false),
+                                        new ColumnModel()
+                                            .name(defaultColumnName)
+                                            .datatype(DATASET_COLUMN_TYPE)
+                                            .arrayOf(false),
+                                        new ColumnModel()
+                                            .name(requiredColumnName)
+                                            .datatype(DATASET_COLUMN_TYPE)
+                                            .required(true)
+                                            .arrayOf(false))))));
+
+    var dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel);
+    var columnMap = dataset.getTables().get(0).getColumnsMap();
+    var pkColumn = columnMap.get(DATASET_COLUMN_NAME);
+    var defaultColumn = columnMap.get(defaultColumnName);
+    var requiredColumn = columnMap.get(requiredColumnName);
+
+    assertThat("Primary key columns are marked as required", pkColumn.isRequired(), is(true));
+    assertThat("Regular columns default to not required", defaultColumn.isRequired(), is(false));
+    assertThat("Required columns are marked as required", requiredColumn.isRequired(), is(true));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -480,6 +480,47 @@ public class DatasetRequestValidatorTest {
   }
 
   @Test
+  public void testNonRequiredPrimaryKeyColumn() throws Exception {
+    TableModel table =
+        new TableModel()
+            .name("table")
+            .columns(List.of(new ColumnModel().name("pkColumn").datatype(TableDataType.STRING)))
+            .primaryKey(Collections.singletonList("pkColumn"));
+
+    DatasetRequestModel req = buildDatasetRequest();
+    req.getSchema()
+        .tables(Collections.singletonList(table))
+        .relationships(Collections.emptyList())
+        .assets(Collections.emptyList());
+
+    ErrorModel errorModel = expectBadDatasetCreateRequest(req);
+    assertThat(errorModel.getErrorDetail(), hasSize(0));
+
+    table.getColumns().get(0).setRequired(false);
+    errorModel = expectBadDatasetCreateRequest(req);
+    checkValidationErrorModel(errorModel, new String[] {"OptionalPrimaryKeyColumn"});
+  }
+
+  @Test
+  public void testDefaultRequiredPrimaryKeyColumn() throws Exception {
+    TableModel table =
+        new TableModel()
+            .name("table")
+            .columns(List.of(new ColumnModel().name("pkColumn").datatype(TableDataType.STRING)))
+            .primaryKey(Collections.singletonList("pkColumn"));
+
+    DatasetRequestModel req = buildDatasetRequest();
+    req.getSchema()
+        .tables(Collections.singletonList(table))
+        .relationships(Collections.emptyList())
+        .assets(Collections.emptyList());
+
+    ErrorModel errorModel = expectBadDatasetCreateRequest(req);
+
+    checkValidationErrorModel(errorModel, new String[] {"OptionalPrimaryKeyColumn"});
+  }
+
+  @Test
   public void testDatePartitionWithBadOptions() throws Exception {
     TableModel table =
         new TableModel()

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -484,7 +484,12 @@ public class DatasetRequestValidatorTest {
     TableModel table =
         new TableModel()
             .name("table")
-            .columns(List.of(new ColumnModel().name("pkColumn").datatype(TableDataType.STRING)))
+            .columns(
+                List.of(
+                    new ColumnModel()
+                        .name("pkColumn")
+                        .datatype(TableDataType.STRING)
+                        .required(false)))
             .primaryKey(Collections.singletonList("pkColumn"));
 
     DatasetRequestModel req = buildDatasetRequest();
@@ -494,29 +499,6 @@ public class DatasetRequestValidatorTest {
         .assets(Collections.emptyList());
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    assertThat(errorModel.getErrorDetail(), hasSize(0));
-
-    table.getColumns().get(0).setRequired(false);
-    errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"OptionalPrimaryKeyColumn"});
-  }
-
-  @Test
-  public void testDefaultRequiredPrimaryKeyColumn() throws Exception {
-    TableModel table =
-        new TableModel()
-            .name("table")
-            .columns(List.of(new ColumnModel().name("pkColumn").datatype(TableDataType.STRING)))
-            .primaryKey(Collections.singletonList("pkColumn"));
-
-    DatasetRequestModel req = buildDatasetRequest();
-    req.getSchema()
-        .tables(Collections.singletonList(table))
-        .relationships(Collections.emptyList())
-        .assets(Collections.emptyList());
-
-    ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-
     checkValidationErrorModel(errorModel, new String[] {"OptionalPrimaryKeyColumn"});
   }
 

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoDatasetConnectedTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoDatasetConnectedTest.java
@@ -156,6 +156,11 @@ public class BigQueryPdaoDatasetConnectedTest {
           BlobInfo.newBuilder(bucket, targetPath + "ingest-test-sample-no-id.json").build();
       BlobInfo nullPkBlob =
           BlobInfo.newBuilder(bucket, targetPath + "ingest-test-sample-null-id.json").build();
+      BlobInfo nulledNonNullBlob =
+          BlobInfo.newBuilder(bucket, targetPath + "ingest-test-sample-null-column.json").build();
+      BlobInfo missingNonNullBlob =
+          BlobInfo.newBuilder(bucket, targetPath + "ingest-test-sample-missing-column.json")
+              .build();
 
       try {
         bigQueryDatasetPdao.createDataset(dataset);
@@ -166,6 +171,8 @@ public class BigQueryPdaoDatasetConnectedTest {
         storage.create(sampleBlob, readFile("ingest-test-sample.json"));
         storage.create(missingPkBlob, readFile("ingest-test-sample-no-id.json"));
         storage.create(nullPkBlob, readFile("ingest-test-sample-null-id.json"));
+        storage.create(nulledNonNullBlob, readFile("ingest-test-sample-null-column.json"));
+        storage.create(missingNonNullBlob, readFile("ingest-test-sample-missing-column.json"));
 
         // Ingest staged data into the new dataset.
         IngestRequestModel ingestRequest =
@@ -180,6 +187,14 @@ public class BigQueryPdaoDatasetConnectedTest {
             datasetId, ingestRequest.table("sample").path(BigQueryPdaoTest.gsPath(missingPkBlob)));
         connectedOperations.ingestTableFailure(
             datasetId, ingestRequest.table("sample").path(BigQueryPdaoTest.gsPath(nullPkBlob)));
+
+        // Check non-nullable columns are enforced.
+        connectedOperations.ingestTableFailure(
+            datasetId,
+            ingestRequest.table("sample").path(BigQueryPdaoTest.gsPath(nulledNonNullBlob)));
+        connectedOperations.ingestTableFailure(
+            datasetId,
+            ingestRequest.table("sample").path(BigQueryPdaoTest.gsPath(missingNonNullBlob)));
 
         // Create a snapshot!
         DatasetSummaryModel datasetSummaryModel = dataset.getDatasetSummary().toModel();

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoDatasetConnectedTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoDatasetConnectedTest.java
@@ -156,9 +156,9 @@ public class BigQueryPdaoDatasetConnectedTest {
           BlobInfo.newBuilder(bucket, targetPath + "ingest-test-sample-no-id.json").build();
       BlobInfo nullPkBlob =
           BlobInfo.newBuilder(bucket, targetPath + "ingest-test-sample-null-id.json").build();
-      BlobInfo nulledNonNullBlob =
+      BlobInfo nulledRequiredFieldBlob =
           BlobInfo.newBuilder(bucket, targetPath + "ingest-test-sample-null-column.json").build();
-      BlobInfo missingNonNullBlob =
+      BlobInfo missingRequiredFieldBlob =
           BlobInfo.newBuilder(bucket, targetPath + "ingest-test-sample-missing-column.json")
               .build();
 
@@ -171,8 +171,9 @@ public class BigQueryPdaoDatasetConnectedTest {
         storage.create(sampleBlob, readFile("ingest-test-sample.json"));
         storage.create(missingPkBlob, readFile("ingest-test-sample-no-id.json"));
         storage.create(nullPkBlob, readFile("ingest-test-sample-null-id.json"));
-        storage.create(nulledNonNullBlob, readFile("ingest-test-sample-null-column.json"));
-        storage.create(missingNonNullBlob, readFile("ingest-test-sample-missing-column.json"));
+        storage.create(nulledRequiredFieldBlob, readFile("ingest-test-sample-null-column.json"));
+        storage.create(
+            missingRequiredFieldBlob, readFile("ingest-test-sample-missing-column.json"));
 
         // Ingest staged data into the new dataset.
         IngestRequestModel ingestRequest =
@@ -188,13 +189,13 @@ public class BigQueryPdaoDatasetConnectedTest {
         connectedOperations.ingestTableFailure(
             datasetId, ingestRequest.table("sample").path(BigQueryPdaoTest.gsPath(nullPkBlob)));
 
-        // Check non-nullable columns are enforced.
+        // Check required columns are enforced.
         connectedOperations.ingestTableFailure(
             datasetId,
-            ingestRequest.table("sample").path(BigQueryPdaoTest.gsPath(nulledNonNullBlob)));
+            ingestRequest.table("sample").path(BigQueryPdaoTest.gsPath(nulledRequiredFieldBlob)));
         connectedOperations.ingestTableFailure(
             datasetId,
-            ingestRequest.table("sample").path(BigQueryPdaoTest.gsPath(missingNonNullBlob)));
+            ingestRequest.table("sample").path(BigQueryPdaoTest.gsPath(missingRequiredFieldBlob)));
 
         // Create a snapshot!
         DatasetSummaryModel datasetSummaryModel = dataset.getDatasetSummary().toModel();

--- a/src/test/resources/ingest-test-dataset-east.json
+++ b/src/test/resources/ingest-test-dataset-east.json
@@ -18,7 +18,7 @@
         "columns": [
           {"name": "id", "datatype": "string"},
           {"name": "participant_ids", "datatype": "string", "array_of": true},
-          {"name": "date_collected", "datatype": "date"},
+          {"name": "date_collected", "datatype": "date", "required": true},
           {"name": "derived_from", "datatype": "string"}
         ],
         "primaryKey": ["id"]

--- a/src/test/resources/ingest-test-dataset.json
+++ b/src/test/resources/ingest-test-dataset.json
@@ -19,7 +19,7 @@
         "columns": [
           {"name": "id", "datatype": "string"},
           {"name": "participant_ids", "datatype": "string", "array_of": true},
-          {"name": "date_collected", "datatype": "date"},
+          {"name": "date_collected", "datatype": "date", "required":  true},
           {"name": "derived_from", "datatype": "string"}
         ],
         "primaryKey": ["id"]

--- a/src/test/resources/ingest-test-sample-missing-column.json
+++ b/src/test/resources/ingest-test-sample-missing-column.json
@@ -1,0 +1,1 @@
+{"id": "sampleMissingNonNullColumn","participant_ids":[],"derived_from":"sample2"}

--- a/src/test/resources/ingest-test-sample-null-column.json
+++ b/src/test/resources/ingest-test-sample-null-column.json
@@ -1,0 +1,1 @@
+{"id": "sampleNulledNonNullColumn","participant_ids":[],"date_collected":null,"derived_from":"sample2"}


### PR DESCRIPTION
The ability to mark columns as required is a basic feature that any datastore should support. Now, TDR will support it! This PR introduces the the ability to mark columns as `required` upon dataset creation. Subsequent ingests will fail if no data is provided for a column marked as `required`. By default, columns are not required.