### PR TITLE
[DR-2750] Support longer dataset and snapshot descriptions.

### DIFF
--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -10,6 +10,9 @@
 
     <property name="identifier_type" value="varchar(63)"/>
     <property name="description_type" value="varchar(2047)"/>
+    <property name="long_description_type" value="text" dbms="postgresql"/>
+    <property name="long_description_type" value="clob" dbms="oracle"/>
+    <property name="long_description_type" value="varchar(max)" dbms="mssql"/>
     <property name="dataset_snapshot_identifier_type" value="varchar(511)"/>
 
     <include file="changesets/20181203_datasettable.yaml" relativeToChangelogFile="true"/>
@@ -58,4 +61,5 @@
     <include file="changesets/20220526_datasetproperties.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220615_snapshotproperties.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220617_addprojectsa.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/2022104_description_to_text.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/2022104_description_to_text.yaml
+++ b/src/main/resources/db/changesets/2022104_description_to_text.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: allowlongdescriptions
+      author: otchet
+      changes:
+        - modifyDataType:
+            tableName: dataset
+            columnName: description
+            newDataType: ${long_description_type}
+        - modifyDataType:
+            tableName: snapshot
+            columnName: description
+            newDataType: ${long_description_type}


### PR DESCRIPTION
As part of the work for [DR-2750](https://broadworkbench.atlassian.net/browse/DR-2750), the underlying database fields for dataset and snapshot descriptions should accommodate longer descriptions.  This PR includes the liquibase change set needed to process the database schema changes.