### PR TITLE
[DR-2737] Associate parent flight ID with child flights

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -347,6 +347,7 @@ public class IngestDriverStep extends DefaultUndoStep {
       inputParameters.put(ProfileMapKeys.PROFILE_MODEL, billingProfileModel);
       inputParameters.put(CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, storageAccountResource);
       inputParameters.put(JobMapKeys.CLOUD_PLATFORM.getKeyName(), platform.name());
+      inputParameters.put(JobMapKeys.PARENT_FLIGHT_ID.getKeyName(), context.getFlightId());
 
       if (platform == CloudPlatform.AZURE) {
         AzureStorageAuthInfo storageAuthInfo =

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -13,6 +13,7 @@ public enum JobMapKeys {
   IAM_ACTION("iamAction"),
   IAM_RESOURCE_TYPE("iamResourceType"),
   IAM_RESOURCE_ID("iamResourceId"),
+  PARENT_FLIGHT_ID("parentFlightId"),
 
   // parameters for specific flight types
   BILLING_ID("billingId"),

--- a/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
+++ b/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.StairwayHook;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -52,7 +53,7 @@ public class StairwayLoggingHooks implements StairwayHook {
     MDC.put(FLIGHT_ID_KEY, context.getFlightId());
     MDC.put(FLIGHT_CLASS_KEY, context.getFlightClassName());
     MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_OPERATION_START);
-    MDC.put(FLIGHT_PARENT_ID_KEY, getParentFlightId(context));
+    getParentFlightId(context).ifPresent(pfid -> MDC.put(FLIGHT_PARENT_ID_KEY, pfid));
     logger.info(
         FLIGHT_LOG_FORMAT,
         FLIGHT_OPERATION_START,
@@ -73,7 +74,7 @@ public class StairwayLoggingHooks implements StairwayHook {
     MDC.put(FLIGHT_STEP_DIRECTION_KEY, context.getDirection().toString());
     MDC.put(FLIGHT_STEP_NUMBER_KEY, Integer.toString(context.getStepIndex()));
     MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_STEP_OPERATION_START);
-    MDC.put(FLIGHT_PARENT_ID_KEY, getParentFlightId(context));
+    getParentFlightId(context).ifPresent(pfid -> MDC.put(FLIGHT_PARENT_ID_KEY, pfid));
     logger.info(
         STEP_LOG_FORMAT,
         FLIGHT_STEP_OPERATION_START,
@@ -139,8 +140,8 @@ public class StairwayLoggingHooks implements StairwayHook {
     return String.format("stairwayStep%s", flightId);
   }
 
-  private String getParentFlightId(FlightContext context) {
+  private Optional<String> getParentFlightId(FlightContext context) {
     FlightMap parameterMap = context.getInputParameters();
-    return parameterMap.get(FLIGHT_PARENT_ID_KEY, String.class);
+    return Optional.ofNullable(parameterMap.get(FLIGHT_PARENT_ID_KEY, String.class));
   }
 }

--- a/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
+++ b/src/main/java/bio/terra/service/job/StairwayLoggingHooks.java
@@ -2,6 +2,7 @@ package bio.terra.service.job;
 
 import bio.terra.app.logging.PerformanceLogger;
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.HookAction;
 import bio.terra.stairway.StairwayHook;
 import java.time.Instant;
@@ -19,6 +20,8 @@ public class StairwayLoggingHooks implements StairwayHook {
           + "stepIndex: {}, direction: {}, timestamp: {}";
   /** Id of the flight */
   private static final String FLIGHT_ID_KEY = "flightId";
+  /** Id of the upstream parent flight, if one exists */
+  private static final String FLIGHT_PARENT_ID_KEY = JobMapKeys.PARENT_FLIGHT_ID.getKeyName();
   /** Class of the flight */
   private static final String FLIGHT_CLASS_KEY = "flightClass";
   /** Class of the flight step */
@@ -49,6 +52,7 @@ public class StairwayLoggingHooks implements StairwayHook {
     MDC.put(FLIGHT_ID_KEY, context.getFlightId());
     MDC.put(FLIGHT_CLASS_KEY, context.getFlightClassName());
     MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_OPERATION_START);
+    MDC.put(FLIGHT_PARENT_ID_KEY, getParentFlightId(context));
     logger.info(
         FLIGHT_LOG_FORMAT,
         FLIGHT_OPERATION_START,
@@ -69,6 +73,7 @@ public class StairwayLoggingHooks implements StairwayHook {
     MDC.put(FLIGHT_STEP_DIRECTION_KEY, context.getDirection().toString());
     MDC.put(FLIGHT_STEP_NUMBER_KEY, Integer.toString(context.getStepIndex()));
     MDC.put(FLIGHT_OPERATION_KEY, FLIGHT_STEP_OPERATION_START);
+    MDC.put(FLIGHT_PARENT_ID_KEY, getParentFlightId(context));
     logger.info(
         STEP_LOG_FORMAT,
         FLIGHT_STEP_OPERATION_START,
@@ -127,9 +132,15 @@ public class StairwayLoggingHooks implements StairwayHook {
     MDC.remove(FLIGHT_STEP_DIRECTION_KEY);
     MDC.remove(FLIGHT_STEP_NUMBER_KEY);
     MDC.remove(FLIGHT_OPERATION_KEY);
+    MDC.remove(FLIGHT_PARENT_ID_KEY);
   }
 
   private String getStepTimerName(final String flightId) {
     return String.format("stairwayStep%s", flightId);
+  }
+
+  private String getParentFlightId(FlightContext context) {
+    FlightMap parameterMap = context.getInputParameters();
+    return parameterMap.get(FLIGHT_PARENT_ID_KEY, String.class);
   }
 }

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestDriverStepTest.java
@@ -100,18 +100,7 @@ public class IngestDriverStepTest extends TestCase {
         .when(loadService)
         .setLoadFileRunning(loadUuid, null, CHILD_FLIGHT_ID);
 
-    StepResult stepResult = step.doStep(flightContext);
-
-    verify(stairway)
-        .submitToQueue(
-            eq(CHILD_FLIGHT_ID), eq(FileIngestWorkerFlight.class), inputParamsCaptor.capture());
-
-    assertThat(
-        "Parent flight ID was passed as an input parameter to child flight",
-        inputParamsCaptor.getValue().get(JobMapKeys.PARENT_FLIGHT_ID.getKeyName(), String.class),
-        equalTo(PARENT_FLIGHT_ID));
-
-    return stepResult;
+    return step.doStep(flightContext);
   }
 
   @Test
@@ -123,6 +112,15 @@ public class IngestDriverStepTest extends TestCase {
 
     // Verify that the step started the candidate file.
     verify(loadService).setLoadFileRunning(loadUuid, null, CHILD_FLIGHT_ID);
+
+    // Verify that the step launched a downstream child job.
+    verify(stairway)
+        .submitToQueue(
+            eq(CHILD_FLIGHT_ID), eq(FileIngestWorkerFlight.class), inputParamsCaptor.capture());
+    assertThat(
+        "Parent flight ID was passed as an input parameter to child flight",
+        inputParamsCaptor.getValue().get(JobMapKeys.PARENT_FLIGHT_ID.getKeyName(), String.class),
+        equalTo(PARENT_FLIGHT_ID));
   }
 
   @Test
@@ -134,5 +132,10 @@ public class IngestDriverStepTest extends TestCase {
 
     // Verify that the step never started the candidate file.
     verify(loadService, never()).setLoadFileRunning(loadUuid, null, CHILD_FLIGHT_ID);
+
+    // Verify that the step never launched a downstream child job.
+    verify(stairway, never())
+        .submitToQueue(
+            eq(CHILD_FLIGHT_ID), eq(FileIngestWorkerFlight.class), inputParamsCaptor.capture());
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2737

**Background**

TDR's Stairway flights which include `IngestDriverStep` spawn child `FlightIngestWorkerFlight`s.  Assessing the progress of the parent flight has been difficult without a straightforward way to connect it to its children.

**Changeset**
- Included parent flight ID as Stairway input parameter for flights spawned in `IngestDriverStep`, which will propagate to the stairway database.
- If it exists, include parent flight ID as MDC key-value pair for Stairway logs to enable Stackdriver querying.
- Expanded unit tests

**Manual Verification**

My developer environment is up to date with my latest changes.  From that environment, here are the Stackdriver logs associated with a `DatasetIngestFlight` and its child flights spawned in `IngestDriverStep`:
https://cloudlogging.app.goo.gl/85PgRHqJKmjYHkpU7

Achieved via this query element:
```(jsonPayload.flightId="s0Dh9FW1TkqYuBLC9Y-AVA" OR jsonPayload.parentFlightId="s0Dh9FW1TkqYuBLC9Y-AVA")```

**Future Opportunities**

I noticed that child flights spawned in `IngestDriverStep` do not benefit from expanded job access work.  As a concrete example, if a service account launched a `FileIngestBulkFlight`, a steward of the same dataset would be able to access the parent job but not the child jobs.  I will file a ticket for a follow-on PR, as I'd like to get this PR in for the Monday release: we'd benefit from increased debugging capabilities straightaway.

This work should make it easier for TDR developers to help users understand the progress of their long-running jobs, but doesn't make it easier for users to assess this progress on their own in a self-service manner (ex. via new TDR API endpoints, inclusion in future work to expose job history in TDR UI).