### PR TITLE
[DR-2930] Increase Sam read timeout from 10s default -> 60s

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -91,7 +92,7 @@ public class SamIam implements IamProviderInterface {
     // call continuing to execute and possibly succeeding.
     int operationTimeoutSeconds =
         configurationService.getParameterValue(ConfigEnum.SAM_OPERATION_TIMEOUT_SECONDS);
-    apiClient.setReadTimeout(operationTimeoutSeconds * 1000);
+    apiClient.setReadTimeout((int) Duration.ofSeconds(operationTimeoutSeconds).toMillis());
 
     return apiClient.setBasePath(samConfig.getBasePath());
   }

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -85,8 +85,14 @@ public class SamIam implements IamProviderInterface {
     ApiClient apiClient = new ApiClient();
     apiClient.setAccessToken(accessToken);
     apiClient.setUserAgent("OpenAPI-Generator/1.0.0 java"); // only logs an error in sam
-    apiClient.setConnectTimeout(
-        configurationService.getParameterValue(ConfigEnum.SAM_OPERATION_TIMEOUT_SECONDS));
+
+    // Sometimes Sam calls can take longer than the OkHttp default of 10 seconds to return a
+    // response.  In those cases, we can see socket timeout exceptions despite the underlying Sam
+    // call continuing to execute and possibly succeeding.
+    int operationTimeoutSeconds =
+        configurationService.getParameterValue(ConfigEnum.SAM_OPERATION_TIMEOUT_SECONDS);
+    apiClient.setReadTimeout(operationTimeoutSeconds * 1000);
+
     return apiClient.setBasePath(samConfig.getBasePath());
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2930

**Background**

Nate reported that trying to remove Firecloud Group emails from snapshot policy members in TDR prod results in a 500 - socket timeout exception.  This specific operation is not something that happens regularly in prod. https://broadinstitute.slack.com/archives/CD4HBRFMG/p1675990435235409

These attempts to remove the group ultimately succeed in Sam but are not reported to the user.  This is because we don't touch Sam's `ApiClient` [read timeout](https://www.baeldung.com/okhttp-timeouts#read), so it uses the OkHttp default value of 10 seconds.  Our `SamRetry` utility attempted this call three times with waits in between, but no attempt waited long enough for the response to come through:

![image (1)](https://user-images.githubusercontent.com/79769153/218545488-1eacf192-dd28-4433-bd1a-2487fcac8e85.png)

The underlying Sam query presently walks a table to facilitate the delete; in production this table is quite large, so the request regularly takes a little over 10 seconds to finish no matter the size of the Firecloud group being removed.  Doug opened a Sam PR to optimize this query to leverage an index instead, which will drive down the response time: https://github.com/broadinstitute/sam/pull/986

**Changes**

Even with the Sam query optimized, we'd like our calls to Sam to be more resilient to slower response times.

I found [existing code](https://github.com/DataBiosphere/jade-data-repo/pull/1256) which intended to override Sam's `ApiClient` [connect timeout](https://www.baeldung.com/okhttp-timeouts#connect) from 10s -> 60s, but instead overrode it to 60ms. Since we haven't seen excessive socket timeout exceptions stemming from this short connect timeout, I removed the override so that it will use the default instead.

Instead we override Sam's ApiClient [read timeout](https://www.baeldung.com/okhttp-timeouts#read) from 10s -> 60s.  In cases where we take advantage of the longer timeout, we may not retry as frequently (if at all) since we use the same operation timeout of 60s when determining whether to initiate a retry attempt.