### PR TITLE
[DR-2852] Add new getSnapshotIdsAndRoles endpoint

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -15,6 +15,7 @@ import bio.terra.model.JobModel;
 import bio.terra.model.PolicyMemberRequest;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
+import bio.terra.model.SnapshotIdsAndRolesModel;
 import bio.terra.model.SnapshotLinkDuosDatasetResponse;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotPatchRequestModel;
@@ -200,6 +201,11 @@ public class SnapshotsApiController implements SnapshotsApi {
         snapshotService.enumerateSnapshots(
             getAuthenticatedInfo(), offset, limit, sort, direction, filter, region, datasetUUIDs);
     return ResponseEntity.ok(esm);
+  }
+
+  @Override
+  public ResponseEntity<SnapshotIdsAndRolesModel> getSnapshotIdsAndRoles() {
+    return ResponseEntity.ok(snapshotService.getSnapshotIdsAndRoles(getAuthenticatedInfo()));
   }
 
   @Override

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -566,6 +566,17 @@ public class SnapshotDao {
   }
 
   /**
+   * @return a list of all snapshot IDs, including those exclusively locked
+   */
+  @Transactional(
+      propagation = Propagation.REQUIRED,
+      isolation = Isolation.SERIALIZABLE,
+      readOnly = true)
+  public List<UUID> getSnapshotIds() {
+    return jdbcTemplate.query("SELECT snapshot.id FROM snapshot", new UuidMapper("id"));
+  }
+
+  /**
    * Fetch a list of all the available snapshots. This method returns summary objects, which do not
    * include sub-objects associated with snapshots (e.g. tables). Note that this method will only
    * return snapshots that are NOT exclusively locked.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -572,6 +572,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
       x-codegen-request-body-name: snapshot
+  /api/repository/v1/snapshots/roleMap:
+    get:
+      tags:
+        - snapshots
+        - repository
+      description: >
+        Get accessible snapshot IDs mapped to the roles which confer access.
+        Access may be granted directly via Sam and/or indirectly via a user's linked RAS passport
+        in Terra.  Snapshot accessibility derived from a linked RAS passport will be attributed to
+        the "reader" role.
+      operationId: getSnapshotIdsAndRoles
+      responses:
+        200:
+          description: Accessible snapshot IDs and roles
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotIdsAndRolesModel"
   /api/repository/v1/snapshots/{id}:
     get:
       tags:
@@ -4868,6 +4886,23 @@ components:
             $ref: '#/components/schemas/ErrorModel'
       description: >
         The total number of snapshots available that match the criteria and a page of summaries
+    SnapshotIdsAndRolesModel:
+      type: object
+      properties:
+        roleMap:
+          type: object
+          description: >
+            Map of snapshot IDs to the calling user's roles.
+            The key is the snapshot ID and the value is a list of role names.
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        errors:
+          type: array
+          description: Errors encountered which may result in a partial role map returned.
+          items:
+            $ref: '#/components/schemas/ErrorModel'
     SnapshotModel:
       type: object
       properties:

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -943,5 +943,5 @@ public class SnapshotDaoTest {
         "Unlocked snapshot UUIDs are returned",
         snapshotDao.getSnapshotIds(),
         containsInAnyOrder(snapshotIdList.toArray()));
-    }
+  }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2852
Spike document: https://docs.google.com/document/d/1d8hbkTFPO_5usKHvxCvCNXMtZpiuSUf5zmK-upXBYU4/edit#heading=h.m1fkr26m39t5

Hannes Schmidt has requested a new variant / mode of TDR’s enumerateSnapshots behavior tailored to the HCA use case:
- Only needs accessible snapshot IDs.
- Does not require paging.
- Highly performant to support HCA’s target SLO of <1s round trip time.  Currently, HCA benchmarks its TDR calls at 2-4s on a cache miss.  HCA requests in batches of 1000 and leverages our provided dataset ID and snapshot name filters.

This PR introduces a new TDR snapshots endpoint: **[getSnapshotIdsAndRoles](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/getSnapshotIdsAndRoles)**. 
- Obtain RAS-accessible snapshot IDs via call to ECM
- Obtain Sam-accessible snapshot IDs and roles via call to Sam
- Filter down to those snapshots present in the calling TDR environment (one Sam environment can power many TDR environments, as with Sam dev)
- Return snapshot IDs accessible to the caller mapped to the roles which confer access

Example invocation and response:
```
curl -X 'GET' \
  'https://jade-ok.datarepo-dev.broadinstitute.org/api/repository/v1/snapshots/roleMap' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <token>'

{
  "roleMap": {
    "ac1ea569-f70d-4189-affd-61a3dc06422a": [
      "steward",
      "admin",
      "discoverer"
    ],
    "1b3b475f-8b70-4972-97f9-61047d26aa30": [
      "steward",
      "admin"
    ]
  },
  "errors": []
}
```

**Performance**
Off of my developer environment I saw response times of 0.5 - 1.5 seconds (initial call).  This is primarily driven by the two external calls to Sam and ECM.  Our call to the database to obtain the TDR environment's snapshot IDs has negligible impact, as does filtering down accessible snapshots to those in the calling TDR environment.

This would represent a >50% performance improvement over HCA's benchmark range of 2 - 4 seconds, with the caveat that performance is subject to vary across environments depending on how many snapshots are accessible to the caller and how many snapshots are present in TDR as a whole.
