### PR TITLE
[DR-2607] IamService.verifyAuthorizations checks for several actions

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -183,7 +184,7 @@ public class DatasetsApiController implements DatasetsApi {
   public ResponseEntity<DatasetSummaryModel> patchDataset(
       UUID id, DatasetPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    List<IamAction> actions = datasetService.patchDatasetIamActions(patchRequest);
+    Set<IamAction> actions = datasetService.patchDatasetIamActions(patchRequest);
     iamService.verifyAuthorizations(userReq, IamResourceType.DATASET, id.toString(), actions);
     return new ResponseEntity<>(datasetService.patch(id, patchRequest), HttpStatus.OK);
   }

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -183,9 +183,8 @@ public class DatasetsApiController implements DatasetsApi {
   public ResponseEntity<DatasetSummaryModel> patchDataset(
       UUID id, DatasetPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    for (IamAction action : datasetService.patchDatasetIamActions(patchRequest)) {
-      iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id.toString(), action);
-    }
+    List<IamAction> actions = datasetService.patchDatasetIamActions(patchRequest);
+    iamService.verifyAuthorizations(userReq, IamResourceType.DATASET, id.toString(), actions);
     return new ResponseEntity<>(datasetService.patch(id, patchRequest), HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/app/controller/GlobalExceptionHandler.java
@@ -11,7 +11,6 @@ import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.model.ErrorModel;
 import bio.terra.service.auth.iam.sam.SamIam;
 import bio.terra.service.job.exception.JobResponseException;
-import java.util.Collections;
 import java.util.List;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.slf4j.Logger;
@@ -79,7 +78,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(UnauthorizedException.class)
   @ResponseStatus(HttpStatus.UNAUTHORIZED)
   public ErrorModel samAuthorizationException(UnauthorizedException ex) {
-    return buildErrorModel(ex, Collections.emptyList());
+    return buildErrorModel(ex, ex.getCauses());
   }
 
   // -- job response exception -- we use the JobResponseException to wrap non-runtime exceptions

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -174,7 +174,7 @@ public class SnapshotsApiController implements SnapshotsApi {
   public ResponseEntity<SnapshotSummaryModel> patchSnapshot(
       UUID id, SnapshotPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    List<IamAction> actions = snapshotService.patchSnapshotIamActions(patchRequest);
+    Set<IamAction> actions = snapshotService.patchSnapshotIamActions(patchRequest);
     iamService.verifyAuthorizations(userReq, IamResourceType.DATASNAPSHOT, id.toString(), actions);
     return new ResponseEntity<>(snapshotService.patch(id, patchRequest), HttpStatus.OK);
   }

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -174,9 +174,8 @@ public class SnapshotsApiController implements SnapshotsApi {
   public ResponseEntity<SnapshotSummaryModel> patchSnapshot(
       UUID id, SnapshotPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    for (IamAction action : snapshotService.patchSnapshotIamActions(patchRequest)) {
-      iamService.verifyAuthorization(userReq, IamResourceType.DATASNAPSHOT, id.toString(), action);
-    }
+    List<IamAction> actions = snapshotService.patchSnapshotIamActions(patchRequest);
+    iamService.verifyAuthorizations(userReq, IamResourceType.DATASNAPSHOT, id.toString(), actions);
     return new ResponseEntity<>(snapshotService.patch(id, patchRequest), HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -81,7 +81,7 @@ public interface IamProviderInterface {
    * @param resourceId resource in question
    * @return true if the user has any actions on that resource
    */
-  boolean hasActions(
+  boolean hasAnyActions(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws InterruptedException;
 

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -63,6 +63,16 @@ public interface IamProviderInterface {
       throws InterruptedException;
 
   /**
+   * @param userReq authenticated user
+   * @param iamResourceType resource type
+   * @param resourceId resource in question
+   * @return the user's available actions on that resource
+   */
+  List<String> listActions(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
+      throws InterruptedException;
+
+  /**
    * If user has any action on a resource than we allow that user to list the resource, rather than
    * have a specific action for listing. That is the Sam convention.
    *

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -191,9 +191,9 @@ public class IamService {
    * @param resourceId resource in question
    * @return true if the user has any actions on that resource
    */
-  public boolean hasActions(
+  public boolean hasAnyActions(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId) {
-    return callProvider(() -> iamProvider.hasActions(userReq, iamResourceType, resourceId));
+    return callProvider(() -> iamProvider.hasAnyActions(userReq, iamResourceType, resourceId));
   }
 
   /**

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -184,7 +184,7 @@ public class SamIam implements IamProviderInterface {
   public boolean hasActions(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws InterruptedException {
-    return (listActions(userReq, iamResourceType, resourceId).size() > 0);
+    return listActions(userReq, iamResourceType, resourceId).size() > 0;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -181,7 +181,7 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
-  public boolean hasActions(
+  public boolean hasAnyActions(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws InterruptedException {
     return listActions(userReq, iamResourceType, resourceId).size() > 0;

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -166,20 +166,25 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
-  public boolean hasActions(
+  public List<String> listActions(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws InterruptedException {
     return SamRetry.retry(
-        configurationService, () -> hasActionsInner(userReq, iamResourceType, resourceId));
+        configurationService, () -> listActionsInner(userReq, iamResourceType, resourceId));
   }
 
-  private boolean hasActionsInner(
+  private List<String> listActionsInner(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws ApiException {
     ResourcesApi samResourceApi = samResourcesApi(userReq.getToken());
-    List<String> actionList =
-        samResourceApi.resourceActionsV2(iamResourceType.toString(), resourceId);
-    return (actionList.size() > 0);
+    return samResourceApi.resourceActionsV2(iamResourceType.toString(), resourceId);
+  }
+
+  @Override
+  public boolean hasActions(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
+      throws InterruptedException {
+    return (listActions(userReq, iamResourceType, resourceId).size() > 0);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -63,8 +63,8 @@ import com.azure.storage.blob.sas.BlobSasPermission;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -265,9 +265,8 @@ public class DatasetService {
    * @param patchRequest updates to merge with an existing dataset
    * @return IAM actions needed to apply the requested patch
    */
-  public List<IamAction> patchDatasetIamActions(DatasetPatchRequestModel patchRequest) {
-    List<IamAction> actions = new ArrayList<>();
-    actions.add(IamAction.MANAGE_SCHEMA);
+  public Set<IamAction> patchDatasetIamActions(DatasetPatchRequestModel patchRequest) {
+    Set<IamAction> actions = EnumSet.of(IamAction.MANAGE_SCHEMA);
     if (patchRequest.getPhsId() != null) {
       actions.add(IamAction.UPDATE_PASSPORT_IDENTIFIER);
     }

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -177,7 +177,7 @@ public class ProfileService {
    * @throws IamUnauthorizedException when the caller does not have access to the billing profile
    */
   public BillingProfileModel getProfileById(UUID id, AuthenticatedUserRequest user) {
-    if (!iamService.hasActions(user, IamResourceType.SPEND_PROFILE, id.toString())) {
+    if (!iamService.hasAnyActions(user, IamResourceType.SPEND_PROFILE, id.toString())) {
       throw new IamUnauthorizedException("unauthorized");
     }
     return getProfileByIdNoCheck(id);

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -56,6 +56,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -143,9 +144,8 @@ public class SnapshotService {
    * @param patchRequest updates to merge with an existing snapshot
    * @return IAM actions needed to apply the requested patch
    */
-  public List<IamAction> patchSnapshotIamActions(SnapshotPatchRequestModel patchRequest) {
-    List<IamAction> actions = new ArrayList<>();
-    actions.add(IamAction.UPDATE_SNAPSHOT);
+  public Set<IamAction> patchSnapshotIamActions(SnapshotPatchRequestModel patchRequest) {
+    Set<IamAction> actions = EnumSet.of(IamAction.UPDATE_SNAPSHOT);
     if (patchRequest.getConsentCode() != null) {
       actions.add(IamAction.UPDATE_PASSPORT_IDENTIFIER);
     }

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -153,7 +153,8 @@ public class ConnectedOperations {
     // Mock the billing profile calls
     when(samService.listAuthorizedResources(any(), eq(IamResourceType.SPEND_PROFILE)))
         .thenAnswer(invocation -> uuidsToAuthMap(createdProfileIds));
-    when(samService.hasActions(any(), eq(IamResourceType.SPEND_PROFILE), any())).thenReturn(true);
+    when(samService.hasAnyActions(any(), eq(IamResourceType.SPEND_PROFILE), any()))
+        .thenReturn(true);
 
     doNothing().when(samService).createProfileResource(any(), any());
     doNothing().when(samService).deleteProfileResource(any(), any());

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -18,7 +18,6 @@ import bio.terra.service.configuration.ConfigurationService;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -95,7 +94,7 @@ public class IamServiceTest {
 
     Set<IamAction> hasActions = EnumSet.of(IamAction.MANAGE_SCHEMA, IamAction.READ_DATA);
     when(iamProvider.listActions(authenticatedUserRequest, resourceType, id))
-        .thenReturn(hasActions.stream().map(IamAction::toString).collect(Collectors.toList()));
+        .thenReturn(hasActions.stream().map(IamAction::toString).toList());
 
     // Checking authorizations for actions associated with the caller should not throw.
     iamService.verifyAuthorizations(authenticatedUserRequest, resourceType, id, Set.of());

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -194,15 +194,15 @@ public class SamIamTest {
   }
 
   @Test
-  public void testHasActions() throws ApiException, InterruptedException {
+  public void testHasAnyActions() throws ApiException, InterruptedException {
     when(samResourceApi.resourceActionsV2(
             IamResourceType.SPEND_PROFILE.getSamResourceName(), "my-id-1"))
         .thenReturn(List.of(IamAction.READ_DATA.toString()));
     when(samResourceApi.resourceActionsV2(
             IamResourceType.SPEND_PROFILE.getSamResourceName(), "my-id-2"))
         .thenReturn(List.of());
-    assertTrue(samIam.hasActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-1"));
-    assertFalse(samIam.hasActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-2"));
+    assertTrue(samIam.hasAnyActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-1"));
+    assertFalse(samIam.hasAnyActions(userReq, IamResourceType.SPEND_PROFILE, "my-id-2"));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -1,7 +1,7 @@
 package bio.terra.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.ArgumentMatchers.any;
@@ -87,16 +87,16 @@ public class DatasetServiceUnitTest {
     assertThat(
         "Patch without PHS ID update does not require passport identifier update permissions",
         datasetService.patchDatasetIamActions(new DatasetPatchRequestModel()),
-        contains(IamAction.MANAGE_SCHEMA));
+        containsInAnyOrder(IamAction.MANAGE_SCHEMA));
 
     assertThat(
         "Patch with PHS ID update to empty string requires passport identifier update permissions",
         datasetService.patchDatasetIamActions(new DatasetPatchRequestModel().phsId("")),
-        contains(IamAction.MANAGE_SCHEMA, IamAction.UPDATE_PASSPORT_IDENTIFIER));
+        containsInAnyOrder(IamAction.MANAGE_SCHEMA, IamAction.UPDATE_PASSPORT_IDENTIFIER));
 
     assertThat(
         "Patch with PHS ID update requires passport identifier update permissions",
         datasetService.patchDatasetIamActions(new DatasetPatchRequestModel().phsId("phs123456")),
-        contains(IamAction.MANAGE_SCHEMA, IamAction.UPDATE_PASSPORT_IDENTIFIER));
+        containsInAnyOrder(IamAction.MANAGE_SCHEMA, IamAction.UPDATE_PASSPORT_IDENTIFIER));
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1,8 +1,9 @@
 package bio.terra.service.snapshot;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -315,16 +316,16 @@ public class SnapshotServiceTest {
     assertThat(
         "Patch without consent code update does not require passport identifier update permissions",
         service.patchSnapshotIamActions(new SnapshotPatchRequestModel()),
-        contains(IamAction.UPDATE_SNAPSHOT));
+        containsInAnyOrder(IamAction.UPDATE_SNAPSHOT));
 
     assertThat(
         "Patch with consent code update to empty string requires passport identifier update permissions",
         service.patchSnapshotIamActions(new SnapshotPatchRequestModel().consentCode("")),
-        contains(IamAction.UPDATE_SNAPSHOT, IamAction.UPDATE_PASSPORT_IDENTIFIER));
+        containsInAnyOrder(IamAction.UPDATE_SNAPSHOT, IamAction.UPDATE_PASSPORT_IDENTIFIER));
 
     assertThat(
         "Patch with consent code update requires passport identifier update permissions",
         service.patchSnapshotIamActions(new SnapshotPatchRequestModel().consentCode("c99")),
-        contains(IamAction.UPDATE_SNAPSHOT, IamAction.UPDATE_PASSPORT_IDENTIFIER));
+        containsInAnyOrder(IamAction.UPDATE_SNAPSHOT, IamAction.UPDATE_PASSPORT_IDENTIFIER));
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2607

In a previous PR I added two `PATCH <resource>` endpoints and built out support for modifying passport identifiers (dataset PHS ID, snapshot consent code): https://github.com/DataBiosphere/jade-data-repo/pull/1284

When verifying authorizations in those endpoints, we could make 2 calls to SAM, a call for every action checked.  This PR introduces `IamService.verifyAuthorizations` to perform this check via single call to SAM.  Patch endpoints now use this method.

Note: this new method doesn't leverage a cache, so every call to it will trigger a call to SAM.  Since we only call it within `PATCH <resource>` endpoints which themselves shouldn't be called frequently, we decided that the added complexity of a cache was not worth it at this time.