### PR TITLE
DR-2542 Return more error messages to users

### DIFF
--- a/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
@@ -92,6 +92,8 @@ public class StairwayExceptionFieldsFactory {
       if (!errorReportException.getCauses().isEmpty()) {
         return errorReportException.getCauses();
       }
+    } else if (StringUtils.isNotEmpty(exception.getMessage())) {
+      return List.of(exception.getMessage());
     }
     return null;
   }


### PR DESCRIPTION
Currently, when most of our steps fail, the user gets a “The step failed for an unknown reason…” message. We should actually return why a step failed to the user.

Now, exceptions that aren't `ErrorReportExceptions` will have the exception message returned to the user, instead of a unknown error telling them to contact TDR support.