### PR TITLE
DR-2757 Refactor Connected/Integration Test Suite

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -12,6 +12,12 @@ env:
   AZURE_CREDENTIALS_HOMETENANTID: fad90753-2022-4456-9b0a-c7e5b934e408
   JADE_USER_EMAIL: connected-tdr-user@notarealemail.org
   RBS_CLIENT_CREDENTIAL_FILE_PATH: rbs-tools-sa.json
+  CACHE_PATHS: |
+    build/jacoco
+    build/reports
+    build/spotless
+    build/test-results
+    build/jacocoHtml
 on:
   pull_request:
     branches:
@@ -56,11 +62,7 @@ jobs:
       - name: "Cache build"
         uses: actions/cache@v3
         with:
-          path: |
-            build/jacoco
-            build/reports
-            build/spotless
-            build/test-results
+          path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests via Gradle"
         uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
@@ -97,11 +99,7 @@ jobs:
       - name: "Cache build"
         uses: actions/cache@v3
         with:
-          path: |
-            build/jacoco
-            build/reports
-            build/spotless
-            build/test-results
+          path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-connected
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
@@ -154,11 +152,7 @@ jobs:
       - name: "Cache build"
         uses: actions/cache@v3
         with:
-          path: |
-            build/jacoco
-            build/reports
-            build/spotless
-            build/test-results
+          path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-integration
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
@@ -240,29 +234,17 @@ jobs:
       - name: "Load unit test cache"
         uses: actions/cache@v3
         with:
-          path: |
-            build/jacoco
-            build/reports
-            build/spotless
-            build/test-results
+          path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-unit
       - name: "Load connected test cache"
         uses: actions/cache@v3
         with:
-          path: |
-            build/jacoco
-            build/reports
-            build/spotless
-            build/test-results
+          path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-connected
       - name: "Load integration test cache"
         uses: actions/cache@v3
         with:
-          path: |
-            build/jacoco
-            build/reports
-            build/spotless
-            build/test-results
+          path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-integration
       - name: "Archive code coverage results"
         uses: actions/upload-artifact@v2
@@ -274,7 +256,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: junit-test-report-integration
+          name: junit-test-reports
           path: build/reports
           retention-days: 10
       - name: "Notify Jade Slack on nightly test run"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -54,9 +54,9 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Cache build"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ~/build
+          path: build
           key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests via Gradle"
         uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
@@ -91,9 +91,9 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Cache build"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ~/build
+          path: build
           key: ${{ runner.os }}-build-connected
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
@@ -144,9 +144,9 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
       - name: "Cache build"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ~/build
+          path: build
           key: ${{ runner.os }}-build-integration
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
@@ -226,19 +226,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Load unit test cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ~/build
+          path: build
           key: ${{ runner.os }}-build-unit
       - name: "Load connected test cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ~/build
+          path: build
           key: ${{ runner.os }}-build-connected
       - name: "Load integration test cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ~/build
+          path: build
           key: ${{ runner.os }}-build-integration
       - name: "Archive code coverage results"
         uses: actions/upload-artifact@v2

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -1,4 +1,4 @@
-name: Integration test and Connected tests
+name: Unit, Smoke, Connected and Integration tests
 env:
   K8_CLUSTER: 'integration-master'
   # This must be defined for the bash redirection
@@ -30,8 +30,46 @@ on:
   schedule:
     - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
 jobs:
+  test_check:
+    name: "Checkout, verify and run unit tests"
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
+    runs-on: ${{ matrix.os }}
+    ## skips if pr label is 'skip-ci'
+    # run a local Postgres container in Docker for the basic check tests
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v2
+      - name: "Cache build"
+        uses: actions/cache@v2
+        with:
+          path: ~/build
+          key: ${{ runner.os }}-build }}
+      - name: "Run unit tests via Gradle"
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        with:
+          actions_subcommand: 'gradleinttest'
+          pgport: ${{ job.services.postgres.ports[5432] }}
+          test_to_run: 'check'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
   test_connected:
+    name: "Run connected tests"
     timeout-minutes: 180
+    needs: test_check
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -52,6 +90,11 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2
+      - name: "Cache build"
+        uses: actions/cache@v2
+        with:
+          path: ~/build
+          key: ${{ runner.os }}-build
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
         with:
@@ -68,23 +111,18 @@ jobs:
         run: |
           # write vault token
           base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
-      - name: "Run Connected test via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
+      - name: "Run connected tests via Gradle"
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testConnected'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
-      - name: "Archive connected junit test reports"
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: junit-test-report-connected
-          path: build/reports
-          retention-days: 10
   deploy_test_integration:
+    name: "Deploy an run smoke and integration tests"
     timeout-minutes: 210
+    needs: test_check
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -105,6 +143,11 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2
+      - name: "Cache build"
+        uses: actions/cache@v2
+        with:
+          path: ~/build
+          key: ${{ runner.os }}-build
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
         with:
@@ -115,22 +158,22 @@ jobs:
           secrets: |
             secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -145,44 +188,63 @@ jobs:
           echo "::set-output name=git_hash::$git_hash"
           echo "Latest git hash for this branch: $git_hash"
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.62.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@dr-2757-nm-better-unit
         timeout-minutes: 20
         env:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
-      - name: "Run Integration test via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
+      - name: "Run integration tests via Gradle"
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
+      - name: "Clean state lock from used Namespace on API deploy"
+        if: always()
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        with:
+          actions_subcommand: 'k8_checknamespace_clean'
+      - name: "Clean whitelisted Runner IP"
+        if: always()
+        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        with:
+          actions_subcommand: 'gcp_whitelist_clean'
+  publish_test_reports:
+    name: "Save execution reports and notify"
+    timeout-minutes: 60
+    needs:
+      - test_connected
+      - deploy_test_integration
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
+    runs-on: ${{ matrix.os }}
+    ## skips if pr label is 'skip-ci'
+    # run a local Postgres container in Docker for the basic check tests
+    steps:
+      - name: "Cache build"
+        uses: actions/cache@v2
+        with:
+          path: ~/build
+          key: ${{ runner.os }}-build
       - name: "Archive code coverage results"
         uses: actions/upload-artifact@v2
         with:
           name: code-coverage-report
           path: build/jacocoHtml
           retention-days: 10
-      - name: "Archive junit test reports"
+      - name: "Archive all junit test reports"
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: junit-test-report
+          name: junit-test-report-integration
           path: build/reports
           retention-days: 10
-      - name: "Clean state lock from used Namespace on API deploy"
-        if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
-        with:
-          actions_subcommand: 'k8_checknamespace_clean'
-      - name: "Clean whitelisted Runner IP"
-        if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.62.0
-        with:
-          actions_subcommand: 'gcp_whitelist_clean'
       - name: "Notify Jade Slack on nightly test run"
         if: ${{ github.event_name == 'schedule' && always() }}
         uses: broadinstitute/action-slack@v3.8.0

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -65,7 +65,7 @@ jobs:
           path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -118,7 +118,7 @@ jobs:
           # write vault token
           base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
       - name: "Run connected tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -164,22 +164,22 @@ jobs:
           secrets: |
             secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -194,29 +194,29 @@ jobs:
           echo "::set-output name=git_hash::$git_hash"
           echo "Latest git hash for this branch: $git_hash"
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.63.0
         timeout-minutes: 20
         env:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run integration tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
+        uses: broadinstitute/datarepo-actions/actions/main@0.63.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
   publish_test_reports:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/build
-          key: ${{ runner.os }}-build }}
+          key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests via Gradle"
         uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
         with:
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/build
-          key: ${{ runner.os }}-build
+          key: ${{ runner.os }}-build-connected
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
         with:
@@ -120,7 +120,7 @@ jobs:
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
   deploy_test_integration:
-    name: "Deploy an run smoke and integration tests"
+    name: "Run integration and smoke tests"
     timeout-minutes: 300
     needs: test_check
     strategy:
@@ -147,7 +147,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/build
-          key: ${{ runner.os }}-build
+          key: ${{ runner.os }}-build-integration
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
         with:
@@ -224,14 +224,22 @@ jobs:
         os: [ ubuntu-latest ]
     if: always()
     runs-on: ${{ matrix.os }}
-    ## skips if pr label is 'skip-ci'
-    # run a local Postgres container in Docker for the basic check tests
     steps:
-      - name: "Cache build"
+      - name: "Load unit test cache"
         uses: actions/cache@v2
         with:
           path: ~/build
-          key: ${{ runner.os }}-build
+          key: ${{ runner.os }}-build-unit
+      - name: "Load connected test cache"
+        uses: actions/cache@v2
+        with:
+          path: ~/build
+          key: ${{ runner.os }}-build-connected
+      - name: "Load integration test cache"
+        uses: actions/cache@v2
+        with:
+          path: ~/build
+          key: ${{ runner.os }}-build-integration
       - name: "Archive code coverage results"
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -121,7 +121,7 @@ jobs:
           secret_id: ${{ secrets.SECRET_ID }}
   deploy_test_integration:
     name: "Deploy an run smoke and integration tests"
-    timeout-minutes: 210
+    timeout-minutes: 300
     needs: test_check
     strategy:
       matrix:
@@ -222,7 +222,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
+    if: always()
     runs-on: ${{ matrix.os }}
     ## skips if pr label is 'skip-ci'
     # run a local Postgres container in Docker for the basic check tests

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -56,7 +56,11 @@ jobs:
       - name: "Cache build"
         uses: actions/cache@v3
         with:
-          path: build
+          path: |
+            build/jacoco
+            build/reports
+            build/spotless
+            build/test-results
           key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests via Gradle"
         uses: broadinstitute/datarepo-actions/actions/main@dr-2757-nm-better-unit
@@ -93,7 +97,11 @@ jobs:
       - name: "Cache build"
         uses: actions/cache@v3
         with:
-          path: build
+          path: |
+            build/jacoco
+            build/reports
+            build/spotless
+            build/test-results
           key: ${{ runner.os }}-build-connected
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
@@ -146,7 +154,11 @@ jobs:
       - name: "Cache build"
         uses: actions/cache@v3
         with:
-          path: build
+          path: |
+            build/jacoco
+            build/reports
+            build/spotless
+            build/test-results
           key: ${{ runner.os }}-build-integration
       - name: "Import Vault dev secrets"
         uses: hashicorp/vault-action@v2.2.0
@@ -228,17 +240,29 @@ jobs:
       - name: "Load unit test cache"
         uses: actions/cache@v3
         with:
-          path: build
+          path: |
+            build/jacoco
+            build/reports
+            build/spotless
+            build/test-results
           key: ${{ runner.os }}-build-unit
       - name: "Load connected test cache"
         uses: actions/cache@v3
         with:
-          path: build
+          path: |
+            build/jacoco
+            build/reports
+            build/spotless
+            build/test-results
           key: ${{ runner.os }}-build-connected
       - name: "Load integration test cache"
         uses: actions/cache@v3
         with:
-          path: build
+          path: |
+            build/jacoco
+            build/reports
+            build/spotless
+            build/test-results
           key: ${{ runner.os }}-build-integration
       - name: "Archive code coverage results"
         uses: actions/upload-artifact@v2

--- a/build.gradle
+++ b/build.gradle
@@ -511,7 +511,7 @@ task testConnected(type: Test) {
             maxRetries = 2
         }
     }
-    maxParallelForks = 2
+    maxParallelForks = 4
     outputs.upToDateWhen { false }
     maxHeapSize = "2g"
 }
@@ -532,7 +532,7 @@ task testIntegration(type: Test) {
             maxRetries = 2
         }
     }
-    maxParallelForks = 2
+    maxParallelForks = 8
     outputs.upToDateWhen { false }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -493,11 +493,6 @@ test {
         includeCategories 'bio.terra.common.category.Unit'
     }
     outputs.upToDateWhen { false }
-    retry {
-        if (isCiServer) {
-           maxRetries = 3
-        }
-    }
     maxParallelForks = 2
 }
 
@@ -546,11 +541,6 @@ task testUnit(type: Test) {
         includeCategories 'bio.terra.common.category.Unit'
     }
     maxParallelForks = 2
-    retry {
-        if (isCiServer) {
-            maxRetries = 3
-        }
-    }
     outputs.upToDateWhen { false }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ plugins {
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id "jacoco"
     id "com.diffplug.spotless" version "6.7.1"
+    id "com.dorongold.task-tree" version "2.1.0"
 }
 
 allprojects {

--- a/docs/jade-getting-started.md
+++ b/docs/jade-getting-started.md
@@ -248,7 +248,7 @@ helm list --namespace ZZ
    `https://jade-ZZ.datarepo-dev.broadinstitute.org/webjars/springfox-swagger-ui/oauth2-redirect.html`
 
 6. Connect to your new dev postgres database instance:
-   Note that this is a different instance than the local one you will configure in [step 10](#10-install-postgres-12).
+   Note that this is a different instance than the local one you will configure in [step 10](#10-install-postgres-11).
    The following command connects to the database via a proxy.
 
 ```
@@ -263,7 +263,7 @@ DB=datarepo-ZZ SUFFIX=ZZ ENVIRONMENT=dev ./db-connect.sh
 create extension pgcrypto;
 ```
 
-## 10. Install Postgres 12
+## 10. Install Postgres 11
 
 [Postgres](https://www.postgresql.org/) is an advanced open-source database.
 **Postgres.app** is used to manage a local installation of Postgres.
@@ -271,10 +271,10 @@ The latest release can be found on the [GitHub releases](https://github.com/Post
 page.
 For compatibility, make sure to select a version which supports
 all the older versions of Postgres including 9.6.
-After launching the application, create a new version 12 database as follows:
+After launching the application, create a new version 11 database as follows:
 
 1. Click the sidebar icon (bottom left-hand corner) and then click the plus sign
-2. Name the new server, making sure to select version **12**, and then
+2. Name the new server, making sure to select version **11**, and then
 **Initialize** it
 3. Add `/Applications/Postgres.app/Contents/Versions/latest/bin` to your path
 (there are multiple ways to achieve this)

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,5 @@ dbDatarepoChangesetFile=src/main/resources/db/changelog.xml
 dbStairwayUri=jdbc:postgresql://127.0.0.1:5432/stairway
 dbStairwayUsername=drmanager
 dbStairwayPassword=drpasswd
+org.gradle.parallel = true
+org.gradle.workers.max = 8

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -59,7 +59,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -160,7 +159,6 @@ public class DrsTest extends UsersBase {
   }
 
   @Test
-  @Ignore
   public void drsHackyTest() throws Exception {
     // Get a DRS ID from the dataset using the custodianToken.
     // Note: the reader does not have permission to run big query jobs anywhere.
@@ -270,7 +268,6 @@ public class DrsTest extends UsersBase {
   }
 
   @Test
-  @Ignore
   public void drsScaleTest() throws Exception {
     String failureMaxValue = "0";
     dataRepoFixtures.resetConfig(steward());
@@ -312,7 +309,6 @@ public class DrsTest extends UsersBase {
   }
 
   @Test
-  @Ignore
   public void testDrsErrorResponses() throws Exception {
     dataRepoFixtures.resetConfig(steward());
 

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -59,6 +59,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -159,6 +160,7 @@ public class DrsTest extends UsersBase {
   }
 
   @Test
+  @Ignore
   public void drsHackyTest() throws Exception {
     // Get a DRS ID from the dataset using the custodianToken.
     // Note: the reader does not have permission to run big query jobs anywhere.
@@ -268,6 +270,7 @@ public class DrsTest extends UsersBase {
   }
 
   @Test
+  @Ignore
   public void drsScaleTest() throws Exception {
     String failureMaxValue = "0";
     dataRepoFixtures.resetConfig(steward());
@@ -309,6 +312,7 @@ public class DrsTest extends UsersBase {
   }
 
   @Test
+  @Ignore
   public void testDrsErrorResponses() throws Exception {
     dataRepoFixtures.resetConfig(steward());
 


### PR DESCRIPTION
This does some clean up to our Gradle tasks

- Pull in Gradle plugin that lets us view task dependencies by running:
```./gradlew <task> taskTree```
(see https://github.com/dorongold/gradle-task-tree)
- Remove retries from unit tests (those should not require retries)
- Pull out the unit tests and have them run (via the `check` Gradle task) _before_ connected and integration tests (the later of which should not longer run check:  https://github.com/broadinstitute/datarepo-actions/pull/73)
- Wire in the dependencies between the jobs so that jobs run in the proper sequence
- Name the jobs to make the DevX better
- Use the github cache to accumulate test/build results from one job to the next

Bonus: now we get the nice view in github! 🎉 
<img width="1768" alt="image" src="https://user-images.githubusercontent.com/5633787/191077474-5c66dd13-9dfb-4db0-8d54-cad46f86da15.png">
