### PR TITLE
[DR-2678] TDR retrieveSnapshotPolicies should gracefully handle inaccessible workspaces

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -4,7 +4,6 @@ import static bio.terra.app.utils.ControllerUtils.jobToResponse;
 
 import bio.terra.app.controller.exception.ValidationException;
 import bio.terra.app.utils.ControllerUtils;
-import bio.terra.app.utils.PolicyUtils;
 import bio.terra.common.ValidationUtils;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
@@ -16,7 +15,6 @@ import bio.terra.model.JobModel;
 import bio.terra.model.PolicyMemberRequest;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
-import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotPatchRequestModel;
 import bio.terra.model.SnapshotPreviewModel;
@@ -24,7 +22,6 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRetrieveIncludeModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.model.SqlSortDirection;
-import bio.terra.model.WorkspacePolicyModel;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
@@ -34,7 +31,6 @@ import bio.terra.service.dataset.AssetModelValidator;
 import bio.terra.service.dataset.IngestRequestValidator;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.job.JobService;
-import bio.terra.service.rawls.RawlsService;
 import bio.terra.service.snapshot.SnapshotRequestValidator;
 import bio.terra.service.snapshot.SnapshotService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -83,8 +79,6 @@ public class SnapshotsApiController implements SnapshotsApi {
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final AssetModelValidator assetModelValidator;
 
-  private final RawlsService rawlsService;
-
   @Autowired
   public SnapshotsApiController(
       ObjectMapper objectMapper,
@@ -96,8 +90,7 @@ public class SnapshotsApiController implements SnapshotsApi {
       IngestRequestValidator ingestRequestValidator,
       FileService fileService,
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
-      AssetModelValidator assetModelValidator,
-      RawlsService rawlsService) {
+      AssetModelValidator assetModelValidator) {
     this.objectMapper = objectMapper;
     this.request = request;
     this.jobService = jobService;
@@ -108,7 +101,6 @@ public class SnapshotsApiController implements SnapshotsApi {
     this.fileService = fileService;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
     this.assetModelValidator = assetModelValidator;
-    this.rawlsService = rawlsService;
   }
 
   @InitBinder
@@ -298,19 +290,8 @@ public class SnapshotsApiController implements SnapshotsApi {
   }
 
   @Override
-  public ResponseEntity<PolicyResponse> retrieveSnapshotPolicies(@PathVariable("id") UUID id) {
-    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    List<SamPolicyModel> samPolicyModels =
-        iamService.retrievePolicies(userRequest, IamResourceType.DATASNAPSHOT, id);
-    List<WorkspacePolicyModel> workspacePolicyModels =
-        samPolicyModels.stream()
-            .flatMap(pm -> rawlsService.resolvePolicyEmails(pm, userRequest).stream())
-            .collect(Collectors.toList());
-    PolicyResponse response =
-        new PolicyResponse()
-            .policies(PolicyUtils.samToTdrPolicyModels(samPolicyModels))
-            .workspaces(workspacePolicyModels);
-
+  public ResponseEntity<PolicyResponse> retrieveSnapshotPolicies(UUID id) {
+    PolicyResponse response = snapshotService.retrieveSnapshotPolicies(id, getAuthenticatedInfo());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/service/rawls/RawlsClient.java
+++ b/src/main/java/bio/terra/service/rawls/RawlsClient.java
@@ -38,6 +38,7 @@ public class RawlsClient {
   public WorkspaceResponse getWorkspace(UUID workspaceId, AuthenticatedUserRequest userRequest) {
     HttpHeaders authedHeaders = new HttpHeaders(headers);
     authedHeaders.setBearerAuth(userRequest.getToken());
+    String userEmail = userRequest.getEmail();
     try {
       ResponseEntity<WorkspaceResponse> workspaceCall =
           restTemplate.exchange(
@@ -47,11 +48,11 @@ public class RawlsClient {
               new HttpEntity<>(headers),
               WorkspaceResponse.class);
       if (!workspaceCall.getStatusCode().is2xxSuccessful()) {
-        logger.warn("Unsuccessful response retrieving workspace{}", workspaceId);
+        logger.warn("Unsuccessful response retrieving workspace {} by {}", workspaceId, userEmail);
       }
       return workspaceCall.getBody();
     } catch (Exception e) {
-      logger.error("Error retrieving workspace {}", workspaceId);
+      logger.warn("Error retrieving workspace {} by {}", workspaceId, userEmail);
       throw e;
     }
   }

--- a/src/main/java/bio/terra/service/rawls/RawlsService.java
+++ b/src/main/java/bio/terra/service/rawls/RawlsService.java
@@ -2,11 +2,15 @@ package bio.terra.service.rawls;
 
 import bio.terra.app.configuration.TerraConfiguration;
 import bio.terra.app.model.rawls.WorkspaceResponse;
+import bio.terra.app.utils.PolicyUtils;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.ErrorModel;
+import bio.terra.model.InaccessibleWorkspacePolicyModel;
 import bio.terra.model.ResourcePolicyModel;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.model.WorkspacePolicyModel;
 import bio.terra.service.auth.iam.IamResourceType;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -16,7 +20,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class RawlsService {
-
   private final RawlsClient rawlsClient;
   private final TerraConfiguration terraConfiguration;
 
@@ -26,21 +29,44 @@ public class RawlsService {
     this.terraConfiguration = terraConfiguration;
   }
 
-  public List<WorkspacePolicyModel> resolvePolicyEmails(
+  public record WorkspacePolicyModels(
+      List<WorkspacePolicyModel> accessible, List<InaccessibleWorkspacePolicyModel> inaccessible) {}
+
+  /**
+   * @param samPolicyModel a policy from SAM with member policies
+   * @param userRequest authenticated user
+   * @return workspaces derived from policy emails, both accessible and inaccessible to the user
+   */
+  public WorkspacePolicyModels resolvePolicyEmails(
       SamPolicyModel samPolicyModel, AuthenticatedUserRequest userRequest) {
     Map<UUID, List<ResourcePolicyModel>> workspaceToPolicy =
         samPolicyModel.getMemberPolicies().stream()
             .filter(p -> p.getResourceTypeName().equals(IamResourceType.WORKSPACE.toString()))
             .collect(Collectors.groupingBy(ResourcePolicyModel::getResourceId));
 
-    return workspaceToPolicy.entrySet().stream()
-        .map(
+    List<WorkspacePolicyModel> accessible = new ArrayList<>();
+    List<InaccessibleWorkspacePolicyModel> inaccessible = new ArrayList<>();
+    workspaceToPolicy.entrySet().stream()
+        .forEach(
             entry -> {
               UUID workspaceId = entry.getKey();
-              WorkspaceResponse workspace = rawlsClient.getWorkspace(workspaceId, userRequest);
-              return workspace.toWorkspacePolicyModel(
-                  entry.getValue(), terraConfiguration.getBasePath());
-            })
-        .collect(Collectors.toList());
+              List<ResourcePolicyModel> policies = entry.getValue();
+              try {
+                WorkspaceResponse workspace = rawlsClient.getWorkspace(workspaceId, userRequest);
+                accessible.add(
+                    workspace.toWorkspacePolicyModel(policies, terraConfiguration.getBasePath()));
+              } catch (Exception ex) {
+                inaccessible.add(toInaccessibleWorkspacePolicyModel(workspaceId, policies, ex));
+              }
+            });
+    return new WorkspacePolicyModels(accessible, inaccessible);
+  }
+
+  public InaccessibleWorkspacePolicyModel toInaccessibleWorkspacePolicyModel(
+      UUID workspaceId, List<ResourcePolicyModel> policies, Exception ex) {
+    return new InaccessibleWorkspacePolicyModel()
+        .workspaceId(workspaceId)
+        .workspacePolicies(PolicyUtils.resourcePolicyToPolicyModel(policies))
+        .error(new ErrorModel().message(ex.getMessage()));
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -530,13 +530,16 @@ public class SnapshotService {
     List<SamPolicyModel> samPolicyModels =
         iamService.retrievePolicies(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
 
-    var workspacePolicyModels =
-        samPolicyModels.stream().map(pm -> rawlsService.resolvePolicyEmails(pm, userReq));
+    List<WorkspacePolicyModel> accessibleWorkspaces = new ArrayList<>();
+    List<InaccessibleWorkspacePolicyModel> inaccessibleWorkspaces = new ArrayList<>();
 
-    List<WorkspacePolicyModel> accessibleWorkspaces =
-        workspacePolicyModels.flatMap(wpms -> wpms.accessible().stream()).toList();
-    List<InaccessibleWorkspacePolicyModel> inaccessibleWorkspaces =
-        workspacePolicyModels.flatMap(wpms -> wpms.inaccessible().stream()).toList();
+    samPolicyModels.stream()
+        .map(pm -> rawlsService.resolvePolicyEmails(pm, userReq))
+        .forEach(
+            wpms -> {
+              accessibleWorkspaces.addAll(wpms.accessible());
+              inaccessibleWorkspaces.addAll(wpms.inaccessible());
+            });
 
     return new PolicyResponse()
         .policies(PolicyUtils.samToTdrPolicyModels(samPolicyModels))

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4785,6 +4785,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PolicyModel'
+    InaccessibleWorkspacePolicyModel:
+      type: object
+      properties:
+        workspaceId:
+          $ref: '#/components/schemas/UniqueIdProperty'
+        workspacePolicies:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyModel'
+        error:
+          $ref: "#/components/schemas/ErrorModel"
     PolicyResponse:
       type: object
       properties:
@@ -4796,6 +4807,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WorkspacePolicyModel'
+        inaccessibleWorkspaces:
+          type: array
+          items:
+            $ref: '#/components/schemas/InaccessibleWorkspacePolicyModel'
       description: >
         email of user or group to add to policy
     DataDeletionRequest:

--- a/src/test/java/bio/terra/service/rawls/RawlsServiceTest.java
+++ b/src/test/java/bio/terra/service/rawls/RawlsServiceTest.java
@@ -2,16 +2,20 @@ package bio.terra.service.rawls;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.app.model.rawls.WorkspaceDetails;
 import bio.terra.app.model.rawls.WorkspaceResponse;
 import bio.terra.common.category.Unit;
+import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.ErrorModel;
+import bio.terra.model.InaccessibleWorkspacePolicyModel;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.ResourcePolicyModel;
 import bio.terra.model.SamPolicyModel;
@@ -63,12 +67,15 @@ public class RawlsServiceTest {
 
   @MockBean private RawlsClient rawlsClient;
   @Autowired private RawlsService rawlsService;
-
   private SamIam samIam;
-
-  private UUID workspaceId;
-  private String workspaceName;
-  private String workspaceNamepace;
+  private static final String OWNER_NAME = "owner";
+  private static final String OWNER_EMAIL = "policy-email@firecloud.org";
+  private static final String WORKSPACE_NAME = "testWorkspace";
+  private static final String WORKSPACE_NAMEPACE = "testNamespace";
+  private final UUID accessibleWorkspaceId = UUID.randomUUID();
+  private final UUID inaccessibleWorkspaceId = UUID.randomUUID();
+  private final UnauthorizedException inaccessibleWorkspaceException =
+      new UnauthorizedException("Workspace inaccessible");
 
   @Before
   public void setUp() throws Exception {
@@ -87,77 +94,105 @@ public class RawlsServiceTest {
     // Mock out the lower level client in individual as needed
     when(samResourceApi.getApiClient()).thenAnswer(a -> apiClient);
 
-    workspaceId = UUID.randomUUID();
-    workspaceName = "testWorkspace";
-    workspaceNamepace = "testNamespace";
-
-    when(rawlsClient.getWorkspace(any(), any()))
+    when(rawlsClient.getWorkspace(accessibleWorkspaceId, userReq))
         .thenReturn(
             new WorkspaceResponse()
                 .workspace(
                     new WorkspaceDetails()
-                        .workspaceId(workspaceId.toString())
-                        .name(workspaceName)
-                        .namespace(workspaceNamepace)));
+                        .workspaceId(accessibleWorkspaceId.toString())
+                        .name(WORKSPACE_NAME)
+                        .namespace(WORKSPACE_NAMEPACE)));
+
+    when(rawlsClient.getWorkspace(inaccessibleWorkspaceId, userReq))
+        .thenThrow(inaccessibleWorkspaceException);
+  }
+
+  private PolicyIdentifiers createPolicyIdentifiers(IamResourceType resourceType, UUID resourceId) {
+    return new PolicyIdentifiers()
+        .policyName(OWNER_NAME)
+        .policyEmail(OWNER_EMAIL)
+        .resourceTypeName(resourceType.toString())
+        .resourceId(resourceId.toString());
+  }
+
+  private ResourcePolicyModel createResourcePolicyModel(
+      IamResourceType resourceType, UUID resourceId) {
+    return new ResourcePolicyModel()
+        .policyName(OWNER_NAME)
+        .policyEmail(OWNER_EMAIL)
+        .resourceTypeName(resourceType.toString())
+        .resourceId(resourceId);
   }
 
   @Test
   public void testRetrievePoliciesAndEmailsWorkspace() throws Exception {
-    final UUID id = UUID.randomUUID();
+    final UUID snapshotId = UUID.randomUUID();
+    final UUID nonWorkspaceResourceId = UUID.randomUUID();
     final String policyEmail = "policygroup@firecloud.org";
     final String memberEmail = "a@a.com";
 
-    final String ownerName = "owner";
-    final String ownerEmail = String.format("policy-%s@firecloud.org", UUID.randomUUID());
-    final String resourceTypeName = IamResourceType.WORKSPACE.toString();
-    final UUID resourceId = UUID.randomUUID();
+    var policyIdentifiers =
+        List.of(
+            createPolicyIdentifiers(IamResourceType.WORKSPACE, accessibleWorkspaceId),
+            createPolicyIdentifiers(IamResourceType.WORKSPACE, inaccessibleWorkspaceId),
+            createPolicyIdentifiers(IamResourceType.DATASNAPSHOT, nonWorkspaceResourceId));
+    var workspacePolicy =
+        new AccessPolicyResponseEntryV2()
+            .policyName(IamRole.READER.toString())
+            .email(policyEmail)
+            .policy(
+                new AccessPolicyMembershipV2()
+                    .addMemberEmailsItem(memberEmail)
+                    .memberPolicies(policyIdentifiers));
     when(samResourceApi.listResourcePoliciesV2(
-            IamResourceType.DATASNAPSHOT.getSamResourceName(), id.toString()))
-        .thenReturn(
-            List.of(
-                new AccessPolicyResponseEntryV2()
-                    .policyName(IamRole.READER.toString())
-                    .email(policyEmail)
-                    .policy(
-                        new AccessPolicyMembershipV2()
-                            .addMemberEmailsItem(memberEmail)
-                            .addMemberPoliciesItem(
-                                new PolicyIdentifiers()
-                                    .policyName(ownerName)
-                                    .policyEmail(ownerEmail)
-                                    .resourceTypeName(resourceTypeName)
-                                    .resourceId(resourceId.toString())))));
+            IamResourceType.DATASNAPSHOT.toString(), snapshotId.toString()))
+        .thenReturn(List.of(workspacePolicy));
 
+    var resourcePolicyModels =
+        List.of(
+            createResourcePolicyModel(IamResourceType.WORKSPACE, accessibleWorkspaceId),
+            createResourcePolicyModel(IamResourceType.WORKSPACE, inaccessibleWorkspaceId),
+            createResourcePolicyModel(IamResourceType.DATASNAPSHOT, nonWorkspaceResourceId));
     List<SamPolicyModel> samPolicyModels =
-        samIam.retrievePolicies(userReq, IamResourceType.DATASNAPSHOT, id);
+        samIam.retrievePolicies(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
     assertThat(
+        "Snapshot resource policies for all resource types are returned by SAM",
         samPolicyModels,
         is(
             List.of(
                 new SamPolicyModel()
                     .name(IamRole.READER.toString())
                     .addMembersItem(memberEmail)
-                    .addMemberPoliciesItem(
-                        new ResourcePolicyModel()
-                            .policyEmail(ownerEmail)
-                            .policyName(ownerName)
-                            .resourceTypeName(resourceTypeName)
-                            .resourceId(resourceId)))));
+                    .memberPolicies(resourcePolicyModels))));
 
-    List<WorkspacePolicyModel> workspacePolicyModels =
-        rawlsService.resolvePolicyEmails(samPolicyModels.get(0), userReq);
+    var workspacePolicyModels = rawlsService.resolvePolicyEmails(samPolicyModels.get(0), userReq);
+    verify(rawlsClient, times(1)).getWorkspace(accessibleWorkspaceId, userReq);
+    verify(rawlsClient, times(1)).getWorkspace(inaccessibleWorkspaceId, userReq);
 
     assertThat(
-        workspacePolicyModels,
+        "Workspace accessible to the user is included in returned policy models",
+        workspacePolicyModels.accessible(),
         is(
             List.of(
                 new WorkspacePolicyModel()
-                    .workspaceName(workspaceName)
-                    .workspaceNamespace(workspaceNamepace)
-                    .workspaceId(workspaceId)
+                    .workspaceName(WORKSPACE_NAME)
+                    .workspaceNamespace(WORKSPACE_NAMEPACE)
+                    .workspaceId(accessibleWorkspaceId)
                     .workspaceLink(
                         "https://bvdp-saturn-dev.appspot.com/#workspaces/testNamespace/testWorkspace")
                     .addWorkspacePoliciesItem(
-                        new PolicyModel().name(ownerName).addMembersItem(ownerEmail)))));
+                        new PolicyModel().name(OWNER_NAME).addMembersItem(OWNER_EMAIL)))));
+
+    assertThat(
+        "Workspace inaccessible to the user is included in returned policy models",
+        workspacePolicyModels.inaccessible(),
+        is(
+            List.of(
+                new InaccessibleWorkspacePolicyModel()
+                    .workspaceId(inaccessibleWorkspaceId)
+                    .addWorkspacePoliciesItem(
+                        new PolicyModel().name(OWNER_NAME).addMembersItem(OWNER_EMAIL))
+                    .error(
+                        new ErrorModel().message(inaccessibleWorkspaceException.getMessage())))));
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -58,6 +58,7 @@ import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
 import bio.terra.service.job.JobService;
 import bio.terra.service.profile.ProfileService;
+import bio.terra.service.rawls.RawlsService;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
@@ -116,6 +117,7 @@ public class SnapshotServiceTest {
   @MockBean private IamService iamService;
   @MockBean private AzureSynapsePdao synapsePdao;
   @MockBean private EcmService ecmService;
+  @MockBean private RawlsService rawlsService;
 
   private final UUID snapshotId = UUID.randomUUID();
   private final UUID datasetId = UUID.randomUUID();

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,6 +33,9 @@ import bio.terra.model.AccessInfoModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.InaccessibleWorkspacePolicyModel;
+import bio.terra.model.PolicyResponse;
+import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotPatchRequestModel;
 import bio.terra.model.SnapshotRequestContentsModel;
@@ -41,6 +45,7 @@ import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.model.StorageResourceModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
+import bio.terra.model.WorkspacePolicyModel;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
@@ -552,6 +557,45 @@ public class SnapshotServiceTest {
         service.retrieveUserSnapshotRoles(snapshotId, TEST_USER),
         contains(samRolesAndReader.toArray()));
     verify(ecmService, times(1)).getRasProviderPassport(TEST_USER);
+  }
+
+  @Test
+  public void retrieveSnapshotPolicies() {
+    SamPolicyModel spm1 = mock(SamPolicyModel.class);
+    SamPolicyModel spm2 = mock(SamPolicyModel.class);
+    when(iamService.retrievePolicies(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
+        .thenReturn(List.of(spm1, spm2));
+
+    List<WorkspacePolicyModel> accessible =
+        List.of(
+            mock(WorkspacePolicyModel.class),
+            mock(WorkspacePolicyModel.class),
+            mock(WorkspacePolicyModel.class));
+    List<InaccessibleWorkspacePolicyModel> inaccessible =
+        List.of(
+            mock(InaccessibleWorkspacePolicyModel.class),
+            mock(InaccessibleWorkspacePolicyModel.class),
+            mock(InaccessibleWorkspacePolicyModel.class));
+
+    when(rawlsService.resolvePolicyEmails(spm1, TEST_USER))
+        .thenReturn(
+            new RawlsService.WorkspacePolicyModels(
+                accessible.subList(0, 1), inaccessible.subList(0, 2)));
+    when(rawlsService.resolvePolicyEmails(spm2, TEST_USER))
+        .thenReturn(
+            new RawlsService.WorkspacePolicyModels(
+                accessible.subList(1, 3), inaccessible.subList(2, 3)));
+
+    PolicyResponse response = service.retrieveSnapshotPolicies(snapshotId, TEST_USER);
+
+    assertThat(
+        "All accessible workspaces from SAM policy models are returned",
+        response.getWorkspaces(),
+        is(accessible));
+    assertThat(
+        "All inaccessible workspaces from SAM policy models are returned",
+        response.getInaccessibleWorkspaces(),
+        is(inaccessible));
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2678

**Background**

Say a user has the needed permissions to view the policies on a snapshot.  When the snapshot has been export-by-copied to an inaccessible workspace, TDR’s `retrieveSnapshotPolicies` endpoint did not not gracefully handle that error, throwing on the first inaccessible workspace like so:

```
{
  "message": "404 Not Found: \"{\"causes\":[],\"message\":\"workspace ad0b2d69-e768-49b4-8954-b4cb55cff0cf does not exist or you do not have permission to use it\",\"source\":\"rawls\",\"stackTrace\":[],\"statusCode\":404}\"",
  "errorDetail": null
}
```

**Objective**

All workspaces to which a snapshot has been exported are represented in the `retrieveSnapshotPolicies` response, regardless of their accessibility.  If a workspace is inaccessible, we can't resolve its ID to a name and URL, but can still share the policy groups and supplement with the cause of inaccessibility.

This has implications for planned work to expand how destination workspaces are represented in TDR's Snapshot UI: https://broadworkbench.atlassian.net/browse/DR-2694

**Changes**

- Refactored `RawlsService.resolvePolicyEmails` to separate workspace policy responses based on accessibility
- Broke out main logic in `SnapshotsApiController.retrieveSnapshotPolicies` to a new method in `SnapshotService` of the same name, with a unit test
- Expanded `RawlsServiceTest.testRetrievePoliciesAndEmailsWorkspace` to offer more complete coverage -- now testing accessible workspaces, inaccessible workspaces, and non-workspace policies.

**Demo**

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/) is up-to-date with these changes.

I've added `DataRepoAdmins@dev.test.firecloud.org` and my Broad email as stewards for the following snapshot: https://jade-ok.datarepo-dev.broadinstitute.org/snapshots/786026c9-b850-49ec-818a-1e1bc4a7db50

As my test (admin) user, I successfully exported this snapshot to a new workspace: https://bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/DR-2678-snapshot-export-to-inaccessible-workspaces/data

[Fetching policies](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/retrieveSnapshotPolicies) as my test user -- workspace is accessible:
```
{
  "policies": [
    {
      "name": "admin",
      "members": [
        "DataRepoAdmins@dev.test.firecloud.org"
      ]
    },
    {
      "name": "reader",
      "members": [
        "policy-38ad2919-0b0c-4857-ba07-e38aadeb8169@dev.test.firecloud.org",
        "policy-c3f152ef-adf8-4c6a-86c4-723f114399af@dev.test.firecloud.org",
        "policy-a3fe2180-b011-4d6d-acba-cf4dae152f7e@dev.test.firecloud.org",
        "policy-e51a073f-a843-497d-8730-d0e33e7a1db0@dev.test.firecloud.org"
      ]
    },
    {
      "name": "discoverer",
      "members": []
    },
    {
      "name": "steward",
      "members": [
        "okotsopo@broadinstitute.org",
        "DataRepoAdmins@dev.test.firecloud.org"
      ]
    }
  ],
  "workspaces": [
    {
      "workspaceId": "81592eb3-fb87-4f8e-8536-af6ee92bd7eb",
      "workspaceName": "DR-2678-snapshot-export-to-inaccessible-workspaces",
      "workspaceNamespace": "general-dev-billing-account",
      "workspaceLink": "https://bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/DR-2678-snapshot-export-to-inaccessible-workspaces",
      "workspacePolicies": [
        {
          "name": "writer",
          "members": [
            "policy-38ad2919-0b0c-4857-ba07-e38aadeb8169@dev.test.firecloud.org"
          ]
        },
        {
          "name": "project-owner",
          "members": [
            "policy-c3f152ef-adf8-4c6a-86c4-723f114399af@dev.test.firecloud.org"
          ]
        },
        {
          "name": "reader",
          "members": [
            "policy-a3fe2180-b011-4d6d-acba-cf4dae152f7e@dev.test.firecloud.org"
          ]
        },
        {
          "name": "owner",
          "members": [
            "policy-e51a073f-a843-497d-8730-d0e33e7a1db0@dev.test.firecloud.org"
          ]
        }
      ]
    }
  ],
  "inaccessibleWorkspaces": []
}
```

[Fetching policies](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/retrieveSnapshotPolicies) as my Broad user -- workspace is inaccessible:
```
{
  "policies": [
    {
      "name": "admin",
      "members": [
        "DataRepoAdmins@dev.test.firecloud.org"
      ]
    },
    {
      "name": "reader",
      "members": [
        "policy-38ad2919-0b0c-4857-ba07-e38aadeb8169@dev.test.firecloud.org",
        "policy-c3f152ef-adf8-4c6a-86c4-723f114399af@dev.test.firecloud.org",
        "policy-a3fe2180-b011-4d6d-acba-cf4dae152f7e@dev.test.firecloud.org",
        "policy-e51a073f-a843-497d-8730-d0e33e7a1db0@dev.test.firecloud.org"
      ]
    },
    {
      "name": "discoverer",
      "members": []
    },
    {
      "name": "steward",
      "members": [
        "okotsopo@broadinstitute.org",
        "DataRepoAdmins@dev.test.firecloud.org"
      ]
    }
  ],
  "workspaces": [],
  "inaccessibleWorkspaces": [
    {
      "workspaceId": "81592eb3-fb87-4f8e-8536-af6ee92bd7eb",
      "workspacePolicies": [
        {
          "name": "writer",
          "members": [
            "policy-38ad2919-0b0c-4857-ba07-e38aadeb8169@dev.test.firecloud.org"
          ]
        },
        {
          "name": "project-owner",
          "members": [
            "policy-c3f152ef-adf8-4c6a-86c4-723f114399af@dev.test.firecloud.org"
          ]
        },
        {
          "name": "reader",
          "members": [
            "policy-a3fe2180-b011-4d6d-acba-cf4dae152f7e@dev.test.firecloud.org"
          ]
        },
        {
          "name": "owner",
          "members": [
            "policy-e51a073f-a843-497d-8730-d0e33e7a1db0@dev.test.firecloud.org"
          ]
        }
      ],
      "error": {
        "message": "404 Not Found: \"{\"causes\":[],\"message\":\"workspace 81592eb3-fb87-4f8e-8536-af6ee92bd7eb does not exist or you do not have permission to use it\",\"source\":\"rawls\",\"stackTrace\":[],\"statusCode\":404}\"",
        "errorDetail": null
      }
    }
  ]
}
```