### PR TITLE
DR-2826 Bulk file ingest mode

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestBulkGcpCombinedIngestStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestBulkGcpCombinedIngestStep.java
@@ -1,0 +1,68 @@
+package bio.terra.service.dataset.flight.ingest;
+
+import bio.terra.common.Column;
+import bio.terra.common.ErrorCollector;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.BulkLoadFileModel;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.flight.ingest.IngestBulkGcpStep;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.stairway.FlightContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Stream;
+
+public class IngestBulkGcpCombinedIngestStep extends IngestBulkGcpStep {
+
+  public IngestBulkGcpCombinedIngestStep(
+      String loadTag,
+      UUID profileId,
+      AuthenticatedUserRequest userReq,
+      GcsPdao gcsPdao,
+      ObjectMapper objectMapper,
+      Dataset dataset,
+      int maxFailedFileLoads,
+      int maxBadLoadFileLineErrorsReported,
+      FireStoreDao fileDao,
+      FileService fileService,
+      ExecutorService executor,
+      int maxPerformanceThreadQueueSize) {
+    super(
+        loadTag,
+        profileId,
+        userReq,
+        gcsPdao,
+        objectMapper,
+        dataset,
+        maxFailedFileLoads,
+        maxBadLoadFileLineErrorsReported,
+        fileDao,
+        fileService,
+        executor,
+        maxPerformanceThreadQueueSize);
+  }
+
+  @Override
+  public Stream<BulkLoadFileModel> getModelsStream(FlightContext context) {
+    IngestRequestModel ingestRequest = IngestUtils.getIngestRequestModel(context);
+    List<Column> fileRefColumns = IngestUtils.getDatasetFileRefColumns(dataset, ingestRequest);
+    ErrorCollector errorCollector =
+        new ErrorCollector(
+            maxBadLoadFileLineErrorsReported,
+            "Ingest control file at " + ingestRequest.getPath() + " could not be processed");
+
+    return IngestUtils.getBulkFileLoadModelsStream(
+        gcsPdao,
+        objectMapper,
+        ingestRequest,
+        userReq,
+        dataset.getProjectResource().getGoogleProjectId(),
+        fileRefColumns,
+        errorCollector);
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestMapKeys.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestMapKeys.java
@@ -10,6 +10,7 @@ public final class IngestMapKeys {
   public static final String STAGING_TABLE_NAME = PREFIX + "stagingTableName";
   public static final String NUM_BULK_LOAD_FILE_MODELS = PREFIX + "numBulkLoadFileModels";
   public static final String BULK_LOAD_RESULT = PREFIX + "bulkLoadResult";
+  public static final String BULK_LOAD_HISTORY_RESULT = PREFIX + "bulkLoadHistoryResult";
   public static final String INGEST_CONTROL_FILE_PATH = PREFIX + "ingestControlFilePath";
   public static final String PARQUET_FILE_PATH = PREFIX + "parquetFilePath";
   public static final String COMBINED_FAILED_ROW_COUNT = PREFIX + "combinedFailedRowCount";

--- a/src/main/java/bio/terra/service/filedata/FileIdService.java
+++ b/src/main/java/bio/terra/service/filedata/FileIdService.java
@@ -3,6 +3,7 @@ package bio.terra.service.filedata;
 import bio.terra.service.dataset.Dataset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +12,11 @@ public class FileIdService {
   private static final String HASH_SEPARATOR = "#";
 
   public UUID calculateFileId(Dataset dataset, FSItem fsItem) {
-    if (dataset.hasPredictableFileIds()) {
+    return calculateFileId(dataset.hasPredictableFileIds(), fsItem);
+  }
+
+  public UUID calculateFileId(boolean hasPredictableFileIds, FSItem fsItem) {
+    if (hasPredictableFileIds) {
       return UUID.nameUUIDFromBytes(createHashableContent(fsItem).getBytes(StandardCharsets.UTF_8));
     } else {
       return UUID.randomUUID();
@@ -21,6 +26,9 @@ public class FileIdService {
   private String createHashableContent(FSItem fsItem) {
     return String.join(
         HASH_SEPARATOR,
-        List.of(fsItem.getPath(), fsItem.getChecksumMd5(), String.valueOf(fsItem.getSize())));
+        List.of(
+            fsItem.getPath(),
+            Objects.requireNonNullElse(fsItem.getChecksumMd5(), ""),
+            String.valueOf(fsItem.getSize())));
   }
 }

--- a/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
+++ b/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
@@ -5,6 +5,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -108,5 +109,26 @@ public class FileMetadataUtils {
       }
     }
     return pathsToCheck;
+  }
+
+  /**
+   * Given an absolute path to a file or directory, return a List of absolute paths for all parent
+   * directories
+   *
+   * @param path An absolute path
+   * @return An ordered list of paths that could potentially be created. Note: this excludes the
+   *     passed in path
+   */
+  public static List<String> extractDirectoryPaths(String path) {
+    List<String> allPaths = new ArrayList<>();
+    String interimPath = "";
+    allPaths.add("/");
+    for (String part : getDirectoryPath(path).split("/")) {
+      if (!StringUtils.isEmpty(part)) {
+        interimPath += "/" + part;
+        allPaths.add(interimPath);
+      }
+    }
+    return allPaths;
   }
 }

--- a/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
+++ b/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
@@ -2,6 +2,7 @@ package bio.terra.service.filedata;
 
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -120,6 +121,7 @@ public class FileMetadataUtils {
    *     passed in path
    */
   public static List<String> extractDirectoryPaths(String path) {
+    Preconditions.checkArgument(path.startsWith("/"), "Paths should be absolute");
     List<String> allPaths = new ArrayList<>();
     String interimPath = "";
     allPaths.add("/");

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -115,7 +115,7 @@ public class FileIngestBulkFlight extends Flight {
           inputParameters.get(JobMapKeys.REQUEST.getKeyName(), BulkLoadArrayRequestModel.class);
       maxFailedFileLoads = loadRequest.getMaxFailedFileLoads();
       profileId = loadRequest.getProfileId();
-      isBulkMode = false;
+      isBulkMode = loadRequest.isBulkMode();
     } else {
       BulkLoadRequestModel loadRequest =
           inputParameters.get(JobMapKeys.REQUEST.getKeyName(), BulkLoadRequestModel.class);
@@ -182,21 +182,38 @@ public class FileIngestBulkFlight extends Flight {
     }
 
     if (isBulkMode) {
-      addStep(
-          new IngestBulkGcpBulkFileStep(
-              loadTag,
-              profileId,
-              userReq,
-              gcsPdao,
-              appConfig.objectMapper(),
-              dataset,
-              maxFailedFileLoads,
-              appConfig.getMaxBadLoadFileLineErrorsReported(),
-              fileDao,
-              fileService,
-              executor,
-              appConfig.getMaxPerformanceThreadQueueSize()));
-      addStep(new IngestBulkBulkModeResponseStep());
+      if (isArray) {
+        addStep(
+            new IngestBulkGcpArrayStep(
+                loadTag,
+                profileId,
+                userReq,
+                gcsPdao,
+                appConfig.objectMapper(),
+                dataset,
+                maxFailedFileLoads,
+                appConfig.getMaxBadLoadFileLineErrorsReported(),
+                fileDao,
+                fileService,
+                executor,
+                appConfig.getMaxPerformanceThreadQueueSize()));
+      } else {
+        addStep(
+            new IngestBulkGcpBulkFileStep(
+                loadTag,
+                profileId,
+                userReq,
+                gcsPdao,
+                appConfig.objectMapper(),
+                dataset,
+                maxFailedFileLoads,
+                appConfig.getMaxBadLoadFileLineErrorsReported(),
+                fileDao,
+                fileService,
+                executor,
+                appConfig.getMaxPerformanceThreadQueueSize()));
+      }
+      addStep(new IngestBulkBulkModeResponseStep(isArray));
     } else {
       if (isArray) {
         addStep(new IngestPopulateFileStateFromArrayStep(loadService));

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -17,7 +17,9 @@ import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetStorageAccountDao;
 import bio.terra.service.dataset.flight.LockDatasetStep;
 import bio.terra.service.dataset.flight.UnlockDatasetStep;
+import bio.terra.service.filedata.FileService;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.job.JobService;
@@ -77,6 +79,8 @@ public class FileIngestBulkFlight extends Flight {
     StorageTableService storageTableService = appContext.getBean(StorageTableService.class);
     AzureBlobStorePdao azureBlobStorePdao = appContext.getBean(AzureBlobStorePdao.class);
     ExecutorService executor = appContext.getBean("performanceThreadpool", ExecutorService.class);
+    FireStoreDao fileDao = appContext.getBean(FireStoreDao.class);
+    FileService fileService = appContext.getBean(FileService.class);
     ObjectMapper bulkLoadObjectMapper = appConfig.bulkLoadObjectMapper();
 
     // Common input parameters
@@ -104,17 +108,20 @@ public class FileIngestBulkFlight extends Flight {
     // Parameters dependent on which request we get
     int maxFailedFileLoads;
     UUID profileId;
+    boolean isBulkMode;
 
     if (isArray) {
       BulkLoadArrayRequestModel loadRequest =
           inputParameters.get(JobMapKeys.REQUEST.getKeyName(), BulkLoadArrayRequestModel.class);
       maxFailedFileLoads = loadRequest.getMaxFailedFileLoads();
       profileId = loadRequest.getProfileId();
+      isBulkMode = false;
     } else {
       BulkLoadRequestModel loadRequest =
           inputParameters.get(JobMapKeys.REQUEST.getKeyName(), BulkLoadRequestModel.class);
       maxFailedFileLoads = loadRequest.getMaxFailedFileLoads();
       profileId = loadRequest.getProfileId();
+      isBulkMode = loadRequest.isBulkMode();
     }
 
     RetryRule randomBackoffRetry =
@@ -151,8 +158,11 @@ public class FileIngestBulkFlight extends Flight {
       addStep(new IngestFileValidateAzureBillingProfileStep(profileId, dataset));
     }
     addStep(new IngestFileValidateCloudPlatformStep(dataset));
-    addStep(new LockDatasetStep(datasetService, datasetUuid, true), randomBackoffRetry);
-    addStep(new LoadLockStep(loadService));
+    // If loading in bulk mode, request an exclusive lock on the dataset
+    addStep(new LockDatasetStep(datasetService, datasetUuid, !isBulkMode), randomBackoffRetry);
+    if (!isBulkMode) {
+      addStep(new LoadLockStep(loadService));
+    }
     if (platform.isGcp()) {
       addStep(new VerifyBillingAccountAccessStep(googleBillingService));
       if (!dataset.isSelfHosted()) {
@@ -171,56 +181,73 @@ public class FileIngestBulkFlight extends Flight {
           randomBackoffRetry);
     }
 
-    if (isArray) {
-      addStep(new IngestPopulateFileStateFromArrayStep(loadService));
+    if (isBulkMode) {
+      addStep(
+          new IngestBulkGcpBulkFileStep(
+              loadTag,
+              profileId,
+              userReq,
+              gcsPdao,
+              appConfig.objectMapper(),
+              dataset,
+              maxFailedFileLoads,
+              appConfig.getMaxBadLoadFileLineErrorsReported(),
+              fileDao,
+              fileService,
+              executor,
+              appConfig.getMaxPerformanceThreadQueueSize()));
+      addStep(new IngestBulkBulkModeResponseStep());
     } else {
-      if (platform.isGcp()) {
-        addStep(
-            new ValidateBucketAccessStep(
-                gcsPdao, dataset.getProjectResource().getGoogleProjectId(), userReq),
-            getDefaultExponentialBackoffRetryRule());
-        addStep(
-            new IngestPopulateFileStateFromFileGcpStep(
-                loadService,
-                appConfig.getMaxBadLoadFileLineErrorsReported(),
-                appConfig.getLoadFilePopulateBatchSize(),
-                gcsPdao,
-                bulkLoadObjectMapper,
-                executor,
-                userReq,
-                dataset));
+      if (isArray) {
+        addStep(new IngestPopulateFileStateFromArrayStep(loadService));
       } else {
-        addStep(
-            new IngestPopulateFileStateFromFileAzureStep(
-                loadService,
-                appConfig.getMaxBadLoadFileLineErrorsReported(),
-                appConfig.getLoadFilePopulateBatchSize(),
-                azureBlobStorePdao,
-                bulkLoadObjectMapper,
-                executor,
-                userReq));
+        if (platform.isGcp()) {
+          addStep(
+              new ValidateBucketAccessStep(
+                  gcsPdao, dataset.getProjectResource().getGoogleProjectId(), userReq),
+              getDefaultExponentialBackoffRetryRule());
+          addStep(
+              new IngestPopulateFileStateFromFileGcpStep(
+                  loadService,
+                  appConfig.getMaxBadLoadFileLineErrorsReported(),
+                  appConfig.getLoadFilePopulateBatchSize(),
+                  gcsPdao,
+                  bulkLoadObjectMapper,
+                  executor,
+                  userReq,
+                  dataset));
+        } else {
+          addStep(
+              new IngestPopulateFileStateFromFileAzureStep(
+                  loadService,
+                  appConfig.getMaxBadLoadFileLineErrorsReported(),
+                  appConfig.getLoadFilePopulateBatchSize(),
+                  azureBlobStorePdao,
+                  bulkLoadObjectMapper,
+                  executor,
+                  userReq));
+        }
+      }
+      addStep(
+          new IngestDriverStep(
+              loadService,
+              configurationService,
+              jobService,
+              datasetId,
+              loadTag,
+              maxFailedFileLoads,
+              driverWaitSeconds,
+              profileId,
+              platform.getCloudPlatform(),
+              userReq),
+          driverRetry);
+
+      if (isArray) {
+        addStep(new IngestBulkArrayResponseStep(loadService, loadTag));
+      } else {
+        addStep(new IngestBulkFileResponseStep(loadService, loadTag));
       }
     }
-    addStep(
-        new IngestDriverStep(
-            loadService,
-            configurationService,
-            jobService,
-            datasetId,
-            loadTag,
-            maxFailedFileLoads,
-            driverWaitSeconds,
-            profileId,
-            platform.getCloudPlatform(),
-            userReq),
-        driverRetry);
-
-    if (isArray) {
-      addStep(new IngestBulkArrayResponseStep(loadService, loadTag));
-    } else {
-      addStep(new IngestBulkFileResponseStep(loadService, loadTag));
-    }
-
     if (platform.isGcp()) {
       addStep(
           new IngestCopyLoadHistoryToBQStep(
@@ -230,7 +257,8 @@ public class FileIngestBulkFlight extends Flight {
               datasetUuid,
               loadTag,
               loadHistoryWaitSeconds,
-              loadHistoryChunkSize),
+              loadHistoryChunkSize,
+              isBulkMode),
           randomBackoffRetry);
     } else if (platform.isAzure()) {
       addStep(
@@ -243,9 +271,11 @@ public class FileIngestBulkFlight extends Flight {
               loadHistoryChunkSize),
           randomBackoffRetry);
     }
-    addStep(new IngestCleanFileStateStep(loadService));
+    if (!isBulkMode) {
+      addStep(new IngestCleanFileStateStep(loadService));
+      addStep(new LoadUnlockStep(loadService));
+    }
 
-    addStep(new LoadUnlockStep(loadService));
-    addStep(new UnlockDatasetStep(datasetService, datasetUuid, true), randomBackoffRetry);
+    addStep(new UnlockDatasetStep(datasetService, datasetUuid, !isBulkMode), randomBackoffRetry);
   }
 }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileAzureStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileAzureStep.java
@@ -48,7 +48,12 @@ public class IngestBuildAndWriteScratchLoadFileAzureStep
             .getTenantId()
             .toString();
     return IngestUtils.getJsonNodesStreamFromFile(
-        azureBlobStorePdao, objectMapper, ingestRequest, userRequest, tenantId, errorCollector);
+        azureBlobStorePdao,
+        objectMapper,
+        ingestRequest.getPath(),
+        userRequest,
+        tenantId,
+        errorCollector);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileGcpStep.java
@@ -37,7 +37,7 @@ public class IngestBuildAndWriteScratchLoadFileGcpStep
     return IngestUtils.getJsonNodesStreamFromFile(
         gcsPdao,
         objectMapper,
-        ingestRequest,
+        ingestRequest.getPath(),
         userRequest,
         dataset.getProjectResource().getGoogleProjectId(),
         errorCollector);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
@@ -7,12 +7,14 @@ import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
+import org.apache.commons.collections4.CollectionUtils;
 
 // It expects the following working map data:
 // - BULK_LOAD_RESULT - a BulkLoadArrayResultModel object
 //
 public class IngestBulkBulkModeResponseStep extends DefaultUndoStep {
 
+  private static final int MAX_FILE_RESULTS = 1000;
   private final boolean isArrayMode;
 
   public IngestBulkBulkModeResponseStep(boolean isArrayMode) {
@@ -28,6 +30,12 @@ public class IngestBulkBulkModeResponseStep extends DefaultUndoStep {
     if (isArrayMode) {
       workingMap.put(JobMapKeys.RESPONSE.getKeyName(), result);
     } else {
+      // Truncate file results if needed.  Note: not doing this for arrays since that API takes in
+      // the values so presumably can return them back.  This is explicitly for the case where the
+      // file data is loaded from a cloud file
+      if (CollectionUtils.size(result.getLoadFileResults()) > MAX_FILE_RESULTS) {
+        result.loadFileResults(result.getLoadFileResults().subList(0, MAX_FILE_RESULTS));
+      }
       workingMap.put(JobMapKeys.RESPONSE.getKeyName(), result.getLoadSummary());
     }
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
@@ -13,13 +13,23 @@ import bio.terra.stairway.StepResult;
 //
 public class IngestBulkBulkModeResponseStep implements Step {
 
+  private final boolean isArrayMode;
+
+  public IngestBulkBulkModeResponseStep(boolean isArrayMode) {
+    this.isArrayMode = isArrayMode;
+  }
+
   @Override
   public StepResult doStep(FlightContext context) {
     FlightMap workingMap = context.getWorkingMap();
     BulkLoadArrayResultModel result =
         workingMap.get(IngestMapKeys.BULK_LOAD_RESULT, BulkLoadArrayResultModel.class);
 
-    workingMap.put(JobMapKeys.RESPONSE.getKeyName(), result.getLoadSummary());
+    if (isArrayMode) {
+      workingMap.put(JobMapKeys.RESPONSE.getKeyName(), result);
+    } else {
+      workingMap.put(JobMapKeys.RESPONSE.getKeyName(), result.getLoadSummary());
+    }
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
@@ -1,0 +1,31 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.model.BulkLoadArrayResultModel;
+import bio.terra.service.dataset.flight.ingest.IngestMapKeys;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+// It expects the following working map data:
+// - BULK_LOAD_RESULT - a BulkLoadArrayResultModel object
+//
+public class IngestBulkBulkModeResponseStep implements Step {
+
+  @Override
+  public StepResult doStep(FlightContext context) {
+    FlightMap workingMap = context.getWorkingMap();
+    BulkLoadArrayResultModel result =
+        workingMap.get(IngestMapKeys.BULK_LOAD_RESULT, BulkLoadArrayResultModel.class);
+
+    workingMap.put(JobMapKeys.RESPONSE.getKeyName(), result.getLoadSummary());
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
@@ -2,16 +2,16 @@ package bio.terra.service.filedata.flight.ingest;
 
 import bio.terra.model.BulkLoadArrayResultModel;
 import bio.terra.service.dataset.flight.ingest.IngestMapKeys;
+import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 
 // It expects the following working map data:
 // - BULK_LOAD_RESULT - a BulkLoadArrayResultModel object
 //
-public class IngestBulkBulkModeResponseStep implements Step {
+public class IngestBulkBulkModeResponseStep extends DefaultUndoStep {
 
   private final boolean isArrayMode;
 
@@ -31,11 +31,6 @@ public class IngestBulkBulkModeResponseStep implements Step {
       workingMap.put(JobMapKeys.RESPONSE.getKeyName(), result.getLoadSummary());
     }
 
-    return StepResult.getStepResultSuccess();
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpArrayStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpArrayStep.java
@@ -1,0 +1,56 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.BulkLoadArrayRequestModel;
+import bio.terra.model.BulkLoadFileModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Stream;
+
+public class IngestBulkGcpArrayStep extends IngestBulkGcpStep {
+
+  public IngestBulkGcpArrayStep(
+      String loadTag,
+      UUID profileId,
+      AuthenticatedUserRequest userReq,
+      GcsPdao gcsPdao,
+      ObjectMapper objectMapper,
+      Dataset dataset,
+      int maxFailedFileLoads,
+      int maxBadLoadFileLineErrorsReported,
+      FireStoreDao fileDao,
+      FileService fileService,
+      ExecutorService executor,
+      int maxPerformanceThreadQueueSize) {
+    super(
+        loadTag,
+        profileId,
+        userReq,
+        gcsPdao,
+        objectMapper,
+        dataset,
+        maxFailedFileLoads,
+        maxBadLoadFileLineErrorsReported,
+        fileDao,
+        fileService,
+        executor,
+        maxPerformanceThreadQueueSize);
+  }
+
+  @Override
+  public Stream<BulkLoadFileModel> getModelsStream(FlightContext context) {
+    BulkLoadArrayRequestModel ingestRequest =
+        context
+            .getInputParameters()
+            .get(JobMapKeys.REQUEST.getKeyName(), BulkLoadArrayRequestModel.class);
+
+    return ingestRequest.getLoadArray().stream();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpBulkFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpBulkFileStep.java
@@ -1,0 +1,73 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.common.ErrorCollector;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.BulkLoadFileModel;
+import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.flight.ingest.IngestUtils;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightContext;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Stream;
+
+public class IngestBulkGcpBulkFileStep extends IngestBulkGcpStep {
+
+  public IngestBulkGcpBulkFileStep(
+      String loadTag,
+      UUID profileId,
+      AuthenticatedUserRequest userReq,
+      GcsPdao gcsPdao,
+      ObjectMapper objectMapper,
+      Dataset dataset,
+      int maxFailedFileLoads,
+      int maxBadLoadFileLineErrorsReported,
+      FireStoreDao fileDao,
+      FileService fileService,
+      ExecutorService executor,
+      int maxPerformanceThreadQueueSize) {
+    super(
+        loadTag,
+        profileId,
+        userReq,
+        gcsPdao,
+        objectMapper,
+        dataset,
+        maxFailedFileLoads,
+        maxBadLoadFileLineErrorsReported,
+        fileDao,
+        fileService,
+        executor,
+        maxPerformanceThreadQueueSize);
+  }
+
+  @Override
+  public Stream<BulkLoadFileModel> getModelsStream(FlightContext context) {
+    BulkLoadRequestModel ingestRequest =
+        context
+            .getInputParameters()
+            .get(JobMapKeys.REQUEST.getKeyName(), BulkLoadRequestModel.class);
+    ErrorCollector errorCollector =
+        new ErrorCollector(
+            maxBadLoadFileLineErrorsReported,
+            "Ingest control file at "
+                + ingestRequest.getLoadControlFile()
+                + " could not be processed");
+
+    return IngestUtils.getStreamFromFile(
+        gcsPdao,
+        objectMapper,
+        ingestRequest.getLoadControlFile(),
+        userReq,
+        dataset.getProjectResource().getGoogleProjectId(),
+        errorCollector,
+        // Casting explicitly since it's losing the type downstream
+        new TypeReference<BulkLoadFileModel>() {});
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
@@ -28,10 +28,10 @@ import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import bio.terra.service.filedata.google.firestore.FireStoreFile;
 import bio.terra.service.filedata.google.firestore.FireStoreUtils;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
@@ -53,7 +53,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class IngestBulkGcpStep implements Step {
+public abstract class IngestBulkGcpStep extends DefaultUndoStep {
 
   private Logger logger = LoggerFactory.getLogger(IngestBulkGcpStep.class);
 
@@ -451,12 +451,6 @@ public abstract class IngestBulkGcpStep implements Step {
               failedFileLoads.stream().map(CopyResult::error).map(Exception::getMessage).toList());
       workingMap.put(CommonMapKeys.COMPLETION_TO_FAILURE_EXCEPTION, ex);
     }
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
-    // Do not to undo
-    return StepResult.getStepResultSuccess();
   }
 
   // Object conversion methods

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
@@ -1,0 +1,520 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.common.FlightUtils;
+import bio.terra.common.FutureUtils;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.BulkLoadArrayResultModel;
+import bio.terra.model.BulkLoadFileModel;
+import bio.terra.model.BulkLoadFileResultModel;
+import bio.terra.model.BulkLoadFileState;
+import bio.terra.model.BulkLoadHistoryModel;
+import bio.terra.model.BulkLoadResultModel;
+import bio.terra.model.FileLoadModel;
+import bio.terra.model.FileModel;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.exception.IngestFailureException;
+import bio.terra.service.dataset.flight.ingest.IngestMapKeys;
+import bio.terra.service.filedata.FSFile;
+import bio.terra.service.filedata.FSFileInfo;
+import bio.terra.service.filedata.FileMetadataUtils;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
+import bio.terra.service.filedata.exception.GoogleInternalServerErrorException;
+import bio.terra.service.filedata.exception.InvalidUserProjectException;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
+import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.filedata.google.firestore.FireStoreUtils;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.collections4.ListUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class IngestBulkGcpStep implements Step {
+
+  private Logger logger = LoggerFactory.getLogger(IngestBulkGcpStep.class);
+
+  protected final String loadTag;
+  protected final UUID profileId;
+  protected final AuthenticatedUserRequest userReq;
+  protected final GcsPdao gcsPdao;
+  protected final ObjectMapper objectMapper;
+  protected final Dataset dataset;
+  protected final int maxFailedFileLoads;
+  protected final int maxBadLoadFileLineErrorsReported;
+  protected final FireStoreDao fileDao;
+  protected final FileService fileService;
+  protected final ExecutorService executor;
+  protected final int maxPerformanceThreadQueueSize;
+
+  // What will ultimately be returned to the end user via flight results
+  private final BulkLoadResultModel resultModel = new BulkLoadResultModel();
+  private final List<BulkLoadFileResultModel> loadedFiles = new ArrayList<>();
+
+  public IngestBulkGcpStep(
+      String loadTag,
+      UUID profileId,
+      AuthenticatedUserRequest userReq,
+      GcsPdao gcsPdao,
+      ObjectMapper objectMapper,
+      Dataset dataset,
+      int maxFailedFileLoads,
+      int maxBadLoadFileLineErrorsReported,
+      FireStoreDao fileDao,
+      FileService fileService,
+      ExecutorService executor,
+      int maxPerformanceThreadQueueSize) {
+    this.loadTag = loadTag;
+    this.profileId = profileId;
+    this.userReq = userReq;
+    this.gcsPdao = gcsPdao;
+    this.objectMapper = objectMapper;
+    this.dataset = dataset;
+    this.maxFailedFileLoads = maxFailedFileLoads;
+    this.maxBadLoadFileLineErrorsReported = maxBadLoadFileLineErrorsReported;
+    this.fileDao = fileDao;
+    this.fileService = fileService;
+    this.executor = executor;
+    this.maxPerformanceThreadQueueSize = maxPerformanceThreadQueueSize;
+  }
+
+  /**
+   * Return a stream of file models representing the files to ingest. The construction of this
+   * stream varies based on the type of ingestion flight
+   */
+  protected abstract Stream<BulkLoadFileModel> getModelsStream(FlightContext context);
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+
+    initializeResultsModel(context.getFlightId(), loadTag);
+
+    FlightMap workingMap = context.getWorkingMap();
+
+    GoogleBucketResource bucketResource =
+        FlightUtils.getContextValue(context, FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+    List<FileModel> ingestedFiles;
+    try (var loadModels = getModelsStream(context)) {
+      ingestedFiles = performIngest(workingMap, loadModels.toList(), bucketResource);
+    } catch (InvalidUserProjectException ex) {
+      // We retry this exception because often when we've seen this error it has been transient
+      // and untruthful -- i.e. the user project specified exists and has a legal id.
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+    } catch (GoogleInternalServerErrorException ex) {
+      // Google's error message suggests retrying the operation
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+    } catch (FileSystemAbortTransactionException rex) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
+    }
+
+    logger.info("Recording results");
+    // Must convert to set so that stairway can deserialize
+    workingMap.put(IngestMapKeys.COMBINED_EXISTING_FILES, new HashSet<>(ingestedFiles));
+    workingMap.put(
+        IngestMapKeys.BULK_LOAD_RESULT,
+        new BulkLoadArrayResultModel().loadSummary(resultModel).loadFileResults(loadedFiles));
+
+    logger.info("Done ingesting files");
+    return StepResult.getStepResultSuccess();
+  }
+
+  /** Main driving method that performs the file ingestion */
+  private List<FileModel> performIngest(
+      FlightMap workingMap, List<BulkLoadFileModel> loadModels, GoogleBucketResource bucketResource)
+      throws InterruptedException {
+
+    resultModel.totalFiles(loadModels.size());
+    List<BulkLoadFileModel> successfulLoadModels;
+    List<FSFileInfo> fsFileInfos = new ArrayList<>();
+    Map<String, UUID> fileIdsByPath = new HashMap<>();
+
+    // In the case where file ids are predictable, the linking / copying of the data must happen
+    // first in order to obtain file ids
+    if (dataset.hasPredictableFileIds()) {
+      List<CopyResult> copyResults =
+          doFileCopy(workingMap, loadModels, fileIdsByPath, bucketResource);
+
+      fsFileInfos.addAll(
+          copyResults.stream()
+              .filter(r -> Objects.isNull(r.error()) && Objects.nonNull(r.fsFileInfo()))
+              .map(CopyResult::fsFileInfo)
+              .toList());
+      fileIdsByPath.putAll(
+          copyResults.stream()
+              .filter(r -> Objects.nonNull(r.fsFileInfo()))
+              .collect(
+                  Collectors.toMap(
+                      CopyResult::targetPath, r -> UUID.fromString(r.fsFileInfo().getFileId()))));
+      successfulLoadModels =
+          loadModels.stream().filter(m -> fileIdsByPath.containsKey(m.getTargetPath())).toList();
+    } else {
+      // Precalculate the fileIds to assign to new file objects (in the predictable fileIds case,
+      // this variable gets set in the doFileCopy method)
+      fileIdsByPath.putAll(
+          loadModels.stream()
+              .collect(Collectors.toMap(BulkLoadFileModel::getTargetPath, f -> UUID.randomUUID())));
+      successfulLoadModels = loadModels;
+    }
+
+    doCreateFileSystemEntries(successfulLoadModels, fileIdsByPath);
+
+    // If not using predictable file ids, we wait until the end to copy the files (to avoid
+    // attempting re-copying files)
+    // For the case where we use predictable file Ids, this is a noop
+    if (!dataset.hasPredictableFileIds()) {
+      fsFileInfos.addAll(
+          doFileCopy(workingMap, loadModels, fileIdsByPath, bucketResource).stream()
+              .filter(r -> Objects.isNull(r.error()) && Objects.nonNull(r.fsFileInfo()))
+              .map(CopyResult::fsFileInfo)
+              .toList());
+    }
+    logger.info("Add file metadata to Firestore");
+    // Finally, add the file entries
+    return doFireStoreFileIngest(successfulLoadModels, fileIdsByPath, fsFileInfos);
+  }
+
+  private record CopyResult(
+      FSFileInfo fsFileInfo, String sourcePath, String targetPath, Exception error) {}
+
+  /**
+   * Link or copy and return the resulting FSFileInfo object . If using predictable Ids, modify
+   * fileIdsByPath with the calculated IDs. If not using predictable Ids, use the file Id values
+   * from the passed in fileIdsByPath Note: the results of the successfully copied / linked files
+   * are stored in the flight's context
+   *
+   * @param workingMap The flight's working map
+   * @param loadModels The models representing each file that the user wants to ingest
+   * @param fileIdsByPath A lookup index that maps the virtual path of a file (e.g. what is being
+   *     recorded by this method) to the id for this file.
+   * @param bucketResource The bucket resource object for the bucket being ingested into
+   * @return A list of {@link CopyResult} objects that contain the results of each copy / link
+   *     operation (e.g. errors, if present, storage location, etc.)
+   */
+  private List<CopyResult> doFileCopy(
+      FlightMap workingMap,
+      List<BulkLoadFileModel> loadModels,
+      Map<String, UUID> fileIdsByPath,
+      GoogleBucketResource bucketResource) {
+    logger.info("Linking / copying %d file(s)".formatted(loadModels.size()));
+    List<Future<CopyResult>> futureFsFileInfos = new ArrayList<>(maxPerformanceThreadQueueSize);
+    List<CopyResult> copyResults = new ArrayList<>(loadModels.size());
+
+    // Need to batch to make sure that we don't overwhelm the perf threadpool
+    for (var batch : ListUtils.partition(loadModels, maxPerformanceThreadQueueSize)) {
+      futureFsFileInfos.clear();
+      for (var fileLoadModel : batch) {
+        UUID fileId;
+        if (dataset.hasPredictableFileIds()) {
+          fileId = null;
+        } else {
+          fileId = fileIdsByPath.get(fileLoadModel.getTargetPath());
+        }
+        if (dataset.isSelfHosted()) {
+          futureFsFileInfos.add(
+              executor.submit(
+                  () -> {
+                    try {
+                      return new CopyResult(
+                          gcsPdao.linkSelfHostedFile(
+                              fromBulkFileLoadModel(fileLoadModel),
+                              Optional.ofNullable(fileId).map(UUID::toString).orElse(null),
+                              dataset.getProjectResource().getGoogleProjectId()),
+                          fileLoadModel.getSourcePath(),
+                          fileLoadModel.getTargetPath(),
+                          null);
+                    } catch (Exception e) {
+                      logger.warn("Error linking file", e);
+                      return new CopyResult(
+                          null, fileLoadModel.getSourcePath(), fileLoadModel.getTargetPath(), e);
+                    }
+                  }));
+        } else {
+          futureFsFileInfos.add(
+              executor.submit(
+                  () -> {
+                    try {
+                      int attemptsLeft = 3;
+                      while (true) {
+                        try {
+                          return new CopyResult(
+                              gcsPdao.copyFile(
+                                  dataset,
+                                  fromBulkFileLoadModel(fileLoadModel),
+                                  Optional.ofNullable(fileId).map(UUID::toString).orElse(null),
+                                  bucketResource),
+                              fileLoadModel.getSourcePath(),
+                              fileLoadModel.getTargetPath(),
+                              null);
+                        } catch (GoogleInternalServerErrorException e) {
+                          TimeUnit.SECONDS.sleep(5);
+                          attemptsLeft--;
+                          if (attemptsLeft == 0) {
+                            throw e;
+                          }
+                        }
+                      }
+                    } catch (Exception e) {
+                      logger.warn("Error copying file", e);
+                      return new CopyResult(
+                          null, fileLoadModel.getSourcePath(), fileLoadModel.getTargetPath(), e);
+                    }
+                  }));
+        }
+      }
+      List<CopyResult> results = FutureUtils.waitFor(futureFsFileInfos);
+      copyResults.addAll(results);
+    }
+
+    long succeededFiles = copyResults.stream().filter(f -> Objects.isNull(f.error())).count();
+
+    resultModel
+        .totalFiles(loadModels.size())
+        .succeededFiles((int) succeededFiles)
+        .failedFiles(loadModels.size() - (int) succeededFiles);
+
+    // Validate that the amount files copied / linked didn't exceed the maximum allowed specified
+    // by the user
+    validateErrors(
+        workingMap, copyResults.stream().filter(r -> !Objects.isNull(r.error())).toList());
+
+    // Save the results of the ingestion to be used to load into the load history table
+    List<BulkLoadHistoryModel> loadHistoryModels =
+        new ArrayList<>(copyResults.stream().map(this::fromCopyResult).toList());
+    workingMap.put(IngestMapKeys.BULK_LOAD_HISTORY_RESULT, loadHistoryModels);
+
+    loadedFiles.addAll(loadHistoryModels.stream().map(this::fromHistoryModel).toList());
+    return copyResults;
+  }
+
+  /**
+   * This method ensures that all filesystem metadata (e.g. data resulting from the target path in
+   * the file ingest) gets properly added to the dataset's firestore db
+   *
+   * @param loadModels The models being ingested whose directories and file entries must be created
+   *     Note: in the case of predictable file ids, this will be the subset of file models specified
+   *     by the user that were able to be successfully copied
+   * @param fileIdsByPath A lookup index that maps the virtual path of a file (e.g. what is being
+   *     recorded by this method) to the id for this file. If a conflict is found (e.g. from a
+   *     previous load) this map gets mutated and updated with the existing file id
+   */
+  @VisibleForTesting
+  void doCreateFileSystemEntries(
+      List<BulkLoadFileModel> loadModels, Map<String, UUID> fileIdsByPath)
+      throws InterruptedException {
+    logger.info("Extracting Directories");
+    // Get all directories to create:
+    List<String> directories =
+        loadModels.stream()
+            .flatMap(l -> FileMetadataUtils.extractDirectoryPaths(l.getTargetPath()).stream())
+            .distinct()
+            .sorted()
+            .toList();
+
+    // Make sure directories are up-to-date (explicitly: NOT the files).  Existing directory
+    // entries will be ignored
+    logger.info("Upserting directories");
+    for (var batch : ListUtils.partition(directories, FireStoreUtils.MAX_FIRESTORE_BATCH_SIZE)) {
+      fileDao.upsertDirectoryEntries(dataset, loadTag, batch);
+    }
+
+    // Create the leaf (file) nodes
+    logger.info("Upserting directory file entries");
+    List<FireStoreDirectoryEntry> leafNodes =
+        loadModels.stream()
+            .map(
+                m ->
+                    new FireStoreDirectoryEntry()
+                        .fileId(fileIdsByPath.get(m.getTargetPath()).toString())
+                        .isFileRef(true)
+                        .path(FileMetadataUtils.getDirectoryPath(m.getTargetPath()))
+                        .name(FileMetadataUtils.getName(m.getTargetPath()))
+                        .datasetId(dataset.getId().toString())
+                        .loadTag(loadTag))
+            .collect(Collectors.toList());
+
+    Map<UUID, UUID> idConflicts = new HashMap<>();
+    // Merge ID conflict into fileId map
+    for (var batch : ListUtils.partition(leafNodes, FireStoreUtils.MAX_FIRESTORE_BATCH_SIZE)) {
+      idConflicts.putAll(fileDao.upsertDirectoryEntries(dataset, batch));
+    }
+
+    if (!idConflicts.isEmpty()) {
+      logger.info("Found {} id conflicts", idConflicts.size());
+
+      // Cycle through the entries in the file map and replace with existing file ids
+      for (var e : fileIdsByPath.entrySet()) {
+        UUID newFileId = idConflicts.get(e.getValue());
+        if (newFileId != null) {
+          e.setValue(newFileId);
+        }
+      }
+    }
+  }
+
+  /**
+   * Records the basic file metadata entry for a file (e.g. it's size, checksum, real location in
+   * the cloud)
+   *
+   * @param loadModels The models being ingested whose file metadata entries must be created Note:
+   *     in the case of predictable file ids, this will be the subset of file models specified by
+   *     the user that were able to be successfully copied
+   * @param fileIdsByPath A lookup index that maps the virtual path of a file (e.g. what is being
+   *     recorded by this method) to the id for this file.
+   * @param fsFileInfos A list of the objects that will be recorded in Firestore
+   * @return The final list of all files that were recorded in Firestore. This is effectively the
+   *     list of successfully ingested files
+   */
+  private List<FileModel> doFireStoreFileIngest(
+      List<BulkLoadFileModel> loadModels,
+      Map<String, UUID> fileIdsByPath,
+      List<FSFileInfo> fsFileInfos)
+      throws InterruptedException {
+
+    Map<String, BulkLoadFileModel> loadModelsById =
+        loadModels.stream()
+            .collect(
+                Collectors.toMap(m -> fileIdsByPath.get(m.getTargetPath()).toString(), m -> m));
+
+    List<FireStoreFile> newFiles =
+        fsFileInfos.stream()
+            .map(
+                fsFileInfo -> {
+                  var fileLoadModel = loadModelsById.get(fsFileInfo.getFileId());
+                  return new FireStoreFile()
+                      .fileId(fsFileInfo.getFileId())
+                      .mimeType(fileLoadModel.getMimeType())
+                      .description(fileLoadModel.getDescription())
+                      .bucketResourceId(fsFileInfo.getBucketResourceId())
+                      .fileCreatedDate(fsFileInfo.getCreatedDate())
+                      .gspath(fsFileInfo.getCloudPath())
+                      .checksumCrc32c(fsFileInfo.getChecksumCrc32c())
+                      .checksumMd5(fsFileInfo.getChecksumMd5())
+                      .size(fsFileInfo.getSize())
+                      .loadTag(loadTag);
+                })
+            .toList();
+
+    List<List<FireStoreFile>> writeBatches =
+        ListUtils.partition(newFiles, FireStoreUtils.MAX_FIRESTORE_BATCH_SIZE);
+    int i = 0;
+    for (var writeBatch : writeBatches) {
+      i++;
+      logger.info("Writing batch {} of {}", i, writeBatches.size());
+      fileDao.createFileMetadata(dataset, writeBatch);
+    }
+    // Retrieve documents from to build the complete FSItems
+    List<FSFile> fsItems = new ArrayList<>(fileIdsByPath.size());
+    logger.info("Reading back metadata to return");
+    for (var fileIdBatch :
+        ListUtils.partition(
+            fileIdsByPath.values().stream().map(UUID::toString).toList(),
+            FireStoreUtils.MAX_FIRESTORE_BATCH_SIZE)) {
+      fsItems.addAll(fileDao.batchRetrieveById(dataset, fileIdBatch, 1));
+    }
+
+    return fsItems.stream().map(fileService::fileModelFromFSItem).toList();
+  }
+
+  /**
+   * Makes sure that not too many file ingest failures occurred
+   *
+   * @param workingMap The flight's working map
+   * @param failedFileLoads A list of all file copy results that failed
+   */
+  private void validateErrors(FlightMap workingMap, List<CopyResult> failedFileLoads) {
+    if (maxFailedFileLoads > -1 && failedFileLoads.size() > maxFailedFileLoads) {
+      String errorMessage =
+          String.format(
+              "More than %d file(s) failed to ingest, which was the allowed amount."
+                  + " For a full report, see the load history table for this dataset.",
+              maxFailedFileLoads);
+
+      Exception ex =
+          new IngestFailureException(
+              errorMessage,
+              failedFileLoads.stream().map(CopyResult::error).map(Exception::getMessage).toList());
+      workingMap.put(CommonMapKeys.COMPLETION_TO_FAILURE_EXCEPTION, ex);
+    }
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // Do not to undo
+    return StepResult.getStepResultSuccess();
+  }
+
+  // Object conversion methods
+  private FileLoadModel fromBulkFileLoadModel(BulkLoadFileModel bulkLoadFileModel) {
+    return new FileLoadModel()
+        .description(bulkLoadFileModel.getDescription())
+        .mimeType(bulkLoadFileModel.getMimeType())
+        .loadTag(loadTag)
+        .targetPath(bulkLoadFileModel.getTargetPath())
+        .sourcePath(bulkLoadFileModel.getSourcePath())
+        .profileId(profileId);
+  }
+
+  private void initializeResultsModel(String flightId, String loadTag) {
+    resultModel
+        .jobId(flightId)
+        .loadTag(loadTag)
+        .totalFiles(0)
+        .succeededFiles(0)
+        .notTriedFiles(0)
+        .failedFiles(0);
+  }
+
+  private BulkLoadHistoryModel fromCopyResult(CopyResult copyResult) {
+    BulkLoadHistoryModel result =
+        new BulkLoadHistoryModel()
+            .sourcePath(copyResult.sourcePath())
+            .targetPath(copyResult.targetPath());
+
+    if (copyResult.fsFileInfo() != null) {
+      result
+          .fileId(copyResult.fsFileInfo().getFileId())
+          .checksumCRC(copyResult.fsFileInfo().getChecksumCrc32c())
+          .checksumMD5(copyResult.fsFileInfo().getChecksumMd5());
+    }
+    if (copyResult.error() != null) {
+      result.error(copyResult.error().getMessage()).state(BulkLoadFileState.FAILED);
+    } else {
+      result.state(BulkLoadFileState.SUCCEEDED);
+    }
+
+    return result;
+  }
+
+  private BulkLoadFileResultModel fromHistoryModel(BulkLoadHistoryModel historyModel) {
+    return new BulkLoadFileResultModel()
+        .fileId(historyModel.getFileId())
+        .error(historyModel.getError())
+        .state(historyModel.getState())
+        .sourcePath(historyModel.getSourcePath())
+        .targetPath(historyModel.getTargetPath());
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryStep.java
@@ -1,7 +1,9 @@
 package bio.terra.service.filedata.flight.ingest;
 
+import bio.terra.model.BulkLoadHistoryModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.flight.ingest.IngestMapKeys;
 import bio.terra.service.load.LoadService;
 import bio.terra.service.load.LoadService.LoadHistoryIterator;
 import bio.terra.service.load.flight.LoadMapKeys;
@@ -9,27 +11,40 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.exception.DatabaseOperationException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class IngestCopyLoadHistoryStep implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(IngestCopyLoadHistoryStep.class);
 
   protected IngestCopyLoadHistoryResources getResources(
       FlightContext context,
       LoadService loadService,
       DatasetService datasetService,
       UUID datasetId,
-      int loadHistoryChunkSize)
+      int loadHistoryChunkSize,
+      boolean isBulkMode)
       throws InterruptedException {
     try {
       FlightMap workingMap = context.getWorkingMap();
-      String loadIdString = workingMap.get(LoadMapKeys.LOAD_ID, String.class);
 
-      UUID loadId = UUID.fromString(loadIdString);
       Dataset dataset = datasetService.retrieve(datasetId);
       Instant loadTime = context.getStairway().getFlightState(context.getFlightId()).getSubmitted();
-      LoadHistoryIterator loadHistoryIterator =
-          loadService.loadHistoryIterator(loadId, loadHistoryChunkSize);
+      LoadHistoryIterator loadHistoryIterator;
+      if (isBulkMode) {
+        List<BulkLoadHistoryModel> loadResults =
+            workingMap.get(IngestMapKeys.BULK_LOAD_HISTORY_RESULT, new TypeReference<>() {});
+        workingMap.putRaw(IngestMapKeys.BULK_LOAD_HISTORY_RESULT, "");
+        loadHistoryIterator = loadService.loadHistoryIterator(loadResults, loadHistoryChunkSize);
+      } else {
+        String loadIdString = workingMap.get(LoadMapKeys.LOAD_ID, String.class);
+        UUID loadId = UUID.fromString(loadIdString);
+        loadHistoryIterator = loadService.loadHistoryIterator(loadId, loadHistoryChunkSize);
+      }
 
       return new IngestCopyLoadHistoryResources(dataset, loadTime, loadHistoryIterator);
     } catch (DatabaseOperationException ex) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryStep.java
@@ -38,6 +38,7 @@ public abstract class IngestCopyLoadHistoryStep implements Step {
       if (isBulkMode) {
         List<BulkLoadHistoryModel> loadResults =
             workingMap.get(IngestMapKeys.BULK_LOAD_HISTORY_RESULT, new TypeReference<>() {});
+        // Clear the working map to save space in the DB
         workingMap.putRaw(IngestMapKeys.BULK_LOAD_HISTORY_RESULT, "");
         loadHistoryIterator = loadService.loadHistoryIterator(loadResults, loadHistoryChunkSize);
       } else {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryToBQStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryToBQStep.java
@@ -25,6 +25,7 @@ public class IngestCopyLoadHistoryToBQStep extends IngestCopyLoadHistoryStep {
   private final String loadTag;
   private final int waitSeconds;
   private final int loadHistoryChunkSize;
+  private final boolean isBulkMode;
 
   public IngestCopyLoadHistoryToBQStep(
       BigQueryDatasetPdao bigQueryDatasetPdao,
@@ -33,7 +34,8 @@ public class IngestCopyLoadHistoryToBQStep extends IngestCopyLoadHistoryStep {
       UUID datasetId,
       String loadTag,
       int waitSeconds,
-      int loadHistoryChunkSize) {
+      int loadHistoryChunkSize,
+      boolean isBulkMode) {
     this.bigQueryDatasetPdao = bigQueryDatasetPdao;
     this.loadService = loadService;
     this.datasetService = datasetService;
@@ -41,12 +43,14 @@ public class IngestCopyLoadHistoryToBQStep extends IngestCopyLoadHistoryStep {
     this.loadTag = loadTag;
     this.waitSeconds = waitSeconds;
     this.loadHistoryChunkSize = loadHistoryChunkSize;
+    this.isBulkMode = isBulkMode;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     IngestCopyLoadHistoryResources resources =
-        getResources(context, loadService, datasetService, datasetId, loadHistoryChunkSize);
+        getResources(
+            context, loadService, datasetService, datasetId, loadHistoryChunkSize, isBulkMode);
     String tableNameFlightId = context.getFlightId().replaceAll("[^a-zA-Z0-9]", "_");
     try {
       bigQueryDatasetPdao.createStagingLoadHistoryTable(resources.dataset, tableNameFlightId);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryToStorageTableStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCopyLoadHistoryToStorageTableStep.java
@@ -50,8 +50,9 @@ public class IngestCopyLoadHistoryToStorageTableStep extends IngestCopyLoadHisto
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
+    // TODO: support bulk mode in azure
     var resources =
-        getResources(context, loadService, datasetService, datasetId, loadHistoryChunkSize);
+        getResources(context, loadService, datasetService, datasetId, loadHistoryChunkSize, false);
     AzureStorageAccountResource storageAccountForFile =
         workingMap.get(
             CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -81,6 +81,48 @@ public class FireStoreDao {
     directoryDao.createDirectoryEntry(firestore, datasetId, newEntry);
   }
 
+  /**
+   * Write directory entries. If attempting to write a document that has a different ID but the same
+   * load tag, leave the entry untouched and return false for that entry. If the load tags don't
+   * match, then throw an exception
+   *
+   * @param dataset The dataset being ingested into
+   * @param loadTag the load tag of the current ingest
+   * @param directories All directories to upsert
+   * @return A list of booleans the same size as the directories parameter where if an entry is
+   *     true, the directory at that location was inserted and if an entry is false, it already
+   *     existed
+   * @throws InterruptedException If something goes wrong talking to Firestore
+   * @throws FileSystemExecutionException If the file already exists but with a different load tag
+   */
+  public void upsertDirectoryEntries(Dataset dataset, String loadTag, List<String> directories)
+      throws InterruptedException {
+    Firestore firestore =
+        FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
+    String datasetId = dataset.getId().toString();
+    directoryDao.upsertDirectoryEntries(firestore, datasetId, loadTag, directories);
+  }
+
+  /**
+   * Write directory entries. If attempting to write a document that has a different ID but the same
+   * load tag, leave the entry untouched and add an entry to the return map. If the load tags don't
+   * match, then throw an exception
+   *
+   * @param dataset The dataset being ingested into
+   * @param newEntries All entries to upsert
+   * @return A map of IDs for entries that already exist. The key is the passed in id and the value
+   *     is the existing value.
+   * @throws InterruptedException If something goes wrong talking to Firestore
+   * @throws FileSystemExecutionException If the file already exists but with a different load tag
+   */
+  public Map<UUID, UUID> upsertDirectoryEntries(
+      Dataset dataset, List<FireStoreDirectoryEntry> newEntries) throws InterruptedException {
+    Firestore firestore =
+        FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
+    String datasetId = dataset.getId().toString();
+    return directoryDao.upsertDirectoryEntries(firestore, datasetId, newEntries);
+  }
+
   public boolean deleteDirectoryEntry(Dataset dataset, String fileId) throws InterruptedException {
     Firestore firestore =
         FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
@@ -88,12 +130,28 @@ public class FireStoreDao {
     return directoryDao.deleteDirectoryEntry(firestore, datasetId, fileId);
   }
 
+  /**
+   * Upserts a file metadata object into Firestore (e.g. this is the metadata that contains size,
+   * checksum, cloud location etc.) of a file, as opposed to the path information for the file
+   */
   public void createFileMetadata(Dataset dataset, FireStoreFile newFile)
       throws InterruptedException {
     Firestore firestore =
         FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
     String datasetId = dataset.getId().toString();
     fileDao.createFileMetadata(firestore, datasetId, newFile);
+  }
+
+  /**
+   * Upserts file metadata objects into Firestore (e.g. this is the metadata that contains size,
+   * checksum, cloud location etc.) of a file, as opposed to the path information for the file
+   */
+  public void createFileMetadata(Dataset dataset, List<FireStoreFile> newFiles)
+      throws InterruptedException {
+    Firestore firestore =
+        FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
+    String datasetId = dataset.getId().toString();
+    fileDao.createFileMetadata(firestore, datasetId, newFiles);
   }
 
   public boolean deleteFileMetadata(Dataset dataset, String fileId) throws InterruptedException {
@@ -399,11 +457,12 @@ public class FireStoreDao {
     return directoryDao.validateRefIds(firestore, datasetId, refIdArray);
   }
 
-  /** Retrieve all fileIds (including directories) from a snapshot */
-  public List<String> retrieveAllFileIds(Snapshot snapshot) throws InterruptedException {
+  /** Retrieve all fileIds (including directories) from a dataset or snapshot */
+  public List<String> retrieveAllFileIds(FSContainerInterface container)
+      throws InterruptedException {
     Firestore firestore =
-        FireStoreProject.get(snapshot.getProjectResource().getGoogleProjectId()).getFirestore();
-    return directoryDao.enumerateAll(firestore, snapshot.getId().toString()).stream()
+        FireStoreProject.get(container.getProjectResource().getGoogleProjectId()).getFirestore();
+    return directoryDao.enumerateAll(firestore, container.getId().toString()).stream()
         .map(FireStoreDirectoryEntry::getFileId)
         .toList();
   }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -100,7 +100,19 @@ public class FireStoreDao {
     Firestore firestore =
         FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
     String datasetId = dataset.getId().toString();
-    directoryDao.upsertDirectoryEntries(firestore, datasetId, loadTag, directories);
+    List<FireStoreDirectoryEntry> entries =
+        directories.stream()
+            .map(
+                d ->
+                    new FireStoreDirectoryEntry()
+                        .fileId(UUID.randomUUID().toString())
+                        .isFileRef(false)
+                        .path(FileMetadataUtils.getDirectoryPath(d))
+                        .name(FileMetadataUtils.getName(d))
+                        .datasetId(datasetId)
+                        .loadTag(loadTag))
+            .toList();
+    directoryDao.upsertDirectoryEntries(firestore, datasetId, entries);
   }
 
   /**

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -89,14 +89,13 @@ public class FireStoreDao {
    * @param dataset The dataset being ingested into
    * @param loadTag the load tag of the current ingest
    * @param directories All directories to upsert
-   * @return A list of booleans the same size as the directories parameter where if an entry is
-   *     true, the directory at that location was inserted and if an entry is false, it already
-   *     existed
+   * @return A map of IDs for entries that already exist. The key is the passed in id and the value
+   *     is the existing value.
    * @throws InterruptedException If something goes wrong talking to Firestore
    * @throws FileSystemExecutionException If the file already exists but with a different load tag
    */
-  public void upsertDirectoryEntries(Dataset dataset, String loadTag, List<String> directories)
-      throws InterruptedException {
+  public Map<UUID, UUID> upsertDirectoryEntries(
+      Dataset dataset, String loadTag, List<String> directories) throws InterruptedException {
     Firestore firestore =
         FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
     String datasetId = dataset.getId().toString();
@@ -112,7 +111,7 @@ public class FireStoreDao {
                         .datasetId(datasetId)
                         .loadTag(loadTag))
             .toList();
-    directoryDao.upsertDirectoryEntries(firestore, datasetId, entries);
+    return directoryDao.upsertDirectoryEntries(firestore, datasetId, entries);
   }
 
   /**

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
@@ -8,6 +8,7 @@ import bio.terra.app.logging.PerformanceLogger;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.FileMetadataUtils;
+import bio.terra.service.filedata.exception.FileAlreadyExistsException;
 import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import com.google.api.core.ApiFuture;
@@ -24,11 +25,14 @@ import com.google.cloud.firestore.WriteResult;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang3.StringUtils;
@@ -134,6 +138,112 @@ public class FireStoreDirectoryDao {
         " creating file directory for collection Id: " + collectionId);
   }
 
+  /**
+   * Write directory entries. If attempting to write a document that has a different ID but the same
+   * load tag, leave the entry untouched and return false for that entry. If the load tags don't
+   * match, then throw an exception
+   *
+   * @param firestore Firestore connection object
+   * @param collectionId the id of the collection being updated
+   * @param loadTag the load tag of the current ingest
+   * @param directories All directories to upsert
+   * @return A list of booleans the same size as the directories parameter where if an entry is
+   *     true, the directory at that location was inserted and if an entry is false, it already
+   *     existed
+   * @throws InterruptedException If something goes wrong talking to Firestore
+   * @throws FileSystemExecutionException If the file already exists but with a different load tag
+   */
+  public List<Boolean> upsertDirectoryEntries(
+      Firestore firestore, String collectionId, String loadTag, List<String> directories)
+      throws InterruptedException {
+    return fireStoreUtils.batchOperation(
+        directories,
+        directory ->
+            firestore.runTransaction(
+                xn -> {
+                  DocumentReference docRef =
+                      getDocRef(
+                          firestore, collectionId, FileMetadataUtils.makeLookupPath(directory));
+                  // If the directory entry already exists, don't try to re-add
+                  DocumentSnapshot documentSnapshot = xn.get(docRef).get();
+                  if (documentSnapshot.exists()) {
+                    FireStoreDirectoryEntry existingEntry =
+                        documentSnapshot.toObject(FireStoreDirectoryEntry.class);
+                    if (Objects.equals(existingEntry.getLoadTag(), loadTag)) {
+                      return false;
+                    } else {
+                      throw new FileAlreadyExistsException(
+                          "Path already exists: %s with load tag %s"
+                              .formatted(directory, existingEntry.getLoadTag()));
+                    }
+                  }
+                  xn.set(
+                      docRef,
+                      new FireStoreDirectoryEntry()
+                          .fileId(UUID.randomUUID().toString())
+                          .isFileRef(false)
+                          .path(FileMetadataUtils.getDirectoryPath(directory))
+                          .name(FileMetadataUtils.getName(directory))
+                          .datasetId(collectionId)
+                          .loadTag(loadTag));
+                  return true;
+                }));
+  }
+
+  /**
+   * Write directory entries. If attempting to write a document that has a different ID but the same
+   * load tag, leave the entry untouched and add an entry to the return map. If the load tags don't
+   * match, then throw an exception
+   *
+   * @param firestore Firestore connection object
+   * @param collectionId the id of the collection being updated
+   * @param entries All entries to upsert
+   * @return A map of IDs for entries that already exist. The key is the passed in id and the value
+   *     is the existing value.
+   * @throws InterruptedException If something goes wrong talking to Firestore
+   * @throws FileSystemExecutionException If the file already exists but with a different load tag
+   */
+  public Map<UUID, UUID> upsertDirectoryEntries(
+      Firestore firestore, String collectionId, List<FireStoreDirectoryEntry> entries)
+      throws InterruptedException {
+
+    return fireStoreUtils
+        .batchOperation(
+            entries,
+            entry ->
+                firestore.runTransaction(
+                    xn -> {
+                      DocumentReference docRef =
+                          getDocRef(firestore, collectionId, entry.getPath(), entry.getName());
+                      DocumentSnapshot documentSnapshot = xn.get(docRef).get();
+                      if (documentSnapshot.exists()) {
+                        FireStoreDirectoryEntry existingEntry =
+                            documentSnapshot.toObject(FireStoreDirectoryEntry.class);
+                        // If the file exists with the same load tag, we assume that it's from
+                        // this load and that this is a recovery.  In that case, just leave the
+                        // entry unchanged and return a mapping from the attempted fileId to the
+                        // existing fileId so that the calling flight's working map can be updated
+                        if (Objects.equals(entry.getLoadTag(), existingEntry.getLoadTag())) {
+                          return new IdConflict(
+                              UUID.fromString(entry.getFileId()),
+                              UUID.fromString(documentSnapshot.get("fileId", String.class)));
+                        } else {
+                          throw new FileAlreadyExistsException(
+                              "Path already exists: %s with load tag %s"
+                                  .formatted(entry.getPath(), existingEntry.getLoadTag()));
+                        }
+                      }
+                      xn.set(docRef, entry);
+                      return null;
+                    }))
+        .stream()
+        .filter(Objects::nonNull)
+        .collect(Collectors.toMap(IdConflict::attemptedId, IdConflict::existingId));
+  }
+  // Need to declare the record class out here and not inline in the method sine that makes spotbugs
+  // mad and I can't disable the check
+  record IdConflict(UUID attemptedId, UUID existingId) {}
+
   // true - directory entry existed and was deleted; false - directory entry did not exist
   public boolean deleteDirectoryEntry(Firestore firestore, String collectionId, String fileId)
       throws InterruptedException {
@@ -182,13 +292,14 @@ public class FireStoreDirectoryDao {
     return fireStoreUtils.transactionGet("deleteDirectoryEntry", transaction);
   }
 
-  private static final int DELETE_BATCH_SIZE = 500;
-
   public void deleteDirectoryEntriesFromCollection(Firestore firestore, String collectionId)
       throws InterruptedException {
 
     fireStoreUtils.scanCollectionObjects(
-        firestore, collectionId, DELETE_BATCH_SIZE, document -> document.getReference().delete());
+        firestore,
+        collectionId,
+        FireStoreUtils.MAX_FIRESTORE_BATCH_SIZE,
+        document -> document.getReference().delete());
   }
 
   interface LookupFunction {
@@ -298,6 +409,10 @@ public class FireStoreDirectoryDao {
   private DocumentReference getDocRef(
       Firestore firestore, String collectionId, String path, String name) {
     String fullPath = FileMetadataUtils.getFullPath(path, name);
+    return getDocRef(firestore, collectionId, fullPath);
+  }
+
+  private DocumentReference getDocRef(Firestore firestore, String collectionId, String fullPath) {
     String lookupPath = FileMetadataUtils.makeLookupPath(fullPath);
     return firestore
         .collection(collectionId)
@@ -489,7 +604,7 @@ public class FireStoreDirectoryDao {
     return entries;
   }
 
-  private List<FireStoreDirectoryEntry> batchRetrieveByPath(
+  public List<FireStoreDirectoryEntry> batchRetrieveByPath(
       Firestore datasetFirestore, String datasetId, List<String> paths)
       throws InterruptedException {
 
@@ -500,14 +615,17 @@ public class FireStoreDirectoryDao {
             paths,
             path -> {
               DocumentReference docRef =
-                  datasetCollection.document(encodePathAsFirestoreDocumentName(path));
+                  datasetCollection.document(
+                      encodePathAsFirestoreDocumentName(FileMetadataUtils.makeLookupPath(path)));
               return docRef.get();
             });
 
     List<FireStoreDirectoryEntry> entries = new ArrayList<>(paths.size());
     for (DocumentSnapshot document : documents) {
-      FireStoreDirectoryEntry entry = document.toObject(FireStoreDirectoryEntry.class);
-      entries.add(entry);
+      if (document.exists()) {
+        FireStoreDirectoryEntry entry = document.toObject(FireStoreDirectoryEntry.class);
+        entries.add(entry);
+      }
     }
 
     return entries;

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -33,6 +33,8 @@ public class FireStoreUtils {
 
   private final Logger logger = LoggerFactory.getLogger(FireStoreUtils.class);
   private static final int SLEEP_BASE_SECONDS = 1;
+  // Firestore limits batches to 500
+  public static final int MAX_FIRESTORE_BATCH_SIZE = 500;
 
   private ConfigurationService configurationService;
 
@@ -284,7 +286,7 @@ public class FireStoreUtils {
 
         return transactionGet(transactionOp, transaction);
       } catch (Exception ex) {
-        final long retryWait = (long) (SLEEP_BASE_SECONDS * Math.pow(2.5, retry));
+        final long retryWait = Math.min(60, (long) (SLEEP_BASE_SECONDS * Math.pow(2.5, retry)));
         if (retry < getFirestoreRetries() && FireStoreUtils.shouldRetry(ex, false)) {
           // perform retry
           retry++;

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -33,6 +33,7 @@ public class FireStoreUtils {
 
   private final Logger logger = LoggerFactory.getLogger(FireStoreUtils.class);
   private static final int SLEEP_BASE_SECONDS = 1;
+  private static final int SLEEP_MAX_SECONDS = 20;
   // Firestore limits batches to 500
   public static final int MAX_FIRESTORE_BATCH_SIZE = 500;
 
@@ -234,7 +235,8 @@ public class FireStoreUtils {
         break;
       }
 
-      final long retryWait = (long) (SLEEP_BASE_SECONDS * Math.pow(2.5, noProgressCount));
+      final long retryWait =
+          (long) Math.min(SLEEP_MAX_SECONDS, (SLEEP_BASE_SECONDS * Math.pow(2.5, noProgressCount)));
       if (completeCount == 0) {
         noProgressCount++;
         if (noProgressCount > getFirestoreRetries()) {
@@ -286,7 +288,8 @@ public class FireStoreUtils {
 
         return transactionGet(transactionOp, transaction);
       } catch (Exception ex) {
-        final long retryWait = Math.min(60, (long) (SLEEP_BASE_SECONDS * Math.pow(2.5, retry)));
+        final long retryWait =
+            Math.min(SLEEP_MAX_SECONDS, (long) (SLEEP_BASE_SECONDS * Math.pow(2.5, retry)));
         if (retry < getFirestoreRetries() && FireStoreUtils.shouldRetry(ex, false)) {
           // perform retry
           retry++;

--- a/src/main/java/bio/terra/service/load/LoadService.java
+++ b/src/main/java/bio/terra/service/load/LoadService.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -120,6 +121,10 @@ public class LoadService {
     return new LoadHistoryIterator(loadId, chunkSize);
   }
 
+  public LoadHistoryIterator loadHistoryIterator(
+      List<BulkLoadHistoryModel> backingList, int chunkSize) {
+    return new LoadHistoryIterator(backingList, chunkSize);
+  }
   /**
    * A convenience class wrapping the getting of load history table rows in an Iterator. The
    * Iterator's elements are a list of BulkLoadHistoryModel chunk of the full results retrieved from
@@ -130,6 +135,8 @@ public class LoadService {
     private final UUID loadId;
     private final int chunkSize;
     private final int loadHistorySize;
+    private final List<List<BulkLoadHistoryModel>> backingList;
+
     private int currentChunk;
 
     public LoadHistoryIterator(UUID loadId, int chunkSize) {
@@ -137,6 +144,15 @@ public class LoadService {
       this.chunkSize = chunkSize;
       this.loadHistorySize = loadDao.bulkLoadFileArraySize(loadId);
       this.currentChunk = 0;
+      this.backingList = null;
+    }
+
+    public LoadHistoryIterator(List<BulkLoadHistoryModel> backingList, int chunkSize) {
+      this.loadId = null;
+      this.chunkSize = chunkSize;
+      this.loadHistorySize = backingList.size();
+      this.currentChunk = 0;
+      this.backingList = ListUtils.partition(backingList, chunkSize);
     }
 
     @Override
@@ -146,7 +162,13 @@ public class LoadService {
 
     @Override
     public List<BulkLoadHistoryModel> next() {
-      return loadDao.makeLoadHistoryArray(loadId, chunkSize, currentChunk++);
+      if (backingList == null) {
+        return loadDao.makeLoadHistoryArray(loadId, chunkSize, currentChunk++);
+      }
+      if (currentChunk < backingList.size()) {
+        return backingList.get(currentChunk++);
+      }
+      return null;
     }
   }
 }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
@@ -1471,7 +1471,7 @@ public class BigQuerySnapshotPdao {
   }
 
   public static void logQuery(QueryJobConfiguration queryConfig) {
-    logger.info(
+    logger.debug(
         "Running query:\n#########\n{}\n#########\nwith parameters {}",
         queryConfig.getQuery(),
         queryConfig.getNamedParameters());

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3666,6 +3666,17 @@ components:
       type: string
       description: >
         Unique identifier for a flights, jobs, etc.
+    BulkModeProperty:
+      type: boolean
+      default: false
+      description: >
+        If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
+        improvements are that:
+        - the dataset will be locked exclusively
+        - some safeguards can not be enforced during loads.  Given that, it's recommended that
+          you use a max_failed_file_loads value of 0
+        - the assumption is that file metadata must all fit into memory so configure the
+          deployment accordingly
     BillingProfileRequestModel:
       required:
         - biller
@@ -4302,16 +4313,7 @@ components:
                          and no duplicate IDs should be found in your ingest, otherwise the ingest job
                          will fail.
         bulkMode:
-          type: boolean
-          default: false
-          description: >
-            If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
-            improvements are that:
-            - the dataset will be locked exclusively
-            - some safeguards can not be enforced during loads.  Given that, it's recommended that
-              you use a max_failed_file_loads value of 0
-            - the assumption is that file metadata must all fit into memory so configure the
-              deployment accordingly
+          $ref: '#/components/schemas/BulkModeProperty'
       description: >
         Request to ingest data from a file in GCS into a table in a dataset.
         The ingest source must be readable by the DR manager.
@@ -4534,16 +4536,7 @@ components:
             BulkLoadFileModel. For example, one line might look like
               '{ "sourcePath":"gs:/bucket/path/file", "targetPath":"/target/path/file" }'
         bulkMode:
-          type: boolean
-          default: false
-          description: >
-            If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
-            improvements are that:
-            - the dataset will be locked exclusively
-            - some safeguards can not be enforced during loads.  Given that, it's recommended that
-              you use a maxFailedFileLoads value of 0
-            - the assumption is that file metadata must all fit into memory so configure the
-              deployment accordingly
+          $ref: '#/components/schemas/BulkModeProperty'
       description: >-
         Body of a bulk file load request. This variant of a bulk load provides the set of
         files to be loaded in a file containing the JSON form of a BulkLoadFileModel.
@@ -4572,16 +4565,7 @@ components:
           items:
             $ref: '#/components/schemas/BulkLoadFileModel'
         bulkMode:
-          type: boolean
-          default: false
-          description: >
-            If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
-            improvements are that:
-            - the dataset will be locked exclusively
-            - some safeguards can not be enforced during loads.  Given that, it's recommended that
-              you use a maxFailedFileLoads value of 0
-            - the assumption is that file metadata must all fit into memory so configure the
-              deployment accordingly
+          $ref: '#/components/schemas/BulkModeProperty'
       description: >-
         Body of a bulk file load request. This variant of a bulk load provides the set of
         files to be loaded in the body of the request. Both the summary of the load and the

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3666,17 +3666,6 @@ components:
       type: string
       description: >
         Unique identifier for a flights, jobs, etc.
-    BulkModeProperty:
-      type: boolean
-      default: false
-      description: >
-        If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
-        improvements are that:
-        - the dataset will be locked exclusively
-        - some safeguards can not be enforced during loads.  Given that, it's recommended that
-          you use a max_failed_file_loads value of 0
-        - the assumption is that file metadata must all fit into memory so configure the
-          deployment accordingly
     BillingProfileRequestModel:
       required:
         - biller
@@ -4313,7 +4302,16 @@ components:
                          and no duplicate IDs should be found in your ingest, otherwise the ingest job
                          will fail.
         bulkMode:
-          $ref: '#/components/schemas/BulkModeProperty'
+          type: boolean
+          default: false
+          description: >
+            If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
+            improvements are that:
+            - the dataset will be locked exclusively
+            - some safeguards can not be enforced during loads.  Given that, it's recommended that
+              you use a max_failed_file_loads value of 0
+            - the assumption is that file metadata must all fit into memory so configure the
+              deployment accordingly
       description: >
         Request to ingest data from a file in GCS into a table in a dataset.
         The ingest source must be readable by the DR manager.
@@ -4536,7 +4534,16 @@ components:
             BulkLoadFileModel. For example, one line might look like
               '{ "sourcePath":"gs:/bucket/path/file", "targetPath":"/target/path/file" }'
         bulkMode:
-          $ref: '#/components/schemas/BulkModeProperty'
+          type: boolean
+          default: false
+          description: >
+            If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
+            improvements are that:
+            - the dataset will be locked exclusively
+            - some safeguards can not be enforced during loads.  Given that, it's recommended that
+              you use a maxFailedFileLoads value of 0
+            - the assumption is that file metadata must all fit into memory so configure the
+              deployment accordingly
       description: >-
         Body of a bulk file load request. This variant of a bulk load provides the set of
         files to be loaded in a file containing the JSON form of a BulkLoadFileModel.
@@ -4565,7 +4572,16 @@ components:
           items:
             $ref: '#/components/schemas/BulkLoadFileModel'
         bulkMode:
-          $ref: '#/components/schemas/BulkModeProperty'
+          type: boolean
+          default: false
+          description: >
+            If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
+            improvements are that:
+            - the dataset will be locked exclusively
+            - some safeguards can not be enforced during loads.  Given that, it's recommended that
+              you use a maxFailedFileLoads value of 0
+            - the assumption is that file metadata must all fit into memory so configure the
+              deployment accordingly
       description: >-
         Body of a bulk file load request. This variant of a bulk load provides the set of
         files to be loaded in the body of the request. Both the summary of the load and the

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4308,7 +4308,8 @@ components:
             If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
             improvements are that:
             - the dataset will be locked exclusively
-            - some safeguards can not be enforced during loads
+            - some safeguards can not be enforced during loads.  Given that, it's recommended that
+              you use a max_failed_file_loads value of 0
             - the assumption is that file metadata must all fit into memory so configure the
               deployment accordingly
       description: >
@@ -4539,7 +4540,8 @@ components:
             If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
             improvements are that:
             - the dataset will be locked exclusively
-            - some safeguards can not be enforced during loads
+            - some safeguards can not be enforced during loads.  Given that, it's recommended that
+              you use a maxFailedFileLoads value of 0
             - the assumption is that file metadata must all fit into memory so configure the
               deployment accordingly
       description: >-
@@ -4569,6 +4571,17 @@ components:
           description: Array files to load
           items:
             $ref: '#/components/schemas/BulkLoadFileModel'
+        bulkMode:
+          type: boolean
+          default: false
+          description: >
+            If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
+            improvements are that:
+            - the dataset will be locked exclusively
+            - some safeguards can not be enforced during loads.  Given that, it's recommended that
+              you use a maxFailedFileLoads value of 0
+            - the assumption is that file metadata must all fit into memory so configure the
+              deployment accordingly
       description: >-
         Body of a bulk file load request. This variant of a bulk load provides the set of
         files to be loaded in the body of the request. Both the summary of the load and the

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4301,6 +4301,16 @@ components:
                          in the matching table row.  Each ingest row must match exactly one table row,
                          and no duplicate IDs should be found in your ingest, otherwise the ingest job
                          will fail.
+        bulkMode:
+          type: boolean
+          default: false
+          description: >
+            If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
+            improvements are that:
+            - the dataset will be locked exclusively
+            - some safeguards can not be enforced during loads
+            - the assumption is that file metadata must all fit into memory so configure the
+              deployment accordingly
       description: >
         Request to ingest data from a file in GCS into a table in a dataset.
         The ingest source must be readable by the DR manager.
@@ -4522,6 +4532,16 @@ components:
             Manager. Each line of the file is interpreted as the JSON form of one
             BulkLoadFileModel. For example, one line might look like
               '{ "sourcePath":"gs:/bucket/path/file", "targetPath":"/target/path/file" }'
+        bulkMode:
+          type: boolean
+          default: false
+          description: >
+            If true, file ingest will be performed in bulk mode.  The tradeoff for the performance
+            improvements are that:
+            - the dataset will be locked exclusively
+            - some safeguards can not be enforced during loads
+            - the assumption is that file metadata must all fit into memory so configure the
+              deployment accordingly
       description: >-
         Body of a bulk file load request. This variant of a bulk load provides the set of
         files to be loaded in a file containing the JSON form of a BulkLoadFileModel.

--- a/src/test/java/bio/terra/common/fixtures/FlightContextFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/FlightContextFixtures.java
@@ -1,0 +1,13 @@
+package bio.terra.common.fixtures;
+
+import bio.terra.stairway.FlightMap;
+import java.util.Map;
+
+public class FlightContextFixtures {
+
+  public static FlightMap makeContextMap(Map<String, Object> context) {
+    FlightMap fMap = new FlightMap();
+    context.forEach(fMap::put);
+    return fMap;
+  }
+}

--- a/src/test/java/bio/terra/common/fixtures/FlightContextFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/FlightContextFixtures.java
@@ -5,6 +5,10 @@ import java.util.Map;
 
 public class FlightContextFixtures {
 
+  /**
+   * Create a flight context map based on a passed in map. This is helpful for mocking flight step
+   * executions.
+   */
   public static FlightMap makeContextMap(Map<String, Object> context) {
     FlightMap fMap = new FlightMap();
     context.forEach(fMap::put);

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -181,6 +181,7 @@ public class DataRepoFixtures {
       boolean usePetAccount,
       boolean selfHosted,
       boolean dedicatedServiceAccount,
+      boolean predictableIds,
       DatasetRequestModelPolicies policies)
       throws Exception {
     DatasetRequestModel requestModel = jsonLoader.loadObject(filename, DatasetRequestModel.class);
@@ -190,6 +191,7 @@ public class DataRepoFixtures {
       requestModel.setCloudPlatform(cloudPlatform);
     }
     requestModel.experimentalSelfHosted(selfHosted);
+    requestModel.experimentalPredictableFileIds(predictableIds);
     requestModel.dedicatedIngestServiceAccount(dedicatedServiceAccount);
     requestModel.policies(policies);
     String json = TestUtils.mapToJson(requestModel);
@@ -231,6 +233,7 @@ public class DataRepoFixtures {
             false,
             true,
             dedicatedServiceAccount,
+            false,
             null);
     return waitForDatasetCreate(user, jobResponse);
   }
@@ -238,7 +241,8 @@ public class DataRepoFixtures {
   public DatasetSummaryModel createDatasetWithOwnServiceAccount(
       TestConfiguration.User user, UUID profileId, String fileName) throws Exception {
     DataRepoResponse<JobModel> jobResponse =
-        createDatasetRaw(user, profileId, fileName, CloudPlatform.GCP, false, false, true, null);
+        createDatasetRaw(
+            user, profileId, fileName, CloudPlatform.GCP, false, false, true, false, null);
     return waitForDatasetCreate(user, jobResponse);
   }
 
@@ -251,7 +255,7 @@ public class DataRepoFixtures {
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
         createDatasetRaw(
-            user, profileId, filename, cloudPlatform, usePetAccount, false, false, null);
+            user, profileId, filename, cloudPlatform, usePetAccount, false, false, false, null);
     return waitForDatasetCreate(user, jobResponse);
   }
 
@@ -263,7 +267,7 @@ public class DataRepoFixtures {
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
         createDatasetRaw(
-            user, profileId, filename, CloudPlatform.GCP, false, false, false, policies);
+            user, profileId, filename, CloudPlatform.GCP, false, false, false, false, policies);
     return waitForDatasetCreate(user, jobResponse);
   }
 
@@ -292,7 +296,8 @@ public class DataRepoFixtures {
       CloudPlatform cloudPlatform)
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
-        createDatasetRaw(user, profileId, filename, cloudPlatform, false, false, false, null);
+        createDatasetRaw(
+            user, profileId, filename, cloudPlatform, false, false, false, false, null);
     assertTrue("dataset create launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
     assertTrue(
         "dataset create launch response is present", jobResponse.getResponseObject().isPresent());

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -73,6 +73,8 @@ public class FileTest extends UsersBase {
 
   private static Logger logger = LoggerFactory.getLogger(FileTest.class);
 
+  private static final int NUM_FILES = 100;
+
   @Autowired private AuthService authService;
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
@@ -179,42 +181,42 @@ public class FileTest extends UsersBase {
   // The purpose of these tests is to ingest files using the bulk mode in various permutations
   @Test
   public void bulkFileLoadTestTdrHostedRandomIdFile() throws Exception {
-    bulkFileLoadTest(100, false, false, false);
+    bulkFileLoadTest(NUM_FILES, false, false, false);
   }
 
   @Test
   public void bulkFileLoadTestTdrHostedRandomIdArray() throws Exception {
-    bulkFileLoadTest(100, false, false, true);
+    bulkFileLoadTest(NUM_FILES, false, false, true);
   }
 
   @Test
   public void bulkFileLoadTestTdrHostedPredictableIdFile() throws Exception {
-    bulkFileLoadTest(100, false, true, false);
+    bulkFileLoadTest(NUM_FILES, false, true, false);
   }
 
   @Test
   public void bulkFileLoadTestTdrHostedPredictableIdArray() throws Exception {
-    bulkFileLoadTest(100, false, true, true);
+    bulkFileLoadTest(NUM_FILES, false, true, true);
   }
 
   @Test
   public void bulkFileLoadTestSelfHostedRandomIdFile() throws Exception {
-    bulkFileLoadTest(100, true, false, false);
+    bulkFileLoadTest(NUM_FILES, true, false, false);
   }
 
   @Test
   public void bulkFileLoadTestSelfHostedRandomIdArray() throws Exception {
-    bulkFileLoadTest(100, true, false, true);
+    bulkFileLoadTest(NUM_FILES, true, false, true);
   }
 
   @Test
   public void bulkFileLoadTestSelfHostedPredictableIdFile() throws Exception {
-    bulkFileLoadTest(100, true, true, false);
+    bulkFileLoadTest(NUM_FILES, true, true, false);
   }
 
   @Test
   public void bulkFileLoadTestSelfHostedPredictableIdArray() throws Exception {
-    bulkFileLoadTest(100, true, true, true);
+    bulkFileLoadTest(NUM_FILES, true, true, true);
   }
 
   private void bulkFileLoadTest(
@@ -236,9 +238,10 @@ public class FileTest extends UsersBase {
       logger.info(
           "bulkFileLoadTest loading " + filesToLoad + " files into dataset id " + datasetId);
 
+      String tailPath = "/fileloadprofiletest/1KBfile.txt";
+      String sourcePath = "gs://jade-testdata-uswestregion" + tailPath;
+
       for (int i = 0; i < filesToLoad; i++) {
-        String tailPath = "/fileloadprofiletest/1KBfile.txt";
-        String sourcePath = "gs://jade-testdata-uswestregion" + tailPath;
         String targetPath = "/" + loadTag + "/" + i + tailPath;
 
         BulkLoadFileModel model = new BulkLoadFileModel().mimeType("application/binary");

--- a/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
@@ -96,12 +96,14 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
         dataRepoFixtures.createDataset(steward(), profileId, "dataset-ingest-combined-array.json");
     datasetId = datasetSummaryModel.getId();
 
+    // Initial uses bulk mode
     IngestRequestModel ingestRequest =
         new IngestRequestModel()
             .format(IngestRequestModel.FormatEnum.JSON)
             .ignoreUnknownValues(false)
             .maxBadRecords(0)
             .table("sample_vcf")
+            .bulkMode(true)
             .path(
                 "gs://jade-testdata-useastregion/dataset-ingest-combined-control-duplicates-array.json");
 

--- a/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
@@ -39,11 +39,11 @@ public class FileIdServiceTest {
   }
 
   @Test
-  public void testPredictableUUIDWithNotMD5Equals() {
+  public void testPredictableUUIDWithNoMD5Equals() {
     when(dataset.hasPredictableFileIds()).thenReturn(true);
-    FSItem fsItem1 = new FSFile().path("/foo/bar").size(123L);
+    FSItem fsItem1 = new FSFile().path("/foo/bar").size(123L).checksumMd5(null);
 
-    FSItem fsItem2 = new FSFile().path("/foo/bar").size(123L);
+    FSItem fsItem2 = new FSFile().path("/foo/bar").size(123L).checksumMd5(null);
     assertEquals(
         "IDs match",
         service.calculateFileId(dataset, fsItem1),

--- a/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
@@ -39,6 +39,18 @@ public class FileIdServiceTest {
   }
 
   @Test
+  public void testPredictableUUIDWithNotMD5Equals() {
+    when(dataset.hasPredictableFileIds()).thenReturn(true);
+    FSItem fsItem1 = new FSFile().path("/foo/bar").size(123L);
+
+    FSItem fsItem2 = new FSFile().path("/foo/bar").size(123L);
+    assertEquals(
+        "IDs match",
+        service.calculateFileId(dataset, fsItem1),
+        service.calculateFileId(dataset, fsItem2));
+  }
+
+  @Test
   public void testPredictableUUIDNotEqualsWhenRandom() {
     when(dataset.hasPredictableFileIds()).thenReturn(false);
     FSItem fsItem1 = new FSFile().path("/foo/bar").size(123L).checksumMd5("foo");

--- a/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertThrows;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
@@ -156,9 +157,15 @@ public class FileMetadataUtilsTest {
 
   @Test
   public void extractDirectoryPathsTest() {
+    assertThat(FileMetadataUtils.extractDirectoryPaths("/foo.txt"), equalTo(List.of("/")));
+
+    assertThat(FileMetadataUtils.extractDirectoryPaths("/"), equalTo(List.of("/")));
+
     assertThat(
         FileMetadataUtils.extractDirectoryPaths("/foo/bar/baz.txt"),
         equalTo(List.of("/", "/foo", "/foo/bar")));
+
+    assertThrows(IllegalArgumentException.class, () -> FileMetadataUtils.extractDirectoryPaths(""));
   }
 
   private List<FireStoreDirectoryEntry> initTestEntries(int numDirectories) {

--- a/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
@@ -149,6 +149,13 @@ public class FileMetadataUtilsTest {
             "/_dr_/test/path-4"));
   }
 
+  @Test
+  public void extractDirectoryPathsTest() {
+    assertThat(
+        FileMetadataUtils.extractDirectoryPaths("/foo/bar/baz.txt"),
+        equalTo(List.of("/", "/foo", "/foo/bar")));
+  }
+
   private List<FireStoreDirectoryEntry> initTestEntries(int numDirectories) {
     List<FireStoreDirectoryEntry> testEntries = new ArrayList<>();
     // Add 4 files per different directory path

--- a/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.hasKey;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +20,10 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles({"google", "unittest"})
 @Category(Unit.class)
+@SuppressFBWarnings(
+    value = "DMI",
+    justification =
+        "This fails with not allowing absolute paths but they're not file paths in our case")
 public class FileMetadataUtilsTest {
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStepTest.java
@@ -1,0 +1,398 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import static bio.terra.common.fixtures.FlightContextFixtures.makeContextMap;
+import static bio.terra.service.filedata.DrsService.getLastNameFromPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.BulkLoadArrayResultModel;
+import bio.terra.model.BulkLoadFileModel;
+import bio.terra.model.BulkLoadHistoryModel;
+import bio.terra.model.BulkLoadResultModel;
+import bio.terra.model.FileLoadModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.flight.ingest.IngestMapKeys;
+import bio.terra.service.filedata.FSFileInfo;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.storage.StorageException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.curator.shaded.com.google.common.base.Charsets;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+@AutoConfigureMockMvc
+public class IngestBulkGcpStepTest {
+
+  private static final String LOAD_TAG = "loadtag";
+  private static final UUID PROFILE_ID = UUID.randomUUID();
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticatedUserRequest.builder()
+          .setSubjectId("DatasetUnit")
+          .setEmail("dataset@unit.com")
+          .setToken("token")
+          .build();
+
+  @MockBean private GcsPdao gcsPdao;
+  @MockBean private ObjectMapper objectMapper;
+  @MockBean private FireStoreDao fileDao;
+  @MockBean private FileService fileService;
+  @MockBean private FlightContext context;
+
+  private ExecutorService executor;
+  private Dataset dataset;
+
+  @Before
+  public void setUp() throws Exception {
+    executor =
+        new ThreadPoolExecutor(10, 10, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(100));
+
+    dataset =
+        new Dataset()
+            .id(UUID.randomUUID())
+            .name("test_ds")
+            .projectResource(new GoogleProjectResource().googleProjectId("google_project_id"));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testHappyPathRandomFileIdsNotSelfHosted() throws InterruptedException {
+    happyPathTest(false, false);
+  }
+
+  @Test
+  public void testHappyPathPredictableFileIdsNotSelfHosted() throws InterruptedException {
+    happyPathTest(true, false);
+  }
+
+  @Test
+  public void testHappyPathRandomFileIdsSelfHosted() throws InterruptedException {
+    happyPathTest(false, true);
+  }
+
+  @Test
+  public void testHappyPathPredictableFileIdsSelfHosted() throws InterruptedException {
+    happyPathTest(true, true);
+  }
+
+  private void happyPathTest(boolean predictableFileIds, boolean selfHosted)
+      throws InterruptedException {
+    dataset.predictableFileIds(predictableFileIds);
+    dataset.getDatasetSummary().selfHosted(selfHosted);
+
+    IngestBulkGcpStep ingestStep =
+        initialize(
+            List.of(
+                new FileToLoad(
+                    new BulkLoadFileModel().sourcePath("gs://s/f1").targetPath("/t/f1"), false),
+                new FileToLoad(
+                    new BulkLoadFileModel().sourcePath("gs://s/f2").targetPath("/t/f2"), false),
+                new FileToLoad(
+                    new BulkLoadFileModel().sourcePath("gs://s/f3").targetPath("/t/f3"), false)));
+
+    StepResult stepResult = ingestStep.doStep(context);
+    assertThat(
+        "step ran successfully",
+        stepResult.getStepStatus(),
+        equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    assertThat(
+        "three files were attempted and all succeeded",
+        context
+            .getWorkingMap()
+            .get(IngestMapKeys.BULK_LOAD_RESULT, BulkLoadArrayResultModel.class)
+            // Clear load summary for testing
+            .loadFileResults(List.of()),
+        equalTo(
+            new BulkLoadArrayResultModel()
+                .loadSummary(
+                    new BulkLoadResultModel()
+                        .loadTag(LOAD_TAG)
+                        .totalFiles(3)
+                        .succeededFiles(3)
+                        .failedFiles(0)
+                        .notTriedFiles(0))
+                .loadFileResults(List.of())));
+
+    assertThat(
+        "file details (target path) are there to be loaded into load history table",
+        context
+            .getWorkingMap()
+            .get(
+                IngestMapKeys.BULK_LOAD_HISTORY_RESULT,
+                new TypeReference<List<BulkLoadHistoryModel>>() {})
+            .stream()
+            .map(BulkLoadHistoryModel::getTargetPath)
+            .toList(),
+        containsInAnyOrder("/t/f1", "/t/f2", "/t/f3"));
+  }
+
+  @Test
+  public void testFailPathRandomFileIdsNotSelfHosted() throws InterruptedException {
+    failPathTest(false, false);
+  }
+
+  @Test
+  public void testFailPathPredictableFileIdsNotSelfHosted() throws InterruptedException {
+    failPathTest(true, false);
+  }
+
+  @Test
+  public void testFailPathRandomFileIdsSelfHosted() throws InterruptedException {
+    failPathTest(false, true);
+  }
+
+  @Test
+  public void testFailPathPredictableFileIdsSelfHosted() throws InterruptedException {
+    failPathTest(true, true);
+  }
+
+  public void failPathTest(boolean predictableFileIds, boolean selfHosted)
+      throws InterruptedException {
+    dataset.predictableFileIds(predictableFileIds);
+    dataset.getDatasetSummary().selfHosted(selfHosted);
+
+    IngestBulkGcpStep ingestStep =
+        initialize(
+            List.of(
+                new FileToLoad(
+                    new BulkLoadFileModel().sourcePath("gs://s/f1").targetPath("/t/f1"), false),
+                new FileToLoad(
+                    new BulkLoadFileModel().sourcePath("gs://s/f2").targetPath("/t/f2"), true),
+                new FileToLoad(
+                    new BulkLoadFileModel().sourcePath("gs://s/f3").targetPath("/t/f3"), false)));
+
+    StepResult stepResult = ingestStep.doStep(context);
+    assertThat(
+        "step ran successfully",
+        stepResult.getStepStatus(),
+        equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    assertThat(
+        "three files were attempted and all succeeded",
+        context
+            .getWorkingMap()
+            .get(IngestMapKeys.BULK_LOAD_RESULT, BulkLoadArrayResultModel.class)
+            // Clear load summary for testing
+            .loadFileResults(List.of()),
+        equalTo(
+            new BulkLoadArrayResultModel()
+                .loadSummary(
+                    new BulkLoadResultModel()
+                        .loadTag(LOAD_TAG)
+                        .totalFiles(3)
+                        .succeededFiles(2)
+                        .failedFiles(1)
+                        .notTriedFiles(0))
+                .loadFileResults(List.of())));
+
+    List<BulkLoadHistoryModel> loadHistoryModels =
+        context
+            .getWorkingMap()
+            .get(IngestMapKeys.BULK_LOAD_HISTORY_RESULT, new TypeReference<>() {});
+
+    assertThat(
+        "file details (target path) are there to be loaded into load history table",
+        loadHistoryModels.stream().map(BulkLoadHistoryModel::getTargetPath).toList(),
+        containsInAnyOrder("/t/f1", "/t/f2", "/t/f3"));
+
+    loadHistoryModels.forEach(
+        m -> {
+          if (m.getTargetPath().equals("/t/f2")) {
+            assertThat("the failing file has an error", m.getError(), equalTo("Error from Google"));
+          } else {
+            assertThat("succeeding files have not error", m.getError(), emptyOrNullString());
+          }
+        });
+  }
+
+  @Test
+  public void testIdConflicts() throws InterruptedException {
+    IngestBulkGcpStep ingestStep =
+        initialize(
+            List.of(
+                new FileToLoad(
+                    new BulkLoadFileModel().sourcePath("gs://s/f1").targetPath("/t/f1"), false),
+                new FileToLoad(
+                    new BulkLoadFileModel().sourcePath("gs://s/f2").targetPath("/t/f2"), false),
+                new FileToLoad(
+                    new BulkLoadFileModel().sourcePath("gs://s/f3").targetPath("/t/f3"), false)));
+
+    UUID existingFileId = UUID.randomUUID();
+    // Mock so that the 2 second file (gs://s/f2) is a conflict
+    when(fileDao.upsertDirectoryEntries(eq(dataset), any()))
+        .thenAnswer(
+            a -> {
+              List<FireStoreDirectoryEntry> newEntries = a.getArgument(1);
+              return Map.of(UUID.fromString(newEntries.get(1).getFileId()), existingFileId);
+            });
+    StepResult stepResult = ingestStep.doStep(context);
+    assertThat(
+        "step ran successfully",
+        stepResult.getStepStatus(),
+        equalTo(StepStatus.STEP_RESULT_SUCCESS));
+
+    List<BulkLoadHistoryModel> loadHistoryModels =
+        context
+            .getWorkingMap()
+            .get(IngestMapKeys.BULK_LOAD_HISTORY_RESULT, new TypeReference<>() {});
+
+    BulkLoadHistoryModel preExistingFile =
+        loadHistoryModels.stream()
+            .filter(m -> m.getTargetPath().equals("/t/f2"))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(
+        "the existing id is reused in case of collision",
+        preExistingFile.getFileId(),
+        equalTo(existingFileId.toString()));
+  }
+
+  private record FileToLoad(BulkLoadFileModel model, boolean shouldFail) {}
+
+  private IngestBulkGcpStep initialize(List<FileToLoad> files) {
+    // Mock common flight context
+    when(context.getInputParameters())
+        .thenReturn(makeContextMap(Map.of(FileMapKeys.BUCKET_INFO, new GoogleBucketResource())));
+    FlightMap workingMap = new FlightMap();
+    when(context.getWorkingMap()).thenReturn(workingMap);
+
+    // Mock the copy operation for the files
+    when(gcsPdao.copyFile(eq(dataset), any(), any(), any()))
+        .thenAnswer(
+            a -> {
+              Dataset dataset = a.getArgument(0);
+              FileLoadModel fileLoadModel = a.getArgument(1);
+              boolean shouldFail =
+                  files.stream()
+                      .filter(
+                          f ->
+                              f.model().getSourcePath().equals(fileLoadModel.getSourcePath())
+                                  && f.model()
+                                      .getTargetPath()
+                                      .equals(fileLoadModel.getTargetPath()))
+                      .findFirst()
+                      .map(FileToLoad::shouldFail)
+                      .orElse(true);
+              String fileId = a.getArgument(2);
+              GoogleBucketResource bucketResource = a.getArgument(3);
+
+              if (shouldFail) {
+                throw new StorageException(500, "Error from Google");
+              }
+
+              String hashingString = fileLoadModel.getSourcePath() + fileLoadModel.getTargetPath();
+              if (dataset.hasPredictableFileIds()) {
+                fileId = UUID.nameUUIDFromBytes(hashingString.getBytes(Charsets.UTF_8)).toString();
+              }
+              return new FSFileInfo()
+                  .fileId(fileId)
+                  .cloudPath(
+                      "gs://%s/%s/%s/%s"
+                          .formatted(
+                              bucketResource.getName(),
+                              dataset.getId().toString(),
+                              fileId,
+                              getLastNameFromPath(fileLoadModel.getTargetPath())))
+                  .checksumMd5(DigestUtils.md5Hex(hashingString))
+                  .size((long) hashingString.length())
+                  .createdDate(Instant.now().toString());
+            });
+
+    // Mock the copy operation for the files
+    when(gcsPdao.linkSelfHostedFile(any(), any(), any()))
+        .thenAnswer(
+            a -> {
+              FileLoadModel fileLoadModel = a.getArgument(0);
+              boolean shouldFail =
+                  files.stream()
+                      .filter(
+                          f ->
+                              f.model().getSourcePath().equals(fileLoadModel.getSourcePath())
+                                  && f.model()
+                                      .getTargetPath()
+                                      .equals(fileLoadModel.getTargetPath()))
+                      .findFirst()
+                      .map(FileToLoad::shouldFail)
+                      .orElse(true);
+              String fileId = a.getArgument(1);
+
+              if (shouldFail) {
+                throw new StorageException(500, "Error from Google");
+              }
+
+              String hashingString = fileLoadModel.getSourcePath() + fileLoadModel.getTargetPath();
+              if (dataset.hasPredictableFileIds()) {
+                fileId = UUID.nameUUIDFromBytes(hashingString.getBytes(Charsets.UTF_8)).toString();
+              }
+              return new FSFileInfo()
+                  .fileId(fileId)
+                  .cloudPath(fileLoadModel.getSourcePath())
+                  .checksumMd5(DigestUtils.md5Hex(hashingString))
+                  .size((long) hashingString.length())
+                  .createdDate(Instant.now().toString());
+            });
+
+    // Instantiate the step
+    return new IngestBulkGcpStep(
+        LOAD_TAG,
+        PROFILE_ID,
+        TEST_USER,
+        gcsPdao,
+        objectMapper,
+        dataset,
+        0,
+        0,
+        fileDao,
+        fileService,
+        executor,
+        10) {
+      @Override
+      protected Stream<BulkLoadFileModel> getModelsStream(FlightContext context) {
+        return files.stream().map(FileToLoad::model);
+      }
+    };
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStepTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BulkLoadArrayResultModel;
 import bio.terra.model.BulkLoadFileModel;
@@ -64,11 +65,7 @@ public class IngestBulkGcpStepTest {
   private static final String LOAD_TAG = "loadtag";
   private static final UUID PROFILE_ID = UUID.randomUUID();
   private static final AuthenticatedUserRequest TEST_USER =
-      AuthenticatedUserRequest.builder()
-          .setSubjectId("DatasetUnit")
-          .setEmail("dataset@unit.com")
-          .setToken("token")
-          .build();
+      AuthenticationFixtures.randomUserRequest();
 
   @MockBean private GcsPdao gcsPdao;
   @MockBean private ObjectMapper objectMapper;

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -171,6 +171,7 @@ public class GcsPdaoTest {
     testCopyBlob(true);
   }
 
+  @Test
   public void testCopyBlobWithoutPredictableFileId() {
     testCopyBlob(false);
   }

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -61,8 +61,8 @@ public class GcsPdaoTest {
   @MockBean private GoogleResourceDao googleResourceDao;
   @Autowired private GcsPdao gcsPdao;
 
-  private Storage storage = StorageOptions.getDefaultInstance().getService();
-  private String projectId = StorageOptions.getDefaultProjectId();
+  private final Storage storage = StorageOptions.getDefaultInstance().getService();
+  private final String projectId = StorageOptions.getDefaultProjectId();
 
   @Before
   public void setUp() throws Exception {

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -3,13 +3,20 @@ package bio.terra.service.filedata.google.gcs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Connected;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.FileLoadModel;
 import bio.terra.service.common.gcs.GcsUriUtils;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.FSFileInfo;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
 import com.google.cloud.storage.Blob;
@@ -21,8 +28,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.junit.Assert;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -71,11 +79,11 @@ public class GcsPdaoTest {
       Blob blob =
           GcsPdao.getBlobFromGsPath(
               storage, "gs://" + testBlob.getBucket() + "/" + testBlob.getName(), projectId);
-      Assert.assertNotNull(blob);
+      assertNotNull(blob);
 
       BlobId actualId = blob.getBlobId();
-      Assert.assertEquals(testBlob.getBucket(), actualId.getBucket());
-      Assert.assertEquals(testBlob.getName(), actualId.getName());
+      assertEquals(testBlob.getBucket(), actualId.getBucket());
+      assertEquals(testBlob.getName(), actualId.getName());
     } finally {
       storage.delete(testBlob);
     }
@@ -91,11 +99,11 @@ public class GcsPdaoTest {
       Blob blob =
           GcsPdao.getBlobFromGsPath(
               storage, "gs://" + testBlob.getBucket() + "/" + testBlob.getName(), projectId);
-      Assert.assertNotNull(blob);
+      assertNotNull(blob);
 
       BlobId actualId = blob.getBlobId();
-      Assert.assertEquals(testBlob.getBucket(), actualId.getBucket());
-      Assert.assertEquals(testBlob.getName(), actualId.getName());
+      assertEquals(testBlob.getBucket(), actualId.getBucket());
+      assertEquals(testBlob.getName(), actualId.getName());
     } finally {
       storage.delete(testBlob);
     }
@@ -155,6 +163,55 @@ public class GcsPdaoTest {
 
     } finally {
       storage.delete(blobIds);
+    }
+  }
+
+  @Test
+  public void testCopyBlobWithPredictableFileId() {
+    testCopyBlob(true);
+  }
+
+  public void testCopyBlobWithoutPredictableFileId() {
+    testCopyBlob(false);
+  }
+
+  private void testCopyBlob(boolean usePredictableFileId) {
+    BlobId sourceBlob =
+        BlobId.of(testConfig.getIngestbucket(), UUID.randomUUID() + "#" + UUID.randomUUID());
+    String sourcePath = "gs://" + sourceBlob.getBucket() + "/" + sourceBlob.getName();
+    FileLoadModel fileLoadModel = new FileLoadModel().sourcePath(sourcePath).targetPath("/foo/bar");
+    try {
+      String fileId = usePredictableFileId ? null : UUID.randomUUID().toString();
+      Dataset dataset =
+          new Dataset()
+              .id(UUID.randomUUID())
+              .predictableFileIds(usePredictableFileId)
+              .name("test_dataset");
+      // Try to copy using predictable and non-predicatble file ids
+      gcsPdao.createGcsFile(sourceBlob, projectId);
+      gcsPdao.writeStreamToCloudFile(sourcePath, Stream.of("foo", "bar"), projectId);
+      // Copy the file once:
+      GoogleBucketResource targetBucket =
+          new GoogleBucketResource()
+              .resourceId(UUID.randomUUID())
+              .name(sourceBlob.getBucket())
+              .projectResource(new GoogleProjectResource().googleProjectId(projectId));
+      FSFileInfo fsFileInfo = gcsPdao.copyFile(dataset, fileLoadModel, fileId, targetBucket);
+      String initialTime = fsFileInfo.getCreatedDate();
+      TimeUnit.SECONDS.sleep(1);
+      assertThat(
+          "times between copies are the same since the file is the same",
+          gcsPdao.copyFile(dataset, fileLoadModel, fileId, targetBucket).getCreatedDate(),
+          equalTo(initialTime));
+      storage.delete(BlobId.fromGsUtilUri(fsFileInfo.getCloudPath()));
+      assertThat(
+          "times between copies is different since file was deleted",
+          gcsPdao.copyFile(dataset, fileLoadModel, fileId, targetBucket).getCreatedDate(),
+          not(equalTo(initialTime)));
+    } catch (InterruptedException e) {
+      storage.delete(sourceBlob);
+    } finally {
+      storage.delete(sourceBlob);
     }
   }
 

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -86,6 +86,7 @@ public class JobPermissionTest extends UsersBase {
             false,
             false,
             false,
+            false,
             new DatasetRequestModelPolicies().addCustodiansItem(custodian().getEmail()));
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.waitForDatasetCreate(steward(), jobResponse);


### PR DESCRIPTION
OK, this is kind of a big one but here we go.  This PR introduces a bulk mode for GCP specifically for dealing with large numbers of files

The problem stems from the fact that the current ingest mechanism splits all file ingests into individual subflights. There's a definite advantage to this when there are smaller numbers of files (e.g. < 10K) since it has all sort so safeguards that are easier to read (by virtue of living in individual steps).  The draw back however is that it does not scale.  We see timings getting exponentially worse as we add more files.

All of this is to say: we are not getting rid of the current ingest mechanism but are adding an new mode of ingest which is specified by setting `bulkMode: true` in the various file and data ingest APIs. (the default is false)

I took pains in the PR to reduce chattiness with the postgres db (which is where a ton of bottleneck comes from) and to reduce where I could the amount of data needed to be stored in the stairway db (by explicitly unsetting working map values so that they don't keep getting copied on subsequent steps)

The main crux of the PR is in the `IngestBulkGcpStep` step.  This step contains most of the logic needed to ingest files:
- it copies files (added some logic to make sure that files aren't copied if they already exist in the target)
- it bulk ingest directory information into firestore (logic and time savings there)
- it bulk ingests file metadata into firestore (logic and time savings here)
- it foregoes the load / load lock tables in favor of storing a blob of file load info in the stairway DB and just using that to populate the load history table

As you can imagine, that's a whole lot moving parts which is why this PR is so big.  I tried really hard to minimize the amount of new integration tests added and tried to focus my efforts on unit and connected tests.

From a metrics standpoint, it's worth noting: I'm able to do an ingest of 100K files in self hosted mode in ~1h10minutes (down from roughly 20 hours)

Drivebys:
- I changed the query logging for BQ queries to debug mode since there were some truly massive log statements and it didn't seem useful