### PR TITLE
DR-2573: Add DRS Authorizations to Access Method

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -439,7 +439,7 @@ public class DrsService {
       if (passportAuth) {
         accessMethods =
             getDrsSignedURLAccessMethods(
-                ACCESS_ID_PREFIX_GCP + ACCESS_ID_PREFIX_PASSPORT, gcpRegion, true);
+                ACCESS_ID_PREFIX_GCP + ACCESS_ID_PREFIX_PASSPORT, gcpRegion, passportAuth);
       } else {
         accessMethods = getDrsAccessMethodsOnGcp(fsFile, authUser, gcpRegion);
       }
@@ -448,9 +448,10 @@ public class DrsService {
       if (passportAuth) {
         accessMethods =
             getDrsSignedURLAccessMethods(
-                ACCESS_ID_PREFIX_AZURE + ACCESS_ID_PREFIX_PASSPORT, azureRegion, true);
+                ACCESS_ID_PREFIX_AZURE + ACCESS_ID_PREFIX_PASSPORT, azureRegion, passportAuth);
       } else {
-        accessMethods = getDrsSignedURLAccessMethods(ACCESS_ID_PREFIX_AZURE, azureRegion, false);
+        accessMethods =
+            getDrsSignedURLAccessMethods(ACCESS_ID_PREFIX_AZURE, azureRegion, passportAuth);
       }
     } else {
       throw new InvalidCloudPlatformException();
@@ -519,13 +520,13 @@ public class DrsService {
   private List<DRSAccessMethod> getDrsSignedURLAccessMethods(
       String prefix, String region, boolean passportAuth) {
     String accessId = prefix + region;
-    DRSAuthorizations authorizationsBearerOnly = buildDRSAuth(passportAuth);
+    DRSAuthorizations authorizations = buildDRSAuth(passportAuth);
     DRSAccessMethod httpsAccessMethod =
         new DRSAccessMethod()
             .type(DRSAccessMethod.TypeEnum.HTTPS)
             .accessId(accessId)
             .region(region)
-            .authorizations(authorizationsBearerOnly);
+            .authorizations(authorizations);
 
     return List.of(httpsAccessMethod);
   }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -172,20 +172,21 @@ public class DrsService {
    */
   public DRSAuthorizations lookupAuthorizationsByDrsId(String drsObjectId) {
     try (DrsRequestResource r = new DrsRequestResource()) {
-      DRSAuthorizations auths = new DRSAuthorizations();
-
       SnapshotCacheResult snapshot = lookupSnapshotForDRSObject(drsObjectId);
       SnapshotSummaryModel snapshotSummary = getSnapshotSummary(snapshot.id);
 
-      if (SnapshotSummary.passportAuthorizationAvailable(snapshotSummary)) {
-        auths.addSupportedTypesItem(DRSAuthorizations.SupportedTypesEnum.PASSPORTAUTH);
-        auths.addPassportAuthIssuersItem(ecmConfiguration.getRasIssuer());
-      }
-
-      auths.addSupportedTypesItem(DRSAuthorizations.SupportedTypesEnum.BEARERAUTH);
-
-      return auths;
+      return buildDRSAuth(SnapshotSummary.passportAuthorizationAvailable(snapshotSummary));
     }
+  }
+
+  private DRSAuthorizations buildDRSAuth(boolean passportAuthorizationAvailable) {
+    DRSAuthorizations auths = new DRSAuthorizations();
+    if (passportAuthorizationAvailable) {
+      auths.addSupportedTypesItem(DRSAuthorizations.SupportedTypesEnum.PASSPORTAUTH);
+      auths.addPassportAuthIssuersItem(ecmConfiguration.getRasIssuer());
+    }
+    auths.addSupportedTypesItem(DRSAuthorizations.SupportedTypesEnum.BEARERAUTH);
+    return auths;
   }
 
   /**
@@ -438,7 +439,7 @@ public class DrsService {
       if (passportAuth) {
         accessMethods =
             getDrsSignedURLAccessMethods(
-                ACCESS_ID_PREFIX_GCP + ACCESS_ID_PREFIX_PASSPORT, gcpRegion);
+                ACCESS_ID_PREFIX_GCP + ACCESS_ID_PREFIX_PASSPORT, gcpRegion, true);
       } else {
         accessMethods = getDrsAccessMethodsOnGcp(fsFile, authUser, gcpRegion);
       }
@@ -447,9 +448,9 @@ public class DrsService {
       if (passportAuth) {
         accessMethods =
             getDrsSignedURLAccessMethods(
-                ACCESS_ID_PREFIX_AZURE + ACCESS_ID_PREFIX_PASSPORT, azureRegion);
+                ACCESS_ID_PREFIX_AZURE + ACCESS_ID_PREFIX_PASSPORT, azureRegion, true);
       } else {
-        accessMethods = getDrsSignedURLAccessMethods(ACCESS_ID_PREFIX_AZURE, azureRegion);
+        accessMethods = getDrsSignedURLAccessMethods(ACCESS_ID_PREFIX_AZURE, azureRegion, false);
       }
     } else {
       throw new InvalidCloudPlatformException();
@@ -489,6 +490,7 @@ public class DrsService {
   private List<DRSAccessMethod> getDrsAccessMethodsOnGcp(
       FSFile fsFile, AuthenticatedUserRequest authUser, String region) {
     DRSAccessURL gsAccessURL = new DRSAccessURL().url(fsFile.getCloudPath());
+    DRSAuthorizations authorizationsBearerOnly = buildDRSAuth(false);
 
     String accessId = ACCESS_ID_PREFIX_GCP + region;
     DRSAccessMethod gsAccessMethod =
@@ -496,8 +498,8 @@ public class DrsService {
             .type(DRSAccessMethod.TypeEnum.GS)
             .accessUrl(gsAccessURL)
             .accessId(accessId)
-            .region(region);
-    //TODO - add authorizations
+            .region(region)
+            .authorizations(authorizationsBearerOnly);
 
     DRSAccessURL httpsAccessURL =
         new DRSAccessURL()
@@ -508,20 +510,22 @@ public class DrsService {
         new DRSAccessMethod()
             .type(DRSAccessMethod.TypeEnum.HTTPS)
             .accessUrl(httpsAccessURL)
-            .region(region);
-    //TODO - add authorizations
+            .region(region)
+            .authorizations(authorizationsBearerOnly);
 
     return List.of(gsAccessMethod, httpsAccessMethod);
   }
 
-  private List<DRSAccessMethod> getDrsSignedURLAccessMethods(String prefix, String region) {
+  private List<DRSAccessMethod> getDrsSignedURLAccessMethods(
+      String prefix, String region, boolean passportAuth) {
     String accessId = prefix + region;
+    DRSAuthorizations authorizationsBearerOnly = buildDRSAuth(passportAuth);
     DRSAccessMethod httpsAccessMethod =
         new DRSAccessMethod()
             .type(DRSAccessMethod.TypeEnum.HTTPS)
             .accessId(accessId)
-            .region(region);
-    // TODO - add authorizations
+            .region(region)
+            .authorizations(authorizationsBearerOnly);
 
     return List.of(httpsAccessMethod);
   }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -497,6 +497,7 @@ public class DrsService {
             .accessUrl(gsAccessURL)
             .accessId(accessId)
             .region(region);
+    //TODO - add authorizations
 
     DRSAccessURL httpsAccessURL =
         new DRSAccessURL()
@@ -508,6 +509,7 @@ public class DrsService {
             .type(DRSAccessMethod.TypeEnum.HTTPS)
             .accessUrl(httpsAccessURL)
             .region(region);
+    //TODO - add authorizations
 
     return List.of(gsAccessMethod, httpsAccessMethod);
   }
@@ -519,6 +521,7 @@ public class DrsService {
             .type(DRSAccessMethod.TypeEnum.HTTPS)
             .accessId(accessId)
             .region(region);
+    // TODO - add authorizations
 
     return List.of(httpsAccessMethod);
   }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -5056,9 +5056,7 @@ components:
             belongs to.
           example: us-east-1
         authorizations:
-          allOf:
-            - $ref: '#/components/schemas/DRSAuthorizations'
-            - description: When `access_id` is provided, `authorizations` provides information about how to authorize the `/access` method.
+          $ref: '#/components/schemas/DRSAuthorizations'
     DRSError:
       type: object
       properties:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -5055,6 +5055,10 @@ components:
           description: Name of the region in the cloud service provider that the object
             belongs to.
           example: us-east-1
+        authorizations:
+          allOf:
+            - $ref: '#/components/schemas/DRSAuthorizations'
+            - description: When `access_id` is provided, `authorizations` provides information about how to authorize the `/access` method.
     DRSError:
       type: object
       properties:

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -373,6 +373,18 @@ public class DrsServiceTest {
   }
 
   @Test
+  public void lookupObjectByDrsId() {
+    when(snapshotService.retrieveSnapshotSummary(snapshotId))
+        .thenReturn(new SnapshotSummaryModel().id(snapshotId));
+    DRSObject object = drsService.lookupObjectByDrsId(authUser, googleDrsObjectId, false);
+    DRSAccessMethod accessMethod = object.getAccessMethods().get(0);
+    assertThat(
+        "Only BEARER authorization is included",
+        accessMethod.getAuthorizations().getSupportedTypes().size(),
+        equalTo(1));
+  }
+
+  @Test
   public void lookupObjectByDrsIdPassport() {
     when(snapshotService.retrieveSnapshotSummary(snapshotId))
         .thenReturn(
@@ -387,6 +399,10 @@ public class DrsServiceTest {
         "Correct access method is returned",
         "gcp-passport-us-central1",
         equalTo(accessMethod.getAccessId()));
+    assertThat(
+        "Both authorization types are included",
+        accessMethod.getAuthorizations().getSupportedTypes().size(),
+        equalTo(2));
     assertThat("Correct drs object is returned", googleDrsObjectId, equalTo(object.getId()));
   }
 


### PR DESCRIPTION
[`authorizations` field](https://github.com/ga4gh/data-repository-service-schemas/blob/04db53e3dc3f6157d7a1d65cd122c30bcda89e82/openapi/components/schemas/AccessMethod.yaml#L32) was added to the AccessMethod object which is returned in the Get/PostObject call. We are now populating this as we do for the new options endpoint. 

Note/Point to look at for reviewers:
- The spec uses the "allOf" tag for the authorization field. According to the docs this is so that it ["validates the value against all the subschemas"](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/). However, we don't have any nested schemas or subschemas in the DRSAuthorization object, so I think we can safely ignore that part of the spec. 
