### PR TITLE
[DR-2647] Improve column schema validation

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -220,6 +220,7 @@ public class DatasetRequestValidator implements Validator {
           if (primaryKeyList.contains(columnModel.getName())) {
             validateColumnType(errors, columnModel, PRIMARY_KEY);
           }
+          validateColumnMode(errors, columnModel);
         }
       }
       context.addTable(tableName, columns);
@@ -277,6 +278,15 @@ public class DatasetRequestValidator implements Validator {
           "schema",
           "OptionalPrimaryKeyColumn",
           String.format("A %s column cannot be marked as not required", PRIMARY_KEY));
+    }
+  }
+
+  private void validateColumnMode(Errors errors, ColumnModel columnModel) {
+    if (columnModel.isRequired() && columnModel.isArrayOf()) {
+      errors.rejectValue(
+          "schema",
+          "InvalidColumnMode",
+          String.format("Array column %s cannot be marked as required", columnModel.getName()));
     }
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -282,7 +282,7 @@ public class DatasetRequestValidator implements Validator {
   }
 
   private void validateColumnMode(Errors errors, ColumnModel columnModel) {
-    if (columnModel.isRequired() && columnModel.isArrayOf()) {
+    if (Boolean.TRUE.equals(columnModel.isRequired()) && columnModel.isArrayOf()) {
       errors.rejectValue(
           "schema",
           "InvalidColumnMode",

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -215,14 +215,14 @@ public class DatasetRequestValidator implements Validator {
               "MissingPrimaryKeyColumn",
               String.format("Expected column(s): %s", String.join(", ", missingKeys)));
         }
-
-        for (ColumnModel columnModel : table.getColumns()) {
-          if (primaryKeyList.contains(columnModel.getName())) {
-            validateColumnType(errors, columnModel, PRIMARY_KEY);
-          }
-          validateColumnMode(errors, columnModel);
-        }
       }
+      for (ColumnModel columnModel : table.getColumns()) {
+        if (primaryKeyList != null && primaryKeyList.contains(columnModel.getName())) {
+          validateColumnType(errors, columnModel, PRIMARY_KEY);
+        }
+        validateColumnMode(errors, columnModel);
+      }
+
       context.addTable(tableName, columns);
     }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -282,6 +282,9 @@ public class DatasetRequestValidator implements Validator {
   }
 
   private void validateColumnMode(Errors errors, ColumnModel columnModel) {
+    // Explicitly check if isRequired is true to avoid a null pointer exception.
+    // isArrayOf has a default value set in the open-api spec so it does not require
+    // the same handling.
     if (Boolean.TRUE.equals(columnModel.isRequired()) && columnModel.isArrayOf()) {
       errors.rejectValue(
           "schema",

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -222,11 +222,7 @@ public class DatasetRequestValidatorTest {
     checkValidationErrorModel(
         errorModel,
         new String[] {
-          "InvalidPrimaryKey",
-          "InvalidPrimaryKey",
-          "InvalidPrimaryKey",
-          "InvalidForeignKey",
-          "InvalidColumnMode"
+          "InvalidPrimaryKey", "InvalidPrimaryKey", "InvalidPrimaryKey", "InvalidForeignKey"
         });
   }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -214,16 +214,39 @@ public class DatasetRequestValidatorTest {
     ColumnModel badColumnFileRefArray = testTable.getColumns().get(0);
     badColumnFileRefArray.setArrayOf(true);
     badColumnFileRefArray.setDatatype(TableDataType.FILEREF);
+    badColumnFileRefArray.setRequired(true);
 
     ColumnModel badColumnDirref = testTable.getColumns().get(1);
     badColumnDirref.setDatatype(TableDataType.DIRREF);
+    badColumnDirref.setRequired(true);
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
         errorModel,
         new String[] {
-          "InvalidPrimaryKey", "InvalidPrimaryKey", "InvalidPrimaryKey", "InvalidForeignKey"
+          "InvalidPrimaryKey",
+          "InvalidPrimaryKey",
+          "InvalidPrimaryKey",
+          "InvalidForeignKey",
+          "InvalidColumnMode"
         });
+  }
+
+  @Test
+  public void testInvalidColumnMode() throws Exception {
+    DatasetRequestModel req = buildDatasetRequest();
+    TableModel testTable = req.getSchema().getTables().get(0);
+    testTable.setPrimaryKey(List.of("id"));
+
+    ColumnModel goodColumn = testTable.getColumns().get(0);
+    goodColumn.setRequired(true);
+
+    ColumnModel badColumn = testTable.getColumns().get(1);
+    badColumn.setArrayOf(true);
+    badColumn.setRequired(true);
+
+    ErrorModel errorModel = expectBadDatasetCreateRequest(req);
+    checkValidationErrorModel(errorModel, new String[] {"InvalidColumnMode"});
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -214,11 +214,9 @@ public class DatasetRequestValidatorTest {
     ColumnModel badColumnFileRefArray = testTable.getColumns().get(0);
     badColumnFileRefArray.setArrayOf(true);
     badColumnFileRefArray.setDatatype(TableDataType.FILEREF);
-    badColumnFileRefArray.setRequired(true);
 
     ColumnModel badColumnDirref = testTable.getColumns().get(1);
     badColumnDirref.setDatatype(TableDataType.DIRREF);
-    badColumnDirref.setRequired(true);
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
@@ -236,12 +234,8 @@ public class DatasetRequestValidatorTest {
   public void testInvalidColumnMode() throws Exception {
     DatasetRequestModel req = buildDatasetRequest();
     TableModel testTable = req.getSchema().getTables().get(0);
-    testTable.setPrimaryKey(List.of("id"));
-
-    ColumnModel goodColumn = testTable.getColumns().get(0);
-    goodColumn.setRequired(true);
-
-    ColumnModel badColumn = testTable.getColumns().get(1);
+    // Test that a required, array_of column causes a validation error
+    ColumnModel badColumn = testTable.getColumns().get(0);
     badColumn.setArrayOf(true);
     badColumn.setRequired(true);
 


### PR DESCRIPTION
Currently if a user defines an `array_of` column that is required, when the dataset is created in BigQuery the column mode is set to `REQUIRED` instead of `REPEATED`. (When the issue was reported, the problematic dataset column was set to NULLABLE in BigQuery but I wasn't able to reproduce it).

To prevent this from occurring, the dataset request validator throws an error if an "array_of" column is also set to "required".