### PR TITLE
DR-2831 Add support for predictable and global DRS IDs

### DIFF
--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -329,6 +329,15 @@ public class Dataset implements FSContainerInterface, LogPrintable {
     return datasetSummary.getCloudPlatform();
   }
 
+  public boolean isPredictableFileIds() {
+    return datasetSummary.isPredictableFileIds();
+  }
+
+  public Dataset predictableFileIDs(boolean predictableFileIDs) {
+    datasetSummary.predictableFileIds(predictableFileIDs);
+    return this;
+  }
+
   @Override
   public String toLogString() {
     return String.format("%s (%s)", this.getName(), this.getId());

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -329,12 +329,12 @@ public class Dataset implements FSContainerInterface, LogPrintable {
     return datasetSummary.getCloudPlatform();
   }
 
-  public boolean isPredictableFileIds() {
-    return datasetSummary.isPredictableFileIds();
+  public boolean hasPredictableFileIds() {
+    return datasetSummary.hasPredictableFileIds();
   }
 
-  public Dataset predictableFileIDs(boolean predictableFileIDs) {
-    datasetSummary.predictableFileIds(predictableFileIDs);
+  public Dataset predictableFileIds(boolean predictableFileIds) {
+    datasetSummary.predictableFileIds(predictableFileIds);
     return this;
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -389,12 +389,12 @@ public class DatasetDao {
     String sql =
         """
         INSERT INTO dataset
-       (name, default_profile_id, id, project_resource_id, application_resource_id, flightid,
-       description, secure_monitoring, phs_id, self_hosted, properties, sharedlock,
-       predictable_file_ids)
-       VALUES (:name, :default_profile_id, :id, :project_resource_id, :application_resource_id,
-       :flightid, :description, :secure_monitoring, :phs_id, :self_hosted,
-       cast(:properties as jsonb), ARRAY[]::TEXT[], :predictable_file_ids)
+        (name, default_profile_id, id, project_resource_id, application_resource_id, flightid,
+         description, secure_monitoring, phs_id, self_hosted, properties, sharedlock,
+         predictable_file_ids)
+        VALUES (:name, :default_profile_id, :id, :project_resource_id, :application_resource_id,
+         :flightid, :description, :secure_monitoring, :phs_id, :self_hosted,
+         cast(:properties as jsonb), ARRAY[]::TEXT[], :predictable_file_ids)
        """;
 
     MapSqlParameterSource params =
@@ -409,7 +409,7 @@ public class DatasetDao {
             .addValue("secure_monitoring", dataset.isSecureMonitoringEnabled())
             .addValue("phs_id", dataset.getPhsId())
             .addValue("self_hosted", dataset.isSelfHosted())
-            .addValue("predictable_file_ids", dataset.isPredictableFileIds())
+            .addValue("predictable_file_ids", dataset.hasPredictableFileIds())
             .addValue(
                 "properties", DaoUtils.propertiesToString(objectMapper, dataset.getProperties()));
 

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -71,7 +71,7 @@ public class DatasetDao {
   private static final String summaryQueryColumns =
       " dataset.id, dataset.name, description, default_profile_id, project_resource_id, "
           + "dataset.application_resource_id, secure_monitoring, phs_id, self_hosted, "
-          + "properties, created_date, ";
+          + "properties, created_date, predictable_file_ids,";
 
   private static final String summaryCloudPlatformQuery =
       "(SELECT pr.google_project_id "
@@ -387,11 +387,15 @@ public class DatasetDao {
     logger.debug(
         "Lock Operation: createAndLock datasetId: {} for flightId: {}", dataset.getId(), flightId);
     String sql =
-        "INSERT INTO dataset "
-            + "(name, default_profile_id, id, project_resource_id, application_resource_id, flightid, description, "
-            + "secure_monitoring, phs_id, self_hosted, properties, sharedlock) "
-            + "VALUES (:name, :default_profile_id, :id, :project_resource_id, :application_resource_id, :flightid, "
-            + ":description, :secure_monitoring, :phs_id, :self_hosted, cast(:properties as jsonb), ARRAY[]::TEXT[]) ";
+        """
+        INSERT INTO dataset
+       (name, default_profile_id, id, project_resource_id, application_resource_id, flightid,
+       description, secure_monitoring, phs_id, self_hosted, properties, sharedlock,
+       predictable_file_ids)
+       VALUES (:name, :default_profile_id, :id, :project_resource_id, :application_resource_id,
+       :flightid, :description, :secure_monitoring, :phs_id, :self_hosted,
+       cast(:properties as jsonb), ARRAY[]::TEXT[], :predictable_file_ids)
+       """;
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -405,6 +409,7 @@ public class DatasetDao {
             .addValue("secure_monitoring", dataset.isSecureMonitoringEnabled())
             .addValue("phs_id", dataset.getPhsId())
             .addValue("self_hosted", dataset.isSelfHosted())
+            .addValue("predictable_file_ids", dataset.isPredictableFileIds())
             .addValue(
                 "properties", DaoUtils.propertiesToString(objectMapper, dataset.getProperties()));
 
@@ -721,6 +726,7 @@ public class DatasetDao {
           .storageAccount(rs.getString("storage_account_name"))
           .phsId(rs.getString("phs_id"))
           .selfHosted(rs.getBoolean("self_hosted"))
+          .predictableFileIds(rs.getBoolean("predictable_file_ids"))
           .properties(properties);
     }
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -78,7 +78,8 @@ public final class DatasetJsonConversion {
                 .secureMonitoringEnabled(enableSecureMonitoring)
                 .phsId(datasetRequest.getPhsId())
                 .selfHosted(datasetRequest.isExperimentalSelfHosted())
-                .properties(datasetRequest.getProperties()))
+                .properties(datasetRequest.getProperties())
+                .predictableFileIds(datasetRequest.isPredictableFileIds()))
         .tables(new ArrayList<>(tablesMap.values()))
         .relationships(new ArrayList<>(relationshipsMap.values()))
         .assetSpecifications(assetSpecifications);
@@ -97,7 +98,8 @@ public final class DatasetJsonConversion {
             .createdDate(dataset.getCreatedDate().toString())
             .secureMonitoringEnabled(dataset.isSecureMonitoringEnabled())
             .phsId(dataset.getPhsId())
-            .selfHosted(dataset.isSelfHosted());
+            .selfHosted(dataset.isSelfHosted())
+            .predictableFileIds(dataset.isPredictableFileIds());
 
     if (include.contains(DatasetRequestAccessIncludeModel.NONE)) {
       return datasetModel;

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -99,7 +99,7 @@ public final class DatasetJsonConversion {
             .secureMonitoringEnabled(dataset.isSecureMonitoringEnabled())
             .phsId(dataset.getPhsId())
             .selfHosted(dataset.isSelfHosted())
-            .predictableFileIds(dataset.isPredictableFileIds());
+            .predictableFileIds(dataset.hasPredictableFileIds());
 
     if (include.contains(DatasetRequestAccessIncludeModel.NONE)) {
       return datasetModel;

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -79,7 +79,7 @@ public final class DatasetJsonConversion {
                 .phsId(datasetRequest.getPhsId())
                 .selfHosted(datasetRequest.isExperimentalSelfHosted())
                 .properties(datasetRequest.getProperties())
-                .predictableFileIds(datasetRequest.isPredictableFileIds()))
+                .predictableFileIds(datasetRequest.isExperimentalPredictableFileIds()))
         .tables(new ArrayList<>(tablesMap.values()))
         .relationships(new ArrayList<>(relationshipsMap.values()))
         .assetSpecifications(assetSpecifications);

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -33,6 +33,7 @@ public class DatasetSummary {
   private String phsId;
   private boolean selfHosted;
   private Object properties;
+  private boolean predictableFileIds;
 
   public UUID getId() {
     return id;
@@ -222,6 +223,15 @@ public class DatasetSummary {
     return this;
   }
 
+  public boolean isPredictableFileIds() {
+    return predictableFileIds;
+  }
+
+  public DatasetSummary predictableFileIds(boolean predictableFileIds) {
+    this.predictableFileIds = predictableFileIds;
+    return this;
+  }
+
   public DatasetSummaryModel toModel() {
     return new DatasetSummaryModel()
         .id(getId())
@@ -235,7 +245,8 @@ public class DatasetSummary {
         .dataProject(getDataProject())
         .storageAccount(getStorageAccount())
         .phsId(getPhsId())
-        .selfHosted(isSelfHosted());
+        .selfHosted(isSelfHosted())
+        .predictableFileIds(isPredictableFileIds());
   }
 
   List<StorageResourceModel> toStorageResourceModel() {

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -223,7 +223,7 @@ public class DatasetSummary {
     return this;
   }
 
-  public boolean isPredictableFileIds() {
+  public boolean hasPredictableFileIds() {
     return predictableFileIds;
   }
 
@@ -246,7 +246,7 @@ public class DatasetSummary {
         .storageAccount(getStorageAccount())
         .phsId(getPhsId())
         .selfHosted(isSelfHosted())
-        .predictableFileIds(isPredictableFileIds());
+        .predictableFileIds(hasPredictableFileIds());
   }
 
   List<StorageResourceModel> toStorageResourceModel() {

--- a/src/main/java/bio/terra/service/filedata/DrsId.java
+++ b/src/main/java/bio/terra/service/filedata/DrsId.java
@@ -44,8 +44,13 @@ public class DrsId {
   }
 
   public String toDrsObjectId() {
-    String vv = version == null ? "v1" : version;
-    return vv + "_" + snapshotId + "_" + fsObjectId;
+    if (version.equals("v1") || version == null) {
+      return "v1_" + snapshotId + "_" + fsObjectId;
+    } else if (version.equals("v2")) {
+      return "v2_" + fsObjectId;
+    } else {
+      throw new InvalidDrsIdException("Unrecognized DRS Object ID version: %s".formatted(version));
+    }
   }
 
   public String toDrsUri() {

--- a/src/main/java/bio/terra/service/filedata/DrsId.java
+++ b/src/main/java/bio/terra/service/filedata/DrsId.java
@@ -44,7 +44,7 @@ public class DrsId {
   }
 
   public String toDrsObjectId() {
-    if (version.equals("v1") || version == null) {
+    if (version == null || version.equals("v1")) {
       return "v1_" + snapshotId + "_" + fsObjectId;
     } else if (version.equals("v2")) {
       return "v2_" + fsObjectId;

--- a/src/main/java/bio/terra/service/filedata/DrsIdDao.java
+++ b/src/main/java/bio/terra/service/filedata/DrsIdDao.java
@@ -20,15 +20,6 @@ public class DrsIdDao {
       INSERT INTO drs_id (drs_object_id, snapshot_id) VALUES (:drs_object_id, :snapshot_id)
       ON CONFLICT DO NOTHING
       """;
-  public static final String DELETE_DRS_ID_BY_SNAPSHOT =
-      """
-      DELETE FROM drs_id WHERE snapshot_id = :snapshot_id
-      """;
-
-  public static final String ENUMERATE_DRS_IDS_BY_DRS_ID =
-      """
-      SELECT id, drs_object_id, snapshot_id FROM drs_id WHERE drs_object_id = :drs_object_id
-      """;
 
   public long recordDrsIdToSnapshot(UUID snapshotId, List<DrsId> drsIds) {
     MapSqlParameterSource[] parameters =
@@ -43,11 +34,21 @@ public class DrsIdDao {
     return Arrays.stream(affectedRows).reduce(0, Integer::sum);
   }
 
+  public static final String DELETE_DRS_ID_BY_SNAPSHOT =
+      """
+      DELETE FROM drs_id WHERE snapshot_id = :snapshot_id
+      """;
+
   public long deleteDrsIdToSnapshotsBySnapshot(UUID snapshotId) {
     MapSqlParameterSource parameters =
         new MapSqlParameterSource().addValue("snapshot_id", snapshotId);
     return jdbcTemplate.update(DELETE_DRS_ID_BY_SNAPSHOT, parameters);
   }
+
+  public static final String ENUMERATE_DRS_IDS_BY_DRS_ID =
+      """
+      SELECT id, drs_object_id, snapshot_id FROM drs_id WHERE drs_object_id = :drs_object_id
+      """;
 
   public List<UUID> retrieveReferencedSnapshotIds(DrsId drsId) {
     MapSqlParameterSource parameters =

--- a/src/main/java/bio/terra/service/filedata/DrsIdDao.java
+++ b/src/main/java/bio/terra/service/filedata/DrsIdDao.java
@@ -1,0 +1,60 @@
+package bio.terra.service.filedata;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DrsIdDao {
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public DrsIdDao(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  public static final String INSERT_DRS_ID =
+      """
+      INSERT INTO drs_id (drs_object_id, snapshot_id) VALUES (:drs_object_id, :snapshot_id)
+      ON CONFLICT DO NOTHING
+      """;
+  public static final String DELETE_DRS_ID_BY_SNAPSHOT =
+      """
+      DELETE FROM drs_id WHERE snapshot_id = :snapshot_id
+      """;
+
+  public static final String ENUMERATE_DRS_IDS_BY_DRS_ID =
+      """
+      SELECT id, drs_object_id, snapshot_id FROM drs_id WHERE drs_object_id = :drs_object_id
+      """;
+
+  public long recordDrsIdToSnapshot(UUID snapshotId, List<DrsId> drsIds) {
+    MapSqlParameterSource[] parameters =
+        drsIds.stream()
+            .map(
+                i ->
+                    new MapSqlParameterSource()
+                        .addValue("drs_object_id", i.toDrsObjectId())
+                        .addValue("snapshot_id", snapshotId))
+            .toArray(MapSqlParameterSource[]::new);
+    int[] affectedRows = jdbcTemplate.batchUpdate(INSERT_DRS_ID, parameters);
+    return Arrays.stream(affectedRows).reduce(0, Integer::sum);
+  }
+
+  public long deleteDrsIdToSnapshotsBySnapshot(UUID snapshotId) {
+    MapSqlParameterSource parameters =
+        new MapSqlParameterSource().addValue("snapshot_id", snapshotId);
+    return jdbcTemplate.update(DELETE_DRS_ID_BY_SNAPSHOT, parameters);
+  }
+
+  public List<UUID> retrieveReferencedSnapshotIds(DrsId drsId) {
+    MapSqlParameterSource parameters =
+        new MapSqlParameterSource().addValue("drs_object_id", drsId.toDrsObjectId());
+    return jdbcTemplate.query(
+        ENUMERATE_DRS_IDS_BY_DRS_ID,
+        parameters,
+        (rs, rowNum) -> UUID.fromString(rs.getString("snapshot_id")));
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -10,6 +10,7 @@ import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BillingProfileModel;
+import bio.terra.model.CloudPlatform;
 import bio.terra.model.DRSAccessMethod;
 import bio.terra.model.DRSAccessURL;
 import bio.terra.model.DRSAuthorizations;
@@ -21,6 +22,7 @@ import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.auth.iam.exception.IamForbiddenException;
 import bio.terra.service.common.gcs.GcsUriUtils;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
@@ -29,6 +31,7 @@ import bio.terra.service.filedata.azure.util.BlobSasTokenOptions;
 import bio.terra.service.filedata.exception.DrsObjectNotFoundException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import bio.terra.service.filedata.exception.InvalidDrsIdException;
+import bio.terra.service.filedata.exception.InvalidDrsObjectException;
 import bio.terra.service.filedata.google.gcs.GcsProjectFactory;
 import bio.terra.service.job.JobService;
 import bio.terra.service.resourcemanagement.ResourceService;
@@ -50,15 +53,24 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import java.net.URL;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -78,6 +90,7 @@ public class DrsService {
   private static final String ACCESS_ID_PREFIX_GCP = "gcp-";
   private static final String ACCESS_ID_PREFIX_AZURE = "az-";
   private static final String ACCESS_ID_PREFIX_PASSPORT = "passport-";
+  private static final String ACCESS_ID_SEPARATOR = "*";
   private static final String DRS_OBJECT_VERSION = "0";
   private static final Duration URL_TTL = Duration.ofMinutes(15);
   private static final String USER_PROJECT_QUERY_PARAM = "userProject";
@@ -96,6 +109,7 @@ public class DrsService {
   private final AzureBlobStorePdao azureBlobStorePdao;
   private final GcsProjectFactory gcsProjectFactory;
   private final EcmConfiguration ecmConfiguration;
+  private final DrsIdDao drsIdDao;
 
   private final Map<UUID, SnapshotProject> snapshotProjectsCache =
       Collections.synchronizedMap(new PassiveExpiringMap<>(15, TimeUnit.MINUTES));
@@ -116,7 +130,8 @@ public class DrsService {
       PerformanceLogger performanceLogger,
       AzureBlobStorePdao azureBlobStorePdao,
       GcsProjectFactory gcsProjectFactory,
-      EcmConfiguration ecmConfiguration) {
+      EcmConfiguration ecmConfiguration,
+      DrsIdDao drsIdDao) {
     this.snapshotService = snapshotService;
     this.fileService = fileService;
     this.drsIdService = drsIdService;
@@ -128,6 +143,7 @@ public class DrsService {
     this.azureBlobStorePdao = azureBlobStorePdao;
     this.gcsProjectFactory = gcsProjectFactory;
     this.ecmConfiguration = ecmConfiguration;
+    this.drsIdDao = drsIdDao;
   }
 
   private class DrsRequestResource implements AutoCloseable {
@@ -165,10 +181,12 @@ public class DrsService {
    */
   public DRSAuthorizations lookupAuthorizationsByDrsId(String drsObjectId) {
     try (DrsRequestResource r = new DrsRequestResource()) {
-      SnapshotCacheResult snapshot = lookupSnapshotForDRSObject(drsObjectId);
-      SnapshotSummaryModel snapshotSummary = getSnapshotSummary(snapshot.id);
+      List<SnapshotCacheResult> snapshots = lookupSnapshotsForDRSObject(drsObjectId);
+      List<SnapshotSummaryModel> snapshotSummaries =
+          snapshots.stream().map(SnapshotCacheResult::getId).map(this::getSnapshotSummary).toList();
 
-      return buildDRSAuth(SnapshotSummary.passportAuthorizationAvailable(snapshotSummary));
+      return buildDRSAuth(
+          snapshotSummaries.stream().anyMatch(SnapshotSummary::passportAuthorizationAvailable));
     }
   }
 
@@ -180,6 +198,18 @@ public class DrsService {
     }
     auths.addSupportedTypesItem(DRSAuthorizations.SupportedTypesEnum.BEARERAUTH);
     return auths;
+  }
+
+  public long recordDrsIdToSnapshot(UUID snapshotId, List<DrsId> drsIds) {
+    return drsIdDao.recordDrsIdToSnapshot(snapshotId, drsIds);
+  }
+
+  public long deleteDrsIdToSnapshotsBySnapshot(UUID snapshotId) {
+    return drsIdDao.deleteDrsIdToSnapshotsBySnapshot(snapshotId);
+  }
+
+  private List<UUID> retrieveReferencedSnapshotIds(DrsId drsId) {
+    return drsIdDao.retrieveReferencedSnapshotIds(drsId);
   }
 
   /**
@@ -197,11 +227,24 @@ public class DrsService {
   public DRSObject lookupObjectByDrsIdPassport(
       String drsObjectId, DRSPassportRequestModel drsPassportRequestModel) {
     try (DrsRequestResource r = new DrsRequestResource()) {
-      SnapshotCacheResult snapshot = lookupSnapshotForDRSObject(drsObjectId);
-      verifyPassportAuth(snapshot.id, drsPassportRequestModel);
+      List<SnapshotCacheResult> cachedSnapshots =
+          lookupSnapshotsForDRSObject(drsObjectId).stream()
+              .parallel()
+              .map(
+                  s -> {
+                    try {
+                      // Only look at snapshots that the user has access to
+                      verifyPassportAuth(s.id, drsPassportRequestModel);
+                      return s;
+                    } catch (IamForbiddenException e) {
+                      return null;
+                    }
+                  })
+              .filter(Objects::nonNull)
+              .toList();
 
-      return lookupDRSObjectAfterAuth(
-          drsPassportRequestModel.isExpand(), snapshot, drsObjectId, null, true);
+      return resolveDRSObject(
+          null, drsObjectId, drsPassportRequestModel.isExpand(), cachedSnapshots, true);
     }
   }
 
@@ -220,46 +263,140 @@ public class DrsService {
   public DRSObject lookupObjectByDrsId(
       AuthenticatedUserRequest authUser, String drsObjectId, Boolean expand) {
     try (DrsRequestResource r = new DrsRequestResource()) {
-      SnapshotCacheResult cachedSnapshot = lookupSnapshotForDRSObject(drsObjectId);
-
       String samTimer = performanceLogger.timerStart();
-      samService.verifyAuthorization(
-          authUser,
-          IamResourceType.DATASNAPSHOT,
-          cachedSnapshot.id.toString(),
-          IamAction.READ_DATA);
+      List<SnapshotCacheResult> cachedSnapshots =
+          lookupSnapshotsForDRSObject(drsObjectId).stream()
+              .parallel()
+              .map(
+                  s -> {
+                    try {
+                      // Only look at snapshots that the user has access to
+                      samService.verifyAuthorization(
+                          authUser,
+                          IamResourceType.DATASNAPSHOT,
+                          s.id.toString(),
+                          IamAction.READ_DATA);
+                      return s;
+                    } catch (IamForbiddenException e) {
+                      return null;
+                    }
+                  })
+              .filter(Objects::nonNull)
+              .toList();
+      if (cachedSnapshots.isEmpty()) {
+        throw new IamForbiddenException("User does not have access");
+      }
       performanceLogger.timerEndAndLog(
           samTimer,
           drsObjectId, // not a flight, so no job id
           this.getClass().getName(),
           "samService.verifyAuthorization");
 
-      return lookupDRSObjectAfterAuth(expand, cachedSnapshot, drsObjectId, authUser, false);
+      return resolveDRSObject(authUser, drsObjectId, expand, cachedSnapshots, false);
     }
   }
 
+  /**
+   * Given the precalculated list of associated snaphots, look up the DRS object in the various
+   * firstore/azure table dbs and merged into a single DRSObject. Note: this will fail if object
+   * overlap in invalid ways, such as mismatched checksums, multiple names, etc.
+   */
+  private DRSObject resolveDRSObject(
+      AuthenticatedUserRequest authUser,
+      String drsObjectId,
+      Boolean expand,
+      List<SnapshotCacheResult> cachedSnapshots,
+      boolean passportAuth) {
+
+    Map<UUID, UUID> snapshotToBillingSnapshot = chooseBillingSnapshotsPerSnapshot(cachedSnapshots);
+    List<DRSObject> drsObjects =
+        cachedSnapshots.stream()
+            .parallel()
+            .map(
+                s ->
+                    lookupDRSObjectAfterAuth(
+                        expand,
+                        s,
+                        drsObjectId,
+                        authUser,
+                        passportAuth,
+                        snapshotToBillingSnapshot.get(s.id).toString()))
+            .toList();
+
+    return mergeDRSObjects(drsObjects);
+  }
+
+  /**
+   * Given a list of snapshots, return a map of snapshot ids mapped to the snapshot to use for
+   * billing
+   */
+  private Map<UUID, UUID> chooseBillingSnapshotsPerSnapshot(
+      List<SnapshotCacheResult> cachedSnapshots) {
+    // First create a multimap keyed on billing profile id whose values are a list of snapshots
+    // sorted by id
+    Map<UUID, List<SnapshotCacheResult>> snapshotsByBillingId =
+        cachedSnapshots.stream()
+            .collect(Collectors.groupingBy(SnapshotCacheResult::getSnapshotBillingProfileId))
+            .entrySet()
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey,
+                    e ->
+                        e.getValue().stream()
+                            .sorted(Comparator.comparing(SnapshotCacheResult::getId))
+                            .toList()));
+
+    // Create the map keyed on each snapshot id and whose value is the first snapshot for that
+    // snapshot's group (when grouped by billing account)
+    record BillingAndSnapshot(UUID billingId, SnapshotCacheResult snapshot) {}
+    return snapshotsByBillingId.entrySet().stream()
+        .flatMap(e -> e.getValue().stream().map(v -> new BillingAndSnapshot(e.getKey(), v)))
+        .collect(
+            Collectors.toMap(
+                e -> e.snapshot().getId(),
+                e -> snapshotsByBillingId.get(e.billingId()).get(0).getId()));
+  }
+
   @VisibleForTesting
-  SnapshotCacheResult lookupSnapshotForDRSObject(String drsObjectId) {
-    DrsId drsId = drsIdService.fromObjectId(drsObjectId);
-    SnapshotCacheResult snapshot;
+  List<SnapshotCacheResult> lookupSnapshotsForDRSObject(String drsObjectId) {
     try {
-      UUID snapshotId = UUID.fromString(drsId.getSnapshotId());
+      DrsId drsId = drsIdService.fromObjectId(drsObjectId);
+      List<UUID> snapshotIds = new ArrayList<>();
+      if (drsId.getVersion().equals("v1")) {
+        snapshotIds.add(UUID.fromString(drsId.getSnapshotId()));
+      } else if (drsId.getVersion().equals("v2")) {
+        snapshotIds.addAll(retrieveReferencedSnapshotIds(drsId));
+      } else {
+        throw new InvalidDrsIdException("Invalid DRS ID version %s".formatted(drsId.getVersion()));
+      }
       // We only look up DRS ids for unlocked snapshots.
       String retrieveTimer = performanceLogger.timerStart();
 
-      snapshot = getSnapshot(snapshotId);
+      List<SnapshotCacheResult> snapshots =
+          snapshotIds.stream()
+              .map(
+                  i -> {
+                    try {
+                      return this.getSnapshot(i);
+                    } catch (SnapshotNotFoundException ex) {
+                      return null;
+                    }
+                  })
+              .filter(Objects::nonNull)
+              .toList();
 
       performanceLogger.timerEndAndLog(
           retrieveTimer,
           drsObjectId, // not a flight, so no job id
           this.getClass().getName(),
           "snapshotService.retrieveAvailable");
-      return snapshot;
+      if (snapshots.isEmpty()) {
+        throw new DrsObjectNotFoundException("No snapshots found for this DRS Object ID");
+      }
+      return snapshots;
     } catch (IllegalArgumentException ex) {
       throw new InvalidDrsIdException("Invalid object id format '" + drsObjectId + "'", ex);
-    } catch (SnapshotNotFoundException ex) {
-      throw new DrsObjectNotFoundException(
-          "No snapshot found for DRS object id '" + drsObjectId + "'", ex);
     }
   }
 
@@ -276,7 +413,8 @@ public class DrsService {
       SnapshotCacheResult snapshot,
       String drsObjectId,
       AuthenticatedUserRequest authUser,
-      boolean passportAuth) {
+      boolean passportAuth,
+      String billingSnapshot) {
     DrsId drsId = drsIdService.fromObjectId(drsObjectId);
     SnapshotProject snapshotProject = getSnapshotProject(snapshot.id);
     int depth = (expand ? -1 : 1);
@@ -297,9 +435,10 @@ public class DrsService {
     }
 
     if (fsObject instanceof FSFile) {
-      return drsObjectFromFSFile((FSFile) fsObject, snapshot, authUser, passportAuth);
+      return drsObjectFromFSFile(
+          (FSFile) fsObject, snapshot, authUser, passportAuth, billingSnapshot);
     } else if (fsObject instanceof FSDir) {
-      return drsObjectFromFSDir((FSDir) fsObject, drsId.getSnapshotId());
+      return drsObjectFromFSDir((FSDir) fsObject, snapshot);
     }
 
     throw new IllegalArgumentException("Invalid object type");
@@ -321,10 +460,19 @@ public class DrsService {
       AuthenticatedUserRequest authUser, DRSObject drsObject, String objectId, String accessId) {
 
     DrsId drsId = drsIdService.fromObjectId(objectId);
-    UUID snapshotId = UUID.fromString(drsId.getSnapshotId());
+    UUID snapshotId;
+    if (drsId.getSnapshotId() != null) {
+      snapshotId = UUID.fromString(drsId.getSnapshotId());
+    } else {
+      String[] parts = accessId.split("\\Q" + ACCESS_ID_SEPARATOR + "\\E");
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("Invalid access id");
+      }
+      snapshotId = UUID.fromString(parts[1]);
+    }
     SnapshotCacheResult cachedSnapshot = getSnapshot(snapshotId);
 
-    BillingProfileModel billingProfileModel = cachedSnapshot.billingProfileModel;
+    BillingProfileModel billingProfileModel = cachedSnapshot.datasetBillingProfileModel;
 
     assertAccessMethodMatchingAccessId(accessId, drsObject);
 
@@ -339,7 +487,8 @@ public class DrsService {
     } catch (InterruptedException e) {
       throw new IllegalArgumentException(e);
     }
-    CloudPlatformWrapper platform = CloudPlatformWrapper.of(billingProfileModel.getCloudPlatform());
+
+    CloudPlatformWrapper platform = CloudPlatformWrapper.of(cachedSnapshot.cloudPlatform);
     if (platform.isGcp()) {
       return signGoogleUrl(cachedSnapshot, fsFile.getCloudPath(), authUser);
     } else if (platform.isAzure()) {
@@ -354,7 +503,7 @@ public class DrsService {
         () -> new IllegalArgumentException("No matching access ID was found for object");
 
     return object.getAccessMethods().stream()
-        .filter(drsAccessMethod -> drsAccessMethod.getAccessId().equals(accessId))
+        .filter(drsAccessMethod -> Objects.equals(drsAccessMethod.getAccessId(), accessId))
         .findFirst()
         .orElseThrow(illegalArgumentExceptionSupplier);
   }
@@ -413,8 +562,9 @@ public class DrsService {
       FSFile fsFile,
       SnapshotCacheResult cachedSnapshot,
       AuthenticatedUserRequest authUser,
-      boolean passportAuth) {
-    DRSObject fileObject = makeCommonDrsObject(fsFile, cachedSnapshot.id.toString());
+      boolean passportAuth,
+      String billingSnapshot) {
+    DRSObject fileObject = makeCommonDrsObject(fsFile, cachedSnapshot);
 
     List<DRSAccessMethod> accessMethods;
     CloudPlatformWrapper platform = CloudPlatformWrapper.of(fsFile.getCloudPlatform());
@@ -423,29 +573,40 @@ public class DrsService {
       if (passportAuth) {
         accessMethods =
             getDrsSignedURLAccessMethods(
-                ACCESS_ID_PREFIX_GCP + ACCESS_ID_PREFIX_PASSPORT, gcpRegion, passportAuth);
+                ACCESS_ID_PREFIX_GCP + ACCESS_ID_PREFIX_PASSPORT,
+                gcpRegion,
+                passportAuth,
+                billingSnapshot);
       } else {
         accessMethods =
-            getDrsAccessMethodsOnGcp(fsFile, authUser, gcpRegion, cachedSnapshot.googleProjectId);
+            getDrsAccessMethodsOnGcp(
+                fsFile, authUser, gcpRegion, cachedSnapshot.googleProjectId, billingSnapshot);
       }
     } else if (platform.isAzure()) {
       String azureRegion = retrieveAzureSnapshotRegion(fsFile);
       if (passportAuth) {
         accessMethods =
             getDrsSignedURLAccessMethods(
-                ACCESS_ID_PREFIX_AZURE + ACCESS_ID_PREFIX_PASSPORT, azureRegion, passportAuth);
+                ACCESS_ID_PREFIX_AZURE + ACCESS_ID_PREFIX_PASSPORT,
+                azureRegion,
+                passportAuth,
+                null);
       } else {
         accessMethods =
-            getDrsSignedURLAccessMethods(ACCESS_ID_PREFIX_AZURE, azureRegion, passportAuth);
+            getDrsSignedURLAccessMethods(ACCESS_ID_PREFIX_AZURE, azureRegion, passportAuth, null);
       }
     } else {
       throw new InvalidCloudPlatformException();
     }
 
+    String selfUri =
+        cachedSnapshot.globalFileIds
+            ? drsIdService.makeDrsId(fsFile).toDrsUri()
+            : drsIdService.makeDrsId(fsFile, cachedSnapshot.id.toString()).toDrsUri();
     fileObject
         .mimeType(fsFile.getMimeType())
         .checksums(fileService.makeChecksums(fsFile))
-        .selfUri(drsIdService.makeDrsId(fsFile, cachedSnapshot.id.toString()).toDrsUri())
+        .selfUri(selfUri)
         .accessMethods(accessMethods);
 
     return fileObject;
@@ -479,11 +640,18 @@ public class DrsService {
   }
 
   private List<DRSAccessMethod> getDrsAccessMethodsOnGcp(
-      FSFile fsFile, AuthenticatedUserRequest authUser, String region, String userProject) {
+      FSFile fsFile,
+      AuthenticatedUserRequest authUser,
+      String region,
+      String userProject,
+      String billingSnapshot) {
     DRSAccessURL gsAccessURL = new DRSAccessURL().url(fsFile.getCloudPath());
     DRSAuthorizations authorizationsBearerOnly = buildDRSAuth(false);
 
-    String accessId = ACCESS_ID_PREFIX_GCP + region;
+    String accessId =
+        ACCESS_ID_PREFIX_GCP
+            + region
+            + Optional.ofNullable(billingSnapshot).map(s -> ACCESS_ID_SEPARATOR + s).orElse("");
     DRSAccessMethod gsAccessMethod =
         new DRSAccessMethod()
             .type(DRSAccessMethod.TypeEnum.GS)
@@ -508,9 +676,12 @@ public class DrsService {
   }
 
   private List<DRSAccessMethod> getDrsSignedURLAccessMethods(
-      String prefix, String region, boolean passportAuth) {
-    String accessId = prefix + region;
+      String prefix, String region, boolean passportAuth, String billingProject) {
     DRSAuthorizations authorizations = buildDRSAuth(passportAuth);
+    String accessId =
+        prefix
+            + region
+            + Optional.ofNullable(billingProject).map(b -> ACCESS_ID_SEPARATOR + b).orElse("");
     DRSAccessMethod httpsAccessMethod =
         new DRSAccessMethod()
             .type(DRSAccessMethod.TypeEnum.HTTPS)
@@ -521,20 +692,28 @@ public class DrsService {
     return List.of(httpsAccessMethod);
   }
 
-  private DRSObject drsObjectFromFSDir(FSDir fsDir, String snapshotId) {
-    DRSObject dirObject = makeCommonDrsObject(fsDir, snapshotId);
+  private DRSObject drsObjectFromFSDir(FSDir fsDir, SnapshotCacheResult snapshot) {
+    DRSObject dirObject = makeCommonDrsObject(fsDir, snapshot);
 
     DRSChecksum drsChecksum = new DRSChecksum().type("crc32c").checksum("0");
-    dirObject.size(0L).addChecksumsItem(drsChecksum).contents(makeContentsList(fsDir, snapshotId));
+    dirObject
+        .size(0L)
+        .addChecksumsItem(drsChecksum)
+        .contents(makeContentsList(fsDir, snapshot.id.toString()));
 
     return dirObject;
   }
 
-  private DRSObject makeCommonDrsObject(FSItem fsObject, String snapshotId) {
+  private DRSObject makeCommonDrsObject(FSItem fsObject, SnapshotCacheResult snapshot) {
     // Compute the time once; used for both created and updated times as per DRS spec for immutable
     // objects
     String theTime = fsObject.getCreatedDate().toString();
-    DrsId drsId = drsIdService.makeDrsId(fsObject, snapshotId);
+    DrsId drsId;
+    if (snapshot.globalFileIds) {
+      drsId = drsIdService.makeDrsId(fsObject);
+    } else {
+      drsId = drsIdService.makeDrsId(fsObject, snapshot.id.toString());
+    }
 
     return new DRSObject()
         .id(drsId.toDrsObjectId())
@@ -613,18 +792,104 @@ public class DrsService {
   }
 
   @VisibleForTesting
+  DRSObject mergeDRSObjects(List<DRSObject> drsObjects) {
+    DRSObject drsObject =
+        new DRSObject()
+            // Extract singleton values
+            .id(extractUniqueDrsObjectValue(drsObjects, DRSObject::getId))
+            .name(extractUniqueDrsObjectValue(drsObjects, DRSObject::getName))
+            .description(extractUniqueDrsObjectValue(drsObjects, DRSObject::getDescription))
+            .size(extractUniqueDrsObjectValue(drsObjects, DRSObject::getSize))
+            .selfUri(extractUniqueDrsObjectValue(drsObjects, DRSObject::getSelfUri))
+            .mimeType(extractUniqueDrsObjectValue(drsObjects, DRSObject::getMimeType))
+            .version(extractUniqueDrsObjectValue(drsObjects, DRSObject::getVersion))
+            // Get the earliest creation date
+            .createdTime(
+                drsObjects.stream()
+                    .map(DRSObject::getCreatedTime)
+                    .map(Instant::parse)
+                    .min(Comparator.naturalOrder())
+                    .map(Instant::toString)
+                    .orElse(""))
+            // Get the latest update date
+            .updatedTime(
+                drsObjects.stream()
+                    .map(DRSObject::getUpdatedTime)
+                    .map(Instant::parse)
+                    .max(Comparator.naturalOrder())
+                    .map(Instant::toString)
+                    .orElse(""))
+            // Get a distinct list of access methods
+            .accessMethods(
+                drsObjects.stream()
+                    .map(DRSObject::getAccessMethods)
+                    .flatMap(Collection::stream)
+                    .distinct()
+                    .toList())
+            // Get a distinct list of checksums methods
+            .checksums(
+                drsObjects.stream()
+                    .map(DRSObject::getChecksums)
+                    .flatMap(Collection::stream)
+                    .distinct()
+                    .toList())
+            // Get a distinct list aliases
+            .aliases(
+                drsObjects.stream()
+                    .map(DRSObject::getAliases)
+                    .flatMap(Collection::stream)
+                    .distinct()
+                    .sorted()
+                    .toList())
+            // Since this only works for files, set contents to be null
+            .contents(null);
+
+    // If there are overlapping checksum types with different values, throw an error
+    Map<String, List<DRSChecksum>> checksumsByType =
+        drsObject.getChecksums().stream().collect(Collectors.groupingBy(DRSChecksum::getType));
+    checksumsByType.forEach(
+        (k, v) -> {
+          if (v.size() > 1) {
+            throw new InvalidDrsObjectException(
+                "Invalid DRS object. Many checksums for %s exist".formatted(k));
+          }
+        });
+    return drsObject;
+  }
+
+  /**
+   * Given a list of DRSObjects, extract a singleton value and fail if there are 0, 2 or more values
+   */
+  private static <R> R extractUniqueDrsObjectValue(
+      List<DRSObject> drsObjects, Function<DRSObject, ? extends R> mapper) {
+    List<R> values = new ArrayList<>();
+    try {
+      values.addAll(drsObjects.stream().map(mapper).distinct().toList());
+      return CollectionUtils.extractSingleton(values);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidDrsObjectException("Found duplicate values: %s".formatted(values), e);
+    }
+  }
+
+  @VisibleForTesting
   static class SnapshotCacheResult {
     private final UUID id;
     private final Boolean isSelfHosted;
-    private final BillingProfileModel billingProfileModel;
+    private final BillingProfileModel datasetBillingProfileModel;
+    private final UUID snapshotBillingProfileId;
+    private final CloudPlatform cloudPlatform;
     private final String googleProjectId;
     private final String datasetProjectId;
+    private final Boolean globalFileIds;
 
     public SnapshotCacheResult(Snapshot snapshot) {
       this.id = snapshot.getId();
       this.isSelfHosted = snapshot.isSelfHosted();
-      this.billingProfileModel =
+      this.globalFileIds = snapshot.isGlobalFileIds();
+      this.datasetBillingProfileModel =
           snapshot.getSourceDataset().getDatasetSummary().getDefaultBillingProfile();
+      this.snapshotBillingProfileId = snapshot.getProfileId();
+      this.cloudPlatform = snapshot.getCloudPlatform();
       var projectResource = snapshot.getProjectResource();
       if (projectResource != null) {
         this.googleProjectId = projectResource.getGoogleProjectId();
@@ -641,6 +906,10 @@ public class DrsService {
 
     public UUID getId() {
       return this.id;
+    }
+
+    public UUID getSnapshotBillingProfileId() {
+      return snapshotBillingProfileId;
     }
   }
 }

--- a/src/main/java/bio/terra/service/filedata/FileIdService.java
+++ b/src/main/java/bio/terra/service/filedata/FileIdService.java
@@ -1,0 +1,26 @@
+package bio.terra.service.filedata;
+
+import bio.terra.service.dataset.Dataset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FileIdService {
+  private static final String HASH_SEPARATOR = "#";
+
+  public UUID calculateFileId(Dataset dataset, FSItem fsItem) {
+    if (dataset.isPredictableFileIds()) {
+      return UUID.nameUUIDFromBytes(createHashableContent(fsItem).getBytes(StandardCharsets.UTF_8));
+    } else {
+      return UUID.randomUUID();
+    }
+  }
+
+  private String createHashableContent(FSItem fsItem) {
+    return String.join(
+        HASH_SEPARATOR,
+        List.of(fsItem.getPath(), fsItem.getChecksumMd5(), String.valueOf(fsItem.getSize())));
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/FileIdService.java
+++ b/src/main/java/bio/terra/service/filedata/FileIdService.java
@@ -11,7 +11,7 @@ public class FileIdService {
   private static final String HASH_SEPARATOR = "#";
 
   public UUID calculateFileId(Dataset dataset, FSItem fsItem) {
-    if (dataset.isPredictableFileIds()) {
+    if (dataset.hasPredictableFileIds()) {
       return UUID.nameUUIDFromBytes(createHashableContent(fsItem).getBytes(StandardCharsets.UTF_8));
     } else {
       return UUID.randomUUID();

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -576,7 +576,6 @@ public class AzureSynapsePdao {
               columns,
               isGlobalFileIds);
 
-      logger.info("((((" + query);
       try {
         int rows = executeSynapseQuery(query);
         tableRowCounts.put(table.getName(), (long) rows);
@@ -810,6 +809,6 @@ public class AzureSynapsePdao {
   }
 
   public static void logQuery(String query) {
-    logger.info("Running query:\n#########\n{}", query);
+    logger.debug("Running query:\n#########\n{}", query);
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -103,9 +103,17 @@ public class AzureSynapsePdao {
                  <columns:{c|
                     <if(c.isFileType)>
                        <if(c.arrayOf)>
-                         (SELECT '[' + STRING_AGG('"drs://<hostname>/v1_<snapshotId>_' + [file_id] + '"', ',') + ']' FROM OPENJSON([<c.name>]) WITH ([file_id] VARCHAR(36) '$') WHERE [<c.name>] != '') AS [<c.name>]
+                         <if(isGlobalFileIds)>
+                           (SELECT '[' + STRING_AGG('"drs://<hostname>/v2_' + [file_id] + '"', ',') + ']' FROM OPENJSON([<c.name>]) WITH ([file_id] VARCHAR(36) '$') WHERE [<c.name>] != '') AS [<c.name>]
+                         <else>
+                           (SELECT '[' + STRING_AGG('"drs://<hostname>/v1_<snapshotId>_' + [file_id] + '"', ',') + ']' FROM OPENJSON([<c.name>]) WITH ([file_id] VARCHAR(36) '$') WHERE [<c.name>] != '') AS [<c.name>]
+                         <endif>
                        <else>
-                         'drs://<hostname>/v1_<snapshotId>_' + [<c.name>] AS [<c.name>]
+                         <if(isGlobalFileIds)>
+                           'drs://<hostname>/v2_' + [<c.name>] AS [<c.name>]
+                         <else>
+                           'drs://<hostname>/v1_<snapshotId>_' + [<c.name>] AS [<c.name>]
+                         <endif>
                        <endif>
                     <else>
                        <c.name> AS [<c.name>]
@@ -491,7 +499,8 @@ public class AzureSynapsePdao {
       String datasetDataSourceName,
       String snapshotDataSourceName,
       String datasetFlightId,
-      SnapshotRequestRowIdModel rowIdModel)
+      SnapshotRequestRowIdModel rowIdModel,
+      boolean isGlobalFileIds)
       throws SQLException {
     Map<String, Long> tableRowCounts = new HashMap<>();
 
@@ -521,7 +530,8 @@ public class AzureSynapsePdao {
                 datasetDataSourceName,
                 snapshotDataSourceName,
                 datasetFlightId,
-                columns);
+                columns,
+                isGlobalFileIds);
 
         List<UUID> rowIds = rowIdTableModel.get().getRowIds();
         params = new MapSqlParameterSource().addValue("datarepoRowIds", rowIds);
@@ -545,7 +555,8 @@ public class AzureSynapsePdao {
       UUID snapshotId,
       String datasetDataSourceName,
       String snapshotDataSourceName,
-      String datasetFlightId)
+      String datasetFlightId,
+      boolean isGlobalFileIds)
       throws SQLException {
     Map<String, Long> tableRowCounts = new HashMap<>();
 
@@ -562,12 +573,16 @@ public class AzureSynapsePdao {
               datasetDataSourceName,
               snapshotDataSourceName,
               datasetFlightId,
-              columns);
+              columns,
+              isGlobalFileIds);
+
+      logger.info("((((" + query);
       try {
         int rows = executeSynapseQuery(query);
         tableRowCounts.put(table.getName(), (long) rows);
       } catch (SQLServerException ex) {
         tableRowCounts.put(table.getName(), 0L);
+        logger.warn("Error running sql", ex);
         logger.info(
             "Unable to copy files from table {} - this usually means that the source dataset's table is empty.",
             table.getName());
@@ -583,7 +598,8 @@ public class AzureSynapsePdao {
       String datasetDataSourceName,
       String snapshotDataSourceName,
       String datasetFlightId,
-      List<SynapseColumn> columns) {
+      List<SynapseColumn> columns,
+      boolean isGlobalFileIds) {
     String datasetParquetFileName =
         IngestUtils.getSourceDatasetParquetFilePath(table.getName(), datasetFlightId);
     String snapshotParquetFileName =
@@ -599,7 +615,8 @@ public class AzureSynapsePdao {
         .add("ingestFileName", datasetParquetFileName)
         .add("ingestFileDataSourceName", datasetDataSourceName)
         .add("hostname", applicationConfiguration.getDnsName())
-        .add("snapshotId", snapshotId);
+        .add("snapshotId", snapshotId)
+        .add("isGlobalFileIds", isGlobalFileIds);
 
     return sqlCreateSnapshotTableTemplate.render();
   }
@@ -681,6 +698,7 @@ public class AzureSynapsePdao {
     SQLServerDataSource ds = getDatasource();
     try (Connection connection = ds.getConnection();
         Statement statement = connection.createStatement()) {
+      logQuery(query);
       statement.execute(query);
       return statement.getUpdateCount();
     }
@@ -690,6 +708,7 @@ public class AzureSynapsePdao {
     SQLServerDataSource ds = getDatasource();
     try (Connection connection = ds.getConnection();
         Statement statement = connection.createStatement()) {
+      logQuery(query);
       try (ResultSet resultSet = statement.executeQuery(query)) {
         resultSet.next();
         return resultSet.getInt(1);
@@ -788,5 +807,9 @@ public class AzureSynapsePdao {
         throw new PdaoException("Could not deserialize value %s".formatted(rawValue), e);
       }
     }
+  }
+
+  public static void logQuery(String query) {
+    logger.info("Running query:\n#########\n{}", query);
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -250,6 +250,14 @@ public class TableDao {
         fileId);
   }
 
+  public List<String> retrieveAllFileIds(TableServiceClient tableServiceClient) {
+    return directoryDao
+        .enumerateAll(tableServiceClient, StorageTableName.SNAPSHOT.toTableName())
+        .stream()
+        .map(FireStoreDirectoryEntry::getFileId)
+        .toList();
+  }
+
   //   -- private methods --
 
   /**

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDependencyDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDependencyDao.java
@@ -1,6 +1,7 @@
 package bio.terra.service.filedata.azure.tables;
 
 import bio.terra.service.common.azure.StorageTableName;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.google.firestore.FireStoreDependency;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.data.tables.TableClient;
@@ -96,6 +97,18 @@ public class TableDependencyDao {
     } else {
       logger.warn("No snapshot file dependencies found to be deleted from dataset");
     }
+  }
+
+  public List<String> getDatasetSnapshotFileIds(
+      TableServiceClient tableServiceClient, Dataset dataset, String snapshotId) {
+    String dependencyTableName = StorageTableName.DEPENDENCIES.toTableName(dataset.getId());
+    TableClient tableClient = tableServiceClient.getTableClient(dependencyTableName);
+    ListEntitiesOptions options =
+        new ListEntitiesOptions().setFilter(String.format("snapshotId eq '%s'", snapshotId));
+    return tableClient.listEntities(options, null, null).stream()
+        .map(FireStoreDependency::fromTableEntity)
+        .map(FireStoreDependency::getFileId)
+        .toList();
   }
 
   public boolean datasetHasSnapshotReference(

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -238,6 +238,16 @@ public class TableDirectoryDao {
         .collect(Collectors.toList());
   }
 
+  public List<FireStoreDirectoryEntry> enumerateAll(
+      TableServiceClient tableServiceClient, String tableName) {
+    TableClient tableClient = tableServiceClient.getTableClient(tableName);
+    ListEntitiesOptions options = new ListEntitiesOptions();
+    PagedIterable<TableEntity> entities = tableClient.listEntities(options, null, null);
+    return entities.stream()
+        .map(FireStoreDirectoryEntry::fromTableEntity)
+        .collect(Collectors.toList());
+  }
+
   List<FireStoreDirectoryEntry> enumerateDirectory(
       TableServiceClient tableServiceClient, String tableName, String dirPath) {
     TableClient tableClient = tableServiceClient.getTableClient(tableName);

--- a/src/main/java/bio/terra/service/filedata/exception/InvalidDrsObjectException.java
+++ b/src/main/java/bio/terra/service/filedata/exception/InvalidDrsObjectException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.filedata.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+public class InvalidDrsObjectException extends BadRequestException {
+  public InvalidDrsObjectException(String message) {
+    super(message);
+  }
+
+  public InvalidDrsObjectException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InvalidDrsObjectException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -31,7 +31,6 @@ import bio.terra.service.profile.flight.VerifyBillingAccountAccessStep;
 import bio.terra.service.profile.google.GoogleBillingService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectService;
-import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.RetryRule;
 import java.util.UUID;
@@ -40,7 +39,7 @@ import org.springframework.context.ApplicationContext;
 // The FileIngestFlight is specific to firestore. Another cloud or file system implementation
 // might be quite different and would need a different flight.
 // TODO: Refactor flights when we do the cloud refactor work.
-public class FileIngestFlight extends Flight {
+public class FileIngestFlight extends FileIngestTypeFlight {
 
   public FileIngestFlight(FlightMap inputParameters, Object applicationContext) {
     super(inputParameters, applicationContext);
@@ -149,13 +148,8 @@ public class FileIngestFlight extends Flight {
             randomBackoffRetry);
         addStep(new IngestFileMakeBucketLinkStep(datasetBucketDao, dataset), randomBackoffRetry);
       }
-      if (dataset.isPredictableFileIds()) {
-        addStep(new IngestFilePrimaryDataStep(dataset, gcsPdao, configService), randomBackoffRetry);
-        addStep(new IngestFileDirectoryStep(fileDao, dataset), randomBackoffRetry);
-      } else {
-        addStep(new IngestFileDirectoryStep(fileDao, dataset), randomBackoffRetry);
-        addStep(new IngestFilePrimaryDataStep(dataset, gcsPdao, configService), randomBackoffRetry);
-      }
+      addFileCopyAndDirectoryRecordStepsGcp(
+          fileDao, gcsPdao, configService, dataset, randomBackoffRetry);
       addStep(new IngestFileFileStep(fileDao, fileService, dataset), randomBackoffRetry);
     } else if (platform.isAzure()) {
       addStep(
@@ -164,17 +158,8 @@ public class FileIngestFlight extends Flight {
           new IngestFileAzureMakeStorageAccountLinkStep(datasetStorageAccountDao, dataset),
           randomBackoffRetry);
       addStep(new ValidateIngestFileAzureDirectoryStep(azureTableDao, dataset), randomBackoffRetry);
-      if (dataset.isPredictableFileIds()) {
-        addStep(
-            new IngestFileAzurePrimaryDataStep(
-                dataset, azureBlobStorePdao, configService, userReq));
-        addStep(new IngestFileAzureDirectoryStep(azureTableDao, dataset), randomBackoffRetry);
-      } else {
-        addStep(new IngestFileAzureDirectoryStep(azureTableDao, dataset), randomBackoffRetry);
-        addStep(
-            new IngestFileAzurePrimaryDataStep(
-                dataset, azureBlobStorePdao, configService, userReq));
-      }
+      addFileCopyAndDirectoryRecordStepsAzure(
+          azureBlobStorePdao, configService, azureTableDao, userReq, dataset, randomBackoffRetry);
       addStep(new IngestFileAzureFileStep(azureTableDao, fileService, dataset), randomBackoffRetry);
     }
     addStep(new LoadUnlockStep(loadService));

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestTypeFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestTypeFlight.java
@@ -1,0 +1,58 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.RetryRule;
+
+public abstract class FileIngestTypeFlight extends Flight {
+
+  public FileIngestTypeFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+  }
+
+  /**
+   * Order depends on how the file id is obtained. If we are generating the file predictably, we
+   * determine it when ingesting the file (by reading the MD5) so we need to run that first.
+   * Otherwise, we need to first perform the directory creation step and then the physical copy of
+   * the file
+   */
+  protected void addFileCopyAndDirectoryRecordStepsGcp(
+      FireStoreDao fileDao,
+      GcsPdao gcsPdao,
+      ConfigurationService configService,
+      Dataset dataset,
+      RetryRule fileSystemRetry) {
+    if (dataset.hasPredictableFileIds()) {
+      addStep(new IngestFilePrimaryDataStep(dataset, gcsPdao, configService), fileSystemRetry);
+      addStep(new IngestFileDirectoryStep(fileDao, dataset), fileSystemRetry);
+    } else {
+      addStep(new IngestFileDirectoryStep(fileDao, dataset), fileSystemRetry);
+      addStep(new IngestFilePrimaryDataStep(dataset, gcsPdao, configService), fileSystemRetry);
+    }
+  }
+
+  protected void addFileCopyAndDirectoryRecordStepsAzure(
+      AzureBlobStorePdao azureBlobStorePdao,
+      ConfigurationService configService,
+      TableDao azureTableDao,
+      AuthenticatedUserRequest userReq,
+      Dataset dataset,
+      RetryRule fileSystemRetry) {
+    if (dataset.hasPredictableFileIds()) {
+      addStep(
+          new IngestFileAzurePrimaryDataStep(dataset, azureBlobStorePdao, configService, userReq));
+      addStep(new IngestFileAzureDirectoryStep(azureTableDao, dataset), fileSystemRetry);
+    } else {
+      addStep(new IngestFileAzureDirectoryStep(azureTableDao, dataset), fileSystemRetry);
+      addStep(
+          new IngestFileAzurePrimaryDataStep(dataset, azureBlobStorePdao, configService, userReq));
+    }
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataStep.java
@@ -51,7 +51,7 @@ public class IngestFileAzurePrimaryDataStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
 
     String fileId = null;
-    if (!dataset.isPredictableFileIds()) {
+    if (!dataset.hasPredictableFileIds()) {
       fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
     }
     Boolean loadComplete = workingMap.get(FileMapKeys.LOAD_COMPLETED, Boolean.class);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
@@ -40,7 +40,7 @@ public class IngestFilePrimaryDataStep implements Step {
 
     FlightMap workingMap = context.getWorkingMap();
     String fileId = null;
-    if (!dataset.isPredictableFileIds()) {
+    if (!dataset.hasPredictableFileIds()) {
       fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
     }
     Boolean loadComplete = workingMap.get(FileMapKeys.LOAD_COMPLETED, Boolean.class);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
@@ -39,7 +39,10 @@ public class IngestFilePrimaryDataStep implements Step {
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
 
     FlightMap workingMap = context.getWorkingMap();
-    String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
+    String fileId = null;
+    if (!dataset.isPredictableFileIds()) {
+      fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
+    }
     Boolean loadComplete = workingMap.get(FileMapKeys.LOAD_COMPLETED, Boolean.class);
     if (loadComplete == null || !loadComplete) {
       FSFileInfo fsFileInfo;
@@ -58,6 +61,9 @@ public class IngestFilePrimaryDataStep implements Step {
           } else {
             fsFileInfo = gcsPdao.copyFile(dataset, fileLoadModel, fileId, bucketResource);
           }
+        }
+        if (fileId == null) {
+          workingMap.put(FileMapKeys.FILE_ID, fsFileInfo.getFileId());
         }
         workingMap.put(FileMapKeys.FILE_INFO, fsFileInfo);
       } catch (InvalidUserProjectException ex) {

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -157,7 +157,13 @@ public class FireStoreDao {
     String snapshotId = snapshot.getId().toString();
 
     directoryDao.addEntriesToSnapshot(
-        datasetFirestore, datasetId, datasetName, snapshotFirestore, snapshotId, refIds);
+        datasetFirestore,
+        datasetId,
+        datasetName,
+        snapshotFirestore,
+        snapshotId,
+        refIds,
+        snapshot.isGlobalFileIds());
   }
 
   public void deleteFilesFromSnapshot(Snapshot snapshot) throws InterruptedException {

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -163,7 +163,7 @@ public class FireStoreDao {
         snapshotFirestore,
         snapshotId,
         refIds,
-        snapshot.isGlobalFileIds());
+        snapshot.hasGlobalFileIds());
   }
 
   public void deleteFilesFromSnapshot(Snapshot snapshot) throws InterruptedException {

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -399,6 +399,15 @@ public class FireStoreDao {
     return directoryDao.validateRefIds(firestore, datasetId, refIdArray);
   }
 
+  /** Retrieve all fileIds (including directories) from a snapshot */
+  public List<String> retrieveAllFileIds(Snapshot snapshot) throws InterruptedException {
+    Firestore firestore =
+        FireStoreProject.get(snapshot.getProjectResource().getGoogleProjectId()).getFirestore();
+    return directoryDao.enumerateAll(firestore, snapshot.getId().toString()).stream()
+        .map(FireStoreDirectoryEntry::getFileId)
+        .toList();
+  }
+
   // -- private methods --
 
   /**

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
@@ -249,14 +249,22 @@ public class FireStoreDirectoryDao {
     return missingIds;
   }
 
+  public List<FireStoreDirectoryEntry> enumerateAll(Firestore firestore, String collectionId)
+      throws InterruptedException {
+    CollectionReference dirColl = firestore.collection(collectionId);
+    return query(dirColl.orderBy("path"));
+  }
   // -- private methods --
 
   List<FireStoreDirectoryEntry> enumerateDirectory(
       Firestore firestore, String collectionId, String dirPath) throws InterruptedException {
+    CollectionReference dirColl = firestore.collection(collectionId);
+    return query(dirColl.whereEqualTo("path", dirPath));
+  }
+
+  List<FireStoreDirectoryEntry> query(Query query) throws InterruptedException {
 
     int batchSize = configurationService.getParameterValue(FIRESTORE_QUERY_BATCH_SIZE);
-    CollectionReference dirColl = firestore.collection(collectionId);
-    Query query = dirColl.whereEqualTo("path", dirPath);
     FireStoreBatchQueryIterator queryIterator =
         new FireStoreBatchQueryIterator(query, batchSize, fireStoreUtils);
 

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
@@ -367,7 +367,8 @@ public class FireStoreDirectoryDao {
       String datasetDirName,
       Firestore snapshotFirestore,
       String snapshotId,
-      List<String> fileIdList)
+      List<String> fileIdList,
+      boolean usesGlobalFileIds)
       throws InterruptedException {
 
     int batchSize = configurationService.getParameterValue(FIRESTORE_SNAPSHOT_BATCH_SIZE);
@@ -406,11 +407,18 @@ public class FireStoreDirectoryDao {
 
       // Create snapshot file system entries
       List<FireStoreDirectoryEntry> snapshotEntries = new ArrayList<>();
-      for (FireStoreDirectoryEntry datasetEntry : datasetEntries) {
-        snapshotEntries.add(datasetEntry.copyEntryUnderNewPath(datasetDirName));
-      }
-      for (FireStoreDirectoryEntry datasetEntry : datasetDirectoryEntries) {
-        snapshotEntries.add(datasetEntry.copyEntryUnderNewPath(datasetDirName));
+      // I don't really think that we need the dataset base path since we only support sourcing
+      // from a single dataset but will leave for backwards compatibility
+      if (usesGlobalFileIds) {
+        snapshotEntries.addAll(datasetEntries);
+        snapshotEntries.addAll(datasetDirectoryEntries);
+      } else {
+        for (FireStoreDirectoryEntry datasetEntry : datasetEntries) {
+          snapshotEntries.add(datasetEntry.copyEntryUnderNewPath(datasetDirName));
+        }
+        for (FireStoreDirectoryEntry datasetEntry : datasetDirectoryEntries) {
+          snapshotEntries.add(datasetEntry.copyEntryUnderNewPath(datasetDirName));
+        }
       }
 
       // Store the batch of entries. This will override existing entries,

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -41,6 +41,7 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
   private Object properties;
   private UUID duosFirecloudGroupId;
   private DuosFirecloudGroupModel duosFirecloudGroup;
+  private boolean globalFileIds;
 
   @Override
   public CollectionType getCollectionType() {
@@ -248,6 +249,15 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
 
   public boolean isSelfHosted() {
     return getSourceDataset().isSelfHosted();
+  }
+
+  public boolean isGlobalFileIds() {
+    return globalFileIds;
+  }
+
+  public Snapshot globalFileIds(boolean globalFileIds) {
+    this.globalFileIds = globalFileIds;
+    return this;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -251,7 +251,7 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
     return getSourceDataset().isSelfHosted();
   }
 
-  public boolean isGlobalFileIds() {
+  public boolean hasGlobalFileIds() {
     return globalFileIds;
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -182,8 +182,8 @@ public class SnapshotDao {
     logger.debug("createAndLock snapshot " + snapshot.getName());
 
     String sql =
-        "INSERT INTO snapshot (name, description, profile_id, project_resource_id, id, consent_code, flightid, creation_information, properties) "
-            + "VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb, :properties::jsonb) ";
+        "INSERT INTO snapshot (name, description, profile_id, project_resource_id, id, consent_code, flightid, creation_information, properties, global_file_ids) "
+            + "VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb, :properties::jsonb, :global_file_ids) ";
     String creationInfo;
     try {
       creationInfo = objectMapper.writeValueAsString(snapshot.getCreationInformation());
@@ -202,7 +202,8 @@ public class SnapshotDao {
             .addValue("flightid", flightId)
             .addValue("creation_information", creationInfo)
             .addValue(
-                "properties", DaoUtils.propertiesToString(objectMapper, snapshot.getProperties()));
+                "properties", DaoUtils.propertiesToString(objectMapper, snapshot.getProperties()))
+            .addValue("global_file_ids", snapshot.isGlobalFileIds());
     try {
       jdbcTemplate.update(sql, params);
     } catch (DuplicateKeyException dkEx) {
@@ -415,6 +416,7 @@ public class SnapshotDao {
                           stringToSnapshotRequestContentsModel(
                               rs.getString("creation_information")))
                       .consentCode(rs.getString("consent_code"))
+                      .globalFileIds(rs.getBoolean("global_file_ids"))
                       .properties(
                           DaoUtils.stringToProperties(objectMapper, rs.getString("properties")))
                       .duosFirecloudGroupId(rs.getObject("duos_firecloud_group_id", UUID.class)));
@@ -650,7 +652,9 @@ public class SnapshotDao {
 
     String sql =
         "SELECT snapshot.id, snapshot.name, snapshot.description, snapshot.created_date, snapshot.profile_id, "
-            + "snapshot_source.id, dataset.secure_monitoring, snapshot.consent_code, dataset.phs_id, dataset.self_hosted,"
+            + "snapshot.global_file_ids, "
+            + "snapshot_source.id, "
+            + "dataset.secure_monitoring, snapshot.consent_code, dataset.phs_id, dataset.self_hosted,"
             + summaryCloudPlatformQuery
             + snapshotSourceStorageQuery
             + "FROM snapshot "
@@ -822,7 +826,8 @@ public class SnapshotDao {
           .storageAccount(rs.getString("storage_account_name"))
           .consentCode(rs.getString("consent_code"))
           .phsId(rs.getString("phs_id"))
-          .selfHosted(rs.getBoolean("self_hosted"));
+          .selfHosted(rs.getBoolean("self_hosted"))
+          .globalFileIds(rs.getBoolean("global_file_ids"));
     }
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -203,7 +203,7 @@ public class SnapshotDao {
             .addValue("creation_information", creationInfo)
             .addValue(
                 "properties", DaoUtils.propertiesToString(objectMapper, snapshot.getProperties()))
-            .addValue("global_file_ids", snapshot.isGlobalFileIds());
+            .addValue("global_file_ids", snapshot.hasGlobalFileIds());
     try {
       jdbcTemplate.update(sql, params);
     } catch (DuplicateKeyException dkEx) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -547,7 +547,8 @@ public class SnapshotService {
         .relationships(createSnapshotRelationships(dataset.getRelationships(), snapshotSource))
         .creationInformation(requestContents)
         .consentCode(snapshotRequestModel.getConsentCode())
-        .properties(snapshotRequestModel.getProperties());
+        .properties(snapshotRequestModel.getProperties())
+        .globalFileIds(snapshotRequestModel.isGlobalFileIds());
   }
 
   public List<UUID> getSourceDatasetIdsFromSnapshotRequest(
@@ -995,7 +996,8 @@ public class SnapshotService {
             .description(snapshot.getDescription())
             .createdDate(snapshot.getCreatedDate().toString())
             .consentCode(snapshot.getConsentCode())
-            .cloudPlatform(snapshot.getCloudPlatform());
+            .cloudPlatform(snapshot.getCloudPlatform())
+            .globalFileIds(snapshot.isGlobalFileIds());
 
     // In case NONE is specified, this should supersede any other value being passed in
     if (include.contains(SnapshotRetrieveIncludeModel.NONE)) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -997,7 +997,7 @@ public class SnapshotService {
             .createdDate(snapshot.getCreatedDate().toString())
             .consentCode(snapshot.getConsentCode())
             .cloudPlatform(snapshot.getCloudPlatform())
-            .globalFileIds(snapshot.isGlobalFileIds());
+            .globalFileIds(snapshot.hasGlobalFileIds());
 
     // In case NONE is specified, this should supersede any other value being passed in
     if (include.contains(SnapshotRetrieveIncludeModel.NONE)) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -24,6 +24,7 @@ public class SnapshotSummary {
   private String consentCode;
   private String phsId;
   private boolean selfHosted;
+  private boolean globalFileIds;
 
   public UUID getId() {
     return id;
@@ -142,6 +143,15 @@ public class SnapshotSummary {
     return this;
   }
 
+  public boolean isGlobalFileIds() {
+    return globalFileIds;
+  }
+
+  public SnapshotSummary globalFileIds(boolean globalFileIds) {
+    this.globalFileIds = globalFileIds;
+    return this;
+  }
+
   public SnapshotSummaryModel toModel() {
     return new SnapshotSummaryModel()
         .id(getId())
@@ -156,7 +166,8 @@ public class SnapshotSummary {
         .storageAccount(getStorageAccount())
         .consentCode(getConsentCode())
         .phsId(getPhsId())
-        .selfHosted(isSelfHosted());
+        .selfHosted(isSelfHosted())
+        .globalFileIds(isGlobalFileIds());
   }
 
   private List<StorageResourceModel> toStorageResourceModel() {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRowIdParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRowIdParquetFilesAzureStep.java
@@ -15,14 +15,12 @@ import java.util.UUID;
 
 public class CreateSnapshotByRowIdParquetFilesAzureStep
     extends CreateSnapshotParquetFilesAzureStep {
-  private final SnapshotRequestModel snapshotReq;
 
   public CreateSnapshotByRowIdParquetFilesAzureStep(
       AzureSynapsePdao azureSynapsePdao,
       SnapshotService snapshotService,
       SnapshotRequestModel snapshotReq) {
-    super(azureSynapsePdao, snapshotService);
-    this.snapshotReq = snapshotReq;
+    super(azureSynapsePdao, snapshotService, snapshotReq);
   }
 
   @Override
@@ -37,6 +35,7 @@ public class CreateSnapshotByRowIdParquetFilesAzureStep
         IngestUtils.getSourceDatasetDataSourceName(context.getFlightId()),
         IngestUtils.getTargetDataSourceName(context.getFlightId()),
         null,
-        rowIdModel);
+        rowIdModel,
+        snapshotReq.isGlobalFileIds());
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotParquetFilesAzureStep.java
@@ -2,6 +2,7 @@ package bio.terra.service.snapshot.flight.create;
 
 import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_TABLE;
 
+import bio.terra.model.SnapshotRequestModel;
 import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.snapshot.SnapshotService;
@@ -22,11 +23,15 @@ public class CreateSnapshotParquetFilesAzureStep implements Step {
 
   protected AzureSynapsePdao azureSynapsePdao;
   private final SnapshotService snapshotService;
+  protected final SnapshotRequestModel snapshotReq;
 
   public CreateSnapshotParquetFilesAzureStep(
-      AzureSynapsePdao azureSynapsePdao, SnapshotService snapshotService) {
+      AzureSynapsePdao azureSynapsePdao,
+      SnapshotService snapshotService,
+      SnapshotRequestModel snapshotReq) {
     this.azureSynapsePdao = azureSynapsePdao;
     this.snapshotService = snapshotService;
+    this.snapshotReq = snapshotReq;
   }
 
   @Override
@@ -63,7 +68,8 @@ public class CreateSnapshotParquetFilesAzureStep implements Step {
         snapshotId,
         IngestUtils.getSourceDatasetDataSourceName(context.getFlightId()),
         IngestUtils.getTargetDataSourceName(context.getFlightId()),
-        null);
+        null,
+        snapshotReq.isGlobalFileIds());
   }
 
   @Override

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -263,7 +263,7 @@ public class SnapshotCreateFlight extends Flight {
       if (snapshotReq.isGlobalFileIds()) {
         addStep(
             new SnapshotRecordFileIdsGcpStep(
-                snapshotService, datasetService, drsIdService, drsService, dependencyDao));
+                snapshotService, datasetService, drsIdService, drsService, fileDao));
       }
     } else if (platform.isAzure()) {
       addStep(
@@ -291,7 +291,7 @@ public class SnapshotCreateFlight extends Flight {
                 datasetService,
                 drsIdService,
                 drsService,
-                tableDependencyDao,
+                tableDao,
                 azureAuthService));
       }
       // cannot clean up azure synapse tables until after gathered refIds in

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -14,6 +14,8 @@ import bio.terra.service.common.JournalRecordUpdateEntryStep;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.DrsIdService;
+import bio.terra.service.filedata.DrsService;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.azure.tables.TableDao;
@@ -75,6 +77,8 @@ public class SnapshotCreateFlight extends Flight {
         appContext.getBean(GoogleResourceManagerService.class);
     JournalService journalService = appContext.getBean(JournalService.class);
     String tdrServiceAccountEmail = appContext.getBean("tdrServiceAccountEmail", String.class);
+    DrsIdService drsIdService = appContext.getBean(DrsIdService.class);
+    DrsService drsService = appContext.getBean(DrsService.class);
 
     SnapshotRequestModel snapshotReq =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), SnapshotRequestModel.class);
@@ -155,7 +159,9 @@ public class SnapshotCreateFlight extends Flight {
           addStep(
               new CreateSnapshotTargetDataSourceAzureStep(
                   azureSynapsePdao, azureBlobStorePdao, userReq));
-          addStep(new CreateSnapshotParquetFilesAzureStep(azureSynapsePdao, snapshotService));
+          addStep(
+              new CreateSnapshotParquetFilesAzureStep(
+                  azureSynapsePdao, snapshotService, snapshotReq));
           addStep(
               new CreateSnapshotCountTableRowsAzureStep(
                   azureSynapsePdao, snapshotDao, snapshotReq));
@@ -253,6 +259,12 @@ public class SnapshotCreateFlight extends Flight {
       addStep(
           new SnapshotAuthzServiceAccountConsumerStep(
               snapshotService, resourceService, snapshotName, tdrServiceAccountEmail));
+      // Record the Drs IDs if this is a global file id snapshot
+      if (snapshotReq.isGlobalFileIds()) {
+        addStep(
+            new SnapshotRecordFileIdsGcpStep(
+                snapshotService, datasetService, drsIdService, drsService, dependencyDao));
+      }
     } else if (platform.isAzure()) {
       addStep(
           new CreateSnapshotStorageTableDataStep(
@@ -270,6 +282,18 @@ public class SnapshotCreateFlight extends Flight {
       addStep(
           new CreateSnapshotStorageTableComputeStep(
               tableDao, snapshotReq, snapshotService, azureAuthService));
+
+      // Record the Drs IDs if this is a global file id snapshot
+      if (snapshotReq.isGlobalFileIds()) {
+        addStep(
+            new SnapshotRecordFileIdsAzureStep(
+                snapshotService,
+                datasetService,
+                drsIdService,
+                drsService,
+                tableDependencyDao,
+                azureAuthService));
+      }
       // cannot clean up azure synapse tables until after gathered refIds in
       // CreateSnapshotStorageTableDataStep
       addStep(new CreateSnapshotCleanSynapseAzureStep(azureSynapsePdao, snapshotService));

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsAzureStep.java
@@ -2,22 +2,21 @@ package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.common.FlightUtils;
 import bio.terra.service.common.CommonMapKeys;
-import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.filedata.DrsIdService;
 import bio.terra.service.filedata.DrsService;
-import bio.terra.service.filedata.azure.tables.TableDependencyDao;
+import bio.terra.service.filedata.azure.tables.TableDao;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAuthInfo;
+import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.stairway.FlightContext;
 import com.azure.data.tables.TableServiceClient;
 import java.util.List;
-import java.util.UUID;
 
 public class SnapshotRecordFileIdsAzureStep extends SnapshotRecordFileIdsStep {
 
-  private final TableDependencyDao tableDependencyDao;
+  private final TableDao tableDao;
   private final AzureAuthService azureAuthService;
 
   public SnapshotRecordFileIdsAzureStep(
@@ -25,23 +24,21 @@ public class SnapshotRecordFileIdsAzureStep extends SnapshotRecordFileIdsStep {
       DatasetService datasetService,
       DrsIdService drsIdService,
       DrsService drsService,
-      TableDependencyDao tableDependencyDao,
+      TableDao tableDao,
       AzureAuthService azureAuthService) {
     super(snapshotService, datasetService, drsIdService, drsService);
-    this.tableDependencyDao = tableDependencyDao;
+    this.tableDao = tableDao;
     this.azureAuthService = azureAuthService;
   }
 
   @Override
-  List<String> getFileIds(FlightContext context, Dataset dataset, UUID snapshotId)
-      throws InterruptedException {
-    AzureStorageAuthInfo datasetStorageAuthInfo =
+  List<String> getFileIds(FlightContext context, Snapshot snapshot) throws InterruptedException {
+    AzureStorageAuthInfo snapshotStorageAuthInfo =
         FlightUtils.getContextValue(
-            context, CommonMapKeys.DATASET_STORAGE_AUTH_INFO, AzureStorageAuthInfo.class);
-    TableServiceClient datasetTableServiceClient =
-        azureAuthService.getTableServiceClient(datasetStorageAuthInfo);
+            context, CommonMapKeys.SNAPSHOT_STORAGE_AUTH_INFO, AzureStorageAuthInfo.class);
+    TableServiceClient snapshotTableServiceClient =
+        azureAuthService.getTableServiceClient(snapshotStorageAuthInfo);
 
-    return tableDependencyDao.getDatasetSnapshotFileIds(
-        datasetTableServiceClient, dataset, snapshotId.toString());
+    return tableDao.retrieveAllFileIds(snapshotTableServiceClient);
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsAzureStep.java
@@ -1,0 +1,47 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.common.FlightUtils;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.DrsIdService;
+import bio.terra.service.filedata.DrsService;
+import bio.terra.service.filedata.azure.tables.TableDependencyDao;
+import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAuthInfo;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightContext;
+import com.azure.data.tables.TableServiceClient;
+import java.util.List;
+import java.util.UUID;
+
+public class SnapshotRecordFileIdsAzureStep extends SnapshotRecordFileIdsStep {
+
+  private final TableDependencyDao tableDependencyDao;
+  private final AzureAuthService azureAuthService;
+
+  public SnapshotRecordFileIdsAzureStep(
+      SnapshotService snapshotService,
+      DatasetService datasetService,
+      DrsIdService drsIdService,
+      DrsService drsService,
+      TableDependencyDao tableDependencyDao,
+      AzureAuthService azureAuthService) {
+    super(snapshotService, datasetService, drsIdService, drsService);
+    this.tableDependencyDao = tableDependencyDao;
+    this.azureAuthService = azureAuthService;
+  }
+
+  @Override
+  List<String> getFileIds(FlightContext context, Dataset dataset, UUID snapshotId)
+      throws InterruptedException {
+    AzureStorageAuthInfo datasetStorageAuthInfo =
+        FlightUtils.getContextValue(
+            context, CommonMapKeys.DATASET_STORAGE_AUTH_INFO, AzureStorageAuthInfo.class);
+    TableServiceClient datasetTableServiceClient =
+        azureAuthService.getTableServiceClient(datasetStorageAuthInfo);
+
+    return tableDependencyDao.getDatasetSnapshotFileIds(
+        datasetTableServiceClient, dataset, snapshotId.toString());
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsGcpStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsGcpStep.java
@@ -1,0 +1,32 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.DrsIdService;
+import bio.terra.service.filedata.DrsService;
+import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightContext;
+import java.util.List;
+import java.util.UUID;
+
+public class SnapshotRecordFileIdsGcpStep extends SnapshotRecordFileIdsStep {
+
+  private final FireStoreDependencyDao fireStoreDao;
+
+  public SnapshotRecordFileIdsGcpStep(
+      SnapshotService snapshotService,
+      DatasetService datasetService,
+      DrsIdService drsIdService,
+      DrsService drsService,
+      FireStoreDependencyDao fireStoreDao) {
+    super(snapshotService, datasetService, drsIdService, drsService);
+    this.fireStoreDao = fireStoreDao;
+  }
+
+  @Override
+  List<String> getFileIds(FlightContext context, Dataset dataset, UUID snapshotId)
+      throws InterruptedException {
+    return fireStoreDao.getDatasetSnapshotFileIds(dataset, snapshotId.toString());
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsGcpStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsGcpStep.java
@@ -1,32 +1,30 @@
 package bio.terra.service.snapshot.flight.create;
 
-import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.filedata.DrsIdService;
 import bio.terra.service.filedata.DrsService;
-import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.stairway.FlightContext;
 import java.util.List;
-import java.util.UUID;
 
 public class SnapshotRecordFileIdsGcpStep extends SnapshotRecordFileIdsStep {
 
-  private final FireStoreDependencyDao fireStoreDao;
+  private final FireStoreDao fireStoreDao;
 
   public SnapshotRecordFileIdsGcpStep(
       SnapshotService snapshotService,
       DatasetService datasetService,
       DrsIdService drsIdService,
       DrsService drsService,
-      FireStoreDependencyDao fireStoreDao) {
+      FireStoreDao fireStoreDao) {
     super(snapshotService, datasetService, drsIdService, drsService);
     this.fireStoreDao = fireStoreDao;
   }
 
   @Override
-  List<String> getFileIds(FlightContext context, Dataset dataset, UUID snapshotId)
-      throws InterruptedException {
-    return fireStoreDao.getDatasetSnapshotFileIds(dataset, snapshotId.toString());
+  List<String> getFileIds(FlightContext context, Snapshot snapshot) throws InterruptedException {
+    return fireStoreDao.retrieveAllFileIds(snapshot);
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsStep.java
@@ -1,0 +1,69 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.DrsIdService;
+import bio.terra.service.filedata.DrsService;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.SnapshotSource;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class SnapshotRecordFileIdsStep implements Step {
+
+  private static final Logger logger = LoggerFactory.getLogger(SnapshotRecordFileIdsStep.class);
+
+  private final SnapshotService snapshotService;
+  private final DatasetService datasetService;
+  private final DrsIdService drsIdService;
+  private final DrsService drsService;
+
+  public SnapshotRecordFileIdsStep(
+      SnapshotService snapshotService,
+      DatasetService datasetService,
+      DrsIdService drsIdService,
+      DrsService drsService) {
+    this.snapshotService = snapshotService;
+    this.datasetService = datasetService;
+    this.drsIdService = drsIdService;
+    this.drsService = drsService;
+  }
+
+  abstract List<String> getFileIds(FlightContext context, Dataset dataset, UUID snapshotId)
+      throws InterruptedException;
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
+    Snapshot snapshot = snapshotService.retrieve(snapshotId);
+    SnapshotSource snapshotSource = snapshot.getFirstSnapshotSource();
+    String datasetId = snapshotSource.getDataset().getId().toString();
+    Dataset dataset = datasetService.retrieve(UUID.fromString(datasetId));
+    List<String> fileIds = getFileIds(context, dataset, snapshotId);
+
+    logger.info(
+        "Inserted {} rows",
+        drsService.recordDrsIdToSnapshot(
+            snapshotId, fileIds.stream().map(drsIdService::makeDrsId).toList()));
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
+    logger.info("Deleted {} rows", drsService.deleteDrsIdToSnapshotsBySnapshot(snapshotId));
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsStep.java
@@ -1,12 +1,10 @@
 package bio.terra.service.snapshot.flight.create;
 
-import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.filedata.DrsIdService;
 import bio.terra.service.filedata.DrsService;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
-import bio.terra.service.snapshot.SnapshotSource;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -37,7 +35,9 @@ public abstract class SnapshotRecordFileIdsStep implements Step {
     this.drsService = drsService;
   }
 
-  abstract List<String> getFileIds(FlightContext context, Dataset dataset, UUID snapshotId)
+  //  abstract List<String> getFileIds(FlightContext context, Dataset dataset, UUID snapshotId)
+  //      throws InterruptedException;
+  abstract List<String> getFileIds(FlightContext context, Snapshot snapshot)
       throws InterruptedException;
 
   @Override
@@ -45,10 +45,7 @@ public abstract class SnapshotRecordFileIdsStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
     Snapshot snapshot = snapshotService.retrieve(snapshotId);
-    SnapshotSource snapshotSource = snapshot.getFirstSnapshotSource();
-    String datasetId = snapshotSource.getDataset().getId().toString();
-    Dataset dataset = datasetService.retrieve(UUID.fromString(datasetId));
-    List<String> fileIds = getFileIds(context, dataset, snapshotId);
+    List<String> fileIds = getFileIds(context, snapshot);
 
     logger.info(
         "Inserted {} rows",

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDrsIdsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDrsIdsStep.java
@@ -1,0 +1,38 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import bio.terra.service.filedata.DrsService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteSnapshotDrsIdsStep implements Step {
+
+  private static final Logger logger = LoggerFactory.getLogger(DeleteSnapshotDrsIdsStep.class);
+
+  private final DrsService drsService;
+  private final UUID snapshotId;
+
+  public DeleteSnapshotDrsIdsStep(DrsService drsService, UUID snapshotId) {
+    this.drsService = drsService;
+    this.snapshotId = snapshotId;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) {
+    logger.info("Deleted {} rows", drsService.deleteDrsIdToSnapshotsBySnapshot(snapshotId));
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    // This step is not undoable. We only get here when the
+    // do method has a dismal failure.
+    return new StepResult(
+        StepStatus.STEP_RESULT_FAILURE_FATAL,
+        new IllegalStateException("Attempt to undo permanent delete"));
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
@@ -11,6 +11,7 @@ import bio.terra.service.common.JournalRecordDeleteEntryStep;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.flight.UnlockDatasetStep;
+import bio.terra.service.filedata.DrsService;
 import bio.terra.service.filedata.azure.tables.TableDependencyDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
@@ -54,6 +55,7 @@ public class SnapshotDeleteFlight extends Flight {
     AzureStorageAccountService azureStorageAccountService =
         appContext.getBean(AzureStorageAccountService.class);
     JournalService journalService = appContext.getBean(JournalService.class);
+    DrsService drsService = appContext.getBean(DrsService.class);
     String tdrServiceAccountEmail = appContext.getBean("tdrServiceAccountEmail", String.class);
 
     RetryRule randomBackoffRetry =
@@ -128,6 +130,7 @@ public class SnapshotDeleteFlight extends Flight {
                 snapshotId, resourceService, azureStorageAccountService)));
 
     // Delete Metadata
+    addStep(new DeleteSnapshotDrsIdsStep(drsService, snapshotId));
     addStep(
         new DeleteSnapshotMetadataStep(snapshotDao, snapshotId, userReq),
         getDefaultExponentialBackoffRetryRule());

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
@@ -1182,8 +1182,6 @@ public class BigQuerySnapshotPdao {
                 throw new PdaoException(
                     "No matching map table for snapshot table " + table.getName());
               }
-              String snapshotId = snapshot.getId().toString();
-
               ST sqlTemplate = new ST(createViewsTemplate);
               sqlTemplate.add("datasetProject", datasetProjectId);
               sqlTemplate.add("snapshotProject", snapshotProjectId);
@@ -1196,7 +1194,7 @@ public class BigQuerySnapshotPdao {
                   .forEach(
                       c -> {
                         sqlTemplate.add("columns", c.getName());
-                        sqlTemplate.add("mappedColumns", sourceSelectSql(snapshotId, c, mapTable));
+                        sqlTemplate.add("mappedColumns", sourceSelectSql(snapshot, c, mapTable));
                       });
 
               // create the view
@@ -1238,7 +1236,7 @@ public class BigQuerySnapshotPdao {
    * any consequences downstream to DRS clients.
    */
   private String sourceSelectSql(
-      String snapshotId, Column targetColumn, SnapshotMapTable mapTable) {
+      Snapshot snapshot, Column targetColumn, SnapshotMapTable mapTable) {
     // In the future, there may not be a column map for a given target column; it might not exist
     // in the table. The logic here covers these cases:
     // 1) no source column: supply NULL
@@ -1258,7 +1256,12 @@ public class BigQuerySnapshotPdao {
 
       if (mapColumn.getFromColumn().isFileOrDirRef()) {
 
-        String drsPrefix = "'drs://" + datarepoDnsName + "/v1_" + snapshotId + "_'";
+        String drsPrefix;
+        if (snapshot.isGlobalFileIds()) {
+          drsPrefix = "'drs://" + datarepoDnsName + "/v2_'";
+        } else {
+          drsPrefix = "'drs://" + datarepoDnsName + "/v1_" + snapshot.getId() + "_'";
+        }
 
         if (targetColumn.isArrayOf()) {
           return "ARRAY(SELECT CONCAT("

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
@@ -1257,7 +1257,7 @@ public class BigQuerySnapshotPdao {
       if (mapColumn.getFromColumn().isFileOrDirRef()) {
 
         String drsPrefix;
-        if (snapshot.isGlobalFileIds()) {
+        if (snapshot.hasGlobalFileIds()) {
           drsPrefix = "'drs://" + datarepoDnsName + "/v2_'";
         } else {
           drsPrefix = "'drs://" + datarepoDnsName + "/v1_" + snapshot.getId() + "_'";

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3825,7 +3825,7 @@ components:
             This might be useful to set as a security improvement since this provides a dedicated account that explicitly
             does not have access to any other buckets.  It's also recommended if you need to authorize a large number of buckets
             since the main service account could run into Google group membership quota violations.
-        predictableFileIds:
+        experimentalPredictableFileIds:
           type: boolean
           default: false
           description: >

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3723,6 +3723,13 @@ components:
           type: string
           description: >
             Google service account to grant storage.object.get access on source Google storage buckets to in order to ingest files
+        predictableFileIds:
+          type: boolean
+          default: false
+          description: >
+            If false, random ids will be created. If true, full target path (e.g. path + name), size and MD5 hash will be used
+
+            Note: this only applies to files.  Directories still have random ids regardless of this value
       description: >
         Complete definition of a dataset.
     DatasetSummaryModel:
@@ -3761,6 +3768,13 @@ components:
           type: boolean
           default: false
           description: denotes whether data files in the dataset are self-hosted or not
+        predictableFileIds:
+          type: boolean
+          default: false
+          description: >
+            If false, random ids will be created. If true, full target path (e.g. path + name), size and MD5 hash will be used
+
+            Note: this only applies to files.  Directories still have random ids regardless of this value
       description: >
         Summary of a dataset.
     DatasetRequestModel:
@@ -3811,6 +3825,13 @@ components:
             This might be useful to set as a security improvement since this provides a dedicated account that explicitly
             does not have access to any other buckets.  It's also recommended if you need to authorize a large number of buckets
             since the main service account could run into Google group membership quota violations.
+        predictableFileIds:
+          type: boolean
+          default: false
+          description: >
+            If false, random ids will be created. If true, full target path (e.g. path + name), size and MD5 hash will be used
+            
+            Note: this only applies to files.  Directories still have random ids regardless of this value
         policies:
           description: User emails to add as dataset policy members.
           type: object

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4628,6 +4628,12 @@ components:
               type: array
               items:
                 type: string
+        globalFileIds:
+          type: boolean
+          default: false
+          description: >
+            if false, the drs ids will be in the format: v1_<snapshotid>_<fileid>
+            if true, drs ids will be in the format: v2_<fileid>
       description: >
         Request for creating a snapshot.
         For now, the API only supports snapshots defined as a single dataset asset and
@@ -4784,6 +4790,12 @@ components:
         selfHosted:
           type: boolean
           description: Denotes whether the data files in this snapshot are self hosted or not
+        globalFileIds:
+          type: boolean
+          default: false
+          description: >
+            if false, the drs ids will be in the format: v1_<snapshotid>_<fileid>
+            if true, drs ids will be in the format: v2_<fileid>
       description: >
         summary of snapshot
     EnumerateSnapshotModel:
@@ -4860,6 +4872,12 @@ components:
           description: Additional JSON metadata about the snapshot (this does not need to adhere to a particular schema)
         duosFirecloudGroup:
           $ref: '#/components/schemas/DuosFirecloudGroupModel'
+        globalFileIds:
+          type: boolean
+          default: false
+          description: >
+            if false, the drs ids will be in the format: v1_<snapshotid>_<fileid>
+            if true, drs ids will be in the format: v2_<fileid>
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
     SnapshotExportResponseModel:

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -67,4 +67,5 @@
     <include file="changesets/20221020_duosfirecloudgroupprimarykey.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20221024_snapshotduosfirecloudgroupid.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20221104_predictablefileidsoption.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20221104_v2drsids.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -66,4 +66,5 @@
     <include file="changesets/20221014_duosfirecloudgroup.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20221020_duosfirecloudgroupprimarykey.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20221024_snapshotduosfirecloudgroupid.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20221104_predictablefileidsoption.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20221104_predictablefileidsoption.yaml
+++ b/src/main/resources/db/changesets/20221104_predictablefileidsoption.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: predictablefileidsoption
+      author: nm
+      changes:
+        - addColumn:
+            tableName: dataset
+            columns:
+              name: predictable_file_ids
+              type: boolean
+              defaultValue: false

--- a/src/main/resources/db/changesets/20221104_v2drsids.yaml
+++ b/src/main/resources/db/changesets/20221104_v2drsids.yaml
@@ -1,0 +1,51 @@
+databaseChangeLog:
+  - changeSet:
+      id: v2drsids
+      author: nm
+      changes:
+        - createTable:
+            tableName: drs_id
+            columns:
+              - column:
+                  name: id
+                  type: ${uuid_type}
+                  defaultValueComputed: ${uuid_function}
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: drs_object_id
+                  type: varchar(256)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: snapshot_id
+                  type: ${uuid_type}
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            constraintName: fk_drs_id_snapshot
+            baseTableName: drs_id
+            baseColumnNames: snapshot_id
+            referencedTableName: snapshot
+            referencedColumnNames: id
+            onDelete: NO ACTION
+            onUpdate: NO ACTION
+            validate: true
+        - createIndex:
+            indexName: drs_ids_object_snapshot_idx
+            tableName: drs_id
+            unique: true
+            columns:
+              - column:
+                  name: drs_object_id
+              - column:
+                  name: snapshot_id
+        - addColumn:
+            tableName: snapshot
+            columns:
+              name: global_file_ids
+              type: boolean
+              defaultValue: false
+              constraints:
+                nullable: false

--- a/src/test/java/bio/terra/service/filedata/DrsIdServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsIdServiceTest.java
@@ -1,0 +1,104 @@
+package bio.terra.service.filedata;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.category.Unit;
+import bio.terra.service.filedata.exception.InvalidDrsIdException;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Unit.class)
+public class DrsIdServiceTest {
+
+  private static final String HOSTNAME = "myhost.org";
+
+  private final ApplicationConfiguration applicationConfiguration = new ApplicationConfiguration();
+
+  private DrsIdService drsIdService;
+
+  @Before
+  public void setUp() throws Exception {
+    applicationConfiguration.setDnsName(HOSTNAME);
+    drsIdService = new DrsIdService(applicationConfiguration);
+  }
+
+  @Test
+  public void testV1DrsIds() {
+    UUID snapshotId = UUID.randomUUID();
+    UUID fileId = UUID.randomUUID();
+    assertThat(
+        "v1 object id can be parsed",
+        drsIdService.fromObjectId("v1_" + snapshotId + "_" + fileId),
+        equalTo(new DrsId(HOSTNAME, "v1", snapshotId.toString(), fileId.toString())));
+    assertThat(
+        "v1 object id can be created",
+        drsIdService.makeDrsId(new FSFile().fileId(fileId), snapshotId.toString()),
+        equalTo(new DrsId(HOSTNAME, "v1", snapshotId.toString(), fileId.toString())));
+    String drsUri = "drs://" + HOSTNAME + "/v1_" + snapshotId + "_" + fileId;
+    assertThat(
+        "v1 drs URI can be parsed",
+        DrsIdService.fromUri(drsUri),
+        equalTo(new DrsId(HOSTNAME, "v1", snapshotId.toString(), fileId.toString())));
+    assertThat(
+        "v1 drs URI can be parsed and returns the same URI",
+        DrsIdService.fromUri(drsUri).toDrsUri(),
+        equalTo(drsUri));
+  }
+
+  @Test
+  public void testV2DrsIds() {
+    UUID fileId = UUID.randomUUID();
+    assertThat(
+        "v2 object id can be parsed",
+        drsIdService.fromObjectId("v2_" + fileId),
+        equalTo(new DrsId(HOSTNAME, "v2", null, fileId.toString())));
+    assertThat(
+        "v2 object id can be created",
+        drsIdService.makeDrsId(new FSFile().fileId(fileId)),
+        equalTo(new DrsId(HOSTNAME, "v2", null, fileId.toString())));
+    String drsUri = "drs://" + HOSTNAME + "/v2_" + fileId;
+    assertThat(
+        "v2 drs URI can be parsed",
+        DrsIdService.fromUri(drsUri),
+        equalTo(new DrsId(HOSTNAME, "v2", null, fileId.toString())));
+    assertThat(
+        "v2 drs URI can be parsed and returns the same URI",
+        DrsIdService.fromUri(drsUri).toDrsUri(),
+        equalTo(drsUri));
+  }
+
+  @Test
+  public void testInvalidDrsIds() {
+    UUID snapshotId = UUID.randomUUID();
+    UUID fileId = UUID.randomUUID();
+    assertThrows(
+        "v3 object id cannot be parsed",
+        InvalidDrsIdException.class,
+        () -> drsIdService.fromObjectId("v3_" + snapshotId + "_" + fileId));
+
+    assertThrows(
+        "badly formed v1 object id cannot be parsed - no snapshot",
+        InvalidDrsIdException.class,
+        () -> drsIdService.fromObjectId("v1_" + fileId));
+
+    assertThrows(
+        "badly formed v1 object id cannot be parsed - extra field",
+        InvalidDrsIdException.class,
+        () -> drsIdService.fromObjectId("v1_" + snapshotId + "_" + fileId + "_foo"));
+
+    assertThrows(
+        "badly formed v2 object id cannot be parsed - has a snapshot",
+        InvalidDrsIdException.class,
+        () -> drsIdService.fromObjectId("v2_" + snapshotId + "_" + fileId));
+
+    assertThrows(
+        "badly formed uri - invalid protocol",
+        InvalidDrsIdException.class,
+        () -> DrsIdService.fromUri("https://notadrsurl.com"));
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/DrsIdTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsIdTest.java
@@ -14,22 +14,33 @@ import org.springframework.test.context.ActiveProfiles;
 public class DrsIdTest {
 
   @Test
-  public void testDrsId() {
+  public void testDrsIdV1() {
     DrsId drsId =
         DrsId.builder()
             .dnsname("dns")
-            .version("vv")
+            .version("v1")
             .snapshotId("snapshot")
             .fsObjectId("file")
             .build();
 
     assertThat("drsid constructor succeeds - dnsname", drsId.getDnsname(), equalTo("dns"));
-    assertThat("drsid constructor succeeds - version", drsId.getVersion(), equalTo("vv"));
+    assertThat("drsid constructor succeeds - version", drsId.getVersion(), equalTo("v1"));
     assertThat(
         "drsid constructor succeeds - snapshotId", drsId.getSnapshotId(), equalTo("snapshot"));
     assertThat("drsid constructor succeeds - fileId", drsId.getFsObjectId(), equalTo("file"));
-    assertThat("drsid toDrsUri works", drsId.toDrsUri(), equalTo("drs://dns/vv_snapshot_file"));
-    assertThat("drsid toObjectId works", drsId.toDrsObjectId(), equalTo("vv_snapshot_file"));
+    assertThat("drsid toDrsUri works", drsId.toDrsUri(), equalTo("drs://dns/v1_snapshot_file"));
+    assertThat("drsid toObjectId works", drsId.toDrsObjectId(), equalTo("v1_snapshot_file"));
+  }
+
+  @Test
+  public void testDrsIdV2() {
+    DrsId drsId = DrsId.builder().dnsname("dns").version("v2").fsObjectId("file").build();
+
+    assertThat("drsid constructor succeeds - dnsname", drsId.getDnsname(), equalTo("dns"));
+    assertThat("drsid constructor succeeds - version", drsId.getVersion(), equalTo("v2"));
+    assertThat("drsid constructor succeeds - fileId", drsId.getFsObjectId(), equalTo("file"));
+    assertThat("drsid toDrsUri works", drsId.toDrsUri(), equalTo("drs://dns/v2_file"));
+    assertThat("drsid toObjectId works", drsId.toDrsObjectId(), equalTo("v2_file"));
   }
 
   @Test(expected = InvalidDrsIdException.class)

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -62,6 +62,7 @@ import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.SnapshotSource;
 import bio.terra.service.snapshot.SnapshotSummary;
 import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
@@ -78,6 +79,10 @@ import org.springframework.test.context.ActiveProfiles;
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 @ActiveProfiles({"google", "unittest"})
 @Category(Unit.class)
+@SuppressFBWarnings(
+    value = "DMI",
+    justification =
+        "This fails with not allowing absolute paths but they're not file paths in our case")
 public class DrsServiceTest {
 
   @Mock private SnapshotService snapshotService;
@@ -749,6 +754,9 @@ public class DrsServiceTest {
         () -> drsService.mergeDRSObjects(List.of(drsObject1, drsObject2)));
   }
 
+  @SuppressFBWarnings(
+      value = "NP",
+      justification = "It's incorrectly complaining about potential NPEs")
   private DRSObject createFileDrsObject(
       String id,
       String path,

--- a/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
@@ -1,0 +1,81 @@
+package bio.terra.service.filedata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.dataset.Dataset;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@Category(Unit.class)
+public class FileIdServiceTest {
+
+  FileIdService service = new FileIdService();
+
+  @Mock Dataset dataset;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testPredictableUUIDEquals() {
+    when(dataset.isPredictableFileIds()).thenReturn(true);
+    FSItem fsItem1 = new FSFile().path("/foo/bar").size(123L).checksumMd5("foo");
+
+    FSItem fsItem2 = new FSFile().path("/foo/bar").size(123L).checksumMd5("foo");
+    assertEquals(
+        "IDs match",
+        service.calculateFileId(dataset, fsItem1),
+        service.calculateFileId(dataset, fsItem2));
+  }
+
+  @Test
+  public void testPredictableUUIDNotEqualsWhenRandom() {
+    when(dataset.isPredictableFileIds()).thenReturn(false);
+    FSItem fsItem1 = new FSFile().path("/foo/bar").size(123L).checksumMd5("foo");
+
+    FSItem fsItem2 = new FSFile().path("/foo/bar").size(123L).checksumMd5("foo");
+    assertNotEquals(
+        "IDs don't match when using random ID mode",
+        service.calculateFileId(dataset, fsItem1),
+        service.calculateFileId(dataset, fsItem2));
+  }
+
+  @Test
+  public void testPredictableUUIDNotEquals() {
+    when(dataset.isPredictableFileIds()).thenReturn(true);
+    record TestCase(FSItem fsItem, FSFileInfo fsFileInfo) {}
+    List<TestCase> testCases =
+        Stream.of("/foo/bar/file1.txt", "/foo/bar/file2.txt")
+            .flatMap(
+                p ->
+                    Stream.of(123L, 456L)
+                        .flatMap(
+                            s ->
+                                Stream.of("foo", "bar")
+                                    .map(
+                                        c ->
+                                            new TestCase(
+                                                new FSFile().path(p).size(s).checksumMd5(c),
+                                                new FSFileInfo().size(s).checksumMd5(c)))))
+            .toList();
+
+    for (int i = 0; i < testCases.size(); i++) {
+      TestCase tc1 = testCases.get(i);
+      TestCase tc2 = testCases.get((i + 1) % testCases.size());
+      assertNotEquals(
+          "IDs don't collide between:\n%s\nand\n%s".formatted(tc1.fsItem, tc2.fsItem),
+          service.calculateFileId(dataset, tc1.fsItem),
+          service.calculateFileId(dataset, tc2.fsItem));
+    }
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
@@ -28,7 +28,7 @@ public class FileIdServiceTest {
 
   @Test
   public void testPredictableUUIDEquals() {
-    when(dataset.isPredictableFileIds()).thenReturn(true);
+    when(dataset.hasPredictableFileIds()).thenReturn(true);
     FSItem fsItem1 = new FSFile().path("/foo/bar").size(123L).checksumMd5("foo");
 
     FSItem fsItem2 = new FSFile().path("/foo/bar").size(123L).checksumMd5("foo");
@@ -40,7 +40,7 @@ public class FileIdServiceTest {
 
   @Test
   public void testPredictableUUIDNotEqualsWhenRandom() {
-    when(dataset.isPredictableFileIds()).thenReturn(false);
+    when(dataset.hasPredictableFileIds()).thenReturn(false);
     FSItem fsItem1 = new FSFile().path("/foo/bar").size(123L).checksumMd5("foo");
 
     FSItem fsItem2 = new FSFile().path("/foo/bar").size(123L).checksumMd5("foo");
@@ -54,7 +54,7 @@ public class FileIdServiceTest {
 
   @Test
   public void testPredictableUUIDNotEquals() {
-    when(dataset.isPredictableFileIds()).thenReturn(true);
+    when(dataset.hasPredictableFileIds()).thenReturn(true);
     List<TestCase> testCases =
         Stream.of("/foo/bar/file1.txt", "/foo/bar/file2.txt")
             .flatMap(

--- a/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
@@ -50,10 +50,11 @@ public class FileIdServiceTest {
         service.calculateFileId(dataset, fsItem2));
   }
 
+  record TestCase(FSItem fsItem, FSFileInfo fsFileInfo) {}
+
   @Test
   public void testPredictableUUIDNotEquals() {
     when(dataset.isPredictableFileIds()).thenReturn(true);
-    record TestCase(FSItem fsItem, FSFileInfo fsFileInfo) {}
     List<TestCase> testCases =
         Stream.of("/foo/bar/file1.txt", "/foo/bar/file2.txt")
             .flatMap(

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -19,6 +19,7 @@ import bio.terra.model.FileLoadModel;
 import bio.terra.model.FileModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.common.azure.StorageTableName;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.filedata.FSFileInfo;
 import bio.terra.service.filedata.FSItem;
@@ -210,7 +211,12 @@ public class AzureIngestFileConnectedTest {
     // 5 - IngestFileAzurePrimaryDataStep
     FSFileInfo fsFileInfo =
         azureBlobStorePdao.copyFile(
-            billingProfile, fileLoadModel, fileId, storageAccountResource, TEST_USER);
+            new Dataset().id(datasetId).predictableFileIDs(false),
+            billingProfile,
+            fileLoadModel,
+            fileId,
+            storageAccountResource,
+            TEST_USER);
 
     // 6 - IngestFileAzureFileStep
     FireStoreFile newFile =

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -211,7 +211,7 @@ public class AzureIngestFileConnectedTest {
     // 5 - IngestFileAzurePrimaryDataStep
     FSFileInfo fsFileInfo =
         azureBlobStorePdao.copyFile(
-            new Dataset().id(datasetId).predictableFileIDs(false),
+            new Dataset().id(datasetId).predictableFileIds(false),
             billingProfile,
             fileLoadModel,
             fileId,

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -19,6 +19,7 @@ import bio.terra.common.exception.PdaoException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.FileLoadModel;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FSFileInfo;
 import bio.terra.service.filedata.azure.util.BlobContainerClientFactory;
 import bio.terra.service.filedata.azure.util.BlobContainerCopier;
@@ -145,6 +146,7 @@ public class AzureBlobStorePdaoTest {
 
     FSFileInfo fsFileInfo =
         dao.copyFile(
+            new Dataset().id(UUID.randomUUID()).predictableFileIDs(false),
             BILLING_PROFILE,
             fileLoadModel,
             fileId.toString(),
@@ -165,6 +167,7 @@ public class AzureBlobStorePdaoTest {
 
     FSFileInfo fsFileInfo =
         dao.copyFile(
+            new Dataset().id(UUID.randomUUID()).predictableFileIDs(false),
             BILLING_PROFILE,
             fileLoadModel,
             fileId.toString(),

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -146,7 +146,7 @@ public class AzureBlobStorePdaoTest {
 
     FSFileInfo fsFileInfo =
         dao.copyFile(
-            new Dataset().id(UUID.randomUUID()).predictableFileIDs(false),
+            new Dataset().id(UUID.randomUUID()).predictableFileIds(false),
             BILLING_PROFILE,
             fileLoadModel,
             fileId.toString(),
@@ -167,7 +167,7 @@ public class AzureBlobStorePdaoTest {
 
     FSFileInfo fsFileInfo =
         dao.copyFile(
-            new Dataset().id(UUID.randomUUID()).predictableFileIDs(false),
+            new Dataset().id(UUID.randomUUID()).predictableFileIds(false),
             BILLING_PROFILE,
             fileLoadModel,
             fileId.toString(),

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
@@ -180,7 +180,7 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
     when(gcsPdao.copyFile(any(), any(), any(), any())).thenReturn(fileInfo);
 
     // Dataset uses predictable file ids
-    when(dataset.isPredictableFileIds()).thenReturn(true);
+    when(dataset.hasPredictableFileIds()).thenReturn(true);
 
     step.doStep(flightContext);
 
@@ -200,7 +200,7 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
     when(gcsPdao.copyFile(any(), any(), any(), any())).thenReturn(fileInfo);
 
     // Dataset uses predictable file ids
-    when(dataset.isPredictableFileIds()).thenReturn(false);
+    when(dataset.hasPredictableFileIds()).thenReturn(false);
 
     step.doStep(flightContext);
 

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
@@ -3,17 +3,24 @@ package bio.terra.service.filedata.flight.ingest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
 import bio.terra.common.exception.PdaoFileCopyException;
+import bio.terra.model.FileLoadModel;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FSFileInfo;
+import bio.terra.service.filedata.FileIdService;
 import bio.terra.service.filedata.exception.GoogleInternalServerErrorException;
 import bio.terra.service.filedata.exception.InvalidUserProjectException;
 import bio.terra.service.filedata.flight.FileMapKeys;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.stairway.FlightContext;
@@ -27,6 +34,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -35,11 +43,21 @@ import org.springframework.test.context.junit4.SpringRunner;
 @Category(Unit.class)
 public class IngestFilePrimaryDataStepTest extends TestCase {
 
+  private static final UUID RANDOM_FILE_ID = UUID.randomUUID();
+
+  private static final FileLoadModel FILE_LOAD_MODEL =
+      new FileLoadModel()
+          .loadTag("lt")
+          .sourcePath("gs://bucket/path/file.txt")
+          .targetPath("/foo/bar/baz.txt");
+
   @MockBean private GcsPdao gcsPdao;
 
   @MockBean private Dataset dataset;
 
   @MockBean private ConfigurationService configService;
+
+  @SpyBean private FileIdService fileIdService;
 
   private IngestFilePrimaryDataStep step;
 
@@ -53,10 +71,11 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
     FlightMap inputParameters = new FlightMap();
     inputParameters.put(
         FileMapKeys.BUCKET_INFO, new GoogleBucketResource().resourceId(UUID.randomUUID()));
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), FILE_LOAD_MODEL);
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
 
     FlightMap workingMap = new FlightMap();
-    workingMap.put(FileMapKeys.FILE_ID, UUID.randomUUID().toString());
+    workingMap.put(FileMapKeys.FILE_ID, RANDOM_FILE_ID.toString());
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
 
     GoogleProjectResource projectResource =
@@ -145,5 +164,49 @@ public class IngestFilePrimaryDataStepTest extends TestCase {
             "Step throws unretryable exception");
     verify(gcsPdao, times(1)).copyFile(any(), any(), any(), any());
     assertThat("Error message reflects cause", thrown.getMessage(), equalTo(errorMessage));
+  }
+
+  @Test
+  public void testThatFileIdIsProperlyCalculatedWhenPredictable() {
+    // This is an ID that is a function of size, checksum and path of the file
+    UUID predictableFileId = UUID.fromString("762d37d3-dccc-3e61-a0fd-c3768f3a975a");
+
+    // Dataset is externally hosted by default
+    FSFileInfo fileInfo = mock(FSFileInfo.class);
+    when(fileInfo.getFileId()).thenReturn(predictableFileId.toString());
+    when(fileInfo.getSize()).thenReturn(123L);
+    when(fileInfo.getChecksumMd5()).thenReturn("foo");
+
+    when(gcsPdao.copyFile(any(), any(), any(), any())).thenReturn(fileInfo);
+
+    // Dataset uses predictable file ids
+    when(dataset.isPredictableFileIds()).thenReturn(true);
+
+    step.doStep(flightContext);
+
+    assertThat(
+        "File ID is predicable",
+        flightContext.getWorkingMap().get(FileMapKeys.FILE_ID, UUID.class),
+        equalTo(predictableFileId));
+  }
+
+  @Test
+  public void testThatFileIdIsProperlyCalculatedWhenRandom() {
+    // Dataset is externally hosted by default
+    FSFileInfo fileInfo = mock(FSFileInfo.class);
+    when(fileInfo.getSize()).thenReturn(123L);
+    when(fileInfo.getChecksumMd5()).thenReturn("foo");
+
+    when(gcsPdao.copyFile(any(), any(), any(), any())).thenReturn(fileInfo);
+
+    // Dataset uses predictable file ids
+    when(dataset.isPredictableFileIds()).thenReturn(false);
+
+    step.doStep(flightContext);
+
+    assertThat(
+        "File ID is random",
+        flightContext.getWorkingMap().get(FileMapKeys.FILE_ID, UUID.class),
+        equalTo(RANDOM_FILE_ID));
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -114,7 +114,7 @@ public class FireStoreDaoTest {
       fileIdList.add(fireStoreDirectoryEntry.getFileId());
     }
     directoryDao.addEntriesToSnapshot(
-        firestore, collectionId, "dataset", firestore, snapshotId, fileIdList);
+        firestore, collectionId, "dataset", firestore, snapshotId, fileIdList, false);
 
     // Validate we can lookup files in the snapshot
     for (FireStoreDirectoryEntry dsetObject : snapObjects) {


### PR DESCRIPTION
Woof...apologies for the size of this PR.  In fairness, a lot of this is testing.  This is really probably 2 PRs.  The first commit and then what's after.

## Intro
This PR aims to solve the issue where a DRS ID really should be able to point to files that exist across multiple regions and multiple clouds.  This is very common in NIH projects and is needed for TDR to be successful in replacing existing solutions there.

The issue is that TDR has a 1:1 Dataset to Snapshot relationship and in order to have multiple regions and clouds, you need different datasets which, using our current DRS ID scheme, won't work since it includes the snapshot id.

The solution implemented in this PR is to introduce:
- Predictable File Ids
- Global Drs Ids

Both are independently useful features but together they allow us to support the NIH use-case.

I'll note one nice side-effect feature with the Global Drs Ids: we can now have a ton of snapshots created from the same Dataset and each snapshot can have the same Drs Ids.  This has been a source of consternation in the past.

More information can be found here: https://docs.google.com/document/d/1i7Nk99fQWZBVeOAvqqTymT1oG27r6koRUnEsE2mYKKA/edit#heading=h.6woj4vghhmz3

## Predictable File IDs
First commit:
- Adds support for predictable file ids (a behavior that is enabled when you create the dataset)
- If false, fileIds continue to be minted randomly the way that it works today
- If true, fileIds are creates as a function of targetPath + size + MD5 hash
  - With this approach, one thing that's fun is that we need to look up the source file before copying it to get its MD5 hash (since we use the fileId for the target location of the file)
  - We also need to swap the order of the steps where we do the file copy and record the directory entry for each file (since the file copy step is the one where we get the file id in the predictable file id case)
  - Note: directories will not have predictable ids. Not sure there's a need and it's a looooot more expensive to calculate

## Global Drs IDs
Following commits:
- Adds support for a new type of Drs ID.  Where before DRS IDs look like `v1_<snapshotuuid>_<fileuuid>`, this PR introduces a new type that is global that looks like `v2_fileuuid`.
- It's enabled via a new (and immutable) Snapshot parameter: `globalFileIds`
- To support this, a new table named `drs_id` is added and it's job is to store a lookup from this drs id to all snapshots that contain it
- A note on perf: I tested with ~10M records in the table the performance of the lookup adds negligible overhead compared to Firestore lookups
- The snapshot creation flight now takes care of:
  - Recording the drs ids
  - Making the views/parquet files show the new drs URI in that case (e.g. `drs://<hostname>/v2_fileuuid`)
- The DrsService changed over its logic (this is where a lot of the code changes are)
  - Snapshots associated with a drs ID are now assumed to be a list, not just a single value
  - The DrsObject lookup looks up the Drs object information for all snapshots that the user has access to and then merges the information.
    - The merging is somewhat straightforward: it does a lookup and assumes single values for everything (and will fail if there are multiple values) except:
      - aliases
      - checksums: it merges on checksum types and fails if there are overlapping checksums that don't match (e.g. if there are 2 md5 hashes that don't match)
      - accessMethods: this is the trickier one. For this, unions all of the access methods but the access Id now has `*<billing snapshot uuid>` appended to it.  The reason that this is there is because in order to access a requester pays bucket, we need to specify a snapshot whose project can be billed for the access.  The algorithm is to group all snapshots by billing id and then use the first (by ID sort order) snapshot in the group (since the snapshot in question doesn't matter, if they all point to the same billing account)

I'll note (and I mentioned in standup) that I haven't added any integration tests here.  Everything is tested via unit tests (a little bit of connected testing for Synapse stuff).  I may still add an integration test for sanity but the real guts of the logic is exercised via unit tests.  So that's good :)