### PR TITLE
[DR-2617] Handle gcs StorageException

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -30,6 +30,7 @@ import com.azure.storage.blob.BlobUrlParts;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.storage.StorageException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -266,7 +267,8 @@ public final class IngestUtils {
                       List.of(loadFileModel.getSourcePath()), userRequest);
                 } catch (BlobAccessNotAuthorizedException
                     | BadRequestException
-                    | IllegalArgumentException ex) {
+                    | IllegalArgumentException
+                    | StorageException ex) {
                   errorCollector.record("Error: %s", ex.getMessage());
                 }
               })


### PR DESCRIPTION
If a gcs path does not exist, validateUserCanRead throws a 404 error that the project cannot be found.