### PR TITLE
DR-2889: Upgrade Github actions due to Node 12 Deprecation

### DIFF
--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -28,9 +28,9 @@ jobs:
           fetch-depth: 0
       - name: 'Get Previous tag'
         id: apiprevioustag
-        uses: "broadinstitute/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          TAG=$(git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/")
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - name: 'Generate IAP token to talk to Sherlock'
         id: 'auth-iap'
         uses: google-github-actions/auth@v0

--- a/.github/workflows/alpha-promotion.yaml
+++ b/.github/workflows/alpha-promotion.yaml
@@ -79,7 +79,7 @@ jobs:
             }"
       - name: "Notify Slack"
         if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -151,7 +151,7 @@ jobs:
         gcloud container images add-tag --quiet "${DEV_IMAGE}" "${PUBLIC_IMAGE}"
     - name: "Notify Slack"
       if: always()
-      uses: broadinstitute/action-slack@v3.8.0
+      uses: broadinstitute/action-slack@v3.15.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -163,7 +163,7 @@ jobs:
         text: "Alpha Tests and GCR Promotion"
     - name: "Notify QA Slack"
       if: always()
-      uses: broadinstitute/action-slack@v3.8.0
+      uses: broadinstitute/action-slack@v3.15.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -39,7 +39,7 @@ jobs:
         git checkout ${{ steps.configuration.outputs.alpha_version_api }}
         echo "Current branch is ${{ github.ref }}"
     - name: "Import Vault Secrets for Alpha Test Runner Service Account"
-      uses: hashicorp/vault-action@v2.2.0
+      uses: hashicorp/vault-action@v2.5.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle
@@ -56,7 +56,7 @@ jobs:
 
         ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
     - name: "Import Vault Secrets for Dev Service Account"
-      uses: hashicorp/vault-action@v2.2.0
+      uses: hashicorp/vault-action@v2.5.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle
@@ -109,7 +109,7 @@ jobs:
         echo "[INFO] Uploading results SUCCEEDED"
         cd ${GITHUB_WORKSPACE}/${workingDir}
     - name: "[Cherry-pick to public GCR] Import Vault Secrets for GCR Service Account"
-      uses: hashicorp/vault-action@v2.2.0
+      uses: hashicorp/vault-action@v2.5.0
       with:
         url: ${{ secrets.VAULT_ADDR }}
         method: approle

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -91,13 +91,18 @@ jobs:
           secret_id: ${{ secrets.SECRET_ID }}
           alpharelease: ${{ steps.bumperstep.outputs.tag }}
           gcr_google_project: 'broad-jade-dev'
-      - name: "Update Version for Integration Namespaces and Helm Charts"
-        uses: broadinstitute/workflow-dispatch@v1
-        with:
-          workflow: Update API Helm Image Tags
-          token: ${{ secrets.BROADBOT_TOKEN }}
+  helm_tag_bumper:
+    needs: update_image
+    uses: ./.github/workflows/helmtagbumper.yaml
+    secrets: inherit
+  action_notify:
+    runs-on: ubuntu-latest
+    # if: always()
+    needs:
+      - update_image
+      - helm_tag_bumper
+    steps:
       - name: Slack job status
-        if: always()
         uses: broadinstitute/action-slack@v3.8.0
         with:
           status: ${{ job.status }}
@@ -108,3 +113,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -68,7 +68,7 @@ jobs:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
       - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
-        uses: broadinstitute/retry@v2.5.1 #forked from nick-invision/retry
+        uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
         with:
           timeout_minutes: 1
           polling_interval_seconds: 5

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -97,7 +97,7 @@ jobs:
     secrets: inherit
   action_notify:
     runs-on: ubuntu-latest
-    # if: always()
+    if: always()
     needs:
       - update_image
       - helm_tag_bumper

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -103,7 +103,7 @@ jobs:
       - helm_tag_bumper
     steps:
       - name: Slack job status
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         with:
           status: ${{ job.status }}
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -108,10 +108,6 @@ jobs:
           status: ${{ job.status }}
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
           author_name: Integration Test
-          mention: fb,muscles
-          if_mention: failure
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -49,7 +49,7 @@ jobs:
           version_variable_name: version
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
       - name: "Publish to Artifactory"
-        uses: broadinstitute/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: ':datarepo-client:artifactoryPublish'
         env:

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -1,6 +1,6 @@
 name: Update API Helm Image Tags
 on:
-  workflow_dispatch: {}
+  workflow_call: {}
 jobs:
 # new integration image updater
   integration_helm_tag_update:
@@ -53,18 +53,6 @@ jobs:
           GITHUB_REPO: datarepo-helm-definitions
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
-      - name: "Notify Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.8.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          fields: job,repo,message,author,took
-          author_name: "[API] [datarepo-helm-definitions] Version update for Integration namespaces"
-          mention: fb,muscles
-          mention_if: failure
   datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
     steps:
@@ -112,15 +100,3 @@ jobs:
           GITHUB_REPO: datarepo-helm
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
-      - name: "Notify Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.8.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          fields: job,repo,message,author,took
-          author_name: "[API] [datarepo-helm] Version update for Helm Charts"
-          mention: fb,muscles
-          if_mention: failure

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -1,6 +1,7 @@
 name: Update API Helm Image Tags
 on:
   workflow_call: {}
+  workflow_dispatch: {}
 jobs:
 # new integration image updater
   integration_helm_tag_update:
@@ -13,9 +14,9 @@ jobs:
           ref: develop
       - name: 'Get Previous tag'
         id: apiprevioustag
-        uses: "broadinstitute/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          TAG=$(git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/")
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - name: 'Checkout datarepo-helm-definitions repo'
         uses: actions/checkout@v3
         with:
@@ -63,9 +64,9 @@ jobs:
           ref: develop
       - name: 'Fetch latest jade-data-repo image tag'
         id: apiprevioustag
-        uses: "broadinstitute/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          TAG=$(git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/")
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - name: '[datarepo-helm] Checkout repo'
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -1,7 +1,15 @@
 name: Update API Helm Image Tags
 on:
-  workflow_call: {}
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      notify-slack:
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      notify-slack:
+        default: false
+        type: boolean
 jobs:
 # new integration image updater
   integration_helm_tag_update:
@@ -55,7 +63,7 @@ jobs:
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
       - name: "Notify Slack"
-        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        if: ${{ inputs.notify-slack && always() }}
         uses: broadinstitute/action-slack@v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -112,7 +120,7 @@ jobs:
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
       - name: "Notify Slack"
-        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        if: ${{ inputs.notify-slack && always() }}
         uses: broadinstitute/action-slack@v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -54,6 +54,16 @@ jobs:
           GITHUB_REPO: datarepo-helm-definitions
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
+      - name: "Notify Slack"
+        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        uses: broadinstitute/action-slack@v3.8.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: job,repo,message,author,took
+          author_name: "[API] [datarepo-helm-definitions] Version update for Integration namespaces"
   datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
     steps:
@@ -101,3 +111,13 @@ jobs:
           GITHUB_REPO: datarepo-helm
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
+      - name: "Notify Slack"
+        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        uses: broadinstitute/action-slack@v3.8.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: job,repo,message,author,took
+          author_name: "[API] [datarepo-helm] Version update for Helm Charts"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -36,277 +36,264 @@ on:
   schedule:
     - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
 jobs:
-#  test_check:
-#    name: "Checkout, verify and run unit tests"
-#    outputs:
-#      job-status: ${{ job.status }}
-#    timeout-minutes: 60
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest]
-#    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
-#    runs-on: ${{ matrix.os }}
-#    ## skips if pr label is 'skip-ci'
-#    # run a local Postgres container in Docker for the basic check tests
-#    services:
-#      postgres:
-#        image: postgres:11
-#        env:
-#          POSTGRES_USER: postgres
-#          POSTGRES_PASSWORD: postgres
-#          POSTGRES_DB: postgres
-#        ports:
-#          - 5432:5432
-#        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-#    steps:
-#      - name: "Checkout code"
-#        uses: actions/checkout@v3
-#      - name: "Cache build"
-#        uses: actions/cache@v3
-#        with:
-#          path: ${{ env.CACHE_PATHS }}
-#          key: ${{ runner.os }}-build-unit }}
-#      - name: "Run unit tests via Gradle"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'gradleinttest'
-#          pgport: ${{ job.services.postgres.ports[5432] }}
-#          test_to_run: 'check'
-#          role_id: ${{ secrets.ROLE_ID }}
-#          secret_id: ${{ secrets.SECRET_ID }}
-#  test_connected:
-#    name: "Run connected tests"
-#    outputs:
-#      job-status: ${{ job.status }}
-#    timeout-minutes: 180
-#    needs: test_check
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest]
-#    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
-#    runs-on: ${{ matrix.os }}
-#    ## skips if pr label is 'skip-ci'
-#    # run a local Postgres container in Docker for the basic check tests
-#    services:
-#      postgres:
-#        image: postgres:11
-#        env:
-#          POSTGRES_USER: postgres
-#          POSTGRES_PASSWORD: postgres
-#          POSTGRES_DB: postgres
-#        ports:
-#          - 5432:5432
-#        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-#    steps:
-#      - name: "Checkout code"
-#        uses: actions/checkout@v3
-#      - name: "Cache build"
-#        uses: actions/cache@v3
-#        with:
-#          path: ${{ env.CACHE_PATHS }}
-#          key: ${{ runner.os }}-build-connected
-#      - name: "Import Vault dev secrets"
-#        uses: hashicorp/vault-action@v2.5.0
-#        with:
-#          url: ${{ secrets.VAULT_ADDR }}
-#          method: approle
-#          roleId: ${{ secrets.INTEGRATION_ROLE_ID }}
-#          secretId: ${{ secrets.INTEGRATION_SECRET_ID }}
-#          secrets: |
-#            secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET ;
-#            secret/dsde/datarepo/integration/helm-azure-integration synapse-us-east-sql-admin-user | AZURE_SYNAPSE_SQLADMINUSER ;
-#            secret/dsde/datarepo/integration/helm-azure-integration synapse-us-east-sql-admin-password | AZURE_SYNAPSE_SQLADMINPASSWORD ;
-#            secret/dsde/terra/kernel/integration/tools/buffer/client-sa key | B64_RBS_APPLICATION_CREDENTIALS ;
-#      - name: "Write RBS SA to a file"
-#        run: |
-#          # write vault token
-#          base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
-#      - name: "Run connected tests via Gradle"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'gradleinttest'
-#          pgport: ${{ job.services.postgres.ports[5432] }}
-#          test_to_run: 'testConnected'
-#          role_id: ${{ secrets.ROLE_ID }}
-#          secret_id: ${{ secrets.SECRET_ID }}
-#      - name: "Temp: Archive all junit test reports"
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: junit-test-reports-for-connected
-#          path: build/reports
-#          retention-days: 5
-#  deploy_test_integration:
-#    name: "Run integration and smoke tests"
-#    outputs:
-#      job-status: ${{ job.status }}
-#    timeout-minutes: 300
-#    needs: test_check
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest]
-#    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
-#    runs-on: ${{ matrix.os }}
-#    ## skips if pr label is 'skip-ci'
-#    # run a local Postgres container in Docker for the basic check tests
-#    services:
-#      postgres:
-#        image: postgres:11
-#        env:
-#          POSTGRES_USER: postgres
-#          POSTGRES_PASSWORD: postgres
-#          POSTGRES_DB: postgres
-#        ports:
-#          - 5432:5432
-#        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-#    steps:
-#      - name: "Checkout code"
-#        uses: actions/checkout@v3
-#      - name: "Cache build"
-#        uses: actions/cache@v3
-#        with:
-#          path: ${{ env.CACHE_PATHS }}
-#          key: ${{ runner.os }}-build-integration
-#      - name: "Import Vault dev secrets"
-#        uses: hashicorp/vault-action@v2.5.0
-#        with:
-#          url: ${{ secrets.VAULT_ADDR }}
-#          method: approle
-#          roleId: ${{ secrets.INTEGRATION_ROLE_ID }}
-#          secretId: ${{ secrets.INTEGRATION_SECRET_ID }}
-#          secrets: |
-#            secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
-#      - name: "Whitelist Runner IP"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'gcp_whitelist'
-#          role_id: ${{ secrets.ROLE_ID }}
-#          secret_id: ${{ secrets.SECRET_ID }}
-#      - name: "Check for an available namespace to deploy API to and set state lock"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'k8_checknamespace'
-#          k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
-#      - name: "Build docker container via Gradle"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'gradlebuild'
-#      - name: "Deploy to cluster with Helm"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'helmdeploy'
-#          helm_create_secret_manager_secret_version: '0.0.6'
-#          helm_datarepo_api_chart_version: 0.0.449
-#          helm_datarepo_ui_chart_version: 0.0.214
-#          helm_gcloud_sqlproxy_chart_version: 0.19.8
-#          helm_oidc_proxy_chart_version: 0.0.39
-#      - name: "Fetch gitHash for deployed integration version"
-#        id: configuration
-#        run: |
-#          git_hash=$(git rev-parse --short HEAD)
-#          echo "::set-output name=git_hash::$git_hash"
-#          echo "Latest git hash for this branch: $git_hash"
-#      - name: "Wait for deployment to come back online"
-#        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.66.0
-#        timeout-minutes: 20
-#        env:
-#          DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
-#          DEPLOYMENT_TYPE: 'api'
-#      - name: "Run Test Runner smoke tests via Gradle"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'gradletestrunnersmoketest'
-#      - name: "Run integration tests via Gradle"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'gradleinttest'
-#          pgport: ${{ job.services.postgres.ports[5432] }}
-#          test_to_run: 'testIntegration'
-#      - name: "Clean state lock from used Namespace on API deploy"
-#        if: always()
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'k8_checknamespace_clean'
-#      - name: "Clean whitelisted Runner IP"
-#        if: always()
-#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-#        with:
-#          actions_subcommand: 'gcp_whitelist_clean'
+  test_check:
+    name: "Checkout, verify and run unit tests"
+    outputs:
+      job-status: ${{ job.status }}
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
+    runs-on: ${{ matrix.os }}
+    ## skips if pr label is 'skip-ci'
+    # run a local Postgres container in Docker for the basic check tests
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+      - name: "Cache build"
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}-build-unit }}
+      - name: "Run unit tests via Gradle"
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'gradleinttest'
+          pgport: ${{ job.services.postgres.ports[5432] }}
+          test_to_run: 'check'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+  test_connected:
+    name: "Run connected tests"
+    outputs:
+      job-status: ${{ job.status }}
+    timeout-minutes: 180
+    needs: test_check
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
+    runs-on: ${{ matrix.os }}
+    ## skips if pr label is 'skip-ci'
+    # run a local Postgres container in Docker for the basic check tests
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+      - name: "Cache build"
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}-build-connected
+      - name: "Import Vault dev secrets"
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.INTEGRATION_ROLE_ID }}
+          secretId: ${{ secrets.INTEGRATION_SECRET_ID }}
+          secrets: |
+            secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET ;
+            secret/dsde/datarepo/integration/helm-azure-integration synapse-us-east-sql-admin-user | AZURE_SYNAPSE_SQLADMINUSER ;
+            secret/dsde/datarepo/integration/helm-azure-integration synapse-us-east-sql-admin-password | AZURE_SYNAPSE_SQLADMINPASSWORD ;
+            secret/dsde/terra/kernel/integration/tools/buffer/client-sa key | B64_RBS_APPLICATION_CREDENTIALS ;
+      - name: "Write RBS SA to a file"
+        run: |
+          # write vault token
+          base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
+      - name: "Run connected tests via Gradle"
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'gradleinttest'
+          pgport: ${{ job.services.postgres.ports[5432] }}
+          test_to_run: 'testConnected'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+      - name: "Temp: Archive all junit test reports"
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: junit-test-reports-for-connected
+          path: build/reports
+          retention-days: 5
+  deploy_test_integration:
+    name: "Run integration and smoke tests"
+    outputs:
+      job-status: ${{ job.status }}
+    timeout-minutes: 300
+    needs: test_check
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
+    runs-on: ${{ matrix.os }}
+    ## skips if pr label is 'skip-ci'
+    # run a local Postgres container in Docker for the basic check tests
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+      - name: "Cache build"
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}-build-integration
+      - name: "Import Vault dev secrets"
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.INTEGRATION_ROLE_ID }}
+          secretId: ${{ secrets.INTEGRATION_SECRET_ID }}
+          secrets: |
+            secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
+      - name: "Whitelist Runner IP"
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'gcp_whitelist'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+      - name: "Check for an available namespace to deploy API to and set state lock"
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'k8_checknamespace'
+          k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
+      - name: "Build docker container via Gradle"
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'gradlebuild'
+      - name: "Deploy to cluster with Helm"
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'helmdeploy'
+          helm_create_secret_manager_secret_version: '0.0.6'
+          helm_datarepo_api_chart_version: 0.0.449
+          helm_datarepo_ui_chart_version: 0.0.214
+          helm_gcloud_sqlproxy_chart_version: 0.19.8
+          helm_oidc_proxy_chart_version: 0.0.39
+      - name: "Fetch gitHash for deployed integration version"
+        id: configuration
+        run: |
+          git_hash=$(git rev-parse --short HEAD)
+          echo "::set-output name=git_hash::$git_hash"
+          echo "Latest git hash for this branch: $git_hash"
+      - name: "Wait for deployment to come back online"
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.66.0
+        timeout-minutes: 20
+        env:
+          DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
+          DEPLOYMENT_TYPE: 'api'
+      - name: "Run Test Runner smoke tests via Gradle"
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'gradletestrunnersmoketest'
+      - name: "Run integration tests via Gradle"
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'gradleinttest'
+          pgport: ${{ job.services.postgres.ports[5432] }}
+          test_to_run: 'testIntegration'
+      - name: "Clean state lock from used Namespace on API deploy"
+        if: always()
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'k8_checknamespace_clean'
+      - name: "Clean whitelisted Runner IP"
+        if: always()
+        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+        with:
+          actions_subcommand: 'gcp_whitelist_clean'
   publish_test_reports:
     name: "Save execution reports and notify"
     timeout-minutes: 60
-#    needs:
-#      - test_check
-#      - test_connected
-#      - deploy_test_integration
+    needs:
+      - test_check
+      - test_connected
+      - deploy_test_integration
     strategy:
       matrix:
         os: [ubuntu-latest]
     if: always()
     runs-on: ${{ matrix.os }}
-#    env:
-#      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#      RUN_STATUS: >-
-#        ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
-#      SLACK_FIELDS: repo,commit,workflow
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      RUN_STATUS: >-
+        ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
+      SLACK_FIELDS: repo,commit,workflow
     steps:
-      - name: Send GitHub Action trigger data to Slack workflow
-        id: slack
-        uses: slackapi/slack-github-action@v1.23.0
+      - name: "Load unit test cache"
+        uses: actions/cache@v3
         with:
-          channel-id: "#jade-alerts"
-          slack-message: "Nightly Unit, Connected and Integration tests"
-          payload: |
-            {
-              "key": "value",
-              "foo": "bar"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#      - name: "Load unit test cache"
-#        uses: actions/cache@v3
-#        with:
-#          path: ${{ env.CACHE_PATHS }}
-#          key: ${{ runner.os }}-build-unit
-#      - name: "Load connected test cache"
-#        uses: actions/cache@v3
-#        with:
-#          path: ${{ env.CACHE_PATHS }}
-#          key: ${{ runner.os }}-build-connected
-#      - name: "Load integration test cache"
-#        uses: actions/cache@v3
-#        with:
-#          path: ${{ env.CACHE_PATHS }}
-#          key: ${{ runner.os }}-build-integration
-#      - name: "Archive code coverage results"
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: code-coverage-report
-#          path: build/jacocoHtml
-#          retention-days: 10
-#      - name: "Archive all junit test reports"
-#        uses: actions/upload-artifact@v2
-#        if: always()
-#        with:
-#          name: junit-test-reports
-#          path: build/reports
-#          retention-days: 10
-#      - name: "Notify Jade Slack on nightly test run"
-#        if: ${{ github.event_name == 'schedule' && always() }}
-#        uses: broadinstitute/action-slack@v3.8.0
-#        with:
-#          status: ${{ env.RUN_STATUS }}
-#          channel: "#jade-alerts"
-#          username: "Data Repo tests"
-#          text: "Nightly Unit, Connected and Integration tests"
-#          fields: ${{ env.SLACK_FIELDS }}
-#      - name: "Notify QA Slack on nightly test run"
-#        if: ${{ github.event_name == 'schedule' && always() }}
-#        uses: broadinstitute/action-slack@v3.8.0
-#        with:
-#          status: ${{ env.RUN_STATUS }}
-#          channel: "#dsde-qa"
-#          username: "Data Repo tests"
-#          text: "Nightly Unit, Connected and Integration tests"
-#          fields: ${{ env.SLACK_FIELDS }}
+          path: ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}-build-unit
+      - name: "Load connected test cache"
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}-build-connected
+      - name: "Load integration test cache"
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}-build-integration
+      - name: "Archive code coverage results"
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: build/jacocoHtml
+          retention-days: 10
+      - name: "Archive all junit test reports"
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: junit-test-reports
+          path: build/reports
+          retention-days: 10
+      - name: "Notify Jade Slack on nightly test run"
+        if: ${{ github.event_name == 'schedule' && always() }}
+        uses: broadinstitute/action-slack@v3.8.0
+        with:
+          status: ${{ env.RUN_STATUS }}
+          channel: "#jade-alerts"
+          username: "Data Repo tests"
+          text: "Nightly Unit, Connected and Integration tests"
+          fields: ${{ env.SLACK_FIELDS }}
+      - name: "Notify QA Slack on nightly test run"
+        if: ${{ github.event_name == 'schedule' && always() }}
+        uses: broadinstitute/action-slack@v3.8.0
+        with:
+          status: ${{ env.RUN_STATUS }}
+          channel: "#dsde-qa"
+          username: "Data Repo tests"
+          text: "Nightly Unit, Connected and Integration tests"
+          fields: ${{ env.SLACK_FIELDS }}

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -36,264 +36,277 @@ on:
   schedule:
     - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
 jobs:
-  test_check:
-    name: "Checkout, verify and run unit tests"
-    outputs:
-      job-status: ${{ job.status }}
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
-    runs-on: ${{ matrix.os }}
-    ## skips if pr label is 'skip-ci'
-    # run a local Postgres container in Docker for the basic check tests
-    services:
-      postgres:
-        image: postgres:11
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v3
-      - name: "Cache build"
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHE_PATHS }}
-          key: ${{ runner.os }}-build-unit }}
-      - name: "Run unit tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'gradleinttest'
-          pgport: ${{ job.services.postgres.ports[5432] }}
-          test_to_run: 'check'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-  test_connected:
-    name: "Run connected tests"
-    outputs:
-      job-status: ${{ job.status }}
-    timeout-minutes: 180
-    needs: test_check
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
-    runs-on: ${{ matrix.os }}
-    ## skips if pr label is 'skip-ci'
-    # run a local Postgres container in Docker for the basic check tests
-    services:
-      postgres:
-        image: postgres:11
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v3
-      - name: "Cache build"
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHE_PATHS }}
-          key: ${{ runner.os }}-build-connected
-      - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.5.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.INTEGRATION_ROLE_ID }}
-          secretId: ${{ secrets.INTEGRATION_SECRET_ID }}
-          secrets: |
-            secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET ;
-            secret/dsde/datarepo/integration/helm-azure-integration synapse-us-east-sql-admin-user | AZURE_SYNAPSE_SQLADMINUSER ;
-            secret/dsde/datarepo/integration/helm-azure-integration synapse-us-east-sql-admin-password | AZURE_SYNAPSE_SQLADMINPASSWORD ;
-            secret/dsde/terra/kernel/integration/tools/buffer/client-sa key | B64_RBS_APPLICATION_CREDENTIALS ;
-      - name: "Write RBS SA to a file"
-        run: |
-          # write vault token
-          base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
-      - name: "Run connected tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'gradleinttest'
-          pgport: ${{ job.services.postgres.ports[5432] }}
-          test_to_run: 'testConnected'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-      - name: "Temp: Archive all junit test reports"
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: junit-test-reports-for-connected
-          path: build/reports
-          retention-days: 5
-  deploy_test_integration:
-    name: "Run integration and smoke tests"
-    outputs:
-      job-status: ${{ job.status }}
-    timeout-minutes: 300
-    needs: test_check
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
-    runs-on: ${{ matrix.os }}
-    ## skips if pr label is 'skip-ci'
-    # run a local Postgres container in Docker for the basic check tests
-    services:
-      postgres:
-        image: postgres:11
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v3
-      - name: "Cache build"
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHE_PATHS }}
-          key: ${{ runner.os }}-build-integration
-      - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.5.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.INTEGRATION_ROLE_ID }}
-          secretId: ${{ secrets.INTEGRATION_SECRET_ID }}
-          secrets: |
-            secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
-      - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'gcp_whitelist'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-      - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'k8_checknamespace'
-          k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
-      - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'gradlebuild'
-      - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'helmdeploy'
-          helm_create_secret_manager_secret_version: '0.0.6'
-          helm_datarepo_api_chart_version: 0.0.449
-          helm_datarepo_ui_chart_version: 0.0.214
-          helm_gcloud_sqlproxy_chart_version: 0.19.8
-          helm_oidc_proxy_chart_version: 0.0.39
-      - name: "Fetch gitHash for deployed integration version"
-        id: configuration
-        run: |
-          git_hash=$(git rev-parse --short HEAD)
-          echo "::set-output name=git_hash::$git_hash"
-          echo "Latest git hash for this branch: $git_hash"
-      - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.66.0
-        timeout-minutes: 20
-        env:
-          DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
-          DEPLOYMENT_TYPE: 'api'
-      - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'gradletestrunnersmoketest'
-      - name: "Run integration tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'gradleinttest'
-          pgport: ${{ job.services.postgres.ports[5432] }}
-          test_to_run: 'testIntegration'
-      - name: "Clean state lock from used Namespace on API deploy"
-        if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'k8_checknamespace_clean'
-      - name: "Clean whitelisted Runner IP"
-        if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
-        with:
-          actions_subcommand: 'gcp_whitelist_clean'
+#  test_check:
+#    name: "Checkout, verify and run unit tests"
+#    outputs:
+#      job-status: ${{ job.status }}
+#    timeout-minutes: 60
+#    strategy:
+#      matrix:
+#        os: [ubuntu-latest]
+#    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
+#    runs-on: ${{ matrix.os }}
+#    ## skips if pr label is 'skip-ci'
+#    # run a local Postgres container in Docker for the basic check tests
+#    services:
+#      postgres:
+#        image: postgres:11
+#        env:
+#          POSTGRES_USER: postgres
+#          POSTGRES_PASSWORD: postgres
+#          POSTGRES_DB: postgres
+#        ports:
+#          - 5432:5432
+#        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+#    steps:
+#      - name: "Checkout code"
+#        uses: actions/checkout@v3
+#      - name: "Cache build"
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ env.CACHE_PATHS }}
+#          key: ${{ runner.os }}-build-unit }}
+#      - name: "Run unit tests via Gradle"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'gradleinttest'
+#          pgport: ${{ job.services.postgres.ports[5432] }}
+#          test_to_run: 'check'
+#          role_id: ${{ secrets.ROLE_ID }}
+#          secret_id: ${{ secrets.SECRET_ID }}
+#  test_connected:
+#    name: "Run connected tests"
+#    outputs:
+#      job-status: ${{ job.status }}
+#    timeout-minutes: 180
+#    needs: test_check
+#    strategy:
+#      matrix:
+#        os: [ubuntu-latest]
+#    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
+#    runs-on: ${{ matrix.os }}
+#    ## skips if pr label is 'skip-ci'
+#    # run a local Postgres container in Docker for the basic check tests
+#    services:
+#      postgres:
+#        image: postgres:11
+#        env:
+#          POSTGRES_USER: postgres
+#          POSTGRES_PASSWORD: postgres
+#          POSTGRES_DB: postgres
+#        ports:
+#          - 5432:5432
+#        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+#    steps:
+#      - name: "Checkout code"
+#        uses: actions/checkout@v3
+#      - name: "Cache build"
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ env.CACHE_PATHS }}
+#          key: ${{ runner.os }}-build-connected
+#      - name: "Import Vault dev secrets"
+#        uses: hashicorp/vault-action@v2.5.0
+#        with:
+#          url: ${{ secrets.VAULT_ADDR }}
+#          method: approle
+#          roleId: ${{ secrets.INTEGRATION_ROLE_ID }}
+#          secretId: ${{ secrets.INTEGRATION_SECRET_ID }}
+#          secrets: |
+#            secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET ;
+#            secret/dsde/datarepo/integration/helm-azure-integration synapse-us-east-sql-admin-user | AZURE_SYNAPSE_SQLADMINUSER ;
+#            secret/dsde/datarepo/integration/helm-azure-integration synapse-us-east-sql-admin-password | AZURE_SYNAPSE_SQLADMINPASSWORD ;
+#            secret/dsde/terra/kernel/integration/tools/buffer/client-sa key | B64_RBS_APPLICATION_CREDENTIALS ;
+#      - name: "Write RBS SA to a file"
+#        run: |
+#          # write vault token
+#          base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
+#      - name: "Run connected tests via Gradle"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'gradleinttest'
+#          pgport: ${{ job.services.postgres.ports[5432] }}
+#          test_to_run: 'testConnected'
+#          role_id: ${{ secrets.ROLE_ID }}
+#          secret_id: ${{ secrets.SECRET_ID }}
+#      - name: "Temp: Archive all junit test reports"
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: junit-test-reports-for-connected
+#          path: build/reports
+#          retention-days: 5
+#  deploy_test_integration:
+#    name: "Run integration and smoke tests"
+#    outputs:
+#      job-status: ${{ job.status }}
+#    timeout-minutes: 300
+#    needs: test_check
+#    strategy:
+#      matrix:
+#        os: [ubuntu-latest]
+#    if: "!contains( github.event.pull_request.labels.*.name, 'skip-ci')"
+#    runs-on: ${{ matrix.os }}
+#    ## skips if pr label is 'skip-ci'
+#    # run a local Postgres container in Docker for the basic check tests
+#    services:
+#      postgres:
+#        image: postgres:11
+#        env:
+#          POSTGRES_USER: postgres
+#          POSTGRES_PASSWORD: postgres
+#          POSTGRES_DB: postgres
+#        ports:
+#          - 5432:5432
+#        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+#    steps:
+#      - name: "Checkout code"
+#        uses: actions/checkout@v3
+#      - name: "Cache build"
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ env.CACHE_PATHS }}
+#          key: ${{ runner.os }}-build-integration
+#      - name: "Import Vault dev secrets"
+#        uses: hashicorp/vault-action@v2.5.0
+#        with:
+#          url: ${{ secrets.VAULT_ADDR }}
+#          method: approle
+#          roleId: ${{ secrets.INTEGRATION_ROLE_ID }}
+#          secretId: ${{ secrets.INTEGRATION_SECRET_ID }}
+#          secrets: |
+#            secret/dsde/datarepo/integration/helm-azure-integration applicationsecret | AZURE_CREDENTIALS_SECRET
+#      - name: "Whitelist Runner IP"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'gcp_whitelist'
+#          role_id: ${{ secrets.ROLE_ID }}
+#          secret_id: ${{ secrets.SECRET_ID }}
+#      - name: "Check for an available namespace to deploy API to and set state lock"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'k8_checknamespace'
+#          k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
+#      - name: "Build docker container via Gradle"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'gradlebuild'
+#      - name: "Deploy to cluster with Helm"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'helmdeploy'
+#          helm_create_secret_manager_secret_version: '0.0.6'
+#          helm_datarepo_api_chart_version: 0.0.449
+#          helm_datarepo_ui_chart_version: 0.0.214
+#          helm_gcloud_sqlproxy_chart_version: 0.19.8
+#          helm_oidc_proxy_chart_version: 0.0.39
+#      - name: "Fetch gitHash for deployed integration version"
+#        id: configuration
+#        run: |
+#          git_hash=$(git rev-parse --short HEAD)
+#          echo "::set-output name=git_hash::$git_hash"
+#          echo "Latest git hash for this branch: $git_hash"
+#      - name: "Wait for deployment to come back online"
+#        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.66.0
+#        timeout-minutes: 20
+#        env:
+#          DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
+#          DEPLOYMENT_TYPE: 'api'
+#      - name: "Run Test Runner smoke tests via Gradle"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'gradletestrunnersmoketest'
+#      - name: "Run integration tests via Gradle"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'gradleinttest'
+#          pgport: ${{ job.services.postgres.ports[5432] }}
+#          test_to_run: 'testIntegration'
+#      - name: "Clean state lock from used Namespace on API deploy"
+#        if: always()
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'k8_checknamespace_clean'
+#      - name: "Clean whitelisted Runner IP"
+#        if: always()
+#        uses: broadinstitute/datarepo-actions/actions/main@0.67.0
+#        with:
+#          actions_subcommand: 'gcp_whitelist_clean'
   publish_test_reports:
     name: "Save execution reports and notify"
     timeout-minutes: 60
-    needs:
-      - test_check
-      - test_connected
-      - deploy_test_integration
+#    needs:
+#      - test_check
+#      - test_connected
+#      - deploy_test_integration
     strategy:
       matrix:
         os: [ubuntu-latest]
     if: always()
     runs-on: ${{ matrix.os }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      RUN_STATUS: >-
-        ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
-      SLACK_FIELDS: repo,commit,workflow
+#    env:
+#      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#      RUN_STATUS: >-
+#        ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
+#      SLACK_FIELDS: repo,commit,workflow
     steps:
-      - name: "Load unit test cache"
-        uses: actions/cache@v3
+      - name: Send GitHub Action trigger data to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
         with:
-          path: ${{ env.CACHE_PATHS }}
-          key: ${{ runner.os }}-build-unit
-      - name: "Load connected test cache"
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHE_PATHS }}
-          key: ${{ runner.os }}-build-connected
-      - name: "Load integration test cache"
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHE_PATHS }}
-          key: ${{ runner.os }}-build-integration
-      - name: "Archive code coverage results"
-        uses: actions/upload-artifact@v2
-        with:
-          name: code-coverage-report
-          path: build/jacocoHtml
-          retention-days: 10
-      - name: "Archive all junit test reports"
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: junit-test-reports
-          path: build/reports
-          retention-days: 10
-      - name: "Notify Jade Slack on nightly test run"
-        if: ${{ github.event_name == 'schedule' && always() }}
-        uses: broadinstitute/action-slack@v3.8.0
-        with:
-          status: ${{ env.RUN_STATUS }}
-          channel: "#jade-alerts"
-          username: "Data Repo tests"
-          text: "Nightly Unit, Connected and Integration tests"
-          fields: ${{ env.SLACK_FIELDS }}
-      - name: "Notify QA Slack on nightly test run"
-        if: ${{ github.event_name == 'schedule' && always() }}
-        uses: broadinstitute/action-slack@v3.8.0
-        with:
-          status: ${{ env.RUN_STATUS }}
-          channel: "#dsde-qa"
-          username: "Data Repo tests"
-          text: "Nightly Unit, Connected and Integration tests"
-          fields: ${{ env.SLACK_FIELDS }}
+          channel-id: "#jade-alerts"
+          slack-message: "Nightly Unit, Connected and Integration tests"
+          payload: |
+            {
+              "key": "value",
+              "foo": "bar"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#      - name: "Load unit test cache"
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ env.CACHE_PATHS }}
+#          key: ${{ runner.os }}-build-unit
+#      - name: "Load connected test cache"
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ env.CACHE_PATHS }}
+#          key: ${{ runner.os }}-build-connected
+#      - name: "Load integration test cache"
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ env.CACHE_PATHS }}
+#          key: ${{ runner.os }}-build-integration
+#      - name: "Archive code coverage results"
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: code-coverage-report
+#          path: build/jacocoHtml
+#          retention-days: 10
+#      - name: "Archive all junit test reports"
+#        uses: actions/upload-artifact@v2
+#        if: always()
+#        with:
+#          name: junit-test-reports
+#          path: build/reports
+#          retention-days: 10
+#      - name: "Notify Jade Slack on nightly test run"
+#        if: ${{ github.event_name == 'schedule' && always() }}
+#        uses: broadinstitute/action-slack@v3.8.0
+#        with:
+#          status: ${{ env.RUN_STATUS }}
+#          channel: "#jade-alerts"
+#          username: "Data Repo tests"
+#          text: "Nightly Unit, Connected and Integration tests"
+#          fields: ${{ env.SLACK_FIELDS }}
+#      - name: "Notify QA Slack on nightly test run"
+#        if: ${{ github.event_name == 'schedule' && always() }}
+#        uses: broadinstitute/action-slack@v3.8.0
+#        with:
+#          status: ${{ env.RUN_STATUS }}
+#          channel: "#dsde-qa"
+#          username: "Data Repo tests"
+#          text: "Nightly Unit, Connected and Integration tests"
+#          fields: ${{ env.SLACK_FIELDS }}

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -106,7 +106,7 @@ jobs:
           path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-connected
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.2.0
+        uses: hashicorp/vault-action@v2.5.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -168,7 +168,7 @@ jobs:
           path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-integration
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.2.0
+        uses: hashicorp/vault-action@v2.5.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -281,7 +281,7 @@ jobs:
           retention-days: 10
       - name: "Notify Jade Slack on nightly test run"
         if: ${{ github.event_name == 'schedule' && always() }}
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         with:
           status: ${{ env.RUN_STATUS }}
           channel: "#jade-alerts"
@@ -290,7 +290,7 @@ jobs:
           fields: ${{ env.SLACK_FIELDS }}
       - name: "Notify QA Slack on nightly test run"
         if: ${{ github.event_name == 'schedule' && always() }}
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         with:
           status: ${{ env.RUN_STATUS }}
           channel: "#dsde-qa"

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: set semver
@@ -21,7 +21,7 @@ jobs:
           CURRENT_SEMVER=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           echo "CURRENT_SEMVER=${CURRENT_SEMVER}" >> "$GITHUB_ENV"
       - name: Use Node.js ${{matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14
       - name: Install openapi-generator-cli

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up Python 3.7
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -89,7 +89,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "Notify Jade Slack"
         if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -101,7 +101,7 @@ jobs:
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
       - name: "Notify QA Slack"
         if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           git checkout ${{ steps.configuration.outputs.staging_version }}
           echo "Current branch is ${{ github.ref }}"
       - name: "Import Vault staging secrets"
-        uses: hashicorp/vault-action@v2.2.0
+        uses: hashicorp/vault-action@v2.5.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -51,7 +51,7 @@ jobs:
 
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.2.0
+        uses: hashicorp/vault-action@v2.5.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -216,7 +216,7 @@ jobs:
           google_project: broad-jade-perf
       - name: "Notify Jade Slack"
         if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: '17'
           cache: 'gradle'
       - name: "Import Vault perf secrets"
-        uses: hashicorp/vault-action@v2.2.0
+        uses: hashicorp/vault-action@v2.5.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -59,7 +59,7 @@ jobs:
 
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
       - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.2.0
+        uses: hashicorp/vault-action@v2.5.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -138,7 +138,7 @@ jobs:
           helmfile apply
           cd ${GITHUB_WORKSPACE}/${workingDir}
       - name: "[Clear Perf Database] Import Perf Database Secret"
-        uses: hashicorp/vault-action@v2.2.0
+        uses: hashicorp/vault-action@v2.5.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/trackdeploys.yaml
+++ b/.github/workflows/trackdeploys.yaml
@@ -20,9 +20,9 @@ jobs:
           ref: develop
       - name: 'Get Previous tag'
         id: apiprevioustag
-        uses: "broadinstitute/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          TAG=$(git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/")
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,12 +10,13 @@ jobs:
       - uses: actions/checkout@v3
 
       # fetch JDK
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: '17'
 
       # set up Gradle cache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
Motivation: The goal of this ticket is to handle the warning messages that we've been getting on our github actions about node.js 12 actions being depreciated. All actions need to now run at least on node 16. 
![image](https://user-images.githubusercontent.com/13254229/216704279-d2fd326f-02a1-4fd9-8f16-c778ef98d5ae.png)

While we're making these upgrades, I'm also making changes according to a few other guiding principles [**In order of preference**]: (official guide [here](https://app.gitbook.com/o/-LVj1clrBdFW94pG2z2w/s/-M1f_HVXo41b0qPSpsGF/best-practices-guides/github-actions), thanks @fboulnois for pointing me to this)
1. Switch actions to default github action features. (e.g. [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows))
2. Switch to trusted third party published github actions (e.g. gradle, hashicorp)
3. If the action is simple enough, remove the third party library and hardcode the functionality into the action step ([github-action-get-previous-tag](https://github.com/WyriHaximus/github-action-get-previous-tag/blob/master/main.js) - the core of this is only two lines!!). This removes the need to upgrade this forked repo, gives us control, and removes a security vulnerability. 

When none of these options are available, I upgraded the forked library and pointed our step to the latest version ([nick-fields/retry](https://github.com/broadinstitute/retry), [action-slack](https://github.com/broadinstitute/action-slack))

Note: I attempted to switch to the [slack action actually built by slack](https://github.com/slackapi/slack-github-action). I spent a good chunk of time just trying to get something basic working according to their documentation, but couldn't figure it out. I don't feel like that's a good sign, so I've upgraded the [forked repo](https://github.com/broadinstitute/action-slack) we've been using instead. 

### Testing
Test runs on each action:
- [Dev Image update & Helm tag bumper](https://github.com/DataBiosphere/jade-data-repo/actions/runs/4117672831)
- Int & Connected test (See latest run on PR)
- Trivy (see latest run on PR)
- [Release Python client](https://github.com/DataBiosphere/jade-data-repo/actions/runs/4117795286)

Skipping testing - no unique changes to these actions and I'd rather not mess with the versions promoted to alpha/staging/force early release of a version
- Alpha promotion
- Alpha test/GCR promotion
- Staging Smoke Tests
- Track Deploys
- Perf test (This wouldn't mess with anything, but includes no unique changes, I don't think it's worth a test run)