### PR TITLE
[DR-2931] SamIam API construction moved to new SamApiService

### DIFF
--- a/src/main/java/bio/terra/app/model/rawls/WorkspaceResponse.java
+++ b/src/main/java/bio/terra/app/model/rawls/WorkspaceResponse.java
@@ -52,16 +52,12 @@ public class WorkspaceResponse {
   }
 
   public WorkspacePolicyModel toWorkspacePolicyModel(
-      List<ResourcePolicyModel> resourcePolicyModels, String terraBasePath) {
+      List<ResourcePolicyModel> resourcePolicyModels) {
     return new WorkspacePolicyModel()
         .workspaceId(UUID.fromString(workspace.getWorkspaceId()))
         .workspaceName(workspace.getName())
         .workspaceNamespace(workspace.getNamespace())
-        .workspacePolicies(PolicyUtils.resourcePolicyToPolicyModel(resourcePolicyModels))
-        .workspaceLink(
-            String.format(
-                "%s/#workspaces/%s/%s",
-                terraBasePath, workspace.getNamespace(), workspace.getName()));
+        .workspacePolicies(PolicyUtils.resourcePolicyToPolicyModel(resourcePolicyModels));
   }
 
   @Override

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamApiService.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamApiService.java
@@ -1,0 +1,73 @@
+package bio.terra.service.auth.iam.sam;
+
+import bio.terra.app.configuration.SamConfiguration;
+import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.configuration.ConfigurationService;
+import java.util.concurrent.TimeUnit;
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
+import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.GroupApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.TermsOfServiceApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SamApiService {
+
+  private final SamConfiguration samConfig;
+  private final ConfigurationService configurationService;
+
+  @Autowired
+  public SamApiService(SamConfiguration samConfig, ConfigurationService configurationService) {
+    this.samConfig = samConfig;
+    this.configurationService = configurationService;
+  }
+
+  public ResourcesApi resourcesApi(String accessToken) {
+    return new ResourcesApi(createApiClient(accessToken));
+  }
+
+  public StatusApi statusApi() {
+    return new StatusApi(createUnauthApiClient());
+  }
+
+  public GoogleApi googleApi(String accessToken) {
+    return new GoogleApi(createApiClient(accessToken));
+  }
+
+  public UsersApi usersApi(String accessToken) {
+    return new UsersApi(createApiClient(accessToken));
+  }
+
+  public TermsOfServiceApi termsOfServiceApi(String accessToken) {
+    return new TermsOfServiceApi(createApiClient(accessToken));
+  }
+
+  public GroupApi groupApi(String accessToken) {
+    return new GroupApi(createApiClient(accessToken));
+  }
+
+  private ApiClient createUnauthApiClient() {
+    ApiClient apiClient = new ApiClient();
+    apiClient.setUserAgent("OpenAPI-Generator/1.0.0 java"); // only logs an error in sam
+    apiClient.setBasePath(samConfig.getBasePath());
+    return apiClient;
+  }
+
+  private ApiClient createApiClient(String accessToken) {
+    ApiClient apiClient = createUnauthApiClient();
+    apiClient.setAccessToken(accessToken);
+
+    // Sometimes Sam calls can take longer than the OkHttp default of 10 seconds to return a
+    // response.  In those cases, we can see socket timeout exceptions despite the underlying Sam
+    // call continuing to execute and possibly succeeding.
+    int operationTimeoutSeconds =
+        configurationService.getParameterValue(ConfigEnum.SAM_OPERATION_TIMEOUT_SECONDS);
+    apiClient.setReadTimeout((int) TimeUnit.SECONDS.toMillis(operationTimeoutSeconds));
+
+    return apiClient;
+  }
+}

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamApiServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamApiServiceTest.java
@@ -54,14 +54,11 @@ public class SamApiServiceTest {
             "UsersApi", samApiService.usersApi(TOKEN).getApiClient(),
             "TermsOfServiceApi", samApiService.termsOfServiceApi(TOKEN).getApiClient(),
             "GroupApi", samApiService.groupApi(TOKEN).getApiClient());
-    authorizedApiClients
-        .keySet()
-        .forEach(
-            name -> {
-              assertThat(
-                  name + " has expected read timeout",
-                  authorizedApiClients.get(name).getReadTimeout(),
-                  equalTo(OPERATION_TIMEOUT_MILLIS));
-            });
+    authorizedApiClients.forEach(
+        (name, client) ->
+            assertThat(
+                name + " has expected read timeout",
+                client.getReadTimeout(),
+                equalTo(OPERATION_TIMEOUT_MILLIS)));
   }
 }

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamApiServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamApiServiceTest.java
@@ -1,0 +1,67 @@
+package bio.terra.service.auth.iam.sam;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+import bio.terra.app.configuration.SamConfiguration;
+import bio.terra.common.category.Unit;
+import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.configuration.ConfigurationService;
+import java.util.Map;
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class SamApiServiceTest {
+
+  @Mock private SamConfiguration samConfig;
+  @Mock private ConfigurationService configurationService;
+  private SamApiService samApiService;
+
+  private static final String TOKEN = "some-access-token";
+  private static final int OPERATION_TIMEOUT_SECONDS = 123;
+  private static final int OPERATION_TIMEOUT_MILLIS = OPERATION_TIMEOUT_SECONDS * 1000;
+
+  @Before
+  public void setUp() throws Exception {
+    samApiService = new SamApiService(samConfig, configurationService);
+
+    when(configurationService.getParameterValue(ConfigEnum.SAM_OPERATION_TIMEOUT_SECONDS))
+        .thenReturn(OPERATION_TIMEOUT_SECONDS);
+  }
+
+  @Test
+  public void testSamApiClientReadTimeouts() {
+    // We only have one unauthorized Sam API -- StatusApi -- and this is unlikely to change.
+    assertThat(
+        "StatusApi keeps default read timeout",
+        samApiService.statusApi().getApiClient().getReadTimeout(),
+        equalTo(new ApiClient().getReadTimeout()));
+
+    var authorizedApiClients =
+        Map.of(
+            "ResourcesApi", samApiService.resourcesApi(TOKEN).getApiClient(),
+            "GoogleApi", samApiService.googleApi(TOKEN).getApiClient(),
+            "UsersApi", samApiService.usersApi(TOKEN).getApiClient(),
+            "TermsOfServiceApi", samApiService.termsOfServiceApi(TOKEN).getApiClient(),
+            "GroupApi", samApiService.groupApi(TOKEN).getApiClient());
+    authorizedApiClients
+        .keySet()
+        .forEach(
+            name -> {
+              assertThat(
+                  name + " has expected read timeout",
+                  authorizedApiClients.get(name).getReadTimeout(),
+                  equalTo(OPERATION_TIMEOUT_MILLIS));
+            });
+  }
+}

--- a/src/test/java/bio/terra/service/rawls/RawlsServiceTest.java
+++ b/src/test/java/bio/terra/service/rawls/RawlsServiceTest.java
@@ -2,17 +2,18 @@ package bio.terra.service.rawls;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import bio.terra.app.configuration.SamConfiguration;
+import bio.terra.app.configuration.TerraConfiguration;
 import bio.terra.app.model.rawls.WorkspaceDetails;
 import bio.terra.app.model.rawls.WorkspaceResponse;
 import bio.terra.common.category.Unit;
 import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.InaccessibleWorkspacePolicyModel;
@@ -22,97 +23,67 @@ import bio.terra.model.SamPolicyModel;
 import bio.terra.model.WorkspacePolicyModel;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
-import bio.terra.service.auth.iam.sam.SamIam;
-import bio.terra.service.configuration.ConfigEnum;
-import bio.terra.service.configuration.ConfigurationService;
 import java.util.List;
 import java.util.UUID;
-import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
-import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
-import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
-import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
-import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
-import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipV2;
-import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntryV2;
-import org.broadinstitute.dsde.workbench.client.sam.model.PolicyIdentifiers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
-@AutoConfigureMockMvc
 @ActiveProfiles({"google", "unittest"})
 @Category(Unit.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class RawlsServiceTest {
 
-  @Mock private SamConfiguration samConfig;
-  @Mock private ConfigurationService configurationService;
-  @Mock private ApiClient apiClient;
-  @Mock private ResourcesApi samResourceApi;
-  @Mock private StatusApi samStatusApi;
-  @Mock private GoogleApi samGoogleApi;
-  @Mock private UsersApi samUsersApi;
-
-  @Mock private AuthenticatedUserRequest userReq;
-
-  @MockBean private RawlsClient rawlsClient;
-  @Autowired private RawlsService rawlsService;
-  private SamIam samIam;
+  @Mock private TerraConfiguration terraConfiguration;
+  @Mock private RawlsClient rawlsClient;
+  private RawlsService rawlsService;
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private static final String BASE_PATH = "terra.base.path";
   private static final String OWNER_NAME = "owner";
   private static final String OWNER_EMAIL = "policy-email@firecloud.org";
   private static final String WORKSPACE_NAME = "testWorkspace";
-  private static final String WORKSPACE_NAMEPACE = "testNamespace";
+  private static final String WORKSPACE_NAMESPACE = "testNamespace";
   private final UUID accessibleWorkspaceId = UUID.randomUUID();
+  private final WorkspaceResponse accessibleWorkspaceResponse =
+      new WorkspaceResponse()
+          .workspace(
+              new WorkspaceDetails()
+                  .workspaceId(accessibleWorkspaceId.toString())
+                  .name(WORKSPACE_NAME)
+                  .namespace(WORKSPACE_NAMESPACE));
   private final UUID inaccessibleWorkspaceId = UUID.randomUUID();
   private final UnauthorizedException inaccessibleWorkspaceException =
       new UnauthorizedException("Workspace inaccessible");
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    samIam = spy(new SamIam(samConfig, configurationService));
-    final String userToken = "some_token";
-    when(userReq.getToken()).thenReturn(userToken);
-    when(configurationService.getParameterValue(ConfigEnum.SAM_RETRY_MAXIMUM_WAIT_SECONDS))
-        .thenReturn(0);
-    when(configurationService.getParameterValue(ConfigEnum.SAM_RETRY_INITIAL_WAIT_SECONDS))
-        .thenReturn(0);
-    when(configurationService.getParameterValue(ConfigEnum.SAM_OPERATION_TIMEOUT_SECONDS))
-        .thenReturn(0);
-    // Mock out samApi, samStatusApi, samGoogleApi, and samUsersApi in individual tests as needed
-    doAnswer(a -> samResourceApi).when(samIam).samResourcesApi(userToken);
-    // Mock out the lower level client in individual as needed
-    when(samResourceApi.getApiClient()).thenAnswer(a -> apiClient);
+    rawlsService = new RawlsService(terraConfiguration, rawlsClient);
 
-    when(rawlsClient.getWorkspace(accessibleWorkspaceId, userReq))
-        .thenReturn(
-            new WorkspaceResponse()
-                .workspace(
-                    new WorkspaceDetails()
-                        .workspaceId(accessibleWorkspaceId.toString())
-                        .name(WORKSPACE_NAME)
-                        .namespace(WORKSPACE_NAMEPACE)));
+    when(terraConfiguration.getBasePath()).thenReturn(BASE_PATH);
 
-    when(rawlsClient.getWorkspace(inaccessibleWorkspaceId, userReq))
+    when(rawlsClient.getWorkspace(accessibleWorkspaceId, TEST_USER))
+        .thenReturn(accessibleWorkspaceResponse);
+    when(rawlsClient.getWorkspace(inaccessibleWorkspaceId, TEST_USER))
         .thenThrow(inaccessibleWorkspaceException);
   }
 
-  private PolicyIdentifiers createPolicyIdentifiers(IamResourceType resourceType, UUID resourceId) {
-    return new PolicyIdentifiers()
-        .policyName(OWNER_NAME)
-        .policyEmail(OWNER_EMAIL)
-        .resourceTypeName(resourceType.toString())
-        .resourceId(resourceId.toString());
+  @Test
+  public void testGetWorkspaceLink() {
+    assertThat(
+        "A workspace response with no workspace yields a null workspace link",
+        rawlsService.getWorkspaceLink(new WorkspaceResponse()),
+        nullValue());
+
+    assertThat(accessibleWorkspaceResponse.getWorkspace(), not(nullValue()));
+    assertThat(
+        "Link can be constructed for a non-null workspace",
+        rawlsService.getWorkspaceLink(accessibleWorkspaceResponse),
+        startsWith(BASE_PATH));
   }
 
   private ResourcePolicyModel createResourcePolicyModel(
@@ -125,49 +96,24 @@ public class RawlsServiceTest {
   }
 
   @Test
-  public void testRetrievePoliciesAndEmailsWorkspace() throws Exception {
-    final UUID snapshotId = UUID.randomUUID();
+  public void testRetrievePoliciesAndEmailsWorkspace() {
     final UUID nonWorkspaceResourceId = UUID.randomUUID();
-    final String policyEmail = "policygroup@firecloud.org";
     final String memberEmail = "a@a.com";
-
-    var policyIdentifiers =
-        List.of(
-            createPolicyIdentifiers(IamResourceType.WORKSPACE, accessibleWorkspaceId),
-            createPolicyIdentifiers(IamResourceType.WORKSPACE, inaccessibleWorkspaceId),
-            createPolicyIdentifiers(IamResourceType.DATASNAPSHOT, nonWorkspaceResourceId));
-    var workspacePolicy =
-        new AccessPolicyResponseEntryV2()
-            .policyName(IamRole.READER.toString())
-            .email(policyEmail)
-            .policy(
-                new AccessPolicyMembershipV2()
-                    .addMemberEmailsItem(memberEmail)
-                    .memberPolicies(policyIdentifiers));
-    when(samResourceApi.listResourcePoliciesV2(
-            IamResourceType.DATASNAPSHOT.toString(), snapshotId.toString()))
-        .thenReturn(List.of(workspacePolicy));
 
     var resourcePolicyModels =
         List.of(
             createResourcePolicyModel(IamResourceType.WORKSPACE, accessibleWorkspaceId),
             createResourcePolicyModel(IamResourceType.WORKSPACE, inaccessibleWorkspaceId),
             createResourcePolicyModel(IamResourceType.DATASNAPSHOT, nonWorkspaceResourceId));
-    List<SamPolicyModel> samPolicyModels =
-        samIam.retrievePolicies(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
-    assertThat(
-        "Snapshot resource policies for all resource types are returned by SAM",
-        samPolicyModels,
-        is(
-            List.of(
-                new SamPolicyModel()
-                    .name(IamRole.READER.toString())
-                    .addMembersItem(memberEmail)
-                    .memberPolicies(resourcePolicyModels))));
+    SamPolicyModel samPolicyModel =
+        new SamPolicyModel()
+            .name(IamRole.READER.toString())
+            .addMembersItem(memberEmail)
+            .memberPolicies(resourcePolicyModels);
 
-    var workspacePolicyModels = rawlsService.resolvePolicyEmails(samPolicyModels.get(0), userReq);
-    verify(rawlsClient, times(1)).getWorkspace(accessibleWorkspaceId, userReq);
-    verify(rawlsClient, times(1)).getWorkspace(inaccessibleWorkspaceId, userReq);
+    var workspacePolicyModels = rawlsService.resolvePolicyEmails(samPolicyModel, TEST_USER);
+    verify(rawlsClient).getWorkspace(accessibleWorkspaceId, TEST_USER);
+    verify(rawlsClient).getWorkspace(inaccessibleWorkspaceId, TEST_USER);
 
     assertThat(
         "Workspace accessible to the user is included in returned policy models",
@@ -176,10 +122,9 @@ public class RawlsServiceTest {
             List.of(
                 new WorkspacePolicyModel()
                     .workspaceName(WORKSPACE_NAME)
-                    .workspaceNamespace(WORKSPACE_NAMEPACE)
+                    .workspaceNamespace(WORKSPACE_NAMESPACE)
                     .workspaceId(accessibleWorkspaceId)
-                    .workspaceLink(
-                        "https://bvdp-saturn-dev.appspot.com/#workspaces/testNamespace/testWorkspace")
+                    .workspaceLink(rawlsService.getWorkspaceLink(accessibleWorkspaceResponse))
                     .addWorkspacePoliciesItem(
                         new PolicyModel().name(OWNER_NAME).addMembersItem(OWNER_EMAIL)))));
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2931

This is a follow-on from https://github.com/DataBiosphere/jade-data-repo/pull/1410 ([PR comment](https://github.com/DataBiosphere/jade-data-repo/pull/1410#issuecomment-1428705514)).

With the way that `SamIam` was previously structured, we needed to spy it in tests for the purpose of stubbing out construction of the various Sam APIs.  When I updated the read timeout on `ApiClient` objects used in Sam API construction, I was unable to unit test it easily.

This PR breaks out Sam API construction into new service `SamApiService` which is now mocked in `SamIamTest`, allowing for us to remove the spy on `SamIam`.  `SamIamService` has unit testing to verify that our `ApiClient` read timeouts are being set as we expect.

While here, I also realized that `RawlsServiceTest` was involving `SamIam` unnecessarily and should only be testing `RawlsService` functionality. I pared down this test substantially and did some light refactoring in the Rawls space to facilitate (moved workspace link generation to a `RawlsService` method for easier testing).

**Personal Deployment**

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/) is up to date with these changes.  Since I modified workspace link generation, I confirmed that a snapshot exported to a workspace is still linking out to that same workspace without issue: https://jade-ok.datarepo-dev.broadinstitute.org/snapshots/786026c9-b850-49ec-818a-1e1bc4a7db50