### PR TITLE
[DR-2673] Expand job endpoint permissions

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/auth/iam/LocalAuthenticatedUserRequestFactory.java
@@ -5,6 +5,7 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +41,10 @@ public class LocalAuthenticatedUserRequestFactory implements AuthenticatedUserRe
     String email =
         Optional.ofNullable(req.getHeader("From")).orElse(applicationConfiguration.getUserEmail());
 
-    String userId = applicationConfiguration.getUserId();
+    String userId =
+        StringUtils.isNotEmpty(req.getHeader("UserId"))
+            ? req.getHeader("UserId")
+            : applicationConfiguration.getUserId();
 
     return AuthenticatedUserRequest.builder()
         .setEmail(email)

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -134,9 +134,10 @@ public class DatasetService {
     loggingMetrics.set(BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, defaultProfileId);
     return jobService
         .newJob(description, DatasetCreateFlight.class, datasetRequest, userReq)
-        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.SPEND_PROFILE)
-        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), defaultProfileId)
-        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.LINK)
+        .addParameter(
+            JobMapKeys.READ_JOB_ACLS.getKeyName(),
+            jobService.readJobAcls(
+                IamResourceType.SPEND_PROFILE, defaultProfileId.toString(), IamAction.LINK))
         .submit();
   }
 
@@ -308,9 +309,9 @@ public class DatasetService {
               .addParameter(JobMapKeys.BILLING_ID.getKeyName(), ingestRequestModel.getProfileId())
               .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
               .addParameter(IngestMapKeys.TABLE_NAME, ingestRequestModel.getTable())
-              .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
-              .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
-              .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
+              .addParameter(
+                  JobMapKeys.READ_JOB_ACLS.getKeyName(),
+                  jobService.readJobAcls(IamResourceType.DATASET, id, IamAction.INGEST_DATA))
               .submitAndWait(String.class);
 
       CloudPlatformWrapper cloudPlatform =
@@ -347,9 +348,9 @@ public class DatasetService {
         .newJob(description, DatasetIngestFlight.class, ingestRequestModel, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
         .addParameter(LoadMapKeys.LOAD_TAG, loadTag)
-        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
-        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
-        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
+        .addParameter(
+            JobMapKeys.READ_JOB_ACLS.getKeyName(),
+            jobService.readJobAcls(IamResourceType.DATASET, id, IamAction.INGEST_DATA))
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -259,6 +259,9 @@ public class DatasetService {
         .newJob(description, DatasetDeleteFlight.class, null, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
         .addParameter(JobMapKeys.CLOUD_PLATFORM.getKeyName(), platform.name())
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.DELETE)
         .submit();
   }
 
@@ -359,6 +362,9 @@ public class DatasetService {
     return jobService
         .newJob(description, AddAssetSpecFlight.class, assetModel, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.MANAGE_SCHEMA)
         .submit();
   }
 
@@ -380,6 +386,9 @@ public class DatasetService {
         .newJob(description, RemoveAssetSpecFlight.class, assetId, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
         .addParameter(JobMapKeys.ASSET_ID.getKeyName(), assetId)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.MANAGE_SCHEMA)
         .submit();
   }
 
@@ -389,6 +398,9 @@ public class DatasetService {
     return jobService
         .newJob(description, DatasetDataDeleteFlight.class, dataDeletionRequest, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SOFT_DELETE)
         .submit();
   }
 
@@ -398,6 +410,9 @@ public class DatasetService {
     return jobService
         .newJob(description, DatasetSchemaUpdateFlight.class, updateModel, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.MANAGE_SCHEMA)
         .submit();
   }
 
@@ -443,6 +458,9 @@ public class DatasetService {
     return jobService
         .newJob(description, TransactionOpenFlight.class, transactionRequest, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 
@@ -482,6 +500,9 @@ public class DatasetService {
         .newJob(description, TransactionCommitFlight.class, null, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
         .addParameter(JobMapKeys.TRANSACTION_ID.getKeyName(), transactionId)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 
@@ -492,6 +513,9 @@ public class DatasetService {
         .newJob(description, TransactionRollbackFlight.class, null, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
         .addParameter(JobMapKeys.TRANSACTION_ID.getKeyName(), transactionId)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -134,10 +134,9 @@ public class DatasetService {
     loggingMetrics.set(BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, defaultProfileId);
     return jobService
         .newJob(description, DatasetCreateFlight.class, datasetRequest, userReq)
-        .addParameter(
-            JobMapKeys.READ_JOB_ACLS.getKeyName(),
-            jobService.readJobAcls(
-                IamResourceType.SPEND_PROFILE, defaultProfileId.toString(), IamAction.LINK))
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.SPEND_PROFILE)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), defaultProfileId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.LINK)
         .submit();
   }
 
@@ -309,9 +308,9 @@ public class DatasetService {
               .addParameter(JobMapKeys.BILLING_ID.getKeyName(), ingestRequestModel.getProfileId())
               .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
               .addParameter(IngestMapKeys.TABLE_NAME, ingestRequestModel.getTable())
-              .addParameter(
-                  JobMapKeys.READ_JOB_ACLS.getKeyName(),
-                  jobService.readJobAcls(IamResourceType.DATASET, id, IamAction.INGEST_DATA))
+              .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+              .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
+              .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
               .submitAndWait(String.class);
 
       CloudPlatformWrapper cloudPlatform =
@@ -348,9 +347,9 @@ public class DatasetService {
         .newJob(description, DatasetIngestFlight.class, ingestRequestModel, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), id)
         .addParameter(LoadMapKeys.LOAD_TAG, loadTag)
-        .addParameter(
-            JobMapKeys.READ_JOB_ACLS.getKeyName(),
-            jobService.readJobAcls(IamResourceType.DATASET, id, IamAction.INGEST_DATA))
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -90,9 +90,9 @@ public class FileService {
         .newJob(description, FileDeleteFlight.class, null, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
         .addParameter(JobMapKeys.FILE_ID.getKeyName(), fileId)
-        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
-        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
-        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
+        .addParameter(
+            JobMapKeys.READ_JOB_ACLS.getKeyName(),
+            jobService.readJobAcls(IamResourceType.DATASET, datasetId, IamAction.INGEST_DATA))
         .submit();
   }
 
@@ -105,9 +105,9 @@ public class FileService {
         .newJob(description, FileIngestFlight.class, fileLoad, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
         .addParameter(LoadMapKeys.LOAD_TAG, loadTag)
-        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
-        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
-        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
+        .addParameter(
+            JobMapKeys.READ_JOB_ACLS.getKeyName(),
+            jobService.readJobAcls(IamResourceType.DATASET, datasetId, IamAction.INGEST_DATA))
         .submit();
   }
 
@@ -135,9 +135,9 @@ public class FileService {
         .addParameter(
             LoadMapKeys.LOAD_HISTORY_WAIT_SECONDS,
             configService.getParameterValue(ConfigEnum.LOAD_HISTORY_WAIT_SECONDS))
-        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
-        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
-        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
+        .addParameter(
+            JobMapKeys.READ_JOB_ACLS.getKeyName(),
+            jobService.readJobAcls(IamResourceType.DATASET, datasetId, IamAction.INGEST_DATA))
         .submit();
   }
 
@@ -174,9 +174,9 @@ public class FileService {
         .addParameter(
             LoadMapKeys.LOAD_HISTORY_WAIT_SECONDS,
             configService.getParameterValue(ConfigEnum.LOAD_HISTORY_WAIT_SECONDS))
-        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
-        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
-        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
+        .addParameter(
+            JobMapKeys.READ_JOB_ACLS.getKeyName(),
+            jobService.readJobAcls(IamResourceType.DATASET, datasetId, IamAction.INGEST_DATA))
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -13,6 +13,8 @@ import bio.terra.model.FileDetailModel;
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.FileModel;
 import bio.terra.model.FileModelType;
+import bio.terra.service.auth.iam.IamAction;
+import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
@@ -88,6 +90,9 @@ public class FileService {
         .newJob(description, FileDeleteFlight.class, null, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
         .addParameter(JobMapKeys.FILE_ID.getKeyName(), fileId)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 
@@ -100,6 +105,9 @@ public class FileService {
         .newJob(description, FileIngestFlight.class, fileLoad, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
         .addParameter(LoadMapKeys.LOAD_TAG, loadTag)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 
@@ -127,6 +135,9 @@ public class FileService {
         .addParameter(
             LoadMapKeys.LOAD_HISTORY_WAIT_SECONDS,
             configService.getParameterValue(ConfigEnum.LOAD_HISTORY_WAIT_SECONDS))
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 
@@ -163,6 +174,9 @@ public class FileService {
         .addParameter(
             LoadMapKeys.LOAD_HISTORY_WAIT_SECONDS,
             configService.getParameterValue(ConfigEnum.LOAD_HISTORY_WAIT_SECONDS))
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -90,9 +90,9 @@ public class FileService {
         .newJob(description, FileDeleteFlight.class, null, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
         .addParameter(JobMapKeys.FILE_ID.getKeyName(), fileId)
-        .addParameter(
-            JobMapKeys.READ_JOB_ACLS.getKeyName(),
-            jobService.readJobAcls(IamResourceType.DATASET, datasetId, IamAction.INGEST_DATA))
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 
@@ -105,9 +105,9 @@ public class FileService {
         .newJob(description, FileIngestFlight.class, fileLoad, userReq)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
         .addParameter(LoadMapKeys.LOAD_TAG, loadTag)
-        .addParameter(
-            JobMapKeys.READ_JOB_ACLS.getKeyName(),
-            jobService.readJobAcls(IamResourceType.DATASET, datasetId, IamAction.INGEST_DATA))
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 
@@ -135,9 +135,9 @@ public class FileService {
         .addParameter(
             LoadMapKeys.LOAD_HISTORY_WAIT_SECONDS,
             configService.getParameterValue(ConfigEnum.LOAD_HISTORY_WAIT_SECONDS))
-        .addParameter(
-            JobMapKeys.READ_JOB_ACLS.getKeyName(),
-            jobService.readJobAcls(IamResourceType.DATASET, datasetId, IamAction.INGEST_DATA))
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 
@@ -174,9 +174,9 @@ public class FileService {
         .addParameter(
             LoadMapKeys.LOAD_HISTORY_WAIT_SECONDS,
             configService.getParameterValue(ConfigEnum.LOAD_HISTORY_WAIT_SECONDS))
-        .addParameter(
-            JobMapKeys.READ_JOB_ACLS.getKeyName(),
-            jobService.readJobAcls(IamResourceType.DATASET, datasetId, IamAction.INGEST_DATA))
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.INGEST_DATA)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -10,7 +10,9 @@ public enum JobMapKeys {
   AUTH_USER_INFO("auth_user_info"),
   SUBJECT_ID("subjectId"),
   CLOUD_PLATFORM("cloudPlatform"),
-  READ_JOB_ACLS("readJobAcls"),
+  IAM_ACTION("iamAction"),
+  IAM_RESOURCE_TYPE("iamResourceType"),
+  IAM_RESOURCE_ID("iamResourceId"),
 
   // parameters for specific flight types
   BILLING_ID("billingId"),

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -10,9 +10,7 @@ public enum JobMapKeys {
   AUTH_USER_INFO("auth_user_info"),
   SUBJECT_ID("subjectId"),
   CLOUD_PLATFORM("cloudPlatform"),
-  IAM_ACTION("iamAction"),
-  IAM_RESOURCE_TYPE("iamResourceType"),
-  IAM_RESOURCE_ID("iamResourceId"),
+  READ_JOB_ACLS("readJobAcls"),
 
   // parameters for specific flight types
   BILLING_ID("billingId"),

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -10,6 +10,9 @@ public enum JobMapKeys {
   AUTH_USER_INFO("auth_user_info"),
   SUBJECT_ID("subjectId"),
   CLOUD_PLATFORM("cloudPlatform"),
+  IAM_ACTION("iamAction"),
+  IAM_RESOURCE_TYPE("iamResourceType"),
+  IAM_RESOURCE_ID("iamResourceId"),
 
   // parameters for specific flight types
   BILLING_ID("billingId"),

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -32,7 +32,6 @@ import bio.terra.stairway.exception.StairwayException;
 import bio.terra.stairway.exception.StairwayExecutionException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -337,15 +336,6 @@ public class JobService {
     }
   }
 
-  String IAM_RESOURCE_TYPE = "iamResourceType";
-  String IAM_RESOURCE_ID = "iamResourceId";
-  String IAM_ACTION = "iamAction";
-
-  public Map<String, Object> readJobAcls(
-      IamResourceType resourceType, String resourceId, IamAction action) {
-    return Map.of(IAM_RESOURCE_TYPE, resourceType, IAM_RESOURCE_ID, resourceId, IAM_ACTION, action);
-  }
-
   /**
    * There are four cases to handle here:
    *
@@ -472,15 +462,17 @@ public class JobService {
           inputParameters.get(JobMapKeys.SUBJECT_ID.getKeyName(), String.class);
 
       if (!StringUtils.equals(flightSubjectId, userReq.getSubjectId())) {
-        Map<String, Object> readJobAcls =
-            inputParameters.get(JobMapKeys.READ_JOB_ACLS.getKeyName(), Map.class);
-        if (readJobAcls != null) {
-          String resourceId = (String) readJobAcls.get(IAM_RESOURCE_ID);
-          IamResourceType resourceType = (IamResourceType) readJobAcls.get(IAM_RESOURCE_TYPE);
-          IamAction iamAction = (IamAction) readJobAcls.get(IAM_ACTION);
-          if (!samService.isAuthorized(userReq, resourceType, resourceId, iamAction)) {
-            throw new JobUnauthorizedException("Unauthorized");
-          }
+        String resourceId =
+            inputParameters.get(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), String.class);
+        IamResourceType resourceType =
+            inputParameters.get(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.class);
+        IamAction iamAction =
+            inputParameters.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class);
+        if (resourceId != null
+            && resourceType != null
+            && iamAction != null
+            && !samService.isAuthorized(userReq, resourceType, resourceId, iamAction)) {
+          throw new JobUnauthorizedException("Unauthorized");
         }
       }
     } catch (FlightNotFoundException ex) {

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -460,8 +460,20 @@ public class JobService {
       FlightMap inputParameters = flightState.getInputParameters();
       String flightSubjectId =
           inputParameters.get(JobMapKeys.SUBJECT_ID.getKeyName(), String.class);
+
       if (!StringUtils.equals(flightSubjectId, userReq.getSubjectId())) {
-        throw new JobUnauthorizedException("Unauthorized");
+        String resourceId =
+            inputParameters.get(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), String.class);
+        IamResourceType resourceType =
+            inputParameters.get(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.class);
+        IamAction iamAction =
+            inputParameters.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class);
+        if (resourceId != null
+            && resourceType != null
+            && iamAction != null
+            && !samService.isAuthorized(userReq, resourceType, resourceId, iamAction)) {
+          throw new JobUnauthorizedException("Unauthorized");
+        }
       }
     } catch (FlightNotFoundException ex) {
       throw new JobNotFoundException("Job not found", ex);

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -111,6 +111,10 @@ public class ProfileService {
         String.format("Update billing for profile id '%s'", billingProfileRequest.getId());
     return jobService
         .newJob(description, ProfileUpdateFlight.class, billingProfileRequest, user)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.SPEND_PROFILE)
+        .addParameter(
+            JobMapKeys.IAM_RESOURCE_ID.getKeyName(), billingProfileRequest.getId().toString())
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.UPDATE_BILLING_ACCOUNT)
         .submit();
   }
 
@@ -146,6 +150,9 @@ public class ProfileService {
         .newJob(description, ProfileDeleteFlight.class, null, user)
         .addParameter(ProfileMapKeys.PROFILE_ID, id)
         .addParameter(JobMapKeys.CLOUD_PLATFORM.getKeyName(), platform.name())
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.SPEND_PROFILE)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.DELETE)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -123,9 +123,14 @@ public class SnapshotService {
   public String createSnapshot(
       SnapshotRequestModel snapshotRequestModel, AuthenticatedUserRequest userReq) {
     String description = "Create snapshot " + snapshotRequestModel.getName();
+    String sourceDatasetName = snapshotRequestModel.getContents().get(0).getDatasetName();
+    Dataset dataset = datasetService.retrieveByName(sourceDatasetName);
     return jobService
         .newJob(description, SnapshotCreateFlight.class, snapshotRequestModel, userReq)
         .addParameter(CommonMapKeys.CREATED_AT, Instant.now().toEpochMilli())
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), dataset.getId())
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.LINK_SNAPSHOT)
         .submit();
   }
 
@@ -151,6 +156,10 @@ public class SnapshotService {
     return jobService
         .newJob(description, SnapshotDeleteFlight.class, null, userReq)
         .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), id.toString())
+        .addParameter(CommonMapKeys.CREATED_AT, Instant.now().toEpochMilli())
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASNAPSHOT)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.DELETE)
         .submit();
   }
 
@@ -183,6 +192,7 @@ public class SnapshotService {
       boolean exportGsPaths,
       boolean validatePrimaryKeyUniqueness) {
     String description = "Export snapshot " + id;
+    // TODO: add parameters to share job status using a new SAM role to export data
     return jobService
         .newJob(description, SnapshotExportFlight.class, null, userReq)
         .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), id.toString())

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -272,6 +272,7 @@ public class DataRepoClient {
     HttpHeaders copy = new HttpHeaders(headers);
     copy.setBearerAuth(authService.getAuthToken(user.getEmail()));
     copy.set("From", user.getEmail());
+    copy.set("UserId", user.getSubjectId());
     return copy;
   }
 
@@ -279,6 +280,7 @@ public class DataRepoClient {
     HttpHeaders copy = new HttpHeaders(headers);
     copy.setBearerAuth(authService.getPetAccountAuthToken(user.getEmail()));
     copy.set("From", user.getEmail());
+    copy.set("UserId", user.getSubjectId());
     return copy;
   }
 }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -1297,27 +1297,18 @@ public class DataRepoFixtures {
 
   // Jobs
 
-  public <T> void getJobSuccess(String jobId, TestConfiguration.User user) throws Exception {
+  public void getJobSuccess(String jobId, TestConfiguration.User user) throws Exception {
     DataRepoResponse<JobModel> jobIdResponse = getJobIdRaw(jobId, user);
-    assertTrue(
-        "transaction create launch succeeded", jobIdResponse.getStatusCode().is2xxSuccessful());
-    assertTrue(
-        "transaction create launch response is present",
-        jobIdResponse.getResponseObject().isPresent());
-
-    //    DataRepoResponse<T> jobResultResponse = getJobResultRaw(jobId, user);
-    //    validateResponse(jobResultResponse, "retrieving job result", HttpStatus.OK,
-    // jobIdResponse);
+    try {
+      assertTrue("job launch succeeded", jobIdResponse.getStatusCode().is2xxSuccessful());
+      assertTrue("job launch response is present", jobIdResponse.getResponseObject().isPresent());
+    } catch (AssertionError e) {
+      throw new AssertionError(String.format("Job launch failed. Got response: %s", jobIdResponse));
+    }
   }
 
   public DataRepoResponse<JobModel> getJobIdRaw(String jobId, TestConfiguration.User user)
       throws Exception {
     return dataRepoClient.get(user, "/api/repository/v1/jobs/" + jobId, new TypeReference<>() {});
-  }
-
-  public <T> DataRepoResponse<T> getJobResultRaw(String jobId, TestConfiguration.User user)
-      throws Exception {
-    return dataRepoClient.get(
-        user, "/api/repository/v1/jobs/" + jobId + "/result", new TypeReference<>() {});
   }
 }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -889,8 +889,6 @@ public class DataRepoFixtures {
       TestConfiguration.User user, UUID datasetId, BulkLoadArrayRequestModel requestModel)
       throws Exception {
 
-    String json = TestUtils.mapToJson(requestModel);
-
     DataRepoResponse<JobModel> launchResponse = bulkLoadArrayRaw(user, datasetId, requestModel);
 
     DataRepoResponse<BulkLoadArrayResultModel> response =

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -1,0 +1,182 @@
+package bio.terra.service.job;
+
+import bio.terra.common.GcsUtils;
+import bio.terra.common.category.Integration;
+import bio.terra.integration.DataRepoClient;
+import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.DataRepoResponse;
+import bio.terra.integration.UsersBase;
+import bio.terra.model.BulkLoadArrayRequestModel;
+import bio.terra.model.BulkLoadArrayResultModel;
+import bio.terra.model.BulkLoadFileModel;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.FileModel;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.model.JobModel;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles({"google", "integrationtest"})
+@AutoConfigureMockMvc
+@Category(Integration.class)
+public class JobPermissionTest extends UsersBase {
+
+  @Autowired private DataRepoFixtures dataRepoFixtures;
+  @Autowired private GcsUtils gcsUtils;
+  @Autowired private DataRepoClient dataRepoClient;
+
+  private UUID datasetId;
+  private UUID profileId;
+
+  @Before
+  public void setup() throws Exception {
+    super.setup();
+    dataRepoFixtures.resetConfig(steward());
+    profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
+    dataRepoFixtures.addPolicyMemberRaw(
+        steward(), profileId, IamRole.OWNER, custodian().getEmail(), IamResourceType.SPEND_PROFILE);
+  }
+
+  @After
+  public void teardown() throws Exception {
+    dataRepoFixtures.resetConfig(steward());
+
+    dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
+
+    dataRepoFixtures.deleteProfileLog(steward(), profileId);
+  }
+
+  @Test
+  public void testJobPermissions() throws Exception {
+    // Create dataset
+    DataRepoResponse<JobModel> jobResponse =
+        dataRepoFixtures.createDatasetRaw(
+            steward(),
+            profileId,
+            "dataset-ingest-combined-array.json",
+            CloudPlatform.GCP,
+            false,
+            false,
+            false);
+    DatasetSummaryModel datasetSummaryModel =
+        dataRepoFixtures.waitForDatasetCreate(steward(), jobResponse);
+
+    datasetId = datasetSummaryModel.getId();
+
+    String datasetCreateJobId = jobResponse.getResponseObject().get().getId();
+    dataRepoFixtures.getJobSuccess(datasetCreateJobId, custodian());
+
+    // Ingest single file
+    String ingestBucket = "jade-testdata-useastregion";
+    String exomeFilePath =
+        gcsUtils.uploadTestFile(
+            ingestBucket,
+            String.format("jobPermissionTest/%s/fake-exome.g.vcf.gz", datasetId),
+            Stream.of("test vcf file"));
+
+    DataRepoResponse<JobModel> fileIngestJobResponse =
+        dataRepoFixtures.ingestFileLaunch(
+            steward(),
+            datasetId,
+            profileId,
+            exomeFilePath,
+            "/vcfs/downsampled/exome/NA12878_PLUMBING.g.vcf.gz");
+
+    DataRepoResponse<FileModel> fileIngestResponse =
+        dataRepoClient.waitForResponse(steward(), fileIngestJobResponse, new TypeReference<>() {});
+    assert (fileIngestResponse.getStatusCode().is2xxSuccessful());
+
+    String fileIngestJobId = fileIngestJobResponse.getResponseObject().get().getId();
+    dataRepoFixtures.getJobSuccess(fileIngestJobId, custodian());
+
+    String vcfIndexFilePath =
+        gcsUtils.uploadTestFile(
+            ingestBucket,
+            String.format("jobPermissionTest/%s/fake-vcf-index.g.vcf.gz.tbi", datasetId),
+            Stream.of("test vcf index file"));
+
+    String vcfIndexFilePath2 =
+        gcsUtils.uploadTestFile(
+            ingestBucket,
+            String.format("jobPermissionTest/%s/fake-vcf-index2.g.vcf.gz.tbi", datasetId),
+            Stream.of("another test vcf index file"));
+
+    List<BulkLoadFileModel> vcfIndexLoadModels =
+        List.of(
+            new BulkLoadFileModel()
+                .mimeType("text/plain")
+                .description("A downsampled exome gVCF index")
+                .sourcePath(vcfIndexFilePath)
+                .targetPath("/vcfs/downsampled/exome/NA12878_PLUMBING.g.vcf.gz.tbi"),
+            new BulkLoadFileModel()
+                .mimeType("text/plain")
+                .description("A downsampled wgs gVCF index")
+                .sourcePath(vcfIndexFilePath2)
+                .targetPath("/vcfs/downsampled/wgs/NA12878_PLUMBING.g.vcf.gz.tbi"));
+
+    // Ingest bulk file array
+    DataRepoResponse<JobModel> bulkLoadJobResponse =
+        dataRepoFixtures.bulkLoadArrayRaw(
+            steward(),
+            datasetId,
+            new BulkLoadArrayRequestModel()
+                .profileId(profileId)
+                .loadArray(vcfIndexLoadModels)
+                .loadTag("bulk-load-" + datasetId)
+                .maxFailedFileLoads(0));
+    DataRepoResponse<BulkLoadArrayResultModel> bulkLoadResponse =
+        dataRepoClient.waitForResponse(steward(), bulkLoadJobResponse, new TypeReference<>() {});
+    assert (bulkLoadResponse.getStatusCode().is2xxSuccessful());
+
+    String bulkLoadJobId = bulkLoadJobResponse.getResponseObject().get().getId();
+    dataRepoFixtures.getJobSuccess(bulkLoadJobId, custodian());
+
+    // Ingest metadata
+    IngestRequestModel metadataIngestRequest =
+        new IngestRequestModel()
+            .format(IngestRequestModel.FormatEnum.ARRAY)
+            .table("sample_vcf")
+            .addRecordsItem(Map.of("sample_name", "sample1", "data_type", "vcf"))
+            .addRecordsItem(Map.of("sample_name", "sample2", "data_type", "vcf"));
+    ;
+    DataRepoResponse<JobModel> metadataIngestJobResponse =
+        dataRepoFixtures.ingestJsonDataLaunch(steward(), datasetId, metadataIngestRequest);
+    assert (metadataIngestJobResponse.getStatusCode().is2xxSuccessful());
+    String metadataIngestJobId = metadataIngestJobResponse.getResponseObject().get().getId();
+    dataRepoFixtures.getJobSuccess(metadataIngestJobId, custodian());
+
+    // Ingest metadata and files
+    IngestRequestModel combinedIngestRequest =
+        new IngestRequestModel()
+            .format(IngestRequestModel.FormatEnum.JSON)
+            .ignoreUnknownValues(false)
+            .maxBadRecords(0)
+            .table("sample_vcf")
+            .path(
+                "gs://jade-testdata-useastregion/dataset-ingest-combined-control-duplicates-array.json");
+
+    DataRepoResponse<JobModel> combinedIngestJobResponse =
+        dataRepoFixtures.ingestJsonDataLaunch(steward(), datasetId, combinedIngestRequest);
+    assert (combinedIngestJobResponse.getStatusCode().is2xxSuccessful());
+    String combinedIngestJobId = combinedIngestJobResponse.getResponseObject().get().getId();
+    dataRepoFixtures.getJobSuccess(combinedIngestJobId, custodian());
+  }
+}

--- a/src/test/java/bio/terra/service/profile/ProfileServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileServiceUnitTest.java
@@ -91,6 +91,15 @@ public class ProfileServiceUnitTest {
     billingProfileUpdateModel.setId(updateId);
 
     var jobBuilder = mock(JobBuilder.class);
+    when(jobBuilder.addParameter(
+            eq(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName()), eq(IamResourceType.SPEND_PROFILE)))
+        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(
+            eq(JobMapKeys.IAM_RESOURCE_ID.getKeyName()), eq(updateId.toString())))
+        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(
+            eq(JobMapKeys.IAM_ACTION.getKeyName()), eq(IamAction.UPDATE_BILLING_ACCOUNT)))
+        .thenReturn(jobBuilder);
 
     String jobId = "jobId";
     when(jobBuilder.submit()).thenReturn(jobId);
@@ -135,6 +144,13 @@ public class ProfileServiceUnitTest {
         .thenReturn(jobBuilder);
     when(jobBuilder.addParameter(
             eq(JobMapKeys.CLOUD_PLATFORM.getKeyName()), eq(CloudPlatform.GCP.name())))
+        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(
+            eq(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName()), eq(IamResourceType.SPEND_PROFILE)))
+        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(eq(JobMapKeys.IAM_RESOURCE_ID.getKeyName()), eq(deleteId)))
+        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(eq(JobMapKeys.IAM_ACTION.getKeyName()), eq(IamAction.DELETE)))
         .thenReturn(jobBuilder);
 
     var billingProfileModel = new BillingProfileModel();


### PR DESCRIPTION
If a user has permission on the SAM resource associated with a job, they can have view access to its status and details.

For example, if a user has the "ingest_data" action on a dataset, they can view any jobs for ingesting data into that dataset (not just their own).

If this approach looks good, I'll go ahead and update the remaining jobs!