### PR TITLE
[DDO-2458] Report new datarepo versions to DevOps's new version system

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -11,6 +11,12 @@ env:
   chartVersion: 0.1.583
 jobs:
   alpha_promotion:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      # broadinstitute/action-slack uses the GitHub token to contact the
+      # actions API to generate a link to this job.
+      actions: 'read'
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -25,6 +31,54 @@ jobs:
         uses: "broadinstitute/github-action-get-previous-tag@master"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: 'Generate IAP token to talk to Sherlock'
+        id: 'auth-iap'
+        uses: google-github-actions/auth@v0
+        with:
+          token_format: 'id_token'
+          id_token_audience: '1038484894585-k8qvf7l876733laev0lm8kenfa2lj6bn.apps.googleusercontent.com'
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+          id_token_include_email: true
+      - name: 'Update Sherlock'
+        run: |
+          curl -X 'POST' \
+            'https://sherlock-dev.dsp-devops.broadinstitute.org/api/v2/procedures/changesets/plan-and-apply' \
+            -H 'accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -H 'Authorization: Bearer ${{ steps.auth-iap.outputs.id_token }}' \
+            -d "{
+              \"chartReleases\": [
+                {
+                  \"chartRelease\": \"alpha/datarepo\",
+                  \"toAppVersionExact\": \"${{ steps.apiprevioustag.outputs.tag }}\",
+                  \"toAppVersionResolver\": \"exact\",
+                  \"toChartVersionExact\": \"${{ env.chartVersion }}\",
+                  \"toChartVersionResolver\": \"exact\",
+                  \"toHelmfileRef\": \"HEAD\"
+                }
+              ]
+            }"
+          curl --fail -X 'POST' \
+            'https://sherlock.dsp-devops.broadinstitute.org/api/v2/procedures/changesets/plan-and-apply' \
+            -H 'accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -H 'Authorization: Bearer ${{ steps.auth-iap.outputs.id_token }}' \
+            -d "{
+              \"chartReleases\": [
+                {
+                  \"chartRelease\": \"alpha/datarepo\",
+                  \"toAppVersionExact\": \"${{ steps.apiprevioustag.outputs.tag }}\",
+                  \"toAppVersionResolver\": \"exact\",
+                  \"toChartVersionExact\": \"${{ env.chartVersion }}\",
+                  \"toChartVersionResolver\": \"exact\",
+                  \"toHelmfileRef\": \"HEAD\"
+                }
+              ]
+            }"
+
+      # Legacy terra-helmfile interaction done for double-writing after Sherlock cut-over, see DDO-2449
       - name: 'Checkout terra-helmfile repo'
         uses: actions/checkout@v2
         with:
@@ -59,6 +113,8 @@ jobs:
             Update versions in **${{ steps.apiprevioustag.outputs.tag }}**.
             *Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).*
           labels: "broadbot,datarepo,automerge,version-update"
+      # End of legacy double-writing
+
       - name: "Notify Slack"
         if: always()
         uses: broadinstitute/action-slack@v3.8.0

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ datarepo-client/gradlew.bat
 env_vars
 jade-dev-account.json
 jade-dev-account.pem
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
We cut over to a new versioning system, Sherlock, but didn't realize that this action also regularly updates dev.yaml in terra-helmfile. This PR adds writing to our new system and documents that the old terra-helmfile bit is temporary double-writing as we transition (just in case we need to revert back).