### PR TITLE
[DR-2723] Add ability to filter enumerateJobs endpoint by list of jobIds

### DIFF
--- a/src/main/java/bio/terra/app/controller/JobsApiController.java
+++ b/src/main/java/bio/terra/app/controller/JobsApiController.java
@@ -97,10 +97,12 @@ public class JobsApiController implements JobsApi {
       Integer offset,
       Integer limit,
       @RequestParam(defaultValue = "desc") SqlSortDirection direction,
-      String className) {
+      String className,
+      List<String> jobIds) {
     validateOffsetAndLimit(offset, limit);
     List<JobModel> results =
-        jobService.enumerateJobs(offset, limit, getAuthenticatedInfo(), direction, className);
+        jobService.enumerateJobs(
+            offset, limit, getAuthenticatedInfo(), direction, className, jobIds);
     return new ResponseEntity<>(results, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/JobsApiController.java
+++ b/src/main/java/bio/terra/app/controller/JobsApiController.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
-import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/bio/terra/app/controller/JobsApiController.java
+++ b/src/main/java/bio/terra/app/controller/JobsApiController.java
@@ -17,9 +17,13 @@ import bio.terra.service.snapshot.SnapshotRequestValidator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,9 +104,10 @@ public class JobsApiController implements JobsApi {
       String className,
       List<String> jobIds) {
     validateOffsetAndLimit(offset, limit);
+    Set<String> jobIdSet = new HashSet<>(Objects.requireNonNullElse(jobIds, List.of()));
     List<JobModel> results =
         jobService.enumerateJobs(
-            offset, limit, getAuthenticatedInfo(), direction, className, jobIds);
+            offset, limit, getAuthenticatedInfo(), direction, className, jobIdSet);
     return new ResponseEntity<>(results, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -33,14 +33,12 @@ import bio.terra.stairway.exception.StairwayExecutionException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -338,8 +336,8 @@ public class JobService {
       }
       filterResults.forEach(
           flightState -> {
-            if ((canListAnyJob || userLaunchedFlight(flightState, userReq)) &&
-                jobIdSet.contains(flightState.getFlightId())) {
+            if ((canListAnyJob || userLaunchedFlight(flightState, userReq))
+                && jobIdSet.contains(flightState.getFlightId())) {
               flightStateList.add(flightState);
             } else {
               FlightMap inputParameters = flightState.getInputParameters();
@@ -357,8 +355,8 @@ public class JobService {
                   userRoles = samService.listActions(userReq, resourceType, resourceId);
                   roleMap.put(key, userRoles);
                 }
-                if (userRoles.contains(action.toString()) &&
-                    jobIdSet.contains(flightState.getFlightId())) {
+                if (userRoles.contains(action.toString())
+                    && jobIdSet.contains(flightState.getFlightId())) {
                   flightStateList.add(flightState);
                 }
               }

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -284,7 +285,7 @@ public class JobService {
       AuthenticatedUserRequest userReq,
       SqlSortDirection direction,
       String className,
-      List<String> jobIds) {
+      Set<String> jobIdSet) {
 
     // if the user has access to all jobs, then fetch everything
     // otherwise, filter the jobs on the user
@@ -306,7 +307,6 @@ public class JobService {
       filter.addFilterFlightClass(FlightFilterOp.EQUAL, className);
     }
 
-    HashSet<String> jobIdSet = new HashSet<>(ListUtils.emptyIfNull(jobIds));
     List<FlightState> flightStateList;
     boolean canListAnyJob = checkUserCanListAnyJob(userReq);
     try {
@@ -335,7 +335,7 @@ public class JobService {
       int limit,
       FlightFilter filter,
       AuthenticatedUserRequest userReq,
-      HashSet<String> jobIdSet)
+      Set<String> jobIdSet)
       throws InterruptedException {
     int start = 0;
     int end = offset + limit;
@@ -383,8 +383,8 @@ public class JobService {
     return flightStateList.subList(offset, offset + limit);
   }
 
-  private boolean includeFlight(FlightState flightState, HashSet<String> jobIdSet) {
-    return jobIdSet.isEmpty() || jobIdSet.contains(flightState.getFlightId());
+  private boolean includeFlight(FlightState flightState, Set<String> jobIdSet) {
+    return jobIdSet.contains(flightState.getFlightId());
   }
 
   private boolean userLaunchedFlight(FlightState flightState, AuthenticatedUserRequest userReq) {

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -348,7 +348,8 @@ public class JobService {
       }
       filterResults.forEach(
           flightState -> {
-            if (userLaunchedFlight(flightState, userReq) && includeFlight(flightState, jobIdSet)) {
+            if (userLaunchedFlight(flightState, userReq) &&
+                jobIdSet.contains(flightState.getFlightId())) {
               flightStateList.add(flightState);
             } else {
               FlightMap inputParameters = flightState.getInputParameters();
@@ -366,7 +367,8 @@ public class JobService {
                   userRoles = samService.listActions(userReq, resourceType, resourceId);
                   roleMap.put(key, userRoles);
                 }
-                if (userRoles.contains(action.toString()) && includeFlight(flightState, jobIdSet)) {
+                if (userRoles.contains(action.toString()) &&
+                    jobIdSet.contains(flightState.getFlightId())) {
                   flightStateList.add(flightState);
                 }
               }
@@ -381,10 +383,6 @@ public class JobService {
       return flightStateList.subList(offset, flightStateList.size());
     }
     return flightStateList.subList(offset, offset + limit);
-  }
-
-  private boolean includeFlight(FlightState flightState, Set<String> jobIdSet) {
-    return jobIdSet.contains(flightState.getFlightId());
   }
 
   private boolean userLaunchedFlight(FlightState flightState, AuthenticatedUserRequest userReq) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2490,6 +2490,16 @@ paths:
           description: Filter by the flight's class
           schema:
             type: string
+        - name: jobIds
+          in: query
+          description: Filter the results to include the specified jobIds.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         200:
           description: List of jobs

--- a/src/test/java/bio/terra/app/controller/JobsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/JobsApiControllerTest.java
@@ -58,24 +58,24 @@ public class JobsApiControllerTest {
 
   @Test
   public void testEnumerateJobs() throws Exception {
-    when(jobService.enumerateJobs(anyInt(), anyInt(), any(), any(), any()))
+    when(jobService.enumerateJobs(anyInt(), anyInt(), any(), any(), any(), any()))
         .thenReturn(List.of(JOB_1, JOB_2));
     mvc.perform(get(ENUMERATE_JOBS_ENDPOINT))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.length()").value(2));
     verify(jobService, times(1))
-        .enumerateJobs(eq(0), eq(10), any(), eq(SqlSortDirection.DESC), isNull());
+        .enumerateJobs(eq(0), eq(10), any(), eq(SqlSortDirection.DESC), isNull(), any());
   }
 
   @Test
   public void testEnumerateJobsWithFilter() throws Exception {
-    when(jobService.enumerateJobs(anyInt(), anyInt(), any(), any(), any()))
+    when(jobService.enumerateJobs(anyInt(), anyInt(), any(), any(), any(), any()))
         .thenReturn(List.of(JOB_1, JOB_2));
     mvc.perform(get(ENUMERATE_JOBS_ENDPOINT).queryParam("className", FLIGHT_CLASS))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.length()").value(2));
     verify(jobService, times(1))
-        .enumerateJobs(eq(0), eq(10), any(), eq(SqlSortDirection.DESC), eq(FLIGHT_CLASS));
+        .enumerateJobs(eq(0), eq(10), any(), eq(SqlSortDirection.DESC), eq(FLIGHT_CLASS), any());
   }
 
   @Test

--- a/src/test/java/bio/terra/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/service/job/JobServiceTest.java
@@ -24,6 +24,7 @@ import bio.terra.stairway.Flight;
 import bio.terra.stairway.exception.StairwayException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -231,8 +232,8 @@ public class JobServiceTest {
             getJobMatcher(accessibleJobs.get(0))));
 
     // Filter by jobIds
-    List<String> jobIds =
-        List.of(privateJobIds.get(0), accessibleJobs.get(0).getId(), accessibleJobs.get(2).getId());
+    Set<String> jobIds =
+        Set.of(privateJobIds.get(0), accessibleJobs.get(0).getId(), accessibleJobs.get(2).getId());
     assertThat(
         "filter by jobIds only returns accessible jobs",
         jobService.enumerateJobs(


### PR DESCRIPTION
Allow users to provide a list of jobIds to filter the enumerate jobs endpoint results. If a user provides a job id they do not have permission to view, it will be excluded.