### PR TITLE
[DR-2595] Update google cloud library versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ dependencies {
     implementation 'com.google.apis:google-api-services-serviceusage:v1-rev20201021-1.30.10'
     implementation 'com.google.apis:google-api-services-appengine:v1-rev20201201-1.31.0'
     implementation 'com.google.cloud:google-cloud-bigquery:1.108.1'
-    implementation 'com.google.cloud:google-cloud-storage:1.108.0'
+    implementation 'com.google.cloud:google-cloud-storage:2.6.1'
     implementation 'com.google.cloud:google-cloud-firestore:1.22.0'
     implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.104.1'
     implementation 'org.apache.commons:commons-dbcp2:2.7.0'     // For database connection support

--- a/build.gradle
+++ b/build.gradle
@@ -173,14 +173,16 @@ ext['log4j2.version'] = '2.17.0'
 
 dependencies {
     // TODO: Unpack the "starter" and include just what we use
-    implementation 'com.google.cloud:google-cloud-billing:1.1.6'
-    implementation 'com.google.cloud:google-cloud-resourcemanager:0.118.2-alpha'
     implementation 'com.google.apis:google-api-services-serviceusage:v1-rev20201021-1.30.10'
     implementation 'com.google.apis:google-api-services-appengine:v1-rev20201201-1.31.0'
-    implementation 'com.google.cloud:google-cloud-bigquery:1.108.1'
-    implementation 'com.google.cloud:google-cloud-storage:2.6.1'
-    implementation 'com.google.cloud:google-cloud-firestore:1.22.0'
-    implementation group: 'com.google.cloud', name: 'google-cloud-pubsub', version: '1.104.1'
+    implementation platform('com.google.cloud:libraries-bom:25.3.0')
+    implementation 'com.google.cloud:google-cloud-billing'
+    implementation 'com.google.cloud:google-cloud-resourcemanager'
+    implementation 'com.google.cloud:google-cloud-bigquery'
+    implementation 'com.google.cloud:google-cloud-storage'
+    implementation 'com.google.cloud:google-cloud-firestore'
+    implementation 'com.google.cloud:google-cloud-pubsub'
+    implementation 'com.google.http-client:google-http-client'
     implementation 'org.apache.commons:commons-dbcp2:2.7.0'     // For database connection support
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
@@ -191,8 +193,6 @@ dependencies {
     implementation 'org.codehaus.janino:janino:3.1.6'           // Provides if/else xml parsing for logback config
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation group: "javax.validation", name: "validation-api"
-    // Fix to this version
-    implementation 'com.google.http-client:google-http-client:1.38.0'
 
     implementation group: "io.swagger.core.v3", name: "swagger-annotations"
     swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -29,11 +29,8 @@ dependencies {
         apacheMath = "3.0"
 
         googleApi = "1.23.0"
-        googleCloud = "2.6.1"
         googlePeople = "v1-rev277-1.23.0"
         googleOauth2 = "0.20.0"
-        googleMonitoring = "2.0.1"
-        googleLogging = "1.101.2"
 
         swaggerAnnotations = "2.1.5"
         jersey = "2.30.1"
@@ -57,10 +54,11 @@ dependencies {
     implementation "com.google.oauth-client:google-oauth-client-jetty:${googleApi}"
     implementation "com.google.apis:google-api-services-people:${googlePeople}"
     implementation "com.google.auth:google-auth-library-oauth2-http:${googleOauth2}"
-    implementation "com.google.cloud:google-cloud-bigquery:${googleCloud}"
-    implementation "com.google.cloud:google-cloud-storage:${googleCloud}"
-    implementation "com.google.cloud:google-cloud-monitoring:${googleMonitoring}"
-    implementation "com.google.cloud:google-cloud-logging:${googleLogging}"
+    implementation platform('com.google.cloud:libraries-bom:25.3.0')
+    implementation "com.google.cloud:google-cloud-bigquery"
+    implementation "com.google.cloud:google-cloud-storage"
+    implementation "com.google.cloud:google-cloud-monitoring"
+    implementation "com.google.cloud:google-cloud-logging"
 
     implementation "org.glassfish.jersey.core:jersey-client:${jersey}"
     implementation "org.glassfish.jersey.media:jersey-media-json-jackson:${jersey}"

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -29,7 +29,7 @@ dependencies {
         apacheMath = "3.0"
 
         googleApi = "1.23.0"
-        googleCloud = "1.108.0"
+        googleCloud = "2.6.1"
         googlePeople = "v1-rev277-1.23.0"
         googleOauth2 = "0.20.0"
         googleMonitoring = "2.0.1"

--- a/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -391,10 +390,9 @@ public class BucketResourceTest {
 
     assertThat("Delete lifecycle action is set for 1 day", lifecycleDeleteAge, equalTo(deleteAge));
 
-    assertThat(
+    assertTrue(
         "Bucket without ttl has no lifecycle rules",
-        bucketWithoutTtl.getLifecycleRules(),
-        nullValue());
+        bucketWithoutTtl.getLifecycleRules().isEmpty());
 
     // delete the bucket and metadata
     for (var bucketResource : List.of(bucketWithTtlResource, bucketWithoutTtlResource)) {


### PR DESCRIPTION
Add the [Google Cloud Libraries Bill of Materials (BOM)](https://cloud.google.com/java/docs/bom) as a gradle [platform dependency](https://docs.gradle.org/current/userguide/platforms.html#sub:using-platform-to-control-transitive-deps).

Each version of the `com.google.cloud:libraries-bom` includes specific versions of google-cloud libraries that are all compatible with each other. So instead of us specifying which versions to use, gradle will use the versions defined in the BOM (specifying a version will override the BOM version). If we want to update any of our google-cloud libraries in the future, we only need to change the `com.google.cloud:libraries-bom` version.