### PR TITLE
DR-2734 Fix flight filtering by classname

### DIFF
--- a/src/main/java/bio/terra/app/controller/JobsApiController.java
+++ b/src/main/java/bio/terra/app/controller/JobsApiController.java
@@ -16,6 +16,7 @@ import bio.terra.service.job.JobService;
 import bio.terra.service.snapshot.SnapshotRequestValidator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
@@ -117,18 +118,18 @@ public class JobsApiController implements JobsApi {
   }
 
   private void validateOffsetAndLimit(Integer offset, Integer limit) {
-    String errors = "";
+    List<String> errors = new ArrayList<>();
     offset = (offset == null) ? offset = 0 : offset;
     if (offset < 0) {
-      errors = "Offset must be greater than or equal to 0.";
+      errors.add("Offset must be greater than or equal to 0.");
     }
 
     limit = (limit == null) ? limit = 10 : limit;
     if (limit < 1) {
-      errors += " Limit must be greater than or equal to 1.";
+      errors.add("Limit must be greater than or equal to 1.");
     }
     if (!errors.isEmpty()) {
-      throw new ValidationException(errors);
+      throw new ValidationException(String.join(" ", errors));
     }
   }
 }

--- a/src/main/java/bio/terra/app/controller/JobsApiController.java
+++ b/src/main/java/bio/terra/app/controller/JobsApiController.java
@@ -27,7 +27,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
@@ -94,32 +93,30 @@ public class JobsApiController implements JobsApi {
   // -- jobs --
   @Override
   public ResponseEntity<List<JobModel>> enumerateJobs(
-      @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
-      @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit,
-      @RequestParam(value = "direction", required = false, defaultValue = "desc")
-          SqlSortDirection direction,
-      @RequestParam(value = "flightClass", required = false, defaultValue = "")
-          String flightClass) {
-    validiateOffsetAndLimit(offset, limit);
+      Integer offset,
+      Integer limit,
+      @RequestParam(defaultValue = "desc") SqlSortDirection direction,
+      String className) {
+    validateOffsetAndLimit(offset, limit);
     List<JobModel> results =
-        jobService.enumerateJobs(offset, limit, getAuthenticatedInfo(), direction, flightClass);
+        jobService.enumerateJobs(offset, limit, getAuthenticatedInfo(), direction, className);
     return new ResponseEntity<>(results, HttpStatus.OK);
   }
 
   @Override
-  public ResponseEntity<JobModel> retrieveJob(@PathVariable("id") String id) {
+  public ResponseEntity<JobModel> retrieveJob(String id) {
     JobModel job = jobService.retrieveJob(id, getAuthenticatedInfo());
     return jobToResponse(job);
   }
 
   @Override
-  public ResponseEntity<Object> retrieveJobResult(@PathVariable("id") String id) {
+  public ResponseEntity<Object> retrieveJobResult(String id) {
     JobService.JobResultWithStatus<Object> resultHolder =
         jobService.retrieveJobResult(id, Object.class, getAuthenticatedInfo());
     return ResponseEntity.status(resultHolder.getStatusCode()).body(resultHolder.getResult());
   }
 
-  private void validiateOffsetAndLimit(Integer offset, Integer limit) {
+  private void validateOffsetAndLimit(Integer offset, Integer limit) {
     String errors = "";
     offset = (offset == null) ? offset = 0 : offset;
     if (offset < 0) {

--- a/src/test/java/bio/terra/app/controller/JobsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/JobsApiControllerTest.java
@@ -1,0 +1,97 @@
+package bio.terra.app.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.JobModel;
+import bio.terra.model.JobModel.JobStatusEnum;
+import bio.terra.model.SqlSortDirection;
+import bio.terra.service.job.JobService;
+import bio.terra.service.job.JobService.JobResultWithStatus;
+import java.util.List;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class JobsApiControllerTest {
+  private static final String FLIGHT_CLASS = "bio.terra.app.flight.TestFlight";
+  private static final JobModel JOB_1 =
+      new JobModel().id("foo").jobStatus(JobStatusEnum.SUCCEEDED).className(FLIGHT_CLASS);
+  private static final JobModel JOB_2 =
+      new JobModel().id("bar").jobStatus(JobStatusEnum.FAILED).className(FLIGHT_CLASS);
+
+  private static final String ENUMERATE_JOBS_ENDPOINT = "/api/repository/v1/jobs";
+  private static final String RETRIEVE_JOB_ENDPOINT = "/api/repository/v1/jobs/{id}";
+  private static final String RETRIEVE_JOB_RESULT_ENDPOINT = "/api/repository/v1/jobs/{id}/result";
+
+  private record ResultClass(String value) {}
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private JobService jobService;
+
+  @Test
+  public void testEnumerateJobs() throws Exception {
+    when(jobService.enumerateJobs(anyInt(), anyInt(), any(), any(), any()))
+        .thenReturn(List.of(JOB_1, JOB_2));
+    mvc.perform(get(ENUMERATE_JOBS_ENDPOINT))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2));
+    verify(jobService, times(1))
+        .enumerateJobs(eq(0), eq(10), any(), eq(SqlSortDirection.DESC), isNull());
+  }
+
+  @Test
+  public void testEnumerateJobsWithFilter() throws Exception {
+    when(jobService.enumerateJobs(anyInt(), anyInt(), any(), any(), any()))
+        .thenReturn(List.of(JOB_1, JOB_2));
+    mvc.perform(get(ENUMERATE_JOBS_ENDPOINT).queryParam("className", FLIGHT_CLASS))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2));
+    verify(jobService, times(1))
+        .enumerateJobs(eq(0), eq(10), any(), eq(SqlSortDirection.DESC), eq(FLIGHT_CLASS));
+  }
+
+  @Test
+  public void testRetrieveJob() throws Exception {
+    when(jobService.retrieveJob(anyString(), any())).thenReturn(JOB_1);
+    mvc.perform(get(RETRIEVE_JOB_ENDPOINT, JOB_1.getId()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(JOB_1.getId()));
+    verify(jobService, times(1)).retrieveJob(eq(JOB_1.getId()), any());
+  }
+
+  @Test
+  public void testRetrieveJobResult() throws Exception {
+    ResultClass result = new ResultClass("fooResult");
+    when(jobService.retrieveJobResult(anyString(), any(), any()))
+        .thenReturn(new JobResultWithStatus<>().result(result).statusCode(HttpStatus.OK));
+    mvc.perform(get(RETRIEVE_JOB_RESULT_ENDPOINT, JOB_2.getId()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.value").value("fooResult"));
+    verify(jobService, times(1)).retrieveJobResult(eq(JOB_2.getId()), eq(Object.class), any());
+  }
+}

--- a/src/test/java/bio/terra/app/controller/JobsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/JobsApiControllerTest.java
@@ -76,6 +76,24 @@ public class JobsApiControllerTest {
   }
 
   @Test
+  public void testEnumerateJobsBadOffsetAndLimit() throws Exception {
+    mvc.perform(get(ENUMERATE_JOBS_ENDPOINT).param("offset", "-1"))
+        .andExpect(status().is4xxClientError())
+        .andExpect(jsonPath("$.message").value("Offset must be greater than or equal to 0."));
+
+    mvc.perform(get(ENUMERATE_JOBS_ENDPOINT).param("limit", "-1"))
+        .andExpect(status().is4xxClientError())
+        .andExpect(jsonPath("$.message").value("Limit must be greater than or equal to 1."));
+
+    mvc.perform(get(ENUMERATE_JOBS_ENDPOINT).param("offset", "-1").param("limit", "-1"))
+        .andExpect(status().is4xxClientError())
+        .andExpect(
+            jsonPath("$.message")
+                .value(
+                    "Offset must be greater than or equal to 0. Limit must be greater than or equal to 1."));
+  }
+
+  @Test
   public void testRetrieveJob() throws Exception {
     when(jobService.retrieveJob(anyString(), any())).thenReturn(JOB_1);
     mvc.perform(get(RETRIEVE_JOB_ENDPOINT, JOB_1.getId()))


### PR DESCRIPTION
This was coming from an incorrectly named parameter in an annotation so I just removed most of the annotations and added unit tests.

I tried to upgrade to the latest and greatest openapi version but the various code generators don't have support.  As such, I simply annotated the default value.

I also added some unit tests to make sure that Spring is doing the right thing