### PR TITLE
DR-2581 - Upgrade Java, Gradle, spotless, and swagger

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -40,7 +40,7 @@ jobs:
           path: datarepo-helm-definitions
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -57,13 +57,13 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
@@ -84,7 +84,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -40,7 +40,7 @@ jobs:
           path: datarepo-helm-definitions
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -57,13 +57,13 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
@@ -84,7 +84,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "[datarepo-helm-definitions] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.59.0
+        uses: broadinstitute/datarepo-actions/actions/merger@sh-dr-2581-upgrade-java
         env:
           COMMIT_MESSAGE: "Datarepo api tag version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -106,7 +106,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
       - name: "[datarepo-helm] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.59.0
+        uses: broadinstitute/datarepo-actions/actions/merger@sh-dr-2581-upgrade-java
         env:
           COMMIT_MESSAGE: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "[datarepo-helm-definitions] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/merger@0.62.0
         env:
           COMMIT_MESSAGE: "Datarepo api tag version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -106,7 +106,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
       - name: "[datarepo-helm] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/merger@0.62.0
         env:
           COMMIT_MESSAGE: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -69,7 +69,7 @@ jobs:
           # write vault token
           base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -115,22 +115,22 @@ jobs:
           secrets: |
             secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -145,17 +145,17 @@ jobs:
           echo "::set-output name=git_hash::$git_hash"
           echo "Latest git hash for this branch: $git_hash"
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@sh-dr-2581-upgrade-java
         timeout-minutes: 20
         env:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -175,12 +175,12 @@ jobs:
           retention-days: 10
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         with:
           actions_subcommand: 'gcp_whitelist_clean'
       - name: "Notify Jade Slack on nightly test run"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -69,7 +69,7 @@ jobs:
           # write vault token
           base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
       - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -115,22 +115,22 @@ jobs:
           secrets: |
             secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -145,17 +145,17 @@ jobs:
           echo "::set-output name=git_hash::$git_hash"
           echo "Latest git hash for this branch: $git_hash"
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.62.0
         timeout-minutes: 20
         env:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -175,12 +175,12 @@ jobs:
           retention-days: 10
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
       - name: "Notify Jade Slack on nightly test run"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -76,7 +76,7 @@ jobs:
             gcloud container clusters get-credentials ${K8_CLUSTER} --zone ${GOOGLE_ZONE}
           fi
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         env:
           GOOGLE_SA_CERT: 'jade-dev-account.pem'
         with:
@@ -98,7 +98,7 @@ jobs:
           args: yq w -i datarepo-helm-definitions/perf/datarepo/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_VERSION }}
       - name: "[Update API version on Perf] [datarepo-helm-definitions] Merge version update"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
-        uses: broadinstitute/datarepo-actions/actions/merger@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/merger@0.62.0
         env:
           COMMIT_MESSAGE:  "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_VERSION }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -146,7 +146,7 @@ jobs:
           echo "Sleep 45 seconds to give the pods a chance to start cycling before checking if up and on correct version"
           sleep 45
       - name: "Wait for Perf Cluster to come back up with correct version"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.62.0
         env:
           NAMESPACEINUSE: perf
           IT_JADE_API_URL: "https://jade-perf.datarepo-perf.broadinstitute.org"
@@ -174,7 +174,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
+        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
         env:
           GOOGLE_SA_CERT: 'jade-dev-account.pem'
         with:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -76,7 +76,7 @@ jobs:
             gcloud container clusters get-credentials ${K8_CLUSTER} --zone ${GOOGLE_ZONE}
           fi
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         env:
           GOOGLE_SA_CERT: 'jade-dev-account.pem'
         with:
@@ -98,7 +98,7 @@ jobs:
           args: yq w -i datarepo-helm-definitions/perf/datarepo/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_VERSION }}
       - name: "[Update API version on Perf] [datarepo-helm-definitions] Merge version update"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
-        uses: broadinstitute/datarepo-actions/actions/merger@0.60.0
+        uses: broadinstitute/datarepo-actions/actions/merger@sh-dr-2581-upgrade-java
         env:
           COMMIT_MESSAGE:  "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_VERSION }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -146,7 +146,7 @@ jobs:
           echo "Sleep 45 seconds to give the pods a chance to start cycling before checking if up and on correct version"
           sleep 45
       - name: "Wait for Perf Cluster to come back up with correct version"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.60.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@sh-dr-2581-upgrade-java
         env:
           NAMESPACEINUSE: perf
           IT_JADE_API_URL: "https://jade-perf.datarepo-perf.broadinstitute.org"
@@ -174,7 +174,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.61.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-dr-2581-upgrade-java
         env:
           GOOGLE_SA_CERT: 'jade-dev-account.pem'
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -12,7 +12,7 @@ jobs:
       # fetch JDK
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
 
       # set up Gradle cache
       - uses: actions/cache@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 language: java
 
 jdk:
-  - openjdk8
+  - openjdk17
 
 addons:
   postgresql: "9.6"

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
 plugins {
     id "com.google.cloud.tools.jib" version "3.2.0"
     id 'org.liquibase.gradle' version '2.1.1'
-    id "org.gradle.test-retry" version "1.2.0"
+    id "org.gradle.test-retry" version "1.4.0"
     id 'antlr'
     id 'com.github.spotbugs' version '4.7.1'
     id "org.hidetake.swagger.generator" version "2.18.2"

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('io.swagger:swagger-codegen:2.4.11')
+        classpath('io.swagger:swagger-codegen:2.4.27')
     }
 }
 
@@ -37,7 +37,7 @@ plugins {
     id "java"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id "jacoco"
-    id "com.diffplug.spotless" version "5.14.0"
+    id "com.diffplug.spotless" version "6.6.1"
 }
 
 allprojects {
@@ -56,7 +56,7 @@ allprojects {
         }
         dependencies {
             dependency group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.1.5"
-            dependency group: "io.swagger.codegen.v3", name: "swagger-codegen-cli", version: "3.0.22"
+            dependency group: "io.swagger.codegen.v3", name: "swagger-codegen-cli", version: "3.0.34"
         }
     }
 }
@@ -72,8 +72,8 @@ subprojects.each { s ->
 
 def boolean isCiServer = System.getenv().containsKey("CI")
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 17
+targetCompatibility = 17
 
 if (hasProperty('buildScan')) {
     buildScan {

--- a/build.gradle
+++ b/build.gradle
@@ -396,7 +396,7 @@ sourceSets {
         runtimeClasspath += generated.output
     }
     jacoco {
-        toolVersion '0.8.3'
+        toolVersion '0.8.7'
     }
 }
 
@@ -416,7 +416,7 @@ jib {
         paths = ['build/gen-expanded']
     }
     from {
-        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian"
+        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian"
     }
     to {
         image = "gcr.io/broad-jade-dev/jade-data-repo:" + (System.env.GCR_TAG ?: getGitHash())

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,11 @@ def boolean isCiServer = System.getenv().containsKey("CI")
 sourceCompatibility = 17
 targetCompatibility = 17
 
+java {
+    sourceCompatibility = 17
+    targetCompatibility = 17
+}
+
 if (hasProperty('buildScan')) {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'

--- a/build.gradle
+++ b/build.gradle
@@ -79,23 +79,23 @@ if (hasProperty('buildScan')) {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
-        publishAlways()
-        def project = ""; def cluster = ""; def nschunk = "";
-        if (System.getenv("NAMESPACEINUSE")) {
-            project = "broad-jade-integration"
-            cluster = "integration-master"
-            def ns = System.getenv("NAMESPACEINUSE")
-            nschunk = "%0Aresource.labels.namespace_name%3D%22${ns}%22%0Alabels.k8s-pod%2Fcomponent%3D%22${ns}-jade-datarepo-api%22"
-        } else {
-            project = System.getenv("GOOGLE_CLOUD_PROJECT")
-            cluster = "jade-master-us-central1"
-            nschunk = ""
-        }
-        def startTest = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC"))
-        buildFinished { ->
-            def endTest = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC"))
-            link "Jump to StackDriver Logs 🔗 ", "https://console.cloud.google.com/logs/viewer?interval=CUSTOM&project=${project}&folder&organizationId&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&scrollTimestamp=${startTest}&dateRangeStart=${startTest}&dateRangeEnd=${endTest}&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22${project}%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22${cluster}%22${nschunk}"
-        }
+//        publishAlways()
+//        def project = ""; def cluster = ""; def nschunk = "";
+//        if (System.getenv("NAMESPACEINUSE")) {
+//            project = "broad-jade-integration"
+//            cluster = "integration-master"
+//            def ns = System.getenv("NAMESPACEINUSE")
+//            nschunk = "%0Aresource.labels.namespace_name%3D%22${ns}%22%0Alabels.k8s-pod%2Fcomponent%3D%22${ns}-jade-datarepo-api%22"
+//        } else {
+//            project = System.getenv("GOOGLE_CLOUD_PROJECT")
+//            cluster = "jade-master-us-central1"
+//            nschunk = ""
+//        }
+//        def startTest = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC"))
+//        buildFinished { ->
+//            def endTest = new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC"))
+//            link "Jump to StackDriver Logs 🔗 ", "https://console.cloud.google.com/logs/viewer?interval=CUSTOM&project=${project}&folder&organizationId&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&scrollTimestamp=${startTest}&dateRangeStart=${startTest}&dateRangeEnd=${endTest}&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22${project}%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22${cluster}%22${nschunk}"
+//        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ if (hasProperty('buildScan')) {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
+        // Note: Hope to reintroduce the following functionality once we get gradle scans working again [DR-1438]
 //        publishAlways()
 //        def project = ""; def cluster = ""; def nschunk = "";
 //        if (System.getenv("NAMESPACEINUSE")) {

--- a/build.gradle
+++ b/build.gradle
@@ -72,9 +72,6 @@ subprojects.each { s ->
 
 def boolean isCiServer = System.getenv().containsKey("CI")
 
-sourceCompatibility = 17
-targetCompatibility = 17
-
 java {
     sourceCompatibility = 17
     targetCompatibility = 17

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -5,8 +5,8 @@ plugins {
     id 'org.hidetake.swagger.generator'
 }
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 17
+targetCompatibility = 17
 
 // TODO: there may be a better way to supply these values than envvars.
 // This and the test below makes sure the build will fail reasonably if you try

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -5,8 +5,8 @@ plugins {
     id 'org.hidetake.swagger.generator'
 }
 
-sourceCompatibility = 17
-targetCompatibility = 17
+sourceCompatibility = 11
+targetCompatibility = 11
 
 // TODO: there may be a better way to supply these values than envvars.
 // This and the test below makes sure the build will fail reasonably if you try

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -8,6 +8,11 @@ plugins {
 sourceCompatibility = 11
 targetCompatibility = 11
 
+java {
+    sourceCompatibility = 11
+    targetCompatibility = 11
+}
+
 // TODO: there may be a better way to supply these values than envvars.
 // This and the test below makes sure the build will fail reasonably if you try
 // to publish without the environment variables defined.

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -5,9 +5,6 @@ plugins {
     id 'org.hidetake.swagger.generator'
 }
 
-sourceCompatibility = 11
-targetCompatibility = 11
-
 java {
     sourceCompatibility = 11
     targetCompatibility = 11

--- a/datarepo-clienttests/.gitignore
+++ b/datarepo-clienttests/.gitignore
@@ -21,8 +21,3 @@ target
 .gradle
 build
 
-# exclude property override that allows using jar for local client build
-# To use, build the jars at the top level with ./gradlew :datarepo-client:jar then add the following to your local
-# gradle.properties as:
-# datarepoclientjar=<absolute path to repo root>/datarepo-client/build/libs/<newest file>.jar
-gradle.properties

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     }
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junit}")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:${junit}")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junit}")
     compileOnly "com.google.code.findbugs:annotations:${findbugsAnnotations}"
 
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jackson}"

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -33,7 +33,7 @@ dependencies {
         googleOauth2 = "0.20.0"
 
         swaggerAnnotations = "2.1.5"
-        jersey = "2.30.1"
+        jersey = "2.32"
 
         datarepoClient = "1.343.0-SNAPSHOT"
         samClient = "0.1-c53306a-SNAP"

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junit}")
     compileOnly "com.google.code.findbugs:annotations:${findbugsAnnotations}"
 
+    implementation "org.awaitility:awaitility:4.0.3"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jackson}"
     implementation "io.kubernetes:client-java:${kubernetesClient}"
     implementation "ch.qos.logback:logback-classic:${logback}"

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation "org.glassfish.jersey.media:jersey-media-json-jackson:${jersey}"
     implementation "org.glassfish.jersey.media:jersey-media-multipart:${jersey}"
     implementation "org.glassfish.jersey.inject:jersey-hk2:${jersey}"
+    implementation "org.glassfish.jersey.connectors:jersey-jdk-connector:${jersey}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jackson}"
 
     // Azure related dependencies

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -88,8 +88,11 @@ dependencies {
 
 group 'bio.terra'
 version '1.0-SNAPSHOT'
-sourceCompatibility = 17
-targetCompatibility = 17
+
+java {
+    sourceCompatibility = 17
+    targetCompatibility = 17
+}
 
 test {
     useJUnitPlatform()

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'application'
     id "com.google.cloud.tools.jib" version "1.6.1"
-    id "com.diffplug.spotless" version "5.14.0"
+    id "com.diffplug.spotless" version "6.6.1"
     id 'com.github.spotbugs' version '4.7.1'
 }
 
@@ -86,8 +86,8 @@ dependencies {
 
 group 'bio.terra'
 version '1.0-SNAPSHOT'
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 17
+targetCompatibility = 17
 
 test {
     useJUnitPlatform()

--- a/datarepo-clienttests/gradle.properties
+++ b/datarepo-clienttests/gradle.properties
@@ -1,0 +1,13 @@
+# Required due to bug in google-java-format plugin. See https://github.com/diffplug/spotless/issues/834
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+
+# Note:
+# In order to exclude property override that allows using jar for local client build
+# To use, build the jars at the top level with ./gradlew :datarepo-client:jar then add the following to your local
+# gradle.properties as:
+# datarepoclientjar=<absolute path to repo root>/datarepo-client/build/libs/<newest file>.jar
+# Local change only - DO NOT CHECK IN

--- a/datarepo-clienttests/gradle/wrapper/gradle-wrapper.properties
+++ b/datarepo-clienttests/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
@@ -1,8 +1,13 @@
 package scripts.testscripts;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
 import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.model.DatasetModel;
+import bio.terra.datarepo.model.DatasetPatchRequestModel;
+import bio.terra.datarepo.model.DatasetSummaryModel;
 import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,5 +32,12 @@ public class RetrieveDataset extends SimpleDataset {
         "Successfully retrieved dataset: name = {}, data project = {}",
         datasetModel.getName(),
         datasetModel.getDataProject());
+
+    DatasetPatchRequestModel request = new DatasetPatchRequestModel();
+    String newPhsId = "phs123456";
+    request.setPhsId(newPhsId);
+    DatasetSummaryModel newDatasetModel =
+        repositoryApi.patchDataset(datasetSummaryModel.getId(), request);
+    assertThat("PhsId has been updated for dataset", newDatasetModel.getPhsId(), equalTo(newPhsId));
   }
 }

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
@@ -5,9 +5,12 @@ import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiClient;
+import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.DatasetModel;
 import bio.terra.datarepo.model.DatasetPatchRequestModel;
 import bio.terra.datarepo.model.DatasetSummaryModel;
+import bio.terra.datarepo.model.PolicyMemberRequest;
+import bio.terra.datarepo.model.PolicyResponse;
 import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +36,19 @@ public class RetrieveDataset extends SimpleDataset {
         datasetModel.getName(),
         datasetModel.getDataProject());
 
+    // add test user as steward so that they have access to edit phs id
+    try {
+      logger.debug("Adding test user {} as steward", testUser.userEmail);
+      PolicyResponse policyResponse =
+          repositoryApi.addDatasetPolicyMember(
+              datasetSummaryModel.getId(),
+              "steward",
+              new PolicyMemberRequest().email(testUser.userEmail));
+    } catch (ApiException e) {
+      throw new RuntimeException("Error adding user as steward", e);
+    }
+
+    // Test editing PhsId via patch endpoint
     DatasetPatchRequestModel request = new DatasetPatchRequestModel();
     String newPhsId = "phs123456";
     request.setPhsId(newPhsId);

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/RetrieveDataset.java
@@ -8,7 +8,6 @@ import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.DatasetModel;
 import bio.terra.datarepo.model.DatasetPatchRequestModel;
-import bio.terra.datarepo.model.DatasetSummaryModel;
 import bio.terra.datarepo.model.PolicyMemberRequest;
 import bio.terra.datarepo.model.PolicyResponse;
 import java.util.Collections;
@@ -54,7 +53,7 @@ public class RetrieveDataset extends SimpleDataset {
     DatasetPatchRequestModel request = new DatasetPatchRequestModel();
     String newPhsId = "phs123456";
     request.setPhsId(newPhsId);
-    DatasetSummaryModel newDatasetModel = new DatasetSummaryModel();
+
     // Retry patch dataset endpoint
     // Can run into concurrent update error
     Awaitility.await()

--- a/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
@@ -32,6 +32,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import javax.ws.rs.client.ClientBuilder;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.jdk.connector.JdkConnectorProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import runner.config.ServerSpecification;
@@ -83,6 +86,10 @@ public final class DataRepoUtils {
     apiClient.setBasePath(server.datarepoUri);
 
     apiClient.setAccessToken(userAccessToken.getTokenValue());
+
+    ClientConfig clientConfig = new ClientConfig();
+    clientConfig.connectorProvider(new JdkConnectorProvider());
+    apiClient.setHttpClient(ClientBuilder.newClient(clientConfig));
 
     apiClientsForTestUsers.put(testUser, apiClient);
     return apiClient;

--- a/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java
@@ -87,6 +87,10 @@ public final class DataRepoUtils {
 
     apiClient.setAccessToken(userAccessToken.getTokenValue());
 
+    // Workaround for jersey bug on upgrading to Java 17
+    // Needed for PATCH endpoints
+    // More details here: https://github.com/eclipse-ee4j/jersey/issues/4825#issuecomment-925836004
+    // And in PR description: https://github.com/DataBiosphere/jade-data-repo/pull/1288
     ClientConfig clientConfig = new ClientConfig();
     clientConfig.connectorProvider(new JdkConnectorProvider());
     apiClient.setHttpClient(ClientBuilder.newClient(clientConfig));

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,9 @@ dbDatarepoChangesetFile=src/main/resources/db/changelog.xml
 dbStairwayUri=jdbc:postgresql://127.0.0.1:5432/stairway
 dbStairwayUsername=drmanager
 dbStairwayPassword=drpasswd
+# Required due to bug in google-java-format plugin. See https://github.com/diffplug/spotless/issues/834
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/bio/terra/app/controller/converters/OpenApiEnumConverter.java
+++ b/src/main/java/bio/terra/app/controller/converters/OpenApiEnumConverter.java
@@ -23,7 +23,9 @@ public abstract class OpenApiEnumConverter<T> implements Converter<String, T> {
    */
   abstract T fromValue(String source);
 
-  /** @return A specific error string for the type T. */
+  /**
+   * @return A specific error string for the type T.
+   */
   abstract String errorString();
 
   @Override

--- a/src/main/java/bio/terra/common/DateTimeUtils.java
+++ b/src/main/java/bio/terra/common/DateTimeUtils.java
@@ -25,8 +25,4 @@ public class DateTimeUtils {
   public static Instant ofEpicMicros(long epochMicros) {
     return Instant.EPOCH.plus(epochMicros, ChronoUnit.MICROS);
   }
-
-  public static Instant ofEpicNanos(long epochMicros) {
-    return Instant.EPOCH.plus(epochMicros, ChronoUnit.NANOS);
-  }
 }

--- a/src/main/java/bio/terra/common/DateTimeUtils.java
+++ b/src/main/java/bio/terra/common/DateTimeUtils.java
@@ -13,7 +13,8 @@ public class DateTimeUtils {
    * @return A long
    */
   public static long toEpochMicros(Instant instant) {
-    return ChronoUnit.MICROS.between(Instant.EPOCH, instant);
+    Instant microInstant = instant.truncatedTo(ChronoUnit.MICROS);
+    return ChronoUnit.MICROS.between(Instant.EPOCH, microInstant);
   }
 
   /**
@@ -24,5 +25,10 @@ public class DateTimeUtils {
    */
   public static Instant ofEpicMicros(long epochMicros) {
     return Instant.EPOCH.plus(epochMicros, ChronoUnit.MICROS);
+  }
+
+  /** Truncates Instant to Microseconds and converts to string */
+  public static String toMicrosString(Instant instant) {
+    return instant.truncatedTo(ChronoUnit.MICROS).toString();
   }
 }

--- a/src/main/java/bio/terra/common/DateTimeUtils.java
+++ b/src/main/java/bio/terra/common/DateTimeUtils.java
@@ -25,4 +25,8 @@ public class DateTimeUtils {
   public static Instant ofEpicMicros(long epochMicros) {
     return Instant.EPOCH.plus(epochMicros, ChronoUnit.MICROS);
   }
+
+  public static Instant ofEpicNanos(long epochMicros) {
+    return Instant.EPOCH.plus(epochMicros, ChronoUnit.NANOS);
+  }
 }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
@@ -27,6 +27,7 @@ import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableResult;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -73,7 +74,7 @@ public class BigQueryTransactionPdao {
     sqlTemplate.add("transactCreatedAtCol", PDAO_TRANSACTION_CREATED_AT_COLUMN);
     sqlTemplate.add("transactCreatedByCol", PDAO_TRANSACTION_CREATED_BY_COLUMN);
 
-    Instant filterBefore = Instant.now();
+    Instant filterBefore = Instant.now().truncatedTo(ChronoUnit.MICROS);
     TransactionModel transaction =
         new TransactionModel()
             .id(UUID.randomUUID())
@@ -387,14 +388,14 @@ public class BigQueryTransactionPdao {
                 .map(Object::toString)
                 .orElse(null))
         .createdAt(
-            DateTimeUtils.ofEpicNanos(
+            DateTimeUtils.ofEpicMicros(
                     values.get(PDAO_TRANSACTION_CREATED_AT_COLUMN).getTimestampValue())
                 .toString())
         .createdBy(values.get(PDAO_TRANSACTION_CREATED_BY_COLUMN).getStringValue())
         .terminatedAt(
             values.get(PDAO_TRANSACTION_TERMINATED_AT_COLUMN).isNull()
                 ? null
-                : DateTimeUtils.ofEpicNanos(
+                : DateTimeUtils.ofEpicMicros(
                         values.get(PDAO_TRANSACTION_TERMINATED_AT_COLUMN).getTimestampValue())
                     .toString())
         .terminatedBy(

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
@@ -27,7 +27,6 @@ import com.google.cloud.bigquery.QueryParameterValue;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableResult;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -74,14 +73,14 @@ public class BigQueryTransactionPdao {
     sqlTemplate.add("transactCreatedAtCol", PDAO_TRANSACTION_CREATED_AT_COLUMN);
     sqlTemplate.add("transactCreatedByCol", PDAO_TRANSACTION_CREATED_BY_COLUMN);
 
-    Instant filterBefore = Instant.now().truncatedTo(ChronoUnit.MICROS);
+    Instant filterBefore = Instant.now();
     TransactionModel transaction =
         new TransactionModel()
             .id(UUID.randomUUID())
             .lock(flightId)
             .description(transactionDescription)
             .status(TransactionModel.StatusEnum.ACTIVE)
-            .createdAt(filterBefore.toString())
+            .createdAt(DateTimeUtils.toMicrosString(filterBefore))
             .createdBy(authedUser.getEmail());
 
     bigQueryProject.query(

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
@@ -387,14 +387,14 @@ public class BigQueryTransactionPdao {
                 .map(Object::toString)
                 .orElse(null))
         .createdAt(
-            DateTimeUtils.ofEpicMicros(
+            DateTimeUtils.ofEpicNanos(
                     values.get(PDAO_TRANSACTION_CREATED_AT_COLUMN).getTimestampValue())
                 .toString())
         .createdBy(values.get(PDAO_TRANSACTION_CREATED_BY_COLUMN).getStringValue())
         .terminatedAt(
             values.get(PDAO_TRANSACTION_TERMINATED_AT_COLUMN).isNull()
                 ? null
-                : DateTimeUtils.ofEpicMicros(
+                : DateTimeUtils.ofEpicNanos(
                         values.get(PDAO_TRANSACTION_TERMINATED_AT_COLUMN).getTimestampValue())
                     .toString())
         .terminatedBy(

--- a/src/test/java/bio/terra/common/DateTimeUtilsTest.java
+++ b/src/test/java/bio/terra/common/DateTimeUtilsTest.java
@@ -11,9 +11,13 @@ import org.junit.experimental.categories.Category;
 @Category(Unit.class)
 public class DateTimeUtilsTest {
 
-  private static final Instant INSTANT = Instant.parse("2022-01-01T03:23:12.87212Z");
+  private static final String INSTANT_STRING = "2022-01-01T03:23:12.872120Z";
+  private static final Instant INSTANT = Instant.parse(INSTANT_STRING);
+  private static final Instant NANO_INSTANT = Instant.parse("2022-01-01T03:23:12.87212123Z");
   // Manually figured out the long representation of CREATED_AT for testing
   private static final long MICROS = 1641007392872120L;
+  // When converted, an additional 1 is added at the end of the long value
+  private static final long CONVERTED_NANOS = 1641007392872121L;
 
   @Test
   public void testToEpochMicros() {
@@ -23,5 +27,21 @@ public class DateTimeUtilsTest {
   @Test
   public void testOfEpochMicros() {
     assertThat("can convert to micros", DateTimeUtils.ofEpicMicros(MICROS), equalTo(INSTANT));
+  }
+
+  @Test
+  public void testNanoToEpochMicros() {
+    assertThat(
+        "Can convert nanos to micros",
+        DateTimeUtils.toEpochMicros(NANO_INSTANT),
+        equalTo(CONVERTED_NANOS));
+  }
+
+  @Test
+  public void testMicrosToString() {
+    assertThat(
+        "to string method is correct",
+        DateTimeUtils.toMicrosString(INSTANT),
+        equalTo(INSTANT_STRING));
   }
 }


### PR DESCRIPTION
### Notes
- Really helpful to follow conversation in #java slack channel
- Also following example from our upgrade to Java 11 - https://github.com/DataBiosphere/jade-data-repo/pull/809

### Progress/Remaining Work
- ✅  Project builds
- ✅  upgrade clienttests to java 17 - Tests run locally + TBD if smoke tests pass
- ✅  Get Github Actions running
-  ✅ Get all tests passing
    -  ✅  [Fixed - truncated created timestamp for transaction to microseconds instead of nanoseconds] All Tests except one connected test fails: BigQueryPdaoDatasetConnectedTest.transactionTest(). Passes locally. 
- ✅  fix Jib command - I'm able to deploy to my dev env using skaffold/jib
- ✅  Add upgrade instructions
- ✅  Test out trying to use the client generated patch endpoint -- Dan has reported some issues w/ this case on the #java channel. Slack conversation [here](https://broadinstitute.slack.com/archives/C03B4RKTA5B/p1651527855852349). 
     -  [More details here](https://github.com/eclipse-ee4j/jersey/issues/4825#issuecomment-925836004)    
     - Ran into the same error in a test runner test using the patchDataset endpoint:
     - `javax.ws.rs.ProcessingException: Unable to make field private final sun.net.www.protocol.https.DelegateHttpsURLConnection sun.net.www.protocol.https.HttpsURLConnectionImpl.delegate accessible: module java.base does not "opens sun.net.www.protocol.https" to unnamed module @41a962cf
        at org.glassfish.jersey.client.ClientRuntime.invoke(ClientRuntime.java:305)`
    -  ✅  Try to implement Phil's fix for WSM and use [jdkconnector](https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/client.html#d0e4979) on building the client for use in testRunner Test
    - ✅  Create test that uses a PATCH endpoint
- ✅  Confirm that client is generated using Java 11 rather than Java 17 
    - ✅  Confirmed that the jar generated for client is java version 11 (inspected the class files in the generated jar) 
![image](https://user-images.githubusercontent.com/13254229/171703604-538d08c5-4452-4b63-950d-e000879841a2.png)
    - ✅  Confirmed test runner tests can still run referencing the Java 11 client 
- ✅  Get corresponding [datarepo-actions PR](https://github.com/broadinstitute/datarepo-actions/pull/72) Reviewed and Merged
- ✅  Update github actions to point to new version of datarepo-actions once PR is merged

### Justification for upgrades
- Jacoco updated due to this error - https://github.com/gradle/gradle/issues/15038
- Gradle Retry plugin needed upgrading to support new version of gradle/java -[ Release log](https://github.com/gradle/test-retry-gradle-plugin/releases)
     -  Should fix errors such as the following, occurring during int/connected test runs: `Unable to determine if class bio.terra.integration.FileTest is a Spock @Stepwise test
java.lang.IllegalArgumentException: Unsupported class file major version 61`
- A few [jvm arguments added to the gradle.properties file](https://github.com/DataBiosphere/terra-data-catalog/blob/main/gradle.properties) as a workaround for a spotless/GoogleJavaFormat issue. Slack conversation [here](https://broadinstitute.slack.com/archives/C03B4RKTA5B/p1649786771006079).
     - Upgraded Spotless in hopes of fixing the GoogleJavaFormat issue from previous bullet, but it did not help. I think we could downgrade if needed.
- Upgraded to [Gradle 7.3 in order to get full support of Java 17](https://docs.gradle.org/7.3/release-notes.html#:~:text=As%20of%20Gradle%207.3%2C%20both,Java%2017%20is%20fully%20supported.). 
- Remember that gross [Handlebars warning that popped up on every build of data repo](https://github.com/DataBiosphere/jade-data-repo/runs/6614539345?check_suite_focus=true#step:7:86)? It upgraded itself to a full blown error and upgrading swagger codegen fixed it. 
     - I think this is the [actual error I was running into](https://github.com/swagger-api/swagger-codegen/issues/10966) -- I didn't record it when it first encountered it, so this is from my search history
- Gradle Retry Plugin upgraded to support Java 17 and avoid 'Unsupported class file major version 61' errors during retry runs
- Jersey version upgraded in clienttests in order to support the "JDKConnector" workaround required for PATCH endpoints

### Upgrade Instructions
I found I was able to upgrade Java versions in Intellij. There were two places I changed the java version and then intellij downloaded the new version. 

1. Project Structure -> Project -> SDKs -> add SDK -> Download JDK -> Version: 17, Vendor - AdoptOpenJDK 17 ( I used Termurin)
![Screen Shot 2022-06-02 at 1 07 48 PM](https://user-images.githubusercontent.com/13254229/171698323-bd3f222c-ffa1-4964-b671-81ce07ca994f.png)
![Screen Shot 2022-06-02 at 1 08 10 PM](https://user-images.githubusercontent.com/13254229/171698449-127ba8a2-9ff6-4bdd-8c73-e3adc8546bd2.png)

2. You can also make sure this is correctly set under Intellij IDEA -> Preferences -> Build, Execution, Deployment -> Gradle -> Gradle JVM
![image](https://user-images.githubusercontent.com/13254229/171262707-65df9785-d0c5-4391-9f39-34b3466a0b35.png)


     