### PR TITLE
[DR-2481] Add SAM 401 exception back

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -17,6 +17,7 @@ import bio.terra.service.auth.iam.exception.IamConflictException;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
 import bio.terra.service.auth.iam.exception.IamInternalServerErrorException;
 import bio.terra.service.auth.iam.exception.IamNotFoundException;
+import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -666,6 +667,10 @@ public class SamIam implements IamProviderInterface {
         {
           return new IamBadRequestException(message, samEx);
         }
+      case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED:
+      {
+        return new IamUnauthorizedException(message, samEx);
+      }
       case HttpStatusCodes.STATUS_CODE_FORBIDDEN:
         {
           return new IamForbiddenException(message, samEx);

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -668,9 +668,9 @@ public class SamIam implements IamProviderInterface {
           return new IamBadRequestException(message, samEx);
         }
       case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED:
-      {
-        return new IamUnauthorizedException(message, samEx);
-      }
+        {
+          return new IamUnauthorizedException(message, samEx);
+        }
       case HttpStatusCodes.STATUS_CODE_FORBIDDEN:
         {
           return new IamForbiddenException(message, samEx);

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamRetry.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamRetry.java
@@ -4,6 +4,7 @@ import static java.time.Instant.now;
 
 import bio.terra.common.exception.ErrorReportException;
 import bio.terra.service.auth.iam.exception.IamInternalServerErrorException;
+import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import com.google.api.client.http.HttpStatusCodes;
@@ -59,6 +60,8 @@ class SamRetry {
         return function.apply();
       } catch (ApiException ex) {
         handleApiException(ex);
+      } catch (IamUnauthorizedException ex) {
+        throw ex;
       } catch (Exception ex) {
         throw new IamInternalServerErrorException(
             "Unexpected exception type: " + ex.toString(), ex);
@@ -76,6 +79,8 @@ class SamRetry {
         return;
       } catch (ApiException ex) {
         handleApiException(ex);
+      } catch (IamUnauthorizedException ex) {
+        throw ex;
       } catch (Exception ex) {
         throw new IamInternalServerErrorException(
             "Unexpected exception type: " + ex.toString(), ex);

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -398,12 +398,4 @@ public class SamIamTest {
     assertThat(uuidSetMap, is((Map.of(id, Set.of(IamRole.OWNER, IamRole.READER)))));
   }
 
-  @Test
-  public void listAuthorizedResourcesTest401Error() throws Exception {
-    when(samResourceApi.listResourcesAndPolicies(IamResourceType.DATASNAPSHOT.getSamResourceName()))
-        .thenThrow(UnauthorizedException.class);
-    assertThrows(
-        IamInternalServerErrorException.class,
-        () -> samIam.listAuthorizedResources(userReq, IamResourceType.DATASNAPSHOT));
-  }
 }

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -15,7 +14,6 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.category.Unit;
-import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
@@ -23,7 +21,6 @@ import bio.terra.model.UserStatusInfo;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
-import bio.terra.service.auth.iam.exception.IamInternalServerErrorException;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import java.util.List;
@@ -397,5 +394,4 @@ public class SamIamTest {
         samIam.listAuthorizedResources(userReq, IamResourceType.DATASNAPSHOT);
     assertThat(uuidSetMap, is((Map.of(id, Set.of(IamRole.OWNER, IamRole.READER)))));
   }
-
 }

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -21,6 +21,7 @@ import bio.terra.model.UserStatusInfo;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import java.util.List;
@@ -393,5 +394,17 @@ public class SamIamTest {
     Map<UUID, Set<IamRole>> uuidSetMap =
         samIam.listAuthorizedResources(userReq, IamResourceType.DATASNAPSHOT);
     assertThat(uuidSetMap, is((Map.of(id, Set.of(IamRole.OWNER, IamRole.READER)))));
+  }
+
+  @Test(expected = IamUnauthorizedException.class)
+  public void listAuthorizedResourcesTest401Error() throws Exception {
+    when(samResourceApi.listResourcesAndPolicies(IamResourceType.DATASNAPSHOT.getSamResourceName()))
+        .thenThrow(IamUnauthorizedException.class);
+    try {
+      samIam.listAuthorizedResources(userReq, IamResourceType.DATASNAPSHOT);
+    } finally {
+      verify(samResourceApi, times(1))
+          .listResourcesAndPolicies(IamResourceType.DATASNAPSHOT.getSamResourceName());
+    }
   }
 }


### PR DESCRIPTION
Adding the exception back in because it's possible for a service account to accidentally be registered in Terra but not in SAM, which would cause legitimate 401 errors. (ty @nmalfroy for figuring that out!)