### PR TITLE
DR-2949 Allow users to specify their own MD5 on ingest

### DIFF
--- a/src/main/java/bio/terra/service/filedata/FSFileInfo.java
+++ b/src/main/java/bio/terra/service/filedata/FSFileInfo.java
@@ -12,6 +12,7 @@ public class FSFileInfo {
   private String cloudPath;
   private String checksumCrc32c;
   private String checksumMd5;
+  private boolean userSpecifiedMd5;
   private Long size;
   private String bucketResourceId;
 
@@ -60,6 +61,15 @@ public class FSFileInfo {
     return this;
   }
 
+  public boolean isUserSpecifiedMd5() {
+    return userSpecifiedMd5;
+  }
+
+  public FSFileInfo userSpecifiedMd5(boolean userSpecifiedMd5) {
+    this.userSpecifiedMd5 = userSpecifiedMd5;
+    return this;
+  }
+
   public Long getSize() {
     return size;
   }
@@ -85,6 +95,7 @@ public class FSFileInfo {
         .append("cloudPath", cloudPath)
         .append("checksumCrc32c", checksumCrc32c)
         .append("checksumMd5", checksumMd5)
+        .append("userSpecifiedMd5", userSpecifiedMd5)
         .append("size", size)
         .append("bucketResourceId", bucketResourceId)
         .toString();
@@ -96,6 +107,7 @@ public class FSFileInfo {
         .bucketResourceId(resourceId)
         .checksumCrc32c(null)
         .checksumMd5("baaaaaad")
+        .userSpecifiedMd5(false)
         .createdDate(Instant.now().toString())
         .cloudPath("https://path")
         .size(100L);

--- a/src/main/java/bio/terra/service/filedata/FileIdService.java
+++ b/src/main/java/bio/terra/service/filedata/FileIdService.java
@@ -27,8 +27,12 @@ public class FileIdService {
     return String.join(
         HASH_SEPARATOR,
         List.of(
-            fsItem.getPath(),
-            Objects.requireNonNullElse(fsItem.getChecksumMd5(), ""),
-            String.valueOf(fsItem.getSize())));
+            Objects.requireNonNull(
+                fsItem.getPath(), "A target path is required to create a file id"),
+            Objects.requireNonNull(
+                fsItem.getChecksumMd5(), "An MD5 checksum is required to create a file id"),
+            String.valueOf(
+                Objects.requireNonNull(
+                    fsItem.getSize(), "A size is required to create a file id"))));
   }
 }

--- a/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
+++ b/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
@@ -144,6 +144,10 @@ public class FileMetadataUtils {
    * @param type Which md5 was actually used
    */
   public record Md5ValidationResult(String effectiveMd5, Md5Type type) {
+    public boolean isUserProvided() {
+      return type().equals(Md5Type.USER_PROVIDED);
+    }
+
     public enum Md5Type {
       USER_PROVIDED, // When the user md5 is used (e.g. when it's not present in the cloud)
       CLOUD_PROVIDED, // When the cloud md5 is used

--- a/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
+++ b/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata;
 
+import bio.terra.service.filedata.FileMetadataUtils.Md5ValidationResult.Md5Type;
 import bio.terra.service.filedata.exception.InvalidFileChecksumException;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import com.google.common.annotations.VisibleForTesting;
@@ -137,6 +138,20 @@ public class FileMetadataUtils {
   }
 
   /**
+   * Results of the successful md5 comparison of user a specified MD5 against a cloud provided MD5
+   *
+   * @param effectiveMd5 The final md5 to record
+   * @param type Which md5 was actually used
+   */
+  public record Md5ValidationResult(String effectiveMd5, Md5Type type) {
+    public enum Md5Type {
+      USER_PROVIDED, // When the user md5 is used (e.g. when it's not present in the cloud)
+      CLOUD_PROVIDED, // When the cloud md5 is used
+      NEITHER // When neither value is provided
+    }
+  }
+
+  /**
    * Validates that a user specified MD5 checksum matches with a cloud provided MD5 checksum. If the
    * user provided checksum is null or empty, then assume the cloud checksum is valid and return
    * that
@@ -147,17 +162,22 @@ public class FileMetadataUtils {
    * @return A hex representation of the file's md5 hash
    * @throws InvalidFileChecksumException if the specified checksums don't match
    */
-  public static String validateFileMd5ForIngest(
+  public static Md5ValidationResult validateFileMd5ForIngest(
       String userSpecifiedMd5, String cloudMd5, String sourcePath)
       throws InvalidFileChecksumException {
-    if (userSpecifiedMd5 != null) {
+    if (!StringUtils.isEmpty(userSpecifiedMd5)) {
       if (!StringUtils.isEmpty(cloudMd5) && !Objects.equals(cloudMd5, userSpecifiedMd5)) {
         throw new InvalidFileChecksumException(
             "Checksums do not match for file %s".formatted(sourcePath));
       }
-      return userSpecifiedMd5;
+      return new Md5ValidationResult(
+          userSpecifiedMd5,
+          Objects.equals(cloudMd5, userSpecifiedMd5)
+              ? Md5Type.CLOUD_PROVIDED
+              : Md5Type.USER_PROVIDED);
     } else {
-      return cloudMd5;
+      return new Md5ValidationResult(
+          cloudMd5, StringUtils.isEmpty(cloudMd5) ? Md5Type.NEITHER : Md5Type.CLOUD_PROVIDED);
     }
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -13,7 +13,6 @@ import bio.terra.service.filedata.FSItem;
 import bio.terra.service.filedata.FileIdService;
 import bio.terra.service.filedata.FileMetadataUtils;
 import bio.terra.service.filedata.FileMetadataUtils.Md5ValidationResult;
-import bio.terra.service.filedata.FileMetadataUtils.Md5ValidationResult.Md5Type;
 import bio.terra.service.filedata.azure.util.AzureBlobStoreBufferedReader;
 import bio.terra.service.filedata.azure.util.AzureBlobStoreBufferedWriter;
 import bio.terra.service.filedata.azure.util.BlobContainerClientFactory;
@@ -168,7 +167,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
     Instant createTime = blobProperties.getCreationTime().toInstant();
 
     String checksumMd5;
-    if (finalMd5.type().equals(Md5Type.USER_PROVIDED)) {
+    if (finalMd5.isUserProvided()) {
       checksumMd5 = finalMd5.effectiveMd5();
     } else {
       checksumMd5 =
@@ -184,7 +183,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
                 "%s/%s",
                 targetClientFactory.getBlobContainerClient().getBlobContainerUrl(), blobName))
         .checksumMd5(checksumMd5)
-        .userSpecifiedMd5(finalMd5.type().equals(Md5Type.USER_PROVIDED))
+        .userSpecifiedMd5(finalMd5.isUserProvided())
         .size(blobProperties.getBlobSize())
         .bucketResourceId(storageAccountResource.getResourceId().toString());
   }

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -11,6 +11,9 @@ import bio.terra.service.filedata.CloudFileReader;
 import bio.terra.service.filedata.FSFileInfo;
 import bio.terra.service.filedata.FSItem;
 import bio.terra.service.filedata.FileIdService;
+import bio.terra.service.filedata.FileMetadataUtils;
+import bio.terra.service.filedata.FileMetadataUtils.Md5ValidationResult;
+import bio.terra.service.filedata.FileMetadataUtils.Md5ValidationResult.Md5Type;
 import bio.terra.service.filedata.azure.util.AzureBlobStoreBufferedReader;
 import bio.terra.service.filedata.azure.util.AzureBlobStoreBufferedWriter;
 import bio.terra.service.filedata.azure.util.BlobContainerClientFactory;
@@ -40,6 +43,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -126,20 +130,28 @@ public class AzureBlobStorePdao implements CloudFileReader {
     BlobUrlParts blobUrl = BlobUrlParts.parse(fileLoadModel.getSourcePath());
     String fileName = getLastNameFromPath(blobUrl.getBlobName());
 
+    BlobProperties sourceBlobProperties =
+        sourceClientFactory
+            .getBlobContainerClient()
+            .getBlobClient(blobUrl.getBlobName())
+            .getProperties();
+    Md5ValidationResult finalMd5 =
+        FileMetadataUtils.validateFileMd5ForIngest(
+            fileLoadModel.getMd5(),
+            Optional.ofNullable(sourceBlobProperties.getContentMd5())
+                .map(Hex::encodeHexString)
+                .orElse(null),
+            fileLoadModel.getSourcePath());
+
     String effectiveFileId;
     if (fileId == null) {
-      BlobProperties sourceBlobProperties =
-          sourceClientFactory
-              .getBlobContainerClient()
-              .getBlobClient(blobUrl.getBlobName())
-              .getProperties();
       effectiveFileId =
           fileIdService
               .calculateFileId(
                   dataset,
                   new FSItem()
                       .path(fileLoadModel.getTargetPath())
-                      .checksumMd5(Hex.encodeHexString(sourceBlobProperties.getContentMd5()))
+                      .checksumMd5(finalMd5.effectiveMd5())
                       .size(sourceBlobProperties.getBlobSize()))
               .toString();
     } else {
@@ -154,6 +166,16 @@ public class AzureBlobStorePdao implements CloudFileReader {
 
     BlobProperties blobProperties = blobCrl.getBlobProperties(blobName);
     Instant createTime = blobProperties.getCreationTime().toInstant();
+
+    String checksumMd5;
+    if (finalMd5.type().equals(Md5Type.USER_PROVIDED)) {
+      checksumMd5 = finalMd5.effectiveMd5();
+    } else {
+      checksumMd5 =
+          Optional.ofNullable(blobProperties.getContentMd5())
+              .map(Hex::encodeHexString)
+              .orElse(null);
+    }
     return new FSFileInfo()
         .fileId(effectiveFileId)
         .createdDate(createTime.toString())
@@ -161,7 +183,8 @@ public class AzureBlobStorePdao implements CloudFileReader {
             String.format(
                 "%s/%s",
                 targetClientFactory.getBlobContainerClient().getBlobContainerUrl(), blobName))
-        .checksumMd5(Hex.encodeHexString(blobProperties.getContentMd5()))
+        .checksumMd5(checksumMd5)
+        .userSpecifiedMd5(finalMd5.type().equals(Md5Type.USER_PROVIDED))
         .size(blobProperties.getBlobSize())
         .bucketResourceId(storageAccountResource.getResourceId().toString());
   }

--- a/src/main/java/bio/terra/service/filedata/exception/InvalidFileChecksumException.java
+++ b/src/main/java/bio/terra/service/filedata/exception/InvalidFileChecksumException.java
@@ -1,0 +1,17 @@
+package bio.terra.service.filedata.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+public class InvalidFileChecksumException extends BadRequestException {
+  public InvalidFileChecksumException(String message) {
+    super(message);
+  }
+
+  public InvalidFileChecksumException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InvalidFileChecksumException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
@@ -405,6 +405,7 @@ public abstract class IngestBulkGcpStep extends DefaultUndoStep {
                       .gspath(fsFileInfo.getCloudPath())
                       .checksumCrc32c(fsFileInfo.getChecksumCrc32c())
                       .checksumMd5(fsFileInfo.getChecksumMd5())
+                      .userSpecifiedMd5(fsFileInfo.isUserSpecifiedMd5())
                       .size(fsFileInfo.getSize())
                       .loadTag(loadTag);
                 })
@@ -461,6 +462,7 @@ public abstract class IngestBulkGcpStep extends DefaultUndoStep {
         .loadTag(loadTag)
         .targetPath(bulkLoadFileModel.getTargetPath())
         .sourcePath(bulkLoadFileModel.getSourcePath())
+        .md5(bulkLoadFileModel.getMd5())
         .profileId(profileId);
   }
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -352,6 +352,7 @@ public class IngestDriverStep extends DefaultUndoStep {
               .sourcePath(loadFile.getSourcePath())
               .targetPath(loadFile.getTargetPath())
               .mimeType(loadFile.getMimeType())
+              .md5(loadFile.getMd5())
               .profileId(profileId)
               .loadTag(loadTag)
               .description(loadFile.getDescription());

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
@@ -57,6 +57,7 @@ public class IngestFileAzureFileStep implements Step {
               .gspath(fsFileInfo.getCloudPath())
               .checksumCrc32c(fsFileInfo.getChecksumCrc32c())
               .checksumMd5(fsFileInfo.getChecksumMd5())
+              .userSpecifiedMd5(fsFileInfo.isUserSpecifiedMd5())
               .size(fsFileInfo.getSize())
               .loadTag(fileLoadModel.getLoadTag());
 

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileFileStep.java
@@ -49,6 +49,7 @@ public class IngestFileFileStep implements Step {
               .gspath(fsFileInfo.getCloudPath())
               .checksumCrc32c(fsFileInfo.getChecksumCrc32c())
               .checksumMd5(fsFileInfo.getChecksumMd5())
+              .userSpecifiedMd5(fsFileInfo.isUserSpecifiedMd5())
               .size(fsFileInfo.getSize())
               .loadTag(fileLoadModel.getLoadTag());
 

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -108,6 +108,7 @@ public class FireStoreDao {
                         .isFileRef(false)
                         .path(FileMetadataUtils.getDirectoryPath(d))
                         .name(FileMetadataUtils.getName(d))
+                        .fileCreatedDate(Instant.now().toString())
                         .datasetId(datasetId)
                         .loadTag(loadTag))
             .toList();

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFile.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFile.java
@@ -23,6 +23,7 @@ public class FireStoreFile {
   private String gspath;
   private String checksumCrc32c;
   private String checksumMd5;
+  private boolean userSpecifiedMd5;
   private Long size;
 
   // Azure table entity field names
@@ -35,6 +36,7 @@ public class FireStoreFile {
   public static final String GS_PATH_FIELD_NAME = "gspath";
   public static final String CHECKSUM_CRC32C_FIELD_NAME = "checksum_crc32c";
   public static final String CHECKSUM_MD5_FIELD_NAME = "checksum_md5";
+  public static final String USER_SPECIFIED_MD5_FIELD_NAME = "userSpecifiedMd5";
   public static final String SIZE_FIELD_NAME = "size";
 
   public FireStoreFile() {}
@@ -81,6 +83,15 @@ public class FireStoreFile {
 
   public FireStoreFile checksumMd5(String checksumMd5) {
     this.checksumMd5 = checksumMd5;
+    return this;
+  }
+
+  public boolean isUserSpecifiedMd5() {
+    return userSpecifiedMd5;
+  }
+
+  public FireStoreFile userSpecifiedMd5(boolean userSpecifiedMd5) {
+    this.userSpecifiedMd5 = userSpecifiedMd5;
     return this;
   }
 
@@ -141,6 +152,7 @@ public class FireStoreFile {
         .append("gspath", gspath)
         .append("checksumCrc32c", checksumCrc32c)
         .append("checksumMd5", checksumMd5)
+        .append("userSpecifiedMd5", userSpecifiedMd5)
         .append("size", size)
         .toString();
   }
@@ -163,6 +175,7 @@ public class FireStoreFile {
         && Objects.equals(gspath, that.gspath)
         && Objects.equals(checksumCrc32c, that.checksumCrc32c)
         && Objects.equals(checksumMd5, that.checksumMd5)
+        && Objects.equals(userSpecifiedMd5, that.userSpecifiedMd5)
         && Objects.equals(size, that.size);
   }
 
@@ -178,6 +191,7 @@ public class FireStoreFile {
         gspath,
         checksumCrc32c,
         checksumMd5,
+        userSpecifiedMd5,
         size);
   }
 
@@ -192,6 +206,10 @@ public class FireStoreFile {
         .gspath(entity.getProperty(GS_PATH_FIELD_NAME).toString())
         .checksumCrc32c((String) entity.getProperty(CHECKSUM_CRC32C_FIELD_NAME))
         .checksumMd5((String) entity.getProperty(CHECKSUM_MD5_FIELD_NAME))
+        .userSpecifiedMd5(
+            (boolean)
+                Objects.requireNonNullElse(
+                    entity.getProperty(USER_SPECIFIED_MD5_FIELD_NAME), false))
         .size((Long) entity.getProperty(SIZE_FIELD_NAME));
   }
 
@@ -206,6 +224,7 @@ public class FireStoreFile {
         .addProperty(GS_PATH_FIELD_NAME, f.getGspath())
         .addProperty(CHECKSUM_CRC32C_FIELD_NAME, f.getChecksumCrc32c())
         .addProperty(CHECKSUM_MD5_FIELD_NAME, f.getChecksumMd5())
+        .addProperty(USER_SPECIFIED_MD5_FIELD_NAME, f.isUserSpecifiedMd5())
         .addProperty(SIZE_FIELD_NAME, f.getSize());
   }
 }

--- a/src/main/java/bio/terra/service/load/LoadFile.java
+++ b/src/main/java/bio/terra/service/load/LoadFile.java
@@ -15,6 +15,7 @@ public class LoadFile {
   private String flightId;
   private String fileId;
   private String error;
+  private String md5;
 
   public UUID getLoadId() {
     return loadId;
@@ -97,6 +98,15 @@ public class LoadFile {
     return this;
   }
 
+  public String getMd5() {
+    return md5;
+  }
+
+  public LoadFile md5(String md5) {
+    this.md5 = md5;
+    return this;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.JSON_STYLE)
@@ -106,6 +116,7 @@ public class LoadFile {
         .append("state", state)
         .append("fileId", fileId)
         .append("error", error)
+        .append("md5", md5)
         .toString();
   }
 }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3852,7 +3852,7 @@ components:
           type: boolean
           default: false
           description: >
-            If false, random ids will be created. If true, full target path (e.g. path + name), size and MD5 hash will be used
+            If false, random ids will be created. If true, full target path (e.g. path + name), size and md5 hash will be used
 
             Note: this only applies to files.  Directories still have random ids regardless of this value
       description: >
@@ -3897,7 +3897,7 @@ components:
           type: boolean
           default: false
           description: >
-            If false, random ids will be created. If true, full target path (e.g. path + name), size and MD5 hash will be used
+            If false, random ids will be created. If true, full target path (e.g. path + name), size and md5 hash will be used
 
             Note: this only applies to files.  Directories still have random ids regardless of this value
       description: >
@@ -3954,7 +3954,7 @@ components:
           type: boolean
           default: false
           description: >
-            If false, random ids will be created. If true, full target path (e.g. path + name), size and MD5 hash will be used
+            If false, random ids will be created. If true, full target path (e.g. path + name), size and md5 hash will be used
 
             Note: this only applies to files.  Directories still have random ids regardless of this value
         policies:
@@ -4451,6 +4451,14 @@ components:
         description:
           type: string
           description: A human readable description of the contents of the Data Object.
+        md5:
+          type: string
+          description: >
+            A hex representation of the  md5 for the file.  If an md5 exists for the file being
+            ingested, it will be validated against this value and the file's ingest will fail if the
+            values do not match.  If no md5 hash is present on the file being ingested, this value
+            will be stored for the file.  If this value is not specified, then the md5 from the file
+            being ingested will be used stored
       description: >
         Information needed to copy a file from a source bucket into the
         dataset bucket.
@@ -4487,7 +4495,7 @@ components:
         checksums:
           type: array
           description: >
-            Always present for files - checksums; always includes crc32c. May include md5.
+            Always present for files - checksums; May include md5 or crc32c.
             Present for directories in snapshots - see DRS spec for algorithm for combining checksums of
             underlying directory contents.
           items:
@@ -4644,6 +4652,14 @@ components:
         description:
           type: string
           description: A human readable description of the contents of the Data Object.
+        md5:
+          type: string
+          description: >
+            A hex representation of the  md5 for the file.  If an md5 exists for the file being
+            ingested, it will be validated against this value and the file's ingest will fail if the
+            values do not match.  If no md5 hash is present on the file being ingested, this value
+            will be stored for the file.  If this value is not specified, then the md5 from the file
+            being ingested will be used stored
       description: Describes one file within a bulk file load
     BulkLoadResultModel:
       type: object
@@ -4718,7 +4734,7 @@ components:
           description: The checksum crc of the loaded file; non-null if state is SUCCEEDED
         checksumMD5:
           type: string
-          description: The checksum mD5 of the loaded file; non-null if state is SUCCEEDED
+          description: The checksum md5 of the loaded file; non-null if state is SUCCEEDED
         error:
           type: string
           description: The error message if state is FAILED

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4452,13 +4452,7 @@ components:
           type: string
           description: A human readable description of the contents of the Data Object.
         md5:
-          type: string
-          description: >
-            A hex representation of the  md5 for the file.  If an md5 exists for the file being
-            ingested, it will be validated against this value and the file's ingest will fail if the
-            values do not match.  If no md5 hash is present on the file being ingested, this value
-            will be stored for the file.  If this value is not specified, then the md5 from the file
-            being ingested will be used stored
+          $ref: '#/components/schemas/Md5OverrideModel'
       description: >
         Information needed to copy a file from a source bucket into the
         dataset bucket.
@@ -4495,7 +4489,7 @@ components:
         checksums:
           type: array
           description: >
-            Always present for files - checksums; May include md5 or crc32c.
+            Always present for files - checksums; May include md5 and/or crc32c.
             Present for directories in snapshots - see DRS spec for algorithm for combining checksums of
             underlying directory contents.
           items:
@@ -4552,6 +4546,14 @@ components:
       description: >
         client-specified tag for a data or file load. If no id is specified, we use the
         string form of the job create time as the tag.
+    Md5OverrideModel:
+      type: string
+      description: >
+        A hex representation of the  md5 for the file.  If an md5 exists for the file being
+        ingested, it will be validated against this value and the file's ingest will fail if the
+        values do not match.  If no md5 hash is present on the file being ingested, this value
+        will be stored for the file.  If this value is not specified, then the md5 from the file
+        being ingested (from the cloud provider) will be used
     BulkLoadRequestModel:
       required:
         - loadControlFile
@@ -4653,13 +4655,7 @@ components:
           type: string
           description: A human readable description of the contents of the Data Object.
         md5:
-          type: string
-          description: >
-            A hex representation of the  md5 for the file.  If an md5 exists for the file being
-            ingested, it will be validated against this value and the file's ingest will fail if the
-            values do not match.  If no md5 hash is present on the file being ingested, this value
-            will be stored for the file.  If this value is not specified, then the md5 from the file
-            being ingested will be used stored
+          $ref: '#/components/schemas/Md5OverrideModel'
       description: Describes one file within a bulk file load
     BulkLoadResultModel:
       type: object

--- a/src/test/java/bio/terra/common/TestUtils.java
+++ b/src/test/java/bio/terra/common/TestUtils.java
@@ -2,8 +2,10 @@ package bio.terra.common;
 
 import static bio.terra.service.filedata.google.gcs.GcsPdao.getBlobFromGsPath;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -55,6 +57,7 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.junit.function.ThrowingRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stringtemplate.v4.ST;
@@ -325,5 +328,22 @@ public final class TestUtils {
       sb.append('\n');
     }
     return sb.toString();
+  }
+
+  /**
+   * Asserts that a command fails with the type passed in with a message that contains the expected
+   * message
+   *
+   * @param expectedThrowable The class that should be thrown. Note: this is the top level exception
+   *     and not the cause exception
+   * @param expectedMessage The partial message that should be present in the exception
+   * @param runnable The code to test
+   */
+  public static void assertError(
+      Class<? extends Throwable> expectedThrowable,
+      String expectedMessage,
+      ThrowingRunnable runnable) {
+    Throwable throwable = assertThrows("expect a failure", expectedThrowable, runnable);
+    assertThat(throwable.getMessage(), containsString(expectedMessage));
   }
 }

--- a/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileIdServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
 import bio.terra.service.dataset.Dataset;
 import java.util.List;
@@ -39,15 +40,19 @@ public class FileIdServiceTest {
   }
 
   @Test
-  public void testPredictableUUIDWithNoMD5Equals() {
-    when(dataset.hasPredictableFileIds()).thenReturn(true);
-    FSItem fsItem1 = new FSFile().path("/foo/bar").size(123L).checksumMd5(null);
-
-    FSItem fsItem2 = new FSFile().path("/foo/bar").size(123L).checksumMd5(null);
-    assertEquals(
-        "IDs match",
-        service.calculateFileId(dataset, fsItem1),
-        service.calculateFileId(dataset, fsItem2));
+  public void testPredictableUUIDWithMissingFieldsFails() {
+    TestUtils.assertError(
+        NullPointerException.class,
+        "A target path is required to create a file id",
+        () -> service.calculateFileId(true, new FSFile().path(null).checksumMd5("md5").size(1L)));
+    TestUtils.assertError(
+        NullPointerException.class,
+        "An MD5 checksum is required to create a file id",
+        () -> service.calculateFileId(true, new FSFile().path("/p").checksumMd5(null).size(1L)));
+    TestUtils.assertError(
+        NullPointerException.class,
+        "A size is required to create a file id",
+        () -> service.calculateFileId(true, new FSFile().path("/p").checksumMd5("md5").size(null)));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
@@ -5,9 +5,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
+import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
+import bio.terra.service.filedata.exception.InvalidFileChecksumException;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
@@ -153,6 +156,33 @@ public class FileMetadataUtilsTest {
             "/_dr_/test/path-2",
             "/_dr_/test/path-3",
             "/_dr_/test/path-4"));
+  }
+
+  @Test
+  public void testValidateFileMd5ForIngest() {
+    assertThat(
+        "matching md5s pass",
+        FileMetadataUtils.validateFileMd5ForIngest("foo", "foo", "gs://bucket/path.txt"),
+        equalTo("foo"));
+
+    assertThat(
+        "user specified md5 returns if no cloud md5 is present",
+        FileMetadataUtils.validateFileMd5ForIngest("foo", null, "gs://bucket/path.txt"),
+        equalTo("foo"));
+
+    assertThat(
+        "cloud md5 returns if no user specified md5 is present",
+        FileMetadataUtils.validateFileMd5ForIngest(null, "foo", "gs://bucket/path.txt"),
+        equalTo("foo"));
+
+    assertNull(
+        "null returned if both inputs are null",
+        FileMetadataUtils.validateFileMd5ForIngest(null, null, "gs://bucket/path.txt"));
+
+    TestUtils.assertError(
+        InvalidFileChecksumException.class,
+        "Checksums do not match for file gs://bucket/path.txt",
+        () -> FileMetadataUtils.validateFileMd5ForIngest("foo", "bar", "gs://bucket/path.txt"));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -33,6 +33,7 @@ import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import bio.terra.service.resourcemanagement.azure.AzureResourceDao;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import com.azure.core.credential.TokenCredential;
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobUrlParts;
 import com.azure.storage.blob.models.BlobProperties;
@@ -292,6 +293,12 @@ public class AzureBlobStorePdaoTest {
     when(blobCrl.createBlobContainerCopier(any(), anyString(), anyString())).thenReturn(copier);
     String targetBlobName = fileId + "/" + SOURCE_FILE_NAME;
     when(blobCrl.getBlobProperties(targetBlobName)).thenReturn(blobProperties);
+    BlobContainerClient sourceBlobContainerClient = mock(BlobContainerClient.class);
+    BlobClient blobClient = mock(BlobClient.class);
+    // use the same blob properties for the source and for the target
+    when(blobClient.getProperties()).thenReturn(blobProperties);
+    when(sourceBlobContainerClient.getBlobClient(any())).thenReturn(blobClient);
+    when(sourceBlobContainerFactory.getBlobContainerClient()).thenReturn(sourceBlobContainerClient);
     BlobContainerClient targetBlobContainerClient = mock(BlobContainerClient.class);
     when(targetBlobContainerFactory.getBlobContainerClient()).thenReturn(targetBlobContainerClient);
     String targetContainerUrl = "https://" + STORAGE_ACCOUNT_NAME + ".blob.core.windows.net/data";

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDaoConnectedTest.java
@@ -281,6 +281,7 @@ public class TableDaoConnectedTest {
             .fileCreatedDate(Instant.now().toString())
             .gspath(endpoint + "/" + fullPath)
             .checksumMd5(SnapshotCompute.computeMd5(fullPath))
+            .userSpecifiedMd5(false)
             .size(size);
 
     tableFileDao.createFileMetadata(tableServiceClient, newFile);

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -182,6 +182,7 @@ public class FireStoreDaoTest {
             .gspath("gs://" + datasetId + "/" + fileId)
             .checksumCrc32c(SnapshotCompute.computeCrc32c(fullPath))
             .checksumMd5(SnapshotCompute.computeMd5(fullPath))
+            .userSpecifiedMd5(false)
             .size(size);
 
     fileDao.createFileMetadata(firestore, datasetId, newFile);

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -2,7 +2,9 @@ package bio.terra.service.filedata.google.gcs;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -10,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
+import bio.terra.common.TestUtils;
 import bio.terra.common.category.Connected;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.FileLoadModel;
@@ -23,9 +26,11 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.ComposeRequest;
 import com.google.cloud.storage.StorageOptions;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -188,10 +193,10 @@ public class GcsPdaoTest {
               .id(UUID.randomUUID())
               .predictableFileIds(usePredictableFileId)
               .name("test_dataset");
-      // Try to copy using predictable and non-predicatble file ids
+      // Try to copy using predictable and non-predictable file ids
       gcsPdao.createGcsFile(sourceBlob, projectId);
       gcsPdao.writeStreamToCloudFile(sourcePath, Stream.of("foo", "bar"), projectId);
-      // Copy the file once:
+      // Copy the file once
       GoogleBucketResource targetBucket =
           new GoogleBucketResource()
               .resourceId(UUID.randomUUID())
@@ -216,9 +221,81 @@ public class GcsPdaoTest {
     }
   }
 
+  @Test
+  public void testCopyBlobWithNoSourceMd5AndPredictableId() {
+    testCopyBlobWithNoSourceMd5(true);
+  }
+
+  @Test
+  public void testCopyBlobWithNoSourceMd5AndRandomId() {
+    testCopyBlobWithNoSourceMd5(false);
+  }
+
+  public void testCopyBlobWithNoSourceMd5(boolean usePredictableFileId) {
+    BlobId sourceBlobId =
+        BlobId.of(testConfig.getIngestbucket(), UUID.randomUUID() + "#" + UUID.randomUUID());
+    BlobId sourceComposedBlobId =
+        BlobId.of(testConfig.getIngestbucket(), UUID.randomUUID() + "#C" + UUID.randomUUID());
+    String fileId = usePredictableFileId ? null : UUID.randomUUID().toString();
+    try {
+      Blob sourceBlob = gcsPdao.createGcsFile(sourceBlobId, projectId);
+      gcsPdao.writeStreamToCloudFile(
+          sourceBlobId.toGsUtilUri(), Stream.of("foo", "bar"), projectId);
+      createCompositeGcsFile(List.of(sourceBlob), sourceComposedBlobId);
+
+      FileLoadModel fileLoadModel =
+          new FileLoadModel().sourcePath(sourceComposedBlobId.toGsUtilUri()).targetPath("/foo/bar");
+
+      Dataset dataset =
+          new Dataset()
+              .id(UUID.randomUUID())
+              .predictableFileIds(usePredictableFileId)
+              .name("test_dataset");
+
+      GoogleBucketResource targetBucket =
+          new GoogleBucketResource()
+              .resourceId(UUID.randomUUID())
+              .name(sourceBlob.getBucket())
+              .projectResource(new GoogleProjectResource().googleProjectId(projectId));
+      // Copy the file with no md5 specified (it should fail for predictable ids)
+      if (usePredictableFileId) {
+        TestUtils.assertError(
+            NullPointerException.class,
+            "An MD5 checksum is required to create a file id",
+            () -> gcsPdao.copyFile(dataset, fileLoadModel, fileId, targetBucket));
+      } else {
+        FSFileInfo fsFileInfo = gcsPdao.copyFile(dataset, fileLoadModel, fileId, targetBucket);
+        assertThat(
+            "file created with no md5", fsFileInfo.getChecksumMd5(), is(emptyOrNullString()));
+        // Delete the target file
+        storage.delete(fsFileInfo.getCloudPath());
+      }
+      // Copy the file with the md5 specified (it should work).  Note: while this will work, this
+      // isn't representative of how this *should* be used.  Typically, the MD5 would be
+      // calculated by the user.  This is to demonstrate that the md5 can be anything here (e.g.
+      // there is no verification)
+      String userMd5 = UUID.randomUUID().toString().replace("-", "");
+      fileLoadModel.md5(userMd5);
+      FSFileInfo fsFileInfo = gcsPdao.copyFile(dataset, fileLoadModel, fileId, targetBucket);
+      assertThat(
+          "file created with user specified md5", fsFileInfo.getChecksumMd5(), equalTo(userMd5));
+      // Delete the target file
+      storage.delete(BlobId.fromGsUtilUri(fsFileInfo.getCloudPath()));
+    } finally {
+      storage.delete(sourceBlobId, sourceComposedBlobId);
+    }
+  }
+
   private List<String> getGcsFilesLines(String path, String projectId) {
     try (var stream = gcsPdao.getBlobsLinesStream(path, projectId, TEST_USER)) {
       return stream.collect(Collectors.toList());
     }
+  }
+
+  private void createCompositeGcsFile(Collection<Blob> sourceBlobs, BlobId targetBlobId) {
+    storage.compose(
+        ComposeRequest.of(
+            sourceBlobs.stream().map(b -> b.getBlobId().getName()).toList(),
+            BlobInfo.newBuilder(targetBlobId).build()));
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -268,7 +268,7 @@ public class GcsPdaoTest {
         assertThat(
             "file created with no md5", fsFileInfo.getChecksumMd5(), is(emptyOrNullString()));
         // Delete the target file
-        storage.delete(fsFileInfo.getCloudPath());
+        storage.delete(BlobId.fromGsUtilUri(fsFileInfo.getCloudPath()));
       }
       // Copy the file with the md5 specified (it should work).  Note: while this will work, this
       // isn't representative of how this *should* be used.  Typically, the MD5 would be


### PR DESCRIPTION
Allow users to specify their own MD5 values as part of file ingest models.

- The behavior is:
  - If the user doesn't specify an MD5, use whatever is present in the cloud object (same as today)
  - If the user specifies an MD5 and there is an MD5 on the cloud object, validate that the MD5's match and fail if they don't
  - If the user specifies an MD5 and there is no MD5 on the cloud object, use the user specified MD5 and store in Firestore/Azure Tables
  - If a user MD5 is used, then record that it was in Firestore/Azure tables for future auditing but don't surface that fact to the user (for now)
- Drive by fix to make sure to record creation time for directory objects

Testing is primarily via unit and connected tests.  I'm happy to add an integration tests if folks find it helpful
