### PR TITLE
[DR-2833] Snapshot discoverers can retrieveSnapshot with allowed inclusions

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -212,7 +212,8 @@ public class SnapshotsApiController implements SnapshotsApi {
           List<SnapshotRetrieveIncludeModel> include) {
     logger.info("Verifying user access");
     AuthenticatedUserRequest authenticatedInfo = getAuthenticatedInfo();
-    snapshotService.verifySnapshotAccessible(id, authenticatedInfo);
+    IamAction action = SnapshotService.retrieveSnapshotIamAction(include);
+    snapshotService.verifySnapshotAccessible(id, authenticatedInfo, action);
     logger.info("Retrieving snapshot");
     SnapshotModel snapshotModel =
         snapshotService.retrieveAvailableSnapshotModel(id, include, authenticatedInfo);

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -604,7 +604,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
         403:
-          description: No permission to see snapshot
+          description: No permission to retrieve snapshot with the specified inclusions
           content:
             application/json:
               schema:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2833

Prior behavior: snapshot retrieval was only permitted to callers holding `read_data` action on the snapshot (i.e. snapshot readers and stewards), even if they requested information already accessible to them in snapshot enumeration.

Now, we allow discoverers to `retrieveSnapshot` if the fields they've included are contained within the following list, via a check for the action `discover_data`:
- NONE
- PROFILE
- DATA_PROJECT
- DUOS

If the retrieval request includes a more sensitive field, we verify that the caller can `read_data` on the snapshot.

Note: the ticket said that we should also make `retrieveDataset` work for discoverers, but:
- Datasets don't have discoverers: they have stewards, custodians, snapshot creators, ingesters, and admins.
- All of the above roles save for admins already hold the `read_dataset` action, which is the one we check when facilitating a call to `retrieveDataset`.
In short, I don't think work is required for dataset retrieval.

**Manual Verification**

My [developer environment](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#) is up to date with these changes.

I added DataRepoAdmins@dev.test.firecloud.org as a discoverer to https://jade-ok.datarepo-dev.broadinstitute.org/snapshots/b872e487-3ebb-408d-96db-12d0b9417850 -- if a non-Jade admin would like me to add them as a discoverer, let me know!

Note that you will not be able to get to this snapshot within the TDR UI, because the request made from the UI specifies inclusions that are inaccessible to discoverers:
<img width="1753" alt="Screen Shot 2022-12-13 at 6 32 55 PM" src="https://user-images.githubusercontent.com/79769153/207468551-23a98e3a-3c71-4c24-b629-39f5fd4bfca7.png">

But as a discoverer, you can retrieve the snapshot with supported inclusions via the TDR API: https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/retrieveSnapshot

I made my non-admin account a discoverer.  Here I specify only supported inclusions and can retrieve the snapshot:
```
https://jade-ok.datarepo-dev.broadinstitute.org/api/repository/v1/snapshots/b872e487-3ebb-408d-96db-12d0b9417850?include=PROFILE&include=DATA_PROJECT&include=DUOS
{
  "id": "b872e487-3ebb-408d-96db-12d0b9417850",
  "name": "DatasetCombinedArrayFileRefSnapshot43555a60_eaaa_4a17_9aa3_007708c04a3a",
  "description": "A snapshot with array of filerefs",
  "createdDate": "2022-12-01T18:42:20.511221Z",
  "consentCode": null,
  "source": null,
  "tables": null,
  "relationships": null,
  "profileId": "dc48c411-5faf-4809-860f-373a5ce37869",
  "dataProject": "datarepo-dev-363e7359",
  "accessInformation": null,
  "creationInformation": null,
  "cloudPlatform": "gcp",
  "properties": null,
  "duosFirecloudGroup": null
}
```

When I add unsupported inclusion `SOURCES`, I get a 403:
```
https://jade-ok.datarepo-dev.broadinstitute.org/api/repository/v1/snapshots/b872e487-3ebb-408d-96db-12d0b9417850?include=SOURCES&include=PROFILE&include=DATA_PROJECT&include=DUOS
{
  "message": "Error accessing snapshot: see errorDetails",
  "errorDetail": [
    "User 'okotsopo@broadinstitute.org' does not have required action: read_data"
  ]
}
```