### PR TITLE
[DR-2758] Document that a snapshot has exactly one source dataset

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4480,6 +4480,8 @@ components:
           $ref: '#/components/schemas/ConsentCode'
         source:
           type: array
+          description: >
+            A singleton collection whose sole element represents the snapshot's source dataset.
           items:
             $ref: '#/components/schemas/SnapshotSourceModel'
         tables:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2758

A `SnapshotModel` returned when [fetching a snapshot](https://data.terra.bio/swagger-ui.html#/snapshots/retrieveSnapshot) includes a list of source datasets as a field, which implies that one snapshot could be created from many datasets.

This structure was likely an attempt at future-proofing, but we've since determined that we will not build out support for multi-dataset snapshots.  This caused some [confusion](https://broadinstitute.slack.com/archives/C01VBGH431S/p1663181064841479?thread_ts=1663176497.494189&cid=C01VBGH431S) for Data Explorer team, who wanted to resolve a snapshot deterministically to its PHS ID, which is set at the dataset level (CC: @s-rubenstein).

This one-line Swagger documentation change clarifies expectations for the caller.

![A38F5B28-9E9A-43D6-84D1-978FEAA2B280_1_201_a](https://user-images.githubusercontent.com/79769153/193652550-4139d44a-a924-4ca0-8310-6c3189346d58.jpeg)
