### PR TITLE
DR-2827 Make sure to sign urls with the ingest account, if appropriate

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -378,11 +378,17 @@ public class DrsService {
 
   private DRSAccessURL signGoogleUrl(
       SnapshotCacheResult cachedSnapshot, String gsPath, AuthenticatedUserRequest authUser) {
-    Storage storage =
-        StorageOptions.newBuilder()
-            .setProjectId(cachedSnapshot.googleProjectId)
-            .build()
-            .getService();
+    Storage storage;
+    if (cachedSnapshot.isSelfHosted) {
+      // In the case of a self-hosted dataset, use the dataset's service account to sign the url
+      storage = gcsProjectFactory.getStorage(cachedSnapshot.datasetProjectId);
+    } else {
+      storage =
+          StorageOptions.newBuilder()
+              .setProjectId(cachedSnapshot.googleProjectId)
+              .build()
+              .getService();
+    }
     BlobId locator = GcsUriUtils.parseBlobUri(gsPath);
 
     BlobInfo blobInfo = BlobInfo.newBuilder(locator).build();


### PR DESCRIPTION
In the case where a user is attempting to get a signed URL of a file using the drs access endpoint and:
- The source dataset is self hosted
- It has a dedicated ingest account
- The TDR does not have read access to the source bucket

(e.g. the case for Anvil)

The user gets back a url that looks like:
```https://storage.googleapis.com/muscles-ingest-rp/snapshot-test-dataset-data.csv?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=jade-k8-sa%40broad-jade-dev.iam.gserviceaccount.com%2F20221110%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20221110T040747Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=nmalfroy.dev%40gmail.com&userProject=datarepo-tools-992b5de4&X-Goog-Signature=REDACTED```

This URL doesn't actually work since the `X-Goog-Credential` is the TDR service account.

In this case, the url should look like:
```https://storage.googleapis.com/muscles-ingest-rp/snapshot-test-dataset-data.csv?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=tdr-ingest-sa%40datarepo-tools-dbd538b6.iam.gserviceaccount.com%2F20221110%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20221110T040613Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&requestedBy=nmalfroy.dev%40gmail.com&userProject=datarepo-tools-992b5de4&X-Goog-Signature=REDACTED```

Note: the `X-Goog-Credential`.  The reason that we mint it is so that users can avoid granting permissions to the main TDR account so this won't work in most cases.

This PR makes this happen (by using the appropriate credentials to sign the URL)

Note: I manually tested this.  The problem with automation is that we'd need a separate test account that has admin permission to the bucket so that we could avoid having the TDR account have permissions but we don't have that and that complicates this pretty significantly.  I was able to reproduce the fix manually and then reproduce that the PR fixes the issue