### PR TITLE
[DR-2759] Propagate parent job identifiers to child jobs

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -38,7 +38,6 @@ import bio.terra.stairway.exception.StairwayExecutionException;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -317,16 +316,16 @@ public class IngestDriverStep extends DefaultUndoStep {
 
   /** Add existing `key`-val pair from `context`'s input parameters to `flightMap`. */
   @VisibleForTesting
-  <T> void propagateContextToFlightMap(
+  static <T> void propagateContextToFlightMap(
       FlightContext context, FlightMap flightMap, String key, Class<T> paramType) {
-    Optional<T> maybeParam;
     try {
-      maybeParam = Optional.ofNullable(context.getInputParameters().get(key, paramType));
+      T param = context.getInputParameters().get(key, paramType);
+      if (param != null) {
+        flightMap.put(key, param);
+      }
     } catch (Exception ex) {
       logger.error("Unable to deserialize context input parameter value", ex);
-      maybeParam = Optional.empty();
     }
-    maybeParam.ifPresent(param -> flightMap.put(key, param));
   }
 
   private void launchLoads(

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -4,6 +4,8 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.FileLoadModel;
+import bio.terra.service.auth.iam.IamAction;
+import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
@@ -33,8 +35,10 @@ import bio.terra.stairway.exception.DatabaseOperationException;
 import bio.terra.stairway.exception.DuplicateFlightIdException;
 import bio.terra.stairway.exception.FlightNotFoundException;
 import bio.terra.stairway.exception.StairwayExecutionException;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -311,6 +315,14 @@ public class IngestDriverStep extends DefaultUndoStep {
     return candidates;
   }
 
+  /** Add existing `key`-val pair from `context`'s input parameters to `flightMap`XS. */
+  @VisibleForTesting
+  <T> void propagateContextToFlightMap(
+      FlightContext context, FlightMap flightMap, String key, Class<T> paramType) {
+    Optional<T> maybeParam = Optional.ofNullable(context.getInputParameters().get(key, paramType));
+    maybeParam.ifPresent(param -> flightMap.put(key, param));
+  }
+
   private void launchLoads(
       FlightContext context,
       AuthenticatedUserRequest userReq,
@@ -348,6 +360,17 @@ public class IngestDriverStep extends DefaultUndoStep {
       inputParameters.put(CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, storageAccountResource);
       inputParameters.put(JobMapKeys.CLOUD_PLATFORM.getKeyName(), platform.name());
       inputParameters.put(JobMapKeys.PARENT_FLIGHT_ID.getKeyName(), context.getFlightId());
+
+      // Permissions to view child jobs are inherited from the parent:
+      propagateContextToFlightMap(
+          context,
+          inputParameters,
+          JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(),
+          IamResourceType.class);
+      propagateContextToFlightMap(
+          context, inputParameters, JobMapKeys.IAM_RESOURCE_ID.getKeyName(), String.class);
+      propagateContextToFlightMap(
+          context, inputParameters, JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class);
 
       if (platform == CloudPlatform.AZURE) {
         AzureStorageAuthInfo storageAuthInfo =

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -315,11 +315,17 @@ public class IngestDriverStep extends DefaultUndoStep {
     return candidates;
   }
 
-  /** Add existing `key`-val pair from `context`'s input parameters to `flightMap`XS. */
+  /** Add existing `key`-val pair from `context`'s input parameters to `flightMap`. */
   @VisibleForTesting
   <T> void propagateContextToFlightMap(
       FlightContext context, FlightMap flightMap, String key, Class<T> paramType) {
-    Optional<T> maybeParam = Optional.ofNullable(context.getInputParameters().get(key, paramType));
+    Optional<T> maybeParam;
+    try {
+      maybeParam = Optional.ofNullable(context.getInputParameters().get(key, paramType));
+    } catch (Exception ex) {
+      logger.error("Unable to deserialize context input parameter value", ex);
+      maybeParam = Optional.empty();
+    }
     maybeParam.ifPresent(param -> flightMap.put(key, param));
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2759

Recently, we expanded job endpoint permissions so that if a caller could have performed the original operation on the resource, then they should be able to access the job even if they didn’t launch it.

Child flights spawned in `IngestDriverStep` now inherit the permission structure of the parent flight: if a user has implicit permissions to view the parent flight, they will now be able to view any child flights.

**Changes**
- `IngestDriverStep` now passes select parent flight input parameters to its child flights: the input parameters used to verify implicit job viewing permissions.
- Expanded unit tests.