### PR TITLE
DR-2656: Retry Google Internal Server Error

### DIFF
--- a/src/main/java/bio/terra/service/filedata/exception/GoogleInternalServerErrorException.java
+++ b/src/main/java/bio/terra/service/filedata/exception/GoogleInternalServerErrorException.java
@@ -1,0 +1,13 @@
+package bio.terra.service.filedata.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class GoogleInternalServerErrorException extends InternalServerErrorException {
+  public GoogleInternalServerErrorException(String message) {
+    super(message);
+  }
+
+  public GoogleInternalServerErrorException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
@@ -8,6 +8,7 @@ import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FSFileInfo;
+import bio.terra.service.filedata.exception.GoogleInternalServerErrorException;
 import bio.terra.service.filedata.exception.InvalidUserProjectException;
 import bio.terra.service.filedata.flight.FileMapKeys;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
@@ -62,6 +63,9 @@ public class IngestFilePrimaryDataStep implements Step {
       } catch (InvalidUserProjectException ex) {
         // We retry this exception because often when we've seen this error it has been transient
         // and untruthful -- i.e. the user project specified exists and has a legal id.
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+      } catch (GoogleInternalServerErrorException ex) {
+        // Google's error message suggests retrying the operation
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
       }
     }

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
@@ -68,12 +68,14 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
   public void testDoStepSelfHostedRetryThenSucceed() {
     // Dataset is self-hosted
     when(dataset.isSelfHosted()).thenReturn(true);
-    // Step Run 1 - throws retryable "InvalidUserProjectException" exception
+    // Step throws two retryable exceptions then succeeds
     FSFileInfo fileInfo = mock(FSFileInfo.class);
     when(gcsPdao.linkSelfHostedFile(any(), any(), any()))
         .thenThrow(new InvalidUserProjectException("retryable"))
+        .thenThrow(new GoogleInternalServerErrorException("retryable"))
         .thenReturn(fileInfo);
 
+    // 1 - throws retryable "InvalidUserProjectException" exception
     StepResult result = step.doStep(flightContext);
     verify(gcsPdao, times(1)).linkSelfHostedFile(any(), any(), any());
     assertThat(
@@ -81,11 +83,7 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
         StepStatus.STEP_RESULT_FAILURE_RETRY,
         equalTo(result.getStepStatus()));
 
-    // Step Run 2 - throws retryable "GoogleInternalServerErrorException" exception
-    when(gcsPdao.linkSelfHostedFile(any(), any(), any()))
-        .thenThrow(new GoogleInternalServerErrorException("retryable"))
-        .thenReturn(fileInfo);
-
+    // 2 - throws retryable "GoogleInternalServerErrorException" exception
     result = step.doStep(flightContext);
     verify(gcsPdao, times(2)).linkSelfHostedFile(any(), any(), any());
     assertThat(
@@ -93,7 +91,7 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
         StepStatus.STEP_RESULT_FAILURE_RETRY,
         equalTo(result.getStepStatus()));
 
-    // Step Run 3 - Succeeds
+    // 3 - Succeeds
     result = step.doStep(flightContext);
     verify(gcsPdao, times(3)).linkSelfHostedFile(any(), any(), any());
     assertThat(
@@ -107,8 +105,10 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
     FSFileInfo fileInfo = mock(FSFileInfo.class);
     when(gcsPdao.copyFile(any(), any(), any(), any()))
         .thenThrow(new InvalidUserProjectException("retryable"))
+        .thenThrow(new GoogleInternalServerErrorException("retryable"))
         .thenReturn(fileInfo);
 
+    // 1 - throws retryable "InvalidUserProjectException" exception
     StepResult result = step.doStep(flightContext);
     verify(gcsPdao, times(1)).copyFile(any(), any(), any(), any());
     assertThat(
@@ -116,11 +116,7 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
         StepStatus.STEP_RESULT_FAILURE_RETRY,
         equalTo(result.getStepStatus()));
 
-    // Step Run 2 - throws retryable "GoogleInternalServerErrorException" exception
-    when(gcsPdao.copyFile(any(), any(), any(), any()))
-        .thenThrow(new GoogleInternalServerErrorException("retryable"))
-        .thenReturn(fileInfo);
-
+    // 2 - throws retryable "GoogleInternalServerErrorException" exception
     result = step.doStep(flightContext);
     verify(gcsPdao, times(2)).copyFile(any(), any(), any(), any());
     assertThat(
@@ -128,7 +124,7 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
         StepStatus.STEP_RESULT_FAILURE_RETRY,
         equalTo(result.getStepStatus()));
 
-    // Step Run 3 - Succeeds
+    // 3 - Succeeds
     result = step.doStep(flightContext);
     verify(gcsPdao, times(3)).copyFile(any(), any(), any(), any());
     assertThat(

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
@@ -101,8 +101,8 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
   @Test
   public void testDoStepExternallyHostedRetryThenSucceed() {
     // Dataset is externally hosted by default
-    // Step Run 1 - throws retryable "InvalidUserProjectException" exception
     FSFileInfo fileInfo = mock(FSFileInfo.class);
+    // Step throws two retryable exceptions then succeeds
     when(gcsPdao.copyFile(any(), any(), any(), any()))
         .thenThrow(new InvalidUserProjectException("retryable"))
         .thenThrow(new GoogleInternalServerErrorException("retryable"))


### PR DESCRIPTION
**Background**
We’ve now seen a few cases of google returning 503 exceptions with the message “We encountered an internal error. Please try again.” We know in particular this is happening on the GcsPdao.copyFile() operation. Yesterday, we had a user that had to just keep retrying their ingest until eventually all of the files were successfully ingested. We should take this burden off of the user and we should handle the retry process. 
