### PR TITLE
[DR-2933] AzureIntegrationTest teardown shouldn't exit prematurely

### DIFF
--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -124,8 +124,10 @@ public class DataRepoFixtures {
     DataRepoResponse<BillingProfileModel> postResponse =
         dataRepoClient.waitForResponse(user, jobResponse, new TypeReference<>() {});
 
-    return validateResponse(
-        postResponse, "billing profile create", HttpStatus.CREATED, jobResponse);
+    BillingProfileModel billingProfile =
+        validateResponse(postResponse, "billing profile create", HttpStatus.CREATED, jobResponse);
+    logger.info("Billing profile created: {}", billingProfile);
+    return billingProfile;
   }
 
   // Create a Billing Profile model: expect successful creation
@@ -275,7 +277,10 @@ public class DataRepoFixtures {
 
     DataRepoResponse<DatasetSummaryModel> response =
         dataRepoClient.waitForResponseLog(user, jobResponse, new TypeReference<>() {});
-    return validateResponse(response, "dataset create", HttpStatus.CREATED, jobResponse);
+    DatasetSummaryModel datasetSummary =
+        validateResponse(response, "dataset create", HttpStatus.CREATED, jobResponse);
+    logger.info("Dataset created: {}", datasetSummary);
+    return datasetSummary;
   }
 
   public void createDatasetError(
@@ -662,7 +667,10 @@ public class DataRepoFixtures {
 
     DataRepoResponse<SnapshotSummaryModel> snapshotResponse =
         dataRepoClient.waitForResponse(user, jobResponse, new TypeReference<>() {});
-    return validateResponse(snapshotResponse, "snapshot create", HttpStatus.CREATED, jobResponse);
+    SnapshotSummaryModel snapshotSummary =
+        validateResponse(snapshotResponse, "snapshot create", HttpStatus.CREATED, jobResponse);
+    logger.info("Snapshot created: {}", snapshotSummary);
+    return snapshotSummary;
   }
 
   public DataRepoResponse<SnapshotModel> getSnapshotRaw(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2933

We've recently seen a few cases where a transient error in one of our `AzureIntegrationTest`s was then followed by `cannot reuse existing application deployment integrationapp from profile <x> with a different profile <y>` errors from the other attempts in the suite.  Example: [Build Scan™ | Gradle Cloud Services](https://scans.gradle.com/s/wieyndsj4hvbu/tests/:testIntegration/bio.terra.integration.AzureIntegrationTest/datasetIngestFileHappyPath?top-execution=1)

This seemed like a symptom of tests not cleaning up after themselves in the way we expected.

When an `AzureIntegrationTest` had 1+ snapshots to delete on teardown, the teardown method would not complete since we tried to remove items from the snapshot ID list while iterating over it.  Locally I saw this yield a `ConcurrentModificationException`: https://mkyong.com/java/java-how-to-remove-items-from-a-list-while-iterating/#javautilconcurrentmodificationexception

Concretely, what this meant is that we would never get to the billing profile delete step in the teardown, and subsequent test runs in the same test suite would fail fast with the billing profile error above.

**Changes**

- Updated method `AzureIntegrationTest.teardown` to no longer remove elements from the snapshot ID list or null out instance-level resource IDs: these instance variables will all be reset in the test setup method.
- Moved contents of helper method `AzureIntegrationTest.clearEnvironment` to `teardown`, and removed `clearEnvironment`: we should be handling this teardown in one place, rather than calling `clearEnvironment` at the end of test runs while also trying to clean up resources in the teardown method (which runs on both expected and premature test exits).  Besides, if we encounter a failure while trying to clean up resources in `teardown` we won't be able to clean up parent resources anyway (i.e. can't delete a dataset or billing profile when associated snapshots still exist).
- Log billing profiles, snapshot summaries, and dataset summaries created in `DataRepoFixtures` for easier debugging in case of test error.  None of these objects are large, and we might end up in a situation where we're debugging a test failure on a test environment that has since been repurposed for another test run.

**Verification**

Locally I modified one of the Azure tests to throw a `RuntimeException` at the same point we encountered a transient error in the linked Gradle scan above.  I observed that the test cleaned up all of its resources in teardown -- snapshots, dataset and billing profile -- and subsequent test runs in the same test suite succeeded without issue.

Within this PR, one of the Azure tests was flaky but its flakiness didn’t prevent it and other tests from ultimately succeeding: https://scans.gradle.com/s/skxla2bz6umh4/tests/:testIntegration/bio.terra.integration.AzureIntegrationTest/datasetIngestFileHappyPath?top-execution=1