### PR TITLE
[DR-2560] Add properties field to snapshot

### DIFF
--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -136,7 +136,7 @@ public final class DaoUtils {
         throw new CorruptMetadataException("Invalid properties field");
       }
     } else {
-      return  null;
+      return null;
     }
   }
 }

--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -4,6 +4,7 @@ import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.SqlSortDirection;
 import bio.terra.service.dataset.exception.InvalidDatasetException;
+import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -124,6 +125,18 @@ public final class DaoUtils {
       }
     } else {
       return null;
+    }
+  }
+
+  public static Object stringToProperties(ObjectMapper objectMapper, String properties) {
+    if (properties != null) {
+      try {
+        return objectMapper.readValue(properties, new TypeReference<>() {});
+      } catch (JsonProcessingException e) {
+        throw new CorruptMetadataException("Invalid properties field");
+      }
+    } else {
+      return  null;
     }
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -36,6 +36,7 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
   private List<Relationship> relationships = Collections.emptyList();
   private SnapshotRequestContentsModel creationInformation;
   private String consentCode;
+  private Object properties;
 
   @Override
   public CollectionType getCollectionType() {
@@ -168,6 +169,15 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
 
   public Snapshot consentCode(String consentCode) {
     this.consentCode = consentCode;
+    return this;
+  }
+
+  public Object getProperties() {
+    return properties;
+  }
+
+  public Snapshot properties(Object properties) {
+    this.properties = properties;
     return this;
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -690,12 +690,14 @@ public class SnapshotDao {
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public boolean patch(UUID id, SnapshotPatchRequestModel patchRequest) {
     String sql =
-        "UPDATE snapshot SET consent_code = COALESCE(:consent_code, consent_code) WHERE id = :id";
+        "UPDATE snapshot SET consent_code = COALESCE(:consent_code, consent_code), " +
+            "properties = COALESCE(cast(:properties as jsonb), properties) WHERE id = :id";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("consent_code", patchRequest.getConsentCode())
-            .addValue("id", id);
+            .addValue("id", id)
+            .addValue("properties", DaoUtils.propertiesToString(objectMapper, patchRequest.getProperties()));
 
     int rowsAffected = jdbcTemplate.update(sql, params);
     boolean patchSucceeded = (rowsAffected == 1);

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -169,8 +169,8 @@ public class SnapshotDao {
     logger.debug("createAndLock snapshot " + snapshot.getName());
 
     String sql =
-        "INSERT INTO snapshot (name, description, profile_id, project_resource_id, id, consent_code, flightid, creation_information) "
-            + "VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb) ";
+        "INSERT INTO snapshot (name, description, profile_id, project_resource_id, id, consent_code, flightid, creation_information, properties) "
+            + "VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb, cast(:properties as jsonb)) ";
     String creationInfo;
     try {
       creationInfo = objectMapper.writeValueAsString(snapshot.getCreationInformation());
@@ -187,7 +187,9 @@ public class SnapshotDao {
             .addValue("id", snapshot.getId())
             .addValue("consent_code", snapshot.getConsentCode())
             .addValue("flightid", flightId)
-            .addValue("creation_information", creationInfo);
+            .addValue("creation_information", creationInfo)
+            .addValue(
+                "properties", DaoUtils.propertiesToString(objectMapper, snapshot.getProperties()));
     try {
       jdbcTemplate.update(sql, params);
     } catch (DuplicateKeyException dkEx) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -401,7 +401,8 @@ public class SnapshotDao {
                       .creationInformation(
                           stringToSnapshotRequestContentsModel(
                               rs.getString("creation_information")))
-                      .consentCode(rs.getString("consent_code")));
+                      .consentCode(rs.getString("consent_code"))
+                      .properties(DaoUtils.stringToProperties(objectMapper, rs.getString("properties"))));
       // needed for findbugs. but really can't be null
       if (snapshot != null) {
         // retrieve the snapshot tables and relationships

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -170,7 +170,7 @@ public class SnapshotDao {
 
     String sql =
         "INSERT INTO snapshot (name, description, profile_id, project_resource_id, id, consent_code, flightid, creation_information, properties) "
-            + "VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb, cast(:properties as jsonb)) ";
+            + "VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb, :properties::jsonb) ";
     String creationInfo;
     try {
       creationInfo = objectMapper.writeValueAsString(snapshot.getCreationInformation());
@@ -692,7 +692,7 @@ public class SnapshotDao {
   public boolean patch(UUID id, SnapshotPatchRequestModel patchRequest) {
     String sql =
         "UPDATE snapshot SET consent_code = COALESCE(:consent_code, consent_code), "
-            + "properties = COALESCE(cast(:properties as jsonb), properties) WHERE id = :id";
+            + "properties = COALESCE(:properties::jsonb, properties) WHERE id = :id";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -402,7 +402,8 @@ public class SnapshotDao {
                           stringToSnapshotRequestContentsModel(
                               rs.getString("creation_information")))
                       .consentCode(rs.getString("consent_code"))
-                      .properties(DaoUtils.stringToProperties(objectMapper, rs.getString("properties"))));
+                      .properties(
+                          DaoUtils.stringToProperties(objectMapper, rs.getString("properties"))));
       // needed for findbugs. but really can't be null
       if (snapshot != null) {
         // retrieve the snapshot tables and relationships
@@ -690,14 +691,16 @@ public class SnapshotDao {
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public boolean patch(UUID id, SnapshotPatchRequestModel patchRequest) {
     String sql =
-        "UPDATE snapshot SET consent_code = COALESCE(:consent_code, consent_code), " +
-            "properties = COALESCE(cast(:properties as jsonb), properties) WHERE id = :id";
+        "UPDATE snapshot SET consent_code = COALESCE(:consent_code, consent_code), "
+            + "properties = COALESCE(cast(:properties as jsonb), properties) WHERE id = :id";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("consent_code", patchRequest.getConsentCode())
             .addValue("id", id)
-            .addValue("properties", DaoUtils.propertiesToString(objectMapper, patchRequest.getProperties()));
+            .addValue(
+                "properties",
+                DaoUtils.propertiesToString(objectMapper, patchRequest.getProperties()));
 
     int rowsAffected = jdbcTemplate.update(sql, params);
     boolean patchSucceeded = (rowsAffected == 1);

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -718,6 +718,10 @@ public class SnapshotService {
     if (include.contains(SnapshotRetrieveIncludeModel.CREATION_INFORMATION)) {
       snapshotModel.creationInformation(snapshot.getCreationInformation());
     }
+    if (include.contains(SnapshotRetrieveIncludeModel.PROPERTIES)) {
+      snapshotModel.properties(snapshot.getProperties());
+    }
+
     return snapshotModel;
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -388,7 +388,8 @@ public class SnapshotService {
         .profileId(snapshotRequestModel.getProfileId())
         .relationships(createSnapshotRelationships(dataset.getRelationships(), snapshotSource))
         .creationInformation(requestContents)
-        .consentCode(snapshotRequestModel.getConsentCode());
+        .consentCode(snapshotRequestModel.getConsentCode())
+        .properties(snapshotRequestModel.getProperties());
   }
 
   public List<UUID> getSourceDatasetIdsFromSnapshotRequest(

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4224,6 +4224,9 @@ components:
             type: string
         profileId:
           $ref: '#/components/schemas/UniqueIdProperty'
+        properties:
+          type: object
+          description: Additional JSON metadata about the snapshot (this does not need to adhere to a particular schema)
       description: >
         Request for creating a snapshot.
         For now, the API only supports snapshots defined as a single dataset asset and
@@ -4319,6 +4322,9 @@ components:
       properties:
         consentCode:
           $ref: '#/components/schemas/ConsentCode'
+        properties:
+          type: object
+          description: Additional JSON metadata about the snapshot (this does not need to adhere to a particular schema)
       description: >
         A 'lite' snapshot definition (used to modify supported fields of a snapshot).
         Null assignments will be ignored.
@@ -4326,7 +4332,7 @@ components:
       type: string
       description: >
         Type of information to include in the response
-      enum: [ NONE, SOURCES, TABLES, RELATIONSHIPS, ACCESS_INFORMATION, PROFILE, DATA_PROJECT, CREATION_INFORMATION ]
+      enum: [ NONE, SOURCES, TABLES, RELATIONSHIPS, ACCESS_INFORMATION, PROFILE, PROPERTIES, DATA_PROJECT, CREATION_INFORMATION ]
     SnapshotSummaryModel:
       type: object
       properties:
@@ -4426,6 +4432,9 @@ components:
           $ref: '#/components/schemas/AccessInfoModel'
         creationInformation:
           $ref: '#/components/schemas/SnapshotRequestContentsModel'
+        properties:
+          type: object
+          description: Additional JSON metadata about the snapshot (this does not need to adhere to a particular schema)
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
     SnapshotExportResponseModel:

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -56,5 +56,6 @@
     <include file="changesets/20220411_requiredcolumns.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220511_dropsnapshotmetadata.yml" relativeToChangelogFile="true" />
     <include file="changesets/20220526_datasetproperties.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20220615_snapshotproperties.yaml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20220615_snapshotproperties.yaml
+++ b/src/main/resources/db/changesets/20220615_snapshotproperties.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: snapshot_properties
+      author: sehsan
+      changes:
+        - addColumn:
+            tableName: snapshot
+            columns:
+              name: properties
+              type: jsonb
+              constraints:
+                nullable: true


### PR DESCRIPTION
- Add `properties` JSONB field to snapshot table
- Update the snapshot create, retrieve and patch endpoint to include the new field