### PR TITLE
DR-2547 Re-enable array foreign key columns

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -262,9 +262,9 @@ public class DatasetRequestValidator implements Validator {
     }
   }
 
-  // Primary Keys and Foreign Keys cannot be arrays or filerefs or dirrefs
+  // Primary Keys and Foreign Keys cannot be filerefs or dirrefs and Primary keys cannot be arrays
   private void validateColumnType(Errors errors, ColumnModel columnModel, String keyType) {
-    if (columnModel.isArrayOf()) {
+    if (keyType.equals(PRIMARY_KEY) && columnModel.isArrayOf()) {
       rejectKey(errors, keyType, columnModel.getName(), "array");
     }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -221,11 +221,7 @@ public class DatasetRequestValidatorTest {
     checkValidationErrorModel(
         errorModel,
         new String[] {
-          "InvalidPrimaryKey",
-          "InvalidPrimaryKey",
-          "InvalidPrimaryKey",
-          "InvalidForeignKey",
-          "InvalidForeignKey"
+          "InvalidPrimaryKey", "InvalidPrimaryKey", "InvalidPrimaryKey", "InvalidForeignKey"
         });
   }
 


### PR DESCRIPTION
It turns out this works well with snapshot creation so re-allowing creating array reference fields