### PR TITLE
[DR-2686] Expand permissions in enumerate jobs endpoint

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -182,6 +182,11 @@ public class IamService {
     }
   }
 
+  public List<String> listActions(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId) {
+    return callProvider(() -> iamProvider.listActions(userReq, iamResourceType, resourceId));
+  }
+
   /**
    * If user has any action on a resource than we allow that user to list the resource, rather than
    * have a specific action for listing. That is the Sam convention.

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -355,7 +355,6 @@ public class JobService {
                 if (userRoles.contains(action.toString())) {
                   flightStateList.add(flightState);
                 }
-                ;
               }
             }
           });

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -31,6 +31,8 @@ import bio.terra.stairway.exception.FlightNotFoundException;
 import bio.terra.stairway.exception.StairwayException;
 import bio.terra.stairway.exception.StairwayExecutionException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -281,36 +283,34 @@ public class JobService {
       SqlSortDirection direction,
       String className) {
 
-    boolean canListAnyJob = checkUserCanListAnyJob(userReq);
-
     // if the user has access to all jobs, then fetch everything
     // otherwise, filter the jobs on the user
+    FlightFilter filter = new FlightFilter();
+    // Set the order to use to return values
+    switch (direction) {
+      case ASC:
+        filter.submittedTimeSortDirection(FlightFilterSortDirection.ASC);
+        break;
+      case DESC:
+        filter.submittedTimeSortDirection(FlightFilterSortDirection.DESC);
+        break;
+      default:
+        throw new IllegalArgumentException(String.format("Unrecognized direction %s", direction));
+    }
+
+    // Filter on FQ class name if specified
+    if (!StringUtils.isEmpty(className)) {
+      filter.addFilterFlightClass(FlightFilterOp.EQUAL, className);
+    }
+
     List<FlightState> flightStateList;
+    boolean canListAnyJob = checkUserCanListAnyJob(userReq);
     try {
-      FlightFilter filter = new FlightFilter();
-
-      if (!canListAnyJob) {
-        filter.addFilterInputParameter(
-            JobMapKeys.SUBJECT_ID.getKeyName(), FlightFilterOp.EQUAL, userReq.getSubjectId());
+      if (canListAnyJob) {
+        flightStateList = stairway.getFlights(offset, limit, filter);
+      } else {
+        flightStateList = getAccessibleFlights(offset, limit, filter, userReq);
       }
-
-      // Set the order to use to return values
-      switch (direction) {
-        case ASC:
-          filter.submittedTimeSortDirection(FlightFilterSortDirection.ASC);
-          break;
-        case DESC:
-          filter.submittedTimeSortDirection(FlightFilterSortDirection.DESC);
-          break;
-        default:
-          throw new IllegalArgumentException(String.format("Unrecognized direction %s", direction));
-      }
-      // Filter on FQ class name if specified
-      if (!StringUtils.isEmpty(className)) {
-        filter.addFilterFlightClass(FlightFilterOp.EQUAL, className);
-      }
-
-      flightStateList = stairway.getFlights(offset, limit, filter);
     } catch (InterruptedException ex) {
       throw new JobServiceShutdownException("Job service interrupted", ex);
     }
@@ -318,6 +318,62 @@ public class JobService {
     return flightStateList.stream()
         .map(this::mapFlightStateToJobModel)
         .collect(Collectors.toList());
+  }
+
+  private List<FlightState> getAccessibleFlights(
+      int offset, int limit, FlightFilter filter, AuthenticatedUserRequest userReq)
+      throws InterruptedException {
+    int start = 0;
+    int end = offset + limit;
+    HashMap<String, List<String>> roleMap = new HashMap<>();
+    ArrayList<FlightState> flightStateList = new ArrayList<>();
+    while (flightStateList.size() < offset + limit) {
+      List<FlightState> filterResults = stairway.getFlights(start, end, filter);
+      if (filterResults.size() == 0) {
+        break;
+      }
+      filterResults.forEach(
+          flightState -> {
+            if (userLaunchedFlight(flightState, userReq)) {
+              flightStateList.add(flightState);
+            } else {
+              FlightMap inputParameters = flightState.getInputParameters();
+              IamResourceType resourceType =
+                  inputParameters.get(
+                      JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.class);
+              String resourceId =
+                  inputParameters.get(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), String.class);
+              IamAction action =
+                  inputParameters.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class);
+              if (resourceType != null & resourceId != null && action != null) {
+                String key = String.format("%s-%s", resourceType, resourceId);
+                List<String> userRoles = roleMap.get(key);
+                if (userRoles == null) {
+                  userRoles = samService.listActions(userReq, resourceType, resourceId);
+                  roleMap.put(key, userRoles);
+                }
+                if (userRoles.contains(action.toString())) {
+                  flightStateList.add(flightState);
+                }
+                ;
+              }
+            }
+          });
+      start = end;
+      end += offset + limit;
+    }
+    if (flightStateList.size() <= offset) {
+      return new ArrayList<>();
+    } else if (flightStateList.size() < offset + limit) {
+      return flightStateList.subList(offset, flightStateList.size());
+    }
+    return flightStateList.subList(offset, offset + limit);
+  }
+
+  private boolean userLaunchedFlight(FlightState flightState, AuthenticatedUserRequest userReq) {
+    FlightMap inputParameters = flightState.getInputParameters();
+    String flightSubjectId = inputParameters.get(JobMapKeys.SUBJECT_ID.getKeyName(), String.class);
+    return StringUtils.equals(flightSubjectId, userReq.getSubjectId());
   }
 
   public JobModel retrieveJob(String jobId, AuthenticatedUserRequest userReq) {

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -1311,4 +1311,16 @@ public class DataRepoFixtures {
       throws Exception {
     return dataRepoClient.get(user, "/api/repository/v1/jobs/" + jobId, new TypeReference<>() {});
   }
+
+  public List<JobModel> enumerateJobs(TestConfiguration.User user) throws Exception {
+    DataRepoResponse<List<JobModel>> response = enumerateJobsRaw(user);
+    assertThat("enumerate jobs is successful", response.getStatusCode(), equalTo(HttpStatus.OK));
+    assertTrue("enumerate jobs response is present", response.getResponseObject().isPresent());
+    return response.getResponseObject().get();
+  }
+
+  public DataRepoResponse<List<JobModel>> enumerateJobsRaw(TestConfiguration.User user)
+      throws Exception {
+    return dataRepoClient.get(user, "/api/repository/v1/jobs/", new TypeReference<>() {});
+  }
 }

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -1,6 +1,7 @@
 package bio.terra.service.job;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import bio.terra.common.GcsUtils;
 import bio.terra.common.category.Integration;
@@ -186,9 +187,27 @@ public class JobPermissionTest extends UsersBase {
     String combinedIngestJobId = combinedIngestJobResponse.getResponseObject().get().getId();
     dataRepoFixtures.getJobSuccess(combinedIngestJobId, custodian());
 
-    assertEquals(dataRepoFixtures.enumerateJobs(admin()).size(), 10);
-    assertEquals(dataRepoFixtures.enumerateJobs(steward()).size(), 10);
-    assertEquals(dataRepoFixtures.enumerateJobs(custodian()).size(), 10);
-    assertEquals(dataRepoFixtures.enumerateJobs(reader()).size(), 0);
+    List<String> jobIds =
+        List.of(
+            datasetCreateJobId,
+            fileIngestJobId,
+            bulkLoadJobId,
+            metadataIngestJobId,
+            combinedIngestJobId);
+
+    assertTrue(
+        "Admin can list jobs", containsJobIds(dataRepoFixtures.enumerateJobs(admin()), jobIds));
+    assertTrue(
+        "Steward can list jobs", containsJobIds(dataRepoFixtures.enumerateJobs(steward()), jobIds));
+    assertTrue(
+        "Custodian can list jobs",
+        containsJobIds(dataRepoFixtures.enumerateJobs(custodian()), jobIds));
+    assertFalse(
+        "Reader cannot list jobs",
+        containsJobIds(dataRepoFixtures.enumerateJobs(reader()), jobIds));
+  }
+
+  private boolean containsJobIds(List<JobModel> jobs, List<String> jobIds) {
+    return jobs.stream().map(JobModel::getId).toList().containsAll(jobIds);
   }
 }

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -1,5 +1,7 @@
 package bio.terra.service.job;
 
+import static org.junit.Assert.assertEquals;
+
 import bio.terra.common.GcsUtils;
 import bio.terra.common.category.Integration;
 import bio.terra.integration.DataRepoClient;
@@ -183,5 +185,10 @@ public class JobPermissionTest extends UsersBase {
 
     String combinedIngestJobId = combinedIngestJobResponse.getResponseObject().get().getId();
     dataRepoFixtures.getJobSuccess(combinedIngestJobId, custodian());
+
+    assertEquals(dataRepoFixtures.enumerateJobs(admin()).size(), 10);
+    assertEquals(dataRepoFixtures.enumerateJobs(steward()).size(), 10);
+    assertEquals(dataRepoFixtures.enumerateJobs(custodian()).size(), 10);
+    assertEquals(dataRepoFixtures.enumerateJobs(reader()).size(), 0);
   }
 }


### PR DESCRIPTION
**Background:**
Update permissions for the enumerate job endpoint so that a user can list a job if any of the following are true:
- The user is an admin (existing behavior)
- The user started the job (existing behavior)
- The user can perform the same action on the resource as the job (e.g. all dataset stewards can list ingest jobs, even if they were performed by another steward/custodian of the dataset)

**Implementation:**
- Fetch a batch of jobs from stairway and check if the user can list any of them. If a user did not launch the job, check if they can perform the job action on the resource in SAM and store those actions in a map to avoid making multiple SAM requests for the same resource.
- Stop when the list of accessible jobs is at least the offset + limit size or there are no more jobs in stairway
- This will take longer as the user pages through jobs, but my assumption here is that users are only interested in listing the most recent jobs.

**Open questions:**
- Would it make more sense to list the job in the enumerate endpoint if the user can perform any action on the associated resource? And then only show the job details if they can perform that action?