### PR TITLE
[DR-2628] Incorporate RAS passport check in snapshot role fetch

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -333,8 +333,7 @@ public class SnapshotsApiController implements SnapshotsApi {
 
   @Override
   public ResponseEntity<List<String>> retrieveUserSnapshotRoles(UUID id) {
-    List<String> roles =
-        iamService.retrieveUserRoles(getAuthenticatedInfo(), IamResourceType.DATASNAPSHOT, id);
+    List<String> roles = snapshotService.retrieveUserSnapshotRoles(id, getAuthenticatedInfo());
     return new ResponseEntity<>(roles, HttpStatus.OK);
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -518,8 +518,8 @@ public class SnapshotService {
    *     user's linked RAS passport.
    */
   public List<String> retrieveUserSnapshotRoles(UUID snapshotId, AuthenticatedUserRequest userReq) {
-    List<String> roles =
-        iamService.retrieveUserRoles(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
+    List<String> roles = new ArrayList<>();
+    roles.addAll(iamService.retrieveUserRoles(userReq, IamResourceType.DATASNAPSHOT, snapshotId));
     if (!roles.contains(IamRole.READER.toString())
         && snapshotAccessibleByPassport(snapshotId, userReq).accessible()) {
       roles.add(IamRole.READER.toString());


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2628

**Objective**

If a user is not a reader of a snapshot per SAM, also check for a linked RAS passport granting reader access from ECM when fetching the roles it has on the snapshot.  We only perform this check if doing so would not be redundant -- i.e. no point in hitting ECM if the user is already a reader.

**Changes**

- Broke out expanded role fetch into `SnapshotService.retrieveUserSnapshotRoles`.
- Refactored out existing passport check from `SnapshotService.verifySnapshotAccessible` for reuse.
- Accordingly refactored and expanded unit tests. (My apologies, the refactoring did a number on the diff view!)

**Deviations from Ticket**

The ticket originally also called for integrating RAS passport checks into snapshot policy fetch's auth checks.  However, the current behavior is that snapshot readers cannot list the policies/users that have access, so no changes are required if the user has reader access to a snapshot via a passport. Slack: https://broadinstitute.slack.com/archives/C01VBGH431S/p1660057642280229

I did not quite follow the ticket's logic behind when to check for a linked passport as it seemed like it could miss valid cases where a user may be a passport-derived reader and make debugging more difficult -- _"If the user does not have access through SAM or only has the discoverer role, check if they have read-access through a passport… Admin users are excluded from this check because that role is only user by Data Repo team members for operational purposes"_.
