### PR TITLE
[DR-2841] Sync DUOS Firecloud group members on creation within flight

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/flight/duos/SnapshotUpdateDuosDatasetFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/duos/SnapshotUpdateDuosDatasetFlight.java
@@ -45,11 +45,14 @@ public class SnapshotUpdateDuosDatasetFlight extends Flight {
     }
     if (linking) {
       addStep(new RetrieveDuosFirecloudGroupStep(duosDao, duosId));
-      // Create a
+
+      // Create, record, and sync a new Firecloud group if we don't have one for the DUOS ID.
       addStep(
           new IfNoGroupRetrievedStep(
               new CreateDuosFirecloudGroupStep(duosService, iamService, duosId)));
       addStep(new IfNoGroupRetrievedStep(new RecordDuosFirecloudGroupStep(duosDao)));
+      addStep(new IfNoGroupRetrievedStep(new SyncDuosFirecloudGroupStep(duosService, duosId)));
+
       addStep(new AddDuosFirecloudReaderStep(iamService, userReq, snapshotId));
     }
     addStep(

--- a/src/main/java/bio/terra/service/snapshot/flight/duos/SyncDuosFirecloudGroupStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/duos/SyncDuosFirecloudGroupStep.java
@@ -1,0 +1,28 @@
+package bio.terra.service.snapshot.flight.duos;
+
+import bio.terra.model.DuosFirecloudGroupModel;
+import bio.terra.service.duos.DuosService;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+
+public class SyncDuosFirecloudGroupStep extends DefaultUndoStep {
+
+  private final DuosService duosService;
+  private final String duosId;
+
+  public SyncDuosFirecloudGroupStep(DuosService duosService, String duosId) {
+    this.duosService = duosService;
+    this.duosId = duosId;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    DuosFirecloudGroupModel synced = duosService.syncDuosDatasetAuthorizedUsers(duosId);
+
+    context.getWorkingMap().put(SnapshotDuosMapKeys.FIRECLOUD_GROUP, synced);
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/test/java/bio/terra/common/fixtures/DuosFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/DuosFixtures.java
@@ -32,4 +32,13 @@ public final class DuosFixtures {
         .created(Instant.now().toString())
         .createdBy("jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com");
   }
+
+  /**
+   * @param duosId DUOS dataset ID
+   * @return a DuosFirecloudGroupModel created from the DUOS ID, populated as if synced and returned
+   *     via database retrieval. No external calls are made.
+   */
+  public static DuosFirecloudGroupModel createDbSyncedFirecloudGroup(String duosId) {
+    return createDbFirecloudGroup(duosId).lastSynced(Instant.now().toString());
+  }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/duos/SnapshotUpdateDuosDatasetFlightTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/duos/SnapshotUpdateDuosDatasetFlightTest.java
@@ -45,12 +45,16 @@ public class SnapshotUpdateDuosDatasetFlightTest {
             "RetrieveDuosFirecloudGroupStep",
             "IfNoGroupRetrievedStep",
             "IfNoGroupRetrievedStep",
+            "IfNoGroupRetrievedStep",
             "AddDuosFirecloudReaderStep",
             "UpdateSnapshotDuosFirecloudGroupIdStep"));
     assertThat(
-        "Firecloud group creation and record steps are optional",
+        "Firecloud group creation, record, and sync steps are optional",
         getFlightOptionalStepNames(flight),
-        contains("CreateDuosFirecloudGroupStep", "RecordDuosFirecloudGroupStep"));
+        contains(
+            "CreateDuosFirecloudGroupStep",
+            "RecordDuosFirecloudGroupStep",
+            "SyncDuosFirecloudGroupStep"));
   }
 
   @Test
@@ -69,12 +73,16 @@ public class SnapshotUpdateDuosDatasetFlightTest {
             "RetrieveDuosFirecloudGroupStep",
             "IfNoGroupRetrievedStep",
             "IfNoGroupRetrievedStep",
+            "IfNoGroupRetrievedStep",
             "AddDuosFirecloudReaderStep",
             "UpdateSnapshotDuosFirecloudGroupIdStep"));
     assertThat(
-        "Firecloud group creation and record steps are optional",
+        "Firecloud group creation, record, and sync steps are optional",
         getFlightOptionalStepNames(flight),
-        contains("CreateDuosFirecloudGroupStep", "RecordDuosFirecloudGroupStep"));
+        contains(
+            "CreateDuosFirecloudGroupStep",
+            "RecordDuosFirecloudGroupStep",
+            "SyncDuosFirecloudGroupStep"));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/flight/duos/SyncDuosFirecloudGroupStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/duos/SyncDuosFirecloudGroupStepTest.java
@@ -1,0 +1,77 @@
+package bio.terra.service.snapshot.flight.duos;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.DuosFixtures;
+import bio.terra.model.DuosFirecloudGroupModel;
+import bio.terra.service.duos.DuosService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.context.ActiveProfiles;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class SyncDuosFirecloudGroupStepTest {
+
+  @Mock private DuosService duosService;
+  @Mock private FlightContext flightContext;
+
+  private static final String DUOS_ID = "DUOS-123456";
+
+  private static final DuosFirecloudGroupModel INSERTED =
+      DuosFixtures.createDbFirecloudGroup(DUOS_ID);
+  private static final DuosFirecloudGroupModel SYNCED =
+      DuosFixtures.createDbSyncedFirecloudGroup(DUOS_ID);
+
+  private SyncDuosFirecloudGroupStep step;
+  private FlightMap workingMap;
+
+  @Before
+  public void setup() {
+    step = new SyncDuosFirecloudGroupStep(duosService, DUOS_ID);
+
+    workingMap = new FlightMap();
+    workingMap.put(SnapshotDuosMapKeys.FIRECLOUD_GROUP, INSERTED);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  public void testDoStepSucceeds() throws InterruptedException {
+    when(duosService.syncDuosDatasetAuthorizedUsers(DUOS_ID)).thenReturn(SYNCED);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(duosService).syncDuosDatasetAuthorizedUsers(DUOS_ID);
+
+    assertThat(
+        "Synced Firecloud group overwrites inserted in working map",
+        SnapshotDuosFlightUtils.getFirecloudGroup(flightContext),
+        equalTo(SYNCED));
+  }
+
+  @Test
+  public void testDoStepThrows() {
+    doThrow(RuntimeException.class).when(duosService).syncDuosDatasetAuthorizedUsers(DUOS_ID);
+    assertThrows(RuntimeException.class, () -> step.doStep(flightContext));
+
+    assertThat(
+        "Inserted Firecloud group remains in working map when sync fails",
+        SnapshotDuosFlightUtils.getFirecloudGroup(flightContext),
+        equalTo(INSERTED));
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2841

When [linking a snapshot to a DUOS Firecloud group](https://data.terra.bio/swagger-ui.html#/snapshots/linkDuosDatasetToSnapshot), TDR will create a new Firecloud group if doesn’t already have one for the DUOS dataset.  We now sync its members on creation since an empty group is not of immediate value to the snapshot steward initiating the link, as well as an unintuitive UX.

I achieved this by adding an additional step to the `SnapshotUpdateDuosDatasetFlight` rather than expand the `DuosService` creation method to also sync the group: this was to ensure that any group created is recorded to the flight's working map and deleted in the event of a flight rollback.

**Manual Demonstration**

My dev environment is up to date with my latest changes.  It previously had no knowledge of DUOS dataset `DUOS-000007`.  I updated a snapshot to link with that DUOS dataset, which created a new Firecloud group.  I can see from the returned value that the group was synced soon after creation:

```
https://jade-ok.datarepo-dev.broadinstitute.org/api/repository/v1/snapshots/ac1ea569-f70d-4189-affd-61a3dc06422a/linkDuosDataset/DUOS-000007

{
  "unlinked": {
    "id": "fdfea409-f6f8-4550-afec-0fb4f48159dc",
    "duosId": "DUOS-000006",
    "firecloudGroupName": "DUOS-000006-users",
    "firecloudGroupEmail": "DUOS-000006-users@dev.test.firecloud.org",
    "createdBy": "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com",
    "created": "2022-12-13T02:28:34.280964Z",
    "lastSynced": "2022-12-13T02:28:34.324471Z"
  },
  "linked": {
    "id": "b103a9fe-6357-4c3d-ad9e-d87c097feadc",
    "duosId": "DUOS-000007",
    "firecloudGroupName": "DUOS-000007-users",
    "firecloudGroupEmail": "DUOS-000007-users@dev.test.firecloud.org",
    "createdBy": "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com",
    "created": "2022-12-13T14:33:32.719245Z",
    "lastSynced": "2022-12-13T14:33:32.756267Z"
  }
}
```

As the TDR dev SA (Firecloud group admin) I can also verify that the group membership matches the DUOS dataset's authorized users:
```
curl -X 'GET' \
  'https://sam.dsde-dev.broadinstitute.org/api/groups/v1/DUOS-000007-users/member' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer '$(gcloud auth print-access-token) | jq .
[
  "jon.nsf@gmail.com"
]
```