### PR TITLE
DR-2599 Eagerly create a GCS bucket when creating a dataset

### DIFF
--- a/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
+++ b/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
@@ -2,6 +2,7 @@ package bio.terra.common;
 
 import bio.terra.buffer.model.ResourceInfo;
 import bio.terra.service.resourcemanagement.BufferService;
+import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -13,10 +14,15 @@ public class GetResourceBufferProjectStep implements Step {
   private final Logger logger = LoggerFactory.getLogger(GetResourceBufferProjectStep.class);
 
   private final BufferService bufferService;
+  private final GoogleResourceManagerService googleResourceManagerService;
   private final boolean enableSecureMonitoring;
 
-  public GetResourceBufferProjectStep(BufferService bufferService, boolean enableSecureMonitoring) {
+  public GetResourceBufferProjectStep(
+      BufferService bufferService,
+      GoogleResourceManagerService googleResourceManagerService,
+      boolean enableSecureMonitoring) {
     this.bufferService = bufferService;
+    this.googleResourceManagerService = googleResourceManagerService;
     this.enableSecureMonitoring = enableSecureMonitoring;
   }
 
@@ -33,6 +39,13 @@ public class GetResourceBufferProjectStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) {
+    FlightMap workingMap = context.getWorkingMap();
+    String projectId = workingMap.get(ProjectCreatingFlightKeys.GOOGLE_PROJECT_ID, String.class);
+    if (projectId != null) {
+      // No need to clean up metadata since this a creation undo step and the metadata could be
+      // incomplete
+      googleResourceManagerService.deleteProject(projectId);
+    }
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetBucketDao.java
@@ -55,7 +55,8 @@ public class DatasetBucketDao {
   // it will decrement to zero.
   private static final String sqlCreateLink =
       "INSERT INTO dataset_bucket "
-          + " (dataset_id, bucket_resource_id, successful_ingests) VALUES (:dataset_id, :bucket_resource_id, 1)";
+          + " (dataset_id, bucket_resource_id, successful_ingests) "
+          + "VALUES (:dataset_id, :bucket_resource_id, :initial_value)";
 
   private static final String whereClause =
       " WHERE dataset_id = :dataset_id AND bucket_resource_id = :bucket_resource_id";
@@ -126,23 +127,28 @@ public class DatasetBucketDao {
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public void createDatasetBucketLink(UUID datasetId, UUID bucketResourceId) {
+    createDatasetBucketLink(datasetId, bucketResourceId, true);
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public void createDatasetBucketLink(UUID datasetId, UUID bucketResourceId, boolean isIngest) {
     if (datasetBucketLinkExists(datasetId, bucketResourceId)) {
       // If the link is already made then increment our use of it.
       incrementDatasetBucketLink(datasetId, bucketResourceId);
     } else {
       // Not there, try creating it
-      datasetBucketLinkUpdate(sqlCreateLink, datasetId, bucketResourceId);
+      datasetBucketLinkUpdate(sqlCreateLink, datasetId, bucketResourceId, isIngest);
     }
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public void deleteDatasetBucketLink(UUID datasetId, UUID bucketResourceId) {
-    datasetBucketLinkUpdate(sqlDeleteLink, datasetId, bucketResourceId);
+    datasetBucketLinkUpdate(sqlDeleteLink, datasetId, bucketResourceId, false);
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public void decrementDatasetBucketLink(UUID datasetId, UUID bucketResourceId) {
-    datasetBucketLinkUpdate(sqlDecrementCount, datasetId, bucketResourceId);
+    datasetBucketLinkUpdate(sqlDecrementCount, datasetId, bucketResourceId, true);
   }
 
   boolean datasetBucketLinkExists(UUID datasetId, UUID bucketResourceId) {
@@ -176,14 +182,17 @@ public class DatasetBucketDao {
   }
 
   private void incrementDatasetBucketLink(UUID datasetId, UUID bucketResourceId) {
-    datasetBucketLinkUpdate(sqlIncrementCount, datasetId, bucketResourceId);
+    datasetBucketLinkUpdate(sqlIncrementCount, datasetId, bucketResourceId, true);
   }
 
-  private void datasetBucketLinkUpdate(String sql, UUID datasetId, UUID bucketResourceId) {
+  private void datasetBucketLinkUpdate(
+      String sql, UUID datasetId, UUID bucketResourceId, boolean isIngest) {
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("dataset_id", datasetId)
-            .addValue("bucket_resource_id", bucketResourceId);
+            .addValue("bucket_resource_id", bucketResourceId)
+            // Only gets used on link creation
+            .addValue("initial_value", isIngest ? 1 : 0);
     try {
       jdbcTemplate.update(sql, params);
     } catch (DataAccessException dataAccessException) {

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateBucketStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateBucketStep.java
@@ -2,14 +2,12 @@ package bio.terra.service.dataset.flight.create;
 
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.filedata.flight.FileMapKeys;
 import bio.terra.service.filedata.flight.ingest.IngestFilePrimaryDataLocationStep;
-import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.exception.BucketLockException;
 import bio.terra.service.resourcemanagement.exception.GoogleResourceNamingException;
@@ -85,23 +83,7 @@ public class CreateDatasetGetOrCreateBucketStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) {
-    // There is not much to undo here. It is possible that a bucket was created in the last step. We
-    // could look to
-    // see if there are no other files in the bucket and delete it here, but I think it is likely
-    // the bucket will
-    // be used again.
-    FlightMap workingMap = context.getWorkingMap();
-    BillingProfileModel billingProfile =
-        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
-    GoogleProjectResource googleProjectResource =
-        workingMap.get(FileMapKeys.PROJECT_RESOURCE, GoogleProjectResource.class);
-
-    try {
-      resourceService.updateBucketMetadata(
-          googleProjectResource.getGoogleProjectId(), billingProfile, context.getFlightId());
-    } catch (GoogleResourceNamingException e) {
-      logger.error(e.getMessage());
-    }
+    // Leaving artifacts on undo
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateBucketStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateBucketStep.java
@@ -1,12 +1,14 @@
-package bio.terra.service.filedata.flight.ingest;
+package bio.terra.service.dataset.flight.create;
 
+import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BillingProfileModel;
+import bio.terra.model.DatasetRequestModel;
 import bio.terra.service.auth.iam.IamResourceType;
-import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
-import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.filedata.flight.ingest.IngestFilePrimaryDataLocationStep;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.exception.BucketLockException;
@@ -20,66 +22,63 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IngestFilePrimaryDataLocationStep implements Step {
+public class CreateDatasetGetOrCreateBucketStep implements Step {
   private static final Logger logger =
-      LoggerFactory.getLogger(IngestFilePrimaryDataLocationStep.class);
-
-  public static final Set<IamRole> BUCKET_READER_ROLES =
-      Set.of(IamRole.STEWARD, IamRole.CUSTODIAN, IamRole.SNAPSHOT_CREATOR);
+      LoggerFactory.getLogger(CreateDatasetGetOrCreateBucketStep.class);
 
   private final AuthenticatedUserRequest userReq;
   private final ResourceService resourceService;
-  private final Dataset dataset;
+  private final DatasetRequestModel datasetRequestModel;
   private final IamService iamService;
 
-  public IngestFilePrimaryDataLocationStep(
+  public CreateDatasetGetOrCreateBucketStep(
       AuthenticatedUserRequest userReq,
       ResourceService resourceService,
-      Dataset dataset,
+      DatasetRequestModel datasetRequestModel,
       IamService iamService) {
     this.userReq = userReq;
     this.resourceService = resourceService;
-    this.dataset = dataset;
+    this.datasetRequestModel = datasetRequestModel;
     this.iamService = iamService;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
-    Boolean loadComplete = workingMap.get(FileMapKeys.LOAD_COMPLETED, Boolean.class);
-    if (loadComplete == null || !loadComplete) {
-      // Retrieve the already authorized billing profile from the working map and retrieve
-      // or create a bucket in the context of that profile and the dataset.
-      GoogleProjectResource googleProjectResource =
-          workingMap.get(FileMapKeys.PROJECT_RESOURCE, GoogleProjectResource.class);
+    UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
+    GoogleRegion region = GoogleRegion.fromValueWithDefault(datasetRequestModel.getRegion());
+    UUID projectId = workingMap.get(DatasetWorkingMapKeys.PROJECT_RESOURCE_ID, UUID.class);
+    GoogleProjectResource googleProjectResource = resourceService.getProjectResource(projectId);
 
-      Callable<List<String>> getReaderGroups =
-          () ->
-              iamService
-                  .retrievePolicyEmails(userReq, IamResourceType.DATASET, dataset.getId())
-                  .entrySet()
-                  .stream()
-                  .filter(entry -> BUCKET_READER_ROLES.contains(entry.getKey()))
-                  .map(Map.Entry::getValue)
-                  .collect(Collectors.toList());
+    Callable<List<String>> getReaderGroups =
+        () ->
+            iamService
+                .retrievePolicyEmails(userReq, IamResourceType.DATASET, datasetId)
+                .entrySet()
+                .stream()
+                .filter(
+                    entry ->
+                        IngestFilePrimaryDataLocationStep.BUCKET_READER_ROLES.contains(
+                            entry.getKey()))
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
 
-      try {
-        GoogleBucketResource bucketForFile =
-            resourceService.getOrCreateBucketForFile(
-                dataset, googleProjectResource, context.getFlightId(), getReaderGroups);
+    try {
+      GoogleBucketResource bucketForFile =
+          resourceService.getOrCreateBucketForFile(
+              region, googleProjectResource, context.getFlightId(), getReaderGroups);
 
-        workingMap.put(FileMapKeys.BUCKET_INFO, bucketForFile);
-      } catch (BucketLockException blEx) {
-        return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, blEx);
-      } catch (GoogleResourceNamingException ex) {
-        return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
-      }
+      workingMap.put(FileMapKeys.BUCKET_INFO, bucketForFile);
+    } catch (BucketLockException blEx) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, blEx);
+    } catch (GoogleResourceNamingException ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -26,6 +26,7 @@ import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
+import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -55,6 +56,8 @@ public class DatasetCreateFlight extends Flight {
         appContext.getBean(DatasetStorageAccountDao.class);
     AzureBlobStorePdao azureBlobStorePdao = appContext.getBean(AzureBlobStorePdao.class);
     GoogleBillingService googleBillingService = appContext.getBean(GoogleBillingService.class);
+    GoogleResourceManagerService googleResourceManagerService =
+        appContext.getBean(GoogleResourceManagerService.class);
 
     DatasetRequestModel datasetRequest =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), DatasetRequestModel.class);
@@ -78,7 +81,9 @@ public class DatasetCreateFlight extends Flight {
       // Get a new google project from RBS and store it in the working map
       addStep(
           new GetResourceBufferProjectStep(
-              bufferService, datasetRequest.isEnableSecureMonitoring()));
+              bufferService,
+              googleResourceManagerService,
+              datasetRequest.isEnableSecureMonitoring()));
 
       // Get or initialize the project where the dataset resources will be created
       addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateMakeBucketLinkStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateMakeBucketLinkStep.java
@@ -1,0 +1,49 @@
+package bio.terra.service.dataset.flight.create;
+
+import bio.terra.common.exception.RetryQueryException;
+import bio.terra.service.dataset.DatasetBucketDao;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.UUID;
+
+public class DatasetCreateMakeBucketLinkStep implements Step {
+  private final DatasetBucketDao datasetBucketDao;
+
+  public DatasetCreateMakeBucketLinkStep(DatasetBucketDao datasetBucketDao) {
+    this.datasetBucketDao = datasetBucketDao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
+    GoogleBucketResource bucketForFile =
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+    try {
+      datasetBucketDao.createDatasetBucketLink(datasetId, bucketForFile.getResourceId(), false);
+    } catch (RetryQueryException ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    FlightMap workingMap = context.getWorkingMap();
+    UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
+    GoogleBucketResource bucketForFile =
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+    try {
+      datasetBucketDao.deleteDatasetBucketLink(datasetId, bucketForFile.getResourceId());
+    } catch (RetryQueryException ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -123,11 +123,36 @@ public class ResourceService {
       String flightId,
       Callable<List<String>> getReaderGroups)
       throws InterruptedException, GoogleResourceNamingException {
+    return getOrCreateBucketForFile(
+        (GoogleRegion)
+            dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.BUCKET),
+        projectResource,
+        flightId,
+        getReaderGroups);
+  }
+
+  /**
+   * Fetch/create a project, then use that to fetch/create a bucket.
+   *
+   * @param flightId used to lock the bucket metadata during possible creation
+   * @return a reference to the bucket as a POJO GoogleBucketResource
+   * @throws CorruptMetadataException in two cases.
+   *     <ul>
+   *       <li>if the bucket already exists, but the metadata does not AND the application property
+   *           allowReuseExistingBuckets=false.
+   *       <li>if the metadata exists, but the bucket does not
+   *     </ul>
+   */
+  public GoogleBucketResource getOrCreateBucketForFile(
+      GoogleRegion region,
+      GoogleProjectResource projectResource,
+      String flightId,
+      Callable<List<String>> getReaderGroups)
+      throws InterruptedException, GoogleResourceNamingException {
     return bucketService.getOrCreateBucket(
         projectService.bucketForFile(projectResource.getGoogleProjectId()),
         projectResource,
-        (GoogleRegion)
-            dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.BUCKET),
+        region,
         flightId,
         null,
         getReaderGroups);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -27,6 +27,7 @@ import bio.terra.service.profile.google.GoogleBillingService;
 import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.exception.InvalidSnapshotException;
@@ -67,6 +68,8 @@ public class SnapshotCreateFlight extends Flight {
     AzureAuthService azureAuthService = appContext.getBean(AzureAuthService.class);
     TableDependencyDao tableDependencyDao = appContext.getBean(TableDependencyDao.class);
     GoogleBillingService googleBillingService = appContext.getBean(GoogleBillingService.class);
+    GoogleResourceManagerService googleResourceManagerService =
+        appContext.getBean(GoogleResourceManagerService.class);
 
     SnapshotRequestModel snapshotReq =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), SnapshotRequestModel.class);
@@ -98,7 +101,9 @@ public class SnapshotCreateFlight extends Flight {
       // Get a new google project from RBS and store it in the working map
       addStep(
           new GetResourceBufferProjectStep(
-              bufferService, sourceDataset.isSecureMonitoringEnabled()));
+              bufferService,
+              googleResourceManagerService,
+              sourceDataset.isSecureMonitoringEnabled()));
 
       // Get or initialize the project where the snapshot resources will be created
       addStep(

--- a/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetConnectedTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.dataset;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
@@ -385,11 +386,12 @@ public class DatasetConnectedTest {
         connectedOperations.ingestFileSuccess(summaryModel.getId(), fileLoadModel);
 
     // Retrieve list of projects associated with dataset/bucket
-    // only one bucket b/c we didn't ingest anything with the first billing profile
+    // there will be two buckets: the primary one and the one where we performed the ingest
     List<UUID> projectResourceIds =
         datasetBucketDao.getProjectResourceIdsForBucketPerDataset(summaryModel.getId());
+    assertThat("There are two buckets", projectResourceIds, hasSize(2));
     String ingestGoogleProjectId =
-        googleResourceDao.retrieveProjectById(projectResourceIds.get(0)).getGoogleProjectId();
+        googleResourceDao.retrieveProjectById(projectResourceIds.get(1)).getGoogleProjectId();
     assertThat(
         "The dataset google project is different from ingest bucket google project that used a different billing profile",
         ingestGoogleProjectId,


### PR DESCRIPTION
Do this rather than lazily creating on the first ingest.  This mitigates a race conditions where a bunch of first time ingests are triggered at the same time.  This makes sure that by the time the dataset is created and ready to use, it has a bucket to accept files

Note: we already follow this pattern for storage accounts and containers for Azure-backed datasets