### PR TITLE
[DR-2675] ECM exception should not block snapshot enumeration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ plugins {
 
 allprojects {
     group 'bio.terra'
-    version '1.378.0-SNAPSHOT'
+    version '1.378.1-SNAPSHOT'
 
     ext {
         resourceDir = "${rootDir}/src/main/resources/api"

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ plugins {
 
 allprojects {
     group 'bio.terra'
-    version '1.378.1-SNAPSHOT'
+    version '1.378.0-SNAPSHOT'
 
     ext {
         resourceDir = "${rootDir}/src/main/resources/api"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2675

Since RAS passports are not yet used in production, for now we do not allow ECM exceptions to block snapshot enumeration, instead logging them as errors.

We can then plan on further investment in ECM error handling and communication without risk to ongoing operations that probably don't care about RAS right now.  Follow-on ticket for that work: https://broadworkbench.atlassian.net/browse/DR-2674

**ETA: This addresses a production issue with HCA and will likely be offcycled.** https://broadinstitute.slack.com/archives/CD4HBRFMG/p1657631835544859

Instead of a staging hotfix, we will pursue an alpha hotfix followed by early promotion of other environments.  The reason being is that our HCA partners are testing off of TDR dev rather than staging, and TDR promotion to dev follows a different process.  No other changes are getting bundled in with our fix. 
