### PR TITLE
[DR-2652] Retry "Too many DML statements outstanding" in IngestCopyLoadHistoryToBQStep

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CombinedIngestLoad.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CombinedIngestLoad.java
@@ -1,0 +1,121 @@
+package scripts.testscripts;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.datarepo.api.RepositoryApi;
+import bio.terra.datarepo.client.ApiClient;
+import bio.terra.datarepo.model.BulkLoadArrayRequestModel;
+import bio.terra.datarepo.model.BulkLoadArrayResultModel;
+import bio.terra.datarepo.model.BulkLoadFileModel;
+import bio.terra.datarepo.model.BulkLoadResultModel;
+import bio.terra.datarepo.model.CloudPlatform;
+import bio.terra.datarepo.model.ErrorModel;
+import bio.terra.datarepo.model.IngestRequestModel;
+import bio.terra.datarepo.model.JobModel;
+import com.google.cloud.storage.BlobId;
+import common.utils.StorageUtils;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import runner.config.TestUserSpecification;
+import scripts.testscripts.baseclasses.SimpleDataset;
+import scripts.utils.BulkLoadUtils;
+import scripts.utils.DataRepoUtils;
+
+public class CombinedIngestLoad extends SimpleDataset {
+  private static final Logger logger = LoggerFactory.getLogger(CombinedIngestLoad.class);
+
+  /** Public constructor so that this class can be instantiated via reflection. */
+  public CombinedIngestLoad() {
+    super();
+    //    manipulatesKubernetes = true; // this test script manipulates Kubernetes
+  }
+
+  private int filesToLoad;
+
+  private static final List<BlobId> scratchFiles = new ArrayList<>();
+
+  public void setup(List<TestUserSpecification> testUsers) throws Exception {
+    // create the profile and dataset
+    super.setup(testUsers);
+
+    // upload scratch files
+    String testConfigGetIngestbucket = "jade-testdata";
+    BulkLoadArrayRequestModel arrayRequestModel =
+        BulkLoadUtils.buildBulkLoadFileRequest100B(filesToLoad, billingProfileModel.getId());
+    String scratchFilePrefix = "bulkCombinedIngestTest/" + datasetSummaryModel.getId();
+
+    for (int i = 0; i < arrayRequestModel.getLoadArray().size(); i++) {
+      BulkLoadFileModel fileModel = arrayRequestModel.getLoadArray().get(i);
+      String scratchFileName = String.format("%s/combined-ingest-%s.json", scratchFilePrefix, i);
+      BlobId scratchFile =
+          BulkLoadUtils.writeScratchFileForCombinedIngestRequest(
+              server.testRunnerServiceAccount,
+              fileModel,
+              testConfigGetIngestbucket,
+              scratchFileName);
+      scratchFiles.add(scratchFile);
+    }
+  }
+
+  public void setParameters(List<String> parameters) throws Exception {
+    if (parameters == null || parameters.size() == 0) {
+      throw new IllegalArgumentException(
+          "Must provide a number of files to load in the parameters list");
+    } else {
+      filesToLoad = Integer.parseInt(parameters.get(0));
+    }
+  }
+
+  // The purpose of this test is to measure scaling of parallel combined file ingests.
+  public void userJourney(TestUserSpecification testUser) throws Exception {
+    ApiClient apiClient = DataRepoUtils.getClientForTestUser(testUser, server);
+    RepositoryApi repositoryApi = new RepositoryApi(apiClient);
+
+    // Launch combined ingest requests
+    ArrayList<JobModel> responses = new ArrayList<>();
+    for (BlobId scratchFile : scratchFiles) {
+      IngestRequestModel ingestRequest =
+          BulkLoadUtils.makeIngestRequestFromScratchFile(scratchFile);
+      JobModel ingestTabularDataJobResponse =
+          repositoryApi.ingestDataset(datasetSummaryModel.getId(), ingestRequest);
+      responses.add(ingestTabularDataJobResponse);
+    }
+
+    // wait for the job to complete and print out results to debug log level
+    ArrayList<String> errors = new ArrayList<>();
+    for (JobModel jobResponse : responses) {
+      JobModel finishedJob = DataRepoUtils.waitForJobToFinish(repositoryApi, jobResponse, testUser);
+      if (finishedJob.getJobStatus().equals(JobModel.JobStatusEnum.FAILED)) {
+        ErrorModel errorModel =
+            DataRepoUtils.getJobResult(repositoryApi, jobResponse, ErrorModel.class);
+        errors.add(errorModel.getMessage());
+      } else {
+        BulkLoadArrayResultModel result =
+            DataRepoUtils.getJobResult(repositoryApi, jobResponse, BulkLoadArrayResultModel.class);
+        BulkLoadResultModel loadSummary = result.getLoadSummary();
+        assertThat(
+            "Number of successful files loaded should equal total files.",
+            loadSummary.getTotalFiles(),
+            equalTo(loadSummary.getSucceededFiles()));
+      }
+      logger.info("Failed combined ingests: " + errors.size());
+      assertThat("No errors present", errors.size(), equalTo(0));
+    }
+  }
+
+  public void cleanup(List<TestUserSpecification> testUsers) throws Exception {
+    logger.info("Tearing down");
+
+    // delete the profile and dataset
+    super.cleanup(testUsers);
+
+    // delete the scratch files used for ingesting metadata
+    if (cloudPlatform.equals(CloudPlatform.GCP)) {
+      StorageUtils.deleteFiles(
+          StorageUtils.getClientForServiceAccount(server.testRunnerServiceAccount), scratchFiles);
+    }
+  }
+}

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CombinedIngestLoad.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CombinedIngestLoad.java
@@ -6,12 +6,12 @@ import static org.hamcrest.Matchers.equalTo;
 import bio.terra.datarepo.api.RepositoryApi;
 import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.model.BulkLoadArrayRequestModel;
-import bio.terra.datarepo.model.BulkLoadArrayResultModel;
 import bio.terra.datarepo.model.BulkLoadFileModel;
 import bio.terra.datarepo.model.BulkLoadResultModel;
 import bio.terra.datarepo.model.CloudPlatform;
 import bio.terra.datarepo.model.ErrorModel;
 import bio.terra.datarepo.model.IngestRequestModel;
+import bio.terra.datarepo.model.IngestResponseModel;
 import bio.terra.datarepo.model.JobModel;
 import com.google.cloud.storage.BlobId;
 import common.utils.StorageUtils;
@@ -93,9 +93,10 @@ public class CombinedIngestLoad extends SimpleDataset {
             DataRepoUtils.getJobResult(repositoryApi, jobResponse, ErrorModel.class);
         errors.add(errorModel.getMessage());
       } else {
-        BulkLoadArrayResultModel result =
-            DataRepoUtils.getJobResult(repositoryApi, jobResponse, BulkLoadArrayResultModel.class);
-        BulkLoadResultModel loadSummary = result.getLoadSummary();
+        IngestResponseModel result =
+            DataRepoUtils.getJobResult(repositoryApi, jobResponse, IngestResponseModel.class);
+        BulkLoadResultModel loadSummary = result.getLoadResult().getLoadSummary();
+        assertThat("Result has expected row count", result.getRowCount(), equalTo(1));
         assertThat(
             "Number of successful files loaded should equal total files.",
             loadSummary.getTotalFiles(),

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/CombinedIngestLoad.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/CombinedIngestLoad.java
@@ -30,7 +30,6 @@ public class CombinedIngestLoad extends SimpleDataset {
   /** Public constructor so that this class can be instantiated via reflection. */
   public CombinedIngestLoad() {
     super();
-    //    manipulatesKubernetes = true; // this test script manipulates Kubernetes
   }
 
   private int filesToLoad;
@@ -96,7 +95,7 @@ public class CombinedIngestLoad extends SimpleDataset {
         IngestResponseModel result =
             DataRepoUtils.getJobResult(repositoryApi, jobResponse, IngestResponseModel.class);
         BulkLoadResultModel loadSummary = result.getLoadResult().getLoadSummary();
-        assertThat("Result has expected row count", result.getRowCount(), equalTo(1));
+        assertThat("Result has expected row count", result.getRowCount(), equalTo(1L));
         assertThat(
             "Number of successful files loaded should equal total files.",
             loadSummary.getTotalFiles(),

--- a/datarepo-clienttests/src/main/java/scripts/utils/BulkLoadUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/BulkLoadUtils.java
@@ -182,6 +182,31 @@ public class BulkLoadUtils {
         fileRefBytes);
   }
 
+  public static BlobId writeScratchFileForCombinedIngestRequest(
+      ServiceAccountSpecification serviceAccount,
+      BulkLoadFileModel fileModel,
+      String bucketName,
+      String ingestFileName)
+      throws Exception {
+    String jsonLine = "{\"VCF_File_Name\":\"%s\", \"Description\":\"%s\", \"VCF_File_Ref\":%s}%n";
+    String scratchFileJson =
+        String.format(
+            jsonLine, "testFile", "combined metadata ingest", bulkLoadFileModelToJson(fileModel));
+    byte[] fileRefBytes = scratchFileJson.getBytes(StandardCharsets.UTF_8);
+    return StorageUtils.writeBytesToFile(
+        StorageUtils.getClientForServiceAccount(serviceAccount),
+        bucketName,
+        ingestFileName,
+        fileRefBytes);
+  }
+
+  private static String bulkLoadFileModelToJson(BulkLoadFileModel fileModel) {
+    String fileJSON =
+        "[{\"description\":\"Test file\", \"mimeType\":\"%s\", \"sourcePath\":\"%s\", \"targetPath\": \"%s\"}]";
+    return String.format(
+        fileJSON, fileModel.getMimeType(), fileModel.getSourcePath(), fileModel.getTargetPath());
+  }
+
   public static String azureWriteScratchFileForIngestRequest(
       BlobIOTestUtility blobIOTestUtility,
       BulkLoadArrayResultModel arrayResultModel,

--- a/datarepo-clienttests/src/main/java/scripts/utils/BulkLoadUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/BulkLoadUtils.java
@@ -202,7 +202,7 @@ public class BulkLoadUtils {
 
   private static String bulkLoadFileModelToJson(BulkLoadFileModel fileModel) {
     String fileJSON =
-        "[{\"description\":\"Test file\", \"mimeType\":\"%s\", \"sourcePath\":\"%s\", \"targetPath\": \"%s\"}]";
+        "{\"description\":\"Test file\", \"mimeType\":\"%s\", \"sourcePath\":\"%s\", \"targetPath\": \"%s\"}";
     return String.format(
         fileJSON, fileModel.getMimeType(), fileModel.getSourcePath(), fileModel.getTargetPath());
   }

--- a/datarepo-clienttests/src/main/resources/configs/profiling/CombinedIngestLoadScale50.json
+++ b/datarepo-clienttests/src/main/resources/configs/profiling/CombinedIngestLoadScale50.json
@@ -1,0 +1,18 @@
+{
+  "name": "CombinedIngestLoadScale50",
+  "description": "One user performs many combined metadata ingests into one dataset",
+  "serverSpecificationFile": "perf.json",
+  "billingAccount": "00708C-45D19D-27AAFA",
+  "application": {},
+  "testScripts": [
+    {
+      "name": "CombinedIngestLoad",
+      "parameters": [50],
+      "numberOfUserJourneyThreadsToRun": 10,
+      "userJourneyThreadPoolSize": 1,
+      "expectedTimeForEach": 1000000,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": ["dumbledore.json"]
+}

--- a/datarepo-clienttests/src/main/resources/configs/profiling/CombinedIngestLoadScale50.json
+++ b/datarepo-clienttests/src/main/resources/configs/profiling/CombinedIngestLoadScale50.json
@@ -8,7 +8,7 @@
     {
       "name": "CombinedIngestLoad",
       "parameters": [50],
-      "numberOfUserJourneyThreadsToRun": 10,
+      "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 1,
       "expectedTimeForEach": 1000000,
       "expectedTimeForEachUnit": "SECONDS"

--- a/datarepo-clienttests/src/main/resources/suites/NightlyPerfWorkflow.json
+++ b/datarepo-clienttests/src/main/resources/suites/NightlyPerfWorkflow.json
@@ -11,6 +11,7 @@
     "profiling/BuildSnapshotWithFiles1000_50.json",
     "profiling/BulkLoadScale200_20.json",
     "functional/CreateSnapshot.json",
-    "functional/AzureCreateSnapshot.json"
+    "functional/AzureCreateSnapshot.json",
+    "profiling/CombinedIngestLoadScale50.json"
   ]
 }

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
@@ -86,7 +86,8 @@ public class DatasetDataDeleteFlight extends Flight {
       String transactionDesc = "Autocommit transaction";
       addStep(
           new TransactionOpenStep(
-              datasetService, bigQueryTransactionPdao, userReq, transactionDesc, false, false));
+              datasetService, bigQueryTransactionPdao, userReq, transactionDesc, false, false),
+          randomBackoffRetry);
       autocommit = true;
     } else {
       addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
@@ -57,6 +57,9 @@ public class DatasetDataDeleteFlight extends Flight {
     RetryRule lockDatasetRetry =
         getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
+    RetryRule randomBackoffRetry =
+        getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+
     DataDeletionRequest request =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), DataDeletionRequest.class);
 
@@ -119,7 +122,8 @@ public class DatasetDataDeleteFlight extends Flight {
               datasetService, bigQueryTransactionPdao, request.getTransactionId(), userReq));
     } else {
       addStep(
-          new TransactionCommitStep(datasetService, bigQueryTransactionPdao, userReq, false, null));
+          new TransactionCommitStep(datasetService, bigQueryTransactionPdao, userReq, false, null),
+          randomBackoffRetry);
     }
 
     // unlock

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -104,6 +104,9 @@ public class DatasetIngestFlight extends Flight {
     RetryRule lockDatasetRetry =
         getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
 
+    RetryRule randomBackoffRetry =
+        getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+
     // Add these steps to clear out scratch file if the flight has failed
     if (cloudPlatform.isGcp()) {
       addStep(new PerformPayloadIngestStep(new IngestLandingFileDeleteGcpStep(true, gcsPdao)));
@@ -154,8 +157,6 @@ public class DatasetIngestFlight extends Flight {
           configService.getParameterValue(ConfigEnum.LOAD_HISTORY_WAIT_SECONDS);
       int loadHistoryChunkSize =
           configService.getParameterValue(ConfigEnum.LOAD_HISTORY_COPY_CHUNK_SIZE);
-      RetryRule randomBackoffRetry =
-          getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
       RetryRule driverRetry = new RetryRuleExponentialBackoff(5, 20, 600);
 
       var profileId =
@@ -271,7 +272,8 @@ public class DatasetIngestFlight extends Flight {
       } else {
         addStep(
             new TransactionCommitStep(
-                datasetService, bigQueryTransactionPdao, userReq, false, null));
+                datasetService, bigQueryTransactionPdao, userReq, false, null),
+            randomBackoffRetry);
       }
     }
     addStep(new UnlockDatasetStep(datasetService, datasetId, true), lockDatasetRetry);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -417,7 +417,8 @@ public class DatasetIngestFlight extends Flight {
             dataset.getId(),
             ingestRequest.getLoadTag(),
             loadHistoryWaitSeconds,
-            loadHistoryChunkSize));
+            loadHistoryChunkSize),
+        randomBackoffRetry);
 
     // Clean up the load table.
     addOptionalCombinedIngestStep(new IngestCleanFileStateStep(loadService));

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -133,7 +133,8 @@ public class DatasetIngestFlight extends Flight {
         String transactionDesc = "Autocommit transaction";
         addStep(
             new TransactionOpenStep(
-                datasetService, bigQueryTransactionPdao, userReq, transactionDesc, false, false));
+                datasetService, bigQueryTransactionPdao, userReq, transactionDesc, false, false),
+            randomBackoffRetry);
         autocommit = true;
       } else {
         addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/transactions/TransactionCommitFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/transactions/TransactionCommitFlight.java
@@ -1,5 +1,8 @@
 package bio.terra.service.dataset.flight.transactions;
 
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.exception.CommonExceptions;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -9,6 +12,7 @@ import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryTransactionPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.RetryRule;
 import java.util.UUID;
 import org.springframework.context.ApplicationContext;
 
@@ -19,6 +23,7 @@ public class TransactionCommitFlight extends Flight {
 
     // get the required daos to pass into the steps
     ApplicationContext appContext = (ApplicationContext) applicationContext;
+    ApplicationConfiguration appConfig = appContext.getBean(ApplicationConfiguration.class);
     DatasetService datasetService = appContext.getBean(DatasetService.class);
     BigQueryTransactionPdao bigQueryTransactionPdao =
         appContext.getBean(BigQueryTransactionPdao.class);
@@ -33,6 +38,9 @@ public class TransactionCommitFlight extends Flight {
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
+    RetryRule randomBackoffRetry =
+        getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+
     if (cloudPlatform.isGcp()) {
       addStep(
           new TransactionLockStep(
@@ -40,7 +48,8 @@ public class TransactionCommitFlight extends Flight {
       addStep(new TransactionVerifyStep(datasetService, bigQueryTransactionPdao, transactionId));
       addStep(
           new TransactionCommitStep(
-              datasetService, bigQueryTransactionPdao, userReq, true, transactionId));
+              datasetService, bigQueryTransactionPdao, userReq, true, transactionId),
+          randomBackoffRetry);
       addStep(
           new TransactionUnlockStep(
               datasetService, bigQueryTransactionPdao, transactionId, userReq));

--- a/src/main/java/bio/terra/service/dataset/flight/transactions/TransactionCommitStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/transactions/TransactionCommitStep.java
@@ -57,6 +57,8 @@ public class TransactionCommitStep implements Step {
       }
     } catch (TooManyDmlStatementsOutstandingException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+    } catch (InterruptedException ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/filedata/exception/TooManyDmlStatementsOutstandingException.java
+++ b/src/main/java/bio/terra/service/filedata/exception/TooManyDmlStatementsOutstandingException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.filedata.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class TooManyDmlStatementsOutstandingException extends InternalServerErrorException {
+  public TooManyDmlStatementsOutstandingException(String message) {
+    super(message);
+  }
+
+  public TooManyDmlStatementsOutstandingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TooManyDmlStatementsOutstandingException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -229,7 +229,8 @@ public class FileIngestBulkFlight extends Flight {
               datasetUuid,
               loadTag,
               loadHistoryWaitSeconds,
-              loadHistoryChunkSize));
+              loadHistoryChunkSize),
+          randomBackoffRetry);
     } else if (platform.isAzure()) {
       addStep(
           new IngestCopyLoadHistoryToStorageTableStep(

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryToBQStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryToBQStep.java
@@ -2,6 +2,7 @@ package bio.terra.service.filedata.flight.ingest;
 
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.exception.TooManyDmlStatementsOutstandingException;
 import bio.terra.service.load.LoadService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.FlightContext;
@@ -66,6 +67,8 @@ public class IngestCopyLoadHistoryToBQStep extends IngestCopyLoadHistoryStep {
       bigQueryDatasetPdao.deleteStagingLoadHistoryTable(resources.dataset, tableNameFlightId);
 
       return StepResult.getStepResultSuccess();
+    } catch (TooManyDmlStatementsOutstandingException ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     } catch (InterruptedException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
     }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -393,7 +393,7 @@ public class BigQueryDatasetPdao {
     bigQueryProject.query(sqlTemplate.render());
   }
 
-  private static final String mergeLoadHistoryStagingTableTemplate =
+  public static final String mergeLoadHistoryStagingTableTemplate =
       "MERGE `<project>.<dataset>.<loadTable>` L"
           + " USING `<project>.<dataset>.<stagingTable>` S"
           + " ON S.load_tag = L.load_tag AND S.load_time = L.load_time"

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -404,11 +404,6 @@ public class BigQueryDatasetPdao {
           + " VALUES (load_tag, load_time, source_name, target_path, state, file_id, checksum_crc32c,"
           + " checksum_md5, error)";
 
-  private boolean tooManyDmlStatementsOutstanding(PdaoException ex) {
-    return ex.getCause() instanceof BigQueryException
-        && ex.getMessage().contains("Too many DML statements outstanding against table");
-  }
-
   public void mergeStagingLoadHistoryTable(Dataset dataset, String flightId)
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
@@ -429,7 +424,7 @@ public class BigQueryDatasetPdao {
     try {
       bigQueryProject.query(sqlTemplate.render());
     } catch (PdaoException ex) {
-      if (tooManyDmlStatementsOutstanding(ex)) {
+      if (BigQueryPdao.tooManyDmlStatementsOutstanding(ex)) {
         throw new TooManyDmlStatementsOutstandingException(ex);
       }
       throw ex;

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -89,6 +89,7 @@ public abstract class BigQueryPdao {
 
   public static boolean tooManyDmlStatementsOutstanding(PdaoException ex) {
     return ex.getCause() instanceof BigQueryException
-        && ex.getMessage().contains("Too many DML statements outstanding against table");
+        && (ex.getCause().getMessage().contains("Too many DML statements outstanding against table")
+            || ((BigQueryException) ex.getCause()).getReason().contains("jobRateLimitExceeded"));
   }
 }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -6,9 +6,11 @@ import static bio.terra.common.PdaoConstant.PDAO_PREFIX;
 
 import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
+import bio.terra.common.exception.PdaoException;
 import bio.terra.service.filedata.FSContainerInterface;
 import bio.terra.service.tabulardata.google.BigQueryProject;
 import com.google.cloud.bigquery.Acl;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.TableResult;
 import java.util.Collection;
@@ -83,5 +85,10 @@ public abstract class BigQueryPdao {
   static long getSingleLongValue(TableResult result) {
     FieldValueList fieldValues = result.getValues().iterator().next();
     return fieldValues.get(0).getLongValue();
+  }
+
+  public static boolean tooManyDmlStatementsOutstanding(PdaoException ex) {
+    return ex.getCause() instanceof BigQueryException
+        && ex.getMessage().contains("Too many DML statements outstanding against table");
   }
 }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
@@ -217,6 +217,7 @@ public class BigQueryTransactionPdao {
       if (BigQueryPdao.tooManyDmlStatementsOutstanding(ex)) {
         throw new TooManyDmlStatementsOutstandingException(ex);
       }
+      throw ex;
     }
     return retrieveTransaction(dataset, transactId);
   }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
@@ -83,23 +83,28 @@ public class BigQueryTransactionPdao {
             .status(TransactionModel.StatusEnum.ACTIVE)
             .createdAt(DateTimeUtils.toMicrosString(filterBefore))
             .createdBy(authedUser.getEmail());
-
-    bigQueryProject.query(
-        sqlTemplate.render(),
-        Map.of(
-            "transactId",
-            QueryParameterValue.string(transaction.getId().toString()),
-            "transactLock",
-            QueryParameterValue.string(transaction.getLock()),
-            "transactDescription",
-            QueryParameterValue.string(transaction.getDescription()),
-            "transactStatus",
-            QueryParameterValue.string(transaction.getStatus().toString()),
-            "transactCreatedAt",
-            QueryParameterValue.timestamp(DateTimeUtils.toEpochMicros(filterBefore)),
-            "transactCreatedBy",
-            QueryParameterValue.string(transaction.getCreatedBy())));
-
+    try {
+      bigQueryProject.query(
+          sqlTemplate.render(),
+          Map.of(
+              "transactId",
+              QueryParameterValue.string(transaction.getId().toString()),
+              "transactLock",
+              QueryParameterValue.string(transaction.getLock()),
+              "transactDescription",
+              QueryParameterValue.string(transaction.getDescription()),
+              "transactStatus",
+              QueryParameterValue.string(transaction.getStatus().toString()),
+              "transactCreatedAt",
+              QueryParameterValue.timestamp(DateTimeUtils.toEpochMicros(filterBefore)),
+              "transactCreatedBy",
+              QueryParameterValue.string(transaction.getCreatedBy())));
+    } catch (PdaoException ex) {
+      if (BigQueryPdao.tooManyDmlStatementsOutstanding(ex)) {
+        throw new TooManyDmlStatementsOutstandingException(ex);
+      }
+      throw ex;
+    }
     return transaction;
   }
 

--- a/src/test/java/bio/terra/common/BQTestUtils.java
+++ b/src/test/java/bio/terra/common/BQTestUtils.java
@@ -37,6 +37,14 @@ public final class BQTestUtils {
     }
   }
 
+  public static void mockBQQueryError(BigQueryProject mockBQProject, String sql, Throwable ex) {
+    try {
+      when(mockBQProject.query(eq(sql))).thenThrow(ex);
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Error mocking query execution");
+    }
+  }
+
   public static void mockBQQuery(
       BigQuery mockBQ,
       QueryJobConfiguration sql,

--- a/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
@@ -161,11 +161,11 @@ public class BigQueryPdaoUnitTest {
 
     when(bigQueryProjectDataset.tableExists(dataset.getName(), PDAO_LOAD_HISTORY_TABLE))
         .thenReturn(true);
-    Throwable cause = new BigQueryException(HttpStatus.BAD_REQUEST.value(), "exception");
+    Throwable cause =
+        new BigQueryException(
+            HttpStatus.BAD_REQUEST.value(), "Too many DML statements outstanding against table");
     BQTestUtils.mockBQQueryError(
-        bigQueryProjectDataset,
-        query,
-        new PdaoException("Too many DML statements outstanding against table", cause));
+        bigQueryProjectDataset, query, new PdaoException("Failure executing query", cause));
     assertThrows(
         TooManyDmlStatementsOutstandingException.class,
         () -> bigQueryDatasetPdao.mergeStagingLoadHistoryTable(dataset, flightId));

--- a/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
@@ -1,5 +1,7 @@
 package bio.terra.service.tabulardata.google.bigquery;
 
+import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_STAGING_TABLE_PREFIX;
+import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_TABLE;
 import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_COLUMN;
 import static bio.terra.common.PdaoConstant.PDAO_TABLE_ID_COLUMN;
 import static bio.terra.service.tabulardata.google.bigquery.BigQueryPdao.prefixName;
@@ -34,6 +36,7 @@ import bio.terra.service.dataset.AssetTable;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.dataset.GoogleStorageResource;
+import bio.terra.service.filedata.exception.TooManyDmlStatementsOutstandingException;
 import bio.terra.service.filedata.google.bq.BigQueryConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.RowIdMatch;
@@ -46,6 +49,7 @@ import bio.terra.service.snapshot.exception.MismatchedValueException;
 import bio.terra.service.tabulardata.google.BigQueryProject;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.FieldValue;
@@ -72,7 +76,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
+import org.stringtemplate.v4.ST;
 
 @ActiveProfiles({"google", "unittest"})
 @Category(Unit.class)
@@ -140,6 +146,29 @@ public class BigQueryPdaoUnitTest {
     bigQuerySnapshotPdao =
         new BigQuerySnapshotPdao(applicationConfiguration, bigQueryConfiguration);
     snapshot = mockSnapshot();
+  }
+
+  @Test
+  public void testMergeStagingHistoryError() throws InterruptedException {
+    Dataset dataset = mockDataset();
+    String flightId = "flightId";
+    ST sqlTemplate = new ST(BigQueryDatasetPdao.mergeLoadHistoryStagingTableTemplate);
+    sqlTemplate.add("project", bigQueryProjectDataset.getProjectId());
+    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
+    sqlTemplate.add("stagingTable", PDAO_LOAD_HISTORY_STAGING_TABLE_PREFIX + flightId);
+    sqlTemplate.add("loadTable", PDAO_LOAD_HISTORY_TABLE);
+    String query = sqlTemplate.render();
+
+    when(bigQueryProjectDataset.tableExists(dataset.getName(), PDAO_LOAD_HISTORY_TABLE))
+        .thenReturn(true);
+    Throwable cause = new BigQueryException(HttpStatus.BAD_REQUEST.value(), "exception");
+    BQTestUtils.mockBQQueryError(
+        bigQueryProjectDataset,
+        query,
+        new PdaoException("Too many DML statements outstanding against table", cause));
+    assertThrows(
+        TooManyDmlStatementsOutstandingException.class,
+        () -> bigQueryDatasetPdao.mergeStagingLoadHistoryTable(dataset, flightId));
   }
 
   @Test
@@ -1049,7 +1078,7 @@ public class BigQueryPdaoUnitTest {
     assertEquals(listTest, result.get(0).get("ARRAY"));
   }
 
-  private Snapshot mockSnapshot() {
+  private Dataset mockDataset() {
     DatasetTable tbl1 =
         DatasetFixtures.generateDatasetTable(
                 TABLE_1_NAME, TableDataType.STRING, List.of(TABLE_1_COL1_NAME, TABLE_1_COL2_NAME))
@@ -1066,6 +1095,26 @@ public class BigQueryPdaoUnitTest {
     tbl2.getColumns().get(0).id(TABLE_2_COL1_ID);
     tbl2.getColumns().get(1).id(TABLE_2_COL2_ID);
     tbl2.getColumns().get(2).id(TABLE_2_COL3_ID);
+
+    return new Dataset()
+        .id(DATASET_ID)
+        .name(DATASET_NAME)
+        .projectResource(
+            new GoogleProjectResource().profileId(PROFILE_1_ID).googleProjectId(DATASET_PROJECT_ID))
+        .tables(List.of(tbl1, tbl2))
+        .storage(
+            List.of(
+                new GoogleStorageResource(
+                    DATASET_ID,
+                    GoogleCloudResource.BIGQUERY,
+                    GoogleRegion.NORTHAMERICA_NORTHEAST1)));
+  }
+
+  private Snapshot mockSnapshot() {
+    Dataset dataset = mockDataset();
+    List<DatasetTable> tables = dataset.getTables();
+    DatasetTable tbl1 = tables.get(0);
+    DatasetTable tbl2 = tables.get(1);
 
     SnapshotTable snpTbl1 =
         new SnapshotTable().id(SNAPSHOT_TABLE_1_ID).name(tbl1.getName()).columns(tbl1.getColumns());
@@ -1092,21 +1141,7 @@ public class BigQueryPdaoUnitTest {
         .snapshotSources(
             List.of(
                 new SnapshotSource()
-                    .dataset(
-                        new Dataset()
-                            .id(DATASET_ID)
-                            .name(DATASET_NAME)
-                            .projectResource(
-                                new GoogleProjectResource()
-                                    .profileId(PROFILE_1_ID)
-                                    .googleProjectId(DATASET_PROJECT_ID))
-                            .tables(List.of(tbl1, tbl2))
-                            .storage(
-                                List.of(
-                                    new GoogleStorageResource(
-                                        DATASET_ID,
-                                        GoogleCloudResource.BIGQUERY,
-                                        GoogleRegion.NORTHAMERICA_NORTHEAST1))))
+                    .dataset(mockDataset())
                     .assetSpecification(
                         new AssetSpecification()
                             .rootTable(new AssetTable().datasetTable(tbl1))


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2652

Checkpointing my work in case someone else would like to take it to completion!

Caveats: untested, wanted to reproduce issue first via load test, wanted to write automated test(s).

---
Updates from Saman:

This PR makes the `TransactionCommitFlight` and `IngestCopyLoadHistoryToBQStep` steps retry on the "Too many DML statements" error.

The load test runs multiple combined metadata/file ingest flights on a single dataset. When I ran this against develop, I was able to reproduce the issue since it caused concurrent updates to the BigQuery load history table.
