### PR TITLE
[DR-2855] Self-hosted dataset integration tests include bulkFileLoad

### DIFF
--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -113,6 +113,8 @@ public class DataRepoFixtures {
 
     DataRepoResponse<JobModel> jobResponse =
         dataRepoClient.post(user, "/api/resources/v1/profiles", json, new TypeReference<>() {});
+    logger.info("Response was: {}", jobResponse);
+
     assertTrue("profile create launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
     assertTrue(
         "profile create launch response is present", jobResponse.getResponseObject().isPresent());

--- a/src/test/resources/self-hosted-dataset-ingest.json
+++ b/src/test/resources/self-hosted-dataset-ingest.json
@@ -1,2 +1,4 @@
-{"sample_name":"NA12878_exome","data_type":"exome","vcf_file_ref": "EXOME_VCF_FILE_ID","vcf_index_file_ref": ["EXOME_VCF_INDEX_FILE_ID"]}
-{"sample_name":"NA12878_wgs","data_type":"wgs","vcf_file_ref": {"description":"A downsampled wgs gVCF","mimeType":"text/plain","sourcePath":"gs://INGEST_BUCKET/selfHostedDatasetTest/vcfs/NA12878_PLUMBING_wgs.g.vcf.gz","targetPath":"/vcfs/downsampled/wgs/NA12878_PLUMBING.g.vcf.gz"},"vcf_index_file_ref": ["WGS_VCF_INDEX_FILE_ID"]}
+{"sample_name":"NA12878_exome1","data_type":"exome","vcf_file_ref": "${EXOME1_VCF_FILE_ID}","vcf_index_file_ref": ["${EXOME_VCF_INDEX_FILE_ID}"]}
+{"sample_name":"NA12878_exome2","data_type":"exome","vcf_file_ref": "${EXOME2_VCF_FILE_ID}","vcf_index_file_ref": ["${EXOME_VCF_INDEX_FILE_ID}"]}
+{"sample_name":"NA12878_exome3","data_type":"exome","vcf_file_ref": "${EXOME3_VCF_FILE_ID}","vcf_index_file_ref": ["${EXOME_VCF_INDEX_FILE_ID}"]}
+{"sample_name":"NA12878_wgs","data_type":"wgs","vcf_file_ref": {"description":"A downsampled wgs gVCF","mimeType":"text/plain","sourcePath":"gs://${INGEST_BUCKET}/selfHostedDatasetTest/vcfs/NA12878_PLUMBING_wgs.g.vcf.gz","targetPath":"/vcfs/downsampled/wgs/NA12878_PLUMBING.g.vcf.gz"},"vcf_index_file_ref": ["${WGS_VCF_INDEX_FILE_ID}"]}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2855

**Background**

Last week, I fixed a bug that prevented bulk file ingests via control file to self-hosted datasets: https://github.com/DataBiosphere/jade-data-repo/pull/1380

To get the fix out in the following release, I elected to merge it and handle integration test expansion separately.  It took me more time to wrap my head around the self-hosted dataset integration test code.

**Test Changes**

The self-hosted dataset lifecycle used in integration tests now includes a bulk file load via control file.

- Broke out code related to various means of ingest into their own methods to make it easier to follow the self-hosted dataset lifecycle.  This stemmed from the difficulty I had distinguishing the boundaries of the lifecycle's operations.  I also wanted to be more explicit in the coverage offered by the lifecycle with respect to different means of ingest.
- Hardened (somewhat) variable substitution utility method against partial string matches, used for populating `self-hosted-data-ingest.json`.

**Notes for Reviewers**

- The diff view makes this look more extensive than it actually was: nearly all of the removed code has actually been broken up into helper methods.
- I tried not to make perfect the enemy of good here :) my goal was to expand our test coverage for the previously broken case but additional refactoring or test improvement is not the highest priority relative to our other work.