### PR TITLE
[DR-2801] Deprecate BillingProfileRequestModel.id in Swagger docs

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3361,8 +3361,6 @@ components:
         - profileName
       type: object
       properties:
-        id:
-          $ref: '#/components/schemas/UniqueIdProperty'
         billingAccountId:
           type: string
           description: unique identifier of the billing account from Google
@@ -3388,6 +3386,14 @@ components:
         applicationDeploymentName:
           type: string
           description: an optional name for an application deployment for Azure
+        id:
+          deprecated: true
+          type: string
+          format: uuid
+          description: >
+            Deprecated: allowed for backwards compatibility.
+            Recommendation: leave this unset for TDR to generate a universally unique identifier
+            for your new billing profile.
     BillingProfileUpdateModel:
       required:
         - id


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2801

**Background**

When creating a billing profile via TDR [createProfile](https://data.terra.bio/swagger-ui.html#/profiles/createProfile) endpoint, we allow the caller to supply its own ID for backwards compatibility.  By default, we generate a new UUID when none is supplied.

This is confusing and in some cases dangerous for the user.  Because we use SAM dev to back our many TDR development environments, we’ve had instances where we accidentally deleted and recreated a billing profile used by others while working locally and working with a common ID.

**Changes**

I marked `BillingProfileRequestModel.id` as deprecated in Swagger, and expand its description to explain the default behavior.  This will still permit the field to be used, but it will no longer be shown in the example schema.
<img width="931" alt="Screen Shot 2022-11-02 at 4 04 38 PM" src="https://user-images.githubusercontent.com/79769153/199592383-0f51d284-f0f5-43f9-bfab-bda2308b1e46.png">
<img width="1440" alt="Screen Shot 2022-11-02 at 4 04 52 PM" src="https://user-images.githubusercontent.com/79769153/199592390-f4d6bf84-6386-499c-aea2-0cd42dd04cac.png">

This is a documentation-only change.