### PR TITLE
DR-2877 - Always run credential step on perf test unlock

### DIFF
--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -195,6 +195,7 @@ jobs:
 
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: 'Re-obtain GKE Credentials'
+        if: always()
         uses: 'google-github-actions/get-gke-credentials@v1'
         with:
           cluster_name: ${{ env.K8_CLUSTER }}


### PR DESCRIPTION
On perf test failure, the unlock step is not currently completing successfully. We need the credential step to always run so that the unlock step has the right permissions. 