### PR TITLE
DR-2608 - Update schedule for alpha promotion

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -3,9 +3,10 @@ on:
   workflow_dispatch: {}
   #Note: We're scheduling this to run before the Jenkins alpha deploy job
   # this schedule is defined here: /dsp-jenkins/src/main/groovy/org/broadinstitute/dspjenkins/FCLegacyDeploy.groovyL130
+  # However, github action runs can be delayed over an hour, so leaving extra buffer
   schedule:
-    - cron: '0 18 * * 5' # Fridays at 1:00 pm EST; 6PM UTC
-    - cron: '0 3 * * 1-5' # Sun - Thurs 10:00 pm EST; 3AM UTC
+    - cron: '0 17 * * 5' # Fridays at 12PM EST or 1PM EDT; 5PM UTC
+    - cron: '0 1 * * 1-5' # Sun - Thurs 8PM EST or 9PM EDT; 1AM UTC
 env:
   chartVersion: 0.1.461
 jobs:


### PR DESCRIPTION
### Background
Originally, our release cycle promoted the latest version of TDR directly to terra-helmfile's alpha.yaml. There was a [change almost a year ago](https://github.com/DataBiosphere/jade-data-repo/pull/1031/files) that instead set our version in terra-helmfile's dev.yaml. So, we now rely fully on the release train to promote to alpha and kick off alpha tests. 

Problem: The timing of our job to promote to dev.yaml does not happen early enough to consistently catch the release train. 
--> Release from dev -> alpha occurs exactly at 11:47PM EDT nightly
--> [TDR job](https://github.com/DataBiosphere/jade-data-repo/actions/workflows/alpha-promotion.yaml) to promote to terra-helmfile's dev occurs sometime between 11:35PM EDT and 12:05AM EDT. So, we sometimes make it on the train and sometimes don't. I don't know why it's not a consistent time – We have the cron job scheduled for [11PM EDT](https://github.com/DataBiosphere/jade-data-repo/blob/develop/.github/workflows/alpha-promotion.yaml#L8).  (The note in the code says 10 PM EST – it's off by an hour due to daylight savings time)

### Explaining the selected time changes
- Added note around delayed cron jobs in GitHub actions: A brief internet search suggested we are not the only ones running into delays with our scheduled GitHub actions. I think adding an hour buffer should be good enough in most cases, but it is unfortunate that we can't seem to guarantee that a job will run in time to get on the release train. **This may be a good reason to have the Jenkins job kick off our promotion job as well so we know it will happen in time.** 
- Friday afternoon's update: I didn't leave as much buffer here since we tend to try to get things merged Friday afternoon.
- Nightly time update: I have us a two hour buffer to get on the release train. I don't think we normally merge after 8/9PM, but if that's a use case, then we should reevaluate. 