### PR TITLE
DR-2775: Sentry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,6 +257,8 @@ dependencies {
     implementation 'com.azure:azure-storage-file-datalake:12.5.1'
     implementation 'com.azure:azure-data-tables:12.1.0'
 
+    implementation 'io.sentry:sentry-logback:6.5.0'
+
     testImplementation "org.apache.parquet:parquet-common:1.12.0"
     testImplementation "org.apache.parquet:parquet-hadoop:1.12.0"
     testImplementation "org.apache.parquet:parquet-hadoop-bundle:1.12.0"

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,6 +10,12 @@
         </then>
     </if>
 
+    <if condition='!isDefined("SENTRY_ENABLED")'>
+      <then>
+        <variable name="SENTRY_ENABLED" value="false" />
+      </then>
+    </if>
+
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <Pattern>%date %-5level [%thread] %logger{36}: %message%n</Pattern>
@@ -41,7 +47,7 @@
     <!--    <logger name="bio.terra.service.iam.sam.SamIam" level="debug" />-->
     <!--    <logger name="bio.terra.service.tabulardata.google.BigQueryProject" level="debug" />-->
 
-    <if condition='isDefined("SENTRY_DSN")'>
+    <if condition="${SENTRY_ENABLED} == true">
         <then>
           <appender name="Sentry" class="io.sentry.logback.SentryAppender"/>
         </then>
@@ -49,7 +55,7 @@
 
     <root level="INFO">
         <appender-ref ref="${TDR_LOG_APPENDER}"/>
-        <if condition='isDefined("SENTRY_DSN")'>
+        <if condition="${SENTRY_ENABLED} == true">
           <then>
             <appender-ref ref="Sentry"/>
           </then>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -41,7 +41,18 @@
     <!--    <logger name="bio.terra.service.iam.sam.SamIam" level="debug" />-->
     <!--    <logger name="bio.terra.service.tabulardata.google.BigQueryProject" level="debug" />-->
 
+    <if condition='isDefined("SENTRY_DSN")'>
+        <then>
+          <appender name="Sentry" class="io.sentry.logback.SentryAppender"/>
+        </then>
+    </if>
+
     <root level="INFO">
         <appender-ref ref="${TDR_LOG_APPENDER}"/>
+        <if condition='isDefined("SENTRY_DSN")'>
+          <then>
+            <appender-ref ref="Sentry"/>
+          </then>
+        </if>
     </root>
 </configuration>

--- a/src/main/resources/sentry.properties
+++ b/src/main/resources/sentry.properties
@@ -1,2 +1,1 @@
 dsn=https://a3d46c70bbc74f32bfc5153fb8f915a6@o54426.ingest.sentry.io/4504044616089600
-environment=local

--- a/src/main/resources/sentry.properties
+++ b/src/main/resources/sentry.properties
@@ -1,0 +1,2 @@
+dsn=https://a3d46c70bbc74f32bfc5153fb8f915a6@o54426.ingest.sentry.io/4504044616089600
+environment=local


### PR DESCRIPTION
Goal: Use Sentry to capture errors encountered in our app and alert us on slack. 

Related PRs:
- Env variables for dev: https://github.com/broadinstitute/datarepo-helm-definitions/pull/454
- Env variables for alpha, staging & Prod: https://github.com/broadinstitute/terra-helmfile/pull/3552

Related work:
- Set up team and project in sentry
- Set up slack integration - Alerts for production environment errors are now sent to our #Jade-alerts channel 

Take a look at our team page, and check out the example alerts recorded: https://sentry.io/organizations/broad-institute/projects/data-repo/?project=4504044616089600

Some notes and referenced PRs can be found in[ this doc](https://docs.google.com/document/d/1E6UTXHbj4Qs9hwujIMHO0vGCLfdrGIsylJZCdLHvMJQ/edit#). 