### PR TITLE
[DR-2558] Add filtering to snapshot preview endpoint

### DIFF
--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -68,6 +68,7 @@ expr : number
 
 column_expr : dataset_name '.' table_name '.' column_name
     | alias_name '.' column_name
+    | column_name
     ;
 
 join_type : INNER

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -267,7 +267,8 @@ public class SnapshotsApiController implements SnapshotsApi {
       Integer offset,
       Integer limit,
       String sort,
-      SqlSortDirection direction) {
+      SqlSortDirection direction,
+      String filter) {
     logger.info("Verifying user access");
     iamService.verifyAuthorization(
         getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id.toString(), IamAction.READ_DATA);
@@ -275,7 +276,7 @@ public class SnapshotsApiController implements SnapshotsApi {
     // TODO: Remove after https://broadworkbench.atlassian.net/browse/DR-2588 is fixed
     SqlSortDirection sortDirection = Objects.requireNonNullElse(direction, SqlSortDirection.ASC);
     SnapshotPreviewModel previewModel =
-        snapshotService.retrievePreview(id, table, limit, offset, sort, sortDirection);
+        snapshotService.retrievePreview(id, table, limit, offset, sort, sortDirection, filter);
     return new ResponseEntity<>(previewModel, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -421,7 +421,8 @@ public class SnapshotService {
       int limit,
       int offset,
       String sort,
-      SqlSortDirection direction) {
+      SqlSortDirection direction,
+      String filter) {
     Snapshot snapshot = retrieve(snapshotId);
 
     SnapshotTable table =
@@ -444,7 +445,7 @@ public class SnapshotService {
     try {
       List<Map<String, Object>> values =
           bigQuerySnapshotPdao.getSnapshotTable(
-              snapshot, tableName, limit, offset, sort, direction);
+              snapshot, tableName, limit, offset, sort, direction, filter);
 
       return new SnapshotPreviewModel().result(List.copyOf(values));
     } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -78,6 +78,7 @@ public class SnapshotService {
   private final FireStoreDependencyDao dependencyDao;
   private final BigQuerySnapshotPdao bigQuerySnapshotPdao;
   private final SnapshotDao snapshotDao;
+  private final SnapshotTableDao snapshotTableDao;
   private final MetadataDataAccessUtils metadataDataAccessUtils;
 
   @Autowired
@@ -87,12 +88,14 @@ public class SnapshotService {
       FireStoreDependencyDao dependencyDao,
       BigQuerySnapshotPdao bigQuerySnapshotPdao,
       SnapshotDao snapshotDao,
+      SnapshotTableDao snapshotTableDao,
       MetadataDataAccessUtils metadataDataAccessUtils) {
     this.jobService = jobService;
     this.datasetService = datasetService;
     this.dependencyDao = dependencyDao;
     this.bigQuerySnapshotPdao = bigQuerySnapshotPdao;
     this.snapshotDao = snapshotDao;
+    this.snapshotTableDao = snapshotTableDao;
     this.metadataDataAccessUtils = metadataDataAccessUtils;
   }
 
@@ -442,10 +445,13 @@ public class SnapshotService {
                       "No snapshot table column exists with the name: " + sort));
     }
 
+    List<String> columns =
+        snapshotTableDao.retrieveColumns(table).stream().map(Column::getName).toList();
+
     try {
       List<Map<String, Object>> values =
           bigQuerySnapshotPdao.getSnapshotTable(
-              snapshot, tableName, limit, offset, sort, direction, filter);
+              snapshot, tableName, columns, limit, offset, sort, direction, filter);
 
       return new SnapshotPreviewModel().result(List.copyOf(values));
     } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
@@ -118,7 +118,7 @@ public class SnapshotTableDao {
         });
   }
 
-  private List<Column> retrieveColumns(Table table) {
+  public List<Column> retrieveColumns(Table table) {
     return jdbcTemplate.query(
         sqlSelectColumn,
         new MapSqlParameterSource().addValue("table_id", table.getId()),

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -758,6 +758,11 @@ paths:
           schema:
             default: asc
             $ref: '#/components/schemas/SqlSortDirection'
+        - name: filter
+          in: query
+          description: A SQL WHERE clause to filter the table results.
+          schema:
+            type: string
       responses:
         200:
           description: Returns the table data from a snapshot

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -49,6 +49,7 @@ public class SearchApiControllerTest {
   private static final SqlSortDirection DIRECTION = SqlSortDirection.ASC;
   private static final int LIMIT = 10;
   private static final int OFFSET = 0;
+  private static final String FILTER = null;
 
   @Autowired private MockMvc mvc;
 
@@ -62,7 +63,7 @@ public class SearchApiControllerTest {
       throws Exception {
     var list = List.of("hello", "world");
     var result = new SnapshotPreviewModel().result(List.copyOf(list));
-    when(snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION))
+    when(snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION, FILTER))
         .thenReturn(result);
     mvc.perform(
             get(GET_PREVIEW_ENDPOINT, id, table)
@@ -75,7 +76,7 @@ public class SearchApiControllerTest {
   }
 
   private void mockSnapshotPreviewByIdError(UUID id, String table, String column) throws Exception {
-    when(snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION))
+    when(snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION, FILTER))
         .thenThrow(SnapshotPreviewException.class);
     mvc.perform(
             get(GET_PREVIEW_ENDPOINT, id, table)
@@ -95,7 +96,7 @@ public class SearchApiControllerTest {
     verify(iamService)
         .verifyAuthorization(
             any(), eq(IamResourceType.DATASNAPSHOT), eq(id.toString()), eq(IamAction.READ_DATA));
-    verify(snapshotService).retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION);
+    verify(snapshotService).retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION, FILTER);
   }
 
   @Test
@@ -107,7 +108,7 @@ public class SearchApiControllerTest {
     verify(iamService)
         .verifyAuthorization(
             any(), eq(IamResourceType.DATASNAPSHOT), eq(id.toString()), eq(IamAction.READ_DATA));
-    verify(snapshotService).retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION);
+    verify(snapshotService).retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION, FILTER);
   }
 
   @Test(expected = SnapshotPreviewException.class)
@@ -119,7 +120,7 @@ public class SearchApiControllerTest {
     verify(iamService)
         .verifyAuthorization(
             any(), eq(IamResourceType.DATASNAPSHOT), eq(id.toString()), eq(IamAction.READ_DATA));
-    snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION);
+    snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION, FILTER);
   }
 
   @Test(expected = SnapshotPreviewException.class)
@@ -131,7 +132,7 @@ public class SearchApiControllerTest {
     verify(iamService)
         .verifyAuthorization(
             any(), eq(IamResourceType.DATASNAPSHOT), eq(id.toString()), eq(IamAction.READ_DATA));
-    snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION);
+    snapshotService.retrievePreview(id, table, LIMIT, OFFSET, column, DIRECTION, FILTER);
   }
 
   @Test

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -855,6 +855,19 @@ public class ConnectedOperations {
     return TestUtils.mapFromJson(response.getContentAsString(), SnapshotPreviewModel.class);
   }
 
+  public ErrorModel retrieveSnapshotPreviewByIdFailure(
+      UUID snapshotId,
+      String tableName,
+      int limit,
+      int offset,
+      String filter,
+      HttpStatus expectedStatus)
+      throws Exception {
+    MockHttpServletResponse response =
+        retrieveSnapshotPreviewByIdRaw(snapshotId, tableName, limit, offset, filter);
+    return handleFailureCase(response, expectedStatus);
+  }
+
   /*
    * WARNING: if making any changes to this method make sure to notify the #dsp-batch channel! Describe the change and
    * any consequences downstream to DRS clients.

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -834,22 +834,23 @@ public class ConnectedOperations {
   }
 
   public MockHttpServletResponse retrieveSnapshotPreviewByIdRaw(
-      UUID snapshotId, String tableName, int limit, int offset) throws Exception {
+      UUID snapshotId, String tableName, int limit, int offset, String filter) throws Exception {
     String url = "/api/repository/v1/snapshots/{id}/data/{table}";
-    MvcResult result =
-        mvc.perform(
-                get(url, snapshotId, tableName)
-                    .param("limit", String.valueOf(limit))
-                    .param("offset", String.valueOf(offset)))
-            .andReturn();
-
+    MockHttpServletRequestBuilder request =
+        get(url, snapshotId, tableName)
+            .param("limit", String.valueOf(limit))
+            .param("offset", String.valueOf(offset));
+    if (filter != null) {
+      request.param("filter", filter);
+    }
+    MvcResult result = mvc.perform(request).andReturn();
     return result.getResponse();
   }
 
   public SnapshotPreviewModel retrieveSnapshotPreviewByIdSuccess(
-      UUID snapshotId, String tableName, int limit, int offset) throws Exception {
+      UUID snapshotId, String tableName, int limit, int offset, String filter) throws Exception {
     MockHttpServletResponse response =
-        retrieveSnapshotPreviewByIdRaw(snapshotId, tableName, limit, offset);
+        retrieveSnapshotPreviewByIdRaw(snapshotId, tableName, limit, offset, filter);
     assertThat(response.getStatus(), equalTo(HttpStatus.OK.value()));
     return TestUtils.mapFromJson(response.getContentAsString(), SnapshotPreviewModel.class);
   }

--- a/src/test/java/bio/terra/grammar/GrammarTest.java
+++ b/src/test/java/bio/terra/grammar/GrammarTest.java
@@ -118,10 +118,11 @@ public class GrammarTest {
     Query.parse("SELECT * FROM 1000GenomesDataset.sample_info");
   }
 
-  @Test(expected = InvalidQueryException.class)
+  @Test
   public void testColumnNotFullyQualifiedName() {
-    // note that the col `datarepo_row_id` does not have a table or dataset attached
+    // allow non-fully qualified column names to support preview filtering
     Query.parse("SELECT datarepo_row_id FROM foo.bar, baz.quux WHERE foo.bar.x = baz.quux.y");
+    Query.parse("SELECT * FROM snapshot.table WHERE column = val");
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTestUtils.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTestUtils.java
@@ -147,10 +147,11 @@ public class SnapshotConnectedTestUtils {
       UUID snapshotId,
       String tableName,
       int limit,
-      int offset)
+      int offset,
+      String filter)
       throws Exception {
     return connectedOperations.retrieveSnapshotPreviewByIdSuccess(
-        snapshotId, tableName, limit, offset);
+        snapshotId, tableName, limit, offset, filter);
   }
 
   static void loadCsvData(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTestUtils.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTestUtils.java
@@ -13,6 +13,7 @@ import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.Names;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.ErrorModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotPreviewModel;
@@ -31,6 +32,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import java.util.UUID;
 import org.apache.commons.io.IOUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
@@ -152,6 +154,19 @@ public class SnapshotConnectedTestUtils {
       throws Exception {
     return connectedOperations.retrieveSnapshotPreviewByIdSuccess(
         snapshotId, tableName, limit, offset, filter);
+  }
+
+  static ErrorModel getTablePreviewFailure(
+      ConnectedOperations connectedOperations,
+      UUID snapshotId,
+      String tableName,
+      int limit,
+      int offset,
+      String filter,
+      HttpStatus expectedStatus)
+      throws Exception {
+    return connectedOperations.retrieveSnapshotPreviewByIdFailure(
+        snapshotId, tableName, limit, offset, filter, expectedStatus);
   }
 
   static void loadCsvData(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -92,23 +92,23 @@ public class SnapshotIntegrationTest extends UsersBase {
 
   @After
   public void tearDown() throws Exception {
-    //    createdSnapshotIds.forEach(
-    //        snapshot -> {
-    //          try {
-    //            dataRepoFixtures.deleteSnapshot(steward(), snapshot);
-    //          } catch (Exception ex) {
-    //            logger.warn("cleanup failed when deleting snapshot " + snapshot);
-    //            ex.printStackTrace();
-    //          }
-    //        });
-    //
-    //    if (datasetId != null) {
-    //      dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
-    //    }
-    //
-    //    if (profileId != null) {
-    //      dataRepoFixtures.deleteProfileLog(steward(), profileId);
-    //    }
+    createdSnapshotIds.forEach(
+        snapshot -> {
+          try {
+            dataRepoFixtures.deleteSnapshot(steward(), snapshot);
+          } catch (Exception ex) {
+            logger.warn("cleanup failed when deleting snapshot " + snapshot);
+            ex.printStackTrace();
+          }
+        });
+
+    if (datasetId != null) {
+      dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
+    }
+
+    if (profileId != null) {
+      dataRepoFixtures.deleteProfileLog(steward(), profileId);
+    }
   }
 
   @Test
@@ -229,8 +229,6 @@ public class SnapshotIntegrationTest extends UsersBase {
     TimeUnit.SECONDS.sleep(10);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    //    dataRepoFixtures.addSnapshotPolicyMember(
-    //        steward(), snapshot.getId(), IamRole.STEWARD, "saman.firecloud@gmail.com");
     assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
     assertEquals("the relationship comes through", 1, snapshot.getRelationships().size());
   }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -92,23 +92,23 @@ public class SnapshotIntegrationTest extends UsersBase {
 
   @After
   public void tearDown() throws Exception {
-    createdSnapshotIds.forEach(
-        snapshot -> {
-          try {
-            dataRepoFixtures.deleteSnapshot(steward(), snapshot);
-          } catch (Exception ex) {
-            logger.warn("cleanup failed when deleting snapshot " + snapshot);
-            ex.printStackTrace();
-          }
-        });
-
-    if (datasetId != null) {
-      dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
-    }
-
-    if (profileId != null) {
-      dataRepoFixtures.deleteProfileLog(steward(), profileId);
-    }
+    //    createdSnapshotIds.forEach(
+    //        snapshot -> {
+    //          try {
+    //            dataRepoFixtures.deleteSnapshot(steward(), snapshot);
+    //          } catch (Exception ex) {
+    //            logger.warn("cleanup failed when deleting snapshot " + snapshot);
+    //            ex.printStackTrace();
+    //          }
+    //        });
+    //
+    //    if (datasetId != null) {
+    //      dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
+    //    }
+    //
+    //    if (profileId != null) {
+    //      dataRepoFixtures.deleteProfileLog(steward(), profileId);
+    //    }
   }
 
   @Test
@@ -229,6 +229,8 @@ public class SnapshotIntegrationTest extends UsersBase {
     TimeUnit.SECONDS.sleep(10);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
+    //    dataRepoFixtures.addSnapshotPolicyMember(
+    //        steward(), snapshot.getId(), IamRole.STEWARD, "saman.firecloud@gmail.com");
     assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
     assertEquals("the relationship comes through", 1, snapshot.getRelationships().size());
   }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
@@ -168,18 +168,14 @@ public class SnapshotMinimalConnectedTest {
             connectedOperations, summaryModel.getId(), "participant", 10, 0, "WHERE age > 1");
 
     assertThat(
-        "participant preview has one record",
-        snapshotPreviewModel.getResult().size(),
-        equalTo(1));
+        "participant preview has one record", snapshotPreviewModel.getResult().size(), equalTo(1));
 
     SnapshotPreviewModel snapshotEmptyPreviewModel =
         SnapshotConnectedTestUtils.getTablePreview(
             connectedOperations, summaryModel.getId(), "participant", 10, 0, "WHERE age > 23");
 
     assertThat(
-        "participant preview is empty",
-        snapshotEmptyPreviewModel.getResult().size(),
-        equalTo(0));
+        "participant preview is empty", snapshotEmptyPreviewModel.getResult().size(), equalTo(0));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.snapshot;
 import static bio.terra.common.PdaoConstant.PDAO_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
@@ -12,6 +13,7 @@ import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.ErrorModel;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotPreviewModel;
@@ -163,6 +165,7 @@ public class SnapshotMinimalConnectedTest {
     SnapshotSummaryModel summaryModel =
         SnapshotConnectedTestUtils.validateSnapshotCreated(
             connectedOperations, snapshotRequest, response);
+
     SnapshotPreviewModel snapshotPreviewModel =
         SnapshotConnectedTestUtils.getTablePreview(
             connectedOperations, summaryModel.getId(), "participant", 10, 0, "WHERE age > 1");
@@ -176,6 +179,21 @@ public class SnapshotMinimalConnectedTest {
 
     assertThat(
         "participant preview is empty", snapshotEmptyPreviewModel.getResult().size(), equalTo(0));
+
+    String joinClause = "JOIN " + summaryModel.getName() + ".sample ON sample.participant_id = id";
+    ErrorModel snapshotPreviewError =
+        SnapshotConnectedTestUtils.getTablePreviewFailure(
+            connectedOperations,
+            summaryModel.getId(),
+            "participant",
+            10,
+            0,
+            joinClause,
+            HttpStatus.INTERNAL_SERVER_ERROR);
+
+    assertTrue(
+        "JOIN with sample table fails",
+        snapshotPreviewError.getMessage().contains("Failure executing query"));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
@@ -143,12 +143,43 @@ public class SnapshotMinimalConnectedTest {
 
     SnapshotPreviewModel snapshotPreviewModel =
         SnapshotConnectedTestUtils.getTablePreview(
-            connectedOperations, summaryModel.getId(), "participant", 10, 0);
+            connectedOperations, summaryModel.getId(), "participant", 10, 0, null);
 
     assertThat(
         "participant has the correct age",
         ((LinkedHashMap) snapshotPreviewModel.getResult().get(0)).get("age"),
         equalTo("23"));
+  }
+
+  @Test
+  public void testPreview() throws Exception {
+    DatasetSummaryModel datasetMinimalSummary = setupMinimalDataset();
+    SnapshotRequestModel snapshotRequest =
+        SnapshotConnectedTestUtils.makeSnapshotTestRequest(
+            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot.json");
+    MockHttpServletResponse response =
+        SnapshotConnectedTestUtils.performCreateSnapshot(
+            connectedOperations, mvc, snapshotRequest, "");
+    SnapshotSummaryModel summaryModel =
+        SnapshotConnectedTestUtils.validateSnapshotCreated(
+            connectedOperations, snapshotRequest, response);
+    SnapshotPreviewModel snapshotPreviewModel =
+        SnapshotConnectedTestUtils.getTablePreview(
+            connectedOperations, summaryModel.getId(), "participant", 10, 0, "WHERE age > 1");
+
+    assertThat(
+        "participant preview has one record",
+        snapshotPreviewModel.getResult().size(),
+        equalTo(1));
+
+    SnapshotPreviewModel snapshotEmptyPreviewModel =
+        SnapshotConnectedTestUtils.getTablePreview(
+            connectedOperations, summaryModel.getId(), "participant", 10, 0, "WHERE age > 23");
+
+    assertThat(
+        "participant preview is empty",
+        snapshotEmptyPreviewModel.getResult().size(),
+        equalTo(0));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -86,6 +86,7 @@ public class SnapshotServiceTest {
   @MockBean private AzureBlobStorePdao azureBlobStorePdao;
   @MockBean private ProfileService profileService;
   @MockBean private SnapshotDao snapshotDao;
+  @MockBean private SnapshotTableDao snapshotTableDao;
 
   private final UUID snapshotId = UUID.randomUUID();
   private final UUID datasetId = UUID.randomUUID();


### PR DESCRIPTION
Add a new `filter` query parameter to the GET `/api/repository/v1/snapshots/{id}/data/{table}` endpoint to allow users to filter the results based on a SQL "where" clause. E.g. `WHERE age > 1 AND age < 60`. The input is parsed according to the ANTLR query definition before it is executed in BigQuery.