### PR TITLE
[DR-2866] Int / connected tests should be release blockers rather than perf tests

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -252,7 +252,7 @@ jobs:
         && needs.test_connected.outputs.job-status == 'success'
         && needs.deploy_test_integration.outputs.job-status == 'success')
         && 'success' || 'failure' }}
-      SLACK_FIELDS: repo,message,commit,author,eventName,workflow
+      SLACK_FIELDS: repo,commit,workflow
     steps:
       - name: "Load unit test cache"
         uses: actions/cache@v3

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -283,13 +283,11 @@ jobs:
           path: build/reports
           retention-days: 10
       - name: "Notify Jade Slack on nightly test run"
-        # if: ${{ github.event_name == 'schedule' && always() }}
-        if: always()
+        if: ${{ github.event_name == 'schedule' && always() }}
         uses: broadinstitute/action-slack@v3.8.0
         with:
           status: ${{ env.RUN_STATUS }}
-          # channel: "#jade-alerts"
-          channel: "#olivia-slack-testing"
+          channel: "#jade-alerts"
           username: "Data Repo tests"
           text: "Nightly Unit, Connected and Integration tests"
           fields: ${{ env.SLACK_FIELDS }}

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -252,7 +252,7 @@ jobs:
         && needs.test_connected.outputs.job-status == 'success'
         && needs.deploy_test_integration.outputs.job-status == 'success')
         && 'success' || 'failure' }}
-      SLACK_FIELDS: repo,message,commit,author,action,eventName,ref,workflow,job,took
+      SLACK_FIELDS: repo,message,commit,author,eventName,workflow
     steps:
       - name: "Load unit test cache"
         uses: actions/cache@v3

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -246,6 +246,8 @@ jobs:
         os: [ubuntu-latest]
     if: always()
     runs-on: ${{ matrix.os }}
+    with:
+      status: ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
     steps:
       - name: "Load unit test cache"
         uses: actions/cache@v3
@@ -280,7 +282,7 @@ jobs:
         if: always()
         uses: broadinstitute/action-slack@v3.8.0
         with:
-          status: ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
+          # status: ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
           # channel: "#jade-alerts"
           channel: "#olivia-slack-testing"
           username: "Data Repo tests"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -247,7 +247,11 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      RUN_STATUS: ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
+      RUN_STATUS: >-
+        ${{ (needs.test_check.outputs.job-status == 'success'
+        && needs.test_connected.outputs.job-status == 'success' 
+        && needs.deploy_test_integration.outputs.job-status == 'success') 
+        && 'success' || 'failure' }}
     steps:
       - name: "Load unit test cache"
         uses: actions/cache@v3

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -249,9 +249,10 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       RUN_STATUS: >-
         ${{ (needs.test_check.outputs.job-status == 'success'
-        && needs.test_connected.outputs.job-status == 'success' 
-        && needs.deploy_test_integration.outputs.job-status == 'success') 
+        && needs.test_connected.outputs.job-status == 'success'
+        && needs.deploy_test_integration.outputs.job-status == 'success')
         && 'success' || 'failure' }}
+      SLACK_FIELDS: repo,message,commit,author,action,eventName,ref,workflow,job,took
     steps:
       - name: "Load unit test cache"
         uses: actions/cache@v3
@@ -282,13 +283,16 @@ jobs:
           path: build/reports
           retention-days: 10
       - name: "Notify Jade Slack on nightly test run"
-        if: ${{ github.event_name == 'schedule' && always() }}
+        # if: ${{ github.event_name == 'schedule' && always() }}
+        if: always()
         uses: broadinstitute/action-slack@v3.8.0
         with:
           status: ${{ env.RUN_STATUS }}
-          channel: "#jade-alerts"
+          # channel: "#jade-alerts"
+          channel: "#olivia-slack-testing"
           username: "Data Repo tests"
           text: "Nightly Unit, Connected and Integration tests"
+          fields: ${{ env.SLACK_FIELDS }}
       - name: "Notify QA Slack on nightly test run"
         if: ${{ github.event_name == 'schedule' && always() }}
         uses: broadinstitute/action-slack@v3.8.0
@@ -297,3 +301,4 @@ jobs:
           channel: "#dsde-qa"
           username: "Data Repo tests"
           text: "Nightly Unit, Connected and Integration tests"
+          fields: ${{ env.SLACK_FIELDS }}

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -18,8 +18,6 @@ env:
     build/spotless
     build/test-results
     build/jacocoHtml
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 on:
   pull_request:
     branches:
@@ -246,8 +244,10 @@ jobs:
         os: [ubuntu-latest]
     if: always()
     runs-on: ${{ matrix.os }}
-    with:
-      status: ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      RUN_STATUS: ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
     steps:
       - name: "Load unit test cache"
         uses: actions/cache@v3
@@ -282,7 +282,7 @@ jobs:
         if: always()
         uses: broadinstitute/action-slack@v3.8.0
         with:
-          # status: ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
+          status: ${{ env.RUN_STATUS }}
           # channel: "#jade-alerts"
           channel: "#olivia-slack-testing"
           username: "Data Repo tests"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -18,6 +18,8 @@ env:
     build/spotless
     build/test-results
     build/jacocoHtml
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 on:
   pull_request:
     branches:
@@ -274,13 +276,12 @@ jobs:
           path: build/reports
           retention-days: 10
       - name: "Notify Jade Slack on nightly test run"
-        if: ${{ github.event_name == 'schedule' && always() }}
+        # if: ${{ github.event_name == 'schedule' && always() }}
+        if: always()
         uses: broadinstitute/action-slack@v3.8.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
-          channel: "#jade-alerts"
+          # channel: "#jade-alerts"
+          channel: "#olivia-slack-testing"
           username: "Data Repo tests"
           text: "Nightly Unit, Connected and Integration tests"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -278,22 +278,18 @@ jobs:
           path: build/reports
           retention-days: 10
       - name: "Notify Jade Slack on nightly test run"
-        # if: ${{ github.event_name == 'schedule' && always() }}
-        if: always()
+        if: ${{ github.event_name == 'schedule' && always() }}
         uses: broadinstitute/action-slack@v3.8.0
         with:
           status: ${{ env.RUN_STATUS }}
-          # channel: "#jade-alerts"
-          channel: "#olivia-slack-testing"
+          channel: "#jade-alerts"
           username: "Data Repo tests"
           text: "Nightly Unit, Connected and Integration tests"
       - name: "Notify QA Slack on nightly test run"
-        # if: ${{ github.event_name == 'schedule' && always() }}
-        if: always()
+        if: ${{ github.event_name == 'schedule' && always() }}
         uses: broadinstitute/action-slack@v3.8.0
         with:
           status: ${{ env.RUN_STATUS }}
-          # channel: "#dsde-qa"
-          channel: "#olivia-slack-testing"
+          channel: "#dsde-qa"
           username: "Data Repo tests"
           text: "Nightly Unit, Connected and Integration tests"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -287,3 +287,13 @@ jobs:
           channel: "#olivia-slack-testing"
           username: "Data Repo tests"
           text: "Nightly Unit, Connected and Integration tests"
+      - name: "Notify QA Slack on nightly test run"
+        # if: ${{ github.event_name == 'schedule' && always() }}
+        if: always()
+        uses: broadinstitute/action-slack@v3.8.0
+        with:
+          status: ${{ env.RUN_STATUS }}
+          # channel: "#dsde-qa"
+          channel: "#olivia-slack-testing"
+          username: "Data Repo tests"
+          text: "Nightly Unit, Connected and Integration tests"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -208,15 +208,3 @@ jobs:
           username: "Data Repo tests"
           text: "Perf tests"
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-      - name: "Notify QA Slack"
-        if: ${{ github.event_name != 'workflow_dispatch' && always() }}
-        uses: broadinstitute/action-slack@v3.8.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#dsde-qa"
-          username: "Data Repo tests"
-          text: "Perf tests"
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2866

As we reconsider the role which perf tests serve in our wider testing strategy (and debug some persistent infrastructure issues where [perf test runs fail to unlock the namespace](https://github.com/DataBiosphere/jade-data-repo/pull/1396)), I've made the following changes to the Slack alerting in our test runs:

- Perf test Slack alert is no longer emitted to #dsde-qa -- in other words, failing perf tests are not automatically assumed to be release blockers until investigated.
- Unit / integration / connected test Slack alert is now emitted #dsde-qa -- in other words, failing tests in any of these suites are automatically assumed to be release blockers until investigated.  (This should have been the case already.)

I tested out the changes to the unit / integration / connected test Slack alerts in my personal Slack channel #olivia-slack-testing first, to make sure that environment variables were being shared appropriately between steps.  You can see what I tried in the individual commits.

Note: I'd like to merge this before the holiday break if possible: it only touches test alerting code and will reduce the external pressure on the team to address perf test failures.