### PR TITLE
DR-2889 - Update slack job result

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -107,7 +107,8 @@ jobs:
         with:
           status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
           fields: repo,message,commit,author,action,eventName,ref,workflow,job
-          author_name: Dev Image Update
+          username: "Data Repo tests"
+          text: "Dev Image Update"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -105,9 +105,9 @@ jobs:
       - name: Slack job status
         uses: broadinstitute/action-slack@v3.15.0
         with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-          author_name: Integration Test
+          status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job
+          author_name: Dev Image Update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -248,7 +248,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       RUN_STATUS: >-
-        ${{ (needs.test_check.outputs.job-status == 'success' && needs.test_connected.outputs.job-status == 'success' && needs.deploy_test_integration.outputs.job-status == 'success') && 'success' || 'failure' }}
+        ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
       SLACK_FIELDS: repo,commit,workflow
     steps:
       - name: "Load unit test cache"


### PR DESCRIPTION
### Background
We must define whether or not a job passes when setting up the slack notification for github action jobs. When there are multiple jobs in a workflow, cannot just use the job.status variable. Instead, we must check that every job has a successful output. 

### Testing changes
Example failing slack notification: https://github.com/broadinstitute/datarepo-helm/actions/runs/4127351926/jobs/7130453816
![image](https://user-images.githubusercontent.com/13254229/217622897-d42e206d-558f-4aa4-a5e7-8291917d41b8.png)
![image](https://user-images.githubusercontent.com/13254229/217622966-81549057-5887-4356-8c29-ce99bc415cd7.png)

Example passing: https://github.com/broadinstitute/datarepo-helm/actions/runs/4127325816
