### PR TITLE
DR-2581 - [Java 17 Upgrade follow-on] - Fix Test runner actions

### DIFF
--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -26,6 +26,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '17'
+        cache: 'gradle'
     - name: "Fetch current alpha version from /configuration endpoint"
       id: configuration
       run: |

--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -21,6 +21,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: "Setup Java 17"
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
     - name: "Fetch current alpha version from /configuration endpoint"
       id: configuration
       run: |

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -52,6 +52,11 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2
+      - name: "Setup Java 17"
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.1.0
         with:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.1.0
         with:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -52,12 +52,6 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2
-      - name: "Setup Java 17"
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.1.0
         with:

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -16,6 +16,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: "Setup Java 17"
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
       - name: "Fetch current staging version from /configuration endpoint"
         id: configuration
         run: |

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -17,12 +17,6 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
-      - name: "Setup Java 17"
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
       - name: "Fetch latest semantic version from data-repo dev"
         id: "read_property"
         run: |
@@ -39,6 +33,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ steps.read_property.outputs.LATEST_VERSION }}
+      - name: "Setup Java 17"
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
       - name: "Import Vault perf secrets"
         uses: hashicorp/vault-action@v2.1.0
         with:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -17,6 +17,12 @@ jobs:
   test-runner-perf:
     runs-on: ubuntu-latest
     steps:
+      - name: "Setup Java 17"
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
       - name: "Fetch latest semantic version from data-repo dev"
         id: "read_property"
         run: |


### PR DESCRIPTION
Since we're running Gradle commands directly in the GitHub action for perf and alpha tests, we need Java 17 installed on the action VM. Github actions provide a step to do just that - https://github.com/actions/setup-java#supported-distributions. 