### PR TITLE
[DR-2843] Run DUOS Firecloud group sync as background task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat
 
 buildscript {
     ext {
-        springBootVersion = '2.5.12'
+        springBootVersion = '3.0.4'
     }
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -218,6 +218,10 @@ dependencies {
 
     implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '9.2.1.jre11'
 
+    // For distributed locking of Spring @Scheduled tasks across multiple instances
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.2.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
+
     // This allows you to build with a local Stairway JAR file, instead of the one from the repository
     // For example, ./gradlew -Pstairwayjar=/Users/dd/code/stairway/build/libs/stairway-0.0.4-SNAPSHOT.jar
     // Or define the environment variable ORG_GRADLE_PROJECT_stairwayjar

--- a/src/main/java/bio/terra/app/configuration/scheduled/README.md
+++ b/src/main/java/bio/terra/app/configuration/scheduled/README.md
@@ -1,0 +1,95 @@
+# Scheduled Background Tasks
+
+One way that we can schedule background tasks within our backend is via **Spring @Scheduled**
+annotation with **ShedLock** distributed locking.
+
+By default, Spring cannot handle scheduler synchronization over multiple instances
+of an application.  If we deploy our backend with multiple replicas, Spring will try
+to run @Scheduled tasks on each replica, which in most cases is not what we want.
+
+A concrete example:
+- We currently deploy `jade-datarepo-api` to production with 3 replicas
+- Let's say that we have a group membership sync that we want to run hourly
+- But we just want this task to run **once** hourly, not hourly on each of our 3 replicas
+  - Could result in unexpected behavior, concurrent DB modification issues, etc.
+
+ShedLock is a distributed locking mechanism for Spring @Scheduled tasks.  It ensures
+that your @Scheduled tasks are executed at most once at the same time.  If a task
+is being executed on a replica, it acquires a lock which prevents execution from another
+replica or thread.  In the presence of an active lock, any other attempts at execution
+are skipped.
+
+## Spring @Scheduled
+
+### Thread Pool Size
+
+All of an application's Spring @Scheduled tasks run by default off of a singleton thread pool.
+This can make debugging difficult: one long-running task will hold the sole thread and prevent
+others from being scheduled.
+
+We can increase the size of the pool via the following application property:
+
+```yaml
+spring.task.scheduling.pool.size=10
+```
+
+### Recommended Schedule
+
+Recommendation: disable Spring @Scheduled jobs by default and conditionally set their schedule
+at the deployment level.
+
+The following example disables our job by default using Spring's cron disable expression: `-`.
+
+```java
+@Scheduled(cron = "${jobs.cronSchedule:-}")
+public void cleanTempDirectory() {
+  // do work here
+}
+```
+
+If we wanted to enable our job, we would need to provide a valid cron expression for
+`jobs.cronSchedule` via environment variable, property file, etc.
+
+## [ShedLock](https://github.com/lukas-krecan/ShedLock)
+
+Let's return to the example above.  Here's how we could annotate the method further to manage its
+locking with ShedLock, to avoid it being scheduled on every replica:
+```java
+@Scheduled(cron = "${jobs.cronSchedule:-}")
+@SchedulerLock(
+  name = "cleanTempDirectory",
+  lockAtLeastFor = "5s",
+  lockAtMostFor = "5m")
+public void cleanTempDirectory() {
+  // do work here
+}
+```
+
+- `name` - required identifier for our job which ShedLock will use in its lock
+- `lockAtLeastFor` - optional minimum lock length, to overcome clock differences across nodes
+for short-running tasks.
+- `lockAtMostFor` - optional maximum lock length, a fallback in case the locking node dies while
+the lock is still active.  This should be set much longer than expected execution time.
+If unspecified, the default set in @EnableSchedulerLock will be used.
+
+More information on this annotation can be found in
+[ShedLock documentation.](https://github.com/lukas-krecan/ShedLock#annotate-your-scheduled-tasks)
+
+## Benefits
+
+By coupling our scheduling with our application code, we hope to make it more clear what we mean
+to run as background tasks, even if the specific schedules are configured per deployment.
+
+Outside of setting cron schedules, this approach should not require any modifications to our
+Helmfiles or other infrastructure-as-code.
+
+Scheduled tasks running with application code means that the logs emitted from these tasks are found
+alongside the rest of our application logs, which should make things easier to debug.
+
+## Caveats
+
+The other side of running scheduled tasks within the application is that they are not insulated
+from issues within our main deployment, or vice-versa.  Consider handing resource-intensive
+or mission-critical scheduled tasks outside of the main deployment.
+
+More consideration is needed to the matter of alerting on issues with scheduled jobs.

--- a/src/main/java/bio/terra/app/configuration/scheduled/ShedlockConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/scheduled/ShedlockConfiguration.java
@@ -1,0 +1,48 @@
+package bio.terra.app.configuration.scheduled;
+
+import bio.terra.app.configuration.DataRepoJdbcConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * ShedLock allows us to safely use Spring's @Scheduled annotation for scheduling background jobs
+ * within a multi-instance environment.
+ *
+ * <p>Spring, by default, cannot handle scheduler synchronization over multiple instances. It
+ * executes the jobs simultaneously on every node instead.
+ *
+ * <p>ShedLock makes sure that your scheduled tasks are executed at most once at the same time. If a
+ * task is being executed on one node, it acquires a lock which prevents execution of the same task
+ * from another node or thread. In the presence of an active lock, execution on other nodes is
+ * skipped.
+ *
+ * <p>More information: https://github.com/lukas-krecan/ShedLock#jdbctemplate
+ */
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "1h")
+public class ShedlockConfiguration {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Autowired
+  public ShedlockConfiguration(DataRepoJdbcConfiguration jdbcConfiguration) {
+    this.jdbcTemplate = new JdbcTemplate(jdbcConfiguration.getDataSource());
+  }
+
+  @Bean("shedlockLockProvider")
+  public LockProvider lockProvider() {
+    // By default, ShedLock looks for a table named `shedlock` in its data source to store its locks
+    return new JdbcTemplateLockProvider(
+        JdbcTemplateLockProvider.Configuration.builder()
+            .withJdbcTemplate(jdbcTemplate)
+            .usingDbTime()
+            .build());
+  }
+}

--- a/src/main/java/bio/terra/service/duos/DuosService.java
+++ b/src/main/java/bio/terra/service/duos/DuosService.java
@@ -22,10 +22,12 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -178,6 +180,11 @@ public class DuosService {
    * @return DUOS Firecloud groups whose members were successfully synced, and any errors occurred
    *     which may have interfered with syncing
    */
+  @Scheduled(cron = "${duos.syncUsers.schedule:-}")
+  @SchedulerLock(
+      name = "DuosService.syncDuosDatasetsAuthorizedUsers",
+      lockAtLeastFor = "5s",
+      lockAtMostFor = "5m")
   public DuosFirecloudGroupsSyncResponse syncDuosDatasetsAuthorizedUsers() {
     // 1. Parallelize our calls to external systems (DUOS, Sam) which perform the sync
     Instant lastSyncedDate = Instant.now();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 spring.liquibase.enabled=false
 spring.profiles.active=google,human-readable-logging,local
 spring.main.allow-bean-definition-overriding=true
+spring.task.scheduling.pool.size=10
 spring.resources.cache.cachecontrol.max-age=0
 spring.resources.cache.cachecontrol.must-revalidate=true
 spring.resources.static-locations=classpath:/api/

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -69,4 +69,5 @@
     <include file="changesets/20221104_predictablefileidsoption.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20221104_v2drsids.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20230208_gcpautoclassbucket.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20230307_shedlock.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20230307_shedlock.yaml
+++ b/src/main/resources/db/changesets/20230307_shedlock.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: shedlock
+      author: okotsopo
+      changes:
+        - createTable:
+            tableName: shedlock
+            remarks: |
+              This table is required for ShedLock's JdbcTemplate implementation of LockProvider.
+              https://github.com/lukas-krecan/ShedLock#jdbctemplate
+            columns:
+              - column:
+                  name: name
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+              - column:
+                  name: lock_until
+                  type: timestamptz
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked_at
+                  type: timestamptz
+                  constraints:
+                    nullable: false
+              - column:
+                  name: locked_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: false


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2843

This PR uses Spring @Scheduled annotation with [ShedLock](https://github.com/lukas-krecan/ShedLock) distributed lock to run the DUOS Firecloud group sync as a background task within the existing application.  Thanks @pshapiro4broad for the suggestion!

It's disabled by default but can be scheduled per deployment by setting environment variable `DUOS_SYNCUSERS_SCHEDULE` to a valid [cron expression](https://spring.io/blog/2020/11/10/new-in-spring-5-3-improved-cron-expressions).  This is the only place where we need to modify our Helm charts / infrastructure-as-code to schedule this task.

**Demonstration**

My [dev environment](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#) is up to date with these changes.

I've upped my [ok-jade-datarepo-api](https://console.cloud.google.com/kubernetes/deployment/us-central1/dev-master/ok/ok-jade-datarepo-api/overview?authuser=1&project=broad-jade-dev) replica count from 1->2 to concretely demonstrate that ShedLock handles the problem we have inherently with Spring @Scheduled tasks.

As part of my dev deployment, I set the following environment variable:
```
DUOS_SYNCUSERS_SCHEDULE: "@hourly"
```

I am seeing in my `ok-jade-datarepo-api` container logs that this sync is running once every hour:
https://cloudlogging.app.goo.gl/YwVqDapJXmgFS1Gv5

And when I fetch the DUOS Firecloud Group records from my dev Swagger, I see that their `last_synced` times are being updated as we'd expect:
```
curl -X 'GET' \
  'https://jade-ok.datarepo-dev.broadinstitute.org/api/repository/v1/duos' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <token>'

[
  {
    "id": "44bfcf29-63b5-42a7-995a-1a9159b5f2b5",
    "duosId": "DUOS-000005",
    "firecloudGroupName": "DUOS-000005-users",
    "firecloudGroupEmail": "DUOS-000005-users@dev.test.firecloud.org",
    "createdBy": "jade-k8-sa@broad-jade-dev.iam.gserviceaccount.com",
    "created": "2022-11-05T16:33:36.019056Z",
    "lastSynced": "2023-03-09T22:00:00.082745Z"
  },
  …
  ```

**Alternatives Considered**

Other teams / projects (IA's Leonardo, Identiteam's NCBI failsafe) leverage Kubernetes CronJobs for their background tasks, but Leo in particular has struggled with the lack of visibility into failed jobs.  They spin up a `leonardo-cron-jobs` application for their job instances so all the logging takes place within the ephemeral clusters.  So if we went this route we wanted our actionable task logs to live with our app logs.

I spent quite a bit of time trying to get this to work via a Kubernetes CronJob hitting a new unauthenticated / unregistered API endpoint.  While I think we could have gotten this working, it would involve a fair amount of Helm boilerplate across several repos.  Consider what's required for what (I think) is TDR's `sqlbackup` Kubernetes CronJob in fake prod:
- https://github.com/broadinstitute/datarepo-helm/tree/master/charts/sqlbackup
- https://github.com/broadinstitute/datarepo-helm-definitions/blob/master/prod/helmfile.yaml#L25-L31
- https://github.com/broadinstitute/datarepo-helm-definitions/blob/master/prod/psqlbackup/psqlbackup.yaml

I also couldn't find a way to specify hidden endpoints in our OpenAPI yaml, which we use for code generation.  So any new endpoints only meant to be hit by Kubernetes would be exposed to users -- not accessible, but confusing all the same.

I was reluctant to add another method for background tasks into consideration, as well as a new dependency to manage, but found ShedLock to be straightforward to get working and use, since we already bear the burden of supporting Spring Boot in our application.  Evidence points to it being a widely used package with frequent updates, fast responses to issues, automated testing, and dependabot integration (in the past we've had issues where transitive dependencies had security vulnerabilities but our direct dependency was slow to upgrade).

**Follow on work**
- Expose group `lastSynced` value in the TDR UI for a visual indication of whether syncs are occurring
- Think of how we'd like to monitor this job for failures: perhaps an alert on Firecloud groups that haven't been synced in <x> hours?
- Schedule syncs for desired environments (dev and prod, can roll out slowly to allow for time to evaluate)
