### PR TITLE
[DR-2611] NPE on UNDO ingest when attempting to delete landing file

### DIFF
--- a/src/test/resources/test-direct-ingest-auth.json
+++ b/src/test/resources/test-direct-ingest-auth.json
@@ -1,0 +1,16 @@
+{
+  "sample_name":"name",
+  "data_type": "type",
+  "vcf_file_ref": {
+    "description": "A file",
+    "mimeType": "text/plain",
+    "sourcePath": "gs://jade-testdata-fake/vcfs/downsampled/NA12878_PLUMBING_wgs.g.vcf.gz.tbi",
+    "targetPath": "/vcfs/downsampled/wgs/NA12878_PLUMBING.g.vcf.gz"
+  },
+  "vcf_index_file_ref": {
+    "description": "A file",
+    "mimeType": "text/plain",
+    "sourcePath": "gs://jade-testdata-fake/vcfs/downsampled/NA12878_PLUMBING_wgs.g.vcf.gz.tbi",
+    "targetPath": "/vcfs/downsampled/wgs/NA12878_PLUMBING.g.vcf.gz"
+  }
+}


### PR DESCRIPTION
The `deleteLandingFile` is only run on the undo step for direct ingests so I was only able to reproduce the error by doing an “array” type combined ingest where the source bucket is a fake bucket