### PR TITLE
[DR-2537] Add new datasets "properties" field

### DIFF
--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -3,6 +3,7 @@ package bio.terra.common;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.SqlSortDirection;
+import bio.terra.service.dataset.exception.InvalidDatasetException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.postgresql.util.PGobject;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.RecoverableDataAccessException;
 import org.springframework.dao.TransientDataAccessException;
@@ -112,5 +114,18 @@ public final class DaoUtils {
   public static boolean retryQuery(DataAccessException dataAccessException) {
     return ExceptionUtils.hasCause(dataAccessException, RecoverableDataAccessException.class)
         || ExceptionUtils.hasCause(dataAccessException, TransientDataAccessException.class);
+  }
+
+  public static PGobject propertiesToPGobject(ObjectMapper objectMapper, Object properties) {
+    String datasetProperties;
+    PGobject jsonObject = new PGobject();
+    try {
+      datasetProperties = objectMapper.writeValueAsString(properties);
+      jsonObject.setType("jsonb");
+      jsonObject.setValue(datasetProperties);
+    } catch (JsonProcessingException | SQLException ex) {
+      throw new InvalidDatasetException("Invalid dataset properties: " + properties.toString(), ex);
+    }
+    return jsonObject;
   }
 }

--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.postgresql.util.PGobject;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.RecoverableDataAccessException;
 import org.springframework.dao.TransientDataAccessException;
@@ -116,16 +115,15 @@ public final class DaoUtils {
         || ExceptionUtils.hasCause(dataAccessException, TransientDataAccessException.class);
   }
 
-  public static PGobject propertiesToPGobject(ObjectMapper objectMapper, Object properties) {
-    String datasetProperties;
-    PGobject jsonObject = new PGobject();
-    try {
-      datasetProperties = objectMapper.writeValueAsString(properties);
-      jsonObject.setType("jsonb");
-      jsonObject.setValue(datasetProperties);
-    } catch (JsonProcessingException | SQLException ex) {
-      throw new InvalidDatasetException("Invalid dataset properties: " + properties.toString(), ex);
+  public static String propertiesToString(ObjectMapper objectMapper, Object properties) {
+    if (properties != null) {
+      try {
+        return objectMapper.writeValueAsString(properties);
+      } catch (JsonProcessingException ex) {
+        throw new InvalidDatasetException("Invalid dataset properties: " + properties, ex);
+      }
+    } else {
+      return null;
     }
-    return jsonObject;
   }
 }

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -233,6 +233,10 @@ public class Dataset implements FSContainerInterface, LogPrintable {
     return datasetSummary.isSelfHosted();
   }
 
+  public Object getProperties() {
+    return datasetSummary.getProperties();
+  }
+
   @Override
   public String toLogString() {
     return String.format("%s (%s)", this.getName(), this.getId());

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -77,7 +77,8 @@ public final class DatasetJsonConversion {
                 .defaultProfileId(defaultProfileId)
                 .secureMonitoringEnabled(enableSecureMonitoring)
                 .phsId(datasetRequest.getPhsId())
-                .selfHosted(datasetRequest.isExperimentalSelfHosted()))
+                .selfHosted(datasetRequest.isExperimentalSelfHosted())
+                .properties(datasetRequest.getProperties()))
         .tables(new ArrayList<>(tablesMap.values()))
         .relationships(new ArrayList<>(relationshipsMap.values()))
         .assetSpecifications(assetSpecifications);
@@ -106,6 +107,10 @@ public final class DatasetJsonConversion {
       datasetModel.defaultProfileId(dataset.getDefaultProfileId());
     }
 
+    if (include.contains(DatasetRequestAccessIncludeModel.PROPERTIES)) {
+      datasetModel.properties(dataset.getProperties());
+    }
+
     if (include.contains(DatasetRequestAccessIncludeModel.SCHEMA)) {
       datasetModel.schema(datasetSpecificationModelFromDatasetSchema(dataset));
     }
@@ -123,6 +128,7 @@ public final class DatasetJsonConversion {
       datasetModel.accessInformation(
           metadataDataAccessUtils.accessInfoFromDataset(dataset, userRequest));
     }
+
     return datasetModel;
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -32,6 +32,7 @@ public class DatasetSummary {
   private String storageAccount;
   private String phsId;
   private boolean selfHosted;
+  private Object properties;
 
   public UUID getId() {
     return id;
@@ -209,6 +210,15 @@ public class DatasetSummary {
 
   public DatasetSummary selfHosted(boolean selfHosted) {
     this.selfHosted = selfHosted;
+    return this;
+  }
+
+  public Object getProperties() {
+    return properties;
+  }
+
+  public DatasetSummary properties(Object properties) {
+    this.properties = properties;
     return this;
   }
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3342,7 +3342,7 @@ components:
           description: denotes whether data files in the dataset are self-hosted or not
         properties:
           type: object
-          description: Additional metadata about the dataset.
+          description: Additional JSON metadata about the dataset (this does not need to adhere to a particular schema)
       description: >
         Complete definition of a dataset.
     DatasetSummaryModel:
@@ -3415,7 +3415,7 @@ components:
             files in their original location.
         properties:
           type: object
-          description: Additional metadata about the dataset.
+          description: Additional JSON metadata about the dataset (this does not need to adhere to a particular schema)
       description: >
         Complete definition of a dataset without the id (used to create a dataset)
     DatasetPatchRequestModel:
@@ -3425,7 +3425,7 @@ components:
           $ref: '#/components/schemas/PhsId'
         properties:
           type: object
-          description: Additional metadata about the dataset.
+          description: Additional JSON metadata about the dataset (this does not need to adhere to a particular schema)
       description: >
         A 'lite' dataset definition (used to modify supported fields of a dataset).
         Null assignments will be ignored.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3423,6 +3423,9 @@ components:
       properties:
         phsId:
           $ref: '#/components/schemas/PhsId'
+        properties:
+          type: object
+          description: Additional metadata about the dataset.
       description: >
         A 'lite' dataset definition (used to modify supported fields of a dataset).
         Null assignments will be ignored.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3340,6 +3340,9 @@ components:
           type: boolean
           default: false
           description: denotes whether data files in the dataset are self-hosted or not
+        properties:
+          type: object
+          description: Additional metadata about the dataset.
       description: >
         Complete definition of a dataset.
     DatasetSummaryModel:
@@ -3410,6 +3413,9 @@ components:
           default: false
           description: Create the dataset in self-hosted mode, where TDR does not ingest files, but rather points to
             files in their original location.
+        properties:
+          type: object
+          description: Additional metadata about the dataset.
       description: >
         Complete definition of a dataset without the id (used to create a dataset)
     DatasetPatchRequestModel:
@@ -3424,7 +3430,7 @@ components:
       type: string
       description: >
         Type of information to include in the response
-      enum: [ NONE, SCHEMA, ACCESS_INFORMATION, PROFILE, DATA_PROJECT, STORAGE ]
+      enum: [ NONE, SCHEMA, ACCESS_INFORMATION, PROFILE, PROPERTIES, DATA_PROJECT, STORAGE ]
     EnumerateDatasetModel:
       type: object
       properties:

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -55,5 +55,6 @@
     <include file="changesets/20220325_selfhosteddatasets.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220411_requiredcolumns.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220511_dropsnapshotmetadata.yml" relativeToChangelogFile="true" />
+    <include file="changesets/20220526_datasetproperties.yaml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20220526_datasetproperties.yaml
+++ b/src/main/resources/db/changesets/20220526_datasetproperties.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: dataset_properties
+      author: sehsan
+      changes:
+        - addColumn:
+            tableName: dataset
+            columns:
+              name: properties
+              type: jsonb
+              constraints:
+                nullable: true

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -911,6 +911,21 @@ public class DatasetDaoTest {
         datasetDao.retrieve(datasetId).getProperties(),
         equalTo(updatedDatasetProperties));
 
+    DatasetPatchRequestModel patchRequestNull = new DatasetPatchRequestModel().phsId("phs123");
+    datasetDao.patch(datasetId, patchRequestNull);
+    assertThat(
+        "dataset properties is unchanged when not in request",
+        datasetDao.retrieve(datasetId).getProperties(),
+        equalTo(updatedDatasetProperties));
+
+    DatasetPatchRequestModel patchRequestExplicitNull =
+        new DatasetPatchRequestModel().properties(null);
+    datasetDao.patch(datasetId, patchRequestExplicitNull);
+    assertThat(
+        "dataset properties is unchanged if set to null",
+        datasetDao.retrieve(datasetId).getProperties(),
+        equalTo(updatedDatasetProperties));
+
     Object unsetDatasetProperties = jsonLoader.loadJson("{}", new TypeReference<>() {});
     DatasetPatchRequestModel patchRequestUnset =
         new DatasetPatchRequestModel().properties(unsetDatasetProperties);

--- a/src/test/resources/dataset-create-with-properties.json
+++ b/src/test/resources/dataset-create-with-properties.json
@@ -1,0 +1,65 @@
+{
+  "name":        "Multiples",
+  "description": "This is a sample dataset definition with multiple tables, relationships and assets",
+  "schema":      {
+    "tables":        [
+      {
+        "name":    "participant",
+        "primaryKey": ["id"],
+        "columns": [
+          {"name": "id", "datatype": "string"},
+          {"name": "age", "datatype": "integer"},
+          {"name": "gender", "datatype": "string"},
+          {"name": "phenotype", "datatype": "string"}
+        ]
+      },
+      {
+        "name":    "sample",
+        "columns": [
+          {"name": "id", "datatype": "string"},
+          {"name": "participant_id", "datatype": "string"},
+          {"name": "date_collected", "datatype": "date"}
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "name": "participant_sample",
+        "from": {"table": "participant", "column": "id"},
+        "to":   {"table": "sample", "column": "participant_id"}
+      },
+      {
+        "name": "parent_with_a_long_pointless_suffix_to_push_the_name_length_over_the_old_limit",
+        "from": {"table": "participant", "column": "id"},
+        "to":   {"table": "participant", "column": "id"}
+      }
+    ],
+    "assets":        [
+      {
+        "name":   "sample",
+        "rootTable": "sample",
+        "rootColumn": "id",
+        "tables": [
+          {"name": "sample", "columns": []},
+          {"name": "participant", "columns": []}
+        ],
+        "follow": [
+          "participant_sample"
+        ]
+      },
+      {
+        "name":   "Trio",
+        "rootTable": "participant",
+        "rootColumn": "id",
+        "tables": [
+          {"name": "participant", "columns": ["id", "age", "gender"]},
+          {"name": "sample", "columns": []}
+        ],
+        "follow": [
+          "participant_sample",
+          "parent_with_a_long_pointless_suffix_to_push_the_name_length_over_the_old_limit"
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/dataset-create-with-properties.json
+++ b/src/test/resources/dataset-create-with-properties.json
@@ -1,65 +1,24 @@
 {
-  "name":        "Multiples",
-  "description": "This is a sample dataset definition with multiple tables, relationships and assets",
-  "schema":      {
-    "tables":        [
+  "name": "DatasetWithProperties",
+  "description": "This is a sample dataset definition with properties",
+  "defaultProfileId": "deadbeef-face-cafe-bead-0ddba11deed5",
+  "schema": {
+    "tables": [
       {
         "name":    "participant",
-        "primaryKey": ["id"],
         "columns": [
           {"name": "id", "datatype": "string"},
-          {"name": "age", "datatype": "integer"},
-          {"name": "gender", "datatype": "string"},
-          {"name": "phenotype", "datatype": "string"}
-        ]
-      },
-      {
-        "name":    "sample",
-        "columns": [
-          {"name": "id", "datatype": "string"},
-          {"name": "participant_id", "datatype": "string"},
-          {"name": "date_collected", "datatype": "date"}
-        ]
-      }
-    ],
-    "relationships": [
-      {
-        "name": "participant_sample",
-        "from": {"table": "participant", "column": "id"},
-        "to":   {"table": "sample", "column": "participant_id"}
-      },
-      {
-        "name": "parent_with_a_long_pointless_suffix_to_push_the_name_length_over_the_old_limit",
-        "from": {"table": "participant", "column": "id"},
-        "to":   {"table": "participant", "column": "id"}
-      }
-    ],
-    "assets":        [
-      {
-        "name":   "sample",
-        "rootTable": "sample",
-        "rootColumn": "id",
-        "tables": [
-          {"name": "sample", "columns": []},
-          {"name": "participant", "columns": []}
-        ],
-        "follow": [
-          "participant_sample"
-        ]
-      },
-      {
-        "name":   "Trio",
-        "rootTable": "participant",
-        "rootColumn": "id",
-        "tables": [
-          {"name": "participant", "columns": ["id", "age", "gender"]},
-          {"name": "sample", "columns": []}
-        ],
-        "follow": [
-          "participant_sample",
-          "parent_with_a_long_pointless_suffix_to_push_the_name_length_over_the_old_limit"
+          {"name": "age", "datatype": "integer"}
         ]
       }
     ]
+  },
+  "properties": {
+    "projectId": "projectId",
+    "authors": ["harry", "ron", "hermionie"],
+    "samples": {
+      "count": 1000,
+      "species": "human"
+    }
   }
 }


### PR DESCRIPTION
This PR adds a new optional "properties" JSON field to datasets that allows users to store additional metadata about a dataset. This can be set when creating a dataset and/or updated using the dataset patch endpoint. Note that the patch endpoint will do a full replace of the value. When getting dataset details, the properties are not included unless `PROPERTIES` is a part of the `includes` list.