### PR TITLE
DR-2778 Enable reading data with DRS from buckets that have "Requester Pays" enabled

### DIFF
--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -41,11 +41,13 @@ import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.storage.Acl;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Blob.BlobSourceOption;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobGetOption;
 import com.google.cloud.storage.Storage.BucketSourceOption;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
@@ -570,9 +572,9 @@ public class GcsPdao implements CloudFileReader {
   private boolean deleteWorker(BlobId blobId, String projectId) {
     GcsProject gcsProject = gcsProjectFactory.get(projectId, true);
     Storage storage = gcsProject.getStorage();
-    Blob blob = storage.get(blobId);
+    Blob blob = storage.get(blobId, BlobGetOption.userProject(projectId));
     if (blob != null) {
-      return blob.delete();
+      return blob.delete(BlobSourceOption.userProject(projectId));
     }
     logger.warn("{} was not found and so deletion was skipped", blobId);
     return false;

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
@@ -1,0 +1,52 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.Collections;
+import java.util.Map;
+
+public class SnapshotAuthzServiceAccountConsumerStep implements Step {
+  private final SnapshotService snapshotService;
+  private final ResourceService resourceService;
+  private final String snapshotName;
+
+  public SnapshotAuthzServiceAccountConsumerStep(
+      SnapshotService snapshotService, ResourceService resourceService, String snapshotName) {
+    this.snapshotService = snapshotService;
+    this.resourceService = resourceService;
+    this.snapshotName = snapshotName;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    Map<IamRole, String> policyMap =
+        workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, new TypeReference<>() {});
+
+    Snapshot snapshot = snapshotService.retrieveByName(snapshotName);
+
+    // Allow the steward and reader to bill this project to read requester pays bucket data.
+    // The underlying service provides retries so we do not need to retry this operation
+    resourceService.grantPoliciesServiceUsageConsumer(
+        snapshot.getProjectResource().getGoogleProjectId(),
+        Collections.singletonList(policyMap.get(IamRole.STEWARD)));
+    resourceService.grantPoliciesServiceUsageConsumer(
+        snapshot.getProjectResource().getGoogleProjectId(),
+        Collections.singletonList(policyMap.get(IamRole.READER)));
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -245,6 +245,9 @@ public class SnapshotCreateFlight extends Flight {
       }
 
       addStep(new SnapshotAuthzBqJobUserStep(snapshotService, resourceService, snapshotName));
+      addStep(
+          new SnapshotAuthzServiceAccountConsumerStep(
+              snapshotService, resourceService, snapshotName));
     } else if (platform.isAzure()) {
       addStep(
           new CreateSnapshotStorageTableDataStep(

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzServiceUsageAclsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzServiceUsageAclsStep.java
@@ -1,0 +1,65 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteSnapshotAuthzServiceUsageAclsStep implements Step {
+  private final IamService sam;
+  private final ResourceService resourceService;
+  private final SnapshotService snapshotService;
+  private final UUID snapshotId;
+  private final AuthenticatedUserRequest userReq;
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(DeleteSnapshotAuthzServiceUsageAclsStep.class);
+
+  public DeleteSnapshotAuthzServiceUsageAclsStep(
+      IamService sam,
+      ResourceService resourceService,
+      SnapshotService snapshotService,
+      UUID snapshotId,
+      AuthenticatedUserRequest userReq) {
+    this.sam = sam;
+    this.resourceService = resourceService;
+    this.snapshotService = snapshotService;
+    this.snapshotId = snapshotId;
+    this.userReq = userReq;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    Snapshot snapshot = snapshotService.retrieve(snapshotId);
+
+    // These policy emails should not change since the snapshot is locked by the flight
+    Map<IamRole, String> policyEmails =
+        sam.retrievePolicyEmails(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
+
+    // Remove the custodian's access to bill this project to read requester pays bucket data.
+    // The underlying service provides retries so we do not need to retry this operation
+    resourceService.revokePoliciesServiceUsageConsumer(
+        snapshot.getProjectResource().getGoogleProjectId(),
+        Arrays.asList(policyEmails.get(IamRole.STEWARD), policyEmails.get(IamRole.READER)));
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    // can't undo delete
+    logger.warn("Trying to undo clear ACLs for snapshot {}", snapshotId);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
@@ -76,6 +76,10 @@ public class SnapshotDeleteFlight extends Flight {
         new PerformGcpStep(
             new DeleteSnapshotAuthzBqAclsStep(
                 iamClient, resourceService, snapshotService, snapshotId, userReq)));
+    addStep(
+        new PerformGcpStep(
+            new DeleteSnapshotAuthzServiceUsageAclsStep(
+                iamClient, resourceService, snapshotService, snapshotId, userReq)));
 
     // Delete access control first so Readers and Discoverers can no longer see snapshot
     // Google auto-magically removes the ACLs from BQ objects when SAM

--- a/src/test/java/bio/terra/common/GcsUtils.java
+++ b/src/test/java/bio/terra/common/GcsUtils.java
@@ -4,7 +4,9 @@ import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.service.common.gcs.GcsUriUtils;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Blob.BlobSourceOption;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobGetOption;
 import com.google.cloud.storage.StorageOptions;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -39,7 +41,7 @@ public class GcsUtils {
 
   public boolean fileExists(String path) {
     logger.info("Checking that file {} exists", path);
-    Blob blob = storage.get(GcsUriUtils.parseBlobUri(path));
-    return blob.exists();
+    Blob blob = storage.get(GcsUriUtils.parseBlobUri(path), BlobGetOption.userProject(projectId));
+    return blob.exists(BlobSourceOption.userProject(projectId));
   }
 }

--- a/src/test/java/bio/terra/common/TestUtils.java
+++ b/src/test/java/bio/terra/common/TestUtils.java
@@ -121,7 +121,7 @@ public final class TestUtils {
 
   public static void verifyHttpAccess(String url, Map<String, String> headers) {
     HttpUriRequest request = new HttpHead(url);
-    headers.entrySet().forEach(e -> request.setHeader(e.getKey(), e.getValue()));
+    headers.forEach(request::setHeader);
     try (CloseableHttpClient client = HttpClients.createDefault()) {
       try (CloseableHttpResponse response = client.execute(request); ) {
         assertThat(

--- a/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
@@ -138,8 +138,16 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
     testSelfHostedDatasetLifecycle("jade_testbucket_no_jade_sa", true);
   }
 
+  @Test
+  public void testSelfHostedDatasetRequesterPaysLifecycle() throws Exception {
+    testSelfHostedDatasetLifecycle("jade_testbucket_requester_pays", false);
+  }
+
   private void testSelfHostedDatasetLifecycle(String ingestBucket, boolean dedicatedServiceAccount)
       throws Exception {
+
+    gcsUtils.fileExists(wgsVcfPath(ingestBucket));
+
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createSelfHostedDataset(
             steward(), profileId, "dataset-ingest-combined-array.json", dedicatedServiceAccount);
@@ -307,6 +315,9 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
           "TDR was able to create a signed URL",
           objectAccessUrl.getUrl(),
           is(not(emptyOrNullString())));
+
+      // Ensure that the signed URL is accessible
+      TestUtils.verifyHttpAccess(objectAccessUrl.getUrl(), Map.of());
     }
 
     // validate that snapshot export works correctly


### PR DESCRIPTION
This is something that is useful when reading data from datasets that have self hosted data turned on.  In the case where the bucket has Requester Pays turned on, the snapshot's project will be billed.

There is no API change involved with this.  This should cause DRS lookups from these types to buckets to "Just Work™"

The self hosted integration test was used to exercise the change

Oh, I also added a thing where, just like Azure, we return a query parameter `requestedBy` with the url encoded email of the requesting user