### PR TITLE
DR-2942 - Validate Column data types match on relationship create

### DIFF
--- a/src/main/java/bio/terra/common/SynapseColumn.java
+++ b/src/main/java/bio/terra/common/SynapseColumn.java
@@ -1,6 +1,7 @@
 package bio.terra.common;
 
 import bio.terra.model.TableDataType;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.ws.rs.NotSupportedException;
@@ -69,7 +70,6 @@ public class SynapseColumn extends Column {
       case FILEREF:
         return "varchar(36)";
       case FLOAT:
-        return "float";
       case FLOAT64:
         return "float";
       case INTEGER:

--- a/src/main/java/bio/terra/common/SynapseColumn.java
+++ b/src/main/java/bio/terra/common/SynapseColumn.java
@@ -1,7 +1,6 @@
 package bio.terra.common;
 
 import bio.terra.model.TableDataType;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.ws.rs.NotSupportedException;

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -253,7 +253,7 @@ public final class ValidationUtils {
     }
 
     if (fromTerm != null && toTerm != null) {
-      validateMatchingColumnDataTypes(fromTerm, toTerm, tables, cloudPlatformWrapper);
+      errors.add(validateMatchingColumnDataTypes(fromTerm, toTerm, tables, cloudPlatformWrapper));
     }
 
     return errors;

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -177,18 +177,22 @@ public final class ValidationUtils {
                         toColumn -> {
                           TableDataType fromColumnDataType = fromColumn.getDatatype();
                           TableDataType toColumnDataType = toColumn.getDatatype();
-                          if (!isCompatibleDataType(
-                              fromColumnDataType, toColumnDataType, cloudPlatformWrapper)) {
-                            termErrors.put(
-                                "RelationshipDatatypeMismatch",
-                                String.format(
-                                    "Column data types in relationship must match: Column %s.%s has data type %s and Column %s.%s has data type %s",
-                                    fromTerm.getTable(),
-                                    fromTerm.getColumn(),
-                                    fromColumnDataType,
-                                    toTerm.getTable(),
-                                    toTerm.getColumn(),
-                                    toColumnDataType));
+                          // If either of the data types are null, then the data type is invalid
+                          // this would have already been caught when validating the table
+                          if (fromColumnDataType != null && toColumnDataType != null) {
+                            if (!isCompatibleDataType(
+                                fromColumnDataType, toColumnDataType, cloudPlatformWrapper)) {
+                              termErrors.put(
+                                  "RelationshipDatatypeMismatch",
+                                  String.format(
+                                      "Column data types in relationship must match: Column %s.%s has data type %s and Column %s.%s has data type %s",
+                                      fromTerm.getTable(),
+                                      fromTerm.getColumn(),
+                                      fromColumnDataType,
+                                      toTerm.getTable(),
+                                      toTerm.getColumn(),
+                                      toColumnDataType));
+                            }
                           }
                         }));
     return termErrors;

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -170,24 +170,28 @@ public final class ValidationUtils {
       List<TableModel> tables,
       CloudPlatformWrapper cloudPlatformWrapper) {
     LinkedHashMap<String, String> termErrors = new LinkedHashMap<>();
-    Optional<ColumnModel> fromColumn = retrieveColumnModelFromTerm(fromTerm, tables);
-    Optional<ColumnModel> toColumn = retrieveColumnModelFromTerm(toTerm, tables);
-    if (fromColumn.isPresent() && toColumn.isPresent()) {
-      TableDataType fromColumnDataType = fromColumn.get().getDatatype();
-      TableDataType toColumnDataType = toColumn.get().getDatatype();
-      if (!isCompatibleDataType(fromColumnDataType, toColumnDataType, cloudPlatformWrapper)) {
-        termErrors.put(
-            "RelationshipDatatypeMismatch",
-            String.format(
-                "Column data types in relationship must match: Column %s.%s has data type %s and Column %s.%s has data type %s",
-                fromTerm.getTable(),
-                fromTerm.getColumn(),
-                fromColumnDataType,
-                toTerm.getTable(),
-                toTerm.getColumn(),
-                toColumnDataType));
-      }
-    }
+    retrieveColumnModelFromTerm(fromTerm, tables)
+        .ifPresent(
+            fromColumn ->
+                retrieveColumnModelFromTerm(toTerm, tables)
+                    .ifPresent(
+                        toColumn -> {
+                          TableDataType fromColumnDataType = fromColumn.getDatatype();
+                          TableDataType toColumnDataType = toColumn.getDatatype();
+                          if (!isCompatibleDataType(
+                              fromColumnDataType, toColumnDataType, cloudPlatformWrapper)) {
+                            termErrors.put(
+                                "RelationshipDatatypeMismatch",
+                                String.format(
+                                    "Column data types in relationship must match: Column %s.%s has data type %s and Column %s.%s has data type %s",
+                                    fromTerm.getTable(),
+                                    fromTerm.getColumn(),
+                                    fromColumnDataType,
+                                    toTerm.getTable(),
+                                    toTerm.getColumn(),
+                                    toColumnDataType));
+                          }
+                        }));
     return termErrors;
   }
 

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -5,6 +5,7 @@ import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -81,119 +82,86 @@ public final class ValidationUtils {
     return value;
   }
 
-  private static boolean compatibleDataType(
+  @VisibleForTesting
+  static boolean isCompatibleDataType(
       TableDataType fromDataType,
       TableDataType toDataType,
       CloudPlatformWrapper cloudPlatformWrapper) {
+    List<TableDataType> compatibleTypes = null;
     if (cloudPlatformWrapper.isGcp()) {
       // https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules
-      switch (fromDataType) {
-        case DATE:
-        case DATETIME:
-          return List.of(TableDataType.DATE, TableDataType.DATETIME).contains(toDataType);
-        case DIRREF:
-        case FILEREF:
-          return List.of(TableDataType.DIRREF, TableDataType.FILEREF).contains(toDataType);
-        case FLOAT:
-        case FLOAT64:
-        case INTEGER:
-        case INT64:
-        case NUMERIC:
-          return List.of(
-                  TableDataType.FLOAT,
-                  TableDataType.FLOAT64,
-                  TableDataType.INTEGER,
-                  TableDataType.INT64,
-                  TableDataType.NUMERIC)
-              .contains(toDataType);
-        case STRING:
-        case TEXT:
-          return List.of(TableDataType.STRING, TableDataType.TEXT).contains(toDataType);
-        default:
-          return fromDataType.equals(toDataType);
-      }
-    }
-    if (cloudPlatformWrapper.isAzure()) {
-      // Following rules for implicit conversion as defined here:
+      compatibleTypes =
+          switch (fromDataType) {
+            case DATE, DATETIME -> List.of(TableDataType.DATE, TableDataType.DATETIME);
+            case DIRREF, FILEREF -> List.of(TableDataType.DIRREF, TableDataType.FILEREF);
+            case FLOAT, FLOAT64, INTEGER, INT64, NUMERIC -> List.of(
+                TableDataType.FLOAT,
+                TableDataType.FLOAT64,
+                TableDataType.INTEGER,
+                TableDataType.INT64,
+                TableDataType.NUMERIC);
+            case STRING, TEXT -> List.of(TableDataType.STRING, TableDataType.TEXT);
+            default -> List.of(fromDataType);
+          };
+    } else if (cloudPlatformWrapper.isAzure()) {
+      // Following rules for implicit conversion in both directions as defined here:
       // https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-type-conversion-database-engine?view=sql-server-ver16
-      switch (fromDataType) {
-        case BOOLEAN:
-        case FLOAT:
-        case FLOAT64:
-        case INTEGER:
-        case INT64:
-        case NUMERIC:
-          return List.of(
-                  TableDataType.BOOLEAN,
-                  TableDataType.BYTES,
-                  TableDataType.FLOAT,
-                  TableDataType.FLOAT64,
-                  TableDataType.INTEGER,
-                  TableDataType.INT64,
-                  TableDataType.NUMERIC,
-                  TableDataType.TEXT,
-                  TableDataType.STRING)
-              .contains(toDataType);
-        case BYTES:
-          return List.of(
-                  TableDataType.BOOLEAN,
-                  TableDataType.BYTES,
-                  TableDataType.INTEGER,
-                  TableDataType.INT64,
-                  TableDataType.TEXT,
-                  TableDataType.STRING)
-              .contains(toDataType);
-        case DATE:
-          return List.of(
-                  TableDataType.DATE,
-                  TableDataType.DATETIME,
-                  TableDataType.TIMESTAMP,
-                  TableDataType.STRING,
-                  TableDataType.TEXT)
-              .contains(toDataType);
-        case DATETIME:
-        case TIMESTAMP:
-          return List.of(
-                  TableDataType.DATE,
-                  TableDataType.DATETIME,
-                  TableDataType.TIMESTAMP,
-                  TableDataType.STRING,
-                  TableDataType.TEXT,
-                  TableDataType.TIME)
-              .contains(toDataType);
-        case DIRREF:
-        case FILEREF:
-          return List.of(TableDataType.DIRREF, TableDataType.FILEREF).contains(toDataType);
-        case TEXT:
-        case STRING:
-          return List.of(
-                  TableDataType.BOOLEAN,
-                  TableDataType.BYTES,
-                  TableDataType.FLOAT,
-                  TableDataType.FLOAT64,
-                  TableDataType.INTEGER,
-                  TableDataType.INT64,
-                  TableDataType.NUMERIC,
-                  TableDataType.TEXT,
-                  TableDataType.STRING,
-                  TableDataType.DATE,
-                  TableDataType.DATETIME,
-                  TableDataType.TIMESTAMP,
-                  TableDataType.TIME)
-              .contains(toDataType);
-        case TIME:
-          return List.of(
-                  TableDataType.DATETIME,
-                  TableDataType.TIMESTAMP,
-                  TableDataType.STRING,
-                  TableDataType.TEXT,
-                  TableDataType.TIME)
-              .contains(toDataType);
-        default:
-          return false;
-      }
+      compatibleTypes =
+          switch (fromDataType) {
+            case BOOLEAN, FLOAT, FLOAT64, INTEGER, INT64, NUMERIC -> List.of(
+                TableDataType.BOOLEAN,
+                TableDataType.FLOAT,
+                TableDataType.FLOAT64,
+                TableDataType.TEXT,
+                TableDataType.STRING,
+                TableDataType.INTEGER,
+                TableDataType.INT64,
+                TableDataType.NUMERIC);
+            case BYTES -> List.of(
+                TableDataType.BOOLEAN,
+                TableDataType.BYTES,
+                TableDataType.INTEGER,
+                TableDataType.INT64,
+                TableDataType.NUMERIC);
+            case DATE -> List.of(
+                TableDataType.DATE,
+                TableDataType.DATETIME,
+                TableDataType.TIMESTAMP,
+                TableDataType.TEXT,
+                TableDataType.STRING);
+            case DATETIME, TIMESTAMP -> List.of(
+                TableDataType.DATE,
+                TableDataType.DATETIME,
+                TableDataType.TIMESTAMP,
+                TableDataType.TIME,
+                TableDataType.TEXT,
+                TableDataType.STRING);
+            case TIME -> List.of(
+                TableDataType.DATETIME,
+                TableDataType.TIMESTAMP,
+                TableDataType.TEXT,
+                TableDataType.STRING);
+            case DIRREF, FILEREF -> List.of(TableDataType.DIRREF, TableDataType.FILEREF);
+            case TEXT, STRING -> List.of(
+                TableDataType.BOOLEAN,
+                TableDataType.BYTES,
+                TableDataType.DATE,
+                TableDataType.DATETIME,
+                TableDataType.TIMESTAMP,
+                TableDataType.FLOAT,
+                TableDataType.FLOAT64,
+                TableDataType.INTEGER,
+                TableDataType.INT64,
+                TableDataType.NUMERIC,
+                TableDataType.TEXT,
+                TableDataType.STRING,
+                TableDataType.TIME);
+            default -> List.of(fromDataType);
+          };
+    } else {
+      compatibleTypes = List.of();
     }
-    return false;
+    return compatibleTypes.contains(toDataType);
   }
 
   public static LinkedHashMap<String, String> validateMatchingColumnDataTypes(
@@ -207,7 +175,7 @@ public final class ValidationUtils {
     if (fromColumn.isPresent() && toColumn.isPresent()) {
       TableDataType fromColumnDataType = fromColumn.get().getDatatype();
       TableDataType toColumnDataType = toColumn.get().getDatatype();
-      if (!compatibleDataType(fromColumnDataType, toColumnDataType, cloudPlatformWrapper)) {
+      if (!isCompatibleDataType(fromColumnDataType, toColumnDataType, cloudPlatformWrapper)) {
         termErrors.put(
             "RelationshipDatatypeMismatch",
             String.format(

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -223,22 +222,19 @@ public final class ValidationUtils {
     return termErrors;
   }
 
-  private static Optional<ColumnModel> retrieveColumnModelFromTerm(
+  @VisibleForTesting
+  static Optional<ColumnModel> retrieveColumnModelFromTerm(
       RelationshipTermModel term, List<TableModel> tables) {
     String tableName = term.getTable();
     String columnName = term.getColumn();
-    try {
-      return tables.stream()
-          .filter(t -> t.getName().equals(tableName))
-          .findFirst()
-          .get()
-          .getColumns()
-          .stream()
-          .filter(c -> c.getName().equals(columnName))
-          .findFirst();
-    } catch (NoSuchElementException ex) {
-      return Optional.empty();
-    }
+    return tables.stream()
+        .filter(t -> t.getName().equals(tableName))
+        .findFirst()
+        .flatMap(
+            tableModel ->
+                tableModel.getColumns().stream()
+                    .filter(c -> c.getName().equals(columnName))
+                    .findFirst());
   }
 
   public static List<Map<String, String>> getRelationshipValidationErrors(

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -7,8 +7,8 @@ import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -164,12 +164,12 @@ public final class ValidationUtils {
     return compatibleTypes.contains(toDataType);
   }
 
-  public static LinkedHashMap<String, String> validateMatchingColumnDataTypes(
+  public static Map<String, String> validateMatchingColumnDataTypes(
       RelationshipTermModel fromTerm,
       RelationshipTermModel toTerm,
       List<TableModel> tables,
       CloudPlatformWrapper cloudPlatformWrapper) {
-    LinkedHashMap<String, String> termErrors = new LinkedHashMap<>();
+    Map<String, String> termErrors = new HashMap<>();
     retrieveColumnModelFromTerm(fromTerm, tables)
         .ifPresent(
             fromColumn ->
@@ -195,11 +195,11 @@ public final class ValidationUtils {
     return termErrors;
   }
 
-  public static LinkedHashMap<String, String> validateRelationshipTerm(
+  public static Map<String, String> validateRelationshipTerm(
       RelationshipTermModel term, List<TableModel> tables) {
     String tableName = term.getTable();
     String columnName = term.getColumn();
-    LinkedHashMap<String, String> termErrors = new LinkedHashMap<>();
+    Map<String, String> termErrors = new HashMap<>();
     Optional<TableModel> table =
         tables.stream().filter(t -> t.getName().equals(tableName)).findFirst();
     if (table.isEmpty()) {
@@ -241,11 +241,11 @@ public final class ValidationUtils {
     }
   }
 
-  public static ArrayList<LinkedHashMap<String, String>> getRelationshipValidationErrors(
+  public static List<Map<String, String>> getRelationshipValidationErrors(
       RelationshipModel relationship,
       List<TableModel> tables,
       CloudPlatformWrapper cloudPlatformWrapper) {
-    ArrayList<LinkedHashMap<String, String>> errors = new ArrayList<>();
+    List<Map<String, String>> errors = new ArrayList<>();
     RelationshipTermModel fromTerm = relationship.getFrom();
     if (fromTerm != null) {
       errors.add(validateRelationshipTerm(fromTerm, tables));

--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -81,6 +81,37 @@ public final class ValidationUtils {
     return value;
   }
 
+  // Following rules for implicit conversion as defined here:
+  // https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-type-conversion-database-engine?view=sql-server-ver16
+  private boolean compatibleDataType(TableDataType fromDataType, TableDataType toDataType) {
+    switch(fromDataType) {
+      case BOOLEAN:
+      case FLOAT:
+      case FLOAT64:
+      case INTEGER:
+      case INT64:
+      case NUMERIC:
+        return List.of(TableDataType.BOOLEAN, TableDataType.BYTES, TableDataType.FLOAT, TableDataType.FLOAT64, TableDataType.INTEGER, TableDataType.INT64, TableDataType.NUMERIC, TableDataType.TEXT, TableDataType.STRING).contains(toDataType);
+      case BYTES:
+        return List.of(TableDataType.BOOLEAN, TableDataType.BYTES, TableDataType.INTEGER, TableDataType.INT64,  TableDataType.TEXT, TableDataType.STRING).contains(toDataType);
+      case DATE:
+        return List.of(TableDataType.DATE, TableDataType.DATETIME, TableDataType.TIMESTAMP, TableDataType.STRING, TableDataType.TEXT).contains(toDataType);
+      case DATETIME:
+      case TIMESTAMP:
+        return List.of(TableDataType.DATE, TableDataType.DATETIME, TableDataType.TIMESTAMP, TableDataType.STRING, TableDataType.TEXT, TableDataType.TIME).contains(toDataType);
+      case DIRREF:
+      case FILEREF:
+        return List.of(TableDataType.DIRREF, TableDataType.FILEREF).contains(toDataType);
+      case TEXT:
+      case STRING:
+        return List.of(TableDataType.BOOLEAN, TableDataType.BYTES, TableDataType.FLOAT, TableDataType.FLOAT64, TableDataType.INTEGER, TableDataType.INT64, TableDataType.NUMERIC, TableDataType.TEXT, TableDataType.STRING, TableDataType.DATE, TableDataType.DATETIME, TableDataType.TIMESTAMP, TableDataType.TIME).contains(toDataType);
+      case TIME:
+        return List.of(TableDataType.DATETIME, TableDataType.TIMESTAMP, TableDataType.STRING, TableDataType.TEXT, TableDataType.TIME).contains(toDataType);
+      default:
+        return false;
+    }
+  }
+
   public static LinkedHashMap<String, String> validateMatchingColumnDataTypes(
       RelationshipTermModel fromTerm, RelationshipTermModel toTerm, List<TableModel> tables) {
     LinkedHashMap<String, String> termErrors = new LinkedHashMap<>();

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -326,7 +325,7 @@ public class DatasetRequestValidator implements Validator {
       Errors errors,
       SchemaValidationContext context,
       CloudPlatformWrapper cloudPlatformWrapper) {
-    ArrayList<LinkedHashMap<String, String>> validationErrors =
+    List<Map<String, String>> validationErrors =
         ValidationUtils.getRelationshipValidationErrors(relationship, tables, cloudPlatformWrapper);
     validationErrors.forEach(e -> rejectValues(errors, e));
 

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -327,7 +327,7 @@ public class DatasetRequestValidator implements Validator {
       SchemaValidationContext context,
       CloudPlatformWrapper cloudPlatformWrapper) {
     ArrayList<LinkedHashMap<String, String>> validationErrors =
-        ValidationUtils.getRelationshipValidationErrors(relationship, tables, cloud);
+        ValidationUtils.getRelationshipValidationErrors(relationship, tables, cloudPlatformWrapper);
     validationErrors.forEach(e -> rejectValues(errors, e));
 
     String relationshipName = relationship.getName();
@@ -415,7 +415,8 @@ public class DatasetRequestValidator implements Validator {
     // been left out to avoid complexity before we know if we're going keep using this or not.
   }
 
-  private void validateSchema(DatasetSpecificationModel schema, CloudPlatformWrapper cloudPlatformWrapper, Errors errors) {
+  private void validateSchema(
+      DatasetSpecificationModel schema, CloudPlatformWrapper cloudPlatformWrapper, Errors errors) {
     SchemaValidationContext context = new SchemaValidationContext();
     List<TableModel> tables = schema.getTables();
     if (tables.isEmpty()) {
@@ -438,7 +439,8 @@ public class DatasetRequestValidator implements Validator {
         errors.rejectValue("schema", "DuplicateRelationshipNames");
       }
       relationships.forEach(
-          (relationship) -> validateRelationship(relationship, tables, errors, context, cloudPlatformWrapper));
+          (relationship) ->
+              validateRelationship(relationship, tables, errors, context, cloudPlatformWrapper));
     }
 
     List<AssetModel> assets = schema.getAssets();
@@ -456,9 +458,10 @@ public class DatasetRequestValidator implements Validator {
     }
   }
 
-  private void validateRegion(DatasetRequestModel datasetRequest, CloudPlatformWrapper cloudWrapper, Errors errors) {
+  private void validateRegion(
+      DatasetRequestModel datasetRequest, CloudPlatformWrapper cloudWrapper, Errors errors) {
     if (datasetRequest.getRegion() != null) {
-        cloudWrapper.ensureValidRegion(datasetRequest.getRegion(), errors);
+      cloudWrapper.ensureValidRegion(datasetRequest.getRegion(), errors);
     }
   }
 
@@ -468,11 +471,9 @@ public class DatasetRequestValidator implements Validator {
       DatasetRequestModel datasetRequest = (DatasetRequestModel) target;
       validateDatasetName(datasetRequest.getName(), errors);
       DatasetSpecificationModel schema = datasetRequest.getSchema();
-      if (datasetRequest.getCloudPlatform() == null ) {
+      if (datasetRequest.getCloudPlatform() == null) {
         errors.rejectValue(
-            "cloudPlatform",
-            "InvalidCloudPlatform",
-            "cloudPlatform must be provided.");
+            "cloudPlatform", "InvalidCloudPlatform", "cloudPlatform must be provided.");
       } else {
         CloudPlatformWrapper cloudWrapper =
             CloudPlatformWrapper.of(datasetRequest.getCloudPlatform());
@@ -481,7 +482,6 @@ public class DatasetRequestValidator implements Validator {
         }
         validateRegion(datasetRequest, cloudWrapper, errors);
       }
-
     }
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateFlight.java
@@ -53,7 +53,9 @@ public class DatasetSchemaUpdateFlight extends Flight {
 
     addStep(new LockDatasetStep(datasetService, datasetId, false));
 
-    addStep(new DatasetSchemaUpdateValidateModelStep(datasetService, datasetId, updateModel));
+    addStep(
+        new DatasetSchemaUpdateValidateModelStep(
+            datasetService, datasetId, updateModel, cloudPlatform));
 
     if (DatasetSchemaUpdateUtils.hasTableAdditions(updateModel)) {
       addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
@@ -19,8 +19,8 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
@@ -113,9 +113,9 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
         allTables.addAll(updateModel.getChanges().getAddTables());
       }
 
-      ArrayList<String> validationErrors = new ArrayList<>();
+      List<String> validationErrors = new ArrayList<>();
       for (var relationship : newRelationships) {
-        ArrayList<LinkedHashMap<String, String>> errors =
+        List<Map<String, String>> errors =
             ValidationUtils.getRelationshipValidationErrors(relationship, allTables, cloudPlatform);
         validationErrors.addAll(formatValidationErrors(errors));
       }
@@ -163,7 +163,7 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
         StepStatus.STEP_RESULT_FAILURE_FATAL, new DatasetSchemaUpdateException(message, reasons));
   }
 
-  private List<String> formatValidationErrors(ArrayList<LinkedHashMap<String, String>> errors) {
+  private List<String> formatValidationErrors(List<Map<String, String>> errors) {
     return errors.stream()
         .flatMap(
             errorMap ->

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.dataset.flight.update;
 
+import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.common.ValidationUtils;
@@ -28,12 +29,17 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
   private final UUID datasetId;
   private final DatasetService datasetService;
   private final DatasetSchemaUpdateModel updateModel;
+  private final CloudPlatformWrapper cloudPlatform;
 
   public DatasetSchemaUpdateValidateModelStep(
-      DatasetService datasetService, UUID datasetId, DatasetSchemaUpdateModel updateModel) {
+      DatasetService datasetService,
+      UUID datasetId,
+      DatasetSchemaUpdateModel updateModel,
+      CloudPlatformWrapper cloudPlatform) {
     this.datasetId = datasetId;
     this.datasetService = datasetService;
     this.updateModel = updateModel;
+    this.cloudPlatform = cloudPlatform;
   }
 
   @Override
@@ -110,7 +116,7 @@ public class DatasetSchemaUpdateValidateModelStep implements Step {
       ArrayList<String> validationErrors = new ArrayList<>();
       for (var relationship : newRelationships) {
         ArrayList<LinkedHashMap<String, String>> errors =
-            ValidationUtils.getRelationshipValidationErrors(relationship, allTables);
+            ValidationUtils.getRelationshipValidationErrors(relationship, allTables, cloudPlatform);
         validationErrors.addAll(formatValidationErrors(errors));
       }
       if (!validationErrors.isEmpty()) {

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -15,8 +15,8 @@ import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import liquibase.util.StringUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -99,7 +99,7 @@ public class ValidationUtilsTest {
     RelationshipTermModel toTerm = new RelationshipTermModel().column("ownerId").table("car");
     defineSampleTables();
 
-    LinkedHashMap errors =
+    Map errors =
         ValidationUtils.validateMatchingColumnDataTypes(fromTerm, toTerm, tables, gcpCloudPlatform);
     assertThat("There should be one error.", errors.size(), equalTo(1));
   }
@@ -110,7 +110,7 @@ public class ValidationUtilsTest {
     RelationshipTermModel toTerm = new RelationshipTermModel().column("ownerId").table("car");
     defineSampleTables();
 
-    LinkedHashMap errors =
+    Map errors =
         ValidationUtils.validateMatchingColumnDataTypes(fromTerm, toTerm, tables, gcpCloudPlatform);
     assertThat("The data types match so there should not be an error.", errors.size(), equalTo(0));
   }
@@ -119,7 +119,7 @@ public class ValidationUtilsTest {
   public void validTermRelationship() {
     RelationshipTermModel validTerm = new RelationshipTermModel().column("id").table("person");
     defineSampleTables();
-    LinkedHashMap errors = ValidationUtils.validateRelationshipTerm(validTerm, tables);
+    Map errors = ValidationUtils.validateRelationshipTerm(validTerm, tables);
     assertThat("The term is valid so there should not be an error.", errors.size(), equalTo(0));
   }
 
@@ -127,7 +127,7 @@ public class ValidationUtilsTest {
   public void invalidTermTable() {
     RelationshipTermModel invalidTable = new RelationshipTermModel().column("id").table("invalid");
     defineSampleTables();
-    LinkedHashMap errors = ValidationUtils.validateRelationshipTerm(invalidTable, tables);
+    Map errors = ValidationUtils.validateRelationshipTerm(invalidTable, tables);
     assertThat("Invalid Table", errors.size(), equalTo(1));
   }
 
@@ -136,7 +136,7 @@ public class ValidationUtilsTest {
     RelationshipTermModel invalidColumn =
         new RelationshipTermModel().column("invalid").table("person");
     defineSampleTables();
-    LinkedHashMap errors = ValidationUtils.validateRelationshipTerm(invalidColumn, tables);
+    Map errors = ValidationUtils.validateRelationshipTerm(invalidColumn, tables);
     assertThat("Invalid Column", errors.size(), equalTo(1));
   }
 

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import bio.terra.common.category.Unit;
 import bio.terra.model.CloudPlatform;
@@ -149,5 +151,36 @@ public class ValidationUtilsTest {
             .name("car")
             .addColumnsItem(new ColumnModel().name("ownerId").datatype(TableDataType.INTEGER));
     tables = List.of(personTable, carTable);
+  }
+
+  @Test
+  public void testIsCompatibleDataType() {
+    assertTrue(
+        ValidationUtils.isCompatibleDataType(
+            TableDataType.STRING, TableDataType.TEXT, CloudPlatformWrapper.of(CloudPlatform.GCP)));
+    assertTrue(
+        ValidationUtils.isCompatibleDataType(
+            TableDataType.DATE,
+            TableDataType.DATETIME,
+            CloudPlatformWrapper.of(CloudPlatform.GCP)));
+    assertTrue(
+        ValidationUtils.isCompatibleDataType(
+            TableDataType.DATE,
+            TableDataType.DATETIME,
+            CloudPlatformWrapper.of(CloudPlatform.AZURE)));
+    assertTrue(
+        ValidationUtils.isCompatibleDataType(
+            TableDataType.TIME,
+            TableDataType.TIMESTAMP,
+            CloudPlatformWrapper.of(CloudPlatform.AZURE)));
+
+    assertFalse(
+        ValidationUtils.isCompatibleDataType(
+            TableDataType.BYTES,
+            TableDataType.BOOLEAN,
+            CloudPlatformWrapper.of(CloudPlatform.GCP)));
+    assertFalse(
+        ValidationUtils.isCompatibleDataType(
+            TableDataType.DATE, TableDataType.FLOAT, CloudPlatformWrapper.of(CloudPlatform.AZURE)));
   }
 }

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -3,6 +3,7 @@ package bio.terra.common;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -111,6 +112,11 @@ public class ValidationUtilsTest {
     Map errors =
         ValidationUtils.validateMatchingColumnDataTypes(fromTerm, toTerm, tables, gcpCloudPlatform);
     assertThat("There should be one error.", errors.size(), equalTo(1));
+    String errorMessage = errors.get("RelationshipDatatypeMismatch").toString();
+    assertThat(
+        "RelationshipDatatypeMismatch error is returned",
+        errorMessage,
+        containsString("Column data types in relationship must match"));
   }
 
   @Test

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.common.category.Unit;
+import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableDataType;
@@ -26,6 +27,7 @@ public class ValidationUtilsTest {
   private TableModel personTable;
   private TableModel carTable;
   private List<TableModel> tables;
+  private final CloudPlatformWrapper gcpCloudPlatform = CloudPlatformWrapper.of(CloudPlatform.GCP);
 
   @Test
   public void testEmailFormats() throws Exception {
@@ -96,7 +98,7 @@ public class ValidationUtilsTest {
     defineSampleTables();
 
     LinkedHashMap errors =
-        ValidationUtils.validateMatchingColumnDataTypes(fromTerm, toTerm, tables);
+        ValidationUtils.validateMatchingColumnDataTypes(fromTerm, toTerm, tables, gcpCloudPlatform);
     assertThat("There should be one error.", errors.size(), equalTo(1));
   }
 
@@ -107,7 +109,7 @@ public class ValidationUtilsTest {
     defineSampleTables();
 
     LinkedHashMap errors =
-        ValidationUtils.validateMatchingColumnDataTypes(fromTerm, toTerm, tables);
+        ValidationUtils.validateMatchingColumnDataTypes(fromTerm, toTerm, tables, gcpCloudPlatform);
     assertThat("The data types match so there should not be an error.", errors.size(), equalTo(0));
   }
 

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import liquibase.util.StringUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -182,5 +183,23 @@ public class ValidationUtilsTest {
     assertFalse(
         ValidationUtils.isCompatibleDataType(
             TableDataType.DATE, TableDataType.FLOAT, CloudPlatformWrapper.of(CloudPlatform.AZURE)));
+  }
+
+  @Test
+  public void testRetrieveColumnModelFromTerm() {
+    defineSampleTables();
+
+    String columnName = "hasCat";
+    RelationshipTermModel hasCatTerm =
+        new RelationshipTermModel().column(columnName).table("person");
+    Optional<ColumnModel> col = ValidationUtils.retrieveColumnModelFromTerm(hasCatTerm, tables);
+    assertThat("Returns correct column", col.get().getName(), equalTo(columnName));
+
+    String invalidColumnName = "invalid";
+    RelationshipTermModel invalidTerm =
+        new RelationshipTermModel().column(invalidColumnName).table("person");
+    Optional<ColumnModel> invalidCol =
+        ValidationUtils.retrieveColumnModelFromTerm(invalidTerm, tables);
+    assertFalse(invalidCol.isPresent());
   }
 }

--- a/src/test/java/bio/terra/common/fixtures/DatasetFixtures.java
+++ b/src/test/java/bio/terra/common/fixtures/DatasetFixtures.java
@@ -3,6 +3,7 @@ package bio.terra.common.fixtures;
 import bio.terra.common.Column;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
+import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSchemaColumnUpdateModel;
@@ -100,6 +101,7 @@ public final class DatasetFixtures {
         .name("Minimal")
         .description("This is a sample dataset definition")
         .defaultProfileId(UUID.randomUUID())
+        .cloudPlatform(CloudPlatform.GCP)
         .schema(buildSchema());
   }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -225,7 +225,8 @@ public class DatasetRequestValidatorTest {
           "InvalidPrimaryKey",
           "InvalidPrimaryKey",
           "InvalidPrimaryKey",
-          "InvalidRelationshipColumnType"
+          "InvalidRelationshipColumnType",
+          "RelationshipDatatypeMismatch"
         });
   }
 

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidationTest.java
@@ -11,10 +11,12 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.DatasetFixtures;
+import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSchemaColumnUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
@@ -64,6 +66,8 @@ public class DatasetSchemaUpdateValidationTest {
   private static final String EXISTING_TABLE_2 = "existing_table_2";
   private static final String EXISTING_COLUMN_2 = "existing_column_2";
   private static final String EXISTING_RELATIONSHIP = "existing_relationship";
+  private static final CloudPlatformWrapper gcpCloudPlatform =
+      CloudPlatformWrapper.of(CloudPlatform.GCP);
 
   @Before
   public void setup() {
@@ -131,7 +135,8 @@ public class DatasetSchemaUpdateValidationTest {
                                             .datatype(TableDataType.STRING))))));
 
     DatasetSchemaUpdateValidateModelStep validateModelStep =
-        new DatasetSchemaUpdateValidateModelStep(datasetService, datasetId, updateModel);
+        new DatasetSchemaUpdateValidateModelStep(
+            datasetService, datasetId, updateModel, gcpCloudPlatform);
 
     FlightContext flightContext = mock(FlightContext.class);
 
@@ -184,7 +189,7 @@ public class DatasetSchemaUpdateValidationTest {
 
     DatasetSchemaUpdateValidateModelStep validateModelStep =
         new DatasetSchemaUpdateValidateModelStep(
-            datasetService, datasetId, duplicateColumnsUpdateModel);
+            datasetService, datasetId, duplicateColumnsUpdateModel, gcpCloudPlatform);
 
     FlightContext flightContext = mock(FlightContext.class);
 
@@ -219,7 +224,7 @@ public class DatasetSchemaUpdateValidationTest {
 
     DatasetSchemaUpdateValidateModelStep validateModelStep =
         new DatasetSchemaUpdateValidateModelStep(
-            datasetService, datasetId, missingTableUpdateModel);
+            datasetService, datasetId, missingTableUpdateModel, gcpCloudPlatform);
 
     FlightContext flightContext = mock(FlightContext.class);
 
@@ -247,7 +252,7 @@ public class DatasetSchemaUpdateValidationTest {
 
     DatasetSchemaUpdateValidateModelStep validateModelStep =
         new DatasetSchemaUpdateValidateModelStep(
-            datasetService, datasetId, relationshipUpdateModel);
+            datasetService, datasetId, relationshipUpdateModel, gcpCloudPlatform);
 
     FlightContext flightContext = mock(FlightContext.class);
 
@@ -283,7 +288,7 @@ public class DatasetSchemaUpdateValidationTest {
 
     DatasetSchemaUpdateValidateModelStep validateModelStep =
         new DatasetSchemaUpdateValidateModelStep(
-            datasetService, datasetId, relationshipUpdateModel);
+            datasetService, datasetId, relationshipUpdateModel, gcpCloudPlatform);
 
     FlightContext flightContext = mock(FlightContext.class);
 
@@ -319,7 +324,7 @@ public class DatasetSchemaUpdateValidationTest {
 
     DatasetSchemaUpdateValidateModelStep validateModelStep =
         new DatasetSchemaUpdateValidateModelStep(
-            datasetService, datasetId, relationshipUpdateModel);
+            datasetService, datasetId, relationshipUpdateModel, gcpCloudPlatform);
 
     FlightContext flightContext = mock(FlightContext.class);
 
@@ -362,7 +367,7 @@ public class DatasetSchemaUpdateValidationTest {
 
     DatasetSchemaUpdateValidateModelStep validateModelStep =
         new DatasetSchemaUpdateValidateModelStep(
-            datasetService, datasetId, relationshipUpdateModel);
+            datasetService, datasetId, relationshipUpdateModel, gcpCloudPlatform);
 
     FlightContext flightContext = mock(FlightContext.class);
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDataTypeTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDataTypeTest.java
@@ -1,0 +1,124 @@
+package bio.terra.service.snapshot;
+
+import static org.junit.Assert.assertEquals;
+
+import bio.terra.common.auth.AuthService;
+import bio.terra.common.category.Integration;
+import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.integration.DataRepoClient;
+import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.TestJobWatcher;
+import bio.terra.integration.UsersBase;
+import bio.terra.model.DatasetModel;
+import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.model.SnapshotSummaryModel;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "integrationtest"})
+@Category(Integration.class)
+public class SnapshotDataTypeTest extends UsersBase {
+  @Autowired private DataRepoClient dataRepoClient;
+
+  @Autowired private JsonLoader jsonLoader;
+
+  @Autowired private DataRepoFixtures dataRepoFixtures;
+
+  @Autowired private AuthService authService;
+
+  private static final Logger logger = LoggerFactory.getLogger(SnapshotDataTypeTest.class);
+  private UUID profileId;
+  private DatasetSummaryModel datasetSummaryModel;
+  private UUID datasetId;
+  private final List<UUID> createdSnapshotIds = new ArrayList<>();
+  private String stewardToken;
+
+  @Rule @Autowired public TestJobWatcher testWatcher;
+
+  @Before
+  public void setup() throws Exception {
+    super.setup();
+    stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
+    profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
+    dataRepoFixtures.addPolicyMember(
+        steward(), profileId, IamRole.USER, custodian().getEmail(), IamResourceType.SPEND_PROFILE);
+
+    datasetSummaryModel =
+        dataRepoFixtures.createDataset(steward(), profileId, "data-types-dataset-create.json");
+    datasetId = datasetSummaryModel.getId();
+    dataRepoFixtures.addDatasetPolicyMember(
+        steward(), datasetId, IamRole.CUSTODIAN, custodian().getEmail());
+
+    IngestRequestModel request =
+        dataRepoFixtures.buildSimpleIngest("table1", "data-types-test/table1.json");
+    dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
+    request = dataRepoFixtures.buildSimpleIngest("table2", "data-types-test/table2.json");
+    dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    createdSnapshotIds.forEach(
+        snapshot -> {
+          try {
+            dataRepoFixtures.deleteSnapshot(steward(), snapshot);
+          } catch (Exception ex) {
+            logger.warn("cleanup failed when deleting snapshot " + snapshot);
+            ex.printStackTrace();
+          }
+        });
+
+    if (datasetId != null) {
+      dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
+    }
+
+    if (profileId != null) {
+      dataRepoFixtures.deleteProfileLog(steward(), profileId);
+    }
+  }
+
+  @Test
+  public void snapshotRowIdsHappyPathTest() throws Exception {
+    // fetch rowIds from the ingested dataset by querying the participant table
+    DatasetModel dataset = dataRepoFixtures.getDataset(steward(), datasetId);
+
+    // swap in these row ids in the request
+    SnapshotRequestModel requestModel =
+        jsonLoader.loadObject("data-types-gcp-snapshot.json", SnapshotRequestModel.class);
+
+    SnapshotSummaryModel snapshotSummary =
+        dataRepoFixtures.createSnapshotWithRequest(
+            steward(), dataset.getName(), profileId, requestModel);
+    TimeUnit.SECONDS.sleep(10);
+    createdSnapshotIds.add(snapshotSummary.getId());
+    SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
+    assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
+    assertEquals(
+        "new snapshot has the correct number of tables",
+        2,
+        snapshot.getTables().size());
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDataTypeTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDataTypeTest.java
@@ -116,9 +116,6 @@ public class SnapshotDataTypeTest extends UsersBase {
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
     assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
-    assertEquals(
-        "new snapshot has the correct number of tables",
-        2,
-        snapshot.getTables().size());
+    assertEquals("new snapshot has the correct number of tables", 2, snapshot.getTables().size());
   }
 }

--- a/src/test/resources/data-types-dataset-create.json
+++ b/src/test/resources/data-types-dataset-create.json
@@ -1,0 +1,252 @@
+{
+  "name": "AllDataTypes",
+  "description": "Dataset for testing joining across dataset data types",
+  "schema": {
+    "tables": [
+      {
+        "name": "table1",
+        "columns": [
+          {
+            "name": "stringCol",
+            "datatype": "string"
+          },
+          {
+            "name": "boolCol",
+            "datatype": "boolean"
+          },
+          {
+            "name": "bytesCol",
+            "datatype": "bytes"
+          },
+          {
+            "name": "dateCol",
+            "datatype": "date"
+          },
+          {
+            "name": "dateTimeCol",
+            "datatype": "datetime"
+          },
+          {
+            "name": "dirRefCol",
+            "datatype": "dirref"
+          },
+          {
+            "name": "fileRefCol",
+            "datatype": "fileref"
+          },
+          {
+            "name": "floatCol",
+            "datatype": "float"
+          },
+          {
+            "name": "float64Col",
+            "datatype": "float64"
+          },
+          {
+            "name": "intCol",
+            "datatype": "integer"
+          },
+          {
+            "name": "int64Col",
+            "datatype": "int64"
+          },
+          {
+            "name": "numericCol",
+            "datatype": "numeric"
+          },
+          {
+            "name": "textCol",
+            "datatype": "text"
+          },
+          {
+            "name": "timeCol",
+            "datatype": "time"
+          },
+          {
+            "name": "timestampCol",
+            "datatype": "timestamp"
+          },
+          {
+            "name": "arrayCol",
+            "datatype": "string",
+            "array_of": true
+          }
+        ],
+        "primaryKey": ["stringCol"]
+      },
+      {
+        "name": "table2",
+        "columns": [
+          {
+            "name": "stringCol",
+            "datatype": "string"
+          },
+          {
+            "name": "boolCol",
+            "datatype": "boolean"
+          },
+          {
+            "name": "bytesCol",
+            "datatype": "bytes"
+          },
+          {
+            "name": "dateCol",
+            "datatype": "date"
+          },
+          {
+            "name": "dateTimeCol",
+            "datatype": "datetime"
+          },
+          {
+            "name": "dirRefCol",
+            "datatype": "dirref"
+          },
+          {
+            "name": "fileRefCol",
+            "datatype": "fileref"
+          },
+          {
+            "name": "floatCol",
+            "datatype": "float"
+          },
+          {
+            "name": "float64Col",
+            "datatype": "float64"
+          },
+          {
+            "name": "intCol",
+            "datatype": "integer"
+          },
+          {
+            "name": "int64Col",
+            "datatype": "int64"
+          },
+          {
+            "name": "numericCol",
+            "datatype": "numeric"
+          },
+          {
+            "name": "textCol",
+            "datatype": "text"
+          },
+          {
+            "name": "timeCol",
+            "datatype": "time"
+          },
+          {
+            "name": "timestampCol",
+            "datatype": "timestamp"
+          },
+          {
+            "name": "arrayCol",
+            "datatype": "string",
+            "array_of": true
+          }
+        ],
+        "primaryKey": ["stringCol"]
+      }
+    ],
+    "relationships": [
+      {
+        "name": "date_datetime",
+        "from": { "table": "table1", "column": "dateCol" },
+        "to": { "table": "table2", "column": "dateTimeCol" }
+      },
+      {
+        "name": "float_float64",
+        "from": { "table": "table1", "column": "floatCol" },
+        "to": { "table": "table2", "column": "float64Col" }
+      },
+      {
+        "name": "float_integer",
+        "from": { "table": "table1", "column": "floatCol" },
+        "to": { "table": "table2", "column": "intCol" }
+      },
+      {
+        "name": "float64_integer",
+        "from": { "table": "table1", "column": "float64Col" },
+        "to": { "table": "table2", "column": "intCol" }
+      },
+      {
+        "name": "float_int64",
+        "from": { "table": "table1", "column": "floatCol" },
+        "to": { "table": "table2", "column": "int64Col" }
+      },
+      {
+        "name": "float64_int64",
+        "from": { "table": "table1", "column": "float64Col" },
+        "to": { "table": "table2", "column": "int64Col" }
+      },
+      {
+        "name": "int64_integer",
+        "from": { "table": "table1", "column": "int64Col" },
+        "to": { "table": "table2", "column": "intCol" }
+      },
+      {
+        "name": "float_numeric",
+        "from": { "table": "table1", "column": "floatCol" },
+        "to": { "table": "table2", "column": "numericCol" }
+      },
+      {
+        "name": "float64_numeric",
+        "from": { "table": "table1", "column": "float64Col" },
+        "to": { "table": "table2", "column": "numericCol" }
+      },
+      {
+        "name": "integer_numeric",
+        "from": { "table": "table1", "column": "intCol" },
+        "to": { "table": "table2", "column": "numericCol" }
+      },
+      {
+        "name": "int64_numeric",
+        "from": { "table": "table1", "column": "int64Col" },
+        "to": { "table": "table2", "column": "numericCol" }
+      },
+      {
+        "name": "string_text",
+        "from": { "table": "table1", "column": "stringCol" },
+        "to": { "table": "table2", "column": "textCol" }
+      },
+      {
+        "name": "date_int_not_allowed",
+        "from": { "table": "table1", "column": "dateCol" },
+        "to": { "table": "table2", "column": "intCol" }
+      }
+    ],
+    "assets": [
+      {
+        "name": "allowed_gcp_relationships",
+        "rootTable": "table1",
+        "rootColumn": "stringCol",
+        "tables": [
+          { "name": "table1", "columns": [] },
+          { "name": "table2", "columns": [] }
+        ],
+        "follow": [
+          "date_datetime",
+          "float_float64",
+          "float_integer",
+          "float64_integer",
+          "float_int64",
+          "float64_int64",
+          "int64_integer",
+          "float_numeric",
+          "float64_numeric",
+          "integer_numeric",
+          "int64_numeric",
+          "string_text"
+        ]
+      },
+      {
+        "name": "example_disallowed_gcp_relationship",
+        "rootTable": "table1",
+        "rootColumn": "stringCol",
+        "tables": [
+          { "name": "table1", "columns": [] },
+          { "name": "table2", "columns": [] }
+        ],
+        "follow": ["date_int_not_allowed"]
+      }
+    ]
+  }
+}

--- a/src/test/resources/data-types-gcp-snapshot.json
+++ b/src/test/resources/data-types-gcp-snapshot.json
@@ -1,0 +1,16 @@
+{
+  "name":"dataTypesGCPSnapshot",
+  "description":"Test creating snapshot with all allowed data type relationshps",
+  "contents":[
+    {
+      "datasetName":"AllDataTypes",
+      "mode": "byAsset",
+      "assetSpec": {
+        "assetName": "allowed_gcp_relationships",
+        "rootValues": [
+          "entry1"
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/dataset/create/invalid-schema.json
+++ b/src/test/resources/dataset/create/invalid-schema.json
@@ -2,6 +2,7 @@
   "name": "testInvalidDataTypes",
   "description": "testInvalidDataTypes",
   "defaultProfileId": "fa8d8a79-5d66-4c42-831b-047dadfe84af",
+  "cloudPlatform": "gcp",
   "schema": {
     "tables": [
       {


### PR DESCRIPTION
When creating a relationship between two columns, the data type should match. This PR add validation on relationship creation to verify this constraint is met. 
Example error message:
`RelationshipDatatypeMismatch -> Column data types in relationship must match: Column person.hasCat has data type boolean and Column car.ownerId has data type integer`