### PR TITLE
DR-2725 Add a project name to dataset and snapshot google projects

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -103,7 +103,8 @@ public class ResourceService {
         (GoogleRegion)
             dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.FIRESTORE);
     // Every bucket needs to live in a project, so we get or create a project first
-    return projectService.initializeGoogleProject(projectId, billingProfile, null, region, labels);
+    return projectService.initializeGoogleProject(
+        projectId, billingProfile, null, region, labels, CollectionType.DATASET);
   }
 
   /**
@@ -468,7 +469,8 @@ public class ResourceService {
             "project-usage", "snapshot");
 
     GoogleProjectResource googleProjectResource =
-        projectService.initializeGoogleProject(projectId, billingProfile, null, region, labels);
+        projectService.initializeGoogleProject(
+            projectId, billingProfile, null, region, labels, CollectionType.SNAPSHOT);
 
     return googleProjectResource.getId();
   }
@@ -495,7 +497,7 @@ public class ResourceService {
 
     GoogleProjectResource googleProjectResource =
         projectService.initializeGoogleProject(
-            projectId, billingProfile, getStewardPolicy(), region, labels);
+            projectId, billingProfile, getStewardPolicy(), region, labels, CollectionType.DATASET);
 
     return googleProjectResource.getId();
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectResource.java
@@ -5,8 +5,8 @@ import java.util.UUID;
 public class GoogleProjectResource {
   private UUID id; // id of the project resource in the datarepo metadata
   private UUID profileId; // id of the associated billing profile
-  private String googleProjectId; // google's name of the project
-  private String googleProjectNumber; // google's id of the project
+  private String googleProjectId; // google's user specified, globally unique id of the project
+  private String googleProjectNumber; // google's auto generated numeric id of the project
   private String serviceAccount; // service account associated with this project
 
   // Default constructor for JSON serdes

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -170,7 +170,8 @@ public class GoogleProjectService {
       BillingProfileModel billingProfile,
       Map<String, List<String>> roleIdentityMapping,
       GoogleRegion region,
-      Map<String, String> labels)
+      Map<String, String> labels,
+      CollectionType collectionType)
       throws InterruptedException {
 
     try {
@@ -199,7 +200,8 @@ public class GoogleProjectService {
     if (project == null) {
       throw new GoogleResourceException("Could not get project after handout");
     }
-    return initializeProject(project, billingProfile, roleIdentityMapping, region, labels);
+    return initializeProject(
+        project, billingProfile, roleIdentityMapping, region, labels, collectionType);
   }
 
   public GoogleProjectResource getProjectResourceById(UUID id) {
@@ -231,7 +233,8 @@ public class GoogleProjectService {
       BillingProfileModel billingProfile,
       Map<String, List<String>> roleIdentityMapping,
       GoogleRegion region,
-      Map<String, String> labels)
+      Map<String, String> labels,
+      CollectionType collectionType)
       throws InterruptedException {
 
     String googleProjectNumber = project.getProjectNumber().toString();
@@ -251,6 +254,15 @@ public class GoogleProjectService {
     resourceManagerService.updateIamPermissions(
         roleIdentityMapping, googleProjectId, PermissionOp.ENABLE_PERMISSIONS);
     resourceManagerService.addLabelsToProject(googleProjectResource.getGoogleProjectId(), labels);
+
+    String projectName;
+    switch (collectionType) {
+      case DATASET -> projectName = "TDR Dataset Project";
+      case SNAPSHOT -> projectName = "TDR Snapshot Project";
+      default -> throw new IllegalArgumentException("Invalid collection type");
+    }
+    resourceManagerService.addOrEditNameOfProject(
+        googleProjectResource.getGoogleProjectId(), projectName);
 
     UUID id = resourceDao.createProject(googleProjectResource);
     googleProjectResource.id(id);

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceManagerService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceManagerService.java
@@ -168,6 +168,19 @@ public class GoogleResourceManagerService {
         });
   }
 
+  public void addOrEditNameOfProject(String googleProjectId, String googleProjectName) {
+    try {
+      CloudResourceManager resourceManager = cloudResourceManager();
+      Project project = resourceManager.projects().get(googleProjectId).execute();
+      project.setName(googleProjectName);
+      logger.info("Setting name for project {}", googleProjectId);
+      resourceManager.projects().update(googleProjectId, project).execute();
+    } catch (Exception ex) {
+      // only a soft failure - we do not want to fail project create just on adding project labels
+      logger.warn("Encountered error while updating project name", ex);
+    }
+  }
+
   public void addLabelsToProject(String googleProjectId, Map<String, String> labels) {
     final Stream<Map.Entry<String, String>> additionalLabels;
     if (Arrays.stream(environment.getActiveProfiles())

--- a/src/test/java/bio/terra/service/profile/GoogleBillingServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/GoogleBillingServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.buffer.model.ResourceInfo;
+import bio.terra.common.CollectionType;
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
@@ -155,6 +156,7 @@ public class GoogleBillingServiceTest {
         profile,
         roleToStewardMap,
         GoogleRegion.DEFAULT_GOOGLE_REGION,
-        Map.of("test-name", "google-billing-service-test"));
+        Map.of("test-name", "google-billing-service-test"),
+        CollectionType.DATASET);
   }
 }

--- a/src/test/java/bio/terra/service/profile/ProfileServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileServiceTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.buffer.model.ResourceInfo;
+import bio.terra.common.CollectionType;
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
@@ -189,6 +190,7 @@ public class ProfileServiceTest {
         profile,
         roleToStewardMap,
         GoogleRegion.DEFAULT_GOOGLE_REGION,
-        Map.of("test-name", "profile-service-test"));
+        Map.of("test-name", "profile-service-test"),
+        CollectionType.DATASET);
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/BucketResourceTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.buffer.model.ResourceInfo;
+import bio.terra.common.CollectionType;
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
@@ -547,6 +548,7 @@ public class BucketResourceTest {
         profile,
         roleToStewardMap,
         GoogleRegion.DEFAULT_GOOGLE_REGION,
-        Map.of("test-name", "bucket-resource-test"));
+        Map.of("test-name", "bucket-resource-test"),
+        CollectionType.DATASET);
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceConnectedTest.java
@@ -2,11 +2,13 @@ package bio.terra.service.resourcemanagement.google;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.not;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.buffer.model.ResourceInfo;
+import bio.terra.common.CollectionType;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.resourcemanagement.BufferService;
@@ -68,10 +70,17 @@ public class ResourceServiceConnectedTest {
             profile,
             roleToStewardMap,
             GoogleRegion.DEFAULT_GOOGLE_REGION,
-            Map.of("test-name", "resource-service-connected-test"));
+            Map.of("test-name", "resource-service-connected-test"),
+            CollectionType.DATASET);
 
     Project project = resourceManagerService.getProject(projectId);
     assertThat("the project is active", project.getLifecycleState(), equalTo("ACTIVE"));
+    assertThat(
+        "the project has the correct label",
+        project.getLabels(),
+        hasEntry(equalTo("test-name"), equalTo("resource-service-connected-test")));
+    assertThat(
+        "the project has the correct name", project.getName(), equalTo("TDR Dataset Project"));
 
     // TODO check to make sure a steward can complete a job in another test
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -45,6 +45,7 @@ import bio.terra.service.filedata.DrsIdService;
 import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.tabulardata.google.BigQueryProject;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.logging.v2.LifecycleState;
@@ -58,7 +59,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -391,14 +391,18 @@ public class SnapshotConnectedTest {
     String googleProjectId = snapshotModel.getDataProject();
 
     // ensure that google project exists
-    Assert.assertNotNull(googleResourceManagerService.getProject(googleProjectId));
+    Project project = googleResourceManagerService.getProject(googleProjectId);
+    assertNotNull(project);
+
+    // Ensure that the name is correct
+    assertEquals("TDR Snapshot Project", project.getName());
 
     // delete snapshot
     connectedOperations.deleteTestSnapshot(snapshotModel.getId());
     connectedOperations.getSnapshotExpectError(snapshotModel.getId(), HttpStatus.NOT_FOUND);
 
     // check that google project doesn't exist
-    Assert.assertEquals(
+    assertEquals(
         LifecycleState.DELETE_REQUESTED.toString(),
         googleResourceManagerService.getProject(googleProjectId).getLifecycleState());
   }


### PR DESCRIPTION
So that the names show up in dataset summary views.  Currently, the name is left blank and it can be surprising for users that see hundreds of TDR projects in their projects list.

E.g. Before

<img width="1366" alt="image" src="https://user-images.githubusercontent.com/5633787/188723574-439f267e-6506-47c1-b784-f965bee778ca.png">

and after:

<img width="820" alt="image" src="https://user-images.githubusercontent.com/5633787/188724168-6d267fd9-11ba-41b1-be0d-6f6d69adc6a5.png">