### PR TITLE
[DR-2465] Add invalid project retry to IngestFilePrimaryDataStep

### DIFF
--- a/src/main/java/bio/terra/service/filedata/exception/InvalidUserProjectException.java
+++ b/src/main/java/bio/terra/service/filedata/exception/InvalidUserProjectException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.filedata.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+public class InvalidUserProjectException extends BadRequestException {
+  public InvalidUserProjectException(String message) {
+    super(message);
+  }
+
+  public InvalidUserProjectException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InvalidUserProjectException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -150,7 +150,7 @@ public class FileIngestFlight extends Flight {
             randomBackoffRetry);
         addStep(new IngestFileMakeBucketLinkStep(datasetBucketDao, dataset), randomBackoffRetry);
       }
-      addStep(new IngestFilePrimaryDataStep(dataset, gcsPdao, configService));
+      addStep(new IngestFilePrimaryDataStep(dataset, gcsPdao, configService), randomBackoffRetry);
       addStep(new IngestFileFileStep(fileDao, fileService, dataset), randomBackoffRetry);
     } else if (platform.isAzure()) {
       addStep(

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestWorkerFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestWorkerFlight.java
@@ -82,7 +82,7 @@ public class FileIngestWorkerFlight extends Flight {
     if (platform.isGcp()) {
       addStep(new ValidateIngestFileDirectoryStep(fileDao, dataset));
       addStep(new IngestFileDirectoryStep(fileDao, dataset), fileSystemRetry);
-      addStep(new IngestFilePrimaryDataStep(dataset, gcsPdao, configService));
+      addStep(new IngestFilePrimaryDataStep(dataset, gcsPdao, configService), fileSystemRetry);
       addStep(new IngestFileFileStep(fileDao, fileService, dataset), fileSystemRetry);
     } else if (platform.isAzure()) {
       addStep(new ValidateIngestFileAzureDirectoryStep(azureTableDao, dataset), fileSystemRetry);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
@@ -60,6 +60,8 @@ public class IngestFilePrimaryDataStep implements Step {
         }
         workingMap.put(FileMapKeys.FILE_INFO, fsFileInfo);
       } catch (InvalidUserProjectException ex) {
+        // We retry this exception because often when we've seen this error it has been transient
+        // and untruthful -- i.e. the user project specified exists and has a legal id.
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
       }
     }

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
@@ -1,0 +1,115 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.exception.PdaoFileCopyException;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.exception.InvalidUserProjectException;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.UUID;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class IngestFilePrimaryDataStepTest extends TestCase {
+
+  @MockBean private GcsPdao gcsPdao;
+
+  @MockBean private Dataset dataset;
+
+  @MockBean private ConfigurationService configService;
+
+  private IngestFilePrimaryDataStep step;
+
+  private FlightContext flightContext;
+
+  @Before
+  public void setup() {
+    step = new IngestFilePrimaryDataStep(dataset, gcsPdao, configService);
+    flightContext = mock(FlightContext.class);
+
+    FlightMap inputParameters = new FlightMap();
+    inputParameters.put(
+        FileMapKeys.BUCKET_INFO, new GoogleBucketResource().resourceId(UUID.randomUUID()));
+    when(flightContext.getInputParameters()).thenReturn(inputParameters);
+
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(FileMapKeys.FILE_ID, UUID.randomUUID().toString());
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+
+    GoogleProjectResource projectResource =
+        new GoogleProjectResource().googleProjectId("googleProjectId");
+    when(dataset.getProjectResource()).thenReturn(projectResource);
+  }
+
+  @Test
+  public void testDoStepSelfHostedRetry() {
+    when(dataset.isSelfHosted()).thenReturn(true);
+    when(gcsPdao.linkSelfHostedFile(any(), any(), any()))
+        .thenThrow(new InvalidUserProjectException("retryable"));
+
+    StepResult result = step.doStep(flightContext);
+    verify(gcsPdao, times(1)).linkSelfHostedFile(any(), any(), any());
+    assertThat(
+        "step failed and should be retried",
+        StepStatus.STEP_RESULT_FAILURE_RETRY,
+        equalTo(result.getStepStatus()));
+  }
+
+  @Test
+  public void testDoStepExternallyHostedRetry() {
+    when(gcsPdao.copyFile(any(), any(), any(), any()))
+        .thenThrow(new InvalidUserProjectException("retryable"));
+
+    StepResult result = step.doStep(flightContext);
+    verify(gcsPdao, times(1)).copyFile(any(), any(), any(), any());
+    assertThat(
+        "Step failed and should be retried",
+        StepStatus.STEP_RESULT_FAILURE_RETRY,
+        equalTo(result.getStepStatus()));
+  }
+
+  @Test
+  public void testDoStepExternallyHostedSuccess() {
+    when(gcsPdao.copyFile(any(), any(), any(), any())).thenReturn(null);
+
+    StepResult result = step.doStep(flightContext);
+    verify(gcsPdao, times(1)).copyFile(any(), any(), any(), any());
+    assertThat("Step succeeded", StepStatus.STEP_RESULT_SUCCESS, equalTo(result.getStepStatus()));
+  }
+
+  @Test
+  public void testDoStepExternallyHostedFailureThrows() {
+    String errorMessage = "failure";
+    when(gcsPdao.copyFile(any(), any(), any(), any()))
+        .thenThrow(new PdaoFileCopyException(errorMessage));
+
+    PdaoFileCopyException thrown =
+        assertThrows(
+            PdaoFileCopyException.class,
+            () -> step.doStep(flightContext),
+            "Step throws unretriable exception");
+    verify(gcsPdao, times(1)).copyFile(any(), any(), any(), any());
+    assertThat("Error message reflects cause", thrown.getMessage(), equalTo(errorMessage));
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2645

**Objective**

This PR introduces a new exception for targeted retry handling within `IngestFilePrimaryDataStep`.

**Background**

Periodically in performance tests as well as in production, `IngestFilePrimaryDataStep` in `FileIngestFlight` fails with an exception like this:

```
Step Result exception
bio.terra.common.exception.PdaoFileCopyException: File ingest failed
	at bio.terra.service.filedata.google.gcs.GcsPdao.copyFile(GcsPdao.java:441)
	at bio.terra.service.filedata.flight.ingest.IngestFilePrimaryDataStep.doStep(IngestFilePrimaryDataStep.java:55)
	at bio.terra.stairway.impl.FlightRunner.stepWithRetry(FlightRunner.java:248)
	at bio.terra.stairway.impl.FlightRunner.runSteps(FlightRunner.java:179)
	at bio.terra.stairway.impl.FlightRunner.fly(FlightRunner.java:110)
	at bio.terra.stairway.impl.FlightRunner.run(FlightRunner.java:68)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: com.google.cloud.storage.StorageException: User project specified in the request is invalid.
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.translate(HttpStorageRpc.java:286)
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.get(HttpStorageRpc.java:511)
	at com.google.cloud.storage.StorageImpl.lambda$get$6(StorageImpl.java:281)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:103)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.storage.Retrying.run(Retrying.java:54)
	at com.google.cloud.storage.StorageImpl.run(StorageImpl.java:1376)
	at com.google.cloud.storage.StorageImpl.get(StorageImpl.java:280)
	at bio.terra.service.filedata.google.gcs.GcsPdao.getBlobFromGsPath(GcsPdao.java:584)
	at bio.terra.service.filedata.google.gcs.GcsPdao.copyFile(GcsPdao.java:385)
	... 10 common frames omitted
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
GET https://storage.googleapis.com/storage/v1/b/jade-testdata/o/loadtest%2Ffile100B-07.txt?projection=full&userProject=datarepo-tools-5e21fdd6
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "User project specified in the request is invalid.",
    "reason" : "invalid"
  } ],
  "message" : "User project specified in the request is invalid."
}
```

This exception is transient and untruthful: when we've investigated, the project in question exists and has a valid ID.

Previous occurrences logged here: https://broadworkbench.atlassian.net/browse/DR-2595

**Code Changes**

- Introduced new exception `InvalidUserProjectException`, thrown when we encounter the exception above
- Modified `gcsPdao` calls which previously could have thrown this exception within `IngestFilePrimaryDataStep`
- Added retry rules to flights which include `IngestFilePrimaryDataStep`
- Added unit tests around retry handling

If anyone has guidance around verifying this behavior manually, I'd appreciate it!
