### PR TITLE
DR-2909: Upgrade Google BOM Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,11 +177,11 @@ ext['log4j2.version'] = '2.17.0'
 
 dependencies {
     // TODO: Unpack the "starter" and include just what we use
-    implementation 'com.google.apis:google-api-services-serviceusage:v1-rev20201021-1.30.10'
-    implementation 'com.google.apis:google-api-services-appengine:v1-rev20201201-1.31.0'
-    implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-1.32.1'
-    implementation 'com.google.apis:google-api-services-iam:v1-rev20220428-1.32.1'
-    implementation platform('com.google.cloud:libraries-bom:25.3.0')
+    implementation 'com.google.apis:google-api-services-serviceusage:v1-rev20230215-2.0.0'
+    implementation 'com.google.apis:google-api-services-appengine:v1-rev20230206-2.0.0'
+    implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-2.0.0'
+    implementation 'com.google.apis:google-api-services-iam:v1-rev20230209-2.0.0'
+    implementation platform('com.google.cloud:libraries-bom:26.6.0')
     implementation 'com.google.cloud:google-cloud-billing'
     implementation 'com.google.cloud:google-cloud-resourcemanager'
     implementation 'com.google.cloud:google-cloud-bigquery'

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -28,10 +28,6 @@ dependencies {
         hamcrest = "2.1"
         apacheMath = "3.0"
 
-        googleApi = "1.23.0"
-        googlePeople = "v1-rev277-1.23.0"
-        googleOauth2 = "0.20.0"
-
         swaggerAnnotations = "2.1.5"
         jersey = "2.32"
 
@@ -51,11 +47,11 @@ dependencies {
     implementation "org.hamcrest:hamcrest:${hamcrest}"
     implementation "org.apache.commons:commons-math3:${apacheMath}"
 
-    implementation "com.google.api-client:google-api-client:${googleApi}"
-    implementation "com.google.oauth-client:google-oauth-client-jetty:${googleApi}"
-    implementation "com.google.apis:google-api-services-people:${googlePeople}"
-    implementation "com.google.auth:google-auth-library-oauth2-http:${googleOauth2}"
-    implementation platform('com.google.cloud:libraries-bom:25.3.0')
+    implementation "com.google.api-client:google-api-client:2.0.0"
+    implementation "com.google.oauth-client:google-oauth-client-jetty:1.34.1"
+    implementation "com.google.apis:google-api-services-people:v1-rev20230103-2.0.0"
+    implementation "com.google.auth:google-auth-library-oauth2-http:1.6.1"
+    implementation platform('com.google.cloud:libraries-bom:26.3.0')
     implementation "com.google.cloud:google-cloud-bigquery"
     implementation "com.google.cloud:google-cloud-storage"
     implementation "com.google.cloud:google-cloud-monitoring"

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceOnDemandTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceOnDemandTest.java
@@ -1,29 +1,65 @@
 package bio.terra.service.resourcemanagement.google;
 
+import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.app.model.GoogleRegion;
+import bio.terra.buffer.model.ResourceInfo;
+import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.OnDemand;
+import bio.terra.common.fixtures.ConnectedOperations;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.auth.iam.IamProviderInterface;
+import bio.terra.service.resourcemanagement.BufferService;
+import com.google.api.services.cloudresourcemanager.model.Project;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@AutoConfigureMockMvc
 @SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
 @Category(OnDemand.class)
+@EmbeddedDatabaseTest
 public class GoogleProjectServiceOnDemandTest {
 
-  @Autowired private GoogleProjectService projectService;
+  @Autowired private BufferService bufferService;
+  @Autowired private GoogleResourceManagerService resourceManagerService;
+  @Autowired private ConnectedOperations connectedOperations;
+  @Autowired private ConnectedTestConfiguration testConfig;
+  @Autowired private GoogleProjectService googleProjectService;
+  @MockBean private IamProviderInterface samService;
+
+  private BillingProfileModel billingProfile;
+  private GoogleRegion region = GoogleRegion.DEFAULT_GOOGLE_REGION;
+  private GoogleProjectResource projectResource;
+
+  @Before
+  public void setup() throws Exception {
+    connectedOperations.stubOutSamCalls(samService);
+    billingProfile =
+        connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
+    ResourceInfo resource = bufferService.handoutResource(false);
+    String projectId = resource.getCloudResourceUid().getGoogleProjectUid().getProjectId();
+    Project project = resourceManagerService.getProject(projectId);
+    String googleProjectNumber = project.getProjectNumber().toString();
+    String googleProjectId = project.getProjectId();
+    projectResource =
+        new GoogleProjectResource()
+            .profileId(billingProfile.getId())
+            .googleProjectId(googleProjectId)
+            .googleProjectNumber(googleProjectNumber);
+    region = GoogleRegion.DEFAULT_GOOGLE_REGION;
+  }
 
   @Test
-  public void testInitFirestore() throws InterruptedException {
-    // Test the explicit activation of a Firestore DB in an empty project
-    // Note, runner needs to populate in a project id and number before running
-    projectService.enableServices(
-        new GoogleProjectResource().googleProjectId("").googleProjectNumber(""),
-        GoogleRegion.DEFAULT_GOOGLE_REGION);
+  public void enableServicesTest() throws InterruptedException {
+    googleProjectService.enableServices(projectResource, region);
   }
 }


### PR DESCRIPTION
# Known Issues
## Unable to upgrade datarepo-clienttests from Google BOM past 26.3.0

- I've created [ticket ](https://broadworkbench.atlassian.net/browse/DR-2946)to handle this upgrade issue
- Upgrading to 26.4.0 causes all authenticated data repo client requests to fail with 401 unauthorized exception. Unauthenticated endpoints complete successfully (BasicAuthenticated Test runner smoke test fails; BasicUnauthenticated passes). 
![image](https://user-images.githubusercontent.com/13254229/221191579-96f3ac32-80fb-468f-9f1a-e74699d0ec3e.png)
- Only occurs when running against integration env, not personally deployed instance (I'm able to reproduce the issue locally by pointing test runner to run against the int server)
- Appears to be an issue with the token generated in [DataRepoUtils.getClientForTestUser()](https://github.com/DataBiosphere/jade-data-repo/blob/develop/datarepo-clienttests/src/main/java/scripts/utils/DataRepoUtils.java#L88). I haven't figured out exactly what changed. It doesn't make sense to me that something has changed with the token generation when upgrading BOM (vs. the oauth library upgrade). 
-> [Valid Token, tests pass] With BOM Version <=26.3.0, the token is a short Bearer token
-> [Invalid Token, tests fail] After upgrading, with BOM version >=26.4.0, the token is much longer

## Stairway hung when unable to initialize Appengine
I ran into odd behavior with stairway. On encountering an error, the step was marked as successfully completed, but the next step never started. This resulted in the flight indefinitely hanging without any steps running. 
- Specific issue happened when [initializing appengine](https://github.com/DataBiosphere/jade-data-repo/blob/develop/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java#L317). The underlying issue was a version mismatch between BOM and the appengine reference (which has now been fixed). 
- I was able to see the actual error via in the enableServicesTest included in this PR. However, it seems as though stairway was not picking up on this exception. 

