### PR TITLE
DR-2824 fix drs lookups with dedicated ingest SA and self hosted buckets

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -129,6 +129,13 @@ jobs:
           test_to_run: 'testConnected'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
+      - name: "Temp: Archive all junit test reports"
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: junit-test-reports-for-connected
+          path: build/reports
+          retention-days: 5
   deploy_test_integration:
     name: "Run integration and smoke tests"
     outputs:

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -625,7 +625,12 @@ public class DrsService {
       } else {
         this.googleProjectId = null;
       }
-      this.datasetProjectId = snapshot.getSourceDataset().getProjectResource().getGoogleProjectId();
+      var datasetProjectResource = snapshot.getSourceDataset().getProjectResource();
+      if (datasetProjectResource != null) {
+        this.datasetProjectId = datasetProjectResource.getGoogleProjectId();
+      } else {
+        this.datasetProjectId = null;
+      }
     }
 
     public UUID getId() {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -74,6 +74,7 @@ public class SnapshotCreateFlight extends Flight {
     GoogleResourceManagerService googleResourceManagerService =
         appContext.getBean(GoogleResourceManagerService.class);
     JournalService journalService = appContext.getBean(JournalService.class);
+    String tdrServiceAccountEmail = appContext.getBean("tdrServiceAccountEmail", String.class);
 
     SnapshotRequestModel snapshotReq =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), SnapshotRequestModel.class);
@@ -251,7 +252,7 @@ public class SnapshotCreateFlight extends Flight {
       addStep(new SnapshotAuthzBqJobUserStep(snapshotService, resourceService, snapshotName));
       addStep(
           new SnapshotAuthzServiceAccountConsumerStep(
-              snapshotService, resourceService, snapshotName));
+              snapshotService, resourceService, snapshotName, tdrServiceAccountEmail));
     } else if (platform.isAzure()) {
       addStep(
           new CreateSnapshotStorageTableDataStep(

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
@@ -53,6 +53,7 @@ public class SnapshotDeleteFlight extends Flight {
     AzureStorageAccountService azureStorageAccountService =
         appContext.getBean(AzureStorageAccountService.class);
     JournalService journalService = appContext.getBean(JournalService.class);
+    String tdrServiceAccountEmail = appContext.getBean("tdrServiceAccountEmail", String.class);
 
     RetryRule randomBackoffRetry =
         getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
@@ -83,7 +84,12 @@ public class SnapshotDeleteFlight extends Flight {
     addStep(
         new PerformGcpStep(
             new DeleteSnapshotAuthzServiceUsageAclsStep(
-                iamClient, resourceService, snapshotService, snapshotId, userReq)));
+                iamClient,
+                resourceService,
+                snapshotService,
+                snapshotId,
+                userReq,
+                tdrServiceAccountEmail)));
 
     // Delete access control first so Readers and Discoverers can no longer see snapshot
     // Google auto-magically removes the ACLs from BQ objects when SAM

--- a/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
@@ -24,6 +24,7 @@ import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestResponseModel;
+import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.storage.StorageRoles;
@@ -56,6 +57,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   @Autowired private SamFixtures samFixtures;
   @Autowired private JsonLoader jsonLoader;
   @Autowired private TestConfiguration testConfiguration;
+  @Autowired private GoogleResourceManagerService resourceManagerService;
   @Rule @Autowired public TestJobWatcher testWatcher;
 
   private String stewardToken;
@@ -459,7 +461,10 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
         ingestServiceAccount,
         startsWith("tdr-ingest-sa"));
     DatasetIntegrationTest.addServiceAccountRoleToBucket(
-        bucketWithNoJadeSa, ingestServiceAccount, StorageRoles.objectViewer());
+        bucketWithNoJadeSa,
+        ingestServiceAccount,
+        StorageRoles.objectViewer(),
+        datasetSummaryModel.getDataProject());
     try {
       IngestResponseModel ingestResponse =
           dataRepoFixtures.ingestJsonData(steward(), datasetId, ingestRequest);
@@ -473,7 +478,10 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
     } finally {
       // Clean up role grants on shared bucket
       DatasetIntegrationTest.removeServiceAccountRoleFromBucket(
-          bucketWithNoJadeSa, ingestServiceAccount, StorageRoles.objectViewer());
+          bucketWithNoJadeSa,
+          ingestServiceAccount,
+          StorageRoles.objectViewer(),
+          datasetSummaryModel.getDataProject());
     }
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -41,6 +41,7 @@ import bio.terra.model.PolicyModel;
 import bio.terra.model.StorageResourceModel;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import com.google.cloud.Identity;
 import com.google.cloud.Policy;
 import com.google.cloud.Role;
@@ -54,6 +55,7 @@ import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.Storage.BucketSourceOption;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Charsets;
 import java.io.IOException;
@@ -99,6 +101,7 @@ public class DatasetIntegrationTest extends UsersBase {
   @Autowired private AuthService authService;
   @Rule @Autowired public TestJobWatcher testWatcher;
   @Autowired private JsonLoader jsonLoader;
+  @Autowired private GoogleResourceManagerService resourceManagerService;
 
   private String stewardToken;
   private UUID datasetId;
@@ -481,22 +484,33 @@ public class DatasetIntegrationTest extends UsersBase {
     return String.format("gs://%s/%s", blob.getBucket(), targetPath);
   }
 
-  static void addServiceAccountRoleToBucket(String bucket, String serviceAccount, Role role) {
+  static void addServiceAccountRoleToBucket(
+      String bucket, String serviceAccount, Role role, String userProject) {
     Storage storage = StorageOptions.getDefaultInstance().getService();
-    Policy iamPolicy = storage.getIamPolicy(bucket);
+    BucketSourceOption[] options =
+        Optional.ofNullable(userProject)
+            .map(p -> new BucketSourceOption[] {BucketSourceOption.userProject(p)})
+            .orElseGet(() -> new BucketSourceOption[0]);
+
+    Policy iamPolicy = storage.getIamPolicy(bucket, options);
     storage.setIamPolicy(
         bucket,
-        iamPolicy.toBuilder().addIdentity(role, Identity.serviceAccount(serviceAccount)).build());
+        iamPolicy.toBuilder().addIdentity(role, Identity.serviceAccount(serviceAccount)).build(),
+        options);
   }
 
-  static void removeServiceAccountRoleFromBucket(String bucket, String serviceAccount, Role role) {
+  static void removeServiceAccountRoleFromBucket(
+      String bucket, String serviceAccount, Role role, String userProject) {
     Storage storage = StorageOptions.getDefaultInstance().getService();
-    Policy iamPolicy = storage.getIamPolicy(bucket);
+    BucketSourceOption[] options =
+        Optional.ofNullable(userProject)
+            .map(p -> new BucketSourceOption[] {BucketSourceOption.userProject(p)})
+            .orElseGet(() -> new BucketSourceOption[0]);
+    Policy iamPolicy = storage.getIamPolicy(bucket, options);
     storage.setIamPolicy(
         bucket,
-        iamPolicy.toBuilder()
-            .removeIdentity(role, Identity.serviceAccount(serviceAccount))
-            .build());
+        iamPolicy.toBuilder().removeIdentity(role, Identity.serviceAccount(serviceAccount)).build(),
+        options);
   }
 
   static void assertTableCount(BigQuery bigQuery, DatasetModel dataset, String tableName, Long n)

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -143,10 +143,13 @@ public class DrsServiceTest {
                         new SnapshotSource()
                             .dataset(
                                 new Dataset(
-                                    new DatasetSummary()
-                                        .selfHosted(false)
-                                        .defaultProfileId(billingProfile.getId())
-                                        .billingProfiles(List.of(billingProfile)))))));
+                                        new DatasetSummary()
+                                            .selfHosted(false)
+                                            .defaultProfileId(billingProfile.getId())
+                                            .billingProfiles(List.of(billingProfile)))
+                                    .projectResource(
+                                        new GoogleProjectResource()
+                                            .googleProjectId("dataset-google-project"))))));
 
     String bucketResourceId = UUID.randomUUID().toString();
     String storageAccountResourceId = UUID.randomUUID().toString();
@@ -436,13 +439,14 @@ public class DrsServiceTest {
     UUID defaultProfileModelId = UUID.randomUUID();
     Dataset dataset =
         new Dataset(
-            new DatasetSummary()
-                .billingProfiles(
-                    List.of(
-                        new BillingProfileModel()
-                            .id(defaultProfileModelId)
-                            .cloudPlatform(CloudPlatform.AZURE)))
-                .defaultProfileId(defaultProfileModelId));
+                new DatasetSummary()
+                    .billingProfiles(
+                        List.of(
+                            new BillingProfileModel()
+                                .id(defaultProfileModelId)
+                                .cloudPlatform(CloudPlatform.AZURE)))
+                    .defaultProfileId(defaultProfileModelId))
+            .projectResource(new GoogleProjectResource().googleProjectId("dataset-google-project"));
     Snapshot snapshot =
         new Snapshot()
             .id(snapshotId)


### PR DESCRIPTION
This PR fixes issues with performing DRS lookups when a dataset happens to be:
- Self hosted
- Uses a dedicated ingest service account

What was happening is that a user would have a dataset with self hosted true and with its own one off ingest service account.  Then they "ingest" (which just stores a pointer to the file).  All good.  The problem is that when the user tries to do a Drs lookup on one of these files, we we need to connect to the source file's bucket in order to report the region (we get it lazily so that we can represent reality...in case a user has dropped and recreated a bucket).  In order to do that, the service account needs to have `storage.bucket.get` permissions.  Before this PR, we were using the TDR service account, instead of the dataset's service account (which is granted that access in order to ingest)