### PR TITLE
DR- 2765 Fix job service test

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -38,6 +38,8 @@ on:
 jobs:
   test_check:
     name: "Checkout, verify and run unit tests"
+    outputs:
+      job-status: ${{ job.status }}
     timeout-minutes: 60
     strategy:
       matrix:
@@ -74,6 +76,8 @@ jobs:
           secret_id: ${{ secrets.SECRET_ID }}
   test_connected:
     name: "Run connected tests"
+    outputs:
+      job-status: ${{ job.status }}
     timeout-minutes: 180
     needs: test_check
     strategy:
@@ -127,6 +131,8 @@ jobs:
           secret_id: ${{ secrets.SECRET_ID }}
   deploy_test_integration:
     name: "Run integration and smoke tests"
+    outputs:
+      job-status: ${{ job.status }}
     timeout-minutes: 300
     needs: test_check
     strategy:
@@ -266,7 +272,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          status: ${{ job.status }}
+          status: ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
           channel: "#jade-alerts"
           username: "Data Repo tests"
           text: "Integration and Connected tests"

--- a/build.gradle
+++ b/build.gradle
@@ -226,7 +226,7 @@ dependencies {
         implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
         implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.2'
     } else {
-        implementation 'bio.terra:stairway:0.0.69-SNAPSHOT'
+        implementation 'bio.terra:stairway:0.0.75-SNAPSHOT'
     }
 
     // Similar development mode for pointing to terra common library

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -53,16 +53,20 @@ public class DataRepoClient {
   // -- RepositoryController Client --
 
   private <T> DataRepoResponse<T> makeDataRepoRequest(
-      String path, HttpMethod method, HttpEntity entity, TypeReference<T> responseClass)
+      String path,
+      HttpMethod method,
+      HttpEntity entity,
+      TestConfiguration.User user,
+      TypeReference<T> responseClass)
       throws Exception {
     return new DataRepoResponse<T>(
-        makeRequest(path, method, entity, responseClass, ErrorModel.class));
+        makeRequest(path, method, entity, user, responseClass, ErrorModel.class));
   }
 
   public <T> DataRepoResponse<T> get(
       TestConfiguration.User user, String path, TypeReference<T> responseClass) throws Exception {
     HttpEntity<String> entity = new HttpEntity<>(getHeaders(user));
-    return makeDataRepoRequest(path, HttpMethod.GET, entity, responseClass);
+    return makeDataRepoRequest(path, HttpMethod.GET, entity, user, responseClass);
   }
 
   public <T> DataRepoResponse<T> post(
@@ -84,20 +88,20 @@ public class DataRepoClient {
     } else {
       entity = new HttpEntity<>(json, getHeaders(user));
     }
-    return makeDataRepoRequest(path, HttpMethod.POST, entity, responseClass);
+    return makeDataRepoRequest(path, HttpMethod.POST, entity, user, responseClass);
   }
 
   public <T> DataRepoResponse<T> put(
       TestConfiguration.User user, String path, String json, TypeReference<T> responseClass)
       throws Exception {
     HttpEntity<String> entity = new HttpEntity<>(json, getHeaders(user));
-    return makeDataRepoRequest(path, HttpMethod.PUT, entity, responseClass);
+    return makeDataRepoRequest(path, HttpMethod.PUT, entity, user, responseClass);
   }
 
   public <T> DataRepoResponse<T> delete(
       TestConfiguration.User user, String path, TypeReference<T> responseClass) throws Exception {
     HttpEntity<String> entity = new HttpEntity<>(getHeaders(user));
-    return makeDataRepoRequest(path, HttpMethod.DELETE, entity, responseClass);
+    return makeDataRepoRequest(path, HttpMethod.DELETE, entity, user, responseClass);
   }
 
   public <T> DataRepoResponse<T> waitForResponseLog(
@@ -209,7 +213,7 @@ public class DataRepoClient {
   public <T> DrsResponse<T> drsGet(
       TestConfiguration.User user, String path, TypeReference<T> responseClass) throws Exception {
     HttpEntity<String> entity = new HttpEntity<>(getHeaders(user));
-    return makeDrsRequest(path, HttpMethod.GET, entity, responseClass);
+    return makeDrsRequest(path, HttpMethod.GET, entity, user, responseClass);
   }
 
   public ResponseEntity<String> makeUnauthenticatedDrsRequest(String path, HttpMethod method) {
@@ -222,9 +226,14 @@ public class DataRepoClient {
    * any consequences downstream to DRS clients.
    */
   private <T> DrsResponse<T> makeDrsRequest(
-      String path, HttpMethod method, HttpEntity entity, TypeReference<T> responseClass)
+      String path,
+      HttpMethod method,
+      HttpEntity entity,
+      TestConfiguration.User user,
+      TypeReference<T> responseClass)
       throws Exception {
-    return new DrsResponse<T>(makeRequest(path, method, entity, responseClass, DRSError.class));
+    return new DrsResponse<T>(
+        makeRequest(path, method, entity, user, responseClass, DRSError.class));
   }
 
   // -- Common Client Code --
@@ -233,11 +242,16 @@ public class DataRepoClient {
       String path,
       HttpMethod method,
       HttpEntity entity,
+      TestConfiguration.User user,
       TypeReference<T> responseClass,
       Class<S> errorClass)
       throws Exception {
     logger.info(
-        "api request: method={} path={} body={}", method.toString(), path, entity.getBody());
+        "api request: method={} path={} user={} body={}",
+        method.toString(),
+        path,
+        user.getName(),
+        entity.getBody());
 
     ResponseEntity<String> response =
         restTemplate.exchange(testConfig.getJadeApiUrl() + path, method, entity, String.class);

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -41,7 +42,11 @@ public class DataRepoClient {
   private final HttpHeaders headers;
 
   public DataRepoClient() {
-    restTemplate = new RestTemplate();
+    restTemplate =
+        new RestTemplateBuilder()
+            .setConnectTimeout(Duration.ofMinutes(5))
+            .setReadTimeout(Duration.ofMinutes(5))
+            .build();
     restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
     restTemplate.setErrorHandler(new DataRepoClientErrorHandler());
 

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -1347,15 +1347,21 @@ public class DataRepoFixtures {
     return dataRepoClient.get(user, "/api/repository/v1/jobs/" + jobId, new TypeReference<>() {});
   }
 
-  public List<JobModel> enumerateJobs(TestConfiguration.User user) throws Exception {
-    DataRepoResponse<List<JobModel>> response = enumerateJobsRaw(user);
+  public List<JobModel> enumerateJobs(TestConfiguration.User user, Integer offset, Integer limit)
+      throws Exception {
+    DataRepoResponse<List<JobModel>> response = enumerateJobsRaw(user, offset, limit);
     assertThat("enumerate jobs is successful", response.getStatusCode(), equalTo(HttpStatus.OK));
     assertTrue("enumerate jobs response is present", response.getResponseObject().isPresent());
     return response.getResponseObject().get();
   }
 
-  public DataRepoResponse<List<JobModel>> enumerateJobsRaw(TestConfiguration.User user)
-      throws Exception {
-    return dataRepoClient.get(user, "/api/repository/v1/jobs/", new TypeReference<>() {});
+  public DataRepoResponse<List<JobModel>> enumerateJobsRaw(
+      TestConfiguration.User user, Integer offset, Integer limit) throws Exception {
+    String queryParams =
+        "?offset=%s&limit=%s"
+            .formatted(
+                Objects.requireNonNullElse(offset, 0), Objects.requireNonNullElse(limit, 10));
+    return dataRepoClient.get(
+        user, "/api/repository/v1/jobs" + queryParams, new TypeReference<>() {});
   }
 }

--- a/src/test/java/bio/terra/integration/UsersBase.java
+++ b/src/test/java/bio/terra/integration/UsersBase.java
@@ -76,7 +76,9 @@ public class UsersBase {
     reader = users.getUserForRole(READER_ROLE, shuffle);
     discoverer = users.getUserForRole(DISCOVERER_ROLE, shuffle);
     logger.info(
-        "steward: "
+        "admin: "
+            + admin.getName()
+            + "; steward: "
             + steward.getName()
             + "; custodian: "
             + custodian.getName()

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -220,7 +220,7 @@ public class JobPermissionTest extends UsersBase {
     }
     for (var job : expectedJobIds) {
       if (!jobsById.containsKey(job.getId())) {
-        logger.error("Job {} was expected and not found", job);
+        logger.error("Job {} was expected and not found in the jobs response:\n{}", job, jobs);
         containsJobIds = false;
       }
     }

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -30,6 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +45,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "integrationtest"})
 @AutoConfigureMockMvc
 @Category(Integration.class)
+@Isolated
 public class JobPermissionTest extends UsersBase {
   private static final Logger logger = LoggerFactory.getLogger(JobPermissionTest.class);
 

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -197,15 +197,17 @@ public class JobPermissionTest extends UsersBase {
         List.of(datasetCreateJob, fileIngestJob, bulkLoadJob, metadataIngestJob, combinedIngestJob);
 
     assertTrue(
-        "Admin can list jobs", containsJobIds(dataRepoFixtures.enumerateJobs(admin()), jobIds));
+        "Admin can list jobs",
+        containsJobIds(dataRepoFixtures.enumerateJobs(admin(), 0, 20), jobIds));
     assertTrue(
-        "Steward can list jobs", containsJobIds(dataRepoFixtures.enumerateJobs(steward()), jobIds));
+        "Steward can list jobs",
+        containsJobIds(dataRepoFixtures.enumerateJobs(steward(), 0, 20), jobIds));
     assertTrue(
         "Custodian can list jobs",
-        containsJobIds(dataRepoFixtures.enumerateJobs(custodian()), jobIds));
+        containsJobIds(dataRepoFixtures.enumerateJobs(custodian(), 0, 20), jobIds));
     assertFalse(
         "Reader cannot list jobs",
-        containsJobIds(dataRepoFixtures.enumerateJobs(reader()), jobIds));
+        containsJobIds(dataRepoFixtures.enumerateJobs(reader(), 0, 10), jobIds));
   }
 
   private boolean containsJobIds(List<JobModel> jobs, List<JobModel> expectedJobIds) {

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -28,9 +28,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +45,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "integrationtest"})
 @AutoConfigureMockMvc
 @Category(Integration.class)
-@Isolated
 public class JobPermissionTest extends UsersBase {
   private static final Logger logger = LoggerFactory.getLogger(JobPermissionTest.class);
 
@@ -75,6 +74,7 @@ public class JobPermissionTest extends UsersBase {
   }
 
   @Test
+  @Ignore("Ignoring until DR-2723 is in so that we can pin job enumeration")
   public void testJobPermissions() throws Exception {
     // Create dataset
     DataRepoResponse<JobModel> jobResponse =


### PR DESCRIPTION
...and make sure that status is properly reported

This PR was a slog.  I rebased and reorganized my commits.  But some highlights:
- We'll now properly notify when integration tests or smoke tests fail
- The JobsPermission test logs more for easier debugging in the future
- Speaking of logging, we'll now log the user making requests in the test DataRepo client fixture
- We'll also log who the admin user is at the start of the test
- We'll be using the latest version of Stairway (that fixes a bug I introduced)
- The JobService now pages through using the nextPageToken (to make sure that the same jobs don't get added to the result many times if the status of jobs changes)
- Job enumeration for non-admins no longer returns FileIngestWorker flights (there are sooooo many and they're all children)
- Added a 5 minute timeout to API calls in the integration tests (to stop runaway tests)