### PR TITLE
[DR-2925] Stabilize DRS tests impacted by slow IAM propagation

### DIFF
--- a/src/test/java/bio/terra/integration/BigQueryFixtures.java
+++ b/src/test/java/bio/terra/integration/BigQueryFixtures.java
@@ -1,8 +1,5 @@
 package bio.terra.integration;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertTrue;
 
 import bio.terra.common.PdaoConstant;
@@ -17,12 +14,9 @@ import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
-import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableResult;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +24,6 @@ import org.threeten.bp.Duration;
 
 public final class BigQueryFixtures {
   private static final Logger logger = LoggerFactory.getLogger(BigQueryFixtures.class);
-  private static final int WAIT_FOR_ACCESS_SECONDS = 180;
 
   private BigQueryFixtures() {}
 
@@ -79,6 +72,10 @@ public final class BigQueryFixtures {
     }
   }
 
+  private static final int RETRY_INITIAL_INTERVAL_SECONDS = 2;
+  private static final int RETRY_MAX_INTERVAL_SECONDS = 30;
+  private static final int RETRY_MAX_SLEEP_SECONDS = 420;
+
   /**
    * Run a query in BigQuery with retries
    *
@@ -91,11 +88,6 @@ public final class BigQueryFixtures {
    * @param bigQuery authenticated BigQuery object to use
    * @return TableResult object returned from BigQuery
    */
-  private static final int RETRY_INITIAL_INTERVAL_SECONDS = 2;
-
-  private static final int RETRY_MAX_INTERVAL_SECONDS = 30;
-  private static final int RETRY_MAX_SLEEP_SECONDS = 420;
-
   public static TableResult queryWithRetry(String sql, BigQuery bigQuery)
       throws InterruptedException {
     int sleptSeconds = 0;
@@ -140,64 +132,43 @@ public final class BigQueryFixtures {
         tableName);
   }
 
-  // Given a dataset, table, and column, query for a DRS URI and extract the DRS Object Id
-  private static final Pattern drsIdRegex = Pattern.compile("([^/]+)$");
-
-  public static String queryForDrsId(
-      BigQuery bigQuery, SnapshotModel snapshotModel, String tableName, String columnName)
-      throws InterruptedException {
-    waitBeforeCheckingAccess();
-
-    String sql =
-        String.format(
-            "SELECT %s FROM %s WHERE %s IS NOT NULL LIMIT 1",
-            columnName, makeTableRef(snapshotModel, tableName), columnName);
-    TableResult ids = BigQueryFixtures.query(sql, bigQuery);
-    assertThat("Got one row", ids.getTotalRows(), equalTo(1L));
-
-    String drsUri = null;
-    for (FieldValueList fieldValueList : ids.iterateAll()) {
-      drsUri = fieldValueList.get(0).getStringValue();
-    }
-    assertThat("DRS URI was found", drsUri, notNullValue());
-
-    Matcher matcher = drsIdRegex.matcher(drsUri);
-    assertThat("matcher found a match in the DRS URI", matcher.find(), equalTo(true));
-    return matcher.group();
-  }
+  private static final int WAIT_FOR_ACCESS_SECONDS = 180;
+  private static final int WAIT_FOR_ACCESS_LOGGING_INTERVAL_SECONDS = 30;
 
   /**
    * Common method to use to wait for SAM to sync to a google group, asserting access is granted to
    * the user associated with the BigQuery instance.
-   */
-  public static void assertBqDatasetAccessible(
-      BigQuery bigQuery, String dataProject, String bqDatasetName) throws Exception {
-    waitBeforeCheckingAccess();
-    assertTrue(
-        "BigQuery dataset exists and is accessible",
-        BigQueryFixtures.datasetExists(bigQuery, dataProject, bqDatasetName));
-  }
-
-  /**
-   * At the beginning of 2023, google rolled out some changes to IAM propagation that make detecting
-   * IAM propagation when google groups are involved tricky. At this time all access to google cloud
-   * resources involves a google group. The problem seems to be that there are multiple eventually
-   * consistent caches. If we test for access and get a denied answer, that information is cached
-   * for an unknown period of time. There is some chance that a future request will fail even though
-   * others succeed. So simple polling won't work and likely poisons the cache.
+   *
+   * <p>At the beginning of 2023, google rolled out some changes to IAM propagation that make
+   * detecting IAM propagation when google groups are involved tricky. At this time all access to
+   * google cloud resources involves a google group. The problem seems to be that there are multiple
+   * eventually consistent caches. If we test for access and get a denied answer, that information
+   * is cached for an unknown period of time. There is some chance that a future request will fail
+   * even though others succeed. So simple polling won't work and likely poisons the cache.
    *
    * <p>The new method is to wait for a fixed time then test access. Callers should then fail
    * immediately if access is still not available: a failure encountered when polling after the wait
    * is susceptible to the poisoned cache issue.
    *
-   * <p>Reference implementation:
-   * https://github.com/broadinstitute/workbench-libs/pull/1234/files#diff-f22cbe85519ed50c31f21ba7f347ed4cfb3615a564edd069b95ca79bdea56780R337
-   *
-   * @throws InterruptedException
+   * <p><a
+   * href="https://github.com/broadinstitute/workbench-libs/pull/1234/files#diff-f22cbe85519ed50c31f21ba7f347ed4cfb3615a564edd069b95ca79bdea56780R337">Reference
+   * implementation</a>
    */
-  private static void waitBeforeCheckingAccess() throws InterruptedException {
-    logger.info("Sleeping " + WAIT_FOR_ACCESS_SECONDS + " prior to checking BigQuery access");
-    TimeUnit.SECONDS.sleep(WAIT_FOR_ACCESS_SECONDS);
-    logger.info("Slept " + WAIT_FOR_ACCESS_SECONDS + " prior to checking BigQuery access");
+  public static void assertBqDatasetAccessible(
+      BigQuery bigQuery, String dataProject, String bqDatasetName) throws Exception {
+    int sleptSeconds = 0;
+    while (sleptSeconds < WAIT_FOR_ACCESS_SECONDS) {
+      logger.info(
+          "Slept {} seconds prior to checking for BigQuery access at {} seconds",
+          sleptSeconds,
+          WAIT_FOR_ACCESS_SECONDS);
+      TimeUnit.SECONDS.sleep(WAIT_FOR_ACCESS_LOGGING_INTERVAL_SECONDS);
+      sleptSeconds += WAIT_FOR_ACCESS_LOGGING_INTERVAL_SECONDS;
+    }
+    logger.info("Slept {} seconds: checking for BigQuery access now", sleptSeconds);
+
+    assertTrue(
+        "BigQuery dataset exists and is accessible",
+        BigQueryFixtures.datasetExists(bigQuery, dataProject, bqDatasetName));
   }
 }

--- a/src/test/java/bio/terra/service/auth/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/AccessTest.java
@@ -278,7 +278,8 @@ public class AccessTest extends UsersBase {
      */
     // Read and validate the DRS URI from the file ref column in the 'file' table.
     String drsObjectId =
-        BigQueryFixtures.queryForDrsId(bigQueryCustodian, snapshotModel, "file", "file_ref");
+        dataRepoFixtures.retrieveDrsIdFromSnapshotPreview(
+            reader(), snapshotModel.getId(), "file", "file_ref");
 
     // Use DRS API to lookup the file by DRS ID (pulled out of the URI).
     DRSObject drsObject = dataRepoFixtures.drsGetObject(reader(), drsObjectId);

--- a/src/test/java/bio/terra/service/auth/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/AccessTest.java
@@ -160,14 +160,8 @@ public class AccessTest extends UsersBase {
         enumDatasets.getStatusCode(),
         equalTo(HttpStatus.OK));
 
-    boolean custodianHasAccess =
-        BigQueryFixtures.hasAccess(
-            custodianBigQuery, dataset.getDataProject(), datasetBqSnapshotName);
-
-    assertThat(
-        "custodian can access the bq snapshot after it has been shared",
-        custodianHasAccess,
-        equalTo(true));
+    BigQueryFixtures.assertBqDatasetAccessible(
+        custodianBigQuery, dataset.getDataProject(), datasetBqSnapshotName);
 
     SnapshotSummaryModel snapshotSummaryModel =
         dataRepoFixtures.createSnapshot(
@@ -209,11 +203,8 @@ public class AccessTest extends UsersBase {
             IamAction.READ_DATA),
         equalTo(true));
 
-    boolean readerHasAccess =
-        BigQueryFixtures.hasAccess(
-            bigQuery, snapshotModel.getDataProject(), snapshotModel.getName());
-    assertThat(
-        "reader can access the snapshot after it has been shared", readerHasAccess, equalTo(true));
+    BigQueryFixtures.assertBqDatasetAccessible(
+        bigQuery, snapshotModel.getDataProject(), snapshotModel.getName());
   }
 
   @Test
@@ -278,7 +269,7 @@ public class AccessTest extends UsersBase {
     // so we have to use the custodian to look up the DRS id.
     BigQuery bigQueryCustodian =
         BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), custodianToken);
-    BigQueryFixtures.hasAccess(
+    BigQueryFixtures.assertBqDatasetAccessible(
         bigQueryCustodian, snapshotModel.getDataProject(), snapshotModel.getName());
 
     /*
@@ -357,11 +348,8 @@ public class AccessTest extends UsersBase {
         enumDatasets.getStatusCode(),
         equalTo(HttpStatus.OK));
 
-    boolean custodianHasAccess =
-        BigQueryFixtures.hasAccess(
-            custodianBigQuery, dataset.getDataProject(), datasetBqSnapshotName);
-
-    assertTrue("custodian can access the bq snapshot after it has been shared", custodianHasAccess);
+    BigQueryFixtures.assertBqDatasetAccessible(
+        custodianBigQuery, dataset.getDataProject(), datasetBqSnapshotName);
 
     // gets the "sample" table and makes a table ref to use in the query
     String tableRef =

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -85,6 +85,13 @@ public class DrsTest extends UsersBase {
 
   private static final Logger logger = LoggerFactory.getLogger(DrsTest.class);
 
+  /**
+   * We are not checking that a snapshot's underlying BigQuery dataset is accessible due to
+   * unpredictable Google-side delays in IAM propagation. Test code should be able to function
+   * without this access: namely, it should not attempt to query BigQuery directly.
+   */
+  private static final boolean SHOULD_ASSERT_BQ_ACCESSIBLE = false;
+
   @Autowired private DataRepoClient dataRepoClient;
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private EncodeFixture encodeFixture;
@@ -109,7 +116,7 @@ public class DrsTest extends UsersBase {
     custodianToken = authService.getDirectAccessAuthToken(custodian().getEmail());
     String stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
     EncodeFixture.SetupResult setupResult =
-        encodeFixture.setupEncode(steward(), custodian(), reader());
+        encodeFixture.setupEncode(steward(), custodian(), reader(), SHOULD_ASSERT_BQ_ACCESSIBLE);
     datasetModel = dataRepoFixtures.getDataset(steward(), setupResult.getDatasetId());
     snapshotModel =
         dataRepoFixtures.getSnapshot(steward(), setupResult.getSummaryModel().getId(), null);

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -16,7 +16,6 @@ import bio.terra.common.TestUtils;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.integration.BigQueryFixtures;
 import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.TestJobWatcher;
@@ -35,7 +34,6 @@ import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.google.firestore.EncodeFixture;
 import com.google.api.services.cloudresourcemanager.model.Binding;
-import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.storage.Acl;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -160,12 +158,10 @@ public class DrsTest extends UsersBase {
 
   @Test
   public void drsHackyTest() throws Exception {
-    // Get a DRS ID from the dataset using the custodianToken.
-    // Note: the reader does not have permission to run big query jobs anywhere.
-    BigQuery bigQueryCustodian =
-        BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), custodianToken);
+    // Get a DRS ID from the snapshot preview as a reader.
     String drsObjectId =
-        BigQueryFixtures.queryForDrsId(bigQueryCustodian, snapshotModel, "file", "file_ref");
+        dataRepoFixtures.retrieveDrsIdFromSnapshotPreview(
+            reader(), snapshotModel.getId(), "file", "file_ref");
 
     // DRS lookup the file and validate
     logger.info("DRS Object Id - file: {}", drsObjectId);
@@ -271,14 +267,11 @@ public class DrsTest extends UsersBase {
   @Test
   public void drsScaleTest() throws Exception {
     String failureMaxValue = "0";
-    dataRepoFixtures.resetConfig(steward());
 
-    // Get a DRS ID from the dataset using the custodianToken.
-    // Note: the reader does not have permission to run big query jobs anywhere.
-    BigQuery bigQueryCustodian =
-        BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), custodianToken);
+    // Get a DRS ID from the snapshot preview as a reader.
     String drsObjectId =
-        BigQueryFixtures.queryForDrsId(bigQueryCustodian, snapshotModel, "file", "file_ref");
+        dataRepoFixtures.retrieveDrsIdFromSnapshotPreview(
+            reader(), snapshotModel.getId(), "file", "file_ref");
 
     // DRS lookup the file and validate
     logger.info("DRS Object Id - file: {}", drsObjectId);
@@ -311,14 +304,10 @@ public class DrsTest extends UsersBase {
 
   @Test
   public void testDrsErrorResponses() throws Exception {
-    dataRepoFixtures.resetConfig(steward());
-
-    // Get a DRS ID from the dataset using the custodianToken.
-    // Note: the reader does not have permission to run big query jobs anywhere.
-    BigQuery bigQueryCustodian =
-        BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), custodianToken);
+    // Get a DRS ID from the snapshot preview as a reader.
     String drsObjectId =
-        BigQueryFixtures.queryForDrsId(bigQueryCustodian, snapshotModel, "file", "file_ref");
+        dataRepoFixtures.retrieveDrsIdFromSnapshotPreview(
+            reader(), snapshotModel.getId(), "file", "file_ref");
 
     String invalidDrsObjectId = drsObjectId.substring(1);
 

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -76,10 +76,19 @@ public class EncodeFixture {
 
   // Create dataset, load files and tables. Create and return snapshot.
   // Steward owns dataset; custodian is custodian on dataset; reader has access to the snapshot.
+
+  /**
+   * Create dataset, load files and tables. Create and return snapshot. Steward owns dataset;
+   * custodian is custodian on dataset; reader has access to the snapshot.
+   *
+   * @param shouldAssertBqDatasetAccessible if set, verify that the snapshot's underlying BigQuery
+   *     dataset is accessible to the reader
+   */
   public SetupResult setupEncode(
       TestConfiguration.User steward,
       TestConfiguration.User custodian,
-      TestConfiguration.User reader)
+      TestConfiguration.User reader,
+      boolean shouldAssertBqDatasetAccessible)
       throws Exception {
 
     UUID profileId = dataRepoFixtures.createBillingProfile(steward).getId();
@@ -127,31 +136,36 @@ public class EncodeFixture {
     dataRepoFixtures.addSnapshotPolicyMember(
         custodian, snapshotSummary.getId(), IamRole.READER, reader.getEmail());
 
-    // We wait here for SAM to sync. We expect this to take 5 minutes. It can take more as recent
-    // issues have shown. We make a BigQuery request as the test to see that READER has access.
-    // We need to get the snapshot, rather than the snapshot summary in order to make a query.
-    // TODO: Add dataProject to SnapshotSummaryModel?
-    SnapshotModel snapshotModel =
-        dataRepoFixtures.getSnapshot(
-            custodian,
-            snapshotSummary.getId(),
-            List.of(SnapshotRetrieveIncludeModel.ACCESS_INFORMATION));
-    logger.info(
-        "Checking BQ access for snapshot {} in data project {} with BQ dataset named {}",
-        snapshotModel.getName(),
-        snapshotModel.getAccessInformation().getBigQuery().getProjectId(),
-        snapshotModel.getAccessInformation().getBigQuery().getDatasetName());
+    if (shouldAssertBqDatasetAccessible) {
+      // We wait here for SAM to sync. We expect this to take 5 minutes. It can take more as recent
+      // issues have shown. We make a BigQuery request as the test to see that READER has access.
+      // We need to get the snapshot, rather than the snapshot summary in order to make a query.
+      // TODO: Add dataProject to SnapshotSummaryModel?
+      SnapshotModel snapshotModel =
+          dataRepoFixtures.getSnapshot(
+              custodian,
+              snapshotSummary.getId(),
+              List.of(SnapshotRetrieveIncludeModel.ACCESS_INFORMATION));
+      logger.info(
+          "Checking BQ access for snapshot {} in data project {} with BQ dataset named {}",
+          snapshotModel.getName(),
+          snapshotModel.getAccessInformation().getBigQuery().getProjectId(),
+          snapshotModel.getAccessInformation().getBigQuery().getDatasetName());
 
-    String readerToken = authService.getDirectAccessAuthToken(reader.getEmail());
-    BigQuery bigQueryReader =
-        BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), readerToken);
+      String readerToken = authService.getDirectAccessAuthToken(reader.getEmail());
+      BigQuery bigQueryReader =
+          BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), readerToken);
 
-    BigQueryFixtures.assertBqDatasetAccessible(
-        bigQueryReader,
-        snapshotModel.getAccessInformation().getBigQuery().getProjectId(),
-        snapshotModel.getAccessInformation().getBigQuery().getDatasetName());
+      BigQueryFixtures.assertBqDatasetAccessible(
+          bigQueryReader,
+          snapshotModel.getAccessInformation().getBigQuery().getProjectId(),
+          snapshotModel.getAccessInformation().getBigQuery().getDatasetName());
 
-    logger.info("Successfully checked access");
+      logger.info("Successfully checked access");
+    } else {
+      logger.info("Skipping BQ dataset access check for snapshot {}", snapshotSummary.getName());
+    }
+
     return new SetupResult(profileId, datasetId, snapshotSummary);
   }
 

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -1,7 +1,5 @@
 package bio.terra.service.filedata.google.firestore;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import bio.terra.common.TestUtils;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.configuration.TestConfiguration;
@@ -147,13 +145,11 @@ public class EncodeFixture {
     String readerToken = authService.getDirectAccessAuthToken(reader.getEmail());
     BigQuery bigQueryReader =
         BigQueryFixtures.getBigQuery(snapshotModel.getDataProject(), readerToken);
-    boolean hasAccess =
-        BigQueryFixtures.hasAccess(
-            bigQueryReader,
-            snapshotModel.getAccessInformation().getBigQuery().getProjectId(),
-            snapshotModel.getAccessInformation().getBigQuery().getDatasetName());
 
-    assertThat("has access to BQ", hasAccess);
+    BigQueryFixtures.assertBqDatasetAccessible(
+        bigQueryReader,
+        snapshotModel.getAccessInformation().getBigQuery().getProjectId(),
+        snapshotModel.getAccessInformation().getBigQuery().getDatasetName());
 
     logger.info("Successfully checked access");
     return new SetupResult(profileId, datasetId, snapshotSummary);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2925

Our DRS integration tests have been experiencing frequent failures due to Google-side delays in IAM propagation.   [Doug's finding](https://broadinstitute.slack.com/archives/C53JYBV9A/p1675700250147059?thread_ts=1675673871.679629&cid=C53JYBV9A) has been that our traditional approach of polling for access has not been working and in fact does harm, poisoning Google's cache.

**Original Attempt: Wait Before Checking**

I first tried to follow Doug's recommendations which have helped stabilize tests elsewhere in Terra:

- Commit 1: We now wait 3 minutes before checking for BQ access in test assertions driving current flakiness in DRS tests to avoid poisoning Google's cache.
- Commit 2: After our initial 3 minute wait, don't bother to poll for access.  If the resource is inaccessible, then fail the test.

Unfortunately we still experienced test instability with these changes.  It's possible that the permission we require -- `bigquery.jobs.create` -- takes longer to propagate than the ones required in Terra tests.

**Final Approach: Cut Out Direct BQ Access**

After discussion with the team, we also now leverage the snapshot preview endpoint to fetch a snapshot's DRS IDs rather than querying BigQuery directly.  Because TDR proxies the request to BigQuery, this workaround provides a tangible stability boost.

We've also disabled the accessibility check previously used in DRS test set up: we know that IAM propagation is unreliable, so the assertion's value does not outweigh the reduced stability and increased test runtime.

**Impact on Runtime**

Here are some example runtimes of the DrsTest suite over the course of this work.

Prior to this PR (polled for access):
- **3h 12m** runtime with flaky and failing tests ([Gradle](https://scans.gradle.com/s/2n5r35mriursy/tests/:testIntegration/bio.terra.service.filedata.DrsTest?top-execution=1))

Original attempt (wait before checking, then fail if inaccessible):
-  **1h 4m** with flaky and failing tests ([Gradle](https://scans.gradle.com/s/2n5r35mriursy/tests/:testIntegration/bio.terra.service.filedata.DrsTest?top-execution=1))

Wait before checking in test setup but use snapshot preview to fetch DRS ID:
- **39m** with flaky tests ([Gradle](https://scans.gradle.com/s/6znqwvp3ebnmg/tests/:testIntegration/bio.terra.service.filedata.DrsTest?top-execution=1))

Disable check in test setup and use snapshot preview to fetch DRS ID:
- **11m** with no flaky or failing tests ([Gradle](https://scans.gradle.com/s/27luu5xm6o6fw/tests/:testIntegration/bio.terra.service.filedata.DrsTest?top-execution=1))