### PR TITLE
[DR-2853] Fix bulk non-array file ingest on self-hosted datasets

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -187,7 +187,8 @@ public class FileIngestBulkFlight extends Flight {
                 gcsPdao,
                 bulkLoadObjectMapper,
                 executor,
-                userReq));
+                userReq,
+                dataset));
       } else {
         addStep(
             new IngestPopulateFileStateFromFileAzureStep(

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileGcpStep.java
@@ -3,6 +3,7 @@ package bio.terra.service.filedata.flight.ingest;
 import bio.terra.common.FlightUtils;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.exception.BulkLoadControlFileException;
 import bio.terra.service.filedata.flight.FileMapKeys;
 import bio.terra.service.filedata.google.gcs.GcsBufferedReader;
@@ -22,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 // Populate the files to be loaded from the incoming array
 public class IngestPopulateFileStateFromFileGcpStep extends IngestPopulateFileStateFromFileStep {
   private final GcsPdao gcsPdao;
+  private final Dataset dataset;
 
   public IngestPopulateFileStateFromFileGcpStep(
       LoadService loadService,
@@ -30,10 +32,12 @@ public class IngestPopulateFileStateFromFileGcpStep extends IngestPopulateFileSt
       GcsPdao gcsPdao,
       ObjectMapper bulkLoadObjectMapper,
       ExecutorService executor,
-      AuthenticatedUserRequest userRequest) {
+      AuthenticatedUserRequest userRequest,
+      Dataset dataset) {
     super(
         loadService, maxBadLines, batchSize, bulkLoadObjectMapper, gcsPdao, executor, userRequest);
     this.gcsPdao = gcsPdao;
+    this.dataset = dataset;
   }
 
   @Override
@@ -42,10 +46,16 @@ public class IngestPopulateFileStateFromFileGcpStep extends IngestPopulateFileSt
     FlightMap inputParameters = context.getInputParameters();
     BulkLoadRequestModel loadRequest =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), BulkLoadRequestModel.class);
-    GoogleBucketResource bucketResource =
-        FlightUtils.getContextValue(context, FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
-    Storage storage = gcsPdao.storageForBucket(bucketResource);
-    String projectId = bucketResource.projectIdForBucket();
+
+    String projectId;
+    if (dataset.isSelfHosted()) {
+      projectId = dataset.getProjectResource().getGoogleProjectId();
+    } else {
+      GoogleBucketResource bucketResource =
+          FlightUtils.getContextValue(context, FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+      projectId = bucketResource.projectIdForBucket();
+    }
+    Storage storage = gcsPdao.storageForProjectId(projectId);
 
     // Stream from control file and build list of files to be ingested
     try (BufferedReader reader =

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -141,8 +141,12 @@ public class GcsPdao implements CloudFileReader {
     this.tdrServiceAccountEmail = tdrServiceAccountEmail;
   }
 
+  public Storage storageForProjectId(String projectId) {
+    return gcsProjectFactory.getStorage(projectId);
+  }
+
   public Storage storageForBucket(GoogleBucketResource bucketResource) {
-    return gcsProjectFactory.getStorage(bucketResource.projectIdForBucket());
+    return storageForProjectId(bucketResource.projectIdForBucket());
   }
 
   /**


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2853

When populating file state from the control file in a [bulkFileLoad](https://data.terra.bio/swagger-ui.html#/datasets/bulkFileLoad) to a self-hosted dataset, we need to obtain the Google project ID from the dataset. Ingests to self-hosted datasets sidestep the Google bucket create-or-fetch process. We follow a similar conditional pattern in [IngestFilePrimaryDataStep](https://github.com/DataBiosphere/jade-data-repo/blob/52bc98720c76fa6ab29cb77e0c42793448d5933c/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java#L47-L61).

This was one logical pathway that was previously untested -- bulk file ingest to a self-hosted dataset via a control file.  We've previously tested individual file ingests, bulk array file ingest, and combined ingest.

**Manual Verification**

On my dev instance I created a self-hosted dataset with DataRepoAdmins@dev.test.firecloud.org made a steward: https://jade-ok.datarepo-dev.broadinstitute.org/datasets/8f20d83c-3cce-4427-8e51-3edcf26433b1

I uploaded a control file to GS: https://console.cloud.google.com/storage/browser/_details/jade-testdata/okotsopo/bulk-file-load-control.json?authuser=2&project=broad-jade-dev

This command initiates a `bulkFileLoad`:
```
curl -X 'POST' \
  'https://jade-ok.datarepo-dev.broadinstitute.org/api/repository/v1/datasets/8f20d83c-3cce-4427-8e51-3edcf26433b1/files/bulk' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <token>' \
  -H 'Content-Type: application/json' \
  -d '{
  "profileId": "8c3aeb0c-8de1-4cdd-92ed-8e03c05acbc9",
  "loadTag": "selfHostedBulkFileControlIngest",
  "maxFailedFileLoads": 0,
  "loadControlFile": "gs://jade-testdata/okotsopo/bulk-file-load-control.json"
}'
```

Job result before the fix matches Andrea's failure:
```
{
  "message": "Cannot invoke \"bio.terra.service.resourcemanagement.google.GoogleBucketResource.projectIdForBucket()\" because \"bucketResource\" is null",
  "errorDetail": [
    "Cannot invoke \"bio.terra.service.resourcemanagement.google.GoogleBucketResource.projectIdForBucket()\" because \"bucketResource\" is null"
  ]
}
```

Job result after the fix indicates a success:
```
{
  "loadTag": "selfHostedBulkFileControlIngest",
  "jobId": "Rd-PVBrpTLeEhCBeN2y6Og",
  "totalFiles": 6,
  "succeededFiles": 6,
  "failedFiles": 0,
  "notTriedFiles": 0
}
```

**To Do**
- Expand automated testing, but I think this can be reviewed without it.  I hope to merge this PR today, Wednesday 11/30 or first thing tomorrow because I'll be OOO on Friday.  This would get the fix on next week's release.  **ETA** broke testing out into its own ticket and will handle in a follow-on PR: https://broadworkbench.atlassian.net/browse/DR-2855