### PR TITLE
[DR-2660] Policy members can be added on dataset creation

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -84,7 +84,7 @@ jobs:
           path: build/reports
           retention-days: 10
   deploy_test_integration:
-    timeout-minutes: 180
+    timeout-minutes: 360
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -84,7 +84,7 @@ jobs:
           path: build/reports
           retention-days: 10
   deploy_test_integration:
-    timeout-minutes: 360
+    timeout-minutes: 180
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -1,6 +1,7 @@
 package bio.terra.service.auth.iam;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SamPolicyModel;
@@ -109,9 +110,11 @@ public interface IamProviderInterface {
    *
    * @param userReq authenticated user
    * @param datasetId id of the dataset
+   * @param policies user emails to add as dataset policy members
    * @return Map of policy group emails for the dataset policies
    */
-  Map<IamRole, String> createDatasetResource(AuthenticatedUserRequest userReq, UUID datasetId)
+  Map<IamRole, String> createDatasetResource(
+      AuthenticatedUserRequest userReq, UUID datasetId, DatasetRequestModelPolicies policies)
       throws InterruptedException;
 
   /**

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -3,6 +3,7 @@ package bio.terra.service.auth.iam;
 import static bio.terra.service.configuration.ConfigEnum.AUTH_CACHE_TIMEOUT_SECONDS;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.model.UserStatusInfo;
@@ -221,11 +222,12 @@ public class IamService {
    *
    * @param userReq authenticated user
    * @param datasetId id of the dataset
+   * @param policies user emails to add as dataset policy members
    * @return List of policy group emails for the dataset policies
    */
   public Map<IamRole, String> createDatasetResource(
-      AuthenticatedUserRequest userReq, UUID datasetId) {
-    return callProvider(() -> iamProvider.createDatasetResource(userReq, datasetId));
+      AuthenticatedUserRequest userReq, UUID datasetId, DatasetRequestModelPolicies policies) {
+    return callProvider(() -> iamProvider.createDatasetResource(userReq, datasetId, policies));
   }
 
   /**

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -270,7 +270,8 @@ public class SamIam implements IamProviderInterface {
         IamRole.SNAPSHOT_CREATOR.toString(),
         createAccessPolicyV2(IamRole.SNAPSHOT_CREATOR, policies.getSnapshotCreators()));
 
-    logger.debug("SAM request: " + req);
+    logger.info("DR-2660 SAM request: " + req);
+    logger.info("DR-2660 " + Arrays.toString(Thread.currentThread().getStackTrace()));
     return req;
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -270,8 +270,7 @@ public class SamIam implements IamProviderInterface {
         IamRole.SNAPSHOT_CREATOR.toString(),
         createAccessPolicyV2(IamRole.SNAPSHOT_CREATOR, policies.getSnapshotCreators()));
 
-    logger.info("DR-2660 SAM request: " + req);
-    logger.info("DR-2660 " + Arrays.toString(Thread.currentThread().getStackTrace()));
+    logger.debug("SAM request: " + req);
     return req;
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -239,10 +239,18 @@ public class SamIam implements IamProviderInterface {
   private void createDatasetResourceInnerV2(
       AuthenticatedUserRequest userReq, UUID datasetId, DatasetRequestModelPolicies policies)
       throws ApiException {
+    ResourcesApi samResourceApi = samResourcesApi(userReq.getToken());
+    CreateResourceRequestV2 req = createDatasetResourceRequest(userReq, datasetId, policies);
+    samResourceApi.createResourceV2(IamResourceType.DATASET.toString(), req);
+  }
+
+  @VisibleForTesting
+  public CreateResourceRequestV2 createDatasetResourceRequest(
+      AuthenticatedUserRequest userReq, UUID datasetId, DatasetRequestModelPolicies policies) {
     policies = Optional.ofNullable(policies).orElse(new DatasetRequestModelPolicies());
     UserStatusInfo userStatusInfo = getUserInfoAndVerify(userReq);
-    CreateResourceRequestV2 req = new CreateResourceRequestV2();
-    req.setResourceId(datasetId.toString());
+
+    CreateResourceRequestV2 req = new CreateResourceRequestV2().resourceId(datasetId.toString());
 
     req.putPoliciesItem(
         IamRole.ADMIN.toString(),
@@ -262,10 +270,8 @@ public class SamIam implements IamProviderInterface {
         IamRole.SNAPSHOT_CREATOR.toString(),
         createAccessPolicyV2(IamRole.SNAPSHOT_CREATOR, policies.getSnapshotCreators()));
 
-    ResourcesApi samResourceApi = samResourcesApi(userReq.getToken());
     logger.debug("SAM request: " + req);
-
-    samResourceApi.createResourceV2(IamResourceType.DATASET.toString(), req);
+    return req;
   }
 
   private Map<IamRole, String> syncDatasetResourcePoliciesInner(

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -238,6 +239,7 @@ public class SamIam implements IamProviderInterface {
   private void createDatasetResourceInnerV2(
       AuthenticatedUserRequest userReq, UUID datasetId, DatasetRequestModelPolicies policies)
       throws ApiException {
+    policies = Optional.ofNullable(policies).orElse(new DatasetRequestModelPolicies());
     UserStatusInfo userStatusInfo = getUserInfoAndVerify(userReq);
     CreateResourceRequestV2 req = new CreateResourceRequestV2();
     req.setResourceId(datasetId.toString());

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -254,11 +254,9 @@ public class SamIam implements IamProviderInterface {
     req.putPoliciesItem(
         IamRole.STEWARD.toString(), createAccessPolicyV2(IamRole.STEWARD, stewards));
 
-    List<String> custodians = new ArrayList<>();
-    custodians.add(userStatusInfo.getUserEmail());
-    custodians.addAll(ListUtils.emptyIfNull(policies.getCustodians()));
     req.putPoliciesItem(
-        IamRole.CUSTODIAN.toString(), createAccessPolicyV2(IamRole.CUSTODIAN, custodians));
+        IamRole.CUSTODIAN.toString(),
+        createAccessPolicyV2(IamRole.CUSTODIAN, policies.getCustodians()));
 
     req.putPoliciesItem(
         IamRole.SNAPSHOT_CREATOR.toString(),

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetAuthzIamStep.java
@@ -3,6 +3,7 @@ package bio.terra.service.dataset.flight.create;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.DatasetRequestModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
@@ -20,18 +21,23 @@ public class CreateDatasetAuthzIamStep implements Step {
 
   private final IamProviderInterface iamClient;
   private final AuthenticatedUserRequest userReq;
+  private final DatasetRequestModel datasetRequest;
 
   public CreateDatasetAuthzIamStep(
-      IamProviderInterface iamClient, AuthenticatedUserRequest userReq) {
+      IamProviderInterface iamClient,
+      AuthenticatedUserRequest userReq,
+      DatasetRequestModel datasetRequest) {
     this.iamClient = iamClient;
     this.userReq = userReq;
+    this.datasetRequest = datasetRequest;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
     UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
-    Map<IamRole, String> policyEmails = iamClient.createDatasetResource(userReq, datasetId);
+    Map<IamRole, String> policyEmails =
+        iamClient.createDatasetResource(userReq, datasetId, datasetRequest.getPolicies());
     workingMap.put(DatasetWorkingMapKeys.POLICY_EMAILS, policyEmails);
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -125,8 +125,9 @@ public class DatasetCreateFlight extends Flight {
           new CreateDatasetCreateStorageAccountLinkStep(datasetStorageAccountDao, datasetRequest));
     }
 
+    // Create the IAM resource for the dataset with any specified policy members.
     // The underlying service provides retries so we do not need to retry for IAM step
-    addStep(new CreateDatasetAuthzIamStep(iamClient, userReq));
+    addStep(new CreateDatasetAuthzIamStep(iamClient, userReq, datasetRequest));
 
     if (platform.isGcp()) {
       addStep(new CreateDatasetPrimaryDataStep(bigQueryDatasetPdao, datasetDao));

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3508,6 +3508,22 @@ components:
             This might be useful to set as a security improvement since this provides a dedicated account that explicitly
             does not have access to any other buckets.  It's also recommended if you need to authorize a large number of buckets
             since the main service account could run into Google group membership quota violations.
+        policies:
+          description: User emails to add as dataset policy members.
+          type: object
+          properties:
+            stewards:
+              type: array
+              items:
+                type: string
+            custodians:
+              type: array
+              items:
+                type: string
+            snapshotCreators:
+              type: array
+              items:
+                type: string
       description: >
         Complete definition of a dataset without the id (used to create a dataset)
     DatasetPatchRequestModel:

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -135,7 +135,7 @@ public class ConnectedOperations {
 
     when(samService.createSnapshotResource(any(), any(), any())).thenReturn(snapshotPolicies);
     when(samService.isAuthorized(any(), any(), any(), any())).thenReturn(Boolean.TRUE);
-    when(samService.createDatasetResource(any(), any())).thenReturn(datasetPolicies);
+    when(samService.createDatasetResource(any(), any(), any())).thenReturn(datasetPolicies);
 
     when(samService.retrievePolicyEmails(any(), eq(IamResourceType.DATASET), any()))
         .thenReturn(datasetPolicies);

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -403,23 +403,21 @@ public class DataRepoFixtures {
       IamResourceType iamResourceType)
       throws Exception {
     PolicyMemberRequest req = new PolicyMemberRequest().email(userEmail);
-    String pathPrefix;
-    switch (iamResourceType) {
-      case DATASET:
-        pathPrefix = "/api/repository/v1/datasets/";
-        break;
-      case DATASNAPSHOT:
-        pathPrefix = "/api/repository/v1/snapshots/";
-        break;
-      case SPEND_PROFILE:
-        pathPrefix = "/api/resources/v1/profiles/";
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "No path prefix defined for IamResourceType " + iamResourceType);
-    }
-    String path = pathPrefix + resourceId + "/policies/" + role.toString() + "/members";
 
+    String resourceType =
+        switch (iamResourceType) {
+          case DATASET -> "datasets";
+          case DATASNAPSHOT -> "snapshots";
+          case SPEND_PROFILE -> "profiles";
+          default -> throw new IllegalArgumentException(
+              "Policy member addition undefined for IamResourceType " + iamResourceType);
+        };
+    String path =
+        String.format(
+            "/api/repository/v1/{}/{}/policies/{}/members",
+            resourceType,
+            resourceId,
+            role.toString());
     return dataRepoClient.post(user, path, TestUtils.mapToJson(req), new TypeReference<>() {});
   }
 
@@ -445,23 +443,18 @@ public class DataRepoFixtures {
     addPolicyMember(user, datasetId, role, newMemberEmail, IamResourceType.DATASET);
   }
 
-  // getting a users roles on a resource
+  // getting a user's roles on a resource
   public DataRepoResponse<List<String>> retrieveUserRolesRaw(
       TestConfiguration.User user, UUID resourceId, IamResourceType iamResourceType)
       throws Exception {
-    String pathPrefix;
-    switch (iamResourceType) {
-      case DATASET:
-        pathPrefix = "/api/repository/v1/datasets/";
-        break;
-      case DATASNAPSHOT:
-        pathPrefix = "/api/repository/v1/snapshots/";
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "No path prefix defined for IamResourceType " + iamResourceType);
-    }
-    String path = pathPrefix + resourceId + "/roles/";
+    String resourceType =
+        switch (iamResourceType) {
+          case DATASET -> "datasets";
+          case DATASNAPSHOT -> "snapshots";
+          default -> throw new IllegalArgumentException(
+              "Role fetch undefined for IamResourceType " + iamResourceType);
+        };
+    String path = String.format("/api/repository/v1/{}/{}/roles", resourceType, resourceId);
 
     return dataRepoClient.get(user, path, new TypeReference<>() {});
   }
@@ -477,22 +470,15 @@ public class DataRepoFixtures {
   public DataRepoResponse<PolicyResponse> retrievePoliciesRaw(
       TestConfiguration.User user, UUID resourceId, IamResourceType iamResourceType)
       throws Exception {
-    String pathPrefix;
-    switch (iamResourceType) {
-      case DATASET:
-        pathPrefix = "/api/repository/v1/datasets/";
-        break;
-      case DATASNAPSHOT:
-        pathPrefix = "/api/repository/v1/snapshots/";
-        break;
-      case SPEND_PROFILE:
-        pathPrefix = "/api/resources/v1/profiles/";
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "No path prefix defined for IamResourceType " + iamResourceType);
-    }
-    String path = pathPrefix + resourceId + "/policies/";
+    String resourceType =
+        switch (iamResourceType) {
+          case DATASET -> "datasets";
+          case DATASNAPSHOT -> "snapshots";
+          case SPEND_PROFILE -> "profiles";
+          default -> throw new IllegalArgumentException(
+              "Policy fetch undefined for IamResourceType " + iamResourceType);
+        };
+    String path = String.format("/api/repository/v1/{}/{}/policies", resourceType, resourceId);
 
     return dataRepoClient.get(user, path, new TypeReference<>() {});
   }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -414,10 +414,8 @@ public class DataRepoFixtures {
         };
     String path =
         String.format(
-            "/api/repository/v1/{}/{}/policies/{}/members",
-            resourceType,
-            resourceId,
-            role.toString());
+            "/api/repository/v1/%s/%s/policies/%s/members",
+            resourceType, resourceId, role.toString());
     return dataRepoClient.post(user, path, TestUtils.mapToJson(req), new TypeReference<>() {});
   }
 
@@ -454,7 +452,7 @@ public class DataRepoFixtures {
           default -> throw new IllegalArgumentException(
               "Role fetch undefined for IamResourceType " + iamResourceType);
         };
-    String path = String.format("/api/repository/v1/{}/{}/roles", resourceType, resourceId);
+    String path = String.format("/api/repository/v1/%s/%s/roles", resourceType, resourceId);
 
     return dataRepoClient.get(user, path, new TypeReference<>() {});
   }
@@ -478,7 +476,7 @@ public class DataRepoFixtures {
           default -> throw new IllegalArgumentException(
               "Policy fetch undefined for IamResourceType " + iamResourceType);
         };
-    String path = String.format("/api/repository/v1/{}/{}/policies", resourceType, resourceId);
+    String path = String.format("/api/repository/v1/%s/%s/policies", resourceType, resourceId);
 
     return dataRepoClient.get(user, path, new TypeReference<>() {});
   }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -403,19 +403,15 @@ public class DataRepoFixtures {
       IamResourceType iamResourceType)
       throws Exception {
     PolicyMemberRequest req = new PolicyMemberRequest().email(userEmail);
-
-    String resourceType =
+    String pathPrefix =
         switch (iamResourceType) {
-          case DATASET -> "datasets";
-          case DATASNAPSHOT -> "snapshots";
-          case SPEND_PROFILE -> "profiles";
+          case DATASET -> "/api/repository/v1/datasets/";
+          case DATASNAPSHOT -> "/api/repository/v1/snapshots/";
+          case SPEND_PROFILE -> "/api/resources/v1/profiles/";
           default -> throw new IllegalArgumentException(
               "Policy member addition undefined for IamResourceType " + iamResourceType);
         };
-    String path =
-        String.format(
-            "/api/repository/v1/%s/%s/policies/%s/members",
-            resourceType, resourceId, role.toString());
+    String path = pathPrefix + resourceId + "/policies/" + role.toString() + "/members";
     return dataRepoClient.post(user, path, TestUtils.mapToJson(req), new TypeReference<>() {});
   }
 
@@ -445,14 +441,14 @@ public class DataRepoFixtures {
   public DataRepoResponse<List<String>> retrieveUserRolesRaw(
       TestConfiguration.User user, UUID resourceId, IamResourceType iamResourceType)
       throws Exception {
-    String resourceType =
+    String pathPrefix =
         switch (iamResourceType) {
-          case DATASET -> "datasets";
-          case DATASNAPSHOT -> "snapshots";
+          case DATASET -> "/api/repository/v1/datasets/";
+          case DATASNAPSHOT -> "/api/repository/v1/snapshots/";
           default -> throw new IllegalArgumentException(
               "Role fetch undefined for IamResourceType " + iamResourceType);
         };
-    String path = String.format("/api/repository/v1/%s/%s/roles", resourceType, resourceId);
+    String path = pathPrefix + resourceId + "/roles";
 
     return dataRepoClient.get(user, path, new TypeReference<>() {});
   }
@@ -468,15 +464,15 @@ public class DataRepoFixtures {
   public DataRepoResponse<PolicyResponse> retrievePoliciesRaw(
       TestConfiguration.User user, UUID resourceId, IamResourceType iamResourceType)
       throws Exception {
-    String resourceType =
+    String pathPrefix =
         switch (iamResourceType) {
-          case DATASET -> "datasets";
-          case DATASNAPSHOT -> "snapshots";
-          case SPEND_PROFILE -> "profiles";
+          case DATASET -> "/api/repository/v1/datasets/";
+          case DATASNAPSHOT -> "/api/repository/v1/snapshots/";
+          case SPEND_PROFILE -> "/api/resources/v1/profiles/";
           default -> throw new IllegalArgumentException(
               "Policy fetch undefined for IamResourceType " + iamResourceType);
         };
-    String path = String.format("/api/repository/v1/%s/%s/policies", resourceType, resourceId);
+    String path = pathPrefix + resourceId + "/policies";
 
     return dataRepoClient.get(user, path, new TypeReference<>() {});
   }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -485,6 +485,9 @@ public class DataRepoFixtures {
       case DATASNAPSHOT:
         pathPrefix = "/api/repository/v1/snapshots/";
         break;
+      case SPEND_PROFILE:
+        pathPrefix = "/api/resources/v1/profiles/";
+        break;
       default:
         throw new IllegalArgumentException(
             "No path prefix defined for IamResourceType " + iamResourceType);

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -74,7 +74,7 @@ public class SamIamTest {
   @Mock private AuthenticatedUserRequest userReq;
 
   private SamIam samIam;
-  private final String ADMIN_EMAIL = "samAdminGroupEmail@a.com";
+  private static final String ADMIN_EMAIL = "samAdminGroupEmail@a.com";
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.when;
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.category.Unit;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SamPolicyModel;
@@ -284,7 +283,7 @@ public class SamIamTest {
     }
 
     assertThat(
-        samIam.createDatasetResource(userReq, datasetId, new DatasetRequestModelPolicies()),
+        samIam.createDatasetResource(userReq, datasetId, null),
         is(
             syncedPolicies.stream()
                 .collect(Collectors.toMap(p -> p, p -> "policygroup-" + p + "@firecloud.org"))));

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.category.Unit;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SamPolicyModel;
@@ -283,7 +284,7 @@ public class SamIamTest {
     }
 
     assertThat(
-        samIam.createDatasetResource(userReq, datasetId),
+        samIam.createDatasetResource(userReq, datasetId, new DatasetRequestModelPolicies()),
         is(
             syncedPolicies.stream()
                 .collect(Collectors.toMap(p -> p, p -> "policygroup-" + p + "@firecloud.org"))));

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -3,6 +3,8 @@ package bio.terra.service.auth.iam.sam;
 import static bio.terra.service.auth.iam.sam.SamIam.TOS_URL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -17,6 +19,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.category.Unit;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SamPolicyModel;
@@ -41,6 +44,7 @@ import org.broadinstitute.dsde.workbench.client.sam.api.TermsOfServiceApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntryV2;
+import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
@@ -70,10 +74,12 @@ public class SamIamTest {
   @Mock private AuthenticatedUserRequest userReq;
 
   private SamIam samIam;
+  private final String ADMIN_EMAIL = "samAdminGroupEmail@a.com";
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
+    when(samConfig.getAdminsGroupEmail()).thenReturn(ADMIN_EMAIL);
     samIam = spy(new SamIam(samConfig, configurationService));
     final String userToken = "some_token";
     when(userReq.getToken()).thenReturn(userToken);
@@ -287,6 +293,95 @@ public class SamIamTest {
         is(
             syncedPolicies.stream()
                 .collect(Collectors.toMap(p -> p, p -> "policygroup-" + p + "@firecloud.org"))));
+  }
+
+  @Test
+  public void testCreateDatasetResourceRequestWithoutPolicySpecifications() throws ApiException {
+    final String userSubjectId = "userid";
+    final String userEmail = "a@a.com";
+    mockUserInfo(userSubjectId, userEmail);
+
+    final UUID datasetId = UUID.randomUUID();
+
+    CreateResourceRequestV2 reqNullPolicies =
+        samIam.createDatasetResourceRequest(userReq, datasetId, null);
+    CreateResourceRequestV2 reqEmptyPolicies =
+        samIam.createDatasetResourceRequest(userReq, datasetId, new DatasetRequestModelPolicies());
+
+    for (CreateResourceRequestV2 req : List.of(reqNullPolicies, reqEmptyPolicies)) {
+      assertThat(req.getResourceId(), is(datasetId.toString()));
+
+      List<IamRole> policyKeys =
+          req.getPolicies().keySet().stream().map(IamRole::fromValue).toList();
+      assertThat(
+          policyKeys,
+          containsInAnyOrder(
+              IamRole.ADMIN, IamRole.STEWARD, IamRole.CUSTODIAN, IamRole.SNAPSHOT_CREATOR));
+
+      AccessPolicyMembershipV2 admin = req.getPolicies().get(IamRole.ADMIN.toString());
+      assertThat(admin.getRoles(), contains(IamRole.ADMIN.toString()));
+      assertThat(admin.getMemberEmails(), contains(ADMIN_EMAIL));
+
+      AccessPolicyMembershipV2 steward = req.getPolicies().get(IamRole.STEWARD.toString());
+      assertThat(steward.getRoles(), contains(IamRole.STEWARD.toString()));
+      assertThat(steward.getMemberEmails(), contains(userEmail));
+
+      AccessPolicyMembershipV2 custodian = req.getPolicies().get(IamRole.CUSTODIAN.toString());
+      assertThat(custodian.getRoles(), contains(IamRole.CUSTODIAN.toString()));
+      assertThat(custodian.getMemberEmails(), empty());
+
+      AccessPolicyMembershipV2 snapshotCreator =
+          req.getPolicies().get(IamRole.SNAPSHOT_CREATOR.toString());
+      assertThat(snapshotCreator.getRoles(), contains(IamRole.SNAPSHOT_CREATOR.toString()));
+      assertThat(snapshotCreator.getMemberEmails(), empty());
+    }
+  }
+
+  @Test
+  public void testCreateDatasetResourceRequestWithPolicySpecifications() throws ApiException {
+    final String userSubjectId = "userid";
+    final String userEmail = "a@a.com";
+    mockUserInfo(userSubjectId, userEmail);
+
+    final UUID datasetId = UUID.randomUUID();
+
+    String stewardEmail1 = "steward1@a.com";
+    String stewardEmail2 = "steward3@a.com";
+    String custodianEmail = "custodian@a.com";
+    String snapshotCreatorEmail = "snapshotCreator@a.com";
+    DatasetRequestModelPolicies policySpecs =
+        new DatasetRequestModelPolicies()
+            .addStewardsItem(stewardEmail1)
+            .addStewardsItem(stewardEmail2)
+            .addCustodiansItem(custodianEmail)
+            .addSnapshotCreatorsItem(snapshotCreatorEmail);
+    CreateResourceRequestV2 req =
+        samIam.createDatasetResourceRequest(userReq, datasetId, policySpecs);
+
+    assertThat(req.getResourceId(), is(datasetId.toString()));
+
+    List<IamRole> policyKeys = req.getPolicies().keySet().stream().map(IamRole::fromValue).toList();
+    assertThat(
+        policyKeys,
+        containsInAnyOrder(
+            IamRole.ADMIN, IamRole.STEWARD, IamRole.CUSTODIAN, IamRole.SNAPSHOT_CREATOR));
+
+    AccessPolicyMembershipV2 admin = req.getPolicies().get(IamRole.ADMIN.toString());
+    assertThat(admin.getRoles(), contains(IamRole.ADMIN.toString()));
+    assertThat(admin.getMemberEmails(), contains(ADMIN_EMAIL));
+
+    AccessPolicyMembershipV2 steward = req.getPolicies().get(IamRole.STEWARD.toString());
+    assertThat(steward.getRoles(), contains(IamRole.STEWARD.toString()));
+    assertThat(steward.getMemberEmails(), contains(userEmail, stewardEmail1, stewardEmail2));
+
+    AccessPolicyMembershipV2 custodian = req.getPolicies().get(IamRole.CUSTODIAN.toString());
+    assertThat(custodian.getRoles(), contains(IamRole.CUSTODIAN.toString()));
+    assertThat(custodian.getMemberEmails(), contains(custodianEmail));
+
+    AccessPolicyMembershipV2 snapshotCreator =
+        req.getPolicies().get(IamRole.SNAPSHOT_CREATOR.toString());
+    assertThat(snapshotCreator.getRoles(), contains(IamRole.SNAPSHOT_CREATOR.toString()));
+    assertThat(snapshotCreator.getMemberEmails(), contains(snapshotCreatorEmail));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
@@ -10,6 +10,7 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.TestJobWatcher;
 import bio.terra.integration.UsersBase;
+import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.auth.iam.IamResourceType;
@@ -83,7 +84,7 @@ public class SamRetryIntegrationTest extends UsersBase {
 
   @Test
   public void retrySyncDatasetPolicies() throws InterruptedException, ApiException {
-    iam.createDatasetResource(userRequest, fakeDatasetId);
+    iam.createDatasetResource(userRequest, fakeDatasetId, new DatasetRequestModelPolicies());
 
     // Should be able to re-run syncDatasetResourcePolicies without an error being thrown
     // Otherwise, need to break up each "SamIam.syncOnePolicy" into own retry loop

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
@@ -10,7 +10,6 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.TestJobWatcher;
 import bio.terra.integration.UsersBase;
-import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.auth.iam.IamResourceType;
@@ -84,7 +83,7 @@ public class SamRetryIntegrationTest extends UsersBase {
 
   @Test
   public void retrySyncDatasetPolicies() throws InterruptedException, ApiException {
-    iam.createDatasetResource(userRequest, fakeDatasetId, new DatasetRequestModelPolicies());
+    iam.createDatasetResource(userRequest, fakeDatasetId, null);
 
     // Should be able to re-run syncDatasetResourcePolicies without an error being thrown
     // Otherwise, need to break up each "SamIam.syncOnePolicy" into own retry loop

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -391,11 +391,12 @@ public class DatasetIntegrationTest extends UsersBase {
   public void testCreateDatasetWithPolicies() throws Exception {
     List<String> stewards = List.of(steward().getEmail(), admin().getEmail());
     String custodianEmail = custodian().getEmail();
+    List<String> custodiansWithDuplicates = List.of(custodianEmail, custodianEmail);
     String snapshotCreatorEmail = reader().getEmail();
     DatasetRequestModelPolicies policiesRequest =
         new DatasetRequestModelPolicies()
             .stewards(stewards)
-            .addCustodiansItem(custodianEmail)
+            .custodians(custodiansWithDuplicates)
             .addSnapshotCreatorsItem(snapshotCreatorEmail);
 
     DatasetSummaryModel summaryModel =
@@ -413,7 +414,7 @@ public class DatasetIntegrationTest extends UsersBase {
         containsInAnyOrder(stewards.toArray()));
 
     assertThat(
-        "Custodian added on dataset creation",
+        "Custodian added on dataset creation, duplicates removed without error",
         rolesToPolicies.get(IamRole.CUSTODIAN.toString()),
         contains(custodianEmail));
 

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -10,6 +10,7 @@ import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadArrayResultModel;
 import bio.terra.model.BulkLoadFileModel;
 import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.FileModel;
 import bio.terra.model.IngestRequestModel;
@@ -75,13 +76,12 @@ public class JobPermissionTest extends UsersBase {
             CloudPlatform.GCP,
             false,
             false,
-            false);
+            false,
+            new DatasetRequestModelPolicies().addCustodiansItem(custodian().getEmail()));
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.waitForDatasetCreate(steward(), jobResponse);
 
     datasetId = datasetSummaryModel.getId();
-    dataRepoFixtures.addPolicyMemberRaw(
-        steward(), datasetId, IamRole.CUSTODIAN, custodian().getEmail(), IamResourceType.DATASET);
 
     // Ingest single file
     String ingestBucket = "jade-testdata-useastregion";


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2660
https://broadworkbench.atlassian.net/browse/DR-2706

**Objective**

When creating a dataset, policy members can optionally be added as part of the dataset creation request:

```
    "policies": {
      "stewards": ["steward@gmail.com"],
      "custodians": ["custodian1@gmail.com", "custodian2@gmail.com"],
      "snapshotCreators": ["snapshot-creator@gmail.com"]
    }
```

Individual policy members can still be added / deleted following dataset creation, but this provides another option for use cases where more than one identity manages the dataset.

**Changes**

- In `SamIam`, refactored `createDatasetResourceRequest` out of `createDatasetResourceInnerV2` to include user-specified stewards, custodians, and/or snapshot creators in the resource's access policies.
- Dataset creators are no longer made custodians.  We still make them stewards: custodian permissions are a strict subset of steward permissions, so the custodianship was redundant and confusing.
- Added unit tests to validate construction of SAM resource requests.
- Expanded test fixtures, added integration test to validate dataset policy fetch from SAM following dataset construction.

**Demonstration**

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/) is up-to-date with these changes.

As my test user, first I created a dataset with no policy members set at creation: https://jade-ok.datarepo-dev.broadinstitute.org/datasets/89b0d499-3872-40b1-99c0-170d509ae725

I observed that the default [policy members](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/datasets/retrieveDatasetPolicies) aligned with our expectations (note that the creator is no longer made a custodian):

```
{
  "policies": [
    {
      "name": "snapshot_creator",
      "members": []
    },
    {
      "name": "steward",
      "members": [
        "okotsopo.broad.test@gmail.com"
      ]
    },
    {
      "name": "custodian",
      "members": []
    },
    {
      "name": "admin",
      "members": [
        "DataRepoAdmins@dev.test.firecloud.org"
      ]
    }
  ],
  "workspaces": null
}
```
<img width="1675" alt="Screen Shot 2022-08-18 at 3 34 51 PM" src="https://user-images.githubusercontent.com/79769153/185481751-1e67b2c2-7f73-41b7-9976-308d9ffd4f6f.png">

As my test user, I then created a dataset with policy members set at creation: https://jade-ok.datarepo-dev.broadinstitute.org/datasets/fea5f1c4-5179-4373-a7cb-afa887187a38

I accomplished this by including the following in the dataset request:
```
"policies": {
        "stewards": ["okotsopo@broadinstitute.org"],
        "custodians": ["DataRepoAdmins@dev.test.firecloud.org", "okotsopo@broadinstitute.org", "okotsopo.broad.test@gmail.com"],
        "snapshotCreators": ["okotsopo.broad.test@gmail.com"]
      }
```

I observed that the resulting [policy members](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/datasets/retrieveDatasetPolicies) aligned with our expectations -- incorporating default members with the members supplied in the request:

```
{
  "policies": [
    {
      "name": "custodian",
      "members": [
        "okotsopo@broadinstitute.org",
        "okotsopo.broad.test@gmail.com",
        "DataRepoAdmins@dev.test.firecloud.org"
      ]
    },
    {
      "name": "admin",
      "members": [
        "DataRepoAdmins@dev.test.firecloud.org"
      ]
    },
    {
      "name": "snapshot_creator",
      "members": [
        "okotsopo.broad.test@gmail.com"
      ]
    },
    {
      "name": "steward",
      "members": [
        "okotsopo@broadinstitute.org",
        "okotsopo.broad.test@gmail.com"
      ]
    }
  ],
  "workspaces": null
}
```
<img width="1696" alt="Screen Shot 2022-08-18 at 3 35 43 PM" src="https://user-images.githubusercontent.com/79769153/185481780-4927ac1f-3d7e-429b-be1c-d29f867305f6.png">
