### PR TITLE
[DR-2833] Introduce new endpoints for retrieving snapshot, dataset summaries

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -171,6 +171,13 @@ public class DatasetsApiController implements DatasetsApi {
   }
 
   @Override
+  public ResponseEntity<DatasetSummaryModel> retrieveDatasetSummary(UUID id) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    iamService.verifyAuthorization(userRequest, IamResourceType.DATASET, id.toString());
+    return ResponseEntity.ok(datasetService.retrieveDatasetSummary(id));
+  }
+
+  @Override
   public ResponseEntity<JobModel> deleteDataset(@PathVariable("id") UUID id) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     iamService.verifyAuthorization(

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -221,10 +221,8 @@ public class SnapshotsApiController implements SnapshotsApi {
 
   @Override
   public ResponseEntity<SnapshotSummaryModel> retrieveSnapshotSummary(UUID id) {
-    logger.info("Verifying user access");
     AuthenticatedUserRequest authenticatedInfo = getAuthenticatedInfo();
     snapshotService.verifySnapshotListable(id, authenticatedInfo);
-    logger.info("Retrieving snapshot summary");
     SnapshotSummaryModel snapshotSummaryModel = snapshotService.retrieveSnapshotSummary(id);
     return ResponseEntity.ok(snapshotSummaryModel);
   }

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -212,7 +212,7 @@ public class SnapshotsApiController implements SnapshotsApi {
           List<SnapshotRetrieveIncludeModel> include) {
     logger.info("Verifying user access");
     AuthenticatedUserRequest authenticatedInfo = getAuthenticatedInfo();
-    snapshotService.verifySnapshotAccessible(id, authenticatedInfo);
+    snapshotService.verifySnapshotReadable(id, authenticatedInfo);
     logger.info("Retrieving snapshot");
     SnapshotModel snapshotModel =
         snapshotService.retrieveAvailableSnapshotModel(id, include, authenticatedInfo);
@@ -256,7 +256,7 @@ public class SnapshotsApiController implements SnapshotsApi {
       SqlSortDirection direction,
       String filter) {
     logger.info("Verifying user access");
-    snapshotService.verifySnapshotAccessible(id, getAuthenticatedInfo());
+    snapshotService.verifySnapshotReadable(id, getAuthenticatedInfo());
     logger.info("Retrieving snapshot id {}", id);
     // TODO: Remove after https://broadworkbench.atlassian.net/browse/DR-2588 is fixed
     SqlSortDirection sortDirection = Objects.requireNonNullElse(direction, SqlSortDirection.ASC);

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -172,7 +172,7 @@ public class SnapshotsApiController implements SnapshotsApi {
   @Override
   public ResponseEntity<JobModel> exportSnapshot(
       @PathVariable("id") UUID id, Boolean exportGsPaths, Boolean validatePrimaryKeyUniqueness) {
-    logger.info("Verifying user access");
+    logger.debug("Verifying user access");
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     iamService.verifyAuthorization(
         userReq, IamResourceType.DATASNAPSHOT, id.toString(), IamAction.EXPORT_SNAPSHOT);
@@ -210,10 +210,10 @@ public class SnapshotsApiController implements SnapshotsApi {
               required = false,
               defaultValue = RETRIEVE_INCLUDE_DEFAULT_VALUE)
           List<SnapshotRetrieveIncludeModel> include) {
-    logger.info("Verifying user access");
+    logger.debug("Verifying user access");
     AuthenticatedUserRequest authenticatedInfo = getAuthenticatedInfo();
     snapshotService.verifySnapshotReadable(id, authenticatedInfo);
-    logger.info("Retrieving snapshot");
+    logger.debug("Retrieving snapshot");
     SnapshotModel snapshotModel =
         snapshotService.retrieveAvailableSnapshotModel(id, include, authenticatedInfo);
     return ResponseEntity.ok(snapshotModel);
@@ -263,9 +263,9 @@ public class SnapshotsApiController implements SnapshotsApi {
       String sort,
       SqlSortDirection direction,
       String filter) {
-    logger.info("Verifying user access");
+    logger.debug("Verifying user access");
     snapshotService.verifySnapshotReadable(id, getAuthenticatedInfo());
-    logger.info("Retrieving snapshot id {}", id);
+    logger.debug("Retrieving snapshot id {}", id);
     // TODO: Remove after https://broadworkbench.atlassian.net/browse/DR-2588 is fixed
     SqlSortDirection sortDirection = Objects.requireNonNullElse(direction, SqlSortDirection.ASC);
     SnapshotPreviewModel previewModel =

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -220,6 +220,16 @@ public class SnapshotsApiController implements SnapshotsApi {
   }
 
   @Override
+  public ResponseEntity<SnapshotSummaryModel> retrieveSnapshotSummary(UUID id) {
+    logger.info("Verifying user access");
+    AuthenticatedUserRequest authenticatedInfo = getAuthenticatedInfo();
+    snapshotService.verifySnapshotListable(id, authenticatedInfo);
+    logger.info("Retrieving snapshot summary");
+    SnapshotSummaryModel snapshotSummaryModel = snapshotService.retrieveSnapshotSummary(id);
+    return ResponseEntity.ok(snapshotSummaryModel);
+  }
+
+  @Override
   public ResponseEntity<FileModel> lookupSnapshotFileById(
       @PathVariable("id") UUID id,
       @PathVariable("fileid") String fileid,

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -149,6 +149,22 @@ public class IamService {
   }
 
   /**
+   * This is a wrapper method around {@link #hasAnyActions(AuthenticatedUserRequest,
+   * IamResourceType, String)} that throws an exception instead of returning false when the user
+   * holds no actions on the resource.
+   *
+   * @throws IamUnauthorizedException if NOT authorized to perform any action on the resource
+   */
+  public void verifyAuthorization(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId) {
+    String userEmail = userReq.getEmail();
+    if (!hasAnyActions(userReq, iamResourceType, resourceId)) {
+      throw new IamForbiddenException(
+          "User '" + userEmail + "' does not have any actions on the resource");
+    }
+  }
+
+  /**
    * List of the ids of the resources of iamResourceType that the user has any access to.
    *
    * @param userReq authenticated user

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -10,7 +10,6 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.model.UserStatusInfo;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
-import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.auth.iam.exception.IamUnavailableException;
 import bio.terra.service.auth.oauth2.GoogleCredentialsService;
 import bio.terra.service.configuration.ConfigurationService;

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -134,7 +134,7 @@ public class IamService {
    * String, IamAction)} that throws an exception instead of returning false when the user is NOT
    * authorized to do the action on the resource.
    *
-   * @throws IamUnauthorizedException if NOT authorized
+   * @throws IamForbiddenException if NOT authorized
    */
   public void verifyAuthorization(
       AuthenticatedUserRequest userReq,
@@ -153,7 +153,7 @@ public class IamService {
    * IamResourceType, String)} that throws an exception instead of returning false when the user
    * holds no actions on the resource.
    *
-   * @throws IamUnauthorizedException if NOT authorized to perform any action on the resource
+   * @throws IamForbiddenException if NOT authorized to perform any action on the resource
    */
   public void verifyAuthorization(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, String resourceId) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -210,6 +210,14 @@ public class DatasetService {
         dataset, include, metadataDataAccessUtils, userRequest);
   }
 
+  /**
+   * @return summary model of the dataset
+   */
+  public DatasetSummaryModel retrieveDatasetSummary(UUID id) {
+    DatasetSummary datasetSummary = datasetDao.retrieveSummaryById(id);
+    return datasetSummary.toModel();
+  }
+
   public EnumerateDatasetModel enumerate(
       int offset,
       int limit,

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1599,6 +1599,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+  /api/repository/v1/datasets/{id}/summary:
+    get:
+      tags:
+        - datasets
+        - repository
+      description: >
+        Retrieve a dataset summary by id.  If the caller has permission to list the dataset in an
+        enumeration, they will have permission to retrieve its summary, whereas they may lack
+        necessary permissions to retrieve the full dataset object.
+      operationId: retrieveDatasetSummary
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: Dataset summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetSummaryModel'
+        400:
+          description: Bad request - invalid id, badly formed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: No permission to see dataset summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: Not found - dataset id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
   /api/repository/v1/datasets/{id}/policies:
     get:
       tags:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -718,6 +718,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+  /api/repository/v1/snapshots/{id}/summary:
+    get:
+      tags:
+        - snapshots
+        - repository
+      description: >
+        Retrieve a snapshot summary by id.  If the caller has permission to list the snapshot in an
+        enumeration, they will have permission to retrieve its summary, whereas they may lack
+        necessary permissions to retrieve the full snapshot object.
+      operationId: retrieveSnapshotSummary
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: Snapshot summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SnapshotSummaryModel'
+        400:
+          description: Bad request - invalid id, badly formed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: No permission to see snapshot summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: Not found - snapshot id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
   /api/repository/v1/snapshots/{id}/data/{table}:
     get:
       tags:

--- a/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SearchApiControllerTest.java
@@ -102,7 +102,7 @@ public class SearchApiControllerTest {
     var table = "good_table";
     var column = "good_column";
     mockSnapshotPreviewByIdSuccess(id, table, column);
-    verify(snapshotService).verifySnapshotAccessible(eq(id), any());
+    verify(snapshotService).verifySnapshotReadable(eq(id), any());
     verify(snapshotService)
         .retrievePreview(
             any(), eq(id), eq(table), eq(LIMIT), eq(OFFSET), eq(column), eq(DIRECTION), eq(FILTER));
@@ -114,7 +114,7 @@ public class SearchApiControllerTest {
     var table = "good_table";
     var column = "datarepo_row_id";
     mockSnapshotPreviewByIdSuccess(id, table, column);
-    verify(snapshotService).verifySnapshotAccessible(eq(id), any());
+    verify(snapshotService).verifySnapshotReadable(eq(id), any());
     verify(snapshotService)
         .retrievePreview(
             any(), eq(id), eq(table), eq(LIMIT), eq(OFFSET), eq(column), eq(DIRECTION), eq(FILTER));
@@ -126,7 +126,7 @@ public class SearchApiControllerTest {
     var table = "good_table";
     var column = "bad_column";
     mockSnapshotPreviewByIdError(id, table, column);
-    verify(snapshotService).verifySnapshotAccessible(eq(id), any());
+    verify(snapshotService).verifySnapshotReadable(eq(id), any());
     snapshotService.retrievePreview(TEST_USER, id, table, LIMIT, OFFSET, column, DIRECTION, FILTER);
   }
 
@@ -136,7 +136,7 @@ public class SearchApiControllerTest {
     var table = "bad_table";
     var column = "good_column";
     mockSnapshotPreviewByIdError(id, table, column);
-    verify(snapshotService).verifySnapshotAccessible(eq(id), any());
+    verify(snapshotService).verifySnapshotReadable(eq(id), any());
     snapshotService.retrievePreview(TEST_USER, id, table, LIMIT, OFFSET, column, DIRECTION, FILTER);
   }
 

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -114,6 +114,26 @@ public class IamServiceTest {
   }
 
   @Test
+  public void testVerifyAuthorizationAnyAction() throws InterruptedException {
+    IamResourceType resourceType = IamResourceType.DATASET;
+    String id = ID.toString();
+
+    when(iamProvider.hasAnyActions(TEST_USER, resourceType, id)).thenReturn(true);
+    iamService.verifyAuthorization(TEST_USER, resourceType, id);
+
+    when(iamProvider.hasAnyActions(TEST_USER, resourceType, id)).thenReturn(false);
+    IamForbiddenException thrown =
+        assertThrows(
+            IamForbiddenException.class,
+            () -> iamService.verifyAuthorization(TEST_USER, resourceType, id),
+            "Authorization verification throws if the caller holds no actions");
+    assertThat(
+        "Error message reflects cause",
+        thrown.getMessage(),
+        containsString("does not have any actions"));
+  }
+
+  @Test
   public void testVerifyAuthorizations() throws Exception {
     IamResourceType resourceType = IamResourceType.DATASET;
     String id = ID.toString();


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2833

**Data Catalog use case**

Data Catalog needs to be able to view an individual snapshot's PHS ID, which is derived from its root dataset and available in the `SnapshotSummary` objects returned in snapshot enumeration.  A summary object will be returned to a user in enumeration if they hold any action at all on the resource, but the user can only retrieve the individual snapshot if they can `read_data` (this blocks snapshot `admin`s and `discoverer`s from snapshot retrieval).

**First attempt**

Originally we thought that we might allow discoverers to `retrieveSnapshot` with a permitted list of `includes` fields.  Closed PR: https://github.com/DataBiosphere/jade-data-repo/pull/1392

This didn't meet Data Catalog's needs, though: while a snapshot’s PHS ID is a top-level field in its summary, it is buried within `source[0].dataset.phsId` in the snapshot.  Because a snapshot’s full `source` is not considered retrievable by discoverers, it seemed messy to slice and dice what was returned.

**General premise behind this PR**

If a user is able to list a resource's summary in an enumeration, they should be able to view that summary individually.

**Changes**

- Introduced new snapshots endpoint [retrieveSnapshotSummary](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/retrieveSnapshotSummary).  We check that the caller holds any action on the snapshot, which is the same criterion used to determine whether to include the snapshot summary in enumeration.
- Refactored `SnapshotService` to support verifying a snapshot's readability or listability via Sam, while falling back to checking for RAS passport-derived accessibility.
- Introduced new datasets endpoint [retrieveDatasetSummary](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/datasets/retrieveDatasetSummary).  We check that the caller holds any action on the dataset, which is the same criterion used to determine whether to include the dataset summary in enumeration.

This should address Data Catalog's use case while also providing a nice usability bump to TDR admins: I know that when I'm investigating a user's issue with their dataset or snapshot, I'd like to quickly get its high-level metadata via an API call as an alternative to adding myself as a steward.

**Manual Demonstration**

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/) is up to date with these changes.

You should be able to `retrieveSnapshotSummary` for any snapshot that you see in enumeration, including those for which you're a discoverer or admin but not a steward or reader.  Behavior for `retrieveSnapshot` remains unchanged.

You should be able to `retrieveDatasetSummary` for any dataset that you see in enumeration, including those for which you're an admin but not a steward, custodian, or snapshot creator.  Behavior for `retrieveDataset` remains unchanged.

[DR-2833]: https://broadworkbench.atlassian.net/browse/DR-2833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ