### PR TITLE
[DR-2597] Bump jib to 3.2.0 for skaffold 1.38.0 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 }
 
 plugins {
-    id "com.google.cloud.tools.jib" version "2.7.1"
+    id "com.google.cloud.tools.jib" version "3.2.0"
     id 'org.liquibase.gradle' version '2.1.1'
     id "org.gradle.test-retry" version "1.2.0"
     id 'antlr'
@@ -411,7 +411,10 @@ jar {
 }
 
 jib {
-    extraDirectories.paths = ['build/gen-expanded']
+    extraDirectories {
+        mkdir 'build/gen-expanded'
+        paths = ['build/gen-expanded']
+    }
     from {
         image = "us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian"
     }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2597

When I onboarded, skaffold 1.38.0 was installed via our team brewfile.  The team members I've talked to all have skaffold <= 1.35.1.  This later version requires a later version of jib:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/okotsopo/jade-data-repo/build.gradle' line: 29

* What went wrong:
An exception occurred applying plugin request [id: 'com.google.cloud.tools.jib', version: '2.7.1']
> Failed to apply plugin 'com.google.cloud.tools.jib'.
   > Jib plugin version is 2.7.1 but is required to be 3.2.0
```

Which itself required a [workaround](https://gitter.im/google/jib?at=61f08fa5d41a5853f96b87a2) for nonexistent `extraDirectories` ([jib PR](https://github.com/GoogleContainerTools/jib/issues/3542) where this enforcement was added):

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':jib'.
> extraDirectories.paths contain "from" directory that doesn't exist locally: /Users/okotsopo/jade-data-repo/build/gen-expanded
```

I was then able to `skaffold run` and see my new `ok-jade-datarepo-api` pod running.

Debugging in Slack: https://broadinstitute.slack.com/archives/C01VBGH431S/p1652730508162889

**Request**

Could someone with skaffold 1.35.1 (@nmalfroy ?) please check this branch out and see if `skaffold run` works for you? 