### PR TITLE
DR-2693 DR-2713 Add ability to export to Azure

### DIFF
--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -7,6 +7,7 @@ import bio.terra.common.Column;
 import bio.terra.common.LogPrintable;
 import bio.terra.common.Relationship;
 import bio.terra.model.AssetModel;
+import bio.terra.model.CloudPlatform;
 import bio.terra.service.dataset.exception.InvalidAssetException;
 import bio.terra.service.filedata.FSContainerInterface;
 import bio.terra.service.filedata.google.firestore.FireStoreProject;
@@ -321,6 +322,11 @@ public class Dataset implements FSContainerInterface, LogPrintable {
 
   public Object getProperties() {
     return datasetSummary.getProperties();
+  }
+
+  @Override
+  public CloudPlatform getCloudPlatform() {
+    return datasetSummary.getCloudPlatform();
   }
 
   @Override

--- a/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
+++ b/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
@@ -1,6 +1,7 @@
 package bio.terra.service.filedata;
 
 import bio.terra.common.CollectionType;
+import bio.terra.model.CloudPlatform;
 import bio.terra.service.filedata.google.firestore.FireStoreProject;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import java.util.UUID;
@@ -17,4 +18,6 @@ public interface FSContainerInterface {
   String getName();
 
   CollectionType getCollectionType();
+
+  CloudPlatform getCloudPlatform();
 }

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -5,6 +5,7 @@ import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
 import bio.terra.common.LogPrintable;
 import bio.terra.common.Relationship;
+import bio.terra.model.CloudPlatform;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FSContainerInterface;
@@ -226,6 +227,11 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
 
   public boolean isSelfHosted() {
     return getSourceDataset().isSelfHosted();
+  }
+
+  @Override
+  public CloudPlatform getCloudPlatform() {
+    return getSourceDataset().getCloudPlatform();
   }
 
   @Override

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -57,7 +57,6 @@ import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.dataset.StorageResource;
 import bio.terra.service.dataset.exception.DatasetNotFoundException;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
-import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.job.JobService;
@@ -108,11 +107,9 @@ public class SnapshotService {
   private final EcmService ecmService;
   private final AzureSynapsePdao azureSynapsePdao;
   private final RawlsService rawlsService;
-  private final AzureBlobStorePdao deletePDAO;
 
   @Autowired
   public SnapshotService(
-      AzureBlobStorePdao deletePDAO,
       JobService jobService,
       DatasetService datasetService,
       FireStoreDependencyDao dependencyDao,
@@ -124,7 +121,6 @@ public class SnapshotService {
       EcmService ecmService,
       AzureSynapsePdao azureSynapsePdao,
       RawlsService rawlsService) {
-    this.deletePDAO = deletePDAO;
     this.jobService = jobService;
     this.datasetService = datasetService;
     this.dependencyDao = dependencyDao;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -223,9 +223,7 @@ public class SnapshotService {
     return jobService
         .newJob(description, SnapshotExportFlight.class, null, userReq)
         .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), id.toString())
-        .addParameter(
-            JobMapKeys.CLOUD_PLATFORM.getKeyName(),
-            snapshot.getSourceDataset().getDatasetSummary().getCloudPlatform())
+        .addParameter(JobMapKeys.CLOUD_PLATFORM.getKeyName(), snapshot.getCloudPlatform())
         .addParameter(ExportMapKeys.EXPORT_GSPATHS, exportGsPaths)
         .addParameter(ExportMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS, validatePrimaryKeyUniqueness)
         .submit();

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -960,7 +960,8 @@ public class SnapshotService {
             .name(snapshot.getName())
             .description(snapshot.getDescription())
             .createdDate(snapshot.getCreatedDate().toString())
-            .consentCode(snapshot.getConsentCode());
+            .consentCode(snapshot.getConsentCode())
+            .cloudPlatform(snapshot.getCloudPlatform());
 
     // In case NONE is specified, this should supersede any other value being passed in
     if (include.contains(SnapshotRetrieveIncludeModel.NONE)) {

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
@@ -1,10 +1,14 @@
 package bio.terra.service.snapshot.flight.export;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryExportPdao;
@@ -27,6 +31,8 @@ public class SnapshotExportFlight extends Flight {
     GcsPdao gcsPdao = appContext.getBean(GcsPdao.class);
     FireStoreDao fireStoreDao = appContext.getBean(FireStoreDao.class);
     ApplicationConfiguration appConfig = appContext.getBean(ApplicationConfiguration.class);
+    AzureBlobStorePdao azureBlobStorePdao = appContext.getBean(AzureBlobStorePdao.class);
+    ProfileService profileService = appContext.getBean(ProfileService.class);
     ObjectMapper objectMapper = appConfig.objectMapper();
 
     AuthenticatedUserRequest userReq =
@@ -34,41 +40,73 @@ public class SnapshotExportFlight extends Flight {
     UUID snapshotId =
         UUID.fromString(inputParameters.get(JobMapKeys.SNAPSHOT_ID.getKeyName(), String.class));
 
+    var platform =
+        CloudPlatformWrapper.of(
+            inputParameters.get(JobMapKeys.CLOUD_PLATFORM.getKeyName(), String.class));
+
     boolean validatePrimaryKeyUniqueness =
         Objects.requireNonNullElse(
             inputParameters.get(ExportMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS, Boolean.class), true);
 
     if (validatePrimaryKeyUniqueness) {
-      addStep(new SnapshotExportValidatePrimaryKeysStep(snapshotService, snapshotId));
+      if (platform.isGcp()) {
+        addStep(new SnapshotExportValidatePrimaryKeysStep(snapshotService, snapshotId));
+      } else {
+        throw new FeatureNotImplementedException(
+            "Key uniqueness validation not implemented in Azure.");
+      }
     }
 
     addStep(new SnapshotExportValidateExportParametersStep(snapshotService, snapshotId));
 
-    addStep(new SnapshotExportCreateBucketStep(resourceService, snapshotService, snapshotId));
-
+    if (platform.isGcp()) {
+      addStep(new SnapshotExportCreateBucketStep(resourceService, snapshotService, snapshotId));
+    }
     boolean exportGsPaths =
         Objects.requireNonNullElse(
             inputParameters.get(ExportMapKeys.EXPORT_GSPATHS, Boolean.class), false);
     if (exportGsPaths) {
-      addStep(
-          new SnapshotExportDumpFirestoreStep(
-              snapshotService, fireStoreDao, gcsPdao, snapshotId, objectMapper));
-      addStep(
-          new SnapshotExportLoadMappingTableStep(snapshotId, snapshotService, bigQueryExportPdao));
+      if (platform.isGcp()) {
+        addStep(
+            new SnapshotExportDumpFirestoreStep(
+                snapshotService, fireStoreDao, gcsPdao, snapshotId, objectMapper));
+        addStep(
+            new SnapshotExportLoadMappingTableStep(
+                snapshotId, snapshotService, bigQueryExportPdao));
+      } else {
+        throw new FeatureNotImplementedException(
+            "GCS path pre-resolution from DRS not implemented in Azure.");
+      }
     }
-    addStep(
-        new SnapshotExportCreateParquetFilesStep(
-            bigQueryExportPdao, gcsPdao, snapshotService, snapshotId, exportGsPaths));
-    addStep(
-        new SnapshotExportWriteManifestStep(
-            snapshotId,
-            snapshotService,
-            gcsPdao,
-            objectMapper,
-            userReq,
-            validatePrimaryKeyUniqueness));
-    addStep(new SnapshotExportGrantPermissionsStep(gcsPdao, userReq));
-    if (exportGsPaths) {
+
+    if (platform.isGcp()) {
+      addStep(
+          new SnapshotExportCreateParquetFilesStep(
+              bigQueryExportPdao, gcsPdao, snapshotService, snapshotId, exportGsPaths));
+      addStep(
+          new SnapshotExportWriteManifestStep(
+              snapshotId,
+              snapshotService,
+              gcsPdao,
+              objectMapper,
+              userReq,
+              validatePrimaryKeyUniqueness));
+    } else if (platform.isAzure()) {
+      addStep(
+          new SnapshotExportListAzureParquetFilesStep(
+              snapshotService, snapshotId, azureBlobStorePdao, userReq));
+      addStep(
+          new SnapshotExportWriteManifestAzureStep(
+              snapshotId,
+              snapshotService,
+              objectMapper,
+              azureBlobStorePdao,
+              resourceService,
+              profileService,
+              userReq));
+    }
+    if (exportGsPaths && platform.isGcp()) {
+      addStep(new SnapshotExportGrantPermissionsStep(gcsPdao, userReq));
       addStep(
           new CleanUpExportGsPathsStep(bigQueryExportPdao, gcsPdao, snapshotService, snapshotId));
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportFlight.java
@@ -105,10 +105,12 @@ public class SnapshotExportFlight extends Flight {
               profileService,
               userReq));
     }
-    if (exportGsPaths && platform.isGcp()) {
+    if (platform.isGcp()) {
       addStep(new SnapshotExportGrantPermissionsStep(gcsPdao, userReq));
-      addStep(
-          new CleanUpExportGsPathsStep(bigQueryExportPdao, gcsPdao, snapshotService, snapshotId));
+      if (exportGsPaths) {
+        addStep(
+            new CleanUpExportGsPathsStep(bigQueryExportPdao, gcsPdao, snapshotService, snapshotId));
+      }
     }
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportListAzureParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportListAzureParquetFilesStep.java
@@ -1,0 +1,63 @@
+package bio.terra.service.snapshot.flight.export;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.AccessInfoParquetModelTable;
+import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotRetrieveIncludeModel;
+import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class SnapshotExportListAzureParquetFilesStep extends DefaultUndoStep {
+
+  private final SnapshotService snapshotService;
+  private final UUID snapshotId;
+  private final AzureBlobStorePdao azureBlobStorePdao;
+  private final AuthenticatedUserRequest userReq;
+
+  public SnapshotExportListAzureParquetFilesStep(
+      SnapshotService snapshotService,
+      UUID snapshotId,
+      AzureBlobStorePdao azureBlobStorePdao,
+      AuthenticatedUserRequest userReq) {
+    this.snapshotService = snapshotService;
+    this.snapshotId = snapshotId;
+    this.azureBlobStorePdao = azureBlobStorePdao;
+    this.userReq = userReq;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    SnapshotModel snapshot =
+        snapshotService.retrieveAvailableSnapshotModel(
+            snapshotId,
+            List.of(
+                SnapshotRetrieveIncludeModel.ACCESS_INFORMATION,
+                SnapshotRetrieveIncludeModel.PROFILE),
+            userReq);
+
+    Map<String, List<String>> tablesToPaths =
+        snapshot.getAccessInformation().getParquet().getTables().stream()
+            .collect(
+                Collectors.toMap(
+                    AccessInfoParquetModelTable::getName,
+                    t ->
+                        azureBlobStorePdao.listChildren(
+                            "%s?%s".formatted(t.getUrl(), t.getSasToken()))));
+
+    workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_EXPORT_PARQUET_PATHS, tablesToPaths);
+    workingMap.put(JobMapKeys.BILLING_ID.getKeyName(), snapshot.getProfileId());
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
@@ -1,0 +1,127 @@
+package bio.terra.service.snapshot.flight.export;
+
+import bio.terra.common.FlightUtils;
+import bio.terra.common.exception.NotFoundException;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.SnapshotExportResponseModel;
+import bio.terra.model.SnapshotExportResponseModelFormat;
+import bio.terra.model.SnapshotExportResponseModelFormatParquet;
+import bio.terra.model.SnapshotExportResponseModelFormatParquetLocation;
+import bio.terra.model.SnapshotExportResponseModelFormatParquetLocationTables;
+import bio.terra.model.SnapshotModel;
+import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.profile.ProfileService;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import com.azure.storage.blob.BlobUrlParts;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class SnapshotExportWriteManifestAzureStep extends DefaultUndoStep {
+
+  private final UUID snapshotId;
+  private final SnapshotService snapshotService;
+  private final ObjectMapper objectMapper;
+  private final AzureBlobStorePdao azureBlobStorePdao;
+  private final ResourceService resourceService;
+  private ProfileService profileService;
+  private final AuthenticatedUserRequest userReq;
+
+  public SnapshotExportWriteManifestAzureStep(
+      UUID snapshotId,
+      SnapshotService snapshotService,
+      ObjectMapper objectMapper,
+      AzureBlobStorePdao azureBlobStorePdao,
+      ResourceService resourceService,
+      ProfileService profileService,
+      AuthenticatedUserRequest userReq) {
+    this.snapshotId = snapshotId;
+    this.snapshotService = snapshotService;
+    this.objectMapper = objectMapper;
+    this.azureBlobStorePdao = azureBlobStorePdao;
+    this.resourceService = resourceService;
+    this.profileService = profileService;
+    this.userReq = userReq;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+
+    Map<String, List<String>> paths =
+        FlightUtils.getTyped(workingMap, SnapshotWorkingMapKeys.SNAPSHOT_EXPORT_PARQUET_PATHS);
+    ContainerType containerType = ContainerType.METADATA;
+
+    UUID billingProfileId = workingMap.get(JobMapKeys.BILLING_ID.getKeyName(), UUID.class);
+    BillingProfileModel billingProfile = profileService.getProfileById(billingProfileId, userReq);
+    AzureStorageAccountResource storageAccountResource =
+        resourceService
+            .getSnapshotStorageAccount(snapshotId)
+            .orElseThrow(() -> new NotFoundException("Snapshot storage account not found"));
+    String exportManifestPath = "manifests/%s/manifest.json".formatted(context.getFlightId());
+    String fullExportManifestPath =
+        "%s/%s/%s"
+            .formatted(
+                storageAccountResource.getStorageAccountUrl(), containerType, exportManifestPath);
+    BlobUrlParts snapshotSignedUrlBlob =
+        azureBlobStorePdao.getOrSignUrlForTargetFactory(
+            fullExportManifestPath, billingProfile, storageAccountResource, containerType, userReq);
+
+    List<SnapshotExportResponseModelFormatParquetLocationTables> tables =
+        paths.entrySet().stream()
+            .map(
+                entry ->
+                    new SnapshotExportResponseModelFormatParquetLocationTables()
+                        .name(entry.getKey())
+                        .paths(entry.getValue()))
+            .collect(Collectors.toList());
+
+    SnapshotModel snapshot = snapshotService.retrieveAvailableSnapshotModel(snapshotId, userReq);
+
+    SnapshotExportResponseModel responseModel =
+        new SnapshotExportResponseModel()
+            .snapshot(snapshot)
+            .format(
+                new SnapshotExportResponseModelFormat()
+                    .parquet(
+                        new SnapshotExportResponseModelFormatParquet()
+                            .manifest(snapshotSignedUrlBlob.toUrl().toString())
+                            .location(
+                                new SnapshotExportResponseModelFormatParquetLocation()
+                                    .tables(tables))));
+
+    try {
+      String manifestContents =
+          objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(responseModel);
+
+      azureBlobStorePdao.writeBlobLines(
+          snapshotSignedUrlBlob.toUrl().toString(), Arrays.stream(manifestContents.split("\n")));
+    } catch (JsonProcessingException ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+    }
+
+    workingMap.put(
+        SnapshotWorkingMapKeys.SNAPSHOT_EXPORT_MANIFEST_PATH,
+        snapshotSignedUrlBlob.toUrl().toString());
+    responseModel.validatedPrimaryKeys(false);
+    context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), responseModel);
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3409,6 +3409,8 @@ components:
           $ref: '#/components/schemas/PhsId'
         accessInformation:
           $ref: '#/components/schemas/AccessInfoModel'
+        cloudPlatform:
+          $ref: '#/components/schemas/CloudPlatform'
         selfHosted:
           type: boolean
           default: false
@@ -4470,6 +4472,8 @@ components:
           $ref: '#/components/schemas/AccessInfoModel'
         creationInformation:
           $ref: '#/components/schemas/SnapshotRequestContentsModel'
+        cloudPlatform:
+          $ref: '#/components/schemas/CloudPlatform'
         properties:
           type: object
           description: Additional JSON metadata about the snapshot (this does not need to adhere to a particular schema)

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -49,6 +49,8 @@ import bio.terra.model.ErrorModel;
 import bio.terra.model.FileModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestResponseModel;
+import bio.terra.model.SnapshotExportResponseModel;
+import bio.terra.model.SnapshotExportResponseModelFormatParquet;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRequestRowIdModel;
@@ -68,6 +70,7 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.common.policy.RequestRetryOptions;
 import com.azure.storage.common.policy.RetryPolicyType;
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -80,6 +83,11 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -567,6 +575,21 @@ public class AzureIntegrationTest extends UsersBase {
             steward(), summaryModel.getName(), profileId, requestModelAll);
     snapshotId = snapshotSummaryAll.getId();
     assertThat("Snapshot exists", snapshotSummaryAll.getName(), equalTo(requestModelAll.getName()));
+
+    // Ensure that export works
+    DataRepoResponse<SnapshotExportResponseModel> snapshotExport =
+        dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, false, false);
+
+    assertThat(
+        "snapshotExport is present", snapshotExport.getResponseObject().isPresent(), is(true));
+    // Verify that the manifest is accessible
+    SnapshotExportResponseModelFormatParquet manifest =
+        snapshotExport.getResponseObject().get().getFormat().getParquet();
+    verifyUrlIsAccessible(manifest.getManifest());
+    // Verify that all files referenced in manifest are accessible
+    manifest.getLocation().getTables().stream()
+        .flatMap(t -> t.getPaths().stream())
+        .forEach(this::verifyUrlIsAccessible);
 
     // Read the ingested metadata
     AccessInfoParquetModel snapshotParquetAccessInfo =
@@ -1179,5 +1202,21 @@ public class AzureIntegrationTest extends UsersBase {
         "Signed url only contains expected permissions",
         blobUrlParts.getCommonSasQueryParameters().getPermissions(),
         equalTo(expectedPermissions));
+    verifyUrlIsAccessible(signedUrl);
+  }
+
+  private void verifyUrlIsAccessible(String signedUrl) {
+    logger.info("Verifying url %s".formatted(signedUrl));
+    try (CloseableHttpClient client = HttpClients.createDefault()) {
+      HttpUriRequest request = new HttpHead(signedUrl);
+      try (CloseableHttpResponse response = client.execute(request); ) {
+        assertThat(
+            "URL can be accessed",
+            response.getStatusLine().getStatusCode(),
+            equalTo(HttpStatus.OK.value()));
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -1,4 +1,4 @@
-package bio.terra.service.dataset;
+package bio.terra.integration;
 
 import static bio.terra.service.filedata.azure.util.BlobIOTestUtility.MIB;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,10 +26,6 @@ import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.common.configuration.TestConfiguration.User;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.Names;
-import bio.terra.integration.DataRepoFixtures;
-import bio.terra.integration.DataRepoResponse;
-import bio.terra.integration.TestJobWatcher;
-import bio.terra.integration.UsersBase;
 import bio.terra.model.AccessInfoParquetModel;
 import bio.terra.model.AccessInfoParquetModelTable;
 import bio.terra.model.BulkLoadArrayRequestModel;
@@ -105,7 +101,7 @@ import org.springframework.util.ResourceUtils;
 @ActiveProfiles({"google", "integrationtest"})
 @AutoConfigureMockMvc
 @Category(Integration.class)
-public class DatasetAzureIntegrationTest extends UsersBase {
+public class AzureIntegrationTest extends UsersBase {
 
   private static final String omopDatasetName = "it_dataset_omop";
   private static final String omopDatasetDesc =
@@ -113,7 +109,7 @@ public class DatasetAzureIntegrationTest extends UsersBase {
   private static final String omopDatasetRegionName = AzureRegion.DEFAULT_AZURE_REGION.toString();
   private static final String omopDatasetGcpRegionName =
       GoogleRegion.DEFAULT_GOOGLE_REGION.toString();
-  private static Logger logger = LoggerFactory.getLogger(DatasetAzureIntegrationTest.class);
+  private static Logger logger = LoggerFactory.getLogger(AzureIntegrationTest.class);
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private AuthService authService;

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -323,6 +323,9 @@ public class DatasetDaoTest {
           "dataset default Billing Profile matches default profile id",
           fromDB.getDatasetSummary().getDefaultBillingProfile().getId(),
           equalTo(fromDB.getDatasetSummary().getDefaultProfileId()));
+
+      assertThat(
+          "Cloud platform is returned", fromDB.getCloudPlatform(), equalTo(CloudPlatform.GCP));
     } finally {
       datasetDao.delete(datasetId);
     }


### PR DESCRIPTION
This PR enables support for exporting Azure snapshots to Terra workspaces:
- On export, enumerates all individual parquet files and returns signed URLs for them
- Writes them to a manifest file in:
`<snapshot storage account>/metadata/manifests/<flightid>/manifest.json`
- Returns the manifest as the response to the flight (that's already in place)

More details can be found here:
https://docs.google.com/document/d/1kVuiK9_VVDXjQPZJyO990sgBmtOHikA6Tv-Jt6Lab8c

Also, in order to support enabling this in the UI, I added cloudPlatform to `DatasetModel` and `SnapshotModel` (the fields were already part of the summary)