### PR TITLE
[DR-2549] Add ability to sort snapshot preview results by column 

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -36,6 +36,7 @@ import io.swagger.annotations.Api;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -252,8 +253,10 @@ public class SnapshotsApiController implements SnapshotsApi {
     iamService.verifyAuthorization(
         getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id.toString(), IamAction.READ_DATA);
     logger.info("Retrieving snapshot id {}", id);
+    // TODO: Remove after https://broadworkbench.atlassian.net/browse/DR-2588 is fixed
+    SqlSortDirection sortDirection = Objects.requireNonNullElse(direction, SqlSortDirection.ASC);
     SnapshotPreviewModel previewModel =
-        snapshotService.retrievePreview(id, table, limit, offset, sort, direction);
+        snapshotService.retrievePreview(id, table, limit, offset, sort, sortDirection);
     return new ResponseEntity<>(previewModel, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -242,12 +242,18 @@ public class SnapshotsApiController implements SnapshotsApi {
 
   @Override
   public ResponseEntity<SnapshotPreviewModel> lookupSnapshotPreviewById(
-      UUID id, String table, Integer offset, Integer limit) {
+      UUID id,
+      String table,
+      Integer offset,
+      Integer limit,
+      String sort,
+      SqlSortDirection direction) {
     logger.info("Verifying user access");
     iamService.verifyAuthorization(
         getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id.toString(), IamAction.READ_DATA);
     logger.info("Retrieving snapshot id {}", id);
-    SnapshotPreviewModel previewModel = snapshotService.retrievePreview(id, table, limit, offset);
+    SnapshotPreviewModel previewModel =
+        snapshotService.retrievePreview(id, table, limit, offset, sort, direction);
     return new ResponseEntity<>(previewModel, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -88,6 +88,10 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
     return this;
   }
 
+  public Optional<SnapshotTable> getTableByName(String tableName) {
+    return this.getTables().stream().filter(t -> t.getName().equals(tableName)).findFirst();
+  }
+
   public List<SnapshotSource> getSnapshotSources() {
     return snapshotSources;
   }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -407,6 +407,7 @@ public class SnapshotService {
                         "No snapshot table exists with the name: " + tableName));
 
     String sortColumn = Optional.ofNullable(sort).orElse(PDAO_ROW_ID_COLUMN);
+    SqlSortDirection sortDirection = Optional.ofNullable(direction).orElse(SqlSortDirection.ASC);
     if (!StringUtils.equals(sortColumn, PDAO_ROW_ID_COLUMN)) {
       table.getColumns().stream()
           .filter(t -> t.getName().equals(sort))
@@ -420,7 +421,7 @@ public class SnapshotService {
     try {
       List<Map<String, Object>> values =
           bigQuerySnapshotPdao.getSnapshotTable(
-              snapshot, tableName, limit, offset, sortColumn, direction);
+              snapshot, tableName, limit, offset, sortColumn, sortDirection);
 
       return new SnapshotPreviewModel().result(List.copyOf(values));
     } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -406,7 +406,6 @@ public class SnapshotService {
                     new SnapshotPreviewException(
                         "No snapshot table exists with the name: " + tableName));
 
-    SqlSortDirection sortDirection = Objects.requireNonNullElse(direction, SqlSortDirection.ASC);
     if (!sort.equalsIgnoreCase(PDAO_ROW_ID_COLUMN)) {
       table
           .getColumnByName(sort)
@@ -419,7 +418,7 @@ public class SnapshotService {
     try {
       List<Map<String, Object>> values =
           bigQuerySnapshotPdao.getSnapshotTable(
-              snapshot, tableName, limit, offset, sort, sortDirection);
+              snapshot, tableName, limit, offset, sort, direction);
 
       return new SnapshotPreviewModel().result(List.copyOf(values));
     } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -58,6 +58,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -405,8 +406,8 @@ public class SnapshotService {
                     new SnapshotPreviewException(
                         "No snapshot table exists with the name: " + tableName));
 
-    SqlSortDirection sortDirection = Optional.ofNullable(direction).orElse(SqlSortDirection.ASC);
-    if (!StringUtils.equals(sort, PDAO_ROW_ID_COLUMN)) {
+    SqlSortDirection sortDirection = Objects.requireNonNullElse(direction, SqlSortDirection.ASC);
+    if (!sort.equalsIgnoreCase(PDAO_ROW_ID_COLUMN)) {
       table
           .getColumnByName(sort)
           .orElseThrow(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -58,7 +58,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -1,5 +1,7 @@
 package bio.terra.service.snapshot;
 
+import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_COLUMN;
+
 import bio.terra.app.controller.SnapshotsApiController;
 import bio.terra.app.controller.exception.ValidationException;
 import bio.terra.common.Column;
@@ -387,20 +389,38 @@ public class SnapshotService {
   }
 
   public SnapshotPreviewModel retrievePreview(
-      UUID snapshotId, String tableName, int limit, int offset) {
+      UUID snapshotId,
+      String tableName,
+      int limit,
+      int offset,
+      String sort,
+      SqlSortDirection direction) {
     Snapshot snapshot = retrieve(snapshotId);
 
-    snapshot.getTables().stream()
-        .filter(t -> t.getName().equals(tableName))
-        .findFirst()
-        .orElseThrow(
-            () ->
-                new SnapshotPreviewException(
-                    "No snapshot table exists with the name: " + tableName));
+    SnapshotTable table =
+        snapshot.getTables().stream()
+            .filter(t -> t.getName().equals(tableName))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new SnapshotPreviewException(
+                        "No snapshot table exists with the name: " + tableName));
+
+    String sortColumn = Optional.ofNullable(sort).orElse(PDAO_ROW_ID_COLUMN);
+    if (!StringUtils.equals(sortColumn, PDAO_ROW_ID_COLUMN)) {
+      table.getColumns().stream()
+          .filter(t -> t.getName().equals(sort))
+          .findFirst()
+          .orElseThrow(
+              () ->
+                  new SnapshotPreviewException(
+                      "No snapshot table column exists with the name: " + sort));
+    }
 
     try {
       List<Map<String, Object>> values =
-          bigQuerySnapshotPdao.getSnapshotTable(snapshot, tableName, limit, offset);
+          bigQuerySnapshotPdao.getSnapshotTable(
+              snapshot, tableName, limit, offset, sortColumn, direction);
 
       return new SnapshotPreviewModel().result(List.copyOf(values));
     } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -398,20 +398,17 @@ public class SnapshotService {
     Snapshot snapshot = retrieve(snapshotId);
 
     SnapshotTable table =
-        snapshot.getTables().stream()
-            .filter(t -> t.getName().equals(tableName))
-            .findFirst()
+        snapshot
+            .getTableByName(tableName)
             .orElseThrow(
                 () ->
                     new SnapshotPreviewException(
                         "No snapshot table exists with the name: " + tableName));
 
-    String sortColumn = Optional.ofNullable(sort).orElse(PDAO_ROW_ID_COLUMN);
     SqlSortDirection sortDirection = Optional.ofNullable(direction).orElse(SqlSortDirection.ASC);
-    if (!StringUtils.equals(sortColumn, PDAO_ROW_ID_COLUMN)) {
-      table.getColumns().stream()
-          .filter(t -> t.getName().equals(sort))
-          .findFirst()
+    if (!StringUtils.equals(sort, PDAO_ROW_ID_COLUMN)) {
+      table
+          .getColumnByName(sort)
           .orElseThrow(
               () ->
                   new SnapshotPreviewException(
@@ -421,7 +418,7 @@ public class SnapshotService {
     try {
       List<Map<String, Object>> values =
           bigQuerySnapshotPdao.getSnapshotTable(
-              snapshot, tableName, limit, offset, sortColumn, sortDirection);
+              snapshot, tableName, limit, offset, sort, sortDirection);
 
       return new SnapshotPreviewModel().result(List.copyOf(values));
     } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTable.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTable.java
@@ -4,6 +4,7 @@ import bio.terra.common.Column;
 import bio.terra.common.Table;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public class SnapshotTable implements Table {
@@ -35,6 +36,10 @@ public class SnapshotTable implements Table {
   @Override
   public List<Column> getColumns() {
     return columns;
+  }
+
+  public Optional<Column> getColumnByName(String columnName) {
+    return this.columns.stream().filter(t -> t.getName().equals(columnName)).findFirst();
   }
 
   public SnapshotTable columns(List<Column> columns) {

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
@@ -17,6 +17,7 @@ import bio.terra.grammar.exception.InvalidQueryException;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SnapshotRequestRowIdModel;
 import bio.terra.model.SnapshotRequestRowIdTableModel;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.AssetSpecification;
 import bio.terra.service.dataset.AssetTable;
 import bio.terra.service.dataset.Dataset;
@@ -814,14 +815,20 @@ public class BigQuerySnapshotPdao {
   }
 
   private static final String SNAPSHOT_DATA_TEMPLATE =
-      "SELECT * FROM `<project>.<snapshot>.<table>` ORDER BY datarepo_row_id"
+      "SELECT * FROM `<project>.<snapshot>.<table>` ORDER BY <sort> <direction>"
           + " LIMIT <limit> OFFSET <offset>";
 
   /*
    * WARNING: Ensure input parameters are validated before executing this method!
    */
   public List<Map<String, Object>> getSnapshotTable(
-      Snapshot snapshot, String tableName, int limit, int offset) throws InterruptedException {
+      Snapshot snapshot,
+      String tableName,
+      int limit,
+      int offset,
+      String sort,
+      SqlSortDirection direction)
+      throws InterruptedException {
     final BigQueryProject bigQueryProject = BigQueryProject.from(snapshot);
     final String snapshotProjectId = bigQueryProject.getProjectId();
     final String sql =
@@ -829,6 +836,8 @@ public class BigQuerySnapshotPdao {
             .add("project", snapshotProjectId)
             .add("snapshot", snapshot.getName())
             .add("table", tableName)
+            .add("sort", sort)
+            .add("direction", direction)
             .add("limit", limit)
             .add("offset", offset)
             .render();

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -475,6 +475,7 @@ paths:
           in: query
           description: The direction to sort.
           schema:
+            default: asc
             $ref: '#/components/schemas/SqlSortDirection'
         - name: filter
           in: query
@@ -701,6 +702,7 @@ paths:
           in: query
           description: The direction to sort.
           schema:
+            default: asc
             $ref: '#/components/schemas/SqlSortDirection'
       responses:
         200:
@@ -1062,6 +1064,7 @@ paths:
           in: query
           description: The direction to sort.
           schema:
+            default: asc
             $ref: '#/components/schemas/SqlSortDirection'
         - name: filter
           in: query
@@ -3143,10 +3146,7 @@ components:
         The type of a column in a table.
     SqlSortDirection:
       type: string
-      enum:
-        - asc
-        - desc
-      default: asc
+      enum: [ asc, desc ]
       description: >
         The sort direction of a query result
     EnumerateSortByParam:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -698,6 +698,7 @@ paths:
           description: The table column to sort by
           schema:
             type: string
+            default: "datarepo_row_id"
         - name: direction
           in: query
           description: The direction to sort.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -475,7 +475,6 @@ paths:
           in: query
           description: The direction to sort.
           schema:
-            default: asc
             $ref: '#/components/schemas/SqlSortDirection'
         - name: filter
           in: query
@@ -693,6 +692,16 @@ paths:
             default: 30
             minimum: 1
             maximum: 1000
+        - name: sort
+          in: query
+          description: The table column to sort by
+          schema:
+            type: string
+        - name: direction
+          in: query
+          description: The direction to sort.
+          schema:
+            $ref: '#/components/schemas/SqlSortDirection'
       responses:
         200:
           description: Returns the table data from a snapshot
@@ -1053,7 +1062,6 @@ paths:
           in: query
           description: The direction to sort.
           schema:
-            default: asc
             $ref: '#/components/schemas/SqlSortDirection'
         - name: filter
           in: query
@@ -3135,7 +3143,10 @@ components:
         The type of a column in a table.
     SqlSortDirection:
       type: string
-      enum: [ asc, desc ]
+      enum:
+        - asc
+        - desc
+      default: asc
       description: >
         The sort direction of a query result
     EnumerateSortByParam:

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -16,6 +16,7 @@ import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
 import bio.terra.model.SearchIndexRequest;
 import bio.terra.model.SnapshotPreviewModel;
+import bio.terra.model.SqlSortDirection;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
@@ -66,21 +67,27 @@ public class SearchApiControllerTest {
   public void testSnapshotPreviewById() throws Exception {
     var id = UUID.randomUUID();
     var table = "good_table";
+    var column = "good_column";
+    var direction = SqlSortDirection.ASC;
     var limit = 10;
     var offset = 0;
     var list = List.of("hello", "world");
     var result = new SnapshotPreviewModel().result(List.copyOf(list));
-    when(snapshotService.retrievePreview(id, table, limit, offset)).thenReturn(result);
+    when(snapshotService.retrievePreview(id, table, limit, offset, column, direction))
+        .thenReturn(result);
     mvc.perform(
             get(GET_PREVIEW_ENDPOINT, id, table)
                 .queryParam("limit", String.valueOf(limit))
-                .queryParam("offset", String.valueOf(offset)))
+                .queryParam("offset", String.valueOf(offset))
+                .queryParam("sort", column)
+                .queryParam("direction", String.valueOf(direction))
+        )
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.result").isArray());
     verify(iamService)
         .verifyAuthorization(
             any(), eq(IamResourceType.DATASNAPSHOT), eq(id.toString()), eq(IamAction.READ_DATA));
-    verify(snapshotService).retrievePreview(id, table, limit, offset);
+    verify(snapshotService).retrievePreview(id, table, limit, offset, column, direction);
   }
 
   @Test

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -25,6 +25,7 @@ import bio.terra.service.search.SearchService;
 import bio.terra.service.search.SnapshotSearchMetadataDao;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.exception.SnapshotPreviewException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,6 +53,9 @@ public class SearchApiControllerTest {
   private static final String GET_PREVIEW_ENDPOINT =
       "/api/repository/v1/snapshots/{id}/data/{table}";
   private static final String UPSERT_DELETE_ENDPOINT = "/api/repository/v1/search/{id}/metadata";
+  private static final SqlSortDirection DIRECTION = SqlSortDirection.ASC;
+  private static final int LIMIT = 10;
+  private static final int OFFSET = 0;
 
   @Autowired private MockMvc mvc;
 
@@ -63,31 +67,80 @@ public class SearchApiControllerTest {
 
   @MockBean private SnapshotService snapshotService;
 
+  private void mockSnapshotPreviewByIdSuccess(UUID id, String table, String column)
+      throws Exception {
+    var list = List.of("hello", "world");
+    var result = new SnapshotPreviewModel().result(List.copyOf(list));
+    when(snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION))
+        .thenReturn(result);
+    mvc.perform(
+            get(GET_PREVIEW_ENDPOINT, id, table)
+                .queryParam("limit", String.valueOf(LIMIT))
+                .queryParam("offset", String.valueOf(OFFSET))
+                .queryParam("sort", column)
+                .queryParam("direction", String.valueOf(DIRECTION)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result").isArray());
+  }
+
+  private void mockSnapshotPreviewByIdError(UUID id, String table, String column) throws Exception {
+    when(snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION))
+        .thenThrow(SnapshotPreviewException.class);
+    mvc.perform(
+            get(GET_PREVIEW_ENDPOINT, id, table)
+                .queryParam("limit", String.valueOf(LIMIT))
+                .queryParam("offset", String.valueOf(OFFSET))
+                .queryParam("sort", column)
+                .queryParam("direction", String.valueOf(DIRECTION)))
+        .andExpect(status().is5xxServerError());
+  }
+
   @Test
   public void testSnapshotPreviewById() throws Exception {
     var id = UUID.randomUUID();
     var table = "good_table";
     var column = "good_column";
-    var direction = SqlSortDirection.ASC;
-    var limit = 10;
-    var offset = 0;
-    var list = List.of("hello", "world");
-    var result = new SnapshotPreviewModel().result(List.copyOf(list));
-    when(snapshotService.retrievePreview(id, table, limit, offset, column, direction))
-        .thenReturn(result);
-    mvc.perform(
-            get(GET_PREVIEW_ENDPOINT, id, table)
-                .queryParam("limit", String.valueOf(limit))
-                .queryParam("offset", String.valueOf(offset))
-                .queryParam("sort", column)
-                .queryParam("direction", String.valueOf(direction))
-        )
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.result").isArray());
+    mockSnapshotPreviewByIdSuccess(id, table, column);
     verify(iamService)
         .verifyAuthorization(
             any(), eq(IamResourceType.DATASNAPSHOT), eq(id.toString()), eq(IamAction.READ_DATA));
-    verify(snapshotService).retrievePreview(id, table, limit, offset, column, direction);
+    verify(snapshotService).retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION);
+  }
+
+  @Test
+  public void testSnapshotPreviewByIdHandlesDataRepoRowId() throws Exception {
+    var id = UUID.randomUUID();
+    var table = "good_table";
+    var column = "datarepo_row_id";
+    mockSnapshotPreviewByIdSuccess(id, table, column);
+    verify(iamService)
+        .verifyAuthorization(
+            any(), eq(IamResourceType.DATASNAPSHOT), eq(id.toString()), eq(IamAction.READ_DATA));
+    verify(snapshotService).retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION);
+  }
+
+  @Test(expected = SnapshotPreviewException.class)
+  public void testSnapshotPreviewByIdBadColumn() throws Exception {
+    var id = UUID.randomUUID();
+    var table = "good_table";
+    var column = "bad_column";
+    mockSnapshotPreviewByIdError(id, table, column);
+    verify(iamService)
+        .verifyAuthorization(
+            any(), eq(IamResourceType.DATASNAPSHOT), eq(id.toString()), eq(IamAction.READ_DATA));
+    snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION);
+  }
+
+  @Test(expected = SnapshotPreviewException.class)
+  public void testSnapshotPreviewByIdBadTable() throws Exception {
+    var id = UUID.randomUUID();
+    var table = "bad_table";
+    var column = "good_column";
+    mockSnapshotPreviewByIdError(id, table, column);
+    verify(iamService)
+        .verifyAuthorization(
+            any(), eq(IamResourceType.DATASNAPSHOT), eq(id.toString()), eq(IamAction.READ_DATA));
+    snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION);
   }
 
   @Test


### PR DESCRIPTION
Add `sort` and `direction` parameters to the snapshot preview endpoint. I noticed the default value for the direction is not getting set even though it is defined in the API spec (I think updating to a newer version of swagger might fix this so I created a follow-on [ticket](https://broadworkbench.atlassian.net/browse/DR-2588))