### PR TITLE
[DR-2529] Record billingProfileId in mixpanel events

### DIFF
--- a/src/main/java/bio/terra/app/usermetrics/BardEventProperties.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardEventProperties.java
@@ -1,0 +1,9 @@
+package bio.terra.app.usermetrics;
+
+public final class BardEventProperties {
+  private BardEventProperties() {}
+
+  public static final String BILLING_PROFILE_ID_FIELD_NAME = "billingProfileId";
+  public static final String METHOD_FIELD_NAME = "method";
+  public static final String PATH_FIELD_NAME = "path";
+}

--- a/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
@@ -3,20 +3,43 @@ package bio.terra.app.usermetrics;
 import java.util.HashMap;
 import org.springframework.stereotype.Component;
 
+/**
+ * This class wraps a ThreadLocal variable to store API request properties to log (e.g. method,
+ * path, billing profile id).
+ *
+ * <p>Only one instance of the ThreadLocal is created per thread, so properties added in a single
+ * API request will get grouped together even if they are set in different methods.
+ */
 @Component
 public class UserLoggingMetrics {
 
   private static final ThreadLocal<HashMap<String, Object>> metrics =
       ThreadLocal.withInitial(() -> new HashMap<>());
 
+  /**
+   * Get the current thread's metrics instance. If no metrics have been set, return the default
+   * empty HashMap.
+   *
+   * @return HashMap<String, Object> metrics
+   */
   public HashMap<String, Object> get() {
     return metrics.get();
   }
 
+  /**
+   * Add a new value to the current thread's metrics map. If the map already contains a value for
+   * this key it will be replaced.
+   */
   public void set(String key, Object value) {
     metrics.get().put(key, value);
   }
 
+  /**
+   * Add multiple values to the current thread's metrics map. Any existing values with the same key
+   * will get replaced.
+   *
+   * @param value HashMap of metrics to add
+   */
   public void setAll(HashMap<String, Object> value) {
     HashMap<String, Object> properties = metrics.get();
     properties.putAll(value);

--- a/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
@@ -1,0 +1,25 @@
+package bio.terra.app.usermetrics;
+
+import java.util.HashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserLoggingMetrics {
+
+  private static final ThreadLocal<HashMap<String, Object>> metrics =
+      ThreadLocal.withInitial(() -> new HashMap<>());
+
+  public HashMap<String, Object> get() {
+    return metrics.get();
+  }
+
+  public void set(String key, Object value) {
+    metrics.get().put(key, value);
+  }
+
+  public void setAll(HashMap<String, Object> value) {
+    HashMap<String, Object> properties = metrics.get();
+    properties.putAll(value);
+    metrics.set(properties);
+  }
+}

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -20,7 +20,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 public class UserMetricsInterceptor implements HandlerInterceptor {
   static final String API_EVENT_NAME = "tdr:api";
-  public static ThreadLocal<HashMap<String, Object>> eventProperties =
+  public static final ThreadLocal<HashMap<String, Object>> eventProperties =
       ThreadLocal.withInitial(() -> new HashMap<>());
   private final BardClient bardClient;
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -5,49 +5,31 @@ import bio.terra.app.configuration.UserMetricsConfiguration;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import liquibase.util.StringUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.util.ContentCachingRequestWrapper;
 
 @Component
 public class UserMetricsInterceptor implements HandlerInterceptor {
   static final String API_EVENT_NAME = "tdr:api";
   static final String METHOD_FIELD_NAME = "method";
   static final String PATH_FIELD_NAME = "path";
-  static final String BILLING_PROFILE_ID_FIELD_NAME = "billingProfileId";
-
-  // Request parameters that contain the billing profile id
-  static final String DEFAULT_BILLING_PROFILE_ID_FIELD_NAME = "defaultProfileId";
-  static final String PROFILE_ID_FIELD_NAME = "profileId";
-  static final List<String> PROFILE_FIELDS =
-      List.of(DEFAULT_BILLING_PROFILE_ID_FIELD_NAME, PROFILE_ID_FIELD_NAME);
-  private static final Logger logger = LoggerFactory.getLogger(UserMetricsInterceptor.class);
-
+  public static final String BILLING_PROFILE_ID_FIELD_NAME = "billingProfileId";
+  public static ThreadLocal<HashMap<String, Object>> eventProperties =
+      ThreadLocal.withInitial(() -> new HashMap<>());
   private final BardClient bardClient;
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final ApplicationConfiguration applicationConfiguration;
   private final UserMetricsConfiguration metricsConfig;
   private final ExecutorService metricsPerformanceThreadpool;
-  private final ObjectMapper objectMapper;
 
   @Autowired
   public UserMetricsInterceptor(
@@ -55,57 +37,19 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
       ApplicationConfiguration applicationConfiguration,
       UserMetricsConfiguration metricsConfig,
-      @Qualifier("metricsReportingThreadpool") ExecutorService metricsPerformanceThreadpool,
-      @Qualifier("objectMapper") ObjectMapper objectMapper) {
+      @Qualifier("metricsReportingThreadpool") ExecutorService metricsPerformanceThreadpool) {
     this.bardClient = bardClient;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
     this.applicationConfiguration = applicationConfiguration;
     this.metricsConfig = metricsConfig;
     this.metricsPerformanceThreadpool = metricsPerformanceThreadpool;
-    this.objectMapper = objectMapper;
-  }
-
-  private HashMap<String, Object> getEventProperties(HttpServletRequest request) {
-    String method = request.getMethod().toUpperCase();
-    String path = request.getRequestURI();
-    HashMap<String, Object> eventProperties =
-        new HashMap<>(
-            Map.of(
-                METHOD_FIELD_NAME, method,
-                PATH_FIELD_NAME, path));
-    if (method.equals("POST")) {
-      try {
-        Optional<String> profileId = getProfileIdFromRequest(request);
-        profileId.ifPresent(s -> eventProperties.put(BILLING_PROFILE_ID_FIELD_NAME, s));
-      } catch (JsonProcessingException e) {
-        logger.info("Could not parse billing profile id from request");
-      }
-    }
-    return eventProperties;
-  }
-
-  @VisibleForTesting
-  public ContentCachingRequestWrapper getRequestWrapper(HttpServletRequest request) {
-    return new ContentCachingRequestWrapper(request);
-  }
-
-  @VisibleForTesting
-  public Optional<String> getProfileIdFromRequest(HttpServletRequest request)
-      throws JsonProcessingException {
-    ContentCachingRequestWrapper requestWrapper = getRequestWrapper(request);
-    String payload = new String(requestWrapper.getContentAsByteArray(), StandardCharsets.UTF_8);
-    JsonNode jsonNode = objectMapper.readTree(payload);
-    return PROFILE_FIELDS.stream()
-        .map(jsonNode::get)
-        .filter(Objects::nonNull)
-        .map(JsonNode::asText)
-        .findFirst();
   }
 
   @Override
   public void afterCompletion(
       HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
       throws Exception {
+    String method = request.getMethod().toUpperCase();
     String path = request.getRequestURI();
     AuthenticatedUserRequest userRequest;
     try {
@@ -114,6 +58,13 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
       // Don't track unauthenticated requests
       return;
     }
+
+    HashMap<String, Object> properties =
+        new HashMap<>(
+            Map.of(
+                METHOD_FIELD_NAME, method,
+                PATH_FIELD_NAME, path));
+    properties.putAll(eventProperties.get());
 
     // Don't log metrics if bard isn't configured or the path is part of the ignore-list
     if (StringUtils.isEmpty(metricsConfig.getBardBasePath()) || ignoreEventForPath(path)) {
@@ -127,7 +78,7 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
                 userRequest,
                 new BardEvent(
                     API_EVENT_NAME,
-                    getEventProperties(request),
+                    properties,
                     metricsConfig.getAppId(),
                     applicationConfiguration.getDnsName())));
   }

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -20,9 +20,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 public class UserMetricsInterceptor implements HandlerInterceptor {
   static final String API_EVENT_NAME = "tdr:api";
-  static final String METHOD_FIELD_NAME = "method";
-  static final String PATH_FIELD_NAME = "path";
-  public static final String BILLING_PROFILE_ID_FIELD_NAME = "billingProfileId";
   public static ThreadLocal<HashMap<String, Object>> eventProperties =
       ThreadLocal.withInitial(() -> new HashMap<>());
   private final BardClient bardClient;
@@ -62,8 +59,8 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
     HashMap<String, Object> properties =
         new HashMap<>(
             Map.of(
-                METHOD_FIELD_NAME, method,
-                PATH_FIELD_NAME, path));
+                BardEventProperties.METHOD_FIELD_NAME, method,
+                BardEventProperties.PATH_FIELD_NAME, path));
     properties.putAll(eventProperties.get());
 
     // Don't log metrics if bard isn't configured or the path is part of the ignore-list

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -5,18 +5,28 @@ import bio.terra.app.configuration.UserMetricsConfiguration;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import liquibase.util.StringUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 @Component
 public class UserMetricsInterceptor implements HandlerInterceptor {
@@ -25,11 +35,19 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
   static final String PATH_FIELD_NAME = "path";
   static final String BILLING_PROFILE_ID_FIELD_NAME = "billingProfileId";
 
+  // Request parameters that contain the billing profile id
+  static final String DEFAULT_BILLING_PROFILE_ID_FIELD_NAME = "defaultProfileId";
+  static final String PROFILE_ID_FIELD_NAME = "profileId";
+  static final List<String> PROFILE_FIELDS =
+      List.of(DEFAULT_BILLING_PROFILE_ID_FIELD_NAME, PROFILE_ID_FIELD_NAME);
+  private static final Logger logger = LoggerFactory.getLogger(UserMetricsInterceptor.class);
+
   private final BardClient bardClient;
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final ApplicationConfiguration applicationConfiguration;
   private final UserMetricsConfiguration metricsConfig;
   private final ExecutorService metricsPerformanceThreadpool;
+  private final ObjectMapper objectMapper;
 
   @Autowired
   public UserMetricsInterceptor(
@@ -37,19 +55,57 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
       ApplicationConfiguration applicationConfiguration,
       UserMetricsConfiguration metricsConfig,
-      @Qualifier("metricsReportingThreadpool") ExecutorService metricsPerformanceThreadpool) {
+      @Qualifier("metricsReportingThreadpool") ExecutorService metricsPerformanceThreadpool,
+      @Qualifier("objectMapper") ObjectMapper objectMapper) {
     this.bardClient = bardClient;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
     this.applicationConfiguration = applicationConfiguration;
     this.metricsConfig = metricsConfig;
     this.metricsPerformanceThreadpool = metricsPerformanceThreadpool;
+    this.objectMapper = objectMapper;
+  }
+
+  private HashMap<String, Object> getEventProperties(HttpServletRequest request) {
+    String method = request.getMethod().toUpperCase();
+    String path = request.getRequestURI();
+    HashMap<String, Object> eventProperties =
+        new HashMap<>(
+            Map.of(
+                METHOD_FIELD_NAME, method,
+                PATH_FIELD_NAME, path));
+    if (method.equals("POST")) {
+      try {
+        Optional<String> profileId = getProfileIdFromRequest(request);
+        profileId.ifPresent(s -> eventProperties.put(BILLING_PROFILE_ID_FIELD_NAME, s));
+      } catch (JsonProcessingException e) {
+        logger.info("Could not parse billing profile id from request");
+      }
+    }
+    return eventProperties;
+  }
+
+  @VisibleForTesting
+  public ContentCachingRequestWrapper getRequestWrapper(HttpServletRequest request) {
+    return new ContentCachingRequestWrapper(request);
+  }
+
+  @VisibleForTesting
+  public Optional<String> getProfileIdFromRequest(HttpServletRequest request)
+      throws JsonProcessingException {
+    ContentCachingRequestWrapper requestWrapper = getRequestWrapper(request);
+    String payload = new String(requestWrapper.getContentAsByteArray(), StandardCharsets.UTF_8);
+    JsonNode jsonNode = objectMapper.readTree(payload);
+    return PROFILE_FIELDS.stream()
+        .map(jsonNode::get)
+        .filter(Objects::nonNull)
+        .map(JsonNode::asText)
+        .findFirst();
   }
 
   @Override
   public void afterCompletion(
       HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
       throws Exception {
-    String method = request.getMethod().toUpperCase();
     String path = request.getRequestURI();
     AuthenticatedUserRequest userRequest;
     try {
@@ -64,15 +120,6 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
       return;
     }
 
-    HashMap<String, Object> eventProperties =
-        new HashMap<>(
-            Map.of(
-                METHOD_FIELD_NAME, method,
-                PATH_FIELD_NAME, path));
-    String[] billingProfileId = request.getParameterMap().get(BILLING_PROFILE_ID_FIELD_NAME);
-    if (ArrayUtils.isNotEmpty(billingProfileId)) {
-      eventProperties.put(BILLING_PROFILE_ID_FIELD_NAME, billingProfileId[0]);
-    }
     // Spawn a thread so that sending the metric doesn't slow down the initial request
     metricsPerformanceThreadpool.submit(
         () ->
@@ -80,7 +127,7 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
                 userRequest,
                 new BardEvent(
                     API_EVENT_NAME,
-                    eventProperties,
+                    getEventProperties(request),
                     metricsConfig.getAppId(),
                     applicationConfiguration.getDnsName())));
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -1,6 +1,7 @@
 package bio.terra.service.dataset;
 
 import bio.terra.app.controller.DatasetsApiController;
+import bio.terra.app.usermetrics.UserMetricsInterceptor;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -119,6 +120,12 @@ public class DatasetService {
   public String createDataset(
       DatasetRequestModel datasetRequest, AuthenticatedUserRequest userReq) {
     String description = "Create dataset " + datasetRequest.getName();
+    HashMap<String, Object> properties =
+        new HashMap<>(
+            Map.of(
+                UserMetricsInterceptor.BILLING_PROFILE_ID_FIELD_NAME,
+                datasetRequest.getDefaultProfileId()));
+    UserMetricsInterceptor.eventProperties.set(properties);
     return jobService
         .newJob(description, DatasetCreateFlight.class, datasetRequest, userReq)
         .submit();

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -1,6 +1,7 @@
 package bio.terra.service.dataset;
 
 import bio.terra.app.controller.DatasetsApiController;
+import bio.terra.app.usermetrics.BardEventProperties;
 import bio.terra.app.usermetrics.UserMetricsInterceptor;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.exception.InvalidCloudPlatformException;
@@ -123,7 +124,7 @@ public class DatasetService {
     HashMap<String, Object> properties =
         new HashMap<>(
             Map.of(
-                UserMetricsInterceptor.BILLING_PROFILE_ID_FIELD_NAME,
+                BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME,
                 datasetRequest.getDefaultProfileId()));
     UserMetricsInterceptor.eventProperties.set(properties);
     return jobService

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -2,7 +2,7 @@ package bio.terra.service.dataset;
 
 import bio.terra.app.controller.DatasetsApiController;
 import bio.terra.app.usermetrics.BardEventProperties;
-import bio.terra.app.usermetrics.UserMetricsInterceptor;
+import bio.terra.app.usermetrics.UserLoggingMetrics;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -87,6 +87,7 @@ public class DatasetService {
   private final ObjectMapper objectMapper;
   private final AzureBlobStorePdao azureBlobStorePdao;
   private final ProfileService profileService;
+  private final UserLoggingMetrics loggingMetrics;
 
   @Autowired
   public DatasetService(
@@ -102,7 +103,8 @@ public class DatasetService {
       GcsPdao gcsPdao,
       ObjectMapper objectMapper,
       AzureBlobStorePdao azureBlobStorePdao,
-      ProfileService profileService) {
+      ProfileService profileService,
+      UserLoggingMetrics loggingMetrics) {
     this.datasetDao = datasetDao;
     this.jobService = jobService;
     this.loadService = loadService;
@@ -116,17 +118,14 @@ public class DatasetService {
     this.objectMapper = objectMapper;
     this.azureBlobStorePdao = azureBlobStorePdao;
     this.profileService = profileService;
+    this.loggingMetrics = loggingMetrics;
   }
 
   public String createDataset(
       DatasetRequestModel datasetRequest, AuthenticatedUserRequest userReq) {
     String description = "Create dataset " + datasetRequest.getName();
-    HashMap<String, Object> properties =
-        new HashMap<>(
-            Map.of(
-                BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME,
-                datasetRequest.getDefaultProfileId()));
-    UserMetricsInterceptor.eventProperties.set(properties);
+    loggingMetrics.set(
+        BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, datasetRequest.getDefaultProfileId());
     return jobService
         .newJob(description, DatasetCreateFlight.class, datasetRequest, userReq)
         .submit();

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -70,8 +70,8 @@ public class UserMetricsInterceptorTest {
                 new BardEvent(
                     UserMetricsInterceptor.API_EVENT_NAME,
                     Map.of(
-                        UserMetricsInterceptor.METHOD_FIELD_NAME, "POST",
-                        UserMetricsInterceptor.PATH_FIELD_NAME, "/foo/bar"),
+                        BardEventProperties.METHOD_FIELD_NAME, "POST",
+                        BardEventProperties.PATH_FIELD_NAME, "/foo/bar"),
                     "testapp",
                     "some.dnsname.org")));
 
@@ -82,8 +82,7 @@ public class UserMetricsInterceptorTest {
   public void testSendEventWithBillingProfileId() throws Exception {
     String billingProfileId = UUID.randomUUID().toString();
     HashMap<String, Object> properties =
-        new HashMap<>(
-            Map.of(UserMetricsInterceptor.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId));
+        new HashMap<>(Map.of(BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId));
     UserMetricsInterceptor.eventProperties.set(properties);
 
     mockRequestAuth(request);
@@ -97,9 +96,9 @@ public class UserMetricsInterceptorTest {
                 new BardEvent(
                     UserMetricsInterceptor.API_EVENT_NAME,
                     Map.of(
-                        UserMetricsInterceptor.METHOD_FIELD_NAME, "POST",
-                        UserMetricsInterceptor.PATH_FIELD_NAME, "/foo/bar",
-                        UserMetricsInterceptor.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId),
+                        BardEventProperties.METHOD_FIELD_NAME, "POST",
+                        BardEventProperties.PATH_FIELD_NAME, "/foo/bar",
+                        BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId),
                     "testapp",
                     "some.dnsname.org")));
 

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -14,7 +14,6 @@ import bio.terra.common.category.Unit;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -44,6 +43,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class UserMetricsInterceptorTest {
   @SpyBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   @MockBean private BardClient bardClient;
+  @Autowired private UserLoggingMetrics loggingMetrics;
   @Autowired private UserMetricsConfiguration metricsConfig;
   @Captor private ArgumentCaptor<AuthenticatedUserRequest> authCaptor;
   @SpyBean private UserMetricsInterceptor metricsInterceptor;
@@ -81,9 +81,7 @@ public class UserMetricsInterceptorTest {
   @Test
   public void testSendEventWithBillingProfileId() throws Exception {
     String billingProfileId = UUID.randomUUID().toString();
-    HashMap<String, Object> properties =
-        new HashMap<>(Map.of(BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId));
-    UserMetricsInterceptor.eventProperties.set(properties);
+    loggingMetrics.set(BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId);
 
     mockRequestAuth(request);
 

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import bio.terra.app.usermetrics.UserLoggingMetrics;
 import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.category.Unit;
 import bio.terra.service.auth.iam.IamRole;
@@ -59,6 +60,7 @@ public class DatasetServiceUnitTest {
   @MockBean private ObjectMapper objectMapper;
   @MockBean private AzureBlobStorePdao azureBlobStorePdao;
   @MockBean private ProfileService profileService;
+  @MockBean private UserLoggingMetrics loggingMetrics;
 
   @Test
   public void enumerate() {


### PR DESCRIPTION
If the `billingProfileId` or `defaultProfileId` are present in a POST request body, include it in the information that gets sent to mixpanel. 