### PR TITLE
[DR-2697] Upgrade hashicorp/vault-action to v2.2.0

### DIFF
--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -39,7 +39,7 @@ jobs:
         git checkout ${{ steps.configuration.outputs.alpha_version_api }}
         echo "Current branch is ${{ github.ref }}"
     - name: "Import Vault Secrets for Alpha Test Runner Service Account"
-      uses: hashicorp/vault-action@v2.1.0
+      uses: hashicorp/vault-action@v2.2.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle
@@ -56,7 +56,7 @@ jobs:
 
         ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
     - name: "Import Vault Secrets for Dev Service Account"
-      uses: hashicorp/vault-action@v2.1.0
+      uses: hashicorp/vault-action@v2.2.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle
@@ -109,7 +109,7 @@ jobs:
         echo "[INFO] Uploading results SUCCEEDED"
         cd ${GITHUB_WORKSPACE}/${workingDir}
     - name: "[Cherry-pick to public GCR] Import Vault Secrets for GCR Service Account"
-      uses: hashicorp/vault-action@v2.1.0
+      uses: hashicorp/vault-action@v2.2.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -53,7 +53,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.1.0
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -106,7 +106,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.1.0
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           git checkout ${{ steps.configuration.outputs.staging_version }}
           echo "Current branch is ${{ github.ref }}"
       - name: "Import Vault staging secrets"
-        uses: hashicorp/vault-action@v2.1.0
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -51,7 +51,7 @@ jobs:
 
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.1.0
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -40,7 +40,7 @@ jobs:
           java-version: '17'
           cache: 'gradle'
       - name: "Import Vault perf secrets"
-        uses: hashicorp/vault-action@v2.1.0
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -58,7 +58,7 @@ jobs:
 
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.1.0
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -122,7 +122,7 @@ jobs:
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "[Clear Perf Database] Import Perf Database Secret"
-        uses: hashicorp/vault-action@v2.1.0
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2697

Dependabot says it best:

> HashiCorp vault-action (aka Vault GitHub Action) before 2.2.0 allows attackers to obtain sensitive information from log files because a multi-line secret was not correctly registered with GitHub Actions for log masking.
>
>The vault-action implementation did not correctly handle the marking of multi-line variables. As a result, multi-line secrets were not correctly masked in vault-action output.
>
>Remediation:
>Customers using vault-action should evaluate the risk associated with this issue, and consider upgrading to vault-action 2.2.0 or newer. Please refer to https://github.com/marketplace/actions/vault-secrets for more information.

Looking at the [changelog](https://github.com/hashicorp/vault-action/blob/main/CHANGELOG.md#220-may-6th-2021), from our current version 2.1.0 -> 2.2.0 nothing jumps out to me that could be a breaking change.  I know that we are dealing with ongoing integration test issues though, so until those are fixed we may have a harder time getting signal here.