### PR TITLE
DR-2569 Fix DISMAL_FAILURE on snapshot delete undo dataset lock step

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStep.java
@@ -78,11 +78,9 @@ public class DeleteSnapshotPopAndLockDatasetStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) {
+    FlightMap workingMap = context.getWorkingMap();
     try {
-      UUID sourceDatasetId =
-          snapshotService.getFirstSourceDatasetIdFromSnapshotId(
-              snapshotId, authenticatedUserRequest);
-
+      UUID sourceDatasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
       datasetService.unlock(sourceDatasetId, context.getFlightId(), sharedLock);
     } catch (DatasetLockException | DatasetNotFoundException ex) {
       // DatasetLockException will be thrown if flight id was not set


### PR DESCRIPTION
We were trying to get the snapshot, to get the source dataset ID, after we had already deleted it from the database! We can just get the dataset ID from the working map, since the DO step puts it in there.