### PR TITLE
DR-2679 Register ingest service account in Terra when creating it

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatus;
 
 /**
  * This is the interface to IAM used in the main body of the repository code. Right now, the only
@@ -195,6 +196,15 @@ public interface IamProviderInterface {
    * @return The google proxy group of a given user
    */
   String getProxyGroup(AuthenticatedUserRequest userReq) throws InterruptedException;
+
+  /**
+   * Register a user in Sam and make it usable (e.g. accept the ToS) using the specified access
+   * token
+   *
+   * @param accessToken valid oauth token for user that is being registered in Terra
+   * @return the fully registered user
+   */
+  UserStatus registerUser(String accessToken) throws InterruptedException;
 
   /**
    * Get Sam Status

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -65,6 +65,7 @@ public class SamIam implements IamProviderInterface {
   private final SamConfiguration samConfig;
   private final ConfigurationService configurationService;
 
+  // This value is the same for all environments which is why this is hardcoded instead of config
   static final String TOS_URL = "app.terra.bio/#terms-of-service";
 
   @Autowired

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -564,7 +564,12 @@ public class SamIam implements IamProviderInterface {
   @Override
   public UserStatus registerUser(String accessToken) throws InterruptedException {
     logger.info("Registering the ingest service account into Terra");
-    SamRetry.retry(configurationService, () -> samUsersApi(accessToken).createUserV2());
+    SamRetry.retry(
+        configurationService,
+        () -> {
+          logger.info("Running the registration process");
+          samUsersApi(accessToken).createUserV2();
+        });
 
     logger.info("Accepting terms of service for the ingest service account in Terra");
     return SamRetry.retry(

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -43,6 +43,7 @@ import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.TermsOfServiceApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntryV2;
@@ -50,6 +51,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV
 import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,6 +64,8 @@ public class SamIam implements IamProviderInterface {
 
   private final SamConfiguration samConfig;
   private final ConfigurationService configurationService;
+
+  static final String TOS_URL = "app.terra.bio/#terms-of-service";
 
   @Autowired
   public SamIam(SamConfiguration samConfig, ConfigurationService configurationService) {
@@ -105,6 +109,11 @@ public class SamIam implements IamProviderInterface {
   @VisibleForTesting
   UsersApi samUsersApi(String accessToken) {
     return new UsersApi(getApiClient(accessToken));
+  }
+
+  @VisibleForTesting
+  TermsOfServiceApi samTosApi(String accessToken) {
+    return new TermsOfServiceApi(getApiClient(accessToken));
   }
 
   /**
@@ -550,6 +559,16 @@ public class SamIam implements IamProviderInterface {
           .ok(false)
           .message(errorMsg + ": " + ExceptionUtils.formatException(ex));
     }
+  }
+
+  @Override
+  public UserStatus registerUser(String accessToken) throws InterruptedException {
+    logger.info("Registering the ingest service account into Terra");
+    SamRetry.retry(configurationService, () -> samUsersApi(accessToken).createUserV2());
+
+    logger.info("Accepting terms of service for the ingest service account in Terra");
+    return SamRetry.retry(
+        configurationService, () -> samTosApi(accessToken).acceptTermsOfService(TOS_URL));
   }
 
   @Override

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -571,7 +571,7 @@ public class SamIam implements IamProviderInterface {
           try {
             logger.info("Running the registration process");
             samUsersApi(accessToken).createUserV2();
-          } catch(ApiException e) {
+          } catch (ApiException e) {
             // This conflict could happen if the request timed out originally.
             // In that case, it's ok to assume that this is a success and move on
             if (e.getCode() == 409) {

--- a/src/main/java/bio/terra/service/dataset/flight/DatasetWorkingMapKeys.java
+++ b/src/main/java/bio/terra/service/dataset/flight/DatasetWorkingMapKeys.java
@@ -14,4 +14,5 @@ public final class DatasetWorkingMapKeys extends ProjectCreatingFlightKeys {
   public static final String PROJECTS_MARKED_FOR_DELETE = "projectsMarkedForDelete";
   public static final String APPLICATION_DEPLOYMENT_RESOURCE_ID = "applicationDeploymentResourceId";
   public static final String STORAGE_ACCOUNT_RESOURCE_ID = "storageAccountResourceId";
+  public static final String SERVICE_ACCOUNT_EMAIL = "serviceAccountEmail";
 }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetCreateIngestServiceAccountStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetCreateIngestServiceAccountStep.java
@@ -27,7 +27,9 @@ public class CreateDatasetCreateIngestServiceAccountStep implements Step {
     String projectId = workingMap.get(DatasetWorkingMapKeys.GOOGLE_PROJECT_ID, String.class);
 
     try {
-      resourceService.createDatasetServiceAccount(projectId, datasetRequestModel.getName());
+      String datasetServiceAccount =
+          resourceService.createDatasetServiceAccount(projectId, datasetRequestModel.getName());
+      workingMap.put(DatasetWorkingMapKeys.SERVICE_ACCOUNT_EMAIL, datasetServiceAccount);
     } catch (GoogleResourceException e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
     }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
@@ -1,0 +1,35 @@
+package bio.terra.service.dataset.flight.create;
+
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+/** The step is only meant to be invoked for GCP backed datasets. */
+public class CreateDatasetRegisterIngestServiceAccountStep implements Step {
+
+  private final IamService iamService;
+
+  public CreateDatasetRegisterIngestServiceAccountStep(IamService iamService) {
+    this.iamService = iamService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    String datasetServiceAccount =
+        workingMap.get(DatasetWorkingMapKeys.SERVICE_ACCOUNT_EMAIL, String.class);
+
+    iamService.registerUser(datasetServiceAccount);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // This will get undone when we delete the project
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -90,9 +90,10 @@ public class DatasetCreateFlight extends Flight {
           new CreateDatasetInitializeProjectStep(resourceService, datasetRequest),
           getDefaultExponentialBackoffRetryRule());
 
-      // Create the service account to use to ingest data
+      // Create the service account to use to ingest data and register it in Terra
       if (datasetRequest.isDedicatedIngestServiceAccount()) {
         addStep(new CreateDatasetCreateIngestServiceAccountStep(resourceService, datasetRequest));
+        addStep(new CreateDatasetRegisterIngestServiceAccountStep(iamService));
       }
     }
 

--- a/src/test/java/bio/terra/integration/SamFixtures.java
+++ b/src/test/java/bio/terra/integration/SamFixtures.java
@@ -1,0 +1,67 @@
+package bio.terra.integration;
+
+import bio.terra.app.configuration.SamConfiguration;
+import bio.terra.common.auth.AuthService;
+import bio.terra.common.configuration.TestConfiguration;
+import java.util.Arrays;
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.AdminApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class SamFixtures {
+
+  @Autowired private SamConfiguration samConfig;
+  @Autowired private AuthService authService;
+  private final HttpHeaders headers;
+  private final RestTemplate restTemplate;
+
+  public SamFixtures() {
+    headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON));
+
+    restTemplate = new RestTemplate();
+    restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+  }
+
+  public void deleteServiceAccountFromTerra(TestConfiguration.User user, String serviceAccount) {
+    try {
+      // Get the user ID to delete
+      getHeaders(user);
+      String accessToken = headers.get(HttpHeaders.AUTHORIZATION).get(0).replaceAll("Bearer ", "");
+      AdminApi samAdminApi = new AdminApi(getApiClient(accessToken));
+      UserStatus userStatus = samAdminApi.adminGetUserByEmail(serviceAccount);
+
+      // Delete the user
+      String userDeletionUrl =
+          "%s/api/admin/v1/user/%s"
+              .formatted(samConfig.getBasePath(), userStatus.getUserInfo().getUserSubjectId());
+      restTemplate.delete(userDeletionUrl);
+    } catch (ApiException e) {
+      throw new RuntimeException(
+          "Error deleting account %s from Terra".formatted(serviceAccount), e);
+    }
+  }
+
+  private ApiClient getApiClient(String accessToken) {
+    ApiClient apiClient = new ApiClient();
+    apiClient.setAccessToken(accessToken);
+    apiClient.setUserAgent("OpenAPI-Generator/1.0.0 java"); // only logs an error in sam
+    return apiClient.setBasePath(samConfig.getBasePath());
+  }
+
+  private HttpHeaders getHeaders(TestConfiguration.User user) {
+    HttpHeaders copy = new HttpHeaders(headers);
+    copy.setBearerAuth(authService.getAuthToken(user.getEmail()));
+    copy.set("From", user.getEmail());
+    return copy;
+  }
+}

--- a/src/test/java/bio/terra/integration/SamFixtures.java
+++ b/src/test/java/bio/terra/integration/SamFixtures.java
@@ -4,6 +4,8 @@ import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.configuration.TestConfiguration;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.AdminApi;
@@ -36,7 +38,14 @@ public class SamFixtures {
     try {
       // Get the user ID to delete
       getHeaders(user);
-      String accessToken = headers.get(HttpHeaders.AUTHORIZATION).get(0).replaceAll("Bearer ", "");
+      String accessToken =
+          Optional.ofNullable(
+                  Optional.ofNullable(headers.get(HttpHeaders.AUTHORIZATION))
+                      .orElse(List.of())
+                      .iterator()
+                      .next())
+              .map(h -> h.replaceAll("Bearer ", ""))
+              .orElseThrow(() -> new IllegalArgumentException("No auth header present"));
       AdminApi samAdminApi = new AdminApi(getApiClient(accessToken));
       UserStatus userStatus = samAdminApi.adminGetUserByEmail(serviceAccount);
 

--- a/src/test/java/bio/terra/integration/SamFixtures.java
+++ b/src/test/java/bio/terra/integration/SamFixtures.java
@@ -41,7 +41,7 @@ public class SamFixtures {
   }
 
   public void deleteServiceAccountFromTerra(TestConfiguration.User user, String serviceAccount) {
-    logger.info("Deleting user {}", serviceAccount);
+    logger.info("Deleting user {} from Sam {}", serviceAccount, samConfig.getBasePath());
     try {
       // Get the user ID to delete
       HttpHeaders authedHeader = getHeaders(user);

--- a/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
@@ -75,16 +75,16 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   public void teardown() throws Exception {
     dataRepoFixtures.resetConfig(steward());
 
+    if (ingestServiceAccount != null) {
+      samFixtures.deleteServiceAccountFromTerra(steward(), ingestServiceAccount);
+    }
+
     if (datasetId != null) {
       dataRepoFixtures.deleteDataset(steward(), datasetId);
     }
 
     if (profileId != null) {
       dataRepoFixtures.deleteProfileLog(steward(), profileId);
-    }
-
-    if (ingestServiceAccount != null) {
-      samFixtures.deleteServiceAccountFromTerra(steward(), ingestServiceAccount);
     }
   }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
@@ -425,9 +425,9 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
         dataRepoFixtures.createDatasetWithOwnServiceAccount(
             steward(), profileId, "dataset-ingest-combined-array.json");
 
+    datasetId = datasetSummaryModel.getId();
     ingestServiceAccount =
         dataRepoFixtures.getDataset(steward(), datasetId).getIngestServiceAccount();
-    datasetId = datasetSummaryModel.getId();
 
     IngestRequestModel ingestRequest =
         new IngestRequestModel()

--- a/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
@@ -17,6 +17,7 @@ import bio.terra.integration.BigQueryFixtures;
 import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.DataRepoResponse;
+import bio.terra.integration.SamFixtures;
 import bio.terra.integration.TestJobWatcher;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.BulkLoadArrayRequestModel;
@@ -77,6 +78,7 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
   @Autowired private DataRepoClient dataRepoClient;
   @Autowired private AuthService authService;
   @Autowired private GcsUtils gcsUtils;
+  @Autowired private SamFixtures samFixtures;
   @Rule @Autowired public TestJobWatcher testWatcher;
 
   private String stewardToken;
@@ -84,7 +86,7 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
   private UUID snapshotId;
   private UUID profileId;
   private List<String> uploadedFiles;
-  private String serviceAccount;
+  private String ingestServiceAccount;
   private String ingestBucket;
 
   @Before
@@ -116,9 +118,13 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
       gcsUtils.deleteTestFile(path);
     }
 
-    if (serviceAccount != null && ingestBucket != null) {
+    if (ingestServiceAccount != null && ingestBucket != null) {
       DatasetIntegrationTest.removeServiceAccountRoleFromBucket(
-          ingestBucket, serviceAccount, StorageRoles.objectViewer());
+          ingestBucket, ingestServiceAccount, StorageRoles.objectViewer());
+    }
+
+    if (ingestServiceAccount != null) {
+      samFixtures.deleteServiceAccountFromTerra(steward(), ingestServiceAccount);
     }
   }
 
@@ -150,11 +156,11 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
 
     // Authorize the ingest source bucket
     if (dedicatedServiceAccount) {
-      serviceAccount = dataset.getIngestServiceAccount();
+      ingestServiceAccount = dataset.getIngestServiceAccount();
       this.ingestBucket = ingestBucket;
       // Note: this role gets removed in teardown
       DatasetIntegrationTest.addServiceAccountRoleToBucket(
-          ingestBucket, serviceAccount, StorageRoles.objectViewer());
+          ingestBucket, ingestServiceAccount, StorageRoles.objectViewer());
     }
 
     // Ingest a single file

--- a/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
@@ -106,6 +106,10 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
       dataRepoFixtures.deleteSnapshotLog(steward(), snapshotId);
     }
 
+    if (ingestServiceAccount != null) {
+      samFixtures.deleteServiceAccountFromTerra(steward(), ingestServiceAccount);
+    }
+
     if (datasetId != null) {
       dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
     }
@@ -121,10 +125,6 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
     if (ingestServiceAccount != null && ingestBucket != null) {
       DatasetIntegrationTest.removeServiceAccountRoleFromBucket(
           ingestBucket, ingestServiceAccount, StorageRoles.objectViewer());
-    }
-
-    if (ingestServiceAccount != null) {
-      samFixtures.deleteServiceAccountFromTerra(steward(), ingestServiceAccount);
     }
   }
 


### PR DESCRIPTION
This fixes the case where users want to ingest data from buckets in terra.  Before, there was really no way to allow a service account to read from terra controlled buckets if using a TDR created service account. This PR:
- Registers the service account in Terra
- Accepts the Terms of Service for that SA
- The integration tests that exercise creating an SA also call the admin api to delete the user from Sam to clean up (it's not in the client so I had to do direct REST calls)