### PR TITLE
DR-2861: Add retry on CannotSerializeTransactionException for DeleteSnapshotMetadataStep

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
@@ -10,6 +10,7 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.UUID;
+import org.springframework.dao.CannotSerializeTransactionException;
 import org.springframework.http.HttpStatus;
 
 public class DeleteSnapshotMetadataStep implements Step {
@@ -35,6 +36,8 @@ public class DeleteSnapshotMetadataStep implements Step {
               : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
     } catch (SnapshotNotFoundException ex) {
       stateEnum = DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
+    } catch (CannotSerializeTransactionException ex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
 
     DeleteResponseModel deleteResponseModel = new DeleteResponseModel().objectState(stateEnum);

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
@@ -1,5 +1,6 @@
 package bio.terra.service.snapshot.flight.delete;
 
+import static bio.terra.common.FlightUtils.getDefaultExponentialBackoffRetryRule;
 import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
@@ -127,7 +128,9 @@ public class SnapshotDeleteFlight extends Flight {
                 snapshotId, resourceService, azureStorageAccountService)));
 
     // Delete Metadata
-    addStep(new DeleteSnapshotMetadataStep(snapshotDao, snapshotId, userReq));
+    addStep(
+        new DeleteSnapshotMetadataStep(snapshotDao, snapshotId, userReq),
+        getDefaultExponentialBackoffRetryRule());
     addStep(new PerformAzureStep(new DeleteSnapshotMetadataAzureStep(azureStorageAccountService)));
     addStep(new PerformSnapshotStep(new UnlockSnapshotStep(snapshotDao, snapshotId)));
 


### PR DESCRIPTION
### Background
This change addresses the root cause for an error reported by user on attempt to delete snapshot. This error was encountered when attempting a postgres call to delete the snapshot entry during the DeleteSnapshotMetadataStep. 

```
CannotSerializeTransactionException: PreparedStatementCallback; SQL [DELETE FROM snapshot WHERE id = ?]; ERROR: could not serialize access due to read/write dependencies among transactions
  Detail: Reason code: Canceled on identification as a pivot, during conflict out checking.
  Hint: The transaction might succeed if retried.
  Where: SQL statement "DELETE FROM ONLY "public"."snapshot_map_column" WHERE $1 OPERATOR(pg_catalog.=) "to_column_id"";
```

We've run into something similar before: https://github.com/DataBiosphere/jade-data-repo/pull/1200/files

### The Change
On encountering the CannotSerializeTransactionException during the DeleteSnapshotMetadataStep, we will retry the entire step. 