### PR TITLE
[DR-2425] Add PatchDataset, PatchSnapshot endpoints for updating passport identifiers

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -182,7 +182,7 @@ public class DatasetsApiController implements DatasetsApi {
   public ResponseEntity<DatasetSummaryModel> patchDataset(
       UUID id, DatasetPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    for (IamAction action : datasetService.iamActions(patchRequest)) {
+    for (IamAction action : datasetService.patchDatasetIamActions(patchRequest)) {
       iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id.toString(), action);
     }
     return new ResponseEntity<>(datasetService.patch(id, patchRequest), HttpStatus.OK);

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -180,11 +180,11 @@ public class DatasetsApiController implements DatasetsApi {
 
   @Override
   public ResponseEntity<DatasetSummaryModel> patchDataset(
-      UUID id, DatasetPatchRequestModel datasetPatchRequest) {
+      UUID id, DatasetPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     iamService.verifyAuthorization(
         userReq, IamResourceType.DATASET, id.toString(), IamAction.MANAGE_SCHEMA);
-    return new ResponseEntity<>(datasetService.patch(id, datasetPatchRequest), HttpStatus.OK);
+    return new ResponseEntity<>(datasetService.patch(id, patchRequest), HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -17,8 +17,10 @@ import bio.terra.model.BulkLoadHistoryModelList;
 import bio.terra.model.BulkLoadRequestModel;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DatasetModel;
+import bio.terra.model.DatasetPatchRequestModel;
 import bio.terra.model.DatasetRequestAccessIncludeModel;
 import bio.terra.model.DatasetRequestModel;
+import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateDatasetModel;
 import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.FileLoadModel;
@@ -174,6 +176,15 @@ public class DatasetsApiController implements DatasetsApi {
     String jobId = datasetService.delete(id.toString(), userReq);
     // we can retrieve the job we just created
     return jobToResponse(jobService.retrieveJob(jobId, userReq));
+  }
+
+  @Override
+  public ResponseEntity<DatasetSummaryModel> patchDataset(
+      UUID id, DatasetPatchRequestModel datasetPatchRequest) {
+    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
+    iamService.verifyAuthorization(
+        userReq, IamResourceType.DATASET, id.toString(), IamAction.MANAGE_SCHEMA);
+    return new ResponseEntity<>(datasetService.patch(id, datasetPatchRequest), HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -182,8 +182,9 @@ public class DatasetsApiController implements DatasetsApi {
   public ResponseEntity<DatasetSummaryModel> patchDataset(
       UUID id, DatasetPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    iamService.verifyAuthorization(
-        userReq, IamResourceType.DATASET, id.toString(), IamAction.MANAGE_SCHEMA);
+    for (IamAction action : datasetService.iamActions(patchRequest)) {
+      iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id.toString(), action);
+    }
     return new ResponseEntity<>(datasetService.patch(id, patchRequest), HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -175,7 +175,7 @@ public class SnapshotsApiController implements SnapshotsApi {
       UUID id, SnapshotPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     iamService.verifyAuthorization(
-        userReq, IamResourceType.DATASNAPSHOT, id.toString(), IamAction.MANAGE_SCHEMA);
+        userReq, IamResourceType.DATASNAPSHOT, id.toString(), IamAction.UPDATE_SNAPSHOT);
     return new ResponseEntity<>(snapshotService.patch(id, patchRequest), HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -174,8 +174,9 @@ public class SnapshotsApiController implements SnapshotsApi {
   public ResponseEntity<SnapshotSummaryModel> patchSnapshot(
       UUID id, SnapshotPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    iamService.verifyAuthorization(
-        userReq, IamResourceType.DATASNAPSHOT, id.toString(), IamAction.UPDATE_SNAPSHOT);
+    for (IamAction action : snapshotService.patchSnapshotIamActions(patchRequest)) {
+      iamService.verifyAuthorization(userReq, IamResourceType.DATASNAPSHOT, id.toString(), action);
+    }
     return new ResponseEntity<>(snapshotService.patch(id, patchRequest), HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -18,9 +18,11 @@ import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotPatchRequestModel;
 import bio.terra.model.SnapshotPreviewModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRetrieveIncludeModel;
+import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.model.SqlSortDirection;
 import bio.terra.model.WorkspacePolicyModel;
 import bio.terra.service.auth.iam.IamAction;
@@ -166,6 +168,15 @@ public class SnapshotsApiController implements SnapshotsApi {
     String jobId = snapshotService.deleteSnapshot(id, userReq);
     // we can retrieve the job we just created
     return jobToResponse(jobService.retrieveJob(jobId, userReq));
+  }
+
+  @Override
+  public ResponseEntity<SnapshotSummaryModel> patchSnapshot(
+      UUID id, SnapshotPatchRequestModel patchRequest) {
+    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
+    iamService.verifyAuthorization(
+        userReq, IamResourceType.DATASNAPSHOT, id.toString(), IamAction.MANAGE_SCHEMA);
+    return new ResponseEntity<>(snapshotService.patch(id, patchRequest), HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/auth/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamAction.java
@@ -36,7 +36,7 @@ public enum IamAction {
   private final String samActionName;
 
   IamAction() {
-    this.samActionName = StringUtils.lowerCase(name());
+    this.samActionName = name().toLowerCase();
   }
 
   @Override

--- a/src/main/java/bio/terra/service/auth/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamAction.java
@@ -4,14 +4,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 
+// NOTE: these action enums must have exactly the same text as the Sam action name.
 public enum IamAction {
   // common
   CREATE,
   DELETE,
-  SHARE_POLICY_STEWARD("share_policy::steward"),
   READ_POLICY,
   READ_POLICIES,
   ALTER_POLICIES,
+  UPDATE_PASSPORT_IDENTIFIER,
   // datarepo
   LIST_JOBS,
   DELETE_JOBS,
@@ -36,16 +37,6 @@ public enum IamAction {
 
   IamAction() {
     this.samActionName = StringUtils.lowerCase(name());
-  }
-
-  /**
-   * When the enum name's text does not exactly match that of the Sam action name, specify it during
-   * construction.
-   *
-   * @param samActionName
-   */
-  IamAction(String samActionName) {
-    this.samActionName = samActionName;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/auth/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamAction.java
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 
-// NOTE: these action enums must have exactly the same text as the Sam action name.
 public enum IamAction {
   // common
   CREATE,
   DELETE,
-  SHARE_POLICY,
+  SHARE_POLICY_STEWARD("share_policy::steward"),
   READ_POLICY,
   READ_POLICIES,
   ALTER_POLICIES,
@@ -33,16 +32,32 @@ public enum IamAction {
   UPDATE_BILLING_ACCOUNT,
   LINK;
 
+  private final String samActionName;
+
+  IamAction() {
+    this.samActionName = StringUtils.lowerCase(name());
+  }
+
+  /**
+   * When the enum name's text does not exactly match that of the Sam action name, specify it during
+   * construction.
+   *
+   * @param samActionName
+   */
+  IamAction(String samActionName) {
+    this.samActionName = samActionName;
+  }
+
   @Override
   @JsonValue
   public String toString() {
-    return StringUtils.lowerCase(name());
+    return samActionName;
   }
 
   @JsonCreator
   public static IamAction fromValue(String text) {
     for (IamAction b : IamAction.values()) {
-      if (String.valueOf(b.name()).equals(StringUtils.upperCase(text))) {
+      if (b.name().equals(StringUtils.upperCase(text))) {
         return b;
       }
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -708,18 +708,18 @@ public class DatasetDao {
    * Update a dataset according to specified fields in the patch request. Any fields unspecified in
    * the request will remain unaltered.
    *
-   * @param datasetId
-   * @param datasetPatchRequest updates to merge with existing dataset.
-   * @return whether the dataset record was updated.
+   * @param id dataset UUID
+   * @param patchRequest updates to merge with existing dataset
+   * @return whether the dataset record was updated
    */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public boolean patch(UUID datasetId, DatasetPatchRequestModel datasetPatchRequest) {
-    String sql = "UPDATE dataset SET phs_id = COALESCE(:phs_id, phs_id) WHERE id = :datasetid";
+  public boolean patch(UUID id, DatasetPatchRequestModel patchRequest) {
+    String sql = "UPDATE dataset SET phs_id = COALESCE(:phs_id, phs_id) WHERE id = :id";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
-            .addValue("phs_id", datasetPatchRequest.getPhsId())
-            .addValue("datasetid", datasetId);
+            .addValue("phs_id", patchRequest.getPhsId())
+            .addValue("id", id);
 
     int rowsAffected = jdbcTemplate.update(sql, params);
     return rowsAffected > 0;

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -705,8 +705,8 @@ public class DatasetDao {
   }
 
   /**
-   * Update a dataset according to specified fields in the patch request.
-   * Any fields unspecified in the request will remain unaltered.
+   * Update a dataset according to specified fields in the patch request. Any fields unspecified in
+   * the request will remain unaltered.
    *
    * @param datasetId
    * @param datasetPatchRequest updates to merge with existing dataset.

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -717,9 +717,7 @@ public class DatasetDao {
     String sql = "UPDATE dataset SET phs_id = COALESCE(:phs_id, phs_id) WHERE id = :id";
 
     MapSqlParameterSource params =
-        new MapSqlParameterSource()
-            .addValue("phs_id", patchRequest.getPhsId())
-            .addValue("id", id);
+        new MapSqlParameterSource().addValue("phs_id", patchRequest.getPhsId()).addValue("id", id);
 
     int rowsAffected = jdbcTemplate.update(sql, params);
     return rowsAffected > 0;

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -8,6 +8,7 @@ import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.exception.RetryQueryException;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetPatchRequestModel;
 import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SqlSortDirection;
@@ -701,6 +702,27 @@ public class DatasetDao {
           .phsId(rs.getString("phs_id"))
           .selfHosted(rs.getBoolean("self_hosted"));
     }
+  }
+
+  /**
+   * Update a dataset according to specified fields in the patch request.
+   * Any fields unspecified in the request will remain unaltered.
+   *
+   * @param datasetId
+   * @param datasetPatchRequest updates to merge with existing dataset.
+   * @return whether the dataset record was updated.
+   */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public boolean patch(UUID datasetId, DatasetPatchRequestModel datasetPatchRequest) {
+    String sql = "UPDATE dataset SET phs_id = COALESCE(:phs_id, phs_id) WHERE id = :datasetid";
+
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("phs_id", datasetPatchRequest.getPhsId())
+            .addValue("datasetid", datasetId);
+
+    int rowsAffected = jdbcTemplate.update(sql, params);
+    return rowsAffected > 0;
   }
 
   /**

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -720,7 +720,12 @@ public class DatasetDao {
         new MapSqlParameterSource().addValue("phs_id", patchRequest.getPhsId()).addValue("id", id);
 
     int rowsAffected = jdbcTemplate.update(sql, params);
-    return rowsAffected > 0;
+    boolean patchSucceeded = (rowsAffected == 1);
+
+    if (patchSucceeded) {
+      logger.info("Dataset {} patched with {}", id, patchRequest.toString());
+    }
+    return patchSucceeded;
   }
 
   /**

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -265,11 +265,11 @@ public class DatasetService {
    * @param patchRequest updates to merge with an existing dataset
    * @return IAM actions needed to apply the requested patch
    */
-  public List<IamAction> iamActions(DatasetPatchRequestModel patchRequest) {
+  public List<IamAction> patchDatasetIamActions(DatasetPatchRequestModel patchRequest) {
     List<IamAction> actions = new ArrayList<>();
     actions.add(IamAction.MANAGE_SCHEMA);
     if (patchRequest.getPhsId() != null) {
-      actions.add(IamAction.SHARE_POLICY_STEWARD);
+      actions.add(IamAction.UPDATE_PASSPORT_IDENTIFIER);
     }
     return actions;
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -25,6 +25,7 @@ import bio.terra.model.SqlSortDirection;
 import bio.terra.model.TransactionCloseModel.ModeEnum;
 import bio.terra.model.TransactionCreateModel;
 import bio.terra.model.TransactionModel;
+import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.dataset.exception.DatasetNotFoundException;
 import bio.terra.service.dataset.exception.IngestFailureException;
@@ -62,6 +63,7 @@ import com.azure.storage.blob.sas.BlobSasPermission;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -254,6 +256,22 @@ public class DatasetService {
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
         .addParameter(JobMapKeys.CLOUD_PLATFORM.getKeyName(), platform.name())
         .submit();
+  }
+
+  /**
+   * Conditionally require sharing privileges when a caller is updating a passport identifier. Such
+   * a modification indirectly affects who can access the underlying data.
+   *
+   * @param patchRequest updates to merge with an existing dataset
+   * @return IAM actions needed to apply the requested patch
+   */
+  public List<IamAction> iamActions(DatasetPatchRequestModel patchRequest) {
+    List<IamAction> actions = new ArrayList<>();
+    actions.add(IamAction.MANAGE_SCHEMA);
+    if (patchRequest.getPhsId() != null) {
+      actions.add(IamAction.SHARE_POLICY_STEWARD);
+    }
+    return actions;
   }
 
   public DatasetSummaryModel patch(UUID id, DatasetPatchRequestModel patchRequest) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -12,6 +12,7 @@ import bio.terra.model.BulkLoadHistoryModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DatasetModel;
+import bio.terra.model.DatasetPatchRequestModel;
 import bio.terra.model.DatasetRequestAccessIncludeModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
@@ -253,6 +254,14 @@ public class DatasetService {
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
         .addParameter(JobMapKeys.CLOUD_PLATFORM.getKeyName(), platform.name())
         .submit();
+  }
+
+  public DatasetSummaryModel patch(UUID id, DatasetPatchRequestModel datasetPatchRequest) {
+    boolean patchSucceeded = datasetDao.patch(id, datasetPatchRequest);
+    if (!patchSucceeded) {
+      throw new RuntimeException("Dataset was not updated");
+    }
+    return datasetDao.retrieveSummaryById(id).toModel();
   }
 
   public String ingestDataset(

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -256,8 +256,8 @@ public class DatasetService {
         .submit();
   }
 
-  public DatasetSummaryModel patch(UUID id, DatasetPatchRequestModel datasetPatchRequest) {
-    boolean patchSucceeded = datasetDao.patch(id, datasetPatchRequest);
+  public DatasetSummaryModel patch(UUID id, DatasetPatchRequestModel patchRequest) {
+    boolean patchSucceeded = datasetDao.patch(id, patchRequest);
     if (!patchSucceeded) {
       throw new RuntimeException("Dataset was not updated");
     }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -6,6 +6,7 @@ import bio.terra.common.DaoUtils;
 import bio.terra.common.MetadataEnumeration;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.EnumerateSortByParam;
+import bio.terra.model.SnapshotPatchRequestModel;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.AssetSpecification;
@@ -673,6 +674,28 @@ public class SnapshotDao {
               .addValue("tableName", tableName);
       jdbcTemplate.update(sql, params);
     }
+  }
+
+  /**
+   * Update a snapshot according to specified fields in the patch request. Any fields unspecified in
+   * the request will remain unaltered.
+   *
+   * @param id snapshot UUID
+   * @param patchRequest updates to merge with existing snapshot
+   * @return whether the snapshot record was updated
+   */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public boolean patch(UUID id, SnapshotPatchRequestModel patchRequest) {
+    String sql =
+        "UPDATE snapshot SET consent_code = COALESCE(:consent_code, consent_code) WHERE id = :id";
+
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("consent_code", patchRequest.getConsentCode())
+            .addValue("id", id);
+
+    int rowsAffected = jdbcTemplate.update(sql, params);
+    return rowsAffected > 0;
   }
 
   private class SnapshotSummaryMapper implements RowMapper<SnapshotSummary> {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -695,7 +695,12 @@ public class SnapshotDao {
             .addValue("id", id);
 
     int rowsAffected = jdbcTemplate.update(sql, params);
-    return rowsAffected > 0;
+    boolean patchSucceeded = (rowsAffected == 1);
+
+    if (patchSucceeded) {
+      logger.info("Snapshot {} patched with {}", id, patchRequest.toString());
+    }
+    return patchSucceeded;
   }
 
   private class SnapshotSummaryMapper implements RowMapper<SnapshotSummary> {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -16,6 +16,7 @@ import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotPatchRequestModel;
 import bio.terra.model.SnapshotPreviewModel;
 import bio.terra.model.SnapshotRequestAssetModel;
 import bio.terra.model.SnapshotRequestContentsModel;
@@ -132,6 +133,14 @@ public class SnapshotService {
         .newJob(description, SnapshotDeleteFlight.class, null, userReq)
         .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), id.toString())
         .submit();
+  }
+
+  public SnapshotSummaryModel patch(UUID id, SnapshotPatchRequestModel patchRequest) {
+    boolean patchSucceeded = snapshotDao.patch(id, patchRequest);
+    if (!patchSucceeded) {
+      throw new RuntimeException("Snapshot was not updated");
+    }
+    return snapshotDao.retrieveSummaryById(id).toModel();
   }
 
   public String exportSnapshot(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -10,7 +10,6 @@ import bio.terra.common.Table;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.grammar.Query;
 import bio.terra.model.ColumnModel;
-import bio.terra.model.DatasetPatchRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateSnapshotModel;
 import bio.terra.model.EnumerateSortByParam;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.lang.StringUtils;
 
 public class SnapshotSummary {
   private UUID id;
@@ -167,6 +168,6 @@ public class SnapshotSummary {
    * @return whether the underlying snapshot can be accessed via RAS passport authorization
    */
   public static boolean passportAuthorizationAvailable(SnapshotSummaryModel model) {
-    return model.getPhsId() != null && model.getConsentCode() != null;
+    return !StringUtils.isBlank(model.getPhsId()) && !StringUtils.isBlank(model.getConsentCode());
   }
 }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -662,6 +662,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+    patch:
+      tags:
+        - snapshots
+        - repository
+      description: Update supported fields of the specified snapshot.
+      operationId: patchSnapshot
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      requestBody:
+        description: >-
+          A 'lite' snapshot definition (used to modify supported fields of a snapshot).
+          Null assignments will be ignored.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SnapshotPatchRequestModel'
+      responses:
+        200:
+          description: Summary of updated snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SnapshotSummaryModel'
+        400:
+          description: Bad request - invalid id, badly formed modification instructions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        401:
+          description: Unauthorized - snapshot does not exist, missing permissions to modify.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: Not found - snapshot does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred - snapshot was not updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
   /api/repository/v1/snapshots/{id}/data/{table}:
     get:
       tags:
@@ -4156,6 +4203,14 @@ components:
             $ref: '#/components/schemas/UniqueIdProperty'
       description: >
         A specification of a table, columns, and row ids to go into a snapshot.
+    SnapshotPatchRequestModel:
+      type: object
+      properties:
+        consentCode:
+          $ref: '#/components/schemas/ConsentCode'
+      description: >
+        A 'lite' snapshot definition (used to modify supported fields of a snapshot).
+        Null assignments will be ignored.
     SnapshotRetrieveIncludeModel:
       type: string
       description: >

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1235,6 +1235,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+    patch:
+      tags:
+        - datasets
+        - repository
+      description: Update supported fields of the specified dataset.
+      operationId: patchDataset
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      requestBody:
+        description: >-
+          A 'lite' dataset definition (used to modify supported fields of a dataset).
+          Null assignments will be ignored.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DatasetPatchRequestModel'
+      responses:
+        200:
+          description: Summary of updated dataset.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetSummaryModel'
+        400:
+          description: Bad request - invalid id, badly formed modification instructions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        401:
+          description: Unauthorized - dataset does not exist, missing permissions to modify.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: Not found - dataset does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred - dataset was not updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
   /api/repository/v1/datasets/{id}/policies:
     get:
       tags:
@@ -3220,8 +3267,7 @@ components:
           type: boolean
           default: false
         phsId:
-          type: string
-          description: PHS ID (DbGap Phenotype Study Identifer) associated with dataset
+          $ref: '#/components/schemas/PhsId'
         accessInformation:
           $ref: '#/components/schemas/AccessInfoModel'
         selfHosted:
@@ -3261,8 +3307,7 @@ components:
           type: string
           description: The azure storage account of this dataset
         phsId:
-          type: string
-          description: PHS ID (DbGap Phenotype Study Identifer) associated with dataset
+          $ref: '#/components/schemas/PhsId'
         selfHosted:
           type: boolean
           default: false
@@ -3293,8 +3338,7 @@ components:
           type: boolean
           default: false
         phsId:
-          type: string
-          description: PHS ID (DbGap Phenotype Study Identifer) associated with dataset
+          $ref: '#/components/schemas/PhsId'
         experimentalSelfHosted:
           type: boolean
           default: false
@@ -3302,6 +3346,14 @@ components:
             files in their original location.
       description: >
         Complete definition of a dataset without the id (used to create a dataset)
+    DatasetPatchRequestModel:
+      type: object
+      properties:
+        phsId:
+          $ref: '#/components/schemas/PhsId'
+      description: >
+        A 'lite' dataset definition (used to modify supported fields of a dataset).
+        Null assignments will be ignored.
     DatasetRequestAccessIncludeModel:
       type: string
       description: >
@@ -4003,8 +4055,7 @@ components:
           type: string
           description: Description of the snapshot
         consentCode:
-          type: string
-          description: Consent code together with PHS Id that will determine user access
+          $ref: '#/components/schemas/ConsentCode'
         contents:
           type: array
           items:
@@ -4133,11 +4184,9 @@ components:
           type: boolean
           default: false
         consentCode:
-          type: string
-          description: Consent code together with PHS Id that will determine user access
+          $ref: '#/components/schemas/ConsentCode'
         phsId:
-          type: string
-          description: PHS ID (DbGap Phenotype Study Identifer) associated with dataset
+          $ref: '#/components/schemas/PhsId'
         cloudPlatform:
           $ref: '#/components/schemas/CloudPlatform'
         dataProject:
@@ -4189,8 +4238,7 @@ components:
           type: string
           description: Date the snapshot was created
         consentCode:
-          type: string
-          description: Consent code together with PHS Id that will determine user access
+          $ref: '#/components/schemas/ConsentCode'
         source:
           type: array
           items:
@@ -4836,6 +4884,16 @@ components:
       enum: [ gcp, azure ]
       default: gcp
       description: Cloud platforms supported by TDR.
+
+    PhsId:
+      type: string
+      description: PHS ID (DbGap Phenotype Study Identifer) associated with dataset
+      example: phs123456
+
+    ConsentCode:
+      type: string
+      description: Consent code together with PHS ID that will determine user access
+      example: c99
 
     ##############################################################################
     ## SEARCH API STANDARD MODELS

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2817,9 +2817,12 @@ paths:
       tags:
         - DataRepositoryService
       summary: Get Authorization info about a DRS Object.
-      description: >-
+      description: >
         Returns `DRSAuthorizations` that can be used to determine
         how to authorize requests to GET or POST a `DRSObject`.
+
+        NOTE: Changes to the object's dataset or snapshot may take up to 15 minutes
+        to be reflected in this response.
       operationId: OptionsObject
       parameters:
         - name: object_id
@@ -2860,8 +2863,12 @@ paths:
       tags:
         - DataRepositoryService
       summary: Get info about an `Object`.
-      description: Returns object metadata, and a list of access methods that can
+      description: >
+        Returns object metadata, and a list of access methods that can
         be used to fetch object bytes.
+
+        NOTE: Changes to the object's dataset or snapshot may take up to 15 minutes
+        to be reflected in this response.
       operationId: GetObject
       parameters:
         - name: object_id
@@ -2930,7 +2937,12 @@ paths:
       tags:
         - DataRepositoryService
       summary:  Get info about a DrsObject through POST'ing a Passport.
-      description:  Returns object metadata, and a list of access methods that can be used to fetch object bytes.  Method is a POST to accomodate a JWT GA4GH Passport sent in the formData in order to authorize access.
+      description:  >
+        Returns object metadata, and a list of access methods that can be used to fetch object bytes.
+        Method is a POST to accommodate a JWT GA4GH Passport sent in the formData in order to authorize access.
+
+        NOTE: Changes to the object's dataset or snapshot may take up to 15 minutes
+        to be reflected in this response.
       operationId: PostObject
       parameters:
         - name: object_id
@@ -2998,10 +3010,14 @@ paths:
       tags:
         - DataRepositoryService
       summary: Get a URL for fetching bytes.
-      description: Returns a URL that can be used to fetch the object bytes. This
+      description: >
+        Returns a URL that can be used to fetch the object bytes. This
         method only needs to be called when using an `AccessMethod` that contains
         an `access_id` (e.g., for servers that use signed URLs for fetching object
         bytes).
+
+        NOTE: Changes to the object's dataset or snapshot may take up to 15 minutes
+        to be reflected in this response.
       operationId: GetAccessURL
       parameters:
         - name: object_id
@@ -3068,13 +3084,16 @@ paths:
       tags:
         - DataRepositoryService
       summary: Get a URL for fetching bytes through POST'ing a Passport
-      description: >-
+      description: >
         Returns a URL that can be used to fetch the bytes of a `DrsObject`.
 
         This method only needs to be called when using an `AccessMethod` that contains an `access_id`
         (e.g., for servers that use signed URLs for fetching object bytes).
 
-        Method is a POST to accomodate a JWT GA4GH Passport sent in the formData in order to authorize access.
+        Method is a POST to accommodate a JWT GA4GH Passport sent in the formData in order to authorize access.
+
+        NOTE: Changes to the object's dataset or snapshot may take up to 15 minutes
+        to be reflected in this response.
       operationId: PostAccessURL
       parameters:
         - name: object_id

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -28,6 +28,7 @@ import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
+import bio.terra.model.DatasetPatchRequestModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.EnumerateSortByParam;
@@ -833,5 +834,40 @@ public class DatasetDaoTest {
 
     datasetDao.delete(dataset1Id);
     datasetDao.delete(dataset2Id);
+  }
+
+  @Test
+  public void patchDatasetPhsId() throws Exception {
+    UUID datasetId = createDataset("dataset-create-test.json");
+
+    assertThat(
+        "dataset's PHS ID is null before patch",
+        datasetDao.retrieve(datasetId).getPhsId(),
+        equalTo(null));
+
+    String phsIdSet = "phs000000";
+    DatasetPatchRequestModel patchRequestSet = new DatasetPatchRequestModel().phsId(phsIdSet);
+    datasetDao.patch(datasetId, patchRequestSet);
+    assertThat(
+        "dataset's PHS ID is set from patch",
+        datasetDao.retrieve(datasetId).getPhsId(),
+        equalTo(phsIdSet));
+
+    String phsIdOverride = "phs111111";
+    DatasetPatchRequestModel patchRequestOverride =
+        new DatasetPatchRequestModel().phsId(phsIdOverride);
+    datasetDao.patch(datasetId, patchRequestOverride);
+    assertThat(
+        "dataset's PHS ID is overridden from patch",
+        datasetDao.retrieve(datasetId).getPhsId(),
+        equalTo(phsIdOverride));
+
+    datasetDao.patch(datasetId, new DatasetPatchRequestModel());
+    assertThat(
+        "dataset's PHS ID is unchanged when unspecified in patch request",
+        datasetDao.retrieve(datasetId).getPhsId(),
+        equalTo(phsIdOverride));
+
+    datasetDao.delete(datasetId);
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -868,6 +868,13 @@ public class DatasetDaoTest {
         datasetDao.retrieve(datasetId).getPhsId(),
         equalTo(phsIdOverride));
 
+    DatasetPatchRequestModel patchRequestBlank = new DatasetPatchRequestModel().phsId("");
+    datasetDao.patch(datasetId, patchRequestBlank);
+    assertThat(
+        "dataset's PHS ID is set to empty string from patch",
+        datasetDao.retrieve(datasetId).getPhsId(),
+        equalTo(""));
+
     datasetDao.delete(datasetId);
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -85,18 +85,18 @@ public class DatasetServiceUnitTest {
   @Test
   public void patchDatasetIamActions() {
     assertThat(
-        "Patch without updating passport identifier does not require share permissions",
-        datasetService.iamActions(new DatasetPatchRequestModel()),
+        "Patch without PHS ID update does not require passport identifier update permissions",
+        datasetService.patchDatasetIamActions(new DatasetPatchRequestModel()),
         contains(IamAction.MANAGE_SCHEMA));
 
     assertThat(
-        "Updating passport identifier requires share permissions",
-        datasetService.iamActions(new DatasetPatchRequestModel().phsId("")),
-        contains(IamAction.MANAGE_SCHEMA, IamAction.SHARE_POLICY_STEWARD));
+        "Patch with PHS ID update to empty string requires passport identifier update permissions",
+        datasetService.patchDatasetIamActions(new DatasetPatchRequestModel().phsId("")),
+        contains(IamAction.MANAGE_SCHEMA, IamAction.UPDATE_PASSPORT_IDENTIFIER));
 
     assertThat(
-        "Updating passport identifier requires share permissions",
-        datasetService.iamActions(new DatasetPatchRequestModel().phsId("phs123456")),
-        contains(IamAction.MANAGE_SCHEMA, IamAction.SHARE_POLICY_STEWARD));
+        "Patch with PHS ID update requires passport identifier update permissions",
+        datasetService.patchDatasetIamActions(new DatasetPatchRequestModel().phsId("phs123456")),
+        contains(IamAction.MANAGE_SCHEMA, IamAction.UPDATE_PASSPORT_IDENTIFIER));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.dataset;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.contains;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -11,6 +12,8 @@ import static org.mockito.Mockito.when;
 import bio.terra.app.usermetrics.UserLoggingMetrics;
 import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.category.Unit;
+import bio.terra.model.DatasetPatchRequestModel;
+import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
@@ -77,5 +80,23 @@ public class DatasetServiceUnitTest {
     var datasets = datasetService.enumerate(0, 10, null, null, null, null, resourcesAndRoles);
     assertThat(datasets.getItems().get(0).getId(), equalTo(uuid));
     assertThat(datasets.getRoleMap(), hasEntry(uuid.toString(), List.of(role.toString())));
+  }
+
+  @Test
+  public void patchDatasetIamActions() {
+    assertThat(
+        "Patch without updating passport identifier does not require share permissions",
+        datasetService.iamActions(new DatasetPatchRequestModel()),
+        contains(IamAction.MANAGE_SCHEMA));
+
+    assertThat(
+        "Updating passport identifier requires share permissions",
+        datasetService.iamActions(new DatasetPatchRequestModel().phsId("")),
+        contains(IamAction.MANAGE_SCHEMA, IamAction.SHARE_POLICY_STEWARD));
+
+    assertThat(
+        "Updating passport identifier requires share permissions",
+        datasetService.iamActions(new DatasetPatchRequestModel().phsId("phs123456")),
+        contains(IamAction.MANAGE_SCHEMA, IamAction.SHARE_POLICY_STEWARD));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -1,9 +1,9 @@
 package bio.terra.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.contains;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -588,5 +588,12 @@ public class SnapshotDaoTest {
         "snapshot's consent code is unchanged when unspecified in patch request",
         snapshotDao.retrieveSnapshot(snapshotId).getConsentCode(),
         equalTo(consentCodeOverride));
+
+    SnapshotPatchRequestModel patchRequestBlank = new SnapshotPatchRequestModel().consentCode("");
+    snapshotDao.patch(snapshotId, patchRequestBlank);
+    assertThat(
+        "snapshot's consent code is set to empty string from patch",
+        snapshotDao.retrieveSnapshot(snapshotId).getConsentCode(),
+        equalTo(""));
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -17,7 +17,6 @@ import bio.terra.model.AccessInfoBigQueryModel;
 import bio.terra.model.AccessInfoBigQueryModelTable;
 import bio.terra.model.AccessInfoModel;
 import bio.terra.model.CloudPlatform;
-import bio.terra.model.DatasetPatchRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotPatchRequestModel;

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1,8 +1,8 @@
 package bio.terra.service.snapshot;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,13 +17,16 @@ import bio.terra.model.AccessInfoBigQueryModel;
 import bio.terra.model.AccessInfoBigQueryModelTable;
 import bio.terra.model.AccessInfoModel;
 import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetPatchRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotPatchRequestModel;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SnapshotRetrieveIncludeModel;
 import bio.terra.model.SnapshotSourceModel;
 import bio.terra.model.StorageResourceModel;
 import bio.terra.model.TableModel;
+import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
@@ -306,5 +309,23 @@ public class SnapshotServiceTest {
         service.enumerateSnapshots(0, 10, null, null, null, null, List.of(), resourcesAndRoles);
     assertThat(snapshots.getItems().get(0).getId(), equalTo(snapshotId));
     assertThat(snapshots.getRoleMap(), hasEntry(snapshotId.toString(), List.of(role.toString())));
+  }
+
+  @Test
+  public void patchSnapshotIamActions() {
+    assertThat(
+        "Patch without consent code update does not require passport identifier update permissions",
+        service.patchSnapshotIamActions(new SnapshotPatchRequestModel()),
+        contains(IamAction.UPDATE_SNAPSHOT));
+
+    assertThat(
+        "Patch with consent code update to empty string requires passport identifier update permissions",
+        service.patchSnapshotIamActions(new SnapshotPatchRequestModel().consentCode("")),
+        contains(IamAction.UPDATE_SNAPSHOT, IamAction.UPDATE_PASSPORT_IDENTIFIER));
+
+    assertThat(
+        "Patch with consent code update requires passport identifier update permissions",
+        service.patchSnapshotIamActions(new SnapshotPatchRequestModel().consentCode("c99")),
+        contains(IamAction.UPDATE_SNAPSHOT, IamAction.UPDATE_PASSPORT_IDENTIFIER));
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2425

**Code Changes**

Added two new endpoints to synchronously modify passport identifiers:

- [PatchDataset](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/datasets/patchDataset) - can set or override PHS ID
- [PatchSnapshot](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/patchSnapshot) - can set or override consent code

In the future, we will expand on these endpoints to support the modification of other resource fields (ex. dataset description).

As we're following a [JSON merge patch](https://www.rfc-editor.org/rfc/rfc7396) approach in our response body format, we can't unset fields via these endpoints.  To work around this, callers can set them to empty strings.  We've changed our "passportabililty" check accordingly.

Because we can modify objects cached in `DrsService`,  I've expanded ga4gh endpoint descriptions to warn of our 15 minute local cache expiration.  A user might be confused by the following experience:
- Call `OptionsObject`: see that their object was missing the necessary passport identifiers.
- Modify dataset and/or snapshot to populate passport identifiers.
- Call `OptionsObject`: no immediate change in response, the service has the old objects cached.

A more sophisticated approach would involve cache eviction, but this was out of scope and would likely involve rethinking our caching strategy.

**Manual Verification**

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#) reflects these changes.
Using the following resources:

- [Dataset](https://jade-ok.datarepo-dev.broadinstitute.org/datasets/79ef03d8-161a-4143-bb09-c00cf7c11570)
- [Snapshot](https://jade-ok.datarepo-dev.broadinstitute.org/snapshots/6510b127-c226-46a1-ac12-c5f2383cbd08) whose sole row has a field with DRS object ID `v1_6510b127-c226-46a1-ac12-c5f2383cbd08_935baf22-8428-4cd1-b229-9e2a9fb2c2d7`

I used my dev Swagger to modify the passport identifiers, and verified that `OptionsObject` reflected the new state of the dataset and snapshot.

I should have added DataRepoAdmins@dev.test.firecloud.org to all necessary resources in case anyone would like to play around!

