### PR TITLE
possible list-of-action cache implementation

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -183,9 +183,8 @@ public class DatasetsApiController implements DatasetsApi {
   public ResponseEntity<DatasetSummaryModel> patchDataset(
       UUID id, DatasetPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    for (IamAction action : datasetService.patchDatasetIamActions(patchRequest)) {
-      iamService.verifyAuthorization(userReq, IamResourceType.DATASET, id.toString(), action);
-    }
+    List<IamAction> actions = datasetService.patchDatasetIamActions(patchRequest);
+    iamService.verifyAuthorizations(userReq, IamResourceType.DATASET, id.toString(), actions);
     return new ResponseEntity<>(datasetService.patch(id, patchRequest), HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -174,9 +174,8 @@ public class SnapshotsApiController implements SnapshotsApi {
   public ResponseEntity<SnapshotSummaryModel> patchSnapshot(
       UUID id, SnapshotPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    for (IamAction action : snapshotService.patchSnapshotIamActions(patchRequest)) {
-      iamService.verifyAuthorization(userReq, IamResourceType.DATASNAPSHOT, id.toString(), action);
-    }
+    List<IamAction> actions = snapshotService.patchSnapshotIamActions(patchRequest);
+    iamService.verifyAuthorizations(userReq, IamResourceType.DATASNAPSHOT, id.toString(), actions);
     return new ResponseEntity<>(snapshotService.patch(id, patchRequest), HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -174,7 +174,7 @@ public class SnapshotsApiController implements SnapshotsApi {
   public ResponseEntity<SnapshotSummaryModel> patchSnapshot(
       UUID id, SnapshotPatchRequestModel patchRequest) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    List<IamAction> actions = snapshotService.patchSnapshotIamActions(patchRequest);
+    var actions = snapshotService.patchSnapshotIamActions(patchRequest);
     iamService.verifyAuthorizations(userReq, IamResourceType.DATASNAPSHOT, id.toString(), actions);
     return new ResponseEntity<>(snapshotService.patch(id, patchRequest), HttpStatus.OK);
   }

--- a/src/main/java/bio/terra/service/auth/iam/AuthorizedCacheKey.java
+++ b/src/main/java/bio/terra/service/auth/iam/AuthorizedCacheKey.java
@@ -1,59 +1,6 @@
 package bio.terra.service.auth.iam;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import java.util.Objects;
 
-public class AuthorizedCacheKey {
-  // purpose of this object is to contain 4 objects
-  private AuthenticatedUserRequest userReq;
-  private IamResourceType iamResourceType;
-  private String resourceId;
-  private IamAction action;
-
-  public AuthorizedCacheKey(
-      AuthenticatedUserRequest userReq,
-      IamResourceType iamResourceType,
-      String resourceId,
-      IamAction action) {
-    this.userReq = userReq;
-    this.iamResourceType = iamResourceType;
-    this.resourceId = resourceId;
-    this.action = action;
-  }
-
-  public AuthenticatedUserRequest getUserReq() {
-    return userReq;
-  }
-
-  public IamResourceType getIamResourceType() {
-    return iamResourceType;
-  }
-
-  public String getResourceId() {
-    return resourceId;
-  }
-
-  public IamAction getAction() {
-    return action;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof AuthorizedCacheKey)) {
-      return false;
-    }
-    AuthorizedCacheKey that = (AuthorizedCacheKey) o;
-    return Objects.equals(getUserReq(), that.getUserReq())
-        && getIamResourceType() == that.getIamResourceType()
-        && Objects.equals(getResourceId(), that.getResourceId())
-        && getAction() == that.getAction();
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(getUserReq(), getIamResourceType(), getResourceId(), getAction());
-  }
-}
+public record AuthorizedCacheKey(
+    AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId) {}

--- a/src/main/java/bio/terra/service/auth/iam/AuthorizedCacheValue.java
+++ b/src/main/java/bio/terra/service/auth/iam/AuthorizedCacheValue.java
@@ -1,22 +1,6 @@
 package bio.terra.service.auth.iam;
 
 import java.time.Instant;
+import java.util.Set;
 
-public class AuthorizedCacheValue {
-  // a timeout and a boolean
-  private Instant timeout;
-  private boolean authorized;
-
-  public AuthorizedCacheValue(Instant timeout, boolean authorized) {
-    this.timeout = timeout;
-    this.authorized = authorized;
-  }
-
-  public Instant getTimeout() {
-    return timeout;
-  }
-
-  public boolean isAuthorized() {
-    return authorized;
-  }
-}
+public record AuthorizedCacheValue(Instant timeout, Set<IamAction> actions) {}

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -68,7 +68,7 @@ public interface IamProviderInterface {
    * @param resourceId resource in question
    * @return the user's available actions on that resource
    */
-  List<String> listActions(
+  Set<IamAction> listActions(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws InterruptedException;
 

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -63,6 +63,16 @@ public interface IamProviderInterface {
       throws InterruptedException;
 
   /**
+   * @param userReq authenticated user
+   * @param iamResourceType resource type
+   * @param resourceId resource in question
+   * @return the user's available actions on that resource
+   */
+  List<String> listActions(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
+      throws InterruptedException;
+
+  /**
    * If user has any action on a resource than we allow that user to list the resource, rather than
    * have a specific action for listing. That is the Sam convention.
    *

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -166,18 +166,20 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
-  public List<String> listActions(
+  public Set<IamAction> listActions(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws InterruptedException {
     return SamRetry.retry(
         configurationService, () -> listActionsInner(userReq, iamResourceType, resourceId));
   }
 
-  private List<String> listActionsInner(
+  private Set<IamAction> listActionsInner(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws ApiException {
     ResourcesApi samResourceApi = samResourcesApi(userReq.getToken());
-    return samResourceApi.resourceActionsV2(iamResourceType.toString(), resourceId);
+    return samResourceApi.resourceActionsV2(iamResourceType.toString(), resourceId).stream()
+        .map(IamAction::valueOf)
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -166,20 +166,25 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
-  public boolean hasActions(
+  public List<String> listActions(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws InterruptedException {
     return SamRetry.retry(
-        configurationService, () -> hasActionsInner(userReq, iamResourceType, resourceId));
+        configurationService, () -> listActionsInner(userReq, iamResourceType, resourceId));
   }
 
-  private boolean hasActionsInner(
+  private List<String> listActionsInner(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
       throws ApiException {
     ResourcesApi samResourceApi = samResourcesApi(userReq.getToken());
-    List<String> actionList =
-        samResourceApi.resourceActionsV2(iamResourceType.toString(), resourceId);
-    return (actionList.size() > 0);
+    return samResourceApi.resourceActionsV2(iamResourceType.toString(), resourceId);
+  }
+
+  @Override
+  public boolean hasActions(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId)
+      throws InterruptedException {
+    return (listActions(userReq, iamResourceType, resourceId).size() > 0);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -56,6 +56,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -143,9 +144,8 @@ public class SnapshotService {
    * @param patchRequest updates to merge with an existing snapshot
    * @return IAM actions needed to apply the requested patch
    */
-  public List<IamAction> patchSnapshotIamActions(SnapshotPatchRequestModel patchRequest) {
-    List<IamAction> actions = new ArrayList<>();
-    actions.add(IamAction.UPDATE_SNAPSHOT);
+  public Set<IamAction> patchSnapshotIamActions(SnapshotPatchRequestModel patchRequest) {
+    Set<IamAction> actions = EnumSet.of(IamAction.UPDATE_SNAPSHOT);
     if (patchRequest.getConsentCode() != null) {
       actions.add(IamAction.UPDATE_PASSPORT_IDENTIFIER);
     }

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -16,9 +16,10 @@ import bio.terra.service.auth.iam.exception.IamForbiddenException;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -109,9 +110,9 @@ public class IamServiceTest {
     IamResourceType resourceType = IamResourceType.DATASET;
     String id = ID.toString();
 
-    List<IamAction> hasActions = List.of(IamAction.MANAGE_SCHEMA, IamAction.READ_DATA);
+    Set<IamAction> hasActions = EnumSet.of(IamAction.MANAGE_SCHEMA, IamAction.READ_DATA);
     when(iamProvider.listActions(eq(authenticatedUserRequest), eq(resourceType), eq(id)))
-        .thenReturn(hasActions.stream().map(IamAction::toString).collect(Collectors.toList()));
+        .thenReturn(hasActions);
 
     // Checking authorizations for actions associated with the caller should not throw.
     iamService.verifyAuthorizations(authenticatedUserRequest, resourceType, id, List.of());


### PR DESCRIPTION
Change IamService to cache a list of actions per user instead of a single action. This also has some non-cache related changes to use `Set` instead of `List` and to use `IamAction` instead of `String` in a couple places.

When working on this I saw that there's a single authorization call chain that bypasses the cache, starting at `VerifyAuthorizationStep`. I don't think there's a need for this to bypass the cache but wasn't sure, so I left it in place.

Note that the action cache code in `IamService.isAuthorized` has no coverage in unit tests. It might be good to add some as part of this work.