### PR TITLE
DR-2702 Fix queries for relationship walking to be less CPU heavy

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -1,5 +1,7 @@
 package bio.terra.service.tabulardata.google;
 
+import static bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao.logQuery;
+
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.AclUtils;
 import bio.terra.common.exception.PdaoException;
@@ -217,6 +219,7 @@ public final class BigQueryProject {
     try {
       QueryJobConfiguration queryConfig =
           QueryJobConfiguration.newBuilder(sql).setNamedParameters(values).build();
+      logQuery(queryConfig);
       return bigQuery.query(queryConfig);
     } catch (BigQueryException e) {
       throw new PdaoException("Failure executing query...\n" + sql, e);

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -15,6 +15,7 @@ import static bio.terra.common.PdaoConstant.PDAO_TRANSACTIONS_TABLE;
 import static bio.terra.common.PdaoConstant.PDAO_TRANSACTION_ID_COLUMN;
 import static bio.terra.common.PdaoConstant.PDAO_TRANSACTION_STATUS_COLUMN;
 import static bio.terra.common.PdaoConstant.PDAO_TRANSACTION_TERMINATED_AT_COLUMN;
+import static bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao.logQuery;
 
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
@@ -457,6 +458,7 @@ public class BigQueryDatasetPdao {
             .build();
 
     try {
+      logQuery(queryConfig);
       var results = bigQueryProject.getBigQuery().query(queryConfig);
       return StreamSupport.stream(results.iterateAll().spliterator(), true)
           .map(BigQueryDatasetPdao::bigQueryResultToBulkLoadHistoryModel)

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
@@ -1077,39 +1077,28 @@ public class BigQuerySnapshotPdao {
     ST toTableTableSelect;
     String fromCol;
     String toCol;
-    if (relationship.getFromColumnIsArray() && relationship.getToColumnIsArray()) {
+    if (relationship.getFromColumnIsArray()) {
       fromTableTableSelect =
           new ST(tableSelectArray)
               .add("toOrFrom", "FROM")
               .add("field", relationship.getFromColumnName());
-      toTableTableSelect =
-          new ST(tableSelectArray)
-              .add("toOrFrom", "TO")
-              .add("field", relationship.getToColumnName());
       fromCol = "FLAT_FROM";
-      toCol = "FLAT_TO";
-    } else if (relationship.getFromColumnIsArray()) {
-      fromTableTableSelect =
-          new ST(tableSelectArray)
-              .add("toOrFrom", "FROM")
-              .add("field", relationship.getFromColumnName());
-      toTableTableSelect = new ST(tableSelectNonArray);
-      fromCol = "FLAT_FROM";
-      toCol = relationship.getToColumnName();
-    } else if (relationship.getToColumnIsArray()) {
-      fromTableTableSelect = new ST(tableSelectNonArray);
-      toTableTableSelect =
-          new ST(tableSelectArray)
-              .add("toOrFrom", "TO")
-              .add("field", relationship.getToColumnName());
-      fromCol = relationship.getFromColumnName();
-      toCol = "FLAT_TO";
     } else {
       fromTableTableSelect = new ST(tableSelectNonArray);
-      toTableTableSelect = new ST(tableSelectNonArray);
       fromCol = relationship.getFromColumnName();
+    }
+
+    if (relationship.getToColumnIsArray()) {
+      toTableTableSelect =
+          new ST(tableSelectArray)
+              .add("toOrFrom", "TO")
+              .add("field", relationship.getToColumnName());
+      toCol = "FLAT_TO";
+    } else {
+      toTableTableSelect = new ST(tableSelectNonArray);
       toCol = relationship.getToColumnName();
     }
+
     fromTableTableSelect.add("tableSelect", liveViewSqlFrom);
     toTableTableSelect.add("tableSelect", liveViewSqlTo);
 

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
@@ -1444,6 +1444,7 @@ public class BigQuerySnapshotPdao {
       logger.info("Retry number {} of a maximum {}", retryNum, maxRetries);
     }
     try {
+      logQuery(queryConfig);
       return bigQuery.query(queryConfig);
     } catch (final BigQueryException qe) {
       if (qe.getError() != null
@@ -1470,5 +1471,12 @@ public class BigQuerySnapshotPdao {
     fieldList.add(Field.of(PDAO_TABLE_ID_COLUMN, LegacySQLTypeName.STRING));
     fieldList.add(Field.of(PDAO_ROW_ID_COLUMN, LegacySQLTypeName.STRING));
     return Schema.of(fieldList);
+  }
+
+  public static void logQuery(QueryJobConfiguration queryConfig) {
+    logger.info(
+        "Running query:\n#########\n{}\n#########\nwith parameters {}",
+        queryConfig.getQuery(),
+        queryConfig.getNamedParameters());
   }
 }

--- a/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
@@ -462,14 +462,14 @@ public class BigQueryPdaoUnitTest {
                         + TABLE_2_ID
                         + "' AS datarepo_table_id, "
                         + "T.datarepo_row_id "
-                        + "FROM ("
+                        + "FROM (("
                         + BigQueryDatasetPdao.renderDatasetLiveViewSql(
                             DATASET_PROJECT_ID, prefixName(DATASET_NAME), table2, null, CREATED_AT)
-                        + ") T, "
-                        + "("
+                        + ")) T, "
+                        + "(("
                         + BigQueryDatasetPdao.renderDatasetLiveViewSql(
                             DATASET_PROJECT_ID, prefixName(DATASET_NAME), table1, null, CREATED_AT)
-                        + ") F, "
+                        + ")) F, "
                         + "`"
                         + SNAPSHOT_PROJECT_ID
                         + "."
@@ -478,11 +478,11 @@ public class BigQueryPdaoUnitTest {
                         + "WHERE R.datarepo_table_id = '"
                         + TABLE_1_ID
                         + "' AND "
-                        + "R.datarepo_row_id = F.datarepo_row_id AND T."
-                        + TABLE_2_COL1_NAME
-                        + " = "
-                        + "F."
+                        + "R.datarepo_row_id = F.datarepo_row_id AND F."
                         + TABLE_1_COL1_NAME
+                        + " = "
+                        + "T."
+                        + TABLE_2_COL1_NAME
                         + ") "
                         + "SELECT datarepo_table_id,datarepo_row_id FROM merged_table WHERE "
                         + "datarepo_row_id NOT IN (SELECT datarepo_row_id "


### PR DESCRIPTION
Before jumping into the query bits note: as part of the PR I added a logging statement to the big query executions to help future us to debug queries (no data gets logged...just the queries and parameters)

The main thing with this PR is to change how the queries that walk the relationship tree when loading rowids do their joins.  The rough change is that queries that used to look like this:
```
SELECT DISTINCT '<table_id>' AS datarepo_table_id, T.datarepo_row_id
    FROM 
        TO_TABLE T, 
        FROM_TABLE F
WHERE 
    EXISTS (SELECT 1
    FROM UNNEST(F.from_id_field) AS flat_from
    WHERE flat_from = T.to_id_field)
```

now look like
```
SELECT DISTINCT '<table_id>' AS datarepo_table_id, T.datarepo_row_id
    FROM 
        TO_TABLE T, 
        (SELECT F0.*, flat_from
           FROM
             FROM_TABLE F0,
             UNNEST(F0.from_id_field) AS flat_from) F
   WHERE  F.flat_from = T.to_id_field
```

This is an example of the case where the **from** column in the relationship is an array.  The case where the **to** column is an array would look like:
```
SELECT DISTINCT '<table_id>' AS datarepo_table_id, T.datarepo_row_id
    FROM 
        (SELECT F0.*, flat_to
           FROM
             TO_TABLE T0,
             UNNEST(F0.to_id_field) AS flat_to) T, 
        FROM_TABLE F
   WHERE  F.from_id_field = T.flat_from
```

The case where **none** are array would look like:
```
SELECT DISTINCT '<table_id>' AS datarepo_table_id, T.datarepo_row_id
    FROM 
        TO_TABLE T, 
        FROM_TABLE F
   WHERE  F.from_id_field = T.to_id_field
```

And finally, the case where **both** are arrays would look like:
```
SELECT DISTINCT '<table_id>' AS datarepo_table_id, T.datarepo_row_id
    FROM 
        (SELECT F0.*, flat_to
           FROM
             TO_TABLE T0,
             UNNEST(F0.to_id_field) AS flat_to) T, 
        (SELECT F0.*, flat_from
           FROM
             FROM_TABLE F0,
             UNNEST(F0.from_id_field) AS flat_from) F
   WHERE  F.flat_to = T.flat_from
```