### PR TITLE
[DR-2784] Use surrogate ID as duos_firecloud_group primary key

### DIFF
--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -63,4 +63,5 @@
     <include file="changesets/20220617_addprojectsa.yaml" relativeToChangelogFile="true" />
     <include file="changesets/2022104_description_to_text.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20221014_duosfirecloudgroup.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20221020_duosfirecloudgroupprimarykey.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20221020_duosfirecloudgroupprimarykey.yaml
+++ b/src/main/resources/db/changesets/20221020_duosfirecloudgroupprimarykey.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: duosfirecloudgroupprimarykey
+      author: okotsopo
+      remarks: |
+        On table creation, we made the DUOS dataset ID our sole primary key, and got uniqueness
+        protection for free as a result.
+        But we prefer to mint a surrogate primary key to guard against the possibility that
+        DUOS IDs could be renamed or otherwise represented differently in the future.
+        As we still want to guard against having multiple rows with the same DUOS ID,
+        we must add a uniqueness constraint to the duos_id column.
+      changes:
+        - dropPrimaryKey:
+            tableName: duos_firecloud_group
+            constraintName: duos_firecloud_group_pkey
+        - addPrimaryKey:
+            tableName: duos_firecloud_group
+            columnNames: id
+        - addUniqueConstraint:
+            tableName: duos_firecloud_group
+            columnNames: duos_id
+

--- a/src/main/resources/db/changesets/20221020_duosfirecloudgroupprimarykey.yaml
+++ b/src/main/resources/db/changesets/20221020_duosfirecloudgroupprimarykey.yaml
@@ -19,4 +19,3 @@ databaseChangeLog:
         - addUniqueConstraint:
             tableName: duos_firecloud_group
             columnNames: duos_id
-


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2784

This is a small follow-on to https://github.com/DataBiosphere/jade-data-repo/pull/1361 (Add initial Firecloud group support for DUOS integration) after talking with @nmalfroy.

I didn't fully grasp the recommendation to use a surrogate `id` column when creating new table `duos_firecloud_group`: https://github.com/DataBiosphere/jade-data-repo/pull/1361#discussion_r999667251

This PR adds a new Liquibase changeset to make this change (see its remarks for more detail).

As this table is not yet wired in anywhere and the `id` column was autogenerated / non-null, we run no risk by altering these constraints.