### PR TITLE
[DR-2877] Perf namespace not unlocking

### DIFF
--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -100,6 +100,11 @@ jobs:
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
           google_project: broad-jade-perf
+      - name: "Check that perf namespace is available and set state lock"
+        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        with:
+          actions_subcommand: 'k8_checknamespace'
+          k8_namespaces: 'perf'
       - name: '[Update API version on Perf] Checkout datarepo-helm-definitions repo'
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: actions/checkout@v2
@@ -179,7 +184,7 @@ jobs:
           echo "ORG_GRADLE_PROJECT_datarepoclientjar = ${ORG_GRADLE_PROJECT_datarepoclientjar}"
 
           echo "Running test suite"
-          ./gradlew lockAndRunTest --args="suites/NightlyPerfWorkflow.json tmp/TestRunnerResults"
+          ./gradlew runTest --args="suites/NightlyPerfWorkflow.json tmp/TestRunnerResults"
 
           echo "Collecting measurements"
           ./gradlew collectMeasurements --args="NightlyPerfWorkflow.json tmp/TestRunnerResults"
@@ -188,6 +193,11 @@ jobs:
           ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults"
 
           cd ${GITHUB_WORKSPACE}/${workingDir}
+      - name: "Clean state lock from perf namespace"
+        if: always()
+        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        with:
+          actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
         uses: broadinstitute/datarepo-actions/actions/main@0.65.0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -7,6 +7,7 @@ env:
   TEST_RUNNER_SERVER_SPECIFICATION_FILE: perf.json
   GOOGLE_ZONE: us-central1
   K8_CLUSTER: jade-master-us-central1
+  K8_NAMESPACES: perf
   TDR_LOG_APPENDER: Console-Standard
   AZURE_CREDENTIALS_APPLICATIONID: 22cb243c-f1a5-43d8-8f12-6566bcce6542
 on:
@@ -100,11 +101,8 @@ jobs:
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
           google_project: broad-jade-perf
-      - name: "Check that perf namespace is available and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
-        with:
-          actions_subcommand: 'k8_checknamespace'
-          k8_namespaces: 'perf'
+      - name: "Lock perf namespace for use"
+        uses: broadinstitute/datarepo-actions/actions/lock-namespace@0.65.0
       - name: '[Update API version on Perf] Checkout datarepo-helm-definitions repo'
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: actions/checkout@v2
@@ -193,11 +191,9 @@ jobs:
           ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults"
 
           cd ${GITHUB_WORKSPACE}/${workingDir}
-      - name: "Clean state lock from perf namespace"
-        if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
-        with:
-          actions_subcommand: 'k8_checknamespace_clean'
+      - name: "Unlock perf namespace if we locked it in this run"
+        if: always() # the task always runs, but the lock is only cleared if this run set it.
+        uses: broadinstitute/datarepo-actions/actions/unlock-namespace@0.65.0
       - name: "Clean whitelisted Runner IP"
         if: always()
         uses: broadinstitute/datarepo-actions/actions/main@0.65.0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -10,7 +10,6 @@ env:
   K8_NAMESPACES: perf
   TDR_LOG_APPENDER: Console-Standard
   AZURE_CREDENTIALS_APPLICATIONID: 22cb243c-f1a5-43d8-8f12-6566bcce6542
-  USE_GKE_GCLOUD_AUTH_PLUGIN: true
 on:
   workflow_dispatch: {}
   schedule:
@@ -102,8 +101,11 @@ jobs:
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
           google_project: broad-jade-perf
-      - name: "Lock perf namespace for use"
-        uses: broadinstitute/datarepo-actions/actions/lock-namespace@0.65.0
+      - name: "Check that perf namespace is available and set state lock"
+        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        with:
+          actions_subcommand: 'k8_checknamespace'
+          k8_namespaces: 'perf'
       - name: '[Update API version on Perf] Checkout datarepo-helm-definitions repo'
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
         uses: actions/checkout@v2
@@ -200,7 +202,9 @@ jobs:
           project_id: ${{ env.GOOGLE_CLOUD_PROJECT }}
       - name: "Unlock perf namespace if we locked it in this run"
         if: always() # the task always runs, but the lock is only cleared if this run set it.
-        uses: broadinstitute/datarepo-actions/actions/unlock-namespace@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        with:
+          actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
         uses: broadinstitute/datarepo-actions/actions/main@0.65.0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -192,6 +192,12 @@ jobs:
           ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults"
 
           cd ${GITHUB_WORKSPACE}/${workingDir}
+      - name: 'Re-obtain GKE Credentials'
+        uses: 'google-github-actions/get-gke-credentials@v1'
+        with:
+          cluster_name: ${{ env.K8_CLUSTER }}
+          location: ${{ env.GOOGLE_ZONE }}
+          project_id: ${{ env.GOOGLE_CLOUD_PROJECT }}
       - name: "Unlock perf namespace if we locked it in this run"
         if: always() # the task always runs, but the lock is only cleared if this run set it.
         uses: broadinstitute/datarepo-actions/actions/unlock-namespace@0.65.0

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -10,6 +10,7 @@ env:
   K8_NAMESPACES: perf
   TDR_LOG_APPENDER: Console-Standard
   AZURE_CREDENTIALS_APPLICATIONID: 22cb243c-f1a5-43d8-8f12-6566bcce6542
+  USE_GKE_GCLOUD_AUTH_PLUGIN: true
 on:
   workflow_dispatch: {}
   schedule:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2877

**Background**

On 12/20 and 12/21, our nightly perf test runs failed due to an existing lock on the perf namespace.  Manually removing the lock allowed the tests to succeed, but the lock persisted even after successful test runs:

<img width="1430" alt="Screen Shot 2022-12-20 at 10 29 06 AM" src="https://user-images.githubusercontent.com/79769153/209003200-20c5f22d-dc21-4af2-aeab-81ecbe3a839b.png">

In `.gradlew lockAndRunTest` logs, I'd expect to see the following logs if the namespace was successfully unlocked (from a [successful run](https://github.com/DataBiosphere/jade-data-repo/actions/runs/3626366930/jobs/6115292053) a few weeks ago):
```
06:03:57.369 [Thread-0] INFO  common.commands.UnlockNamespace - Unlock namespace by deleting secret named perf-inuse
06:03:57.768 [Thread-0] INFO  common.commands.UnlockNamespace - secret "perf-inuse" deleted
```

But on the last few runs I've only seen this log, indicating that we attempted to unlock the namespace but maybe it silently failed (from [today's run](https://github.com/DataBiosphere/jade-data-repo/actions/runs/3746319838/jobs/6368919743) that only succeeded when I manually removed the existing lock):
```
15:48:52.143 [Thread-0] INFO  common.commands.UnlockNamespace - Unlock namespace by deleting secret named perf-inuse
```

**Changes**

We need to lock / unlock a namespace in integration test runs, and those seem to be working.  I followed a similar paradigm here:
- Add a separate task to [lock perf namespace](https://github.com/broadinstitute/datarepo-actions/blob/master/actions/main/src/checknamespace.sh)
- Switch test runner from `./gradlew lockAndRunTest` to `./gradlew runTest`
- Add a separate task to reauthenticate before unlocking namespace (thanks, @nmalfroy !)
- Add a separate task to [unlock perf namespace](https://github.com/broadinstitute/datarepo-actions/blob/master/actions/main/src/checknamespaceclean.sh), which runs conditionally but only unlocks the namespace if this test run was the one that locked it.  This ensures that a mid-workflow failure will remove the lock.

We had a successful test run off of this branch: https://github.com/DataBiosphere/jade-data-repo/actions/runs/3840685078/jobs/6540030142
I then verified in Lens that the perf-inuse secret was not there:
<img width="1135" alt="Screen Shot 2023-01-04 at 3 56 23 PM" src="https://user-images.githubusercontent.com/79769153/210648345-fb3fe8c2-0635-4431-9264-a1636bc6a04c.png">

I also checked a few different edge cases for expected locking / unlocking behavior:
- Perf namespace is locked initially, but unlocked within the test suite's timeout -> a new lock is obtained and removed at the end, even if the tests themselves fail: https://github.com/DataBiosphere/jade-data-repo/actions/runs/3841558278/jobs/6541920725
- Perf namespace is locked initially, and remains locked until the test suite "times out" (mimicked by cancelling the workflow run) -> no new lock is obtained and the existing lock is not removed: https://github.com/DataBiosphere/jade-data-repo/actions/runs/3841655591

[DR-2877]: https://broadworkbench.atlassian.net/browse/DR-2877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ