### PR TITLE
[DR-2784] Add initial Firecloud group support for DUOS integration

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -230,4 +230,10 @@ public interface IamProviderInterface {
    * @param groupName name of Firecloud managed group to create
    */
   void createGroup(String accessToken, String groupName) throws InterruptedException;
+
+  /**
+   * @param accessToken valid oauth token for the account creating the group
+   * @param groupName name of Firecloud managed group to delete
+   */
+  void deleteGroup(String accessToken, String groupName) throws InterruptedException;
 }

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -217,4 +217,17 @@ public interface IamProviderInterface {
    *     statuses
    */
   RepositoryStatusModelSystems samStatus();
+
+  /**
+   * @param accessToken valid oauth token for the account fetching the group email
+   * @param groupName name of Firecloud managed group
+   * @return the group's email address
+   */
+  String getGroupEmail(String accessToken, String groupName) throws InterruptedException;
+
+  /**
+   * @param accessToken valid oauth token for the account creating the group
+   * @param groupName name of Firecloud managed group to create
+   */
+  void createGroup(String accessToken, String groupName) throws InterruptedException;
 }

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -219,17 +219,11 @@ public interface IamProviderInterface {
   RepositoryStatusModelSystems samStatus();
 
   /**
-   * @param accessToken valid oauth token for the account fetching the group email
-   * @param groupName name of Firecloud managed group
-   * @return the group's email address
-   */
-  String getGroupEmail(String accessToken, String groupName) throws InterruptedException;
-
-  /**
    * @param accessToken valid oauth token for the account creating the group
    * @param groupName name of Firecloud managed group to create
+   * @return the new group's email address
    */
-  void createGroup(String accessToken, String groupName) throws InterruptedException;
+  String createGroup(String accessToken, String groupName) throws InterruptedException;
 
   /**
    * @param accessToken valid oauth token for the account creating the group

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -364,6 +364,11 @@ public class IamService {
     callProvider(() -> iamProvider.createGroup(getAccessToken(tdrSaCreds), groupName));
   }
 
+  public void deleteGroup(String groupName) {
+    GoogleCredentials tdrSaCreds = getGoogleCredentialsApplicationDefault();
+    callProvider(() -> iamProvider.deleteGroup(getAccessToken(tdrSaCreds), groupName));
+  }
+
   // -- credential utilities --
   private GoogleCredentials getGoogleCredentialsApplicationDefault() {
     try {

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -354,16 +354,19 @@ public class IamService {
   }
 
   // -- managed group support --
-  public String getGroupEmail(String groupName) {
+
+  /**
+   * @param groupName Firecloud managed group to create as the TDR SA
+   * @return the email for the newly created group
+   */
+  public String createGroup(String groupName) {
     GoogleCredentials tdrSaCreds = getGoogleCredentialsApplicationDefault();
-    return callProvider(() -> iamProvider.getGroupEmail(getAccessToken(tdrSaCreds), groupName));
+    return callProvider(() -> iamProvider.createGroup(getAccessToken(tdrSaCreds), groupName));
   }
 
-  public void createGroup(String groupName) {
-    GoogleCredentials tdrSaCreds = getGoogleCredentialsApplicationDefault();
-    callProvider(() -> iamProvider.createGroup(getAccessToken(tdrSaCreds), groupName));
-  }
-
+  /**
+   * @param groupName Firecloud managed group to delete as the TDR SA
+   */
   public void deleteGroup(String groupName) {
     GoogleCredentials tdrSaCreds = getGoogleCredentialsApplicationDefault();
     callProvider(() -> iamProvider.deleteGroup(getAccessToken(tdrSaCreds), groupName));

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -642,6 +642,15 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
+  public void deleteGroup(String accessToken, String groupName) throws InterruptedException {
+    SamRetry.retry(configurationService, () -> deleteGroupInner(accessToken, groupName));
+  }
+
+  private void deleteGroupInner(String accessToken, String groupName) throws ApiException {
+    samGroupApi(accessToken).deleteGroup(groupName);
+  }
+
+  @Override
   public String getPetToken(AuthenticatedUserRequest userReq, List<String> scopes)
       throws InterruptedException {
     return SamRetry.retry(configurationService, () -> getPetTokenInner(userReq, scopes));

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -624,21 +624,17 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
-  public String getGroupEmail(String accessToken, String groupName) throws InterruptedException {
-    return SamRetry.retry(configurationService, () -> getGroupEmailInner(accessToken, groupName));
-  }
-
-  private String getGroupEmailInner(String accessToken, String groupName) throws ApiException {
-    return samGroupApi(accessToken).getGroup(groupName);
-  }
-
-  @Override
-  public void createGroup(String accessToken, String groupName) throws InterruptedException {
+  public String createGroup(String accessToken, String groupName) throws InterruptedException {
     SamRetry.retry(configurationService, () -> createGroupInner(accessToken, groupName));
+    return SamRetry.retry(configurationService, () -> getGroupEmail(accessToken, groupName));
   }
 
   private void createGroupInner(String accessToken, String groupName) throws ApiException {
     samGroupApi(accessToken).postGroup(groupName);
+  }
+
+  private String getGroupEmail(String accessToken, String groupName) throws ApiException {
+    return samGroupApi(accessToken).getGroup(groupName);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.GroupApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.TermsOfServiceApi;
@@ -119,6 +120,11 @@ public class SamIam implements IamProviderInterface {
   @VisibleForTesting
   TermsOfServiceApi samTosApi(String accessToken) {
     return new TermsOfServiceApi(getApiClient(accessToken));
+  }
+
+  @VisibleForTesting
+  GroupApi samGroupApi(String accessToken) {
+    return new GroupApi(getApiClient(accessToken));
   }
 
   /**
@@ -615,6 +621,24 @@ public class SamIam implements IamProviderInterface {
     logger.info("Accepting terms of service for the ingest service account in Terra");
     return SamRetry.retry(
         configurationService, () -> samTosApi(accessToken).acceptTermsOfService(TOS_URL));
+  }
+
+  @Override
+  public String getGroupEmail(String accessToken, String groupName) throws InterruptedException {
+    return SamRetry.retry(configurationService, () -> getGroupEmailInner(accessToken, groupName));
+  }
+
+  private String getGroupEmailInner(String accessToken, String groupName) throws ApiException {
+    return samGroupApi(accessToken).getGroup(groupName);
+  }
+
+  @Override
+  public void createGroup(String accessToken, String groupName) throws InterruptedException {
+    SamRetry.retry(configurationService, () -> createGroupInner(accessToken, groupName));
+  }
+
+  private void createGroupInner(String accessToken, String groupName) throws ApiException {
+    samGroupApi(accessToken).postGroup(groupName);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/duos/DuosDao.java
+++ b/src/main/java/bio/terra/service/duos/DuosDao.java
@@ -39,13 +39,13 @@ public class DuosDao {
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public boolean insertFirecloudGroup(
+  public DuosFirecloudGroupModel insertAndRetrieveFirecloudGroup(
       String duosId, String firecloudGroupName, String firecloudGroupEmail) {
     String sql =
         """
         INSERT INTO duos_firecloud_group
-        (duos_id, firecloud_group_name, firecloud_group_email, created_by) VALUES
-        (:duos_id, :firecloud_group_name, :firecloud_group_email, :created_by)
+        (duos_id, firecloud_group_name, firecloud_group_email, created_by)
+        VALUES (:duos_id, :firecloud_group_name, :firecloud_group_email, :created_by)
         """;
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -53,13 +53,9 @@ public class DuosDao {
             .addValue("firecloud_group_name", firecloudGroupName)
             .addValue("firecloud_group_email", firecloudGroupEmail)
             .addValue("created_by", tdrServiceAccountEmail);
-    int rowsAffected = jdbcTemplate.update(sql, params);
-    boolean insertSucceeded = (rowsAffected == 1);
-
-    if (insertSucceeded) {
-      logger.info("Inserted {} -> {} into duos_firecloud_group", duosId, firecloudGroupName);
-    }
-    return insertSucceeded;
+    jdbcTemplate.update(sql, params);
+    logger.info("Inserted {} -> {} into duos_firecloud_group", duosId, firecloudGroupName);
+    return retrieveFirecloudGroup(duosId);
   }
 
   @Transactional(

--- a/src/main/java/bio/terra/service/duos/DuosDao.java
+++ b/src/main/java/bio/terra/service/duos/DuosDao.java
@@ -68,7 +68,13 @@ public class DuosDao {
       readOnly = true)
   public DuosFirecloudGroupModel retrieveFirecloudGroup(String duosId) {
     try {
-      String sql = "SELECT * FROM duos_firecloud_group WHERE duos_id = :duos_id";
+      String sql =
+          """
+          SELECT duos_id, firecloud_group_name, firecloud_group_email, created_by, created_date,
+            last_synced_date
+          FROM duos_firecloud_group
+          WHERE duos_id = :duos_id
+          """;
       MapSqlParameterSource params = new MapSqlParameterSource().addValue("duos_id", duosId);
       return jdbcTemplate.queryForObject(sql, params, new DuosFirecloudGroupMapper());
     } catch (EmptyResultDataAccessException ex) {

--- a/src/main/java/bio/terra/service/duos/DuosDao.java
+++ b/src/main/java/bio/terra/service/duos/DuosDao.java
@@ -1,0 +1,98 @@
+package bio.terra.service.duos;
+
+import bio.terra.model.DuosFirecloudGroupModel;
+import com.google.common.annotations.VisibleForTesting;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class DuosDao {
+  private static final Logger logger = LoggerFactory.getLogger(DuosDao.class);
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final String tdrServiceAccountEmail;
+
+  @Autowired
+  public DuosDao(
+      NamedParameterJdbcTemplate jdbcTemplate,
+      @Qualifier("tdrServiceAccountEmail") String tdrServiceAccountEmail) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.tdrServiceAccountEmail = tdrServiceAccountEmail;
+  }
+
+  @VisibleForTesting
+  String getTdrServiceAccountEmail() {
+    return tdrServiceAccountEmail;
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public boolean insertFirecloudGroup(
+      String duosId, String firecloudGroupName, String firecloudGroupEmail) {
+    String sql =
+        """
+        INSERT INTO duos_firecloud_group
+        (duos_id, firecloud_group_name, firecloud_group_email, created_by) VALUES
+        (:duos_id, :firecloud_group_name, :firecloud_group_email, :created_by)
+        """;
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("duos_id", duosId)
+            .addValue("firecloud_group_name", firecloudGroupName)
+            .addValue("firecloud_group_email", firecloudGroupEmail)
+            .addValue("created_by", tdrServiceAccountEmail);
+    int rowsAffected = jdbcTemplate.update(sql, params);
+    boolean insertSucceeded = (rowsAffected == 1);
+
+    if (insertSucceeded) {
+      logger.info("Inserted {} -> {} into duos_firecloud_group", duosId, firecloudGroupName);
+    }
+    return insertSucceeded;
+  }
+
+  @Transactional(
+      propagation = Propagation.REQUIRED,
+      isolation = Isolation.SERIALIZABLE,
+      readOnly = true)
+  public DuosFirecloudGroupModel retrieveFirecloudGroup(String duosId) {
+    try {
+      String sql = "SELECT * FROM duos_firecloud_group WHERE duos_id = :duos_id";
+      MapSqlParameterSource params = new MapSqlParameterSource().addValue("duos_id", duosId);
+      return jdbcTemplate.queryForObject(sql, params, new DuosFirecloudGroupMapper());
+    } catch (EmptyResultDataAccessException ex) {
+      return null;
+    }
+  }
+
+  private static class DuosFirecloudGroupMapper implements RowMapper<DuosFirecloudGroupModel> {
+    public DuosFirecloudGroupModel mapRow(ResultSet rs, int rowNum) throws SQLException {
+      return new DuosFirecloudGroupModel()
+          .duosId(rs.getString("duos_id"))
+          .firecloudGroupName(rs.getString("firecloud_group_name"))
+          .firecloudGroupEmail(rs.getString("firecloud_group_email"))
+          .createdBy(rs.getString("created_by"))
+          .created(getInstantString(rs, "created_date"))
+          .lastSynced(getInstantString(rs, "last_synced_date"));
+    }
+
+    private String getInstantString(ResultSet rs, String columnLabel) throws SQLException {
+      Timestamp timestamp = rs.getTimestamp(columnLabel);
+      if (timestamp != null) {
+        return timestamp.toInstant().toString();
+      }
+      return null;
+    }
+  }
+}

--- a/src/main/java/bio/terra/service/duos/DuosService.java
+++ b/src/main/java/bio/terra/service/duos/DuosService.java
@@ -50,13 +50,13 @@ public class DuosService {
     // teardown of resources created earlier, rather than having to
     // introduce a fallback behavior flow.
     // https://broadworkbench.atlassian.net/browse/DR-2787
-    boolean inserted = duosDao.insertFirecloudGroup(duosId, groupName, groupEmail);
-    if (!inserted) {
+    try {
+      return duosDao.insertAndRetrieveFirecloudGroup(duosId, groupName, groupEmail);
+    } catch (Exception ex) {
       iamService.deleteGroup(groupName);
       throw new DuosFirecloudGroupInsertException(
           "Firecloud group " + groupName + " was not inserted into the DB and has been deleted");
     }
-    return duosDao.retrieveFirecloudGroup(duosId);
   }
 
   public DuosFirecloudGroupModel retrieveOrCreateFirecloudGroup(String duosId) {

--- a/src/main/java/bio/terra/service/duos/DuosService.java
+++ b/src/main/java/bio/terra/service/duos/DuosService.java
@@ -1,0 +1,76 @@
+package bio.terra.service.duos;
+
+import bio.terra.model.DuosFirecloudGroupModel;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.auth.iam.exception.IamConflictException;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DuosService {
+  private static final Logger logger = LoggerFactory.getLogger(DuosService.class);
+
+  private final DuosDao duosDao;
+  private final IamService iamService;
+
+  @Autowired
+  public DuosService(DuosDao duosDao, IamService iamService) {
+    this.duosDao = duosDao;
+    this.iamService = iamService;
+  }
+
+  public Optional<DuosFirecloudGroupModel> retrieveFirecloudGroup(String duosId) {
+    return Optional.ofNullable(duosDao.retrieveFirecloudGroup(duosId));
+  }
+
+  public DuosFirecloudGroupModel createFirecloudGroup(String duosId) {
+    logger.info("Creating Firecloud group for {} users", duosId);
+
+    // First try with the more readable group name.
+    String groupName = constructFirecloudGroupName(duosId);
+    try {
+      iamService.createGroup(groupName);
+    } catch (IamConflictException ex) {
+      logger.warn(
+          "Firecloud group {} already exists: trying creation with a unique name", groupName);
+      groupName = constructUniqueFirecloudGroupName(duosId);
+      iamService.createGroup(groupName);
+    }
+    String groupEmail = iamService.getGroupEmail(groupName);
+    logger.info("Successfully created Firecloud group {} for {} users", groupName, duosId);
+
+    boolean inserted = duosDao.insertFirecloudGroup(duosId, groupName, groupEmail);
+    if (!inserted) {
+      iamService.deleteGroup(groupName);
+      throw new RuntimeException(
+          "Firecloud group " + groupName + " was not inserted into the DB and has been deleted");
+    }
+
+    return duosDao.retrieveFirecloudGroup(duosId);
+  }
+
+  public DuosFirecloudGroupModel retrieveOrCreateFirecloudGroup(String duosId) {
+    Optional<DuosFirecloudGroupModel> maybeGroup = retrieveFirecloudGroup(duosId);
+    if (maybeGroup.isEmpty()) {
+      return createFirecloudGroup(duosId);
+    } else {
+      logger.info("Firecloud group exists for {}, retrieving.", duosId);
+      return maybeGroup.get();
+    }
+  }
+
+  @VisibleForTesting
+  String constructFirecloudGroupName(String duosId) {
+    return String.format("%s-users", duosId);
+  }
+
+  @VisibleForTesting
+  String constructUniqueFirecloudGroupName(String duosId) {
+    return String.format("%s-%s", constructFirecloudGroupName(duosId), UUID.randomUUID());
+  }
+}

--- a/src/main/java/bio/terra/service/duos/DuosService.java
+++ b/src/main/java/bio/terra/service/duos/DuosService.java
@@ -33,15 +33,15 @@ public class DuosService {
 
     // First try with the more readable group name.
     String groupName = constructFirecloudGroupName(duosId);
+    String groupEmail;
     try {
-      iamService.createGroup(groupName);
+      groupEmail = iamService.createGroup(groupName);
     } catch (IamConflictException ex) {
       logger.warn(
           "Firecloud group {} already exists: trying creation with a unique name", groupName);
       groupName = constructUniqueFirecloudGroupName(duosId);
-      iamService.createGroup(groupName);
+      groupEmail = iamService.createGroup(groupName);
     }
-    String groupEmail = iamService.getGroupEmail(groupName);
     logger.info("Successfully created Firecloud group {} for {} users", groupName, duosId);
 
     boolean inserted = duosDao.insertFirecloudGroup(duosId, groupName, groupEmail);

--- a/src/main/java/bio/terra/service/duos/exception/DuosFirecloudGroupInsertException.java
+++ b/src/main/java/bio/terra/service/duos/exception/DuosFirecloudGroupInsertException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.duos.exception;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class DuosFirecloudGroupInsertException extends InternalServerErrorException {
+  public DuosFirecloudGroupInsertException(String message) {
+    super(message);
+  }
+
+  public DuosFirecloudGroupInsertException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DuosFirecloudGroupInsertException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -5177,7 +5177,11 @@ components:
     ConsentCode:
       type: string
       description: Consent code together with PHS ID that will determine user access
-      example: c99
+
+    DuosId:
+      type: string
+      description: DUOS dataset identifier
+      example: DUOS-123456
 
     ##############################################################################
     ## SEARCH API STANDARD MODELS
@@ -5236,6 +5240,33 @@ components:
           items:
             type: object
       description: List of snapshot metadata
+    DuosFirecloudGroupModel:
+      type: object
+      description: >
+        A Firecloud managed group for the authorized users of a DUOS dataset.
+        This group has a TDR service account as its sole administrator.
+        Only those DUOS datasets known to TDR will have Firecloud groups for their users.
+      properties:
+        duosId:
+          $ref: '#/components/schemas/DuosId'
+        firecloudGroupName:
+          description: Name of Firecloud managed group
+          type: string
+          example: DUOS-123456-users
+        firecloudGroupEmail:
+          description: Email of Firecloud managed group
+          type: string
+          example: DUOS-123456-users@dev.test.firecloud.org
+        createdBy:
+          description: The TDR service account which created this group
+          type: string
+          example: jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com
+        created:
+          description: Time when TDR created this group
+          type: string
+        lastSynced:
+          description: Last time TDR queried DUOS for its dataset's authorized users
+          type: string
 
     ##############################################################################
     ## DRS STANDARD MODELS

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -62,4 +62,5 @@
     <include file="changesets/20220615_snapshotproperties.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20220617_addprojectsa.yaml" relativeToChangelogFile="true" />
     <include file="changesets/2022104_description_to_text.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20221014_duosfirecloudgroup.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20221014_duosfirecloudgroup.yaml
+++ b/src/main/resources/db/changesets/20221014_duosfirecloudgroup.yaml
@@ -7,6 +7,13 @@ databaseChangeLog:
             tableName: duos_firecloud_group
             columns:
               - column:
+                  name: id
+                  type: ${uuid_type}
+                  defaultValueComputed: ${uuid_function}
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
                   name: duos_id
                   type: varchar(36)
                   constraints:

--- a/src/main/resources/db/changesets/20221014_duosfirecloudgroup.yaml
+++ b/src/main/resources/db/changesets/20221014_duosfirecloudgroup.yaml
@@ -1,0 +1,38 @@
+databaseChangeLog:
+  - changeSet:
+      id: duosfirecloudgroup
+      author: okotsopo
+      changes:
+        - createTable:
+            tableName: duos_firecloud_group
+            columns:
+              - column:
+                  name: duos_id
+                  type: varchar(36)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+              - column:
+                  name: firecloud_group_name
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: firecloud_group_email
+                  type: varchar(256)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_by
+                  type: varchar(256)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_date
+                  type: timestamptz
+                  defaultValueComputed: now()
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_synced_date
+                  type: timestamptz

--- a/src/main/resources/db/changesets/20221014_duosfirecloudgroup.yaml
+++ b/src/main/resources/db/changesets/20221014_duosfirecloudgroup.yaml
@@ -11,7 +11,6 @@ databaseChangeLog:
                   type: ${uuid_type}
                   defaultValueComputed: ${uuid_function}
                   constraints:
-                    primaryKey: true
                     nullable: false
               - column:
                   name: duos_id

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -675,4 +675,22 @@ public class SamIamTest {
         () -> samIam.createGroup(accessToken, groupName));
     verify(samGroupApi, times(2)).postGroup(groupName);
   }
+
+  @Test
+  public void testDeleteGroup() throws ApiException, InterruptedException {
+    String accessToken = userReq.getToken();
+    String groupName = "firecloud_group_name";
+
+    doNothing().when(samGroupApi).deleteGroup(groupName);
+    samIam.deleteGroup(accessToken, groupName);
+    verify(samGroupApi, times(1)).deleteGroup(groupName);
+
+    ApiException samEx = new ApiException(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "Group not found");
+    doThrow(samEx).when(samGroupApi).deleteGroup(groupName);
+    assertThrows(
+        "IamNotFoundException is thrown when the user cannot access the group",
+        IamNotFoundException.class,
+        () -> samIam.deleteGroup(accessToken, groupName));
+    verify(samGroupApi, times(2)).deleteGroup(groupName);
+  }
 }

--- a/src/test/java/bio/terra/service/duos/DuosDaoTest.java
+++ b/src/test/java/bio/terra/service/duos/DuosDaoTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
@@ -15,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -55,5 +57,11 @@ public class DuosDaoTest {
     assertThat(retrieveAfterInsert.getCreatedBy(), equalTo(tdrServiceAccountEmail));
     assertThat(retrieveAfterInsert.getCreated(), notNullValue());
     assertThat(retrieveAfterInsert.getLastSynced(), nullValue());
+
+    assertThrows(
+        DuplicateKeyException.class,
+        () ->
+            duosDao.insertAndRetrieveFirecloudGroup(
+                DUOS_ID, "different_firecloud_group_name", "different_firecloud_group_email"));
   }
 }

--- a/src/test/java/bio/terra/service/duos/DuosDaoTest.java
+++ b/src/test/java/bio/terra/service/duos/DuosDaoTest.java
@@ -47,9 +47,12 @@ public class DuosDaoTest {
     DuosFirecloudGroupModel retrieveBeforeInsert = duosDao.retrieveFirecloudGroup(DUOS_ID);
     assertThat(retrieveBeforeInsert, nullValue());
 
-    duosDao.insertFirecloudGroup(DUOS_ID, FIRECLOUD_GROUP_NAME, FIRECLOUD_GROUP_EMAIL);
-
+    DuosFirecloudGroupModel retrieveOnCreate =
+        duosDao.insertAndRetrieveFirecloudGroup(
+            DUOS_ID, FIRECLOUD_GROUP_NAME, FIRECLOUD_GROUP_EMAIL);
     DuosFirecloudGroupModel retrieveAfterInsert = duosDao.retrieveFirecloudGroup(DUOS_ID);
+
+    assertThat(retrieveOnCreate, equalTo(retrieveAfterInsert));
 
     assertThat(retrieveAfterInsert, notNullValue());
     assertThat(retrieveAfterInsert.getFirecloudGroupName(), equalTo(FIRECLOUD_GROUP_NAME));

--- a/src/test/java/bio/terra/service/duos/DuosDaoTest.java
+++ b/src/test/java/bio/terra/service/duos/DuosDaoTest.java
@@ -1,0 +1,59 @@
+package bio.terra.service.duos;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import bio.terra.common.EmbeddedDatabaseTest;
+import bio.terra.common.category.Unit;
+import bio.terra.model.DuosFirecloudGroupModel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+@EmbeddedDatabaseTest
+public class DuosDaoTest {
+
+  @Autowired private DuosDao duosDao;
+
+  private static final String DUOS_ID = "DUOS-123456";
+  private static final String FIRECLOUD_GROUP_NAME = String.format("%s_users", DUOS_ID);
+  private static final String FIRECLOUD_GROUP_EMAIL =
+      String.format("%s@dev.test.firecloud.org", FIRECLOUD_GROUP_NAME);
+
+  private String tdrServiceAccountEmail;
+
+  @Before
+  public void before() {
+    tdrServiceAccountEmail = duosDao.getTdrServiceAccountEmail();
+  }
+
+  @Test
+  public void testInsertAndRetrieveFirecloudGroup() {
+    DuosFirecloudGroupModel retrieveBeforeInsert = duosDao.retrieveFirecloudGroup(DUOS_ID);
+    assertThat(retrieveBeforeInsert, nullValue());
+
+    duosDao.insertFirecloudGroup(DUOS_ID, FIRECLOUD_GROUP_NAME, FIRECLOUD_GROUP_EMAIL);
+
+    DuosFirecloudGroupModel retrieveAfterInsert = duosDao.retrieveFirecloudGroup(DUOS_ID);
+
+    assertThat(retrieveAfterInsert, notNullValue());
+    assertThat(retrieveAfterInsert.getFirecloudGroupName(), equalTo(FIRECLOUD_GROUP_NAME));
+    assertThat(retrieveAfterInsert.getFirecloudGroupEmail(), equalTo(FIRECLOUD_GROUP_EMAIL));
+    assertThat(retrieveAfterInsert.getCreatedBy(), equalTo(tdrServiceAccountEmail));
+    assertThat(retrieveAfterInsert.getCreated(), notNullValue());
+    assertThat(retrieveAfterInsert.getLastSynced(), nullValue());
+  }
+}

--- a/src/test/java/bio/terra/service/duos/DuosServiceTest.java
+++ b/src/test/java/bio/terra/service/duos/DuosServiceTest.java
@@ -18,6 +18,7 @@ import bio.terra.model.DuosFirecloudGroupModel;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.exception.IamConflictException;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
+import bio.terra.service.duos.exception.DuosFirecloudGroupInsertException;
 import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
@@ -120,7 +121,8 @@ public class DuosServiceTest {
     when(duosDao.insertFirecloudGroup(DUOS_ID, FIRECLOUD_GROUP_NAME, firecloudGroupEmail))
         .thenReturn(false);
 
-    assertThrows(RuntimeException.class, () -> duosService.createFirecloudGroup(DUOS_ID));
+    assertThrows(
+        DuosFirecloudGroupInsertException.class, () -> duosService.createFirecloudGroup(DUOS_ID));
     verify(iamService, times(1)).createGroup(FIRECLOUD_GROUP_NAME);
     verify(iamService, times(1)).deleteGroup(FIRECLOUD_GROUP_NAME);
     verify(duosDao, never()).retrieveFirecloudGroup(DUOS_ID);

--- a/src/test/java/bio/terra/service/duos/DuosServiceTest.java
+++ b/src/test/java/bio/terra/service/duos/DuosServiceTest.java
@@ -1,0 +1,155 @@
+package bio.terra.service.duos;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.DuosFirecloudGroupModel;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.auth.iam.exception.IamConflictException;
+import bio.terra.service.auth.iam.exception.IamForbiddenException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class DuosServiceTest {
+
+  @Mock private DuosDao duosDao;
+  @Mock private IamService iamService;
+  private DuosService duosService;
+
+  private static final String DUOS_ID = "DUOS-123456";
+  private static final String FIRECLOUD_GROUP_NAME = String.format("%s-users", DUOS_ID);
+  private String firecloudGroupEmail;
+
+  @Before
+  public void before() {
+    duosService = new DuosService(duosDao, iamService);
+    firecloudGroupEmail = firecloudGroupEmail(FIRECLOUD_GROUP_NAME);
+  }
+
+  @Test
+  public void testRetrieveFirecloudGroup() {
+    assertTrue(duosService.retrieveFirecloudGroup(DUOS_ID).isEmpty());
+
+    DuosFirecloudGroupModel group = new DuosFirecloudGroupModel().duosId(DUOS_ID);
+    when(duosDao.retrieveFirecloudGroup(DUOS_ID)).thenReturn(group);
+    Optional<DuosFirecloudGroupModel> retrieved = duosService.retrieveFirecloudGroup(DUOS_ID);
+
+    assertTrue(retrieved.isPresent());
+    assertThat(retrieved.get(), equalTo(group));
+  }
+
+  private String firecloudGroupEmail(String groupName) {
+    return String.format("%s@dev.test.firecloud.org", groupName);
+  }
+
+  @Test
+  public void testCreateFirecloudGroup() {
+    when(iamService.getGroupEmail(FIRECLOUD_GROUP_NAME)).thenReturn(firecloudGroupEmail);
+    when(duosDao.insertFirecloudGroup(DUOS_ID, FIRECLOUD_GROUP_NAME, firecloudGroupEmail))
+        .thenReturn(true);
+    DuosFirecloudGroupModel group = new DuosFirecloudGroupModel().duosId(DUOS_ID);
+    when(duosDao.retrieveFirecloudGroup(DUOS_ID)).thenReturn(group);
+
+    assertThat(duosService.createFirecloudGroup(DUOS_ID), equalTo(group));
+    verify(iamService, times(1)).createGroup(FIRECLOUD_GROUP_NAME);
+    verify(iamService, never()).deleteGroup(FIRECLOUD_GROUP_NAME);
+  }
+
+  @Test
+  public void testCreateFirecloudGroupWithNamingConflict() {
+    String groupEmailNew = firecloudGroupEmail(FIRECLOUD_GROUP_NAME + "-new");
+
+    IamConflictException iamConflictEx =
+        new IamConflictException("Group already existed", List.of());
+    doThrow(iamConflictEx).when(iamService).createGroup(FIRECLOUD_GROUP_NAME);
+
+    // If we encounter a naming collision when trying to create a Firecloud group,
+    // we don't know exactly what our backstop name will be as it will be suffixed by a new UUID,
+    // but we know that it will start with our more readable group name.
+    when(iamService.getGroupEmail(startsWith(FIRECLOUD_GROUP_NAME))).thenReturn(groupEmailNew);
+    when(iamService.getGroupEmail(FIRECLOUD_GROUP_NAME)).thenReturn(firecloudGroupEmail);
+
+    when(duosDao.insertFirecloudGroup(
+            eq(DUOS_ID), startsWith(FIRECLOUD_GROUP_NAME), eq(groupEmailNew)))
+        .thenReturn(true);
+    DuosFirecloudGroupModel group = new DuosFirecloudGroupModel().duosId(DUOS_ID);
+    when(duosDao.retrieveFirecloudGroup(DUOS_ID)).thenReturn(group);
+
+    assertThat(duosService.createFirecloudGroup(DUOS_ID), equalTo(group));
+    // Our first creation attempt failed, so we tried to create again with our unique group name.
+    verify(iamService, times(2)).createGroup(startsWith(FIRECLOUD_GROUP_NAME));
+
+    verify(iamService, never()).getGroupEmail(firecloudGroupEmail);
+    verify(duosDao, never())
+        .insertFirecloudGroup(DUOS_ID, FIRECLOUD_GROUP_NAME, firecloudGroupEmail);
+
+    verify(iamService, times(1)).getGroupEmail(startsWith(FIRECLOUD_GROUP_NAME));
+    verify(duosDao, times(1))
+        .insertFirecloudGroup(eq(DUOS_ID), startsWith(FIRECLOUD_GROUP_NAME), eq(groupEmailNew));
+  }
+
+  @Test
+  public void testCreateFirecloudGroupWithUnretriableCreationException() {
+    IamForbiddenException iamForbiddenException =
+        new IamForbiddenException("Unexpected SAM error", List.of());
+    doThrow(iamForbiddenException).when(iamService).createGroup(FIRECLOUD_GROUP_NAME);
+
+    assertThrows(IamForbiddenException.class, () -> duosService.createFirecloudGroup(DUOS_ID));
+    verify(duosDao, never())
+        .insertFirecloudGroup(eq(DUOS_ID), eq(FIRECLOUD_GROUP_NAME), anyString());
+  }
+
+  @Test
+  public void testCreateFirecloudGroupWithDbInsertionFailure() {
+    doNothing().when(iamService).createGroup(FIRECLOUD_GROUP_NAME);
+    when(iamService.getGroupEmail(FIRECLOUD_GROUP_NAME)).thenReturn(firecloudGroupEmail);
+    when(duosDao.insertFirecloudGroup(DUOS_ID, FIRECLOUD_GROUP_NAME, firecloudGroupEmail))
+        .thenReturn(false);
+
+    assertThrows(RuntimeException.class, () -> duosService.createFirecloudGroup(DUOS_ID));
+    verify(iamService, times(1)).createGroup(FIRECLOUD_GROUP_NAME);
+    verify(iamService, times(1)).deleteGroup(FIRECLOUD_GROUP_NAME);
+    verify(duosDao, never()).retrieveFirecloudGroup(DUOS_ID);
+  }
+
+  @Test
+  public void testRetrieveOrCreateFirecloudGroup() {
+    when(iamService.getGroupEmail(FIRECLOUD_GROUP_NAME)).thenReturn(firecloudGroupEmail);
+    when(duosDao.insertFirecloudGroup(DUOS_ID, FIRECLOUD_GROUP_NAME, firecloudGroupEmail))
+        .thenReturn(true);
+    DuosFirecloudGroupModel group = new DuosFirecloudGroupModel().duosId(DUOS_ID);
+    when(duosDao.retrieveFirecloudGroup(DUOS_ID)).thenReturn(null).thenReturn(group);
+
+    // First invocation: we create
+    assertThat(duosService.retrieveOrCreateFirecloudGroup(DUOS_ID), equalTo(group));
+    verify(iamService, times(1)).createGroup(FIRECLOUD_GROUP_NAME);
+    verify(iamService, never()).deleteGroup(FIRECLOUD_GROUP_NAME);
+
+    // Second invocation: we retrieve existing
+    assertThat(duosService.retrieveOrCreateFirecloudGroup(DUOS_ID), equalTo(group));
+    verify(iamService, times(1)).createGroup(FIRECLOUD_GROUP_NAME);
+    verify(iamService, never()).deleteGroup(FIRECLOUD_GROUP_NAME);
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2784

This PR adds support for creating, recording, and retrieving the Firecloud groups which will serve as containers for a DUOS dataset’s authorized users.  Presently, this code is not yet wired in anywhere or accessible to the end user, but I've elected to break up my work with the goal of easier review.

**Changes**
I broke these up into logical commits if you'd prefer to step through them.
- We can now call `IamService` to create or delete a Firecloud managed group.  All of these actions are performed as the TDR service account, which will be the group's sole administrator.
- We store records of our TDR-managed Firecloud groups in new Postgres table `duos_firecloud_group`, which associates these groups with their DUOS dataset ID.
- `DuosService` introduces support for creating or retrieving TDR-managed Firecloud groups, leveraging `DuosDao` to record them.
- Added unit tests throughout.