### PR TITLE
DR-2871 - Fix Perf Test Action by using new GKE GCloud Auth Plugin

### DIFF
--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -77,13 +77,16 @@ jobs:
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
 
           gcloud auth configure-docker  --quiet
+      - name: "Set up Cloud SDK"
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          install_components: 'gke-gcloud-auth-plugin'
       - name: 'Get GKE Credentials'
         uses: 'google-github-actions/get-gke-credentials@v1'
         with:
           cluster_name: ${{ env.K8_CLUSTER }}
           location: ${{ env.GOOGLE_ZONE }}
           project_id: ${{ env.GOOGLE_CLOUD_PROJECT }}
-          use_auth_provider: 'true'
       - name: "Whitelist Runner IP"
         uses: broadinstitute/datarepo-actions/actions/main@0.65.0
         env:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -83,7 +83,7 @@ jobs:
           cluster_name: ${{ env.K8_CLUSTER }}
           location: ${{ env.GOOGLE_ZONE }}
           project_id: ${{ env.GOOGLE_CLOUD_PROJECT }}
-          use_auth_provider: true
+          use_auth_provider: 'true'
       - name: "Whitelist Runner IP"
         uses: broadinstitute/datarepo-actions/actions/main@0.65.0
         env:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -77,6 +77,10 @@ jobs:
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
 
           gcloud auth configure-docker  --quiet
+
+          if [[ -n "${K8_CLUSTER}" ]]; then
+            gcloud container clusters get-credentials ${K8_CLUSTER} --zone ${GOOGLE_ZONE}
+          fi
       - name: "Set up Cloud SDK"
         uses: google-github-actions/setup-gcloud@v1
         with:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -77,10 +77,12 @@ jobs:
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
 
           gcloud auth configure-docker  --quiet
-
-          if [[ -n "${K8_CLUSTER}" ]]; then
-            gcloud container clusters get-credentials ${K8_CLUSTER} --zone ${GOOGLE_ZONE}
-          fi
+      - name: 'Get GKE Credentials'
+        uses: 'google-github-actions/get-gke-credentials@v1'
+        with:
+          cluster_name: ${{ env.K8_CLUSTER }}
+          location: ${{ env.GOOGLE_ZONE }}
+          project_id: ${{ env.GOOGLE_CLOUD_PROJECT }}
       - name: "Whitelist Runner IP"
         uses: broadinstitute/datarepo-actions/actions/main@0.65.0
         env:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -83,6 +83,7 @@ jobs:
           cluster_name: ${{ env.K8_CLUSTER }}
           location: ${{ env.GOOGLE_ZONE }}
           project_id: ${{ env.GOOGLE_CLOUD_PROJECT }}
+          use_auth_provider: true
       - name: "Whitelist Runner IP"
         uses: broadinstitute/datarepo-actions/actions/main@0.65.0
         env:


### PR DESCRIPTION
Error encountered during perf test run when attempting to [make kubectl call](https://github.com/DataBiosphere/jade-data-repo/blob/develop/.github/workflows/test-runner-on-perf.yml#L141):
![image](https://user-images.githubusercontent.com/13254229/208196802-ea477f80-f352-4112-968c-0e1746a68552.png)

This is the same error encountered in our datarepo-actions repo and addressed in this PR: https://github.com/broadinstitute/datarepo-actions/pull/76

Notes on the changes:
- Adding the ["get-gke-credentials" step ](https://github.com/google-github-actions/get-gke-credentials
)got us to the following error, claiming that the plugin could not be found
![image](https://user-images.githubusercontent.com/13254229/208197078-fe2231df-50cd-4c53-8659-802ef3b61e4b.png)
- add the cloud-sdk step to install the plugin