### PR TITLE
[DR-2703] Fix ANTLR grammar for BETWEEN clause

### DIFF
--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -40,6 +40,7 @@ expr : number
     | expr '&' expr
     | expr '^' expr
     | expr '|' expr
+    | expr NOT? BETWEEN expr AND expr
     | expr ( '='
         | '<'
         | '>'
@@ -48,7 +49,6 @@ expr : number
         | '!='
         | '<>'
         | NOT? LIKE
-        | NOT? BETWEEN expr AND expr
         )  expr
     | expr   IS NOT? S_NULL
         | IS NOT? TRUE

--- a/src/test/java/bio/terra/grammar/GrammarTest.java
+++ b/src/test/java/bio/terra/grammar/GrammarTest.java
@@ -113,6 +113,12 @@ public class GrammarTest {
   }
 
   @Test
+  public void testBetween() {
+    // test for DR-2703 Fix ANTLR error when parsing between clause
+    Query.parse("SELECT foo.bar.datarepo_row_id FROM foo.bar WHERE foo.bar.x BETWEEN 1 and 2");
+  }
+
+  @Test
   public void test1000Genomes() {
     // test for DR-2143 Fix validating dataset names that start with a number
     Query.parse("SELECT * FROM 1000GenomesDataset.sample_info");


### PR DESCRIPTION
When trying to create a snapshot by query where a field is between two values, the ANTRL SQL parser throws a 400 error because the grammar definition was expecting an extra expression after the between clause.