### PR TITLE
[DR-2785] Include DUOS firecloud group when retrieving a snapshot

### DIFF
--- a/src/main/java/bio/terra/service/duos/DuosService.java
+++ b/src/main/java/bio/terra/service/duos/DuosService.java
@@ -26,7 +26,7 @@ public class DuosService {
   }
 
   public Optional<DuosFirecloudGroupModel> retrieveFirecloudGroup(String duosId) {
-    return Optional.ofNullable(duosDao.retrieveFirecloudGroup(duosId));
+    return Optional.ofNullable(duosDao.retrieveFirecloudGroupByDuosId(duosId));
   }
 
   public DuosFirecloudGroupModel createFirecloudGroup(String duosId) {
@@ -50,13 +50,15 @@ public class DuosService {
     // teardown of resources created earlier, rather than having to
     // introduce a fallback behavior flow.
     // https://broadworkbench.atlassian.net/browse/DR-2787
+    UUID duosFirecloudGroupId;
     try {
-      return duosDao.insertAndRetrieveFirecloudGroup(duosId, groupName, groupEmail);
+      duosFirecloudGroupId = duosDao.insertFirecloudGroup(duosId, groupName, groupEmail);
     } catch (Exception ex) {
       iamService.deleteGroup(groupName);
       throw new DuosFirecloudGroupInsertException(
           "Firecloud group " + groupName + " was not inserted into the DB and has been deleted");
     }
+    return duosDao.retrieveFirecloudGroupById(duosFirecloudGroupId);
   }
 
   public DuosFirecloudGroupModel retrieveOrCreateFirecloudGroup(String duosId) {

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -6,6 +6,7 @@ import bio.terra.common.Column;
 import bio.terra.common.LogPrintable;
 import bio.terra.common.Relationship;
 import bio.terra.model.CloudPlatform;
+import bio.terra.model.DuosFirecloudGroupModel;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FSContainerInterface;
@@ -38,6 +39,8 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
   private SnapshotRequestContentsModel creationInformation;
   private String consentCode;
   private Object properties;
+  private UUID duosFirecloudGroupId;
+  private DuosFirecloudGroupModel duosFirecloudGroup;
 
   @Override
   public CollectionType getCollectionType() {
@@ -188,6 +191,24 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
 
   public Snapshot relationships(List<Relationship> relationships) {
     this.relationships = relationships;
+    return this;
+  }
+
+  public UUID getDuosFirecloudGroupId() {
+    return duosFirecloudGroupId;
+  }
+
+  public Snapshot duosFirecloudGroupId(UUID duosFirecloudGroupId) {
+    this.duosFirecloudGroupId = duosFirecloudGroupId;
+    return this;
+  }
+
+  public DuosFirecloudGroupModel getDuosFirecloudGroup() {
+    return duosFirecloudGroup;
+  }
+
+  public Snapshot duosFirecloudGroup(DuosFirecloudGroupModel duosFirecloudGroup) {
+    this.duosFirecloudGroup = duosFirecloudGroup;
     return this;
   }
 

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -6,7 +6,6 @@ import bio.terra.common.Column;
 import bio.terra.common.LogPrintable;
 import bio.terra.common.Relationship;
 import bio.terra.model.CloudPlatform;
-import bio.terra.model.DuosFirecloudGroupModel;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FSContainerInterface;
@@ -40,7 +39,6 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
   private String consentCode;
   private Object properties;
   private UUID duosFirecloudGroupId;
-  private DuosFirecloudGroupModel duosFirecloudGroup;
 
   @Override
   public CollectionType getCollectionType() {
@@ -200,15 +198,6 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
 
   public Snapshot duosFirecloudGroupId(UUID duosFirecloudGroupId) {
     this.duosFirecloudGroupId = duosFirecloudGroupId;
-    return this;
-  }
-
-  public DuosFirecloudGroupModel getDuosFirecloudGroup() {
-    return duosFirecloudGroup;
-  }
-
-  public Snapshot duosFirecloudGroup(DuosFirecloudGroupModel duosFirecloudGroup) {
-    this.duosFirecloudGroup = duosFirecloudGroup;
     return this;
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -15,7 +15,6 @@ import bio.terra.service.dataset.AssetSpecification;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.dataset.StorageResource;
-import bio.terra.service.duos.DuosDao;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import bio.terra.service.snapshot.exception.InvalidSnapshotException;
@@ -60,7 +59,6 @@ public class SnapshotDao {
   private final DatasetDao datasetDao;
   private final ResourceService resourceService;
   private final ObjectMapper objectMapper;
-  private final DuosDao duosDao;
 
   private static final String TABLE_NAME = "snapshot";
 
@@ -87,8 +85,7 @@ public class SnapshotDao {
       SnapshotRelationshipDao snapshotRelationshipDao,
       DatasetDao datasetDao,
       ResourceService resourceService,
-      ObjectMapper objectMapper,
-      DuosDao duosDao) {
+      ObjectMapper objectMapper) {
     this.jdbcTemplate = jdbcTemplate;
     this.snapshotTableDao = snapshotTableDao;
     this.snapshotMapTableDao = snapshotMapTableDao;
@@ -96,7 +93,6 @@ public class SnapshotDao {
     this.datasetDao = datasetDao;
     this.resourceService = resourceService;
     this.objectMapper = objectMapper;
-    this.duosDao = duosDao;
   }
 
   /**
@@ -439,12 +435,6 @@ public class SnapshotDao {
         resourceService
             .getSnapshotStorageAccount(snapshot.getId())
             .ifPresent(snapshot::storageAccountResource);
-
-        // Retrieve the DUOS Firecloud group associated with the snapshot.
-        UUID duosFirecloudGroupId = snapshot.getDuosFirecloudGroupId();
-        if (duosFirecloudGroupId != null) {
-          snapshot.duosFirecloudGroup(duosDao.retrieveFirecloudGroupById(duosFirecloudGroupId));
-        }
       }
       return snapshot;
     } catch (EmptyResultDataAccessException ex) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -974,7 +974,8 @@ public class SnapshotService {
             .description(snapshot.getDescription())
             .createdDate(snapshot.getCreatedDate().toString())
             .consentCode(snapshot.getConsentCode())
-            .cloudPlatform(snapshot.getCloudPlatform());
+            .cloudPlatform(snapshot.getCloudPlatform())
+            .duosFirecloudGroup(snapshot.getDuosFirecloudGroup());
 
     // In case NONE is specified, this should supersede any other value being passed in
     if (include.contains(SnapshotRetrieveIncludeModel.NONE)) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -975,7 +975,7 @@ public class SnapshotService {
             .createdDate(snapshot.getCreatedDate().toString())
             .consentCode(snapshot.getConsentCode())
             .cloudPlatform(snapshot.getCloudPlatform())
-            .duosFirecloudGroup(snapshot.getDuosFirecloudGroup());
+            .duosFirecloudGroupId(snapshot.getDuosFirecloudGroupId());
 
     // In case NONE is specified, this should supersede any other value being passed in
     if (include.contains(SnapshotRetrieveIncludeModel.NONE)) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4526,6 +4526,8 @@ components:
         properties:
           type: object
           description: Additional JSON metadata about the snapshot (this does not need to adhere to a particular schema)
+        duosFirecloudGroup:
+          $ref: '#/components/schemas/DuosFirecloudGroupModel'
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
     SnapshotExportResponseModel:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4526,8 +4526,8 @@ components:
         properties:
           type: object
           description: Additional JSON metadata about the snapshot (this does not need to adhere to a particular schema)
-        duosFirecloudGroup:
-          $ref: '#/components/schemas/DuosFirecloudGroupModel'
+        duosFirecloudGroupId:
+          $ref: '#/components/schemas/UniqueIdProperty'
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
     SnapshotExportResponseModel:

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -64,4 +64,5 @@
     <include file="changesets/2022104_description_to_text.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20221014_duosfirecloudgroup.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20221020_duosfirecloudgroupprimarykey.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20221024_snapshotduosfirecloudgroupid.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20221024_snapshotduosfirecloudgroupid.yaml
+++ b/src/main/resources/db/changesets/20221024_snapshotduosfirecloudgroupid.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: snapshotduosfirecloudgroupid
+      author: okotsopo
+      changes:
+        - addColumn:
+            tableName: snapshot
+            columns:
+              name: duos_firecloud_group_id
+              type: ${uuid_type}
+              constraints:
+                nullable: true
+                foreignKeyName: fk_snapshot_duos_firecloud_group
+                references: duos_firecloud_group(id)
+                deleteCascade: false

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import bio.terra.app.model.CloudRegion;
@@ -92,7 +91,6 @@ public class SnapshotDaoTest {
   private UUID profileId;
   private UUID projectId;
   private UUID duosFirecloudGroupId;
-  private String duosId;
 
   @Before
   public void setup() throws Exception {
@@ -131,7 +129,7 @@ public class SnapshotDaoTest {
     snapshotId = UUID.randomUUID();
     datasetIds = new ArrayList<>();
 
-    duosId = UUID.randomUUID().toString();
+    String duosId = UUID.randomUUID().toString();
     String firecloudGroupName = "firecloudGroupName";
     String firecloudGroupEmail = "firecloudGroupEmail";
     duosFirecloudGroupId =
@@ -174,7 +172,8 @@ public class SnapshotDaoTest {
         snapshotService
             .makeSnapshotFromSnapshotRequest(snapshotRequest)
             .projectResourceId(projectId)
-            .id(snapshotId);
+            .id(snapshotId)
+            .duosFirecloudGroupId(duosFirecloudGroupId);
     Snapshot fromDB = insertAndRetrieveSnapshot(snapshot, "happyInOutTest_flightId");
     assertThat("snapshot name set correctly", fromDB.getName(), equalTo(snapshot.getName()));
 
@@ -288,29 +287,10 @@ public class SnapshotDaoTest {
         snapshotTable2.getColumns().stream().map(Column::getName).collect(Collectors.toList()),
         contains("anothercolumn3", "anothercolumn2", "anothercolumn1"));
 
-    // Verify absence of linked DUOS Firecloud group
-    assertNull(fromDB.getDuosFirecloudGroupId());
-    assertNull(fromDB.getDuosFirecloudGroup());
-  }
-
-  @Test
-  public void insertAndRetrieveSnapshotWithLinkedDuosDataset() {
-    snapshotRequest.name(snapshotRequest.getName() + UUID.randomUUID());
-
-    Snapshot snapshot =
-        snapshotService
-            .makeSnapshotFromSnapshotRequest(snapshotRequest)
-            .projectResourceId(projectId)
-            .id(snapshotId)
-            .duosFirecloudGroupId(duosFirecloudGroupId);
-    Snapshot fromDB = insertAndRetrieveSnapshot(snapshot, "snapshotWithDuos_flightId");
-
-    assertThat(fromDB.getDuosFirecloudGroupId(), equalTo(duosFirecloudGroupId));
-    // (Note: more complete DuosDao verfication can be found in DuosDaoTest.)
     assertThat(
-        "Linked DUOS Firecloud group is obtained",
-        fromDB.getDuosFirecloudGroup().getDuosId(),
-        equalTo(duosId));
+        "Correct DUOS Firecloud group ID",
+        fromDB.getDuosFirecloudGroupId(),
+        equalTo(duosFirecloudGroupId));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -34,7 +34,6 @@ import bio.terra.model.AccessInfoModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSummaryModel;
-import bio.terra.model.DuosFirecloudGroupModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.InaccessibleWorkspacePolicyModel;
 import bio.terra.model.PolicyResponse;
@@ -111,7 +110,6 @@ public class SnapshotServiceTest {
   private static final String PHS_ID = "phs123456";
   private static final String CONSENT_CODE = "c99";
   private static final String PASSPORT = "passportJwt";
-  private static final String DUOS_ID = "DUOS-123456";
 
   @MockBean private JobService jobService;
   @MockBean private DatasetService datasetService;
@@ -336,8 +334,7 @@ public class SnapshotServiceTest {
                     new SnapshotRequestContentsModel()
                         .mode(SnapshotRequestContentsModel.ModeEnum.BYFULLVIEW)
                         .datasetName(DATASET_NAME))
-                .duosFirecloudGroupId(duosFirecloudGroupId)
-                .duosFirecloudGroup(new DuosFirecloudGroupModel().duosId(DUOS_ID)));
+                .duosFirecloudGroupId(duosFirecloudGroupId));
   }
 
   private SnapshotModel expectedSnapshotModelBase() {
@@ -346,7 +343,7 @@ public class SnapshotServiceTest {
         .name(SNAPSHOT_NAME)
         .description(SNAPSHOT_DESCRIPTION)
         .createdDate(createdDate.toString())
-        .duosFirecloudGroup(new DuosFirecloudGroupModel().duosId(DUOS_ID));
+        .duosFirecloudGroupId(duosFirecloudGroupId);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -34,6 +34,7 @@ import bio.terra.model.AccessInfoModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.DuosFirecloudGroupModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.InaccessibleWorkspacePolicyModel;
 import bio.terra.model.PolicyResponse;
@@ -110,6 +111,7 @@ public class SnapshotServiceTest {
   private static final String PHS_ID = "phs123456";
   private static final String CONSENT_CODE = "c99";
   private static final String PASSPORT = "passportJwt";
+  private static final String DUOS_ID = "DUOS-123456";
 
   @MockBean private JobService jobService;
   @MockBean private DatasetService datasetService;
@@ -130,6 +132,7 @@ public class SnapshotServiceTest {
   private final UUID datasetId = UUID.randomUUID();
   private final UUID snapshotTableId = UUID.randomUUID();
   private final UUID profileId = UUID.randomUUID();
+  private final UUID duosFirecloudGroupId = UUID.randomUUID();
   private final Instant createdDate = Instant.now();
 
   @Autowired private SnapshotService service;
@@ -140,11 +143,7 @@ public class SnapshotServiceTest {
     assertThat(
         service.retrieveAvailableSnapshotModel(snapshotId, TEST_USER),
         equalTo(
-            new SnapshotModel()
-                .id(snapshotId)
-                .name(SNAPSHOT_NAME)
-                .description(SNAPSHOT_DESCRIPTION)
-                .createdDate(createdDate.toString())
+            expectedSnapshotModelBase()
                 .source(
                     List.of(
                         new SnapshotSourceModel()
@@ -184,12 +183,7 @@ public class SnapshotServiceTest {
     assertThat(
         service.retrieveAvailableSnapshotModel(
             snapshotId, List.of(SnapshotRetrieveIncludeModel.NONE), TEST_USER),
-        equalTo(
-            new SnapshotModel()
-                .id(snapshotId)
-                .name(SNAPSHOT_NAME)
-                .description(SNAPSHOT_DESCRIPTION)
-                .createdDate(createdDate.toString())));
+        equalTo(expectedSnapshotModelBase()));
   }
 
   @Test
@@ -215,11 +209,7 @@ public class SnapshotServiceTest {
         service.retrieveAvailableSnapshotModel(
             snapshotId, List.of(SnapshotRetrieveIncludeModel.CREATION_INFORMATION), TEST_USER),
         equalTo(
-            new SnapshotModel()
-                .id(snapshotId)
-                .name(SNAPSHOT_NAME)
-                .description(SNAPSHOT_DESCRIPTION)
-                .createdDate(createdDate.toString())
+            expectedSnapshotModelBase()
                 .creationInformation(
                     new SnapshotRequestContentsModel()
                         .mode(SnapshotRequestContentsModel.ModeEnum.BYFULLVIEW)
@@ -233,11 +223,7 @@ public class SnapshotServiceTest {
         service.retrieveAvailableSnapshotModel(
             snapshotId, List.of(SnapshotRetrieveIncludeModel.ACCESS_INFORMATION), TEST_USER),
         equalTo(
-            new SnapshotModel()
-                .id(snapshotId)
-                .name(SNAPSHOT_NAME)
-                .description(SNAPSHOT_DESCRIPTION)
-                .createdDate(createdDate.toString())
+            expectedSnapshotModelBase()
                 .accessInformation(
                     new AccessInfoModel()
                         .bigQuery(
@@ -302,13 +288,7 @@ public class SnapshotServiceTest {
                 SnapshotRetrieveIncludeModel.PROFILE, SnapshotRetrieveIncludeModel.DATA_PROJECT),
             TEST_USER),
         equalTo(
-            new SnapshotModel()
-                .id(snapshotId)
-                .name(SNAPSHOT_NAME)
-                .description(SNAPSHOT_DESCRIPTION)
-                .createdDate(createdDate.toString())
-                .profileId(profileId)
-                .dataProject(SNAPSHOT_DATA_PROJECT)));
+            expectedSnapshotModelBase().profileId(profileId).dataProject(SNAPSHOT_DATA_PROJECT)));
   }
 
   private void mockSnapshot() {
@@ -355,7 +335,18 @@ public class SnapshotServiceTest {
                 .creationInformation(
                     new SnapshotRequestContentsModel()
                         .mode(SnapshotRequestContentsModel.ModeEnum.BYFULLVIEW)
-                        .datasetName(DATASET_NAME)));
+                        .datasetName(DATASET_NAME))
+                .duosFirecloudGroupId(duosFirecloudGroupId)
+                .duosFirecloudGroup(new DuosFirecloudGroupModel().duosId(DUOS_ID)));
+  }
+
+  private SnapshotModel expectedSnapshotModelBase() {
+    return new SnapshotModel()
+        .id(snapshotId)
+        .name(SNAPSHOT_NAME)
+        .description(SNAPSHOT_DESCRIPTION)
+        .createdDate(createdDate.toString())
+        .duosFirecloudGroup(new DuosFirecloudGroupModel().duosId(DUOS_ID));
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2785

When retrieving a snapshot, if it contains a pointer to a `duos_firecloud_group` entry, then return a representation of its associated DUOS Firecloud group.

<img width="1260" alt="Screen Shot 2022-10-25 at 4 30 32 PM" src="https://user-images.githubusercontent.com/79769153/197875775-9c536635-d691-400b-b67a-244f5c3affcf.png">

For now, the only impact on users is that the [retrieveSnapshot](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/retrieveSnapshot) response body will include new field `duosFirecloudGroup`, which will be null in all cases.  Outside of tests, there is not currently a way to set a snapshot's `duos_firecloud_group_id` (but this is coming soon!)

I elected to leave `SnapshotSummary` and `SnapshotSummaryModel` unchanged (returned in snapshot enumeration) -- when we have a better sense of what Data Catalog might need to support DUOS integration end-to-end, we can revisit.

I broke up my commits for (hopefully) easier review, if you would prefer to step through them.