### PR TITLE
DR-2902, DR-2889 - Update actions/checkout version; Fix action failure due to unsafe directory in containerized actions

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: 'Get Previous tag'

--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout jade-data-repo and latest tags"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: "Setup Java 17"
@@ -132,7 +132,7 @@ jobs:
         echo "Cherry picking ${{ steps.configuration.outputs.alpha_version_api }} from ${DEV_IMAGE} to ${PUBLIC_IMAGE}"
         gcloud container images add-tag --quiet "${DEV_IMAGE}" "${PUBLIC_IMAGE}"
     - name: "[UI][Cherry-pick to public GCR] Checkout datarepo-helm repo"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: 'broadinstitute/datarepo-helm'
         token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -40,7 +40,7 @@ jobs:
           path: datarepo-helm-definitions
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -57,13 +57,13 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
@@ -84,7 +84,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -28,12 +28,12 @@ jobs:
     if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - name: Checkout Develop branch of jade-data-repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Checkout datarepo-helm-definitions repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.BROADBOT_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
             git fetch --all --tags
             git checkout ${{ steps.bumperstep.outputs.tag }}
       - name: 'Release Candidate Container Build: Checkout DataBiosphere/jade-data-repo-ui repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'DataBiosphere/jade-data-repo-ui'
           token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: develop
@@ -17,7 +17,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: 'Checkout datarepo-helm-definitions repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.BROADBOT_TOKEN}}
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: 'Checkout develop branch of jade-data-repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: develop
@@ -79,7 +79,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: '[datarepo-helm] Checkout repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'broadinstitute/datarepo-helm'
           path: datarepo-helm

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "[datarepo-helm-definitions] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
         env:
           COMMIT_MESSAGE: "Datarepo api tag version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -106,7 +106,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
       - name: "[datarepo-helm] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
         env:
           COMMIT_MESSAGE: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -60,14 +60,14 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Cache build"
         uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -99,7 +99,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Cache build"
         uses: actions/cache@v3
         with:
@@ -122,7 +122,7 @@ jobs:
           # write vault token
           base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
       - name: "Run connected tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -161,7 +161,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Cache build"
         uses: actions/cache@v3
         with:
@@ -177,22 +177,22 @@ jobs:
           secrets: |
             secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -207,29 +207,29 @@ jobs:
           echo "::set-output name=git_hash::$git_hash"
           echo "Latest git hash for this branch: $git_hash"
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@sh-safe
         timeout-minutes: 20
         env:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run integration tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
         with:
           actions_subcommand: 'gcp_whitelist_clean'
   publish_test_reports:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -67,7 +67,7 @@ jobs:
           path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -122,7 +122,7 @@ jobs:
           # write vault token
           base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
       - name: "Run connected tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -177,22 +177,22 @@ jobs:
           secrets: |
             secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gradlebuild'
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -207,29 +207,29 @@ jobs:
           echo "::set-output name=git_hash::$git_hash"
           echo "Latest git hash for this branch: $git_hash"
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.66.0
         timeout-minutes: 20
         env:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run integration tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@sh-safe
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
   publish_test_reports:

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout jade-data-repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: "Setup Java 17"

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -93,7 +93,7 @@ jobs:
           location: ${{ env.GOOGLE_ZONE }}
           project_id: ${{ env.GOOGLE_CLOUD_PROJECT }}
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         env:
           GOOGLE_SA_CERT: 'jade-dev-account.pem'
         with:
@@ -102,7 +102,7 @@ jobs:
           secret_id: ${{ secrets.SECRET_ID }}
           google_project: broad-jade-perf
       - name: "Check that perf namespace is available and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'perf'
@@ -120,7 +120,7 @@ jobs:
           args: yq w -i datarepo-helm-definitions/perf/datarepo/datarepo-api.yaml image.tag ${{ steps.read_property.outputs.LATEST_VERSION }}
       - name: "[Update API version on Perf] [datarepo-helm-definitions] Merge version update"
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
-        uses: broadinstitute/datarepo-actions/actions/merger@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
         env:
           COMMIT_MESSAGE:  "Perf Datarepo version update: ${{ steps.read_property.outputs.LATEST_VERSION }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -168,7 +168,7 @@ jobs:
           echo "Sleep 45 seconds to give the pods a chance to start cycling before checking if up and on correct version"
           sleep 45
       - name: "Wait for Perf Cluster to come back up with correct version"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.66.0
         env:
           NAMESPACEINUSE: perf
           IT_JADE_API_URL: "https://jade-perf.datarepo-perf.broadinstitute.org"
@@ -203,12 +203,12 @@ jobs:
           project_id: ${{ env.GOOGLE_CLOUD_PROJECT }}
       - name: "Unlock perf namespace if we locked it in this run"
         if: always() # the task always runs, but the lock is only cleared if this run set it.
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.65.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.66.0
         env:
           GOOGLE_SA_CERT: 'jade-dev-account.pem'
         with:

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -31,7 +31,7 @@ jobs:
           echo "Latest git hash: $LATEST_GITHASH"
           echo "::set-output name=LATEST_GITHASH::$LATEST_GITHASH"
       - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_VERSION }} branch"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.read_property.outputs.LATEST_VERSION }}
       - name: "Setup Java 17"
@@ -108,7 +108,7 @@ jobs:
           k8_namespaces: 'perf'
       - name: '[Update API version on Perf] Checkout datarepo-helm-definitions repo'
         if: ${{ steps.read_property.outputs.LATEST_VERSION != steps.read_property.outputs.CURRENT_SEMVER }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/trackdeploys.yaml
+++ b/.github/workflows/trackdeploys.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: develop

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,7 +7,7 @@ jobs:
     name: DSP AppSec Trivy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # fetch JDK
       - uses: actions/setup-java@v1


### PR DESCRIPTION
Failure during unit test run:

<img width="596" alt="image" src="https://user-images.githubusercontent.com/13254229/215854557-2c984e02-ad96-4040-b419-8c0a2690612c.png">

[L340 of our build.gradle ](https://github.com/DataBiosphere/jade-data-repo/blob/develop/build.gradle#L341)is referencing a git command we call in order to generate a git hash used for versioning. 

This error seems to be appearing due to an upgrade in git versions where they have [addressed a security vulnerability](https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765). Specifically, we are encountering this error when we making a **git call from a containerized action** built via our datarepo-actions repo. When the git call is made inside of the container, it looks as if another author is making the call.  We can rectify this by calling setting /github/workspace as a safe directory within the action. This change is made in a separate datarepo-actions PR. ([idea behind containerized action root cause](https://github.com/actions/runner/issues/2033), [documentation from actions/checkout repo](https://github.com/actions/checkout/issues/766))


https://github.com/broadinstitute/datarepo-actions/pull/77 (must merge first and update versions in this PR)
