### PR TITLE
[DR-2554] Add relationships to schema update endpoint

### DIFF
--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -6,8 +6,8 @@ import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,11 +80,11 @@ public final class ValidationUtils {
     return value;
   }
 
-  public static Map<String, String> validateRelationshipTerm(
+  public static LinkedHashMap<String, String> validateRelationshipTerm(
       RelationshipTermModel term, List<TableModel> tables) {
     String tableName = term.getTable();
     String columnName = term.getColumn();
-    Map<String, String> termErrors = new HashMap<>();
+    LinkedHashMap<String, String> termErrors = new LinkedHashMap<>();
     Optional<TableModel> table =
         tables.stream().filter(t -> t.getName().equals(tableName)).findFirst();
     if (table.isEmpty()) {
@@ -109,9 +109,9 @@ public final class ValidationUtils {
     return termErrors;
   }
 
-  public static ArrayList<Map<String, String>> getRelationshipValidationErrors(
+  public static ArrayList<LinkedHashMap<String, String>> getRelationshipValidationErrors(
       RelationshipModel relationship, List<TableModel> tables) {
-    ArrayList<Map<String, String>> errors = new ArrayList<>();
+    ArrayList<LinkedHashMap<String, String>> errors = new ArrayList<>();
     RelationshipTermModel fromTerm = relationship.getFrom();
     if (fromTerm != null) {
       errors.add(validateRelationshipTerm(fromTerm, tables));

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -1,13 +1,21 @@
 package bio.terra.common;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import bio.terra.model.ColumnModel;
+import bio.terra.model.RelationshipModel;
+import bio.terra.model.RelationshipTermModel;
+import bio.terra.model.TableDataType;
+import bio.terra.model.TableModel;
 import org.apache.commons.lang3.StringUtils;
 
 public final class ValidationUtils {
@@ -71,4 +79,52 @@ public final class ValidationUtils {
 
     return value;
   }
+
+  public static Map<String, String> validateRelationshipTerm(RelationshipTermModel term, List<TableModel> tables) {
+    String tableName = term.getTable();
+    String columnName = term.getColumn();
+    Map<String, String> termErrors = new HashMap<>();
+    Optional<TableModel> table = tables.stream().filter(t -> t.getName().equals(tableName)).findFirst();
+    if (table.isEmpty()) {
+      termErrors.put("InvalidRelationshipTermTable",
+          String.format("Invalid table %s", tableName));
+    } else {
+      Optional<ColumnModel> columnModel = table.get().getColumns().stream()
+          .filter(c -> c.getName().equals(columnName)).findFirst();
+      if (columnModel.isEmpty()) {
+        termErrors.put("InvalidRelationshipTermTableColumn",
+            String.format("invalid table %s.%s", tableName, columnName));
+      } else {
+        if (!isInvalidPrimaryOrForeignKeyType(columnModel.get())) {
+          termErrors.put("OptionalForeignKeyColumn",
+              String.format("Foreign key column %s cannot be marked as not required",
+                  columnName));
+        }
+      }
+    }
+    return termErrors;
+  }
+
+  public static ArrayList<Map<String, String>> getRelationshipValidationErrors(
+      RelationshipModel relationship,
+      List<TableModel> tables) {
+    ArrayList<Map<String, String>> errors = new ArrayList<>();
+      RelationshipTermModel fromTerm = relationship.getFrom();
+      if (fromTerm != null) {
+        errors.add(validateRelationshipTerm(fromTerm, tables));
+      }
+
+      RelationshipTermModel toTerm = relationship.getTo();
+      if (toTerm != null) {
+        errors.add(validateRelationshipTerm(toTerm, tables));
+      }
+    return errors;
+  }
+
+  public static boolean isInvalidPrimaryOrForeignKeyType(ColumnModel columnModel) {
+    Set<TableDataType> invalidTypes = Set.of(TableDataType.DIRREF, TableDataType.FILEREF);
+    return columnModel.getDatatype() != null && invalidTypes.contains(columnModel.getDatatype());
+  }
+
+
 }

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -1,5 +1,10 @@
 package bio.terra.common;
 
+import bio.terra.model.ColumnModel;
+import bio.terra.model.RelationshipModel;
+import bio.terra.model.RelationshipTermModel;
+import bio.terra.model.TableDataType;
+import bio.terra.model.TableModel;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -11,11 +16,6 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import bio.terra.model.ColumnModel;
-import bio.terra.model.RelationshipModel;
-import bio.terra.model.RelationshipTermModel;
-import bio.terra.model.TableDataType;
-import bio.terra.model.TableModel;
 import org.apache.commons.lang3.StringUtils;
 
 public final class ValidationUtils {
@@ -80,25 +80,27 @@ public final class ValidationUtils {
     return value;
   }
 
-  public static Map<String, String> validateRelationshipTerm(RelationshipTermModel term, List<TableModel> tables) {
+  public static Map<String, String> validateRelationshipTerm(
+      RelationshipTermModel term, List<TableModel> tables) {
     String tableName = term.getTable();
     String columnName = term.getColumn();
     Map<String, String> termErrors = new HashMap<>();
-    Optional<TableModel> table = tables.stream().filter(t -> t.getName().equals(tableName)).findFirst();
+    Optional<TableModel> table =
+        tables.stream().filter(t -> t.getName().equals(tableName)).findFirst();
     if (table.isEmpty()) {
-      termErrors.put("InvalidRelationshipTermTable",
-          String.format("Invalid table %s", tableName));
+      termErrors.put("InvalidRelationshipTermTable", String.format("Invalid table %s", tableName));
     } else {
-      Optional<ColumnModel> columnModel = table.get().getColumns().stream()
-          .filter(c -> c.getName().equals(columnName)).findFirst();
+      Optional<ColumnModel> columnModel =
+          table.get().getColumns().stream().filter(c -> c.getName().equals(columnName)).findFirst();
       if (columnModel.isEmpty()) {
-        termErrors.put("InvalidRelationshipTermTableColumn",
+        termErrors.put(
+            "InvalidRelationshipTermTableColumn",
             String.format("invalid table %s.%s", tableName, columnName));
       } else {
         if (!isInvalidPrimaryOrForeignKeyType(columnModel.get())) {
-          termErrors.put("OptionalForeignKeyColumn",
-              String.format("Foreign key column %s cannot be marked as not required",
-                  columnName));
+          termErrors.put(
+              "OptionalForeignKeyColumn",
+              String.format("Foreign key column %s cannot be marked as not required", columnName));
         }
       }
     }
@@ -106,18 +108,17 @@ public final class ValidationUtils {
   }
 
   public static ArrayList<Map<String, String>> getRelationshipValidationErrors(
-      RelationshipModel relationship,
-      List<TableModel> tables) {
+      RelationshipModel relationship, List<TableModel> tables) {
     ArrayList<Map<String, String>> errors = new ArrayList<>();
-      RelationshipTermModel fromTerm = relationship.getFrom();
-      if (fromTerm != null) {
-        errors.add(validateRelationshipTerm(fromTerm, tables));
-      }
+    RelationshipTermModel fromTerm = relationship.getFrom();
+    if (fromTerm != null) {
+      errors.add(validateRelationshipTerm(fromTerm, tables));
+    }
 
-      RelationshipTermModel toTerm = relationship.getTo();
-      if (toTerm != null) {
-        errors.add(validateRelationshipTerm(toTerm, tables));
-      }
+    RelationshipTermModel toTerm = relationship.getTo();
+    if (toTerm != null) {
+      errors.add(validateRelationshipTerm(toTerm, tables));
+    }
     return errors;
   }
 
@@ -125,6 +126,4 @@ public final class ValidationUtils {
     Set<TableDataType> invalidTypes = Set.of(TableDataType.DIRREF, TableDataType.FILEREF);
     return columnModel.getDatatype() != null && invalidTypes.contains(columnModel.getDatatype());
   }
-
-
 }

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -95,7 +95,7 @@ public final class ValidationUtils {
       if (columnModel.isEmpty()) {
         termErrors.put(
             "InvalidRelationshipTermTableColumn",
-            String.format("invalid table %s.%s", tableName, columnName));
+            String.format("Invalid column %s.%s", tableName, columnName));
       } else {
         if (isInvalidPrimaryOrForeignKeyType(columnModel.get())) {
           termErrors.put(

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -99,9 +99,9 @@ public final class ValidationUtils {
       } else {
         if (isInvalidPrimaryOrForeignKeyType(columnModel.get())) {
           termErrors.put(
-              "InvalidForeignKey",
+              "InvalidRelationshipColumnType",
               String.format(
-                  "Foreign key %s cannot be a column with %s type",
+                  "Relationship column %s cannot be %s type",
                   columnName, columnModel.get().getDatatype()));
         }
       }

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -97,10 +97,12 @@ public final class ValidationUtils {
             "InvalidRelationshipTermTableColumn",
             String.format("invalid table %s.%s", tableName, columnName));
       } else {
-        if (!isInvalidPrimaryOrForeignKeyType(columnModel.get())) {
+        if (isInvalidPrimaryOrForeignKeyType(columnModel.get())) {
           termErrors.put(
-              "OptionalForeignKeyColumn",
-              String.format("Foreign key column %s cannot be marked as not required", columnName));
+              "InvalidForeignKey",
+              String.format(
+                  "Foreign key %s cannot be a column with %s type",
+                  columnName, columnModel.get().getDatatype()));
         }
       }
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -410,7 +410,7 @@ public class DatasetDao {
     }
     dataset.createdDate(keyHolder.getCreatedDate());
     tableDao.createTables(dataset.getId(), dataset.getTables());
-    relationshipDao.createDatasetRelationships(dataset);
+    relationshipDao.createDatasetRelationships(dataset.getRelationships());
     assetDao.createAssets(dataset);
     storageResourceDao.createStorageAttributes(
         dataset.getDatasetSummary().getStorage(), dataset.getId());

--- a/src/main/java/bio/terra/service/dataset/DatasetRelationshipDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRelationshipDao.java
@@ -11,6 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public class DatasetRelationshipDao {
@@ -23,10 +26,15 @@ public class DatasetRelationshipDao {
   }
 
   // part of a transaction propagated from DatasetDao
-  public void createDatasetRelationships(Dataset dataset) {
-    for (Relationship rel : dataset.getRelationships()) {
+  public void createDatasetRelationships(List<Relationship> relationships) {
+    for (Relationship rel : relationships) {
       create(rel);
     }
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public void createDatasetRelationshipsWithTransaction(List<Relationship> relationships) {
+    createDatasetRelationships(relationships);
   }
 
   protected void create(Relationship relationship) {

--- a/src/main/java/bio/terra/service/dataset/DatasetRelationshipDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRelationshipDao.java
@@ -33,10 +33,6 @@ public class DatasetRelationshipDao {
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public void createDatasetRelationshipsWithTransaction(List<Relationship> relationships) {
-    createDatasetRelationships(relationships);
-  }
-
   protected void create(Relationship relationship) {
     String sql =
         "INSERT INTO dataset_relationship "
@@ -82,5 +78,13 @@ public class DatasetRelationshipDao {
                 .fromColumn(columns.get(rs.getObject("from_column", UUID.class)))
                 .toTable(tables.get(rs.getObject("to_table", UUID.class)))
                 .toColumn(columns.get(rs.getObject("to_column", UUID.class))));
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public boolean delete(UUID id) {
+    String sql = "DELETE FROM dataset_relationship WHERE id = :id";
+    MapSqlParameterSource params = new MapSqlParameterSource().addValue("id", id);
+    int rowsAffected = jdbcTemplate.update(sql, params);
+    return rowsAffected > 0;
   }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -324,7 +324,8 @@ public class DatasetRequestValidator implements Validator {
       List<TableModel> tables,
       Errors errors,
       SchemaValidationContext context) {
-    ArrayList<Map<String, String>> validationErrors = ValidationUtils.getRelationshipValidationErrors(relationship, tables);
+    ArrayList<Map<String, String>> validationErrors =
+        ValidationUtils.getRelationshipValidationErrors(relationship, tables);
     validationErrors.forEach(e -> rejectValues(errors, e));
 
     String relationshipName = relationship.getName();

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -11,7 +11,6 @@ import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.DatePartitionOptionsModel;
 import bio.terra.model.IntPartitionOptionsModel;
 import bio.terra.model.RelationshipModel;
-import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
 import java.util.ArrayList;
@@ -19,6 +18,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -319,50 +319,25 @@ public class DatasetRequestValidator implements Validator {
     }
   }
 
-  private void validateRelationshipTerm(
-      RelationshipTermModel term,
-      List<TableModel> tables,
-      Errors errors,
-      SchemaValidationContext context) {
-    String tableName = term.getTable();
-    String column = term.getColumn();
-    if (tableName != null && column != null) {
-      if (!context.isValidTableColumn(tableName, column)) {
-        errors.rejectValue(
-            "schema",
-            "InvalidRelationshipTermTableColumn",
-            "invalid table '" + tableName + "." + column + "'");
-      }
-    }
-    for (TableModel tableModel : tables) {
-      if (term.getTable().equals(tableModel.getName())) {
-        for (ColumnModel columnModel : tableModel.getColumns()) {
-          if (term.getColumn().equals(columnModel.getName())) {
-            validateColumnType(errors, columnModel, FOREIGN_KEY);
-          }
-        }
-      }
-    }
-  }
-
   private void validateRelationship(
       RelationshipModel relationship,
       List<TableModel> tables,
       Errors errors,
       SchemaValidationContext context) {
-    RelationshipTermModel fromTerm = relationship.getFrom();
-    if (fromTerm != null) {
-      validateRelationshipTerm(fromTerm, tables, errors, context);
-    }
-
-    RelationshipTermModel toTerm = relationship.getTo();
-    if (toTerm != null) {
-      validateRelationshipTerm(toTerm, tables, errors, context);
-    }
+    ArrayList<Map<String, String>> validationErrors = ValidationUtils.getRelationshipValidationErrors(relationship, tables);
+    validationErrors.forEach(e -> rejectValues(errors, e));
 
     String relationshipName = relationship.getName();
     if (relationshipName != null) {
       context.addRelationship(relationshipName);
+    }
+  }
+
+  private void rejectValues(Errors errors, Map<String, String> errorMap) {
+    for (var entry : errorMap.entrySet()) {
+      var errorCode = entry.getKey();
+      var errorMessage = entry.getValue();
+      errors.rejectValue("schema", errorCode, errorMessage);
     }
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -324,7 +325,7 @@ public class DatasetRequestValidator implements Validator {
       List<TableModel> tables,
       Errors errors,
       SchemaValidationContext context) {
-    ArrayList<Map<String, String>> validationErrors =
+    ArrayList<LinkedHashMap<String, String>> validationErrors =
         ValidationUtils.getRelationshipValidationErrors(relationship, tables);
     validationErrors.forEach(e -> rejectValues(errors, e));
 

--- a/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
@@ -68,12 +68,17 @@ public class DatasetSchemaUpdateValidator implements Validator {
       }
     }
 
-    List<RelationshipModel> newRelationships = updateModel.getChanges().getAddRelationships();
     if (DatasetSchemaUpdateUtils.hasRelationshipAdditions(updateModel)) {
+      List<RelationshipModel> newRelationships = updateModel.getChanges().getAddRelationships();
       List<String> relationshipNames =
           newRelationships.stream().map(RelationshipModel::getName).collect(Collectors.toList());
-      if (ValidationUtils.hasDuplicates(relationshipNames)) {
-        errors.rejectValue("schema", "DuplicateRelationshipNames");
+      List<String> duplicateRelationships = ValidationUtils.findDuplicates(relationshipNames);
+      if (!duplicateRelationships.isEmpty()) {
+        errors.rejectValue(
+            "changes.addRelationships",
+            "DuplicateRelationshipNames",
+            "Cannot add multiple relationships of the same name: "
+                + String.join(",", duplicateRelationships));
       }
     }
   }

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddRelationshipsPostgresStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateAddRelationshipsPostgresStep.java
@@ -1,0 +1,60 @@
+package bio.terra.service.dataset.flight.update;
+
+import bio.terra.common.Relationship;
+import bio.terra.model.DatasetSchemaUpdateModel;
+import bio.terra.service.dataset.DatasetJsonConversion;
+import bio.terra.service.dataset.DatasetRelationshipDao;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.DatasetTableDao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class DatasetSchemaUpdateAddRelationshipsPostgresStep implements Step {
+  private final DatasetTableDao datasetTableDao;
+  private final UUID datasetId;
+  private final DatasetRelationshipDao relationshipDao;
+  private final DatasetSchemaUpdateModel updateModel;
+
+  public DatasetSchemaUpdateAddRelationshipsPostgresStep(
+      DatasetTableDao datasetTableDao,
+      UUID datasetId,
+      DatasetRelationshipDao relationshipDao,
+      DatasetSchemaUpdateModel updateModel) {
+    this.datasetTableDao = datasetTableDao;
+    this.datasetId = datasetId;
+    this.relationshipDao = relationshipDao;
+    this.updateModel = updateModel;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Map<String, DatasetTable> tables =
+        datasetTableDao.retrieveTables(datasetId).stream()
+            .collect(Collectors.toMap(DatasetTable::getName, Function.identity()));
+    List<Relationship> relationships =
+        updateModel.getChanges().getAddRelationships().stream()
+            .map(r -> DatasetJsonConversion.relationshipModelToDatasetRelationship(r, tables))
+            .collect(Collectors.toList());
+    try {
+      relationshipDao.createDatasetRelationshipsWithTransaction(relationships);
+    } catch (Exception e) {
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new DatasetSchemaUpdateException("Failed to add relationships to the dataset", e));
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
@@ -70,7 +70,7 @@ public class DatasetSchemaUpdateFlight extends Flight {
     if (DatasetSchemaUpdateUtils.hasRelationshipAdditions(updateModel)) {
       addStep(
           new DatasetSchemaUpdateAddRelationshipsPostgresStep(
-              datasetTableDao, datasetId, relationshipDao, updateModel));
+              datasetDao, datasetTableDao, datasetId, relationshipDao, updateModel));
     }
 
     addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
@@ -6,6 +6,7 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.dataset.DatasetRelationshipDao;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetTableDao;
 import bio.terra.service.dataset.flight.LockDatasetStep;
@@ -26,6 +27,7 @@ public class DatasetSchemaUpdateFlight extends Flight {
     DatasetDao datasetDao = appContext.getBean(DatasetDao.class);
     DatasetTableDao datasetTableDao = appContext.getBean(DatasetTableDao.class);
     DatasetService datasetService = appContext.getBean(DatasetService.class);
+    DatasetRelationshipDao relationshipDao = appContext.getBean(DatasetRelationshipDao.class);
     BigQueryDatasetPdao bigQueryDatasetPdao = appContext.getBean(BigQueryDatasetPdao.class);
 
     AuthenticatedUserRequest userRequest =
@@ -63,6 +65,12 @@ public class DatasetSchemaUpdateFlight extends Flight {
       addStep(
           new DatasetSchemaUpdateAddColumnsBigQueryStep(
               bigQueryDatasetPdao, datasetDao, datasetId, updateModel));
+    }
+
+    if (DatasetSchemaUpdateUtils.hasRelationshipAdditions(updateModel)) {
+      addStep(
+          new DatasetSchemaUpdateAddRelationshipsPostgresStep(
+              datasetTableDao, datasetId, relationshipDao, updateModel));
     }
 
     addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateUtils.java
@@ -23,6 +23,13 @@ public class DatasetSchemaUpdateUtils {
     return !(columns == null || columns.isEmpty());
   }
 
+  public static boolean hasRelationshipAdditions(DatasetSchemaUpdateModel updateModel) {
+    var changes =
+        Objects.requireNonNullElse(updateModel.getChanges(), new DatasetSchemaUpdateModelChanges());
+    var relationships = changes.getAddRelationships();
+    return !(relationships == null || relationships.isEmpty());
+  }
+
   public static List<String> getNewTableNames(DatasetSchemaUpdateModel updateModel) {
     return updateModel.getChanges().getAddTables().stream()
         .map(TableModel::getName)

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
@@ -99,9 +99,13 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
                 String.join(", ", conflictingRelationshipNames)));
       }
 
-      List<TableModel> allTables =
-          dataset.getTables().stream().map(DatasetJsonConversion::tableModelFromTable).toList();
-      allTables.addAll(updateModel.getChanges().getAddTables());
+      ArrayList<TableModel> allTables =
+          dataset.getTables().stream()
+              .map(DatasetJsonConversion::tableModelFromTable)
+              .collect(Collectors.toCollection(ArrayList::new));
+      if (DatasetSchemaUpdateUtils.hasTableAdditions(updateModel)) {
+        allTables.addAll(updateModel.getChanges().getAddTables());
+      }
 
       ArrayList<String> validationErrors = new ArrayList<>();
       for (var relationship : newRelationships) {

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
@@ -1,11 +1,15 @@
 package bio.terra.service.dataset.flight.update;
 
 import bio.terra.common.Column;
+import bio.terra.common.Relationship;
+import bio.terra.common.ValidationUtils;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSchemaColumnUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
+import bio.terra.model.RelationshipModel;
 import bio.terra.model.TableModel;
 import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetJsonConversion;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.stairway.FlightContext;
@@ -15,6 +19,7 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
@@ -81,7 +86,46 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
       }
     }
 
+    if (DatasetSchemaUpdateUtils.hasRelationshipAdditions(updateModel)) {
+      List<Relationship> existingRelationships = dataset.getRelationships();
+      List<RelationshipModel> newRelationships = updateModel.getChanges().getAddRelationships();
+      List<String> conflictingRelationshipNames = conflictingRelationshipNames(existingRelationships, newRelationships);
+      if (!conflictingRelationshipNames.isEmpty()) {
+        return failsValidation(
+            "Could not validate relationship additions",
+            List.of(
+                "Relationships with these names already exist for this dataset: ",
+                String.join(", ", conflictingRelationshipNames)));
+      }
+
+      List<TableModel> allTables = dataset.getTables().stream().map(DatasetJsonConversion::tableModelFromTable).toList();
+      allTables.addAll(updateModel.getChanges().getAddTables());
+
+      ArrayList<String> validationErrors = new ArrayList<>();
+      for (var relationship : newRelationships) {
+        ArrayList<Map<String, String>> errors = ValidationUtils.getRelationshipValidationErrors(relationship, allTables);
+        validationErrors.addAll(formatValidationErrors(errors));
+      }
+      if (!validationErrors.isEmpty()) {
+        return failsValidation(
+            "Could not validate relationship additions",
+            List.of(
+                "Found invalid terms: ",
+                String.join(", ", validationErrors)));
+      }
+    }
     return StepResult.getStepResultSuccess();
+  }
+
+  private List<String> conflictingRelationshipNames(List<Relationship> existingRelationships,
+                                                    List<RelationshipModel> newRelationships) {
+    List<String> existingRelationshipNames =
+        existingRelationships.stream().map(Relationship::getName).collect(Collectors.toList());
+    List<String> newRelationshipNames = newRelationships.stream()
+        .map(RelationshipModel::getName)
+        .toList();
+    return ListUtils.intersection(existingRelationshipNames,
+        newRelationshipNames);
   }
 
   private List<String> conflictingNewColumns(String tableName, List<ColumnModel> newColumns) {
@@ -108,6 +152,13 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
   private StepResult failsValidation(String message, List<String> reasons) {
     return new StepResult(
         StepStatus.STEP_RESULT_FAILURE_FATAL, new DatasetSchemaUpdateException(message, reasons));
+  }
+
+  private List<String> formatValidationErrors(ArrayList<Map<String, String>> errors) {
+    return errors.stream()
+        .flatMap(errorMap -> errorMap.entrySet().stream().map(entry ->
+            String.format("%s: %s", entry.getKey(), entry.getValue())
+        )).collect(Collectors.toList());
   }
 
   private static List<String> newColumnNames(List<ColumnModel> columns) {

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
@@ -89,7 +89,8 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
     if (DatasetSchemaUpdateUtils.hasRelationshipAdditions(updateModel)) {
       List<Relationship> existingRelationships = dataset.getRelationships();
       List<RelationshipModel> newRelationships = updateModel.getChanges().getAddRelationships();
-      List<String> conflictingRelationshipNames = conflictingRelationshipNames(existingRelationships, newRelationships);
+      List<String> conflictingRelationshipNames =
+          conflictingRelationshipNames(existingRelationships, newRelationships);
       if (!conflictingRelationshipNames.isEmpty()) {
         return failsValidation(
             "Could not validate relationship additions",
@@ -98,34 +99,32 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
                 String.join(", ", conflictingRelationshipNames)));
       }
 
-      List<TableModel> allTables = dataset.getTables().stream().map(DatasetJsonConversion::tableModelFromTable).toList();
+      List<TableModel> allTables =
+          dataset.getTables().stream().map(DatasetJsonConversion::tableModelFromTable).toList();
       allTables.addAll(updateModel.getChanges().getAddTables());
 
       ArrayList<String> validationErrors = new ArrayList<>();
       for (var relationship : newRelationships) {
-        ArrayList<Map<String, String>> errors = ValidationUtils.getRelationshipValidationErrors(relationship, allTables);
+        ArrayList<Map<String, String>> errors =
+            ValidationUtils.getRelationshipValidationErrors(relationship, allTables);
         validationErrors.addAll(formatValidationErrors(errors));
       }
       if (!validationErrors.isEmpty()) {
         return failsValidation(
             "Could not validate relationship additions",
-            List.of(
-                "Found invalid terms: ",
-                String.join(", ", validationErrors)));
+            List.of("Found invalid terms: ", String.join(", ", validationErrors)));
       }
     }
     return StepResult.getStepResultSuccess();
   }
 
-  private List<String> conflictingRelationshipNames(List<Relationship> existingRelationships,
-                                                    List<RelationshipModel> newRelationships) {
+  private List<String> conflictingRelationshipNames(
+      List<Relationship> existingRelationships, List<RelationshipModel> newRelationships) {
     List<String> existingRelationshipNames =
         existingRelationships.stream().map(Relationship::getName).collect(Collectors.toList());
-    List<String> newRelationshipNames = newRelationships.stream()
-        .map(RelationshipModel::getName)
-        .toList();
-    return ListUtils.intersection(existingRelationshipNames,
-        newRelationshipNames);
+    List<String> newRelationshipNames =
+        newRelationships.stream().map(RelationshipModel::getName).toList();
+    return ListUtils.intersection(existingRelationshipNames, newRelationshipNames);
   }
 
   private List<String> conflictingNewColumns(String tableName, List<ColumnModel> newColumns) {
@@ -156,9 +155,11 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
 
   private List<String> formatValidationErrors(ArrayList<Map<String, String>> errors) {
     return errors.stream()
-        .flatMap(errorMap -> errorMap.entrySet().stream().map(entry ->
-            String.format("%s: %s", entry.getKey(), entry.getValue())
-        )).collect(Collectors.toList());
+        .flatMap(
+            errorMap ->
+                errorMap.entrySet().stream()
+                    .map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue())))
+        .collect(Collectors.toList());
   }
 
   private static List<String> newColumnNames(List<ColumnModel> columns) {

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
@@ -18,8 +18,8 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
@@ -109,7 +109,7 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
 
       ArrayList<String> validationErrors = new ArrayList<>();
       for (var relationship : newRelationships) {
-        ArrayList<Map<String, String>> errors =
+        ArrayList<LinkedHashMap<String, String>> errors =
             ValidationUtils.getRelationshipValidationErrors(relationship, allTables);
         validationErrors.addAll(formatValidationErrors(errors));
       }
@@ -157,7 +157,7 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
         StepStatus.STEP_RESULT_FAILURE_FATAL, new DatasetSchemaUpdateException(message, reasons));
   }
 
-  private List<String> formatValidationErrors(ArrayList<Map<String, String>> errors) {
+  private List<String> formatValidationErrors(ArrayList<LinkedHashMap<String, String>> errors) {
     return errors.stream()
         .flatMap(
             errorMap ->

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3501,10 +3501,10 @@ components:
             This service account must be granted `storage.objects.get` permissions on any source buckets that TDR will ingest data from.
             The service account can be obtained when retrieving the dataset.  If this value is false and the dataset
             is a GCP-backed dataset, then the global service account must be granted `storage.objects.get` permissions to source buckets.
-            
+
             Note: this can be done by granting the "Storage Object Viewer", "Storage Legacy Object Reader", or "Storage Legacy Object Owner"
             role to the source buckets
-            
+
             This might be useful to set as a security improvement since this provides a dedicated account that explicitly
             does not have access to any other buckets.  It's also recommended if you need to authorize a large number of buckets
             since the main service account could run into Google group membership quota violations.
@@ -3755,6 +3755,11 @@ components:
               nullable: false
               items:
                 $ref: '#/components/schemas/DatasetSchemaColumnUpdateModel'
+            addRelationships:
+              type: array
+              nullable: false
+              items:
+                $ref: '#/components/schemas/RelationshipModel'
     DatasetSchemaColumnUpdateModel:
       type: object
       properties:

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -175,8 +175,8 @@ public class DatasetRequestValidatorTest {
         errorModel,
         new String[] {
           "DuplicateTableNames",
-          "InvalidRelationshipTermTableColumn",
-          "InvalidRelationshipTermTableColumn",
+          "InvalidRelationshipTermTable",
+          "InvalidRelationshipTermTable",
           "InvalidAssetTable",
           "InvalidAssetTableColumn",
           "InvalidAssetTableColumn",
@@ -196,8 +196,8 @@ public class DatasetRequestValidatorTest {
         errorModel,
         new String[] {
           "DuplicateColumnNames",
-          "InvalidRelationshipTermTableColumn",
-          "InvalidRelationshipTermTableColumn",
+          "InvalidRelationshipTermTable",
+          "InvalidRelationshipTermTable",
           "InvalidAssetTable",
           "InvalidAssetTableColumn",
           "InvalidAssetTableColumn",

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -222,7 +222,10 @@ public class DatasetRequestValidatorTest {
     checkValidationErrorModel(
         errorModel,
         new String[] {
-          "InvalidPrimaryKey", "InvalidPrimaryKey", "InvalidPrimaryKey", "InvalidForeignKey"
+          "InvalidPrimaryKey",
+          "InvalidPrimaryKey",
+          "InvalidPrimaryKey",
+          "InvalidRelationshipColumnType"
         });
   }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateIntegrationTest.java
@@ -12,6 +12,8 @@ import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModelChanges;
 import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.RelationshipModel;
+import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableModel;
 import java.util.List;
 import java.util.Optional;
@@ -163,5 +165,30 @@ public class DatasetSchemaUpdateIntegrationTest extends UsersBase {
             .collect(Collectors.toList())
             .containsAll(List.of(newTableColumnName, anotherNewColumnName));
     assertThat("The new table includes the new columns in the update response", columns);
+  }
+
+  @Test
+  public void testDatasetAddNewRelationshipSuccess() throws Exception {
+    DatasetSummaryModel datasetSummaryModel =
+        dataRepoFixtures.createDataset(steward(), profileId, "snapshot-test-dataset.json");
+    datasetId = datasetSummaryModel.getId();
+    String relationshipName = "testRelationship";
+    RelationshipModel relationshipModel =
+        new RelationshipModel()
+            .name(relationshipName)
+            .from(new RelationshipTermModel().table("thetable").column("thecolumn"))
+            .to(new RelationshipTermModel().table("anothertable").column("anothercolumn"));
+
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Integration test relationship addition")
+            .changes(
+                new DatasetSchemaUpdateModelChanges().addRelationships(List.of(relationshipModel)));
+    DatasetModel response = dataRepoFixtures.updateSchema(steward(), datasetId, updateModel);
+    Optional<RelationshipModel> createdRelationship =
+        response.getSchema().getRelationships().stream()
+            .filter(r -> r.getName().equals(relationshipName))
+            .findFirst();
+    assertThat("The new relationship is in the update response", createdRelationship.isPresent());
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateRequestValidatorTest.java
@@ -100,4 +100,22 @@ public class DatasetSchemaUpdateRequestValidatorTest {
         errorModel.getErrorDetail().get(0),
         containsString("RequiredColumns"));
   }
+
+  @Test
+  public void testSchemaUpdateWithDuplicateRelationships() throws Exception {
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("duplicate relationship test")
+            .changes(
+                new DatasetSchemaUpdateModelChanges()
+                    .addRelationships(
+                        List.of(
+                            buildParticipantSampleRelationship(),
+                            buildParticipantSampleRelationship())));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Duplicate relationship throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("DuplicateRelationshipNames"));
+  }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateConnectedTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateConnectedTest.java
@@ -7,10 +7,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.Column;
 import bio.terra.common.EmbeddedDatabaseTest;
+import bio.terra.common.Relationship;
 import bio.terra.common.category.Connected;
 import bio.terra.common.exception.PdaoException;
 import bio.terra.common.fixtures.ConnectedOperations;
@@ -23,12 +25,15 @@ import bio.terra.model.DatasetSchemaColumnUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModelChanges;
 import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.RelationshipModel;
+import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.dataset.DatasetRelationshipDao;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.dataset.DatasetTableDao;
@@ -78,6 +83,7 @@ public class DatasetSchemaUpdateConnectedTest {
   @Autowired private ConfigurationService configService;
   @Autowired private ConnectedTestConfiguration testConfig;
   @Autowired private BigQueryDatasetPdao bigQueryDatasetPdao;
+  @Autowired private DatasetRelationshipDao relationshipDao;
   @MockBean private IamProviderInterface samService;
 
   private BillingProfileModel billingProfile;
@@ -101,6 +107,7 @@ public class DatasetSchemaUpdateConnectedTest {
         .defaultProfileId(billingProfile.getId());
     summaryModel = connectedOperations.createDataset(datasetRequest);
     datasetId = summaryModel.getId();
+    relationshipDao = spy(relationshipDao);
     logger.info("--------begin test---------");
   }
 
@@ -479,6 +486,36 @@ public class DatasetSchemaUpdateConnectedTest {
           String.format("the new table %s does not exist in BigQuery", postUndoBigQueryTable),
           bigQueryDatasetPdao.tableExists(postUpdateDataset, postUndoBigQueryTable));
     }
+  }
+
+  private RelationshipModel testRelationshipModel(String relationshipName) {
+    return new RelationshipModel()
+        .name(relationshipName)
+        .from(new RelationshipTermModel().table("thetable").column("thecolumn"))
+        .to(new RelationshipTermModel().table("anothertable").column("anothercolumn"));
+  }
+
+  @Test
+  public void testRelationshipAdditionSteps() throws Exception {
+    String relationshipName = UUID.randomUUID().toString();
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Connected test relationship addition")
+            .changes(
+                new DatasetSchemaUpdateModelChanges()
+                    .addRelationships(List.of(testRelationshipModel(relationshipName))));
+
+    FlightContext flightContext = mock(FlightContext.class);
+    DatasetSchemaUpdateAddRelationshipsPostgresStep postgresStep =
+        new DatasetSchemaUpdateAddRelationshipsPostgresStep(
+            datasetTableDao, datasetId, relationshipDao, updateModel);
+
+    postgresStep.doStep(flightContext);
+
+    Dataset postUpdateDataset = datasetDao.retrieve(datasetId);
+    List<String> postUpdateRelationships =
+        postUpdateDataset.getRelationships().stream().map(Relationship::getName).toList();
+    assertTrue("New relationship was created", postUpdateRelationships.contains(relationshipName));
   }
 
   private Map<String, Field> getBigQueryFieldsMap(

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateConnectedTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateConnectedTest.java
@@ -508,7 +508,7 @@ public class DatasetSchemaUpdateConnectedTest {
     FlightContext flightContext = mock(FlightContext.class);
     DatasetSchemaUpdateAddRelationshipsPostgresStep postgresStep =
         new DatasetSchemaUpdateAddRelationshipsPostgresStep(
-            datasetTableDao, datasetId, relationshipDao, updateModel);
+            datasetDao, datasetTableDao, datasetId, relationshipDao, updateModel);
 
     postgresStep.doStep(flightContext);
 
@@ -516,6 +516,12 @@ public class DatasetSchemaUpdateConnectedTest {
     List<String> postUpdateRelationships =
         postUpdateDataset.getRelationships().stream().map(Relationship::getName).toList();
     assertTrue("New relationship was created", postUpdateRelationships.contains(relationshipName));
+
+    postgresStep.undoStep(flightContext);
+    Dataset postUndoDataset = datasetDao.retrieve(datasetId);
+    List<String> postUndoRelationships =
+        postUndoDataset.getRelationships().stream().map(Relationship::getName).toList();
+    assertFalse("New relationship was deleted", postUndoRelationships.contains(relationshipName));
   }
 
   private Map<String, Field> getBigQueryFieldsMap(

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
@@ -334,7 +334,7 @@ public class DatasetSchemaUpdateValidationTest {
         invalidRelationshipException
             .getCauses()
             .contains(
-                "InvalidRelationshipTermTableColumn: Invalid table new_table.nonexistent_column"));
+                "InvalidRelationshipTermTableColumn: invalid table new_table.nonexistent_column"));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
@@ -334,7 +334,7 @@ public class DatasetSchemaUpdateValidationTest {
         invalidRelationshipException
             .getCauses()
             .contains(
-                "InvalidRelationshipTermTableColumn: invalid table new_table.nonexistent_column"));
+                "InvalidRelationshipTermTableColumn: Invalid column new_table.nonexistent_column"));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
@@ -374,10 +374,8 @@ public class DatasetSchemaUpdateValidationTest {
         invalidRelationshipException.getMessage(),
         containsString("Could not validate relationship additions"));
     assertThat(
-        invalidRelationshipException.getCauses().get(1), containsString("InvalidForeignKey"));
-    assertThat(
         invalidRelationshipException.getCauses().get(1),
         containsString(
-            "InvalidForeignKey: Foreign key new_column cannot be a column with fileref type"));
+            "InvalidRelationshipColumnType: Relationship column new_column cannot be fileref type"));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
@@ -6,19 +6,25 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.Column;
+import bio.terra.common.Relationship;
 import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.DatasetFixtures;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSchemaColumnUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModelChanges;
+import bio.terra.model.RelationshipModel;
+import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
 import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.BigQueryPartitionConfigV1;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetTable;
@@ -53,33 +59,50 @@ public class DatasetSchemaUpdateValidationTest {
   @MockBean private ConfigurationService configurationService;
 
   private UUID datasetId;
-  private static final String EXISTING_TABLE_NAME = "existing_table";
-  private static final String EXISTING_COLUMN_NAME = "existing_column";
+  private static final String EXISTING_TABLE = "existing_table";
+  private static final String EXISTING_COLUMN = "existing_column";
+  private static final String EXISTING_TABLE_2 = "existing_table_2";
+  private static final String EXISTING_COLUMN_2 = "existing_column_2";
+  private static final String EXISTING_RELATIONSHIP = "existing_relationship";
 
   @Before
   public void setup() {
     datasetId = UUID.randomUUID();
     UUID existingTableId = UUID.randomUUID();
     UUID existingColumnId = UUID.randomUUID();
+    BigQueryPartitionConfigV1 config = BigQueryPartitionConfigV1.none();
+    DatasetTable table =
+        new DatasetTable()
+            .name(EXISTING_TABLE)
+            .id(existingTableId)
+            .columns(
+                List.of(
+                    new Column()
+                        .name(EXISTING_COLUMN)
+                        .id(existingColumnId)
+                        .type(TableDataType.STRING)
+                        .arrayOf(false)
+                        .required(true)))
+            .bigQueryPartitionConfig(config);
+    DatasetTable table2 =
+        DatasetFixtures.generateDatasetTable(
+                EXISTING_TABLE_2, TableDataType.STRING, List.of(EXISTING_COLUMN_2))
+            .bigQueryPartitionConfig(config);
+    Relationship relationship =
+        new Relationship()
+            .name(EXISTING_RELATIONSHIP)
+            .fromTable(table)
+            .fromColumn(table.getColumns().get(0))
+            .toTable(table2)
+            .toColumn(table2.getColumns().get(0));
     when(datasetService.retrieve(datasetId))
         .thenReturn(
             new Dataset()
                 .id(datasetId)
                 .name("ValidationTestDataset")
                 .description("A dataset to test schema update validation")
-                .tables(
-                    List.of(
-                        new DatasetTable()
-                            .name(EXISTING_TABLE_NAME)
-                            .id(existingTableId)
-                            .columns(
-                                List.of(
-                                    new Column()
-                                        .name(EXISTING_COLUMN_NAME)
-                                        .id(existingColumnId)
-                                        .type(TableDataType.STRING)
-                                        .arrayOf(false)
-                                        .required(false))))));
+                .tables(List.of(table, table2))
+                .relationships(List.of(relationship)));
     given(jobService.getActivePodCount()).willReturn(1);
   }
 
@@ -100,7 +123,7 @@ public class DatasetSchemaUpdateValidationTest {
                                             .name("new_table_column")
                                             .datatype(TableDataType.STRING))),
                             new TableModel()
-                                .name(EXISTING_TABLE_NAME)
+                                .name(EXISTING_TABLE)
                                 .columns(
                                     List.of(
                                         new ColumnModel()
@@ -119,7 +142,7 @@ public class DatasetSchemaUpdateValidationTest {
 
     assertThat(exception.getMessage(), containsString("Could not validate"));
     assertThat(exception.getCauses().get(0), containsString("overwrite"));
-    assertThat(exception.getCauses().get(1), is(EXISTING_TABLE_NAME));
+    assertThat(exception.getCauses().get(1), is(EXISTING_TABLE));
     assertThat(exception.getCauses(), hasSize(2));
   }
 
@@ -142,11 +165,11 @@ public class DatasetSchemaUpdateValidationTest {
                     .addColumns(
                         List.of(
                             new DatasetSchemaColumnUpdateModel()
-                                .tableName(EXISTING_TABLE_NAME)
+                                .tableName(EXISTING_TABLE)
                                 .columns(
                                     List.of(
                                         new ColumnModel()
-                                            .name(EXISTING_COLUMN_NAME)
+                                            .name(EXISTING_COLUMN)
                                             .datatype(TableDataType.STRING),
                                         new ColumnModel()
                                             .name("new_column")
@@ -206,5 +229,155 @@ public class DatasetSchemaUpdateValidationTest {
 
     assertThat(missingTableException.getMessage(), containsString("Could not find tables"));
     assertThat(missingTableException.getCauses(), contains(containsString("not_a_real_table")));
+  }
+
+  @Test
+  public void testRelationshipDuplicateName() throws Exception {
+    String newTableName = "new_table";
+    String newColumnName = "new_column";
+    RelationshipModel newRelationship =
+        new RelationshipModel()
+            .name(EXISTING_RELATIONSHIP)
+            .from(new RelationshipTermModel().table(EXISTING_TABLE).column(EXISTING_COLUMN))
+            .to(new RelationshipTermModel().table(newTableName).column(newColumnName));
+    DatasetSchemaUpdateModel relationshipUpdateModel =
+        new DatasetSchemaUpdateModel()
+            .changes(
+                new DatasetSchemaUpdateModelChanges().addRelationships(List.of(newRelationship)));
+
+    DatasetSchemaUpdateValidateModelStep validateModelStep =
+        new DatasetSchemaUpdateValidateModelStep(
+            datasetService, datasetId, relationshipUpdateModel);
+
+    FlightContext flightContext = mock(FlightContext.class);
+
+    DatasetSchemaUpdateException invalidRelationshipException =
+        (DatasetSchemaUpdateException)
+            validateModelStep.doStep(flightContext).getException().orElseThrow();
+
+    assertThat(
+        invalidRelationshipException.getMessage(),
+        containsString("Could not validate relationship additions"));
+    assertTrue(
+        invalidRelationshipException
+            .getCauses()
+            .get(0)
+            .contains("Relationships with these names already exist for this dataset"));
+    assertTrue(invalidRelationshipException.getCauses().get(1).contains(EXISTING_RELATIONSHIP));
+  }
+
+  @Test
+  public void testRelationshipMissingTable() throws Exception {
+    RelationshipModel newRelationship =
+        new RelationshipModel()
+            .name("new_relationship")
+            .from(new RelationshipTermModel().table(EXISTING_TABLE).column(EXISTING_COLUMN))
+            .to(
+                new RelationshipTermModel()
+                    .table("nonexistent_table")
+                    .column("nonexistent_column"));
+    DatasetSchemaUpdateModel relationshipUpdateModel =
+        new DatasetSchemaUpdateModel()
+            .changes(
+                new DatasetSchemaUpdateModelChanges().addRelationships(List.of(newRelationship)));
+
+    DatasetSchemaUpdateValidateModelStep validateModelStep =
+        new DatasetSchemaUpdateValidateModelStep(
+            datasetService, datasetId, relationshipUpdateModel);
+
+    FlightContext flightContext = mock(FlightContext.class);
+
+    DatasetSchemaUpdateException invalidRelationshipException =
+        (DatasetSchemaUpdateException)
+            validateModelStep.doStep(flightContext).getException().orElseThrow();
+
+    assertThat(
+        invalidRelationshipException.getMessage(),
+        containsString("Could not validate relationship additions"));
+    assertTrue(
+        invalidRelationshipException
+            .getCauses()
+            .get(1)
+            .contains("InvalidRelationshipTermTable: Invalid table nonexistent_table"));
+  }
+
+  @Test
+  public void testRelationshipMissingColumn() throws Exception {
+    String newTableName = "new_table";
+    RelationshipModel newRelationship =
+        new RelationshipModel()
+            .name("relationship_missing_column")
+            .from(new RelationshipTermModel().table(EXISTING_TABLE).column(EXISTING_COLUMN))
+            .to(new RelationshipTermModel().table(newTableName).column("nonexistent_column"));
+    DatasetSchemaUpdateModel relationshipUpdateModel =
+        new DatasetSchemaUpdateModel()
+            .changes(
+                new DatasetSchemaUpdateModelChanges()
+                    .addTables(
+                        List.of(DatasetFixtures.tableModel(newTableName, List.of("new_column"))))
+                    .addRelationships(List.of(newRelationship)));
+
+    DatasetSchemaUpdateValidateModelStep validateModelStep =
+        new DatasetSchemaUpdateValidateModelStep(
+            datasetService, datasetId, relationshipUpdateModel);
+
+    FlightContext flightContext = mock(FlightContext.class);
+
+    DatasetSchemaUpdateException invalidRelationshipException =
+        (DatasetSchemaUpdateException)
+            validateModelStep.doStep(flightContext).getException().orElseThrow();
+
+    assertThat(
+        invalidRelationshipException.getMessage(),
+        containsString("Could not validate relationship additions"));
+    assertTrue(
+        invalidRelationshipException
+            .getCauses()
+            .contains(
+                "InvalidRelationshipTermTableColumn: Invalid table new_table.nonexistent_column"));
+  }
+
+  @Test
+  public void testColumnRelationshipInvalidType() throws Exception {
+    String newTableName = "new_table";
+    String newColumnName = "new_column";
+    TableModel newTable =
+        new TableModel()
+            .name(newTableName)
+            .columns(
+                List.of(
+                    DatasetFixtures.columnModel(
+                        newColumnName, TableDataType.FILEREF, false, true)));
+    RelationshipModel newRelationship =
+        new RelationshipModel()
+            .name("relationship_invalid_type")
+            .from(new RelationshipTermModel().table(EXISTING_TABLE).column(EXISTING_COLUMN))
+            .to(new RelationshipTermModel().table(newTableName).column(newColumnName));
+    DatasetSchemaUpdateModel relationshipUpdateModel =
+        new DatasetSchemaUpdateModel()
+            .changes(
+                new DatasetSchemaUpdateModelChanges()
+                    .addTables(List.of(newTable))
+                    .addRelationships(List.of(newRelationship)));
+
+    DatasetSchemaUpdateValidateModelStep validateModelStep =
+        new DatasetSchemaUpdateValidateModelStep(
+            datasetService, datasetId, relationshipUpdateModel);
+
+    FlightContext flightContext = mock(FlightContext.class);
+
+    DatasetSchemaUpdateException invalidRelationshipException =
+        (DatasetSchemaUpdateException)
+            validateModelStep.doStep(flightContext).getException().orElseThrow();
+
+    assertThat(
+        invalidRelationshipException.getMessage(),
+        containsString("Could not validate relationship additions"));
+    assertThat(
+        invalidRelationshipException.getCauses().get(1), containsString("InvalidForeignKey"));
+    assertThat(
+        invalidRelationshipException.getCauses().get(1),
+        containsString(
+            "InvalidForeignKey: Foreign key new_column cannot be a column with fileref type"));
   }
 }


### PR DESCRIPTION
Update the `/api/repository/v1/datasets/{id}/schemaUpdate` endpoint to allow adding new dataset relationships. Things to note:
- Relationship names must be unique within a dataset, so the `DatasetSchemaUpdateValidator` ensures that there are no duplicates within the request. 
- In the flight, the `DatasetSchemaUpdateValidateModelStep.java` validates the new relationships against the existing dataset schema. I refactored the DatasetRequestValidator.java to make validation more reusable.
- `DatasetSchemaUpdateAddRelationshipsPostgresStep.java` adds the relationships in postgres. I added a transaction annotation so that postgres will roll back the transaction if there is an error creating any of the relationships (let me know if my understanding of this is incorrect!). The undo step can be left empty here because this is the only step required to create relationships.