### PR TITLE
DR-2664 - Asset Validation should allow null `follow` parameter

### DIFF
--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -132,12 +132,14 @@ public class Dataset implements FSContainerInterface, LogPrintable {
 
     // Follow should reference an existing relationship as defined in the original dataset create
     // query
-    for (var assetFollow : assetModel.getFollow()) {
-      if (!relationships.stream().anyMatch(r -> r.getName().equals(assetFollow))) {
-        errors.add(
-            "Relationship specified in follow list '"
-                + assetFollow
-                + "' does not exist in dataset's list of relationships");
+    if (assetModel.getFollow() != null) {
+      for (var assetFollow : assetModel.getFollow()) {
+        if (!relationships.stream().anyMatch(r -> r.getName().equals(assetFollow))) {
+          errors.add(
+              "Relationship specified in follow list '"
+                  + assetFollow
+                  + "' does not exist in dataset's list of relationships");
+        }
       }
     }
 

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class Dataset implements FSContainerInterface, LogPrintable {
@@ -132,14 +133,12 @@ public class Dataset implements FSContainerInterface, LogPrintable {
 
     // Follow should reference an existing relationship as defined in the original dataset create
     // query
-    if (assetModel.getFollow() != null) {
-      for (var assetFollow : assetModel.getFollow()) {
-        if (!relationships.stream().anyMatch(r -> r.getName().equals(assetFollow))) {
-          errors.add(
-              "Relationship specified in follow list '"
-                  + assetFollow
-                  + "' does not exist in dataset's list of relationships");
-        }
+    for (var assetFollow : ListUtils.emptyIfNull(assetModel.getFollow())) {
+      if (!relationships.stream().anyMatch(r -> r.getName().equals(assetFollow))) {
+        errors.add(
+            "Relationship specified in follow list '"
+                + assetFollow
+                + "' does not exist in dataset's list of relationships");
       }
     }
 

--- a/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
@@ -23,6 +23,7 @@ import bio.terra.service.tabulardata.azure.StorageTableService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryTransactionPdao;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -116,6 +117,12 @@ public class ValidateAssetUnitTest {
   @Test
   public void testNoFollow() {
     assetModel.follow(null);
+    dataset.validateDatasetAssetSpecification(assetModel);
+  }
+
+  @Test
+  public void testEmptyFollowList() {
+    assetModel.follow(Collections.emptyList());
     dataset.validateDatasetAssetSpecification(assetModel);
   }
 

--- a/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
@@ -113,6 +113,12 @@ public class ValidateAssetUnitTest {
         "invalid column", "Column " + col3Name + " does not exist in table " + tableName);
   }
 
+  @Test
+  public void testNoFollow() {
+    assetModel.follow(null);
+    dataset.validateDatasetAssetSpecification(assetModel);
+  }
+
   @Test(expected = InvalidAssetException.class)
   public void testInvalidColumn() {
     String invalidColumn = "InvalidCol";


### PR DESCRIPTION
**Background**
We recently [added validation on the request used to add an asset to a dataset](https://github.com/DataBiosphere/jade-data-repo/pull/1301). The changes incorrectly assumed that there would at least be an empty list for the follow relationship, but it is not a required field so it can in fact be null. 

![image](https://user-images.githubusercontent.com/13254229/176699508-ece05250-a924-426a-ace9-54f4e5fa9fee.png)

**Job Result Reported by User**
User reported the following response when nothing was defined for the follow list.
```
{
  "message": "Cannot invoke \"java.util.List.iterator()\" because the return value of \"bio.terra.model.AssetModel.getFollow()\" is null",
  "errorDetail": [
    "Cannot invoke \"java.util.List.iterator()\" because the return value of \"bio.terra.model.AssetModel.getFollow()\" is null"
  ]
}
```

**Reproduced Error Encountered by User with test that set follow to null**
![image](https://user-images.githubusercontent.com/13254229/176697919-0a51bc65-e1b4-4756-8683-81e7b6f5c5ba.png)

With code change included in PR, this test now passes. 
