### PR TITLE
[DR-2843] Introduce new endpoint for scheduled sync of DUOS group members

### DIFF
--- a/src/main/java/bio/terra/app/controller/ScheduledApiController.java
+++ b/src/main/java/bio/terra/app/controller/ScheduledApiController.java
@@ -1,0 +1,48 @@
+package bio.terra.app.controller;
+
+import bio.terra.common.exception.ForbiddenException;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import bio.terra.controller.ScheduledApi;
+import bio.terra.model.DuosFirecloudGroupsSyncResponse;
+import bio.terra.service.duos.DuosService;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class ScheduledApiController implements ScheduledApi {
+
+  private final HttpServletRequest request;
+  private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  private final DuosService duosService;
+  private final String tdrServiceAccountEmail;
+
+  public ScheduledApiController(
+      HttpServletRequest request,
+      AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
+      DuosService duosService,
+      @Qualifier("tdrServiceAccountEmail") String tdrServiceAccountEmail) {
+    this.request = request;
+    this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
+    this.duosService = duosService;
+    this.tdrServiceAccountEmail = tdrServiceAccountEmail;
+  }
+
+  @Override
+  public ResponseEntity<DuosFirecloudGroupsSyncResponse> syncDuosDatasetsAuthorizedUsers() {
+    String callerEmail = getAuthenticatedInfo().getEmail();
+    if (tdrServiceAccountEmail != callerEmail) {
+      // TODO maybe introduce a more specific variety of ForbiddenException
+      throw new ForbiddenException(
+          "Only %s may call this endpoint (called as %s)"
+              .formatted(tdrServiceAccountEmail, callerEmail));
+    }
+    return ResponseEntity.ok(duosService.syncDuosDatasetsAuthorizedUsers());
+  }
+
+  private AuthenticatedUserRequest getAuthenticatedInfo() {
+    return authenticatedUserRequestFactory.from(request);
+  }
+}

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -13,6 +13,7 @@ info:
      * /configuration - provides the basic configuration and information about the service
      * /api - is the authenticated and authorized Data Repository API
      * /ga4gh/drs/v1 - is a transcription of the Data Repository Service API
+     * /scheduled - powers scheduled background tasks
 
     The API endpoints are organized by interface. Each interface is separately versioned.
     <p>
@@ -82,6 +83,7 @@ paths:
       description: >
         Requests that this instance of DR Manager shut down. In production, this must be configured to
         only be callable by Kubernetes.
+        TODO: how do we handle this configuration? Could it be applicable for our DUOS sync via k8s cron?
       operationId: shutdownRequest
       responses:
         204:
@@ -3655,6 +3657,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+
+
+#################################################################
+#####                    SCHEDULED TASKS                    #####
+#################################################################
+  # TODO: do we really need a new endpoint here, or should we just expand the existing endpoint's
+  # authorization check to allow the env's SA to call?
+  # If not, should we remove the existing endpoint entirely?
+  /scheduled/duos/syncAuthorizedUsers:
+    put:
+      tags:
+        - scheduled
+      description: >
+        Sync the members of all TDR-managed DUOS Firecloud groups with the authorized users of their
+        corresponding DUOS datasets.  Any snapshots linked to a DUOS dataset have its Firecloud
+        group as a reader, which means its members are also snapshot readers.
+        NOTE: This is an experimental feature and its response body may change.
+      operationId: syncDuosDatasetsAuthorizedUsers
+      responses:
+        200:
+          description: Sync complete - see contents to gauge overall success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DuosFirecloudGroupsSyncResponse'
+        403:
+          description: >
+            Unauthorized - the caller must be the environment's TDR SA to facilitate sync.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: >
+            An unexpected error occurred - Firecloud group contents may not have been updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+
 components:
   schemas:
     TableDataType:


### PR DESCRIPTION
This endpoint should only be callable by the environment-specific SA.  We will probably schedule calls to this endpoint using [k8s CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).

My developer environment includes this new endpoint: https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/scheduled/syncDuosDatasetsAuthorizedUsers

But to call it we likely need to muck with the oidc proxy settings, currently we get back this:
```
<html>
<head><title>405 Not Allowed</title></head>
<body>
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
</html>
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
```

However, we could instead expand the authorization check in the existing DUOS sync endpoint to allow the TDR SA to call it, and shouldn't need to modify the oidc proxy.  Otherwise I don't see much point in keeping the existing endpoint at all.  This general pattern may not be suitable for future scheduled tasks, though.