### PR TITLE
[DR-2740] Users must have their profiles synced when logging Bard events.

### DIFF
--- a/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
@@ -19,7 +19,7 @@ public class UserMetricsConfiguration {
   private String bardBasePath;
   private Integer metricsReportingPoolSize;
 
-  private Integer syncRefreshInterval;
+  private Integer syncRefreshIntervalSeconds;
   private List<String> ignorePaths;
 
   public String getAppId() {
@@ -42,16 +42,16 @@ public class UserMetricsConfiguration {
     return metricsReportingPoolSize;
   }
 
-  public Integer getSyncRefreshInterval() {
-    return syncRefreshInterval;
+  public Integer getSyncRefreshIntervalSeconds() {
+    return syncRefreshIntervalSeconds;
   }
 
   public void setMetricsReportingPoolSize(Integer metricsReportingPoolSize) {
     this.metricsReportingPoolSize = metricsReportingPoolSize;
   }
 
-  public void setSyncRefreshInterval(Integer syncRefreshInterval) {
-    this.syncRefreshInterval = syncRefreshInterval;
+  public void setSyncRefreshIntervalSeconds(Integer syncRefreshIntervalSeconds) {
+    this.syncRefreshIntervalSeconds = syncRefreshIntervalSeconds;
   }
 
   public List<String> getIgnorePaths() {

--- a/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
@@ -18,6 +18,8 @@ public class UserMetricsConfiguration {
   private String appId;
   private String bardBasePath;
   private Integer metricsReportingPoolSize;
+
+  private Integer syncRefreshInterval;
   private List<String> ignorePaths;
 
   public String getAppId() {
@@ -40,8 +42,16 @@ public class UserMetricsConfiguration {
     return metricsReportingPoolSize;
   }
 
+  public Integer getSyncRefreshInterval() {
+    return syncRefreshInterval;
+  }
+
   public void setMetricsReportingPoolSize(Integer metricsReportingPoolSize) {
     this.metricsReportingPoolSize = metricsReportingPoolSize;
+  }
+
+  public void setSyncRefreshInterval(Integer syncRefreshInterval) {
+    this.syncRefreshInterval = syncRefreshInterval;
   }
 
   public List<String> getIgnorePaths() {

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -37,6 +37,9 @@ public class BardClient {
 
   private final Map<String, String> bearerCache;
 
+  private static final String API_PATH = "/api/event";
+  private static final String SYNC_PATH = "/api/syncProfile";
+
   @Autowired
   public BardClient(UserMetricsConfiguration metricsConfig) {
     this.restTemplate = new RestTemplate();
@@ -63,10 +66,7 @@ public class BardClient {
       ResponseEntity<Void> eventCall =
           getRestTemplate()
               .exchange(
-                  metricsConfig.getBardBasePath() + "/api/event",
-                  HttpMethod.POST,
-                  new HttpEntity<>(event, authedHeaders),
-                  Void.class);
+                  getApiURL(), HttpMethod.POST, new HttpEntity<>(event, authedHeaders), Void.class);
       if (!eventCall.getStatusCode().is2xxSuccessful()) {
         logger.warn(
             "Error logging event {}%n{}",
@@ -103,7 +103,7 @@ public class BardClient {
       ResponseEntity<Void> syncCall =
           getRestTemplate()
               .exchange(
-                  metricsConfig.getBardBasePath() + "/api/syncProfile",
+                  getSyncPathURL(),
                   HttpMethod.POST,
                   new HttpEntity<>(null, authedHeaders),
                   Void.class);
@@ -127,5 +127,14 @@ public class BardClient {
   @VisibleForTesting
   RestTemplate getRestTemplate() {
     return restTemplate;
+  }
+
+  @VisibleForTesting
+  String getApiURL() {
+    return metricsConfig.getBardBasePath() + API_PATH;
+  }
+
+  String getSyncPathURL() {
+    return metricsConfig.getBardBasePath() + SYNC_PATH;
   }
 }

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -36,7 +36,7 @@ public class BardClient {
 
   private static final int DEFAULT_BEARER_TOKEN_CACHE_TIMEOUT_SECONDS = 3600;
 
-  private final Map<String, Object> bearerCache;
+  private final Map<String, String> bearerCache;
 
   @Autowired
   public BardClient(UserMetricsConfiguration metricsConfig) {
@@ -85,21 +85,10 @@ public class BardClient {
    * expired.
    *
    * @param userReq - the AuthenticatedUserRequest that represents the current user.
-   * @return boolean - Returns true if the cache was updated. Only consumed by tests at this time.
    */
-  boolean syncUser(AuthenticatedUserRequest userReq) {
-    boolean updatedEntry = false;
+  private void syncUser(AuthenticatedUserRequest userReq) {
     String key = userReq.getToken();
-    synchronized (bearerCache) {
-      if (!bearerCache.containsKey(key)) {
-        if (syncProfile(userReq)) {
-          // only cache the key if the sync request was successful.
-          bearerCache.put(key, null);
-          updatedEntry = true;
-        }
-      }
-    }
-    return updatedEntry;
+    bearerCache.computeIfAbsent(key, k -> syncProfile(userReq) ? "" : null);
   }
 
   /**

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -85,6 +85,7 @@ public class BardClient {
    * expired.
    *
    * @param userReq - the AuthenticatedUserRequest that represents the current user.
+   * @return boolean - Returns true if the cache was updated.  Only consumed by tests at this time.
    */
   boolean syncUser(AuthenticatedUserRequest userReq) {
     boolean updatedEntry = false;

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -134,6 +134,7 @@ public class BardClient {
     return metricsConfig.getBardBasePath() + API_PATH;
   }
 
+  @VisibleForTesting
   String getSyncPathURL() {
     return metricsConfig.getBardBasePath() + SYNC_PATH;
   }

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -31,7 +31,7 @@ public class BardClient {
 
   private final RestTemplate apiRestTemplate;
 
-  private final RestTemplate syncRestTemplate;
+  // private final RestTemplate syncRestTemplate;
   private final HttpHeaders headers;
 
   private static final int DEFAULT_BEARER_TOKEN_CACHE_TIMEOUT_SECONDS = 3600;
@@ -42,8 +42,6 @@ public class BardClient {
   public BardClient(UserMetricsConfiguration metricsConfig) {
     this.apiRestTemplate = new RestTemplate();
     apiRestTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
-    this.syncRestTemplate = new RestTemplate();
-    syncRestTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
 
     this.headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
@@ -64,7 +62,7 @@ public class BardClient {
     syncUser(userReq);
     try {
       ResponseEntity<Void> eventCall =
-          getApiRestTemplate()
+          getRestTemplate()
               .exchange(
                   metricsConfig.getBardBasePath() + "/api/event",
                   HttpMethod.POST,
@@ -104,7 +102,7 @@ public class BardClient {
     authedHeaders.setBearerAuth(userReq.getToken());
     try {
       ResponseEntity<Void> syncCall =
-          getSyncRestTemplate()
+          getRestTemplate()
               .exchange(
                   metricsConfig.getBardBasePath() + "/api/syncProfile",
                   HttpMethod.POST,
@@ -128,12 +126,7 @@ public class BardClient {
   }
 
   @VisibleForTesting
-  RestTemplate getApiRestTemplate() {
+  RestTemplate getRestTemplate() {
     return apiRestTemplate;
-  }
-
-  @VisibleForTesting
-  RestTemplate getSyncRestTemplate() {
-    return syncRestTemplate;
   }
 }

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -29,9 +29,8 @@ public class BardClient {
 
   private final UserMetricsConfiguration metricsConfig;
 
-  private final RestTemplate apiRestTemplate;
+  private final RestTemplate restTemplate;
 
-  // private final RestTemplate syncRestTemplate;
   private final HttpHeaders headers;
 
   private static final int DEFAULT_BEARER_TOKEN_CACHE_TIMEOUT_SECONDS = 3600;
@@ -40,8 +39,8 @@ public class BardClient {
 
   @Autowired
   public BardClient(UserMetricsConfiguration metricsConfig) {
-    this.apiRestTemplate = new RestTemplate();
-    apiRestTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+    this.restTemplate = new RestTemplate();
+    restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
 
     this.headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
@@ -127,6 +126,6 @@ public class BardClient {
 
   @VisibleForTesting
   RestTemplate getRestTemplate() {
-    return apiRestTemplate;
+    return restTemplate;
   }
 }

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -85,7 +85,7 @@ public class BardClient {
    * expired.
    *
    * @param userReq - the AuthenticatedUserRequest that represents the current user.
-   * @return boolean - Returns true if the cache was updated.  Only consumed by tests at this time.
+   * @return boolean - Returns true if the cache was updated. Only consumed by tests at this time.
    */
   boolean syncUser(AuthenticatedUserRequest userReq) {
     boolean updatedEntry = false;

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -2,7 +2,13 @@ package bio.terra.app.usermetrics;
 
 import bio.terra.app.configuration.UserMetricsConfiguration;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,16 +29,30 @@ public class BardClient {
 
   private final UserMetricsConfiguration metricsConfig;
 
-  private final RestTemplate restTemplate;
+  private final RestTemplate apiRestTemplate;
+
+  private final RestTemplate syncRestTemplate;
   private final HttpHeaders headers;
+
+  private static final int BEARER_TOKEN_CACHE_TIMEOUT_SECONDS = 3600;
+
+  private final Map<String, Object> bearerCache;
 
   @Autowired
   public BardClient(UserMetricsConfiguration metricsConfig) {
-    this.restTemplate = new RestTemplate();
-    restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+    this.apiRestTemplate = new RestTemplate();
+    apiRestTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+    this.syncRestTemplate = new RestTemplate();
+    syncRestTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
     this.headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON));
+
+    int ttl =
+        Objects.requireNonNullElse(
+            metricsConfig.getSyncRefreshInterval(), BEARER_TOKEN_CACHE_TIMEOUT_SECONDS);
+    this.bearerCache = Collections.synchronizedMap(new PassiveExpiringMap<>(ttl, TimeUnit.SECONDS));
 
     this.metricsConfig = metricsConfig;
   }
@@ -40,13 +60,15 @@ public class BardClient {
   public void logEvent(AuthenticatedUserRequest userReq, BardEvent event) {
     HttpHeaders authedHeaders = new HttpHeaders(headers);
     authedHeaders.setBearerAuth(userReq.getToken());
+    syncUser(userReq);
     try {
       ResponseEntity<Void> eventCall =
-          restTemplate.exchange(
-              metricsConfig.getBardBasePath() + "/api/event",
-              HttpMethod.POST,
-              new HttpEntity<>(event, authedHeaders),
-              Void.class);
+          getApiRestTemplate()
+              .exchange(
+                  metricsConfig.getBardBasePath() + "/api/event",
+                  HttpMethod.POST,
+                  new HttpEntity<>(event, authedHeaders),
+                  Void.class);
       if (!eventCall.getStatusCode().is2xxSuccessful()) {
         logger.warn(
             "Error logging event {}%n{}",
@@ -55,5 +77,70 @@ public class BardClient {
     } catch (Exception e) {
       logger.warn("Error logging event {}", event.getEvent(), e);
     }
+  }
+
+  /**
+   * Syncing a user is only needed when a new token is not already cached or the cache entry has
+   * expired.
+   *
+   * @param userReq - the AuthenticatedUserRequest that represents the current user.
+   */
+  boolean syncUser(AuthenticatedUserRequest userReq) {
+    boolean updatedEntry = false;
+    String key = userReq.getToken();
+    if (!bearerCache.containsKey(key)) {
+      if (syncProfile(userReq)) {
+        // only cache the key if the sync request was successful.
+        bearerCache.put(key, null);
+        updatedEntry = true;
+      }
+    }
+    return updatedEntry;
+  }
+
+  /**
+   * Syncs profile info from orchestration to mixpanel to improve querying/reporting capabilities in
+   * the mixpanel reports.
+   *
+   * @param userReq - the user to sync.
+   * @return boolean - if the sync request was successful.
+   */
+  boolean syncProfile(AuthenticatedUserRequest userReq) {
+    boolean result = false;
+    HttpHeaders authedHeaders = new HttpHeaders(headers);
+    authedHeaders.setBearerAuth(userReq.getToken());
+    try {
+      ResponseEntity<Void> syncCall =
+          getSyncRestTemplate()
+              .exchange(
+                  metricsConfig.getBardBasePath() + "/api/syncProfile",
+                  HttpMethod.POST,
+                  new HttpEntity<>(null, authedHeaders),
+                  Void.class);
+      if (!syncCall.getStatusCode().is2xxSuccessful()) {
+        logger.warn(
+            "Error calling sync for user {}%n{}",
+            userReq.getEmail(), syncCall.getStatusCode().getReasonPhrase());
+      } else {
+        result = true;
+      }
+    } catch (Exception e) {
+      logger.warn(
+          "Unable to sync profile for user {} token {} because {}",
+          userReq.getEmail(),
+          userReq.getToken(),
+          e.getMessage());
+    }
+    return result;
+  }
+
+  @VisibleForTesting
+  RestTemplate getApiRestTemplate() {
+    return apiRestTemplate;
+  }
+
+  @VisibleForTesting
+  RestTemplate getSyncRestTemplate() {
+    return syncRestTemplate;
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -121,5 +121,6 @@ ecm.rasIssuer=https://stsstg.nih.gov
 usermetrics.appId=datarepo
 usermetrics.bardBasePath=
 usermetrics.metricsReportingPoolSize=10
+usermetrics.syncRefreshInterval=3600
 usermetrics.ignorePaths=/api/repository/v1/jobs/*,/api/repository/v1/configs*,/api/repository/v1/upgrade,/actuator/*,/configuration,/status
 rawls.basePath=https://rawls.dsde-dev.broadinstitute.org

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -121,6 +121,6 @@ ecm.rasIssuer=https://stsstg.nih.gov
 usermetrics.appId=datarepo
 usermetrics.bardBasePath=
 usermetrics.metricsReportingPoolSize=10
-usermetrics.syncRefreshInterval=3600
+usermetrics.syncRefreshIntervalSeconds=3600
 usermetrics.ignorePaths=/api/repository/v1/jobs/*,/api/repository/v1/configs*,/api/repository/v1/upgrade,/actuator/*,/configuration,/status
 rawls.basePath=https://rawls.dsde-dev.broadinstitute.org

--- a/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
@@ -5,11 +5,10 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 import bio.terra.app.configuration.UserMetricsConfiguration;
 import bio.terra.common.category.Unit;
@@ -70,12 +69,7 @@ public class BardClientTest {
 
   @Test
   public void testBardClientLogEvent() {
-    BardClient bardClient =
-        mock(
-            BardClient.class,
-            withSettings()
-                .useConstructor(userMetricsConfiguration)
-                .defaultAnswer(CALLS_REAL_METHODS));
+    BardClient bardClient = spy(new BardClient(userMetricsConfiguration));
     RestTemplate apiRestTemplate = mock(RestTemplate.class);
     RestTemplate syncRestTemplate = mock(RestTemplate.class);
     ResponseEntity responseEntity = mock(ResponseEntity.class);
@@ -102,12 +96,7 @@ public class BardClientTest {
 
   @Test
   public void testBardClientSyncProfile_happy() {
-    BardClient bardClient =
-        mock(
-            BardClient.class,
-            withSettings()
-                .useConstructor(userMetricsConfiguration)
-                .defaultAnswer(CALLS_REAL_METHODS));
+    BardClient bardClient = spy(new BardClient(userMetricsConfiguration));
     RestTemplate restTemplate = mock(RestTemplate.class);
     ResponseEntity responseEntity = mock(ResponseEntity.class);
     when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
@@ -127,12 +116,7 @@ public class BardClientTest {
 
   @Test
   public void testBardClientSyncProfile_sad() {
-    BardClient bardClient =
-        mock(
-            BardClient.class,
-            withSettings()
-                .useConstructor(userMetricsConfiguration)
-                .defaultAnswer(CALLS_REAL_METHODS));
+    BardClient bardClient = spy(new BardClient(userMetricsConfiguration));
     RestTemplate restTemplate = mock(RestTemplate.class);
     ResponseEntity responseEntity = mock(ResponseEntity.class);
     when(responseEntity.getStatusCode()).thenReturn(HttpStatus.FORBIDDEN);

--- a/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
@@ -145,7 +145,6 @@ public class BardClientTest {
     assertFalse(bardClient.syncUser(user1));
     assertFalse(bardClient.syncUser(user2));
 
-
     // even when the calls continue to fail.
     assertFalse(bardClient.syncUser(user1));
     assertFalse(bardClient.syncUser(user2));

--- a/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
@@ -65,37 +65,35 @@ public class BardClientTest {
   }
 
   @Test
-  public void testBardClientLogEvent_one_user_happy() {
+  public void testBardClientLogEvent_happy() {
     BardClient bardClient = spy(new BardClient(userMetricsConfiguration));
     RestTemplate apiRestTemplate = mock(RestTemplate.class);
-    RestTemplate syncRestTemplate = mock(RestTemplate.class);
     when(apiRestTemplate.exchange(
             eq(API_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.OK));
-    when(syncRestTemplate.exchange(
+    when(apiRestTemplate.exchange(
             eq(SYNC_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.OK));
-    when(bardClient.getApiRestTemplate()).thenReturn(apiRestTemplate);
-    when(bardClient.getSyncRestTemplate()).thenReturn(syncRestTemplate);
+    when(bardClient.getRestTemplate()).thenReturn(apiRestTemplate);
 
     logEventForUser(bardClient, user1);
 
-    verifyRestTemplatePathAndCount(syncRestTemplate, SYNC_PATH, 1);
+    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 1);
     verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 1);
 
     logEventForUser(bardClient, user1);
 
-    verifyRestTemplatePathAndCount(syncRestTemplate, SYNC_PATH, 1);
+    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 1);
     verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 2);
 
     logEventForUser(bardClient, user2);
 
-    verifyRestTemplatePathAndCount(syncRestTemplate, SYNC_PATH, 2);
+    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 2);
     verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 3);
 
     logEventForUser(bardClient, user2);
 
-    verifyRestTemplatePathAndCount(syncRestTemplate, SYNC_PATH, 2);
+    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 2);
     verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 4);
   }
 
@@ -103,24 +101,22 @@ public class BardClientTest {
   public void testBardClientLogEvent_sad_sync() {
     BardClient bardClient = spy(new BardClient(userMetricsConfiguration));
     RestTemplate apiRestTemplate = mock(RestTemplate.class);
-    RestTemplate syncRestTemplate = mock(RestTemplate.class);
     when(apiRestTemplate.exchange(
             eq(API_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.OK));
-    when(syncRestTemplate.exchange(
+    when(apiRestTemplate.exchange(
             eq(SYNC_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.FORBIDDEN));
-    when(bardClient.getApiRestTemplate()).thenReturn(apiRestTemplate);
-    when(bardClient.getSyncRestTemplate()).thenReturn(syncRestTemplate);
+    when(bardClient.getRestTemplate()).thenReturn(apiRestTemplate);
 
     logEventForUser(bardClient, user1);
 
-    verifyRestTemplatePathAndCount(syncRestTemplate, SYNC_PATH, 1);
+    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 1);
     verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 1);
 
     logEventForUser(bardClient, user1);
 
-    verifyRestTemplatePathAndCount(syncRestTemplate, SYNC_PATH, 2);
+    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 2);
     verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 2);
   }
 

--- a/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
@@ -1,0 +1,170 @@
+package bio.terra.app.usermetrics;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import bio.terra.app.configuration.UserMetricsConfiguration;
+import bio.terra.common.category.Unit;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+@SuppressWarnings("rawtypes")
+public class BardClientTest {
+
+  @SpyBean UserMetricsConfiguration userMetricsConfiguration;
+
+  private AuthenticatedUserRequest user1;
+
+  private AuthenticatedUserRequest user2;
+
+  private String SYNC_PATH;
+
+  private String API_PATH;
+
+  @Before
+  public void setup() {
+    SYNC_PATH = userMetricsConfiguration.getBardBasePath() + "/api/syncProfile";
+    API_PATH = userMetricsConfiguration.getBardBasePath() + "/api/event";
+    user1 =
+        AuthenticatedUserRequest.builder()
+            .setSubjectId("Bob")
+            .setEmail("bob")
+            .setToken("bob token")
+            .build();
+
+    user2 =
+        AuthenticatedUserRequest.builder()
+            .setSubjectId("alice")
+            .setEmail("alice")
+            .setToken("alice token")
+            .build();
+  }
+
+  @Test
+  public void testBardClientLogEvent() {
+    BardClient bardClient =
+        mock(
+            BardClient.class,
+            withSettings()
+                .useConstructor(userMetricsConfiguration)
+                .defaultAnswer(CALLS_REAL_METHODS));
+    RestTemplate apiRestTemplate = mock(RestTemplate.class);
+    RestTemplate syncRestTemplate = mock(RestTemplate.class);
+    ResponseEntity responseEntity = mock(ResponseEntity.class);
+    when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
+    when(apiRestTemplate.exchange(
+            eq(API_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
+        .thenReturn(responseEntity);
+    when(syncRestTemplate.exchange(
+            eq(SYNC_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
+        .thenReturn(responseEntity);
+    doReturn(apiRestTemplate).when(bardClient).getApiRestTemplate();
+    doReturn(syncRestTemplate).when(bardClient).getSyncRestTemplate();
+
+    logEventForUser(bardClient, user1);
+
+    verifyRestTemplatePathAndCount(syncRestTemplate, SYNC_PATH, 1);
+    verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 1);
+
+    logEventForUser(bardClient, user1);
+
+    verifyRestTemplatePathAndCount(syncRestTemplate, SYNC_PATH, 1);
+    verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 2);
+  }
+
+  @Test
+  public void testBardClientSyncProfile_happy() {
+    BardClient bardClient =
+        mock(
+            BardClient.class,
+            withSettings()
+                .useConstructor(userMetricsConfiguration)
+                .defaultAnswer(CALLS_REAL_METHODS));
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ResponseEntity responseEntity = mock(ResponseEntity.class);
+    when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
+    when(restTemplate.exchange(
+            anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
+        .thenReturn(responseEntity);
+    doReturn(restTemplate).when(bardClient).getSyncRestTemplate();
+
+    // new users should be added to the cache.
+    assertTrue(bardClient.syncUser(user1));
+    assertTrue(bardClient.syncUser(user2));
+
+    // if the users are in the cache, they shouldn't be added again.
+    assertFalse(bardClient.syncUser(user1));
+    assertFalse(bardClient.syncUser(user2));
+  }
+
+  @Test
+  public void testBardClientSyncProfile_sad() {
+    BardClient bardClient =
+        mock(
+            BardClient.class,
+            withSettings()
+                .useConstructor(userMetricsConfiguration)
+                .defaultAnswer(CALLS_REAL_METHODS));
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ResponseEntity responseEntity = mock(ResponseEntity.class);
+    when(responseEntity.getStatusCode()).thenReturn(HttpStatus.FORBIDDEN);
+    when(restTemplate.exchange(
+            anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
+        .thenReturn(responseEntity);
+    doReturn(restTemplate).when(bardClient).getSyncRestTemplate();
+
+    // if the remote service returns something but a 2XX error, call sync on each request.
+    assertFalse(bardClient.syncUser(user1));
+    assertFalse(bardClient.syncUser(user2));
+
+    // even when the calls continue to fail.
+    assertFalse(bardClient.syncUser(user1));
+    assertFalse(bardClient.syncUser(user2));
+  }
+
+  private void verifyRestTemplatePathAndCount(RestTemplate template, String path, int count) {
+    verify(template, Mockito.times(count))
+        .exchange(eq(path), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class));
+  }
+
+  private void logEventForUser(BardClient bardClient, AuthenticatedUserRequest user) {
+    bardClient.logEvent(
+        user,
+        new BardEvent(
+            UserMetricsInterceptor.API_EVENT_NAME,
+            Map.of(
+                BardEventProperties.METHOD_FIELD_NAME, "POST",
+                BardEventProperties.PATH_FIELD_NAME, "/foo/bar"),
+            "test app",
+            "some.dns.entry.org"));
+  }
+}

--- a/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
@@ -45,10 +45,23 @@ public class BardClientTest {
 
   private String API_PATH;
 
+  private BardClient bardClient;
+
+  private RestTemplate restTemplate;
+
   @Before
   public void setup() {
-    SYNC_PATH = userMetricsConfiguration.getBardBasePath() + "/api/syncProfile";
-    API_PATH = userMetricsConfiguration.getBardBasePath() + "/api/event";
+    bardClient = spy(new BardClient(userMetricsConfiguration));
+    restTemplate = mock(RestTemplate.class);
+
+    when(restTemplate.exchange(
+            eq(bardClient.getApiURL()), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
+        .thenReturn(new ResponseEntity(HttpStatus.OK));
+    when(bardClient.getRestTemplate()).thenReturn(restTemplate);
+
+    API_PATH = bardClient.getApiURL();
+    SYNC_PATH = bardClient.getSyncPathURL();
+
     user1 =
         AuthenticatedUserRequest.builder()
             .setSubjectId("Bob")
@@ -66,15 +79,9 @@ public class BardClientTest {
 
   @Test
   public void testBardClientLogEvent_happy() {
-    BardClient bardClient = spy(new BardClient(userMetricsConfiguration));
-    RestTemplate restTemplate = mock(RestTemplate.class);
-    when(restTemplate.exchange(
-            eq(API_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
-        .thenReturn(new ResponseEntity(HttpStatus.OK));
     when(restTemplate.exchange(
             eq(SYNC_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.OK));
-    when(bardClient.getRestTemplate()).thenReturn(restTemplate);
 
     logEventForUser(bardClient, user1);
 
@@ -99,15 +106,9 @@ public class BardClientTest {
 
   @Test
   public void testBardClientLogEvent_sad_sync() {
-    BardClient bardClient = spy(new BardClient(userMetricsConfiguration));
-    RestTemplate restTemplate = mock(RestTemplate.class);
-    when(restTemplate.exchange(
-            eq(API_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
-        .thenReturn(new ResponseEntity(HttpStatus.OK));
     when(restTemplate.exchange(
             eq(SYNC_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.FORBIDDEN));
-    when(bardClient.getRestTemplate()).thenReturn(restTemplate);
 
     logEventForUser(bardClient, user1);
 

--- a/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
@@ -141,9 +141,10 @@ public class BardClientTest {
         .thenReturn(responseEntity);
     when(bardClient.getSyncRestTemplate()).thenReturn(restTemplate);
 
-    // if the remote service returns something but a 2XX error, call sync on each request.
+    // if the remote service returns something other than a 2XX response, call sync on each request.
     assertFalse(bardClient.syncUser(user1));
     assertFalse(bardClient.syncUser(user2));
+
 
     // even when the calls continue to fail.
     assertFalse(bardClient.syncUser(user1));

--- a/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
@@ -67,57 +67,57 @@ public class BardClientTest {
   @Test
   public void testBardClientLogEvent_happy() {
     BardClient bardClient = spy(new BardClient(userMetricsConfiguration));
-    RestTemplate apiRestTemplate = mock(RestTemplate.class);
-    when(apiRestTemplate.exchange(
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.exchange(
             eq(API_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.OK));
-    when(apiRestTemplate.exchange(
+    when(restTemplate.exchange(
             eq(SYNC_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.OK));
-    when(bardClient.getRestTemplate()).thenReturn(apiRestTemplate);
+    when(bardClient.getRestTemplate()).thenReturn(restTemplate);
 
     logEventForUser(bardClient, user1);
 
-    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 1);
-    verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 1);
+    verifyRestTemplatePathAndCount(restTemplate, SYNC_PATH, 1);
+    verifyRestTemplatePathAndCount(restTemplate, API_PATH, 1);
 
     logEventForUser(bardClient, user1);
 
-    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 1);
-    verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 2);
+    verifyRestTemplatePathAndCount(restTemplate, SYNC_PATH, 1);
+    verifyRestTemplatePathAndCount(restTemplate, API_PATH, 2);
 
     logEventForUser(bardClient, user2);
 
-    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 2);
-    verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 3);
+    verifyRestTemplatePathAndCount(restTemplate, SYNC_PATH, 2);
+    verifyRestTemplatePathAndCount(restTemplate, API_PATH, 3);
 
     logEventForUser(bardClient, user2);
 
-    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 2);
-    verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 4);
+    verifyRestTemplatePathAndCount(restTemplate, SYNC_PATH, 2);
+    verifyRestTemplatePathAndCount(restTemplate, API_PATH, 4);
   }
 
   @Test
   public void testBardClientLogEvent_sad_sync() {
     BardClient bardClient = spy(new BardClient(userMetricsConfiguration));
-    RestTemplate apiRestTemplate = mock(RestTemplate.class);
-    when(apiRestTemplate.exchange(
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.exchange(
             eq(API_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.OK));
-    when(apiRestTemplate.exchange(
+    when(restTemplate.exchange(
             eq(SYNC_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(new ResponseEntity(HttpStatus.FORBIDDEN));
-    when(bardClient.getRestTemplate()).thenReturn(apiRestTemplate);
+    when(bardClient.getRestTemplate()).thenReturn(restTemplate);
 
     logEventForUser(bardClient, user1);
 
-    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 1);
-    verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 1);
+    verifyRestTemplatePathAndCount(restTemplate, SYNC_PATH, 1);
+    verifyRestTemplatePathAndCount(restTemplate, API_PATH, 1);
 
     logEventForUser(bardClient, user1);
 
-    verifyRestTemplatePathAndCount(apiRestTemplate, SYNC_PATH, 2);
-    verifyRestTemplatePathAndCount(apiRestTemplate, API_PATH, 2);
+    verifyRestTemplatePathAndCount(restTemplate, SYNC_PATH, 2);
+    verifyRestTemplatePathAndCount(restTemplate, API_PATH, 2);
   }
 
   private void verifyRestTemplatePathAndCount(RestTemplate template, String path, int count) {

--- a/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,8 +86,8 @@ public class BardClientTest {
     when(syncRestTemplate.exchange(
             eq(SYNC_PATH), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(responseEntity);
-    doReturn(apiRestTemplate).when(bardClient).getApiRestTemplate();
-    doReturn(syncRestTemplate).when(bardClient).getSyncRestTemplate();
+    when(bardClient.getApiRestTemplate()).thenReturn(apiRestTemplate);
+    when(bardClient.getSyncRestTemplate()).thenReturn(syncRestTemplate);
 
     logEventForUser(bardClient, user1);
 
@@ -115,7 +114,7 @@ public class BardClientTest {
     when(restTemplate.exchange(
             anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(responseEntity);
-    doReturn(restTemplate).when(bardClient).getSyncRestTemplate();
+    when(bardClient.getSyncRestTemplate()).thenReturn(restTemplate);
 
     // new users should be added to the cache.
     assertTrue(bardClient.syncUser(user1));
@@ -140,7 +139,7 @@ public class BardClientTest {
     when(restTemplate.exchange(
             anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(Void.class)))
         .thenReturn(responseEntity);
-    doReturn(restTemplate).when(bardClient).getSyncRestTemplate();
+    when(bardClient.getSyncRestTemplate()).thenReturn(restTemplate);
 
     // if the remote service returns something but a 2XX error, call sync on each request.
     assertFalse(bardClient.syncUser(user1));

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -61,7 +61,7 @@ public class UserMetricsInterceptorTest {
   public void testSendEvent() throws Exception {
     mockRequestAuth(request);
 
-    runAnWait(request, response);
+    runAndWait(request, response);
 
     verify(bardClient, times(1))
         .logEvent(
@@ -85,7 +85,7 @@ public class UserMetricsInterceptorTest {
 
     mockRequestAuth(request);
 
-    runAnWait(request, response);
+    runAndWait(request, response);
 
     verify(bardClient, times(1))
         .logEvent(
@@ -109,7 +109,7 @@ public class UserMetricsInterceptorTest {
         .when(authenticatedUserRequestFactory)
         .from(any());
 
-    runAnWait(request, response);
+    runAndWait(request, response);
 
     verify(bardClient, times(0)).logEvent(any(), any());
   }
@@ -119,7 +119,7 @@ public class UserMetricsInterceptorTest {
     metricsConfig.setIgnorePaths(List.of("/foo/bar"));
     mockRequestAuth(request);
 
-    runAnWait(request, response);
+    runAndWait(request, response);
 
     verify(bardClient, times(0)).logEvent(any(), any());
   }
@@ -129,7 +129,7 @@ public class UserMetricsInterceptorTest {
     metricsConfig.setIgnorePaths(List.of("/foo/*"));
     mockRequestAuth(request);
 
-    runAnWait(request, response);
+    runAndWait(request, response);
 
     verify(bardClient, times(0)).logEvent(any(), any());
   }
@@ -139,7 +139,7 @@ public class UserMetricsInterceptorTest {
     when(request.getHeader("From")).thenReturn("me@me.me");
   }
 
-  private void runAnWait(HttpServletRequest request, HttpServletResponse response)
+  private void runAndWait(HttpServletRequest request, HttpServletResponse response)
       throws Exception {
     metricsInterceptor.afterCompletion(request, response, new Object(), null);
     // This waits for the threadpool to wrap up so that we can examine the results

--- a/src/test/resources/application-unittest.properties
+++ b/src/test/resources/application-unittest.properties
@@ -3,3 +3,4 @@ datarepo.testWithEmbeddedDatabase=true
 usermetrics.appId=testapp
 usermetrics.bardBasePath=https://bard.com
 usermetrics.metricsReportingPoolSize=10
+usermetrics.syncRefreshInterval=3600

--- a/src/test/resources/application-unittest.properties
+++ b/src/test/resources/application-unittest.properties
@@ -3,4 +3,4 @@ datarepo.testWithEmbeddedDatabase=true
 usermetrics.appId=testapp
 usermetrics.bardBasePath=https://bard.com
 usermetrics.metricsReportingPoolSize=10
-usermetrics.syncRefreshInterval=3600
+usermetrics.syncRefreshIntervalSeconds=3600


### PR DESCRIPTION
[DR-2740](https://broadworkbench.atlassian.net/browse/DR-2740)
When we see new OAUTH tokens, we need to explicitly call the Bard "snycProfile" endpoint to associate the app session with the mixpanel user.  This PR:
- Updates the BardClient to support the additional service endpoint and caching approach needed.
- Adds unit tests to verify the sync endpoint is invoked and the result is cached.
- Uses an application configuration property to control the cache duration if one is provided.

Drive by updates:
- Fix typo in UserMetricsInterceptorTest.java

Mockito had consistency issues with repurposing the RestTemplate in the BardClient for both the API and Sync calls.  As a result, this implementation dedicates a RestTemplate for each type of request in the BardClient.