### PR TITLE
DR-2552 dataset schema column additions

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
@@ -1,5 +1,6 @@
 package bio.terra.service.dataset;
 
+import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.model.TableModel;
 import bio.terra.service.dataset.flight.update.DatasetSchemaUpdateUtils;
@@ -45,6 +46,21 @@ public class DatasetSchemaUpdateValidator implements Validator {
             "DuplicateTableNames",
             duplicateTables,
             "Cannot add multiple tables of the same name");
+      }
+      if (DatasetSchemaUpdateUtils.hasColumnAdditions(updateModel)) {
+        Object[] requiredColumns =
+            updateModel.getChanges().getAddColumns().stream()
+                .flatMap(c -> c.getColumns().stream())
+                .filter(c -> c.isRequired())
+                .map(ColumnModel::getName)
+                .toArray();
+        if (requiredColumns.length > 0) {
+          errors.rejectValue(
+              "changes.addColumns",
+              "RequiredColumns",
+              requiredColumns,
+              "Cannot add required columns to existing tables");
+        }
       }
     }
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetTable.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTable.java
@@ -115,4 +115,9 @@ public class DatasetTable implements Table, LogPrintable {
   public String toLogString() {
     return String.format("%s (%s)", this.getName(), this.getId());
   }
+
+  public List<String> getBigQueryTableNames() {
+    return List.of(
+        this.name, this.rawTableName, this.softDeleteTableName, this.rowMetadataTableName);
+  }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -14,7 +14,6 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -150,15 +149,6 @@ public class DatasetTableDao {
     }
   }
 
-  private void removeColumns(UUID datasetId, UUID tableId, Collection<Column> columns) {
-    removeColumns(
-        retrieveTables(datasetId).stream()
-            .filter(dt -> dt.getId().equals(tableId))
-            .findFirst()
-            .orElseThrow(),
-        columns);
-  }
-
   public void removeColumns(Table table, Collection<Column> columns) {
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("table_id", table.getId());
@@ -169,6 +159,15 @@ public class DatasetTableDao {
       params.addValue("column_id", column.getId());
       jdbcTemplate.update(sqlDeleteColumn, params);
     }
+  }
+
+  private void removeColumns(UUID datasetId, UUID tableId, Collection<Column> columns) {
+    removeColumns(
+        retrieveTables(datasetId).stream()
+            .filter(dt -> dt.getId().equals(tableId))
+            .findFirst()
+            .orElseThrow(),
+        columns);
   }
 
   public List<DatasetTable> retrieveTables(UUID parentId) {

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -131,7 +131,7 @@ public class DatasetTableDao {
     params.addValue("table_id", tableId);
     Integer maxOrdinal = jdbcTemplate.queryForObject(sqlGetMaxColumnOrdinal, params, Integer.class);
     // Need to requireNonNull or else SpotBugs complains
-    createColumns(tableId, columns, Objects.requireNonNullElse(maxOrdinal, 0));
+    createColumns(tableId, columns, Objects.requireNonNullElse(maxOrdinal, 0) + 1);
   }
 
   private void createColumns(UUID tableId, Collection<Column> columns, int ordinal) {

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -130,7 +131,8 @@ public class DatasetTableDao {
     params.addValue("table_id", tableId);
     @SuppressWarnings("ConstantConditions")
     int maxOrdinal = jdbcTemplate.queryForObject(sqlGetMaxColumnOrdinal, params, Integer.class);
-    createColumns(tableId, columns, maxOrdinal);
+    // Need to requireNonNull or else SpotBugs complains
+    createColumns(tableId, columns, Objects.requireNonNullElse(maxOrdinal, 0));
   }
 
   private void createColumns(UUID tableId, Collection<Column> columns, int ordinal) {

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -129,9 +129,9 @@ public class DatasetTableDao {
   public void createColumnsExistingTable(UUID tableId, Collection<Column> columns) {
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("table_id", tableId);
-    Integer maxOrdinal = jdbcTemplate.queryForObject(sqlGetMaxColumnOrdinal, params, Integer.class);
-    // Need to requireNonNull or else SpotBugs complains
-    createColumns(tableId, columns, Objects.requireNonNullElse(maxOrdinal, 0));
+    @SuppressWarnings("ConstantConditions")
+    int maxOrdinal = jdbcTemplate.queryForObject(sqlGetMaxColumnOrdinal, params, Integer.class);
+    createColumns(tableId, columns, maxOrdinal);
   }
 
   private void createColumns(UUID tableId, Collection<Column> columns, int ordinal) {

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -129,8 +129,7 @@ public class DatasetTableDao {
   public void createColumnsExistingTable(UUID tableId, Collection<Column> columns) {
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("table_id", tableId);
-    @SuppressWarnings("ConstantConditions")
-    int maxOrdinal = jdbcTemplate.queryForObject(sqlGetMaxColumnOrdinal, params, Integer.class);
+    Integer maxOrdinal = jdbcTemplate.queryForObject(sqlGetMaxColumnOrdinal, params, Integer.class);
     // Need to requireNonNull or else SpotBugs complains
     createColumns(tableId, columns, Objects.requireNonNullElse(maxOrdinal, 0));
   }

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddColumnsBigQueryStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddColumnsBigQueryStep.java
@@ -1,35 +1,32 @@
 package bio.terra.service.dataset.flight.update;
 
+import bio.terra.common.Column;
+import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.dataset.DatasetJsonConversion;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.tabulardata.google.BigQueryProject;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
-import bio.terra.service.tabulardata.google.bigquery.BigQueryPdao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import com.google.cloud.bigquery.BigQuery;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class DatasetSchemaUpdateAddTablesBigQueryStep implements Step {
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(DatasetSchemaUpdateAddTablesBigQueryStep.class);
-
+public class DatasetSchemaUpdateAddColumnsBigQueryStep implements Step {
   private final BigQueryDatasetPdao bigQueryDatasetPdao;
   private final DatasetDao datasetDao;
   private final UUID datasetId;
-
   private final DatasetSchemaUpdateModel updateModel;
 
-  public DatasetSchemaUpdateAddTablesBigQueryStep(
+  private static final List<String> EMPTY_LIST = Collections.emptyList();
+
+  public DatasetSchemaUpdateAddColumnsBigQueryStep(
       BigQueryDatasetPdao bigQueryDatasetPdao,
       DatasetDao datasetDao,
       UUID datasetId,
@@ -43,34 +40,31 @@ public class DatasetSchemaUpdateAddTablesBigQueryStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     Dataset dataset = datasetDao.retrieve(datasetId);
-    List<String> newTableNames = DatasetSchemaUpdateUtils.getNewTableNames(updateModel);
-    List<DatasetTable> tables =
-        dataset.getTables().stream()
-            .filter(dt -> newTableNames.contains(dt.getName()))
-            .collect(Collectors.toList());
 
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
     BigQuery bigQuery = bigQueryProject.getBigQuery();
-    String datasetName = BigQueryPdao.prefixName(dataset.getName());
 
-    for (DatasetTable table : tables) {
-      bigQueryDatasetPdao.createTable(bigQueryProject, bigQuery, datasetName, table);
+    for (var columnChanges : updateModel.getChanges().getAddColumns()) {
+      DatasetTable table = dataset.getTableByName(columnChanges.getTableName()).orElseThrow();
+      for (ColumnModel columnModel : columnChanges.getColumns()) {
+        Column column = DatasetJsonConversion.columnModelToDatasetColumn(columnModel, EMPTY_LIST);
+        bigQueryDatasetPdao.createColumn(bigQueryProject, bigQuery, table, column);
+      }
     }
-
     return StepResult.getStepResultSuccess();
   }
 
   @Override
   public StepResult undoStep(FlightContext context) throws InterruptedException {
     Dataset dataset = datasetDao.retrieve(datasetId);
-    List<String> newTableNames = DatasetSchemaUpdateUtils.getNewTableNames(updateModel);
-    for (String tableName : newTableNames) {
-      boolean success = bigQueryDatasetPdao.deleteDatasetTable(dataset, tableName);
-      if (!success) {
-        logger.warn(
-            "Could not delete table '{}' from dataset '{}' in BigQuery",
-            tableName,
-            dataset.getName());
+
+    BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
+    BigQuery bigQuery = bigQueryProject.getBigQuery();
+
+    for (var columnChanges : updateModel.getChanges().getAddColumns()) {
+      DatasetTable table = dataset.getTableByName(columnChanges.getTableName()).orElseThrow();
+      for (ColumnModel columnModel : columnChanges.getColumns()) {
+        bigQueryDatasetPdao.deleteColumn(bigQueryProject, bigQuery, table, columnModel.getName());
       }
     }
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddColumnsBigQueryStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddColumnsBigQueryStep.java
@@ -15,7 +15,6 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import com.google.cloud.bigquery.BigQuery;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -26,8 +25,6 @@ public class DatasetSchemaUpdateAddColumnsBigQueryStep implements Step {
   private final DatasetDao datasetDao;
   private final UUID datasetId;
   private final DatasetSchemaUpdateModel updateModel;
-
-  private static final List<String> EMPTY_LIST = Collections.emptyList();
 
   public DatasetSchemaUpdateAddColumnsBigQueryStep(
       BigQueryDatasetPdao bigQueryDatasetPdao,
@@ -51,7 +48,7 @@ public class DatasetSchemaUpdateAddColumnsBigQueryStep implements Step {
     for (var columnChanges : updateModel.getChanges().getAddColumns()) {
       DatasetTable table = dataset.getTableByName(columnChanges.getTableName()).orElseThrow();
       for (ColumnModel columnModel : columnChanges.getColumns()) {
-        Column column = DatasetJsonConversion.columnModelToDatasetColumn(columnModel, EMPTY_LIST);
+        Column column = DatasetJsonConversion.columnModelToDatasetColumn(columnModel, List.of());
         bigQueryDatasetPdao.createColumn(datasetName, bigQuery, table, column);
       }
       bigQuery.update(

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddColumnsBigQueryStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddColumnsBigQueryStep.java
@@ -9,6 +9,7 @@ import bio.terra.service.dataset.DatasetJsonConversion;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.tabulardata.google.BigQueryProject;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
+import bio.terra.service.tabulardata.google.bigquery.BigQueryPdao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
@@ -16,7 +17,9 @@ import bio.terra.stairway.exception.RetryException;
 import com.google.cloud.bigquery.BigQuery;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class DatasetSchemaUpdateAddColumnsBigQueryStep implements Step {
   private final BigQueryDatasetPdao bigQueryDatasetPdao;
@@ -43,13 +46,16 @@ public class DatasetSchemaUpdateAddColumnsBigQueryStep implements Step {
 
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
     BigQuery bigQuery = bigQueryProject.getBigQuery();
+    String datasetName = BigQueryPdao.prefixName(dataset.getName());
 
     for (var columnChanges : updateModel.getChanges().getAddColumns()) {
       DatasetTable table = dataset.getTableByName(columnChanges.getTableName()).orElseThrow();
       for (ColumnModel columnModel : columnChanges.getColumns()) {
         Column column = DatasetJsonConversion.columnModelToDatasetColumn(columnModel, EMPTY_LIST);
-        bigQueryDatasetPdao.createColumn(bigQueryProject, bigQuery, table, column);
+        bigQueryDatasetPdao.createColumn(datasetName, bigQuery, table, column);
       }
+      bigQuery.update(
+          BigQueryDatasetPdao.buildLiveView(bigQueryProject.getProjectId(), datasetName, table));
     }
     return StepResult.getStepResultSuccess();
   }
@@ -60,12 +66,30 @@ public class DatasetSchemaUpdateAddColumnsBigQueryStep implements Step {
 
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
     BigQuery bigQuery = bigQueryProject.getBigQuery();
+    String datasetName = BigQueryPdao.prefixName(dataset.getName());
 
     for (var columnChanges : updateModel.getChanges().getAddColumns()) {
       DatasetTable table = dataset.getTableByName(columnChanges.getTableName()).orElseThrow();
-      for (ColumnModel columnModel : columnChanges.getColumns()) {
-        bigQueryDatasetPdao.deleteColumn(bigQueryProject, bigQuery, table, columnModel.getName());
-      }
+      Set<String> columnNames =
+          columnChanges.getColumns().stream().map(ColumnModel::getName).collect(Collectors.toSet());
+      table.columns(
+          table.getColumns().stream()
+              .filter(c -> !columnNames.contains(c.getName()))
+              .collect(Collectors.toList()));
+
+      // We can't actually drop columns from a BigQuery table. All we can do is update the live view
+      // to exclude deleted columns.
+      //
+      // The other option would be to:
+      // 1. copy the table contents to a scratch table
+      // 2. delete the original table
+      // 3. select from the scratch table into a new table with the same name as the original
+      // table, excluding the columns to be deleted.
+      //
+      // This may be worth it for a future iteration, but I'm not sure putting that much effort
+      // into an 'undo' step is worth it for the initial implementation
+      bigQuery.update(
+          BigQueryDatasetPdao.buildLiveView(bigQueryProject.getProjectId(), datasetName, table));
     }
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddColumnsPostgresStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddColumnsPostgresStep.java
@@ -1,0 +1,77 @@
+package bio.terra.service.dataset.flight.update;
+
+import bio.terra.common.Column;
+import bio.terra.model.ColumnModel;
+import bio.terra.model.DatasetSchemaColumnUpdateModel;
+import bio.terra.model.DatasetSchemaUpdateModel;
+import bio.terra.service.dataset.DatasetJsonConversion;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.DatasetTableDao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class DatasetSchemaUpdateAddColumnsPostgresStep implements Step {
+  private final DatasetTableDao datasetTableDao;
+  private final UUID datasetId;
+  private final DatasetSchemaUpdateModel updateModel;
+
+  // We need to provide a list of primary key names to the column creation method, but no new
+  // primary keys can be added during column updates, so we just provide an empty list.
+  private static final List<String> EMPTY_PK_LIST = Collections.emptyList();
+
+  public DatasetSchemaUpdateAddColumnsPostgresStep(
+      DatasetTableDao datasetTableDao, UUID datasetId, DatasetSchemaUpdateModel updateModel) {
+    this.datasetTableDao = datasetTableDao;
+    this.datasetId = datasetId;
+    this.updateModel = updateModel;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    List<DatasetSchemaColumnUpdateModel> addColumns = updateModel.getChanges().getAddColumns();
+    Map<String, DatasetTable> datasetTables = getDatasetTableMap();
+
+    for (var columnAddition : addColumns) {
+      DatasetTable table = datasetTables.get(columnAddition.getTableName());
+      List<Column> columns =
+          columnAddition.getColumns().stream()
+              .map(c -> DatasetJsonConversion.columnModelToDatasetColumn(c, EMPTY_PK_LIST))
+              .collect(Collectors.toList());
+      datasetTableDao.createColumnsExistingTable(table.getId(), columns);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    List<DatasetSchemaColumnUpdateModel> addColumns = updateModel.getChanges().getAddColumns();
+    Map<String, DatasetTable> datasetTables = getDatasetTableMap();
+    for (var columnAddition : addColumns) {
+      DatasetTable table = datasetTables.get(columnAddition.getTableName());
+      Set<String> columnAdditionNames =
+          columnAddition.getColumns().stream()
+              .map(ColumnModel::getName)
+              .collect(Collectors.toSet());
+      List<Column> columnsToRemove =
+          table.getColumns().stream()
+              .filter(c -> columnAdditionNames.contains(c.getName()))
+              .collect(Collectors.toList());
+      datasetTableDao.removeColumns(table, columnsToRemove);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  private Map<String, DatasetTable> getDatasetTableMap() {
+    return datasetTableDao.retrieveTables(datasetId).stream()
+        .collect(Collectors.toMap(DatasetTable::getName, Function.identity()));
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
@@ -53,6 +53,11 @@ public class DatasetSchemaUpdateFlight extends Flight {
               bigQueryDatasetPdao, datasetDao, datasetId, updateModel));
     }
 
+    if (DatasetSchemaUpdateUtils.hasColumnAdditions(updateModel)) {
+      addStep(
+          new DatasetSchemaUpdateAddColumnsPostgresStep(datasetTableDao, datasetId, updateModel));
+    }
+
     addStep(new UnlockDatasetStep(datasetService, datasetId, false));
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
@@ -56,6 +56,9 @@ public class DatasetSchemaUpdateFlight extends Flight {
     if (DatasetSchemaUpdateUtils.hasColumnAdditions(updateModel)) {
       addStep(
           new DatasetSchemaUpdateAddColumnsPostgresStep(datasetTableDao, datasetId, updateModel));
+      addStep(
+          new DatasetSchemaUpdateAddColumnsBigQueryStep(
+              bigQueryDatasetPdao, datasetDao, datasetId, updateModel));
     }
 
     addStep(new UnlockDatasetStep(datasetService, datasetId, false));

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateUtils.java
@@ -1,12 +1,9 @@
 package bio.terra.service.dataset.flight.update;
 
-import bio.terra.model.ColumnModel;
-import bio.terra.model.DatasetSchemaColumnUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModelChanges;
 import bio.terra.model.TableModel;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -30,14 +27,5 @@ public class DatasetSchemaUpdateUtils {
     return updateModel.getChanges().getAddTables().stream()
         .map(TableModel::getName)
         .collect(Collectors.toList());
-  }
-
-  public static Map<String, List<ColumnModel>> makeNewColumnsMap(
-      DatasetSchemaUpdateModel updateModel) {
-    return updateModel.getChanges().getAddColumns().stream()
-        .collect(
-            Collectors.toMap(
-                DatasetSchemaColumnUpdateModel::getTableName,
-                DatasetSchemaColumnUpdateModel::getColumns));
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateUtils.java
@@ -1,9 +1,12 @@
 package bio.terra.service.dataset.flight.update;
 
+import bio.terra.model.ColumnModel;
+import bio.terra.model.DatasetSchemaColumnUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModelChanges;
 import bio.terra.model.TableModel;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -16,9 +19,25 @@ public class DatasetSchemaUpdateUtils {
     return !(tables == null || tables.isEmpty());
   }
 
+  public static boolean hasColumnAdditions(DatasetSchemaUpdateModel updateModel) {
+    var changes =
+        Objects.requireNonNullElse(updateModel.getChanges(), new DatasetSchemaUpdateModelChanges());
+    var columns = changes.getAddColumns();
+    return !(columns == null || columns.isEmpty());
+  }
+
   public static List<String> getNewTableNames(DatasetSchemaUpdateModel updateModel) {
     return updateModel.getChanges().getAddTables().stream()
         .map(TableModel::getName)
         .collect(Collectors.toList());
+  }
+
+  public static Map<String, List<ColumnModel>> makeNewColumnsMap(
+      DatasetSchemaUpdateModel updateModel) {
+    return updateModel.getChanges().getAddColumns().stream()
+        .collect(
+            Collectors.toMap(
+                DatasetSchemaColumnUpdateModel::getTableName,
+                DatasetSchemaColumnUpdateModel::getColumns));
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
@@ -75,7 +75,6 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
             "Could not find tables to add columns to",
             List.of(String.format("Missing tables: %s", String.join(", ", missingTables))));
       }
-
       if (!duplicateColumns.isEmpty()) {
         return failsValidation(
             "Cannot overwrite existing or to-be-added columns in tables", duplicateColumns);

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
@@ -1,6 +1,9 @@
 package bio.terra.service.dataset.flight.update;
 
+import bio.terra.common.Column;
+import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
+import bio.terra.model.TableModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetTable;
@@ -9,11 +12,12 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 
 public class DatasetSchemaUpdateValidateModelStep implements Step {
   private final UUID datasetId;
@@ -32,20 +36,87 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
     Dataset dataset = datasetService.retrieve(datasetId);
     List<String> existingTableNames =
         dataset.getTables().stream().map(DatasetTable::getName).collect(Collectors.toList());
-    List<String> newTableNames = DatasetSchemaUpdateUtils.getNewTableNames(updateModel);
-    Collection<String> uniqueTableNames =
-        CollectionUtils.intersection(existingTableNames, newTableNames);
-
-    if (!uniqueTableNames.isEmpty()) {
-      return new StepResult(
-          StepStatus.STEP_RESULT_FAILURE_FATAL,
-          new DatasetSchemaUpdateException(
-              "Could not validate table additions",
-              List.of(
-                  "Found new tables that would overwrite existing tables",
-                  String.join(", ", uniqueTableNames))));
+    final List<String> newTableNames;
+    if (DatasetSchemaUpdateUtils.hasTableAdditions(updateModel)) {
+      newTableNames = DatasetSchemaUpdateUtils.getNewTableNames(updateModel);
+      List<String> uniqueTableNames = ListUtils.intersection(existingTableNames, newTableNames);
+      if (!uniqueTableNames.isEmpty()) {
+        return failsValidation(
+            "Could not validate table additions",
+            List.of(
+                "Found new tables that would overwrite existing tables",
+                String.join(", ", uniqueTableNames)));
+      }
+    } else {
+      newTableNames = List.of();
     }
+
+    if (DatasetSchemaUpdateUtils.hasColumnAdditions(updateModel)) {
+      Map<String, List<ColumnModel>> newColumnsMap =
+          DatasetSchemaUpdateUtils.makeNewColumnsMap(updateModel);
+      List<String> newAndExistingTableNames = ListUtils.union(existingTableNames, newTableNames);
+
+      List<String> missingTables = new ArrayList<>();
+      List<String> duplicateColumns = new ArrayList<>();
+      for (var entry : newColumnsMap.entrySet()) {
+        String tableName = entry.getKey();
+        if (!newAndExistingTableNames.contains(tableName)) {
+          missingTables.add(tableName);
+          continue;
+        }
+        if (newTableNames.contains(tableName)) {
+          duplicateColumns.addAll(conflictingNewColumns(tableName, entry.getValue()));
+        } else {
+          duplicateColumns.addAll(conflictingExistingColumns(tableName, dataset, entry.getValue()));
+        }
+      }
+      if (!missingTables.isEmpty()) {
+        return failsValidation(
+            "Could not find tables to add columns to",
+            List.of(String.format("Missing tables: %s", String.join(", ", missingTables))));
+      }
+
+      if (!duplicateColumns.isEmpty()) {
+        return failsValidation(
+            "Cannot overwrite existing or to-be-added columns in tables", duplicateColumns);
+      }
+    }
+
     return StepResult.getStepResultSuccess();
+  }
+
+  private List<String> conflictingNewColumns(String tableName, List<ColumnModel> newColumns) {
+    TableModel tableModel =
+        updateModel.getChanges().getAddTables().stream()
+            .filter(tm -> tm.getName().equals(tableName))
+            .findFirst()
+            .orElseThrow();
+    List<String> newTableColumnNames =
+        tableModel.getColumns().stream().map(ColumnModel::getName).collect(Collectors.toList());
+    List<String> newColumnNames = newColumnNames(newColumns);
+    return prependTableName(tableName, ListUtils.intersection(newTableColumnNames, newColumnNames));
+  }
+
+  private List<String> conflictingExistingColumns(
+      String tableName, Dataset dataset, List<ColumnModel> newColumns) {
+    DatasetTable table = dataset.getTableByName(tableName).orElseThrow();
+    List<String> existingColumnNames =
+        table.getColumns().stream().map(Column::getName).collect(Collectors.toList());
+    List<String> newColumnNames = newColumnNames(newColumns);
+    return prependTableName(tableName, ListUtils.intersection(existingColumnNames, newColumnNames));
+  }
+
+  private StepResult failsValidation(String message, List<String> reasons) {
+    return new StepResult(
+        StepStatus.STEP_RESULT_FAILURE_FATAL, new DatasetSchemaUpdateException(message, reasons));
+  }
+
+  private static List<String> newColumnNames(List<ColumnModel> columns) {
+    return columns.stream().map(ColumnModel::getName).collect(Collectors.toList());
+  }
+
+  private static List<String> prependTableName(String tableName, List<String> columnNames) {
+    return columnNames.stream().map(n -> tableName + ":" + n).collect(Collectors.toList());
   }
 
   @Override

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -132,10 +132,9 @@ public class BigQueryDatasetPdao {
   }
 
   public void createColumn(
-      BigQueryProject bigQueryProject, BigQuery bigQuery, DatasetTable table, Column column) {
+      String datasetName, BigQuery bigQuery, DatasetTable table, Column column) {
     // Shamelessly pulled from the BigQuery documentation
-    Table bigQueryTable =
-        bigQuery.getTable(TableId.of(bigQueryProject.getProjectId(), table.getRawTableName()));
+    Table bigQueryTable = bigQuery.getTable(TableId.of(datasetName, table.getRawTableName()));
     Schema schema = bigQueryTable.getDefinition().getSchema();
     FieldList fields = schema.getFields();
 
@@ -143,8 +142,9 @@ public class BigQueryDatasetPdao {
     Field newField = Field.of(column.getName(), translateType(column.getType()));
 
     // Create a new schema adding the current fields, plus the new one
-    fields.add(newField);
-    Schema newSchema = Schema.of(fields);
+    List<Field> newFields = new ArrayList<>(fields);
+    newFields.add(newField);
+    Schema newSchema = Schema.of(newFields);
 
     // Update the table with the new schema
     Table updatedTable =
@@ -153,9 +153,8 @@ public class BigQueryDatasetPdao {
   }
 
   public void deleteColumn(
-      BigQueryProject bigQueryProject, BigQuery bigQuery, DatasetTable table, String columnName) {
-    Table bigQueryTable =
-        bigQuery.getTable(TableId.of(bigQueryProject.getProjectId(), table.getRawTableName()));
+      String datasetName, BigQuery bigQuery, DatasetTable table, String columnName) {
+    Table bigQueryTable = bigQuery.getTable(TableId.of(datasetName, table.getRawTableName()));
     Schema schema = bigQueryTable.getDefinition().getSchema();
     FieldList fields = schema.getFields();
 
@@ -984,7 +983,8 @@ public class BigQueryDatasetPdao {
             Field.of(PDAO_DELETED_BY_COLUMN, LegacySQLTypeName.STRING)));
   }
 
-  private TableInfo buildLiveView(String bigQueryProject, String datasetName, DatasetTable table) {
+  public static TableInfo buildLiveView(
+      String bigQueryProject, String datasetName, DatasetTable table) {
     TableId liveViewId = TableId.of(datasetName, table.getName());
     return TableInfo.of(
         liveViewId,

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -138,8 +138,8 @@ public class BigQueryDatasetPdao {
     Schema schema = bigQueryTable.getDefinition().getSchema();
     FieldList fields = schema.getFields();
 
-    boolean fieldExists = fields.stream()
-        .anyMatch(field -> field.getName().equalsIgnoreCase(column.getName()));
+    boolean fieldExists =
+        fields.stream().anyMatch(field -> field.getName().equalsIgnoreCase(column.getName()));
     if (!fieldExists) {
       // Create the new field/column
       Field newField = Field.of(column.getName(), translateType(column.getType()));
@@ -153,8 +153,8 @@ public class BigQueryDatasetPdao {
           bigQueryTable.toBuilder().setDefinition(StandardTableDefinition.of(newSchema)).build();
       updatedTable.update();
     } else {
-      logger.warn("Column {} already exists in table {}",
-          column.getName(), table.getRawTableName());
+      logger.warn(
+          "Column {} already exists in table {}", column.getName(), table.getRawTableName());
     }
   }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -802,6 +802,25 @@ public class BigQueryDatasetPdao {
     return bigQueryProject.deleteTable(BigQueryPdao.prefixName(dataset.getName()), tableName);
   }
 
+  public void undoDatasetTableCreate(Dataset dataset, DatasetTable table)
+      throws InterruptedException {
+    List<String> tableNames =
+        List.of(
+            table.getRawTableName(),
+            table.getSoftDeleteTableName(),
+            table.getRowMetadataTableName(),
+            table.getName());
+    for (String tableName : tableNames) {
+      boolean success = deleteDatasetTable(dataset, tableName);
+      if (!success) {
+        logger.warn(
+            "Could not delete table '{}' from dataset '{}' in BigQuery",
+            tableName,
+            dataset.getName());
+      }
+    }
+  }
+
   @VisibleForTesting
   static String renderDatasetLiveViewSql(
       String bigQueryProject,

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -810,12 +810,7 @@ public class BigQueryDatasetPdao {
 
   public void undoDatasetTableCreate(Dataset dataset, DatasetTable table)
       throws InterruptedException {
-    List<String> tableNames =
-        List.of(
-            table.getRawTableName(),
-            table.getSoftDeleteTableName(),
-            table.getRowMetadataTableName(),
-            table.getName());
+    List<String> tableNames = table.getBigQueryTableNames();
     for (String tableName : tableNames) {
       boolean success = deleteDatasetTable(dataset, tableName);
       if (!success) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3641,12 +3641,30 @@ components:
         description:
           type: string
         changes:
+          nullable: false
           type: object
           properties:
             addTables:
               type: array
+              nullable: false
               items:
                 $ref: '#/components/schemas/TableModel'
+            addColumns:
+              type: array
+              nullable: false
+              items:
+                $ref: '#/components/schemas/DatasetSchemaColumnUpdateModel'
+    DatasetSchemaColumnUpdateModel:
+      type: object
+      properties:
+        tableName:
+          type: string
+          nullable: false
+        columns:
+          type: array
+          nullable: false
+          items:
+            $ref: '#/components/schemas/ColumnModel'
     IngestRequestModel:
       required:
         - format

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
@@ -118,8 +118,8 @@ public class DatasetSchemaUpdateValidationTest {
         (DatasetSchemaUpdateException) stepResult.getException().orElseThrow();
 
     assertThat(exception.getMessage(), containsString("Could not validate"));
-    assertThat(exception.getCauses(), contains(containsString("overwrite")));
-    assertThat(exception.getCauses(), contains(is(EXISTING_TABLE_NAME)));
+    assertThat(exception.getCauses().get(0), containsString("overwrite"));
+    assertThat(exception.getCauses().get(1), is(EXISTING_TABLE_NAME));
     assertThat(exception.getCauses(), hasSize(2));
   }
 

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
@@ -1,6 +1,7 @@
 package bio.terra.service.dataset.flight.update;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -117,8 +118,8 @@ public class DatasetSchemaUpdateValidationTest {
         (DatasetSchemaUpdateException) stepResult.getException().orElseThrow();
 
     assertThat(exception.getMessage(), containsString("Could not validate"));
-    assertThat(exception.getCauses().get(0), containsString("overwrite"));
-    assertThat(exception.getCauses().get(1), is(EXISTING_TABLE_NAME));
+    assertThat(exception.getCauses(), contains(containsString("overwrite")));
+    assertThat(exception.getCauses(), contains(is(EXISTING_TABLE_NAME)));
     assertThat(exception.getCauses(), hasSize(2));
   }
 
@@ -204,7 +205,6 @@ public class DatasetSchemaUpdateValidationTest {
             validateModelStep.doStep(flightContext).getException().orElseThrow();
 
     assertThat(missingTableException.getMessage(), containsString("Could not find tables"));
-    assertThat(missingTableException.getCauses(), hasSize(1));
-    assertThat(missingTableException.getCauses().get(0), containsString("not_a_real_table"));
+    assertThat(missingTableException.getCauses(), contains(containsString("not_a_real_table")));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
@@ -2,6 +2,8 @@ package bio.terra.service.dataset.flight.update;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -10,6 +12,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.Column;
 import bio.terra.common.category.Unit;
 import bio.terra.model.ColumnModel;
+import bio.terra.model.DatasetSchemaColumnUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModelChanges;
 import bio.terra.model.TableDataType;
@@ -50,7 +53,7 @@ public class DatasetSchemaUpdateValidationTest {
 
   private UUID datasetId;
   private static final String EXISTING_TABLE_NAME = "existing_table";
-  public static final String EXISTING_COLUMN_NAME = "existing_column";
+  private static final String EXISTING_COLUMN_NAME = "existing_column";
 
   @Before
   public void setup() {
@@ -80,7 +83,7 @@ public class DatasetSchemaUpdateValidationTest {
   }
 
   @Test
-  public void testValidations() throws Exception {
+  public void testTableValidations() throws Exception {
     DatasetSchemaUpdateModel updateModel =
         new DatasetSchemaUpdateModel()
             .description("test changeset")
@@ -89,14 +92,19 @@ public class DatasetSchemaUpdateValidationTest {
                     .addTables(
                         List.of(
                             new TableModel()
+                                .name("new_table")
+                                .columns(
+                                    List.of(
+                                        new ColumnModel()
+                                            .name("new_table_column")
+                                            .datatype(TableDataType.STRING))),
+                            new TableModel()
                                 .name(EXISTING_TABLE_NAME)
                                 .columns(
                                     List.of(
                                         new ColumnModel()
                                             .name("new_column")
-                                            .datatype(TableDataType.STRING)
-                                            .arrayOf(false)
-                                            .required(false))))));
+                                            .datatype(TableDataType.STRING))))));
 
     DatasetSchemaUpdateValidateModelStep validateModelStep =
         new DatasetSchemaUpdateValidateModelStep(datasetService, datasetId, updateModel);
@@ -111,5 +119,86 @@ public class DatasetSchemaUpdateValidationTest {
     assertThat(exception.getMessage(), containsString("Could not validate"));
     assertThat(exception.getCauses().get(0), containsString("overwrite"));
     assertThat(exception.getCauses().get(1), is(EXISTING_TABLE_NAME));
+    assertThat(exception.getCauses(), hasSize(2));
+  }
+
+  @Test
+  public void testColumnValidations() throws Exception {
+    DatasetSchemaUpdateModel duplicateColumnsUpdateModel =
+        new DatasetSchemaUpdateModel()
+            .description("test changeset")
+            .changes(
+                new DatasetSchemaUpdateModelChanges()
+                    .addTables(
+                        List.of(
+                            new TableModel()
+                                .name("new_table")
+                                .columns(
+                                    List.of(
+                                        new ColumnModel()
+                                            .name("new_table_column")
+                                            .datatype(TableDataType.STRING)))))
+                    .addColumns(
+                        List.of(
+                            new DatasetSchemaColumnUpdateModel()
+                                .tableName(EXISTING_TABLE_NAME)
+                                .columns(
+                                    List.of(
+                                        new ColumnModel()
+                                            .name(EXISTING_COLUMN_NAME)
+                                            .datatype(TableDataType.STRING),
+                                        new ColumnModel()
+                                            .name("new_column")
+                                            .datatype(TableDataType.STRING))),
+                            new DatasetSchemaColumnUpdateModel()
+                                .tableName("new_table")
+                                .columns(
+                                    List.of(
+                                        new ColumnModel()
+                                            .name("new_table_column")
+                                            .datatype(TableDataType.STRING))))));
+
+    DatasetSchemaUpdateValidateModelStep validateModelStep =
+        new DatasetSchemaUpdateValidateModelStep(
+            datasetService, datasetId, duplicateColumnsUpdateModel);
+
+    FlightContext flightContext = mock(FlightContext.class);
+
+    DatasetSchemaUpdateException duplicateColumnsException =
+        (DatasetSchemaUpdateException)
+            validateModelStep.doStep(flightContext).getException().orElseThrow();
+
+    DatasetSchemaUpdateModel missingTableUpdateModel =
+        new DatasetSchemaUpdateModel()
+            .changes(
+                new DatasetSchemaUpdateModelChanges()
+                    .addColumns(
+                        List.of(
+                            new DatasetSchemaColumnUpdateModel()
+                                .tableName("not_a_real_table")
+                                .columns(
+                                    List.of(
+                                        new ColumnModel()
+                                            .name("new_column")
+                                            .datatype(TableDataType.STRING))))));
+    validateModelStep =
+        new DatasetSchemaUpdateValidateModelStep(
+            datasetService, datasetId, missingTableUpdateModel);
+
+    DatasetSchemaUpdateException missingTableException =
+        (DatasetSchemaUpdateException)
+            validateModelStep.doStep(flightContext).getException().orElseThrow();
+
+    assertThat(
+        duplicateColumnsException.getMessage(),
+        containsString("overwrite existing or to-be-added"));
+    assertThat(duplicateColumnsException.getCauses(), hasSize(2));
+    assertThat(
+        duplicateColumnsException.getCauses(),
+        equalTo(List.of("existing_table:existing_column", "new_table:new_table_column")));
+
+    assertThat(missingTableException.getMessage(), containsString("Could not find tables"));
+    assertThat(missingTableException.getCauses(), hasSize(1));
+    assertThat(missingTableException.getCauses().get(0), containsString("not_a_real_table"));
   }
 }


### PR DESCRIPTION
This PR adds support for the addition of columns to dataset tables. Columns can be added to existing tables, or added to a table being created in the submitted changeset. This is done solely as a convenience, as the new table will always exist before columns are added. I can't think of a compelling use-case for it, but it exists, so 🤷‍♂️.

New columns cannot be marked as required. We'll check the API request for that, so there's not need to validate it in the flight. Even if a required column did get through, the actual addition of the column to BigQuery wouldn't mark it as required, as it can't do so with the current implementation. You might be able to do it using a DDL, but we don't have the semantics set up to provide default values for columns, so I'm classifying that work as out-of-scope.

The undo step of the BigQuery column additions is a little weird. We can't drop columns from a BigQuery table, so we just make the live view not include the column in its query. 