### PR TITLE
[DR-2762] Remove token from logging statement when sync call fails.

### DIFF
--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -116,9 +116,7 @@ public class BardClient {
       }
     } catch (Exception e) {
       logger.warn(
-          "Unable to sync profile for user {} because {}",
-          userReq.getEmail(),
-          e.getMessage());
+          "Unable to sync profile for user {} because {}", userReq.getEmail(), e.getMessage());
     }
     return result;
   }

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -116,9 +116,8 @@ public class BardClient {
       }
     } catch (Exception e) {
       logger.warn(
-          "Unable to sync profile for user {} token {} because {}",
+          "Unable to sync profile for user {} because {}",
           userReq.getEmail(),
-          userReq.getToken(),
           e.getMessage());
     }
     return result;


### PR DESCRIPTION
[DR-2740](https://broadworkbench.atlassian.net/browse/DR-2740) included logging the token when syncProfile requests to Bard failed.  This PR removes the token from the log statement.