### PR TITLE
DR-2707 Don't restrict blob names with container naming constraints

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -152,8 +152,8 @@ public final class IngestUtils {
           "Ingest source is not a valid blob url: '"
               + url
               + "'. "
-              + " The container and each blob name must meet the following requirements: "
-              + "They must start and end with a letter or number. Valid characters include "
+              + "The container must meet the following requirements: "
+              + "It must start and end with a letter or number. Valid characters include "
               + "letters, numbers, and the dash (-) character. "
               + "Every dash (-) character must be immediately preceded and followed by a letter or number; "
               + "consecutive dashes are not permitted in container names.");

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
@@ -43,6 +43,17 @@ public class IngestUtilsTest {
         equalTo("test/azure-simple-dataset-ingest-request.csv"));
   }
 
+  public void testValidURLWithSpecialCharaterBlobPaths() {
+    IngestUtils.validateBlobAzureBlobFileURL(
+        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/azure_simple_dataset_ingest_request.csv");
+    IngestUtils.validateBlobAzureBlobFileURL(
+        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/AZURE_SIMPLE_DATASET_INGEST_REQUEST.CSV");
+    IngestUtils.validateBlobAzureBlobFileURL(
+        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/----.json");
+    IngestUtils.validateBlobAzureBlobFileURL(
+        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/nested/0_o.json");
+  }
+
   @Test(expected = InvalidBlobURLException.class)
   public void testInvalidScheme() {
     IngestUtils.validateBlobAzureBlobFileURL(
@@ -64,6 +75,12 @@ public class IngestUtilsTest {
   @Test(expected = InvalidBlobURLException.class)
   public void testNoDoubleDash() {
     IngestUtils.validateBlobAzureBlobFileURL(
-        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/azure-simple--dataset-ingest-request.csv");
+        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetest--data/test/azure-simple-dataset-ingest-request.csv");
+  }
+
+  @Test(expected = InvalidBlobURLException.class)
+  public void testNoUpperCase() {
+    IngestUtils.validateBlobAzureBlobFileURL(
+        "https://tdrconnectedsrc1.blob.core.windows.net/SYNAPSETEST/test/azure-simple-dataset-ingest-request.csv");
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
@@ -43,15 +43,12 @@ public class IngestUtilsTest {
         equalTo("test/azure-simple-dataset-ingest-request.csv"));
   }
 
-  public void testValidURLWithSpecialCharaterBlobPaths() {
-    IngestUtils.validateBlobAzureBlobFileURL(
-        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/azure_simple_dataset_ingest_request.csv");
-    IngestUtils.validateBlobAzureBlobFileURL(
-        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/AZURE_SIMPLE_DATASET_INGEST_REQUEST.CSV");
-    IngestUtils.validateBlobAzureBlobFileURL(
-        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/----.json");
-    IngestUtils.validateBlobAzureBlobFileURL(
-        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/nested/0_o.json");
+  public void testValidURLWithSpecialCharacterBlobPaths() {
+    String urlPrefix = "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata";
+    IngestUtils.validateBlobAzureBlobFileURL(urlPrefix + "/test/azure_simple_dataset_ingest.csv");
+    IngestUtils.validateBlobAzureBlobFileURL(urlPrefix + "/test/AZURE_SIMPLE_DATASET_INGEST.CSV");
+    IngestUtils.validateBlobAzureBlobFileURL(urlPrefix + "/test/----.json");
+    IngestUtils.validateBlobAzureBlobFileURL(urlPrefix + "/test/nested/0_o.json");
   }
 
   @Test(expected = InvalidBlobURLException.class)


### PR DESCRIPTION
Given that Azure urls are roughly in the form of:
`https://{storage account}.{blob|dfs}.core.windows.net/{container name}/{blob name}`
We are currently applying container name restrictions (very restricted) to blob names (virtually no restrictions)

This PR simplifies the validation logic to only apply the container restriction regex to the container and not blob path components.

Updated the tests to reflect this too (e.g. happy path tests with restricted container names but less restricted blob names)