### PR TITLE
[DR-2677] Fix snapshot export permissions check

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -84,7 +84,7 @@ jobs:
           path: build/reports
           retention-days: 10
   deploy_test_integration:
-    timeout-minutes: 180
+    timeout-minutes: 210
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -185,7 +185,7 @@ public class SnapshotsApiController implements SnapshotsApi {
     logger.info("Verifying user access");
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     iamService.verifyAuthorization(
-        userReq, IamResourceType.DATASNAPSHOT, id.toString(), IamAction.READ_DATA);
+        userReq, IamResourceType.DATASNAPSHOT, id.toString(), IamAction.EXPORT_SNAPSHOT);
     String jobId =
         snapshotService.exportSnapshot(id, userReq, exportGsPaths, validatePrimaryKeyUniqueness);
     // we can retrieve the job we just created

--- a/src/main/java/bio/terra/service/auth/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamAction.java
@@ -29,6 +29,7 @@ public enum IamAction {
   UPDATE_SNAPSHOT,
   READ_DATA,
   DISCOVER_DATA,
+  EXPORT_SNAPSHOT,
   // billing profiles
   UPDATE_BILLING_ACCOUNT,
   LINK;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -211,6 +211,9 @@ public class SnapshotService {
         .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), id.toString())
         .addParameter(ExportMapKeys.EXPORT_GSPATHS, exportGsPaths)
         .addParameter(ExportMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS, validatePrimaryKeyUniqueness)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASNAPSHOT)
+        .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id.toString())
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.EXPORT_SNAPSHOT)
         .submit();
   }
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -23,6 +23,7 @@ import bio.terra.integration.UsersBase;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.IngestRequestModel;
+import bio.terra.model.JobModel;
 import bio.terra.model.SnapshotExportResponseModel;
 import bio.terra.model.SnapshotExportResponseModelFormatParquet;
 import bio.terra.model.SnapshotExportResponseModelFormatParquetLocationTables;
@@ -61,6 +62,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -143,6 +145,14 @@ public class SnapshotExportIntegrationTest extends UsersBase {
 
     UUID snapshotId = snapshotSummary.getId();
     createdSnapshotIds.add(snapshotId);
+
+    DataRepoResponse<JobModel> failedExportResponse =
+        dataRepoFixtures.exportSnapshot(reader(), snapshotSummary.getId(), false, false);
+    assertThat(
+        "Reader is not authorized to export a snapshot",
+        failedExportResponse.getStatusCode(),
+        equalTo(HttpStatus.UNAUTHORIZED));
+
     DataRepoResponse<SnapshotExportResponseModel> exportResponse =
         dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, false, true);
 


### PR DESCRIPTION
TDR allows snapshot readers to export a snapshot to a Terra workspace, but the flight fails because the user also needs permission to modify the snapshot policies. This now checks if the user has the "export_snapshot" action on the snapshot (added in https://github.com/broadinstitute/sam/pull/782).

This also adds information to allow other snapshot stewards to retrieve the job information.