### PR TITLE
[DR-2682] Investigate integration test timeouts

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -84,7 +84,7 @@ jobs:
           path: build/reports
           retention-days: 10
   deploy_test_integration:
-    timeout-minutes: 180
+    timeout-minutes: 360
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
Temporarily double timeout from 3 -> 6 hours to see if we can get test run to finish