### PR TITLE
[DR-2674] EnumerateSnapshotModel includes ECM errors

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -24,7 +24,6 @@ import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.model.SqlSortDirection;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
-import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.dataset.AssetModelValidator;
@@ -37,7 +36,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -194,16 +192,13 @@ public class SnapshotsApiController implements SnapshotsApi {
       String region,
       List<String> datasetIds) {
     ControllerUtils.validateEnumerateParams(offset, limit);
-    Map<UUID, Set<IamRole>> idsAndRoles =
-        snapshotService.listAuthorizedSnapshots(getAuthenticatedInfo());
-
     List<UUID> datasetUUIDs =
         ListUtils.emptyIfNull(datasetIds).stream()
             .map(UUID::fromString)
             .collect(Collectors.toList());
     var esm =
         snapshotService.enumerateSnapshots(
-            offset, limit, sort, direction, filter, region, datasetUUIDs, idsAndRoles);
+            getAuthenticatedInfo(), offset, limit, sort, direction, filter, region, datasetUUIDs);
     return ResponseEntity.ok(esm);
   }
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4432,6 +4432,11 @@ components:
             type: array
             items:
               type: string
+        errors:
+          type: array
+          description: Errors encountered which may result in a partial enumeration returned.
+          items:
+            $ref: '#/components/schemas/ErrorModel'
       description: >
         The total number of snapshots available that match the criteria and a page of summaries
     SnapshotModel:

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.snapshot;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
@@ -443,8 +444,8 @@ public class SnapshotServiceTest {
     assertThat("ECM error added to error list", errors.size(), equalTo(1));
     assertThat(
         "ECM error contents match expectations",
-        errors.get(0).getErrorDetail().get(0),
-        equalTo(ecmException.getMessage()));
+        errors.get(0).getMessage(),
+        containsString("Error listing RAS-authorized snapshots"));
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2674

**Background**
 
We previously expanded snapshot enumeration to check for a user's linked RAS passport: if one exists we'd decode it and include any matching snapshots in the enumeration response.  At the time we agreed that an ECM error should not cause the overall enumeration to fail.  But by logging ECM exceptions without throwing them, callers would not know that they might be receiving a partial enumeration.

**Objective**

Expanded the snapshot enumeration response to include information on any errors encountered when communicating with ECM that may result in an incomplete enumeration returned.  The caller can then decide what to do with it.

**Demonstration**

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/enumerateSnapshots) is up to date with my latest changes.  The schema for the `enumerateSnapshots` response includes this new `errors` list, which is empty under normal circumstances when no ECM errors are encountered.  Automated tests were expanded to verify new behavior; in the absence of RAS test accounts, we don't get very far down the RAS path but I would be happy to introduce a fault locally to force the behavior in a demo if there's interest.