### PR TITLE
[DR-2752] Fix validation to match API; enrich incoming Snapshot requests with the dataset defaultProfileId if needed.

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/SnapshotRequestValidator.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotRequestValidator.java
@@ -126,12 +126,6 @@ public class SnapshotRequestValidator implements Validator {
     }
   }
 
-  private void validateSnapshotProfileId(UUID profileId, Errors errors) {
-    if (profileId == null) {
-      errors.rejectValue("profileId", "SnapshotMissingProfileId");
-    }
-  }
-
   @Override
   public void validate(@NotNull Object target, Errors errors) {
     if (target != null && target instanceof SnapshotRequestModel) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotRequestValidator.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotRequestValidator.java
@@ -137,7 +137,6 @@ public class SnapshotRequestValidator implements Validator {
     if (target != null && target instanceof SnapshotRequestModel) {
       SnapshotRequestModel snapshotRequestModel = (SnapshotRequestModel) target;
       validateSnapshotName(snapshotRequestModel.getName(), errors);
-      validateSnapshotProfileId(snapshotRequestModel.getProfileId(), errors);
       validateSnapshotDescription(snapshotRequestModel.getDescription(), errors);
       validateSnapshotContents(snapshotRequestModel.getContents(), errors);
     }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -151,9 +151,10 @@ public class SnapshotService {
     if (snapshotRequestModel.getProfileId() == null) {
       snapshotRequestModel.setProfileId(dataset.getDefaultProfileId());
       logger.warn(
-          String.format(
-              "Enriching %s snapshot %s request with dataset default profileId %s",
-              userReq.getEmail(), snapshotRequestModel.getName(), dataset.getDefaultProfileId()));
+          "Enriching {} snapshot {} request with dataset default profileId {}",
+          userReq.getEmail(),
+          snapshotRequestModel.getName(),
+          dataset.getDefaultProfileId());
     }
     return jobService
         .newJob(description, SnapshotCreateFlight.class, snapshotRequestModel, userReq)

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -150,6 +150,10 @@ public class SnapshotService {
     Dataset dataset = datasetService.retrieveByName(sourceDatasetName);
     if (snapshotRequestModel.getProfileId() == null) {
       snapshotRequestModel.setProfileId(dataset.getDefaultProfileId());
+      logger.warn(
+          String.format(
+              "Enriching %s snapshot %s request with dataset default profileId %s",
+              userReq.getEmail(), snapshotRequestModel.getName(), dataset.getDefaultProfileId()));
     }
     return jobService
         .newJob(description, SnapshotCreateFlight.class, snapshotRequestModel, userReq)

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -148,6 +148,9 @@ public class SnapshotService {
     String description = "Create snapshot " + snapshotRequestModel.getName();
     String sourceDatasetName = snapshotRequestModel.getContents().get(0).getDatasetName();
     Dataset dataset = datasetService.retrieveByName(sourceDatasetName);
+    if (snapshotRequestModel.getProfileId() == null) {
+      snapshotRequestModel.setProfileId(dataset.getDefaultProfileId());
+    }
     return jobService
         .newJob(description, SnapshotCreateFlight.class, snapshotRequestModel, userReq)
         .addParameter(CommonMapKeys.CREATED_AT, Instant.now().toEpochMilli())

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -663,9 +663,9 @@ public class SnapshotService {
       iamAuthorized = true;
     } catch (Exception iamEx) {
       logger.warn(
-          String.format(
-              "Snapshot %s inaccessible via SAM for %s, checking for linked RAS passport",
-              snapshotId, userReq.getEmail()),
+          "Snapshot {} inaccessible via SAM for {}, checking for linked RAS passport",
+          snapshotId,
+          userReq.getEmail(),
           iamEx);
       causes.add(iamEx.getMessage());
       SnapshotAccessibleResult byPassport = snapshotAccessibleByPassport(snapshotId, userReq);

--- a/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
@@ -293,13 +293,6 @@ public class SnapshotValidationTest {
     checkValidationErrorModel(errorModel, new String[] {"SnapshotNameMissing", "NotNull"});
   }
 
-  @Test
-  public void testMissingProfileId() throws Exception {
-    snapshotByAssetRequest.profileId(null);
-    ErrorModel errorModel = expectBadSnapshotCreateRequest(snapshotByAssetRequest);
-    checkValidationErrorModel(errorModel, new String[] {"SnapshotMissingProfileId"});
-  }
-
   private void checkValidationErrorModel(ErrorModel errorModel, String[] messageCodes) {
     List<String> details = errorModel.getErrorDetail();
     assertThat(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -153,7 +153,7 @@ public class SnapshotConnectedTest {
 
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetArraySummary, "snapshot-array-struct.json");
+            jsonLoader, datasetArraySummary, "snapshot-array-struct.json", true);
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
     SnapshotConnectedTestUtils.getTestSnapshot(
@@ -184,7 +184,7 @@ public class SnapshotConnectedTest {
     // Create three snapshots with consent code -- authorized indirectly via a linked RAS passport.
     SnapshotRequestModel rasSnapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-                jsonLoader, datasetSummary, "snapshot-test-snapshot.json")
+                jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true)
             .consentCode(CONSENT_CODE);
     List<UUID> rasSnapshotIds = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
@@ -198,7 +198,7 @@ public class SnapshotConnectedTest {
     // Create two snapshots without consent code -- not authorized via a linked RAS passport.
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot.json");
+            jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true);
     List<UUID> samSnapshotIds = new ArrayList<>();
     for (int i = 0; i < 2; i++) {
       MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_en_");
@@ -268,7 +268,7 @@ public class SnapshotConnectedTest {
   public void testBadData() throws Exception {
     SnapshotRequestModel badDataRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot-baddata.json");
+            jsonLoader, datasetSummary, "snapshot-test-snapshot-baddata.json", true);
 
     MockHttpServletResponse response = performCreateSnapshot(badDataRequest, "_baddata_");
     ErrorModel errorModel = handleCreateSnapshotFailureCase(response);
@@ -280,7 +280,7 @@ public class SnapshotConnectedTest {
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot.json");
+            jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true);
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
@@ -333,7 +333,7 @@ public class SnapshotConnectedTest {
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot.json");
+            jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true);
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
@@ -379,7 +379,7 @@ public class SnapshotConnectedTest {
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot.json");
+            jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true);
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -153,7 +153,10 @@ public class SnapshotConnectedTest {
 
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetArraySummary, "snapshot-array-struct.json", true);
+            jsonLoader,
+            datasetArraySummary,
+            "snapshot-array-struct.json",
+            datasetArraySummary.getDefaultProfileId());
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
     SnapshotConnectedTestUtils.getTestSnapshot(
@@ -184,7 +187,10 @@ public class SnapshotConnectedTest {
     // Create three snapshots with consent code -- authorized indirectly via a linked RAS passport.
     SnapshotRequestModel rasSnapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-                jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true)
+                jsonLoader,
+                datasetSummary,
+                "snapshot-test-snapshot.json",
+                datasetSummary.getDefaultProfileId())
             .consentCode(CONSENT_CODE);
     List<UUID> rasSnapshotIds = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
@@ -198,7 +204,10 @@ public class SnapshotConnectedTest {
     // Create two snapshots without consent code -- not authorized via a linked RAS passport.
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true);
+            jsonLoader,
+            datasetSummary,
+            "snapshot-test-snapshot.json",
+            datasetSummary.getDefaultProfileId());
     List<UUID> samSnapshotIds = new ArrayList<>();
     for (int i = 0; i < 2; i++) {
       MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_en_");
@@ -268,7 +277,10 @@ public class SnapshotConnectedTest {
   public void testBadData() throws Exception {
     SnapshotRequestModel badDataRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot-baddata.json", true);
+            jsonLoader,
+            datasetSummary,
+            "snapshot-test-snapshot-baddata.json",
+            datasetSummary.getDefaultProfileId());
 
     MockHttpServletResponse response = performCreateSnapshot(badDataRequest, "_baddata_");
     ErrorModel errorModel = handleCreateSnapshotFailureCase(response);
@@ -280,7 +292,10 @@ public class SnapshotConnectedTest {
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true);
+            jsonLoader,
+            datasetSummary,
+            "snapshot-test-snapshot.json",
+            datasetSummary.getDefaultProfileId());
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
@@ -333,7 +348,10 @@ public class SnapshotConnectedTest {
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true);
+            jsonLoader,
+            datasetSummary,
+            "snapshot-test-snapshot.json",
+            datasetSummary.getDefaultProfileId());
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
@@ -379,7 +397,10 @@ public class SnapshotConnectedTest {
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "snapshot-test-snapshot.json", true);
+            jsonLoader,
+            datasetSummary,
+            "snapshot-test-snapshot.json",
+            datasetSummary.getDefaultProfileId());
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTestUtils.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTestUtils.java
@@ -45,7 +45,7 @@ public class SnapshotConnectedTestUtils {
       JsonLoader jsonLoader,
       DatasetSummaryModel datasetSummaryModel,
       String resourcePath,
-      boolean provideProfileId)
+      UUID profileId)
       throws Exception {
     SnapshotRequestModel snapshotRequest =
         jsonLoader.loadObject(resourcePath, SnapshotRequestModel.class);
@@ -56,9 +56,7 @@ public class SnapshotConnectedTestUtils {
     // swap in the correct dataset name (with the id at the end)
     content.setDatasetName(newDatasetName);
     // provide the profileId for the request.  The API does not require this value.
-    if (provideProfileId) {
-      snapshotRequest.profileId(datasetSummaryModel.getDefaultProfileId());
-    }
+    snapshotRequest.profileId(profileId);
     if (content.getMode().equals(SnapshotRequestContentsModel.ModeEnum.BYQUERY)) {
       // if its by query, also set swap in the correct dataset name in the query
       String query = content.getQuerySpec().getQuery();

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTestUtils.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTestUtils.java
@@ -42,7 +42,10 @@ import org.stringtemplate.v4.ST;
 public class SnapshotConnectedTestUtils {
 
   static SnapshotRequestModel makeSnapshotTestRequest(
-      JsonLoader jsonLoader, DatasetSummaryModel datasetSummaryModel, String resourcePath)
+      JsonLoader jsonLoader,
+      DatasetSummaryModel datasetSummaryModel,
+      String resourcePath,
+      boolean provideProfileId)
       throws Exception {
     SnapshotRequestModel snapshotRequest =
         jsonLoader.loadObject(resourcePath, SnapshotRequestModel.class);
@@ -52,7 +55,10 @@ public class SnapshotConnectedTestUtils {
     String origDatasetName = content.getDatasetName();
     // swap in the correct dataset name (with the id at the end)
     content.setDatasetName(newDatasetName);
-    snapshotRequest.profileId(datasetSummaryModel.getDefaultProfileId());
+    // provide the profileId for the request.  The API does not require this value.
+    if (provideProfileId) {
+      snapshotRequest.profileId(datasetSummaryModel.getDefaultProfileId());
+    }
     if (content.getMode().equals(SnapshotRequestContentsModel.ModeEnum.BYQUERY)) {
       // if its by query, also set swap in the correct dataset name in the query
       String query = content.getQuerySpec().getQuery();

--- a/src/test/java/bio/terra/service/snapshot/SnapshotHappyPathConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotHappyPathConnectedTest.java
@@ -107,7 +107,8 @@ public class SnapshotHappyPathConnectedTest {
 
   private void snapshotHappyPathTestingHelper(String path) throws Exception {
     SnapshotRequestModel snapshotRequest =
-        SnapshotConnectedTestUtils.makeSnapshotTestRequest(jsonLoader, datasetSummary, path, true);
+        SnapshotConnectedTestUtils.makeSnapshotTestRequest(
+            jsonLoader, datasetSummary, path, datasetSummary.getDefaultProfileId());
     MockHttpServletResponse response =
         SnapshotConnectedTestUtils.performCreateSnapshot(
             connectedOperations, mvc, snapshotRequest, "_thp_");

--- a/src/test/java/bio/terra/service/snapshot/SnapshotHappyPathConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotHappyPathConnectedTest.java
@@ -107,7 +107,7 @@ public class SnapshotHappyPathConnectedTest {
 
   private void snapshotHappyPathTestingHelper(String path) throws Exception {
     SnapshotRequestModel snapshotRequest =
-        SnapshotConnectedTestUtils.makeSnapshotTestRequest(jsonLoader, datasetSummary, path);
+        SnapshotConnectedTestUtils.makeSnapshotTestRequest(jsonLoader, datasetSummary, path, true);
     MockHttpServletResponse response =
         SnapshotConnectedTestUtils.performCreateSnapshot(
             connectedOperations, mvc, snapshotRequest, "_thp_");

--- a/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.storage.StorageOptions;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -86,6 +87,7 @@ public class SnapshotMinimalConnectedTest {
   public void testMinimal() throws Exception {
     DatasetSummaryModel datasetMinimalSummary = setupMinimalDataset();
     String datasetName = PDAO_PREFIX + datasetMinimalSummary.getName();
+    UUID datasetMinimalSummaryDefaultProfileId = datasetMinimalSummary.getDefaultProfileId();
     BigQueryProject bigQueryProject =
         TestUtils.bigQueryProjectForDatasetName(datasetDao, datasetMinimalSummary.getName());
     long datasetParticipants =
@@ -97,7 +99,9 @@ public class SnapshotMinimalConnectedTest {
 
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot.json");
+            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot.json", false);
+    assertThat(
+        "SnapshotRequestModel profileId is empty", snapshotRequest.getProfileId(), equalTo(null));
     MockHttpServletResponse response =
         SnapshotConnectedTestUtils.performCreateSnapshot(
             connectedOperations, mvc, snapshotRequest, "");
@@ -114,6 +118,10 @@ public class SnapshotMinimalConnectedTest {
         tables.stream().filter(t -> t.getName().equals("sample")).findFirst();
     assertThat("participant table exists", participantTable.isPresent(), equalTo(true));
     assertThat("sample table exists", sampleTable.isPresent(), equalTo(true));
+    assertThat(
+        "defaultProfileId from dataset was used for snapshot",
+        snapshotModel.getProfileId(),
+        equalTo(datasetMinimalSummaryDefaultProfileId));
 
     BigQueryProject bigQuerySnapshotProject =
         TestUtils.bigQueryProjectForSnapshotName(snapshotDao, snapshotModel.getName());
@@ -156,9 +164,16 @@ public class SnapshotMinimalConnectedTest {
   @Test
   public void testPreview() throws Exception {
     DatasetSummaryModel datasetMinimalSummary = setupMinimalDataset();
+    UUID datasetMinimalSummaryProfileId = datasetMinimalSummary.getDefaultProfileId();
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot.json");
+            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot.json", true);
+
+    assertThat(
+        "dataset default profile Id was included in snapshot request",
+        snapshotRequest.getProfileId(),
+        equalTo(datasetMinimalSummaryProfileId));
+
     MockHttpServletResponse response =
         SnapshotConnectedTestUtils.performCreateSnapshot(
             connectedOperations, mvc, snapshotRequest, "");
@@ -179,6 +194,11 @@ public class SnapshotMinimalConnectedTest {
 
     assertThat(
         "participant preview is empty", snapshotEmptyPreviewModel.getResult().size(), equalTo(0));
+
+    assertThat(
+        "preview model uses provided id",
+        summaryModel.getProfileId(),
+        equalTo(datasetMinimalSummaryProfileId));
 
     String joinClause = "JOIN " + summaryModel.getName() + ".sample ON sample.participant_id = id";
     ErrorModel snapshotPreviewError =
@@ -201,7 +221,7 @@ public class SnapshotMinimalConnectedTest {
     DatasetSummaryModel datasetMinimalSummary = setupMinimalDataset();
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot-bad-asset.json");
+            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot-bad-asset.json", true);
     MvcResult result = SnapshotConnectedTestUtils.launchCreateSnapshot(mvc, snapshotRequest, "");
     MockHttpServletResponse response = connectedOperations.validateJobModelAndWait(result);
     assertThat(response.getStatus(), equalTo(HttpStatus.NOT_FOUND.value()));

--- a/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
@@ -99,7 +99,7 @@ public class SnapshotMinimalConnectedTest {
 
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot.json", false);
+            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot.json", null);
     assertThat(
         "SnapshotRequestModel profileId is empty", snapshotRequest.getProfileId(), equalTo(null));
     MockHttpServletResponse response =
@@ -167,7 +167,10 @@ public class SnapshotMinimalConnectedTest {
     UUID datasetMinimalSummaryProfileId = datasetMinimalSummary.getDefaultProfileId();
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot.json", true);
+            jsonLoader,
+            datasetMinimalSummary,
+            "dataset-minimal-snapshot.json",
+            datasetMinimalSummary.getDefaultProfileId());
 
     assertThat(
         "dataset default profile Id was included in snapshot request",
@@ -221,7 +224,10 @@ public class SnapshotMinimalConnectedTest {
     DatasetSummaryModel datasetMinimalSummary = setupMinimalDataset();
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetMinimalSummary, "dataset-minimal-snapshot-bad-asset.json", true);
+            jsonLoader,
+            datasetMinimalSummary,
+            "dataset-minimal-snapshot-bad-asset.json",
+            datasetMinimalSummary.getDefaultProfileId());
     MvcResult result = SnapshotConnectedTestUtils.launchCreateSnapshot(mvc, snapshotRequest, "");
     MockHttpServletResponse response = connectedOperations.validateJobModelAndWait(result);
     assertThat(response.getStatus(), equalTo(HttpStatus.NOT_FOUND.value()));

--- a/src/test/java/bio/terra/service/snapshot/SnapshotScaleConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotScaleConnectedTest.java
@@ -95,7 +95,7 @@ public class SnapshotScaleConnectedTest {
     // TODO put big snapshot request into a GCS bucket
     SnapshotRequestModel snapshotRequestScale =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "hca-mvp-analysis-file-row-ids-snapshot.json");
+            jsonLoader, datasetSummary, "hca-mvp-analysis-file-row-ids-snapshot.json", true);
 
     MockHttpServletResponse response =
         SnapshotConnectedTestUtils.performCreateSnapshot(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotScaleConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotScaleConnectedTest.java
@@ -95,7 +95,10 @@ public class SnapshotScaleConnectedTest {
     // TODO put big snapshot request into a GCS bucket
     SnapshotRequestModel snapshotRequestScale =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
-            jsonLoader, datasetSummary, "hca-mvp-analysis-file-row-ids-snapshot.json", true);
+            jsonLoader,
+            datasetSummary,
+            "hca-mvp-analysis-file-row-ids-snapshot.json",
+            datasetSummary.getDefaultProfileId());
 
     MockHttpServletResponse response =
         SnapshotConnectedTestUtils.performCreateSnapshot(


### PR DESCRIPTION
The API [model](https://github.com/DataBiosphere/jade-data-repo/blob/develop/src/main/resources/api/data-repository-openapi.yaml) indicates a request to create a new Snapshot does not require a profileId.  This was not the realized behavior.
Snapshot creation request would fail validation because the validator required it.  Logically speaking, a profileId is required, but the user doesn't have to provide it.  As documented in the [ticket](https://broadworkbench.atlassian.net/browse/DR-2752), acceptance criteria indicates it is acceptable to enrich a snapshot request with the dataset's default profile Id when a snapshot "create" is requested  without providing a profileId.
- Removes the SnapshotRequest Validator's profileId requirement and test
- Inserts logic in the SnapshotService create method to test if the request included a projectId.  If not, the code enriches the request to include the datasource's defaultProfileId as this request's profileId.
- Log the user, the snapshot name, and the defaultProfileId used when enrichment occurs.
- Update connected tests to test snapshot creation without supplying the profileId.