### PR TITLE
[DR-2764] Policy members can be added on snapshot creation

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -5,6 +5,7 @@ import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SamPolicyModel;
+import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.model.UserStatusInfo;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import java.util.List;
@@ -122,11 +123,11 @@ public interface IamProviderInterface {
    *
    * @param userReq authenticated user
    * @param snapshotId id of the snapshot
-   * @param readersList list of emails of users to add as readers of the snapshot
-   * @return Policy group email for the snapshot reader policy
+   * @param policies user emails to add as snapshot policy members
+   * @return Map of policy group emails for the snapshot policies
    */
   Map<IamRole, String> createSnapshotResource(
-      AuthenticatedUserRequest userReq, UUID snapshotId, List<String> readersList)
+      AuthenticatedUserRequest userReq, UUID snapshotId, SnapshotRequestModelPolicies policies)
       throws InterruptedException;
 
   // -- billing profile resource support --

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -261,6 +261,8 @@ public class IamService {
     SnapshotRequestModelPolicies policies =
         Optional.ofNullable(request.getPolicies()).orElseGet(SnapshotRequestModelPolicies::new);
 
+    // While duplicate readers are possible in this combination, we do not need to deduplicate:
+    // SAM handles duplicate policy members without issue.
     List<String> combinedReaders = new ArrayList<>();
     combinedReaders.addAll(ListUtils.emptyIfNull(policies.getReaders()));
     combinedReaders.addAll(ListUtils.emptyIfNull(request.getReaders()));

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -6,6 +6,8 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.DatasetRequestModelPolicies;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.SamPolicyModel;
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.model.UserStatusInfo;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
@@ -16,14 +18,17 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatus;
 import org.slf4j.Logger;
@@ -240,12 +245,27 @@ public class IamService {
    *
    * @param userReq authenticated user
    * @param snapshotId id of the snapshot
-   * @param readersList list of emails of users to add as readers of the snapshot
-   * @return Policy group map
+   * @param policies user emails to add as snapshot policy members
+   * @return Map of policy group emails for the snapshot policies
    */
   public Map<IamRole, String> createSnapshotResource(
-      AuthenticatedUserRequest userReq, UUID snapshotId, List<String> readersList) {
-    return callProvider(() -> iamProvider.createSnapshotResource(userReq, snapshotId, readersList));
+      AuthenticatedUserRequest userReq, UUID snapshotId, SnapshotRequestModelPolicies policies) {
+    return callProvider(() -> iamProvider.createSnapshotResource(userReq, snapshotId, policies));
+  }
+
+  /**
+   * @param request snapshot creation request
+   * @return user-defined snapshot policy object, supplemented with readers from deprecated input
+   */
+  public SnapshotRequestModelPolicies deriveSnapshotPolicies(SnapshotRequestModel request) {
+    SnapshotRequestModelPolicies policies =
+        Optional.ofNullable(request.getPolicies()).orElseGet(SnapshotRequestModelPolicies::new);
+
+    List<String> combinedReaders = new ArrayList<>();
+    combinedReaders.addAll(ListUtils.emptyIfNull(policies.getReaders()));
+    combinedReaders.addAll(ListUtils.emptyIfNull(request.getReaders()));
+
+    return policies.readers(combinedReaders);
   }
 
   // -- billing profile resource support --

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
@@ -39,10 +39,9 @@ public class SnapshotAuthzIamStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
     UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-
-    // This returns the policy email created by Google to correspond to the readers list in SAM
     Map<IamRole, String> policies =
-        sam.createSnapshotResource(userReq, snapshotId, snapshotRequestModel.getReaders());
+        sam.createSnapshotResource(
+            userReq, snapshotId, sam.deriveSnapshotPolicies(snapshotRequestModel));
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policies);
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4278,6 +4278,10 @@ components:
           items:
             $ref: '#/components/schemas/SnapshotRequestContentsModel'
         readers:
+          description: >
+            Deprecated -- use `policies.readers` instead. Any readers specified here will supplement
+            those set in `policies.readers`.
+          deprecated: true
           type: array
           items:
             type: string
@@ -4286,6 +4290,22 @@ components:
         properties:
           type: object
           description: Additional JSON metadata about the snapshot (this does not need to adhere to a particular schema)
+        policies:
+          description: User emails to add as snapshot policy members.
+          type: object
+          properties:
+            stewards:
+              type: array
+              items:
+                type: string
+            readers:
+              type: array
+              items:
+                type: string
+            discoverers:
+              type: array
+              items:
+                type: string
       description: >
         Request for creating a snapshot.
         For now, the API only supports snapshots defined as a single dataset asset and

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -484,6 +484,13 @@ public class DataRepoFixtures {
     return validateResponse(response, "retrieving dataset policies", HttpStatus.OK, null);
   }
 
+  public PolicyResponse retrieveSnapshotPolicies(TestConfiguration.User user, UUID snapshotId)
+      throws Exception {
+    DataRepoResponse<PolicyResponse> response =
+        retrievePoliciesRaw(user, snapshotId, IamResourceType.DATASNAPSHOT);
+    return validateResponse(response, "retrieving snapshot policies", HttpStatus.OK, null);
+  }
+
   // adding dataset asset
   public DataRepoResponse<JobModel> addDatasetAssetRaw(
       TestConfiguration.User user, UUID datasetId, AssetModel assetModel) throws Exception {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2764

**Objective**

When creating a snapshot, policy members can optionally be added as part of the snapshot creation request:

```
    "policies": {
      "stewards": ["steward@gmail.com"],
      "readers": ["reader1@gmail.com", "reader2@gmail.com"],
      "discoverers": ["discoverers@gmail.com"]
    }
```

The existing `readers` input has been marked as deprecated, but if specified its contents will supplement `policies.readers`.

Individual policy members can still be added / deleted following snapshot creation, but this provides another option for use cases where more than one identity manages the snapshot.

**Changes**

- In `SamIam`, refactored `createSnapshotResourceRequest` out of `createSnapshotResourceInnerV2` to include user-specified stewards, readers, and/or discoverers in the resource's access policies.
- Added unit tests to validate construction of SAM resource requests.
- Expanded test fixtures, added integration test to validate snapshot policy fetch from SAM following snapshot construction.

**Demonstration**

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/createSnapshot) is up-to-date with these changes.

I created this [snapshot](https://jade-ok.datarepo-dev.broadinstitute.org/datasets/89b0d499-3872-40b1-99c0-170d509ae725) with no `readers` or `policies` set on creation. I verified that the default policy members match expectations:

<img width="1773" alt="Screen Shot 2022-10-03 at 11 29 25 AM" src="https://user-images.githubusercontent.com/79769153/193616940-225bca51-d2a3-4d9b-a14f-391993881f6b.png">

I created this [snapshot](https://jade-ok.datarepo-dev.broadinstitute.org/datasets/fea5f1c4-5179-4373-a7cb-afa887187a38) with `readers` and `policies` set on creation.  I verified that `readers` were integrated into `policies` for the resulting snapshot, while other default policy members were honored:
<img width="1763" alt="Screen Shot 2022-10-03 at 11 29 34 AM" src="https://user-images.githubusercontent.com/79769153/193616857-6ec91e0f-d0cb-40f1-a3e4-7bfd76ba23c9.png">



**Future Opportunities**
When expanding integration tests I investigated optimization opportunities if we moved select set-up / tear-down operations to happen once per class rather than once per test run.  Any further pursuit should be ticketed separately, as I think we'll need to upgrade to JUnit 5 (looks to require refactoring).  More detailed benchmarking and findings in Slack:
https://broadinstitute.slack.com/archives/C01VBGH431S/p1664547470796279