### PR TITLE
[DC-669] stub out cohort builder apis

### DIFF
--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -4,6 +4,7 @@ import bio.terra.app.logging.LoggerInterceptor;
 import bio.terra.app.usermetrics.UserMetricsInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -24,5 +25,13 @@ public class WebConfig implements WebMvcConfigurer {
     registry
         .addResourceHandler("/webjars/swagger-ui-dist/**")
         .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui-dist/4.3.0/");
+  }
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry
+        .addMapping("/**")
+        .allowedOrigins("*")
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD");
   }
 }

--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -28,6 +28,8 @@ public class WebConfig implements WebMvcConfigurer {
   }
 
   @Override
+  // This should be removed before this code comes out of prototype phase, only important to power
+  // the Tanagra UI, which doesn't handle CORS to other localhosts properly
   public void addCorsMappings(CorsRegistry registry) {
     registry
         .addMapping("/**")

--- a/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
+++ b/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
@@ -86,7 +86,7 @@ public class CohortBuilderApiController implements CohortBuilderApi {
     return new ResponseEntity<>(
         new InstanceCountList()
             .sql(
-                "SELECT p.gender AS gender, p.race AS race, COUNT(p.id) AS t_count, p.t_display_gender AS t_display_gender, p.t_display_race AS t_display_race, p.year_of_birth AS year_of_birth FROM `broad-tanagra-dev.cmssynpuf_index_011523`.person AS p GROUP BY p.gender, p.t_display_gender, p.race, p.t_display_race, p.year_of_birth ORDER BY p.gender ASC, p.t_display_gender ASC, p.race ASC, p.t_display_race ASC, p.year_of_birth ASC")
+                "SQL goes here")
             .instanceCounts(
                 createInstanceCountsYearGenderRace(
                     // Stub values based on what the API synthetic data returns in the other API -
@@ -193,8 +193,7 @@ public class CohortBuilderApiController implements CohortBuilderApi {
 
     return new ResponseEntity<>(
         new InstanceList()
-            .sql(
-                "SELECT c.concept_code AS concept_code, c.id AS id, c.name AS name, c.standard_concept AS standard_concept, c.t_count_person AS t_count_person, c.t_count_person_standard AS t_count_person_standard, c.t_display_standard_concept AS t_display_standard_concept, c.t_display_vocabulary AS t_display_vocabulary, c.t_standard_num_children AS t_standard_num_children, c.t_standard_path AS t_standard_path, c.vocabulary AS vocabulary FROM `broad-tanagra-dev.cmssynpuf_index_011523`.condition AS c WHERE (c.t_standard_path IS NOT NULL AND c.t_standard_path = '') ORDER BY c.t_count_person_standard DESC LIMIT 250")
+            .sql("SQL Goes here")
             .instances(instances),
         HttpStatus.OK);
   }

--- a/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
+++ b/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
@@ -1,7 +1,6 @@
 package bio.terra.app.controller;
 
 import bio.terra.controller.CohortBuilderApi;
-import bio.terra.model.Attribute;
 import bio.terra.model.Cohort;
 import bio.terra.model.CohortCreateInfo;
 import bio.terra.model.CohortList;
@@ -11,409 +10,105 @@ import bio.terra.model.ConceptSetCreateInfo;
 import bio.terra.model.ConceptSetList;
 import bio.terra.model.ConceptSetUpdateInfo;
 import bio.terra.model.CountQuery;
-import bio.terra.model.Criteria;
-import bio.terra.model.CriteriaGroup;
-import bio.terra.model.DataType;
-import bio.terra.model.DisplayHint;
-import bio.terra.model.DisplayHintDisplayHint;
-import bio.terra.model.DisplayHintEnum;
-import bio.terra.model.DisplayHintEnumEnumHintValues;
 import bio.terra.model.DisplayHintList;
-import bio.terra.model.DisplayHintNumericRange;
 import bio.terra.model.HintQuery;
-import bio.terra.model.Instance;
-import bio.terra.model.InstanceCount;
 import bio.terra.model.InstanceCountList;
-import bio.terra.model.InstanceHierarchyFields;
 import bio.terra.model.InstanceList;
-import bio.terra.model.InstanceRelationshipFields;
-import bio.terra.model.Literal;
-import bio.terra.model.LiteralValueUnion;
 import bio.terra.model.Query;
-import bio.terra.model.ValueDisplay;
+import bio.terra.service.cohortbuilder.CohortService;
+import bio.terra.service.cohortbuilder.ConceptSetService;
+import bio.terra.service.cohortbuilder.HintsService;
+import bio.terra.service.cohortbuilder.InstancesService;
 import io.swagger.annotations.Api;
-import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @Api(tags = {"cohort-builder"})
 public class CohortBuilderApiController implements CohortBuilderApi {
+  private final CohortService cohortService;
+  private final ConceptSetService conceptSetService;
+  private final HintsService hintsService;
+  private final InstancesService instancesService;
 
-  @Autowired
-  public CohortBuilderApiController() {}
+  public CohortBuilderApiController(
+      CohortService cohortService,
+      ConceptSetService conceptSetService,
+      HintsService hintsService,
+      InstancesService instancesService) {
+    this.cohortService = cohortService;
+    this.conceptSetService = conceptSetService;
+    this.hintsService = hintsService;
+    this.instancesService = instancesService;
+  }
 
   @Override
   public ResponseEntity<CohortList> listCohorts(Integer offset, Integer limit) {
-    CohortList response = new CohortList();
-    response.add(generateStubCohort());
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return ResponseEntity.ok(cohortService.listCohorts(offset, limit));
   }
 
   @Override
   public ResponseEntity<Cohort> createCohort(CohortCreateInfo cohortCreateInfo) {
-    return new ResponseEntity<>(generateStubCohort(), HttpStatus.OK);
+    return ResponseEntity.ok(cohortService.createCohort(cohortCreateInfo));
   }
 
   @Override
   public ResponseEntity<Cohort> getCohort(String cohortId) {
-    Cohort response = generateStubCohort();
-    return new ResponseEntity<>(response, HttpStatus.OK);
+    return ResponseEntity.ok(cohortService.getCohort(cohortId));
   }
 
   @Override
   public ResponseEntity<Cohort> updateCohort(String cohortId, CohortUpdateInfo cohortUpdateInfo) {
-    return new ResponseEntity<>(generateStubCohort(), HttpStatus.OK);
+    return ResponseEntity.ok(cohortService.updateCohort(cohortId, cohortUpdateInfo));
   }
 
   @Override
   public ResponseEntity<Void> deleteCohort(String cohortId) {
-    return new ResponseEntity<>(HttpStatus.OK);
+    cohortService.deleteCohort(cohortId);
+    return ResponseEntity.noContent().build();
   }
 
   @Override
   public ResponseEntity<InstanceCountList> countInstances(
       String entityName, CountQuery countQuery) {
-
-    return new ResponseEntity<>(
-        new InstanceCountList()
-            .sql("SQL goes here")
-            .instanceCounts(
-                createInstanceCountsYearGenderRace(
-                    // Stub values based on what the API synthetic data returns in the other API -
-                    // not representative of life
-                    List.of(
-                        new ValueDisplay()
-                            .value(
-                                new Literal()
-                                    .dataType(DataType.INT64)
-                                    .valueUnion(new LiteralValueUnion().int64Val(8507L)))
-                            .display("MALE"),
-                        new ValueDisplay()
-                            .value(
-                                new Literal()
-                                    .dataType(DataType.INT64)
-                                    .valueUnion(new LiteralValueUnion().int64Val(8532L)))
-                            .display("FEMALE")),
-                    List.of(
-                        new ValueDisplay()
-                            .value(
-                                new Literal()
-                                    .dataType(DataType.INT64)
-                                    .valueUnion(new LiteralValueUnion().int64Val(0L)))
-                            .display("No matching concept"),
-                        new ValueDisplay()
-                            .value(
-                                new Literal()
-                                    .dataType(DataType.INT64)
-                                    .valueUnion(new LiteralValueUnion().int64Val(8516L)))
-                            .display("Black or African American"),
-                        new ValueDisplay()
-                            .value(
-                                new Literal()
-                                    .dataType(DataType.INT64)
-                                    .valueUnion(new LiteralValueUnion().int64Val(8527L)))
-                            .display("White")),
-                    LongStream.range(1909, 1984)
-                        .mapToObj(
-                            yearOfBirth ->
-                                new ValueDisplay()
-                                    .value(
-                                        new Literal()
-                                            .dataType(DataType.INT64)
-                                            .valueUnion(
-                                                new LiteralValueUnion().int64Val(yearOfBirth))))
-                        .collect(Collectors.toList()))),
-        HttpStatus.OK);
+    return ResponseEntity.ok(instancesService.countInstances(entityName, countQuery));
   }
 
   @Override
   public ResponseEntity<InstanceList> queryInstances(String entityName, Query query) {
-    List<InstanceRelationshipFields> relationshipFields =
-        List.of(
-            new InstanceRelationshipFields()
-                .relatedEntity("person")
-                .hierarchy("standard")
-                .count(1970071),
-            new InstanceRelationshipFields().relatedEntity("person").count(0));
-
-    List<InstanceHierarchyFields> hierarchyFields =
-        List.of(new InstanceHierarchyFields().hierarchy("standard").path("").numChildren(29));
-
-    Map<String, ValueDisplay> attributes =
-        Map.of(
-            "standard_concept",
-                new ValueDisplay()
-                    .display("Standard")
-                    .value(
-                        new Literal()
-                            .dataType(DataType.STRING)
-                            .valueUnion(new LiteralValueUnion().stringVal("S"))),
-            "vocabulary",
-                new ValueDisplay()
-                    .display("Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO)")
-                    .value(
-                        new Literal()
-                            .dataType(DataType.STRING)
-                            .valueUnion(new LiteralValueUnion().stringVal("SNOMED"))),
-            "name",
-                new ValueDisplay()
-                    .value(
-                        new Literal()
-                            .dataType(DataType.STRING)
-                            .valueUnion(new LiteralValueUnion().stringVal("Clinical finding"))),
-            "concept_code",
-                new ValueDisplay()
-                    .value(
-                        new Literal()
-                            .dataType(DataType.STRING)
-                            .valueUnion(new LiteralValueUnion().stringVal("404684003"))),
-            "id",
-                new ValueDisplay()
-                    .value(
-                        new Literal()
-                            .dataType(DataType.INT64)
-                            .valueUnion(new LiteralValueUnion().int64Val(441840L))));
-
-    List<Instance> instances =
-        List.of(
-            new Instance()
-                .relationshipFields(relationshipFields)
-                .hierarchyFields(hierarchyFields)
-                .attributes(attributes));
-
-    return new ResponseEntity<>(
-        new InstanceList().sql("SQL Goes here").instances(instances), HttpStatus.OK);
+    return ResponseEntity.ok(instancesService.queryInstances(entityName, query));
   }
 
   @Override
-  public ResponseEntity<ConceptSetList> listConceptSets(
-      @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
-      @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
-    ConceptSetList response = new ConceptSetList();
-    response.add(generateStubConceptSet());
-    return new ResponseEntity<>(response, HttpStatus.OK);
+  public ResponseEntity<ConceptSetList> listConceptSets(Integer offset, Integer limit) {
+    return ResponseEntity.ok(conceptSetService.listConceptSets(offset, limit));
   }
 
   @Override
   public ResponseEntity<ConceptSet> createConceptSet(ConceptSetCreateInfo conceptSetCreateInfo) {
-    return new ResponseEntity<>(generateStubConceptSet(), HttpStatus.OK);
+    return ResponseEntity.ok(conceptSetService.createConceptSet(conceptSetCreateInfo));
   }
 
   @Override
-  public ResponseEntity<ConceptSet> getConceptSet(String ConceptSetId) {
-    return new ResponseEntity<>(generateStubConceptSet(), HttpStatus.OK);
+  public ResponseEntity<ConceptSet> getConceptSet(String conceptSetId) {
+    return ResponseEntity.ok(conceptSetService.getConceptSet(conceptSetId));
   }
 
   @Override
   public ResponseEntity<ConceptSet> updateConceptSet(
       String conceptSetId, ConceptSetUpdateInfo conceptSetUpdateInfo) {
-    return new ResponseEntity<>(generateStubConceptSet(), HttpStatus.OK);
+    return ResponseEntity.ok(
+        conceptSetService.updateConceptSet(conceptSetId, conceptSetUpdateInfo));
   }
 
   @Override
   public ResponseEntity<Void> deleteConceptSet(String conceptSetId) {
-    return new ResponseEntity<>(HttpStatus.OK);
+    conceptSetService.deleteConceptSet(conceptSetId);
+    return ResponseEntity.noContent().build();
   }
 
   @Override
   public ResponseEntity<DisplayHintList> queryHints(String entityId, HintQuery hintQuery) {
-    DisplayHintList response =
-        new DisplayHintList()
-            .addDisplayHintsItem(
-                new DisplayHint()
-                    .attribute(
-                        new Attribute()
-                            .name("gender")
-                            .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
-                            .dataType(DataType.INT64))
-                    .displayHint(
-                        new DisplayHintDisplayHint()
-                            .enumHint(
-                                new DisplayHintEnum()
-                                    .enumHintValues(
-                                        List.of(
-                                            new DisplayHintEnumEnumHintValues()
-                                                .enumVal(
-                                                    new ValueDisplay()
-                                                        .display("FEMALE")
-                                                        .value(
-                                                            new Literal()
-                                                                .dataType(DataType.INT64)
-                                                                .valueUnion(
-                                                                    new LiteralValueUnion()
-                                                                        .int64Val(8532L))))
-                                                .count(1292861),
-                                            new DisplayHintEnumEnumHintValues()
-                                                .enumVal(
-                                                    new ValueDisplay()
-                                                        .display("MALE")
-                                                        .value(
-                                                            new Literal()
-                                                                .dataType(DataType.INT64)
-                                                                .valueUnion(
-                                                                    new LiteralValueUnion()
-                                                                        .int64Val(8507L))))
-                                                .count(1033995))))))
-            .addDisplayHintsItem(
-                new DisplayHint()
-                    .attribute(
-                        new Attribute()
-                            .name("race")
-                            .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
-                            .dataType(DataType.INT64))
-                    .displayHint(
-                        new DisplayHintDisplayHint()
-                            .enumHint(
-                                new DisplayHintEnum()
-                                    .enumHintValues(
-                                        Arrays.asList(
-                                            new DisplayHintEnumEnumHintValues()
-                                                .enumVal(
-                                                    new ValueDisplay()
-                                                        .display("Black or African American")
-                                                        .value(
-                                                            new Literal()
-                                                                .dataType(DataType.INT64)
-                                                                .valueUnion(
-                                                                    new LiteralValueUnion()
-                                                                        .int64Val(8516L))))
-                                                .count(247723),
-                                            new DisplayHintEnumEnumHintValues()
-                                                .enumVal(
-                                                    new ValueDisplay()
-                                                        .display("No matching concept")
-                                                        .value(
-                                                            new Literal()
-                                                                .dataType(DataType.INT64)
-                                                                .valueUnion(
-                                                                    new LiteralValueUnion()
-                                                                        .int64Val(0L))))
-                                                .count(152425),
-                                            new DisplayHintEnumEnumHintValues()
-                                                .enumVal(
-                                                    new ValueDisplay()
-                                                        .display("White")
-                                                        .value(
-                                                            new Literal()
-                                                                .dataType(DataType.INT64)
-                                                                .valueUnion(
-                                                                    new LiteralValueUnion()
-                                                                        .int64Val(8527L))))
-                                                .count(1926708))))))
-            .addDisplayHintsItem(
-                new DisplayHint()
-                    .attribute(
-                        new Attribute()
-                            .name("ethnicity")
-                            .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
-                            .dataType(DataType.INT64))
-                    .displayHint(
-                        new DisplayHintDisplayHint()
-                            .enumHint(
-                                new DisplayHintEnum()
-                                    .enumHintValues(
-                                        Arrays.asList(
-                                            new DisplayHintEnumEnumHintValues()
-                                                .enumVal(
-                                                    new ValueDisplay()
-                                                        .display("Hispanic or Latino")
-                                                        .value(
-                                                            new Literal()
-                                                                .dataType(DataType.INT64)
-                                                                .valueUnion(
-                                                                    new LiteralValueUnion()
-                                                                        .int64Val(38003563L))))
-                                                .count(54453),
-                                            new DisplayHintEnumEnumHintValues()
-                                                .enumVal(
-                                                    new ValueDisplay()
-                                                        .display("Not Hispanic or Latino")
-                                                        .value(
-                                                            new Literal()
-                                                                .dataType(DataType.INT64)
-                                                                .valueUnion(
-                                                                    new LiteralValueUnion()
-                                                                        .int64Val(38003564L))))
-                                                .count(2272403))))))
-            .addDisplayHintsItem(
-                new DisplayHint()
-                    .attribute(
-                        new Attribute()
-                            .name("year_of_birth")
-                            .type(Attribute.TypeEnum.SIMPLE)
-                            .dataType(DataType.INT64))
-                    .displayHint(
-                        new DisplayHintDisplayHint()
-                            .numericRangeHint(
-                                new DisplayHintNumericRange().min(1909.0D).max(1983.0D))));
-
-    return new ResponseEntity<>(response, HttpStatus.OK);
-  }
-
-  // Our stubs have the same count for everything
-  private List<InstanceCount> createInstanceCountsYearGenderRace(
-      List<ValueDisplay> genders, List<ValueDisplay> races, List<ValueDisplay> yearsOfBirth) {
-    record GR(ValueDisplay gender, ValueDisplay race) {}
-    record GRY(ValueDisplay gender, ValueDisplay race, ValueDisplay year) {}
-
-    return genders.stream()
-        .flatMap(gender -> races.stream().map(race -> new GR(gender, race)))
-        .flatMap(
-            gr ->
-                yearsOfBirth.stream().map(yearOfBirth -> new GRY(gr.gender, gr.race, yearOfBirth)))
-        .map(
-            gry ->
-                new InstanceCount()
-                    .count(20000)
-                    .attributes(
-                        Map.of("gender", gry.gender, "race", gry.race, "year_of_birth", gry.year)))
-        .collect(Collectors.toList());
-  }
-
-  private Cohort generateStubCohort() {
-    return new Cohort()
-        .id("42VHg43VxA")
-        .displayName("My Cohort")
-        .criteriaGroups(
-            List.of(
-                new CriteriaGroup()
-                    .id("A3FJlc87")
-                    .displayName("")
-                    .criteria(
-                        List.of(
-                            new Criteria()
-                                .id("Q1Ng787e")
-                                .displayName("")
-                                .pluginName("classification")
-                                .selectionData(
-                                    "{\"selected\":[{\"key\":4047779,\"name\":\"Disorder by body site\"}]}")
-                                .uiConfig(
-                                    "{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}")))));
-  }
-
-  private ConceptSet generateStubConceptSet() {
-    return new ConceptSet()
-        .id("Mu6OSPzPdp")
-        .entity("condition_occurrence")
-        .created(OffsetDateTime.now())
-        .lastModified(OffsetDateTime.now())
-        .criteria(
-            new Criteria()
-                .id("DrX3z0V9")
-                .displayName("")
-                .pluginName("classification")
-                .selectionData("{\"selected\":[{\"key\":441840,\"name\":\"Clinical finding\"}]}")
-                .uiConfig(
-                    "{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}"))
-        .createdBy("authentication-disabled");
+    return ResponseEntity.ok(hintsService.queryHints(entityId, hintQuery));
   }
 }

--- a/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
+++ b/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
@@ -85,8 +85,7 @@ public class CohortBuilderApiController implements CohortBuilderApi {
 
     return new ResponseEntity<>(
         new InstanceCountList()
-            .sql(
-                "SQL goes here")
+            .sql("SQL goes here")
             .instanceCounts(
                 createInstanceCountsYearGenderRace(
                     // Stub values based on what the API synthetic data returns in the other API -
@@ -192,10 +191,7 @@ public class CohortBuilderApiController implements CohortBuilderApi {
                 .attributes(attributes));
 
     return new ResponseEntity<>(
-        new InstanceList()
-            .sql("SQL Goes here")
-            .instances(instances),
-        HttpStatus.OK);
+        new InstanceList().sql("SQL Goes here").instances(instances), HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
+++ b/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
@@ -1,0 +1,278 @@
+package bio.terra.app.controller;
+
+import bio.terra.controller.CohortBuilderApi;
+import bio.terra.model.Attribute;
+import bio.terra.model.Cohort;
+import bio.terra.model.CohortCreateInfo;
+import bio.terra.model.CohortList;
+import bio.terra.model.CohortUpdateInfo;
+import bio.terra.model.ConceptSet;
+import bio.terra.model.ConceptSetCreateInfo;
+import bio.terra.model.ConceptSetList;
+import bio.terra.model.ConceptSetUpdateInfo;
+import bio.terra.model.CountQuery;
+import bio.terra.model.Criteria;
+import bio.terra.model.CriteriaGroup;
+import bio.terra.model.DataType;
+import bio.terra.model.DisplayHint;
+import bio.terra.model.DisplayHintDisplayHint;
+import bio.terra.model.DisplayHintEnum;
+import bio.terra.model.DisplayHintEnumEnumHintValues;
+import bio.terra.model.DisplayHintList;
+import bio.terra.model.DisplayHintNumericRange;
+import bio.terra.model.HintQuery;
+import bio.terra.model.Instance;
+import bio.terra.model.InstanceCount;
+import bio.terra.model.InstanceCountList;
+import bio.terra.model.InstanceHierarchyFields;
+import bio.terra.model.InstanceList;
+import bio.terra.model.InstanceRelationshipFields;
+import bio.terra.model.Literal;
+import bio.terra.model.LiteralValueUnion;
+import bio.terra.model.Query;
+import bio.terra.model.ValueDisplay;
+import io.swagger.annotations.Api;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestParam;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@Api(tags = {"cohort-builder"})
+public class CohortBuilderApiController implements CohortBuilderApi {
+
+  @Autowired
+  public CohortBuilderApiController() {}
+
+  @Override
+  public ResponseEntity<CohortList> listCohorts(@RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
+                                                @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
+    CohortList response = new CohortList();
+    response.add(generateStubCohort());
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<Cohort> createCohort(CohortCreateInfo cohortCreateInfo) {
+    return new ResponseEntity<>(generateStubCohort(), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<Cohort> getCohort(String cohortId) {
+    Cohort response = generateStubCohort();
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<Cohort> updateCohort(String cohortId, CohortUpdateInfo cohortUpdateInfo) {
+    return new ResponseEntity<>(generateStubCohort(), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteCohort(String cohortId) {
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<InstanceCountList> countInstances(String entityName, CountQuery countQuery) {
+    // Stub values based on what the API synthetic data returns in the other API - not representative of life
+    List<ValueDisplay> yearsOfBirth = new ArrayList<>();
+    for (long i = 1909; i <= 1983; i++) {
+      yearsOfBirth.add(new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(i))));
+    }
+    return new ResponseEntity<>(
+        new InstanceCountList()
+            .sql("SELECT p.gender AS gender, p.race AS race, COUNT(p.id) AS t_count, p.t_display_gender AS t_display_gender, p.t_display_race AS t_display_race, p.year_of_birth AS year_of_birth FROM `broad-tanagra-dev.cmssynpuf_index_011523`.person AS p GROUP BY p.gender, p.t_display_gender, p.race, p.t_display_race, p.year_of_birth ORDER BY p.gender ASC, p.t_display_gender ASC, p.race ASC, p.t_display_race ASC, p.year_of_birth ASC")
+            .instanceCounts(createInstanceCountsYearGenderRace(
+                // Stub values based on what the API synthetic data returns in the other API - not representative of life
+                List.of(
+                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8507L))).display("MALE"),
+                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8532L))).display("FEMALE")
+                ),
+                List.of(
+                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(0L))).display("No matching concept"),
+                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8516L))).display("Black or African American"),
+                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8527L))).display("White")
+                ),
+                yearsOfBirth)
+            ),
+        HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<InstanceList> queryInstances(String entityName, Query query) {
+    List<InstanceRelationshipFields> relationshipFields = List.of(
+        new InstanceRelationshipFields().relatedEntity("person").hierarchy("standard").count(1970071),
+        new InstanceRelationshipFields().relatedEntity("person").count(0)
+    );
+
+    List<InstanceHierarchyFields> hierarchyFields = List.of(
+        new InstanceHierarchyFields().hierarchy("standard").path("").numChildren(29)
+    );
+
+    Map<String, ValueDisplay> attributes = Map.of(
+        "standard_concept", new ValueDisplay().display("Standard").value(new Literal().dataType(DataType.STRING).valueUnion(new LiteralValueUnion().stringVal("S"))),
+        "vocabulary", new ValueDisplay().display("Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO)").value(new Literal().dataType(DataType.STRING).valueUnion(new LiteralValueUnion().stringVal("SNOMED"))),
+        "name", new ValueDisplay().value(new Literal().dataType(DataType.STRING).valueUnion(new LiteralValueUnion().stringVal("Clinical finding"))),
+        "concept_code", new ValueDisplay().value(new Literal().dataType(DataType.STRING).valueUnion(new LiteralValueUnion().stringVal("404684003"))),
+        "id", new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(441840L)))
+    );
+
+    List<Instance> instances = List.of(new Instance().relationshipFields(relationshipFields).hierarchyFields(hierarchyFields).attributes(attributes));
+
+    return new ResponseEntity<>(new InstanceList()
+        .sql("SELECT c.concept_code AS concept_code, c.id AS id, c.name AS name, c.standard_concept AS standard_concept, c.t_count_person AS t_count_person, c.t_count_person_standard AS t_count_person_standard, c.t_display_standard_concept AS t_display_standard_concept, c.t_display_vocabulary AS t_display_vocabulary, c.t_standard_num_children AS t_standard_num_children, c.t_standard_path AS t_standard_path, c.vocabulary AS vocabulary FROM `broad-tanagra-dev.cmssynpuf_index_011523`.condition AS c WHERE (c.t_standard_path IS NOT NULL AND c.t_standard_path = '') ORDER BY c.t_count_person_standard DESC LIMIT 250")
+        .instances(instances), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ConceptSetList> listConceptSets(@RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
+                                                        @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
+    ConceptSetList response = new ConceptSetList();
+    response.add(generateStubConceptSet());
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ConceptSet> createConceptSet(ConceptSetCreateInfo conceptSetCreateInfo) {
+    return new ResponseEntity<>(generateStubConceptSet(), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ConceptSet> getConceptSet(String ConceptSetId) {
+    return new ResponseEntity<>(generateStubConceptSet(), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ConceptSet> updateConceptSet(String conceptSetId, ConceptSetUpdateInfo conceptSetUpdateInfo) {
+    return new ResponseEntity<>(generateStubConceptSet(), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteConceptSet(String conceptSetId) {
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<DisplayHintList> queryHints(String entityId, HintQuery hintQuery) {
+    DisplayHintList response = new DisplayHintList()
+        .addDisplayHintsItem(new DisplayHint()
+            .attribute(new Attribute()
+                .name("gender")
+                .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
+                .dataType(DataType.INT64)
+            ).displayHint(new DisplayHintDisplayHint()
+                .enumHint(new DisplayHintEnum().enumHintValues(List.of(
+                    new DisplayHintEnumEnumHintValues()
+                        .enumVal(new ValueDisplay().display("FEMALE").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8532L))))
+                        .count(1292861),
+                    new DisplayHintEnumEnumHintValues()
+                        .enumVal(new ValueDisplay().display("MALE").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8507L))))
+                        .count(1033995)
+                )))))
+        .addDisplayHintsItem(new DisplayHint()
+            .attribute(new Attribute()
+                .name("race")
+                .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
+                .dataType(DataType.INT64)
+            ).displayHint(new DisplayHintDisplayHint()
+                .enumHint(new DisplayHintEnum().enumHintValues(Arrays.asList(
+                    new DisplayHintEnumEnumHintValues()
+                        .enumVal(new ValueDisplay().display("Black or African American").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8516L))))
+                        .count(247723),
+                    new DisplayHintEnumEnumHintValues()
+                        .enumVal(new ValueDisplay().display("No matching concept").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(0L))))
+                        .count(152425),
+                    new DisplayHintEnumEnumHintValues()
+                        .enumVal(new ValueDisplay().display("White").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8527L))))
+                        .count(1926708)
+                ))))
+        )
+        .addDisplayHintsItem(new DisplayHint()
+            .attribute(new Attribute()
+                .name("ethnicity")
+                .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
+                .dataType(DataType.INT64)
+            ).displayHint(new DisplayHintDisplayHint()
+                .enumHint(new DisplayHintEnum().enumHintValues(Arrays.asList(
+                    new DisplayHintEnumEnumHintValues()
+                        .enumVal(new ValueDisplay().display("Hispanic or Latino").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(38003563L))))
+                        .count(54453),
+                    new DisplayHintEnumEnumHintValues()
+                        .enumVal(new ValueDisplay().display("Not Hispanic or Latino").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(38003564L))))
+                        .count(2272403)
+                ))))
+        )
+        .addDisplayHintsItem(new DisplayHint()
+            .attribute(new Attribute()
+                .name("year_of_birth")
+                .type(Attribute.TypeEnum.SIMPLE)
+                .dataType(DataType.INT64)
+            ).displayHint(new DisplayHintDisplayHint().numericRangeHint(new DisplayHintNumericRange().min(1909.0D).max(1983.0D)))
+        );
+
+    return new ResponseEntity<>(new DisplayHintList(), HttpStatus.NOT_IMPLEMENTED);
+  }
+
+  // Our stubs have the same count for everything
+  private List<InstanceCount> createInstanceCountsYearGenderRace(List<ValueDisplay> genders, List<ValueDisplay> races, List<ValueDisplay> yearsOfBirth) {
+    List<InstanceCount> instanceCounts = new ArrayList<>();
+    genders.forEach((ValueDisplay gender) ->
+        races.forEach(race ->
+            yearsOfBirth.forEach((ValueDisplay yearOfBirth) -> {
+              instanceCounts.add(new InstanceCount().count(20000).attributes(Map.of(
+                  "gender", new ValueDisplay().value(gender.getValue()).display(gender.getDisplay()),
+                  "race", new ValueDisplay().value(race.getValue()).display(race.getDisplay()),
+                  "year_of_birth", new ValueDisplay().value(yearOfBirth.getValue()).display(yearOfBirth.getDisplay())
+              )));
+            })
+        )
+    );
+    return instanceCounts;
+  }
+
+  private Cohort generateStubCohort() {
+    List<CriteriaGroup> criteriaGroups = new java.util.ArrayList<>();
+    List<Criteria> criteria = new java.util.ArrayList<>();
+    criteria.add(new Criteria()
+        .id("Q1Ng787e")
+        .displayName("")
+        .pluginName("classification")
+        .selectionData("{\"selected\":[{\"key\":4047779,\"name\":\"Disorder by body site\"}]}")
+        .uiConfig("{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}"
+        ));
+    criteriaGroups.add(new CriteriaGroup()
+        .id("A3FJlc87")
+        .displayName("")
+        .criteria(
+            criteria
+        ));
+    return new Cohort()
+        .id("42VHg43VxA")
+        .displayName("My Cohort")
+        .criteriaGroups(criteriaGroups);
+  }
+
+  private ConceptSet generateStubConceptSet() {
+    Criteria criteria = new Criteria()
+        .id("DrX3z0V9")
+        .displayName("")
+        .pluginName("classification")
+        .selectionData("{\"selected\":[{\"key\":441840,\"name\":\"Clinical finding\"}]}")
+        .uiConfig("{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}"
+        );
+    return new ConceptSet()
+        .id("Mu6OSPzPdp")
+        .entity("condition_occurrence")
+        .created(OffsetDateTime.now())
+        .lastModified(OffsetDateTime.now())
+        .criteria(criteria)
+        .createdBy("authentication-disabled");
+  }
+}

--- a/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
+++ b/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
@@ -32,16 +32,16 @@ import bio.terra.model.LiteralValueUnion;
 import bio.terra.model.Query;
 import bio.terra.model.ValueDisplay;
 import io.swagger.annotations.Api;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestParam;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @Api(tags = {"cohort-builder"})
@@ -51,8 +51,9 @@ public class CohortBuilderApiController implements CohortBuilderApi {
   public CohortBuilderApiController() {}
 
   @Override
-  public ResponseEntity<CohortList> listCohorts(@RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
-                                                @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
+  public ResponseEntity<CohortList> listCohorts(
+      @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
+      @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
     CohortList response = new CohortList();
     response.add(generateStubCohort());
     return new ResponseEntity<>(response, HttpStatus.OK);
@@ -80,60 +81,130 @@ public class CohortBuilderApiController implements CohortBuilderApi {
   }
 
   @Override
-  public ResponseEntity<InstanceCountList> countInstances(String entityName, CountQuery countQuery) {
-    // Stub values based on what the API synthetic data returns in the other API - not representative of life
+  public ResponseEntity<InstanceCountList> countInstances(
+      String entityName, CountQuery countQuery) {
+    // Stub values based on what the API synthetic data returns in the other API - not
+    // representative of life
     List<ValueDisplay> yearsOfBirth = new ArrayList<>();
     for (long i = 1909; i <= 1983; i++) {
-      yearsOfBirth.add(new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(i))));
+      yearsOfBirth.add(
+          new ValueDisplay()
+              .value(
+                  new Literal()
+                      .dataType(DataType.INT64)
+                      .valueUnion(new LiteralValueUnion().int64Val(i))));
     }
     return new ResponseEntity<>(
         new InstanceCountList()
-            .sql("SELECT p.gender AS gender, p.race AS race, COUNT(p.id) AS t_count, p.t_display_gender AS t_display_gender, p.t_display_race AS t_display_race, p.year_of_birth AS year_of_birth FROM `broad-tanagra-dev.cmssynpuf_index_011523`.person AS p GROUP BY p.gender, p.t_display_gender, p.race, p.t_display_race, p.year_of_birth ORDER BY p.gender ASC, p.t_display_gender ASC, p.race ASC, p.t_display_race ASC, p.year_of_birth ASC")
-            .instanceCounts(createInstanceCountsYearGenderRace(
-                // Stub values based on what the API synthetic data returns in the other API - not representative of life
-                List.of(
-                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8507L))).display("MALE"),
-                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8532L))).display("FEMALE")
-                ),
-                List.of(
-                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(0L))).display("No matching concept"),
-                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8516L))).display("Black or African American"),
-                    new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8527L))).display("White")
-                ),
-                yearsOfBirth)
-            ),
+            .sql(
+                "SELECT p.gender AS gender, p.race AS race, COUNT(p.id) AS t_count, p.t_display_gender AS t_display_gender, p.t_display_race AS t_display_race, p.year_of_birth AS year_of_birth FROM `broad-tanagra-dev.cmssynpuf_index_011523`.person AS p GROUP BY p.gender, p.t_display_gender, p.race, p.t_display_race, p.year_of_birth ORDER BY p.gender ASC, p.t_display_gender ASC, p.race ASC, p.t_display_race ASC, p.year_of_birth ASC")
+            .instanceCounts(
+                createInstanceCountsYearGenderRace(
+                    // Stub values based on what the API synthetic data returns in the other API -
+                    // not representative of life
+                    List.of(
+                        new ValueDisplay()
+                            .value(
+                                new Literal()
+                                    .dataType(DataType.INT64)
+                                    .valueUnion(new LiteralValueUnion().int64Val(8507L)))
+                            .display("MALE"),
+                        new ValueDisplay()
+                            .value(
+                                new Literal()
+                                    .dataType(DataType.INT64)
+                                    .valueUnion(new LiteralValueUnion().int64Val(8532L)))
+                            .display("FEMALE")),
+                    List.of(
+                        new ValueDisplay()
+                            .value(
+                                new Literal()
+                                    .dataType(DataType.INT64)
+                                    .valueUnion(new LiteralValueUnion().int64Val(0L)))
+                            .display("No matching concept"),
+                        new ValueDisplay()
+                            .value(
+                                new Literal()
+                                    .dataType(DataType.INT64)
+                                    .valueUnion(new LiteralValueUnion().int64Val(8516L)))
+                            .display("Black or African American"),
+                        new ValueDisplay()
+                            .value(
+                                new Literal()
+                                    .dataType(DataType.INT64)
+                                    .valueUnion(new LiteralValueUnion().int64Val(8527L)))
+                            .display("White")),
+                    yearsOfBirth)),
         HttpStatus.OK);
   }
 
   @Override
   public ResponseEntity<InstanceList> queryInstances(String entityName, Query query) {
-    List<InstanceRelationshipFields> relationshipFields = List.of(
-        new InstanceRelationshipFields().relatedEntity("person").hierarchy("standard").count(1970071),
-        new InstanceRelationshipFields().relatedEntity("person").count(0)
-    );
+    List<InstanceRelationshipFields> relationshipFields =
+        List.of(
+            new InstanceRelationshipFields()
+                .relatedEntity("person")
+                .hierarchy("standard")
+                .count(1970071),
+            new InstanceRelationshipFields().relatedEntity("person").count(0));
 
-    List<InstanceHierarchyFields> hierarchyFields = List.of(
-        new InstanceHierarchyFields().hierarchy("standard").path("").numChildren(29)
-    );
+    List<InstanceHierarchyFields> hierarchyFields =
+        List.of(new InstanceHierarchyFields().hierarchy("standard").path("").numChildren(29));
 
-    Map<String, ValueDisplay> attributes = Map.of(
-        "standard_concept", new ValueDisplay().display("Standard").value(new Literal().dataType(DataType.STRING).valueUnion(new LiteralValueUnion().stringVal("S"))),
-        "vocabulary", new ValueDisplay().display("Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO)").value(new Literal().dataType(DataType.STRING).valueUnion(new LiteralValueUnion().stringVal("SNOMED"))),
-        "name", new ValueDisplay().value(new Literal().dataType(DataType.STRING).valueUnion(new LiteralValueUnion().stringVal("Clinical finding"))),
-        "concept_code", new ValueDisplay().value(new Literal().dataType(DataType.STRING).valueUnion(new LiteralValueUnion().stringVal("404684003"))),
-        "id", new ValueDisplay().value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(441840L)))
-    );
+    Map<String, ValueDisplay> attributes =
+        Map.of(
+            "standard_concept",
+                new ValueDisplay()
+                    .display("Standard")
+                    .value(
+                        new Literal()
+                            .dataType(DataType.STRING)
+                            .valueUnion(new LiteralValueUnion().stringVal("S"))),
+            "vocabulary",
+                new ValueDisplay()
+                    .display("Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO)")
+                    .value(
+                        new Literal()
+                            .dataType(DataType.STRING)
+                            .valueUnion(new LiteralValueUnion().stringVal("SNOMED"))),
+            "name",
+                new ValueDisplay()
+                    .value(
+                        new Literal()
+                            .dataType(DataType.STRING)
+                            .valueUnion(new LiteralValueUnion().stringVal("Clinical finding"))),
+            "concept_code",
+                new ValueDisplay()
+                    .value(
+                        new Literal()
+                            .dataType(DataType.STRING)
+                            .valueUnion(new LiteralValueUnion().stringVal("404684003"))),
+            "id",
+                new ValueDisplay()
+                    .value(
+                        new Literal()
+                            .dataType(DataType.INT64)
+                            .valueUnion(new LiteralValueUnion().int64Val(441840L))));
 
-    List<Instance> instances = List.of(new Instance().relationshipFields(relationshipFields).hierarchyFields(hierarchyFields).attributes(attributes));
+    List<Instance> instances =
+        List.of(
+            new Instance()
+                .relationshipFields(relationshipFields)
+                .hierarchyFields(hierarchyFields)
+                .attributes(attributes));
 
-    return new ResponseEntity<>(new InstanceList()
-        .sql("SELECT c.concept_code AS concept_code, c.id AS id, c.name AS name, c.standard_concept AS standard_concept, c.t_count_person AS t_count_person, c.t_count_person_standard AS t_count_person_standard, c.t_display_standard_concept AS t_display_standard_concept, c.t_display_vocabulary AS t_display_vocabulary, c.t_standard_num_children AS t_standard_num_children, c.t_standard_path AS t_standard_path, c.vocabulary AS vocabulary FROM `broad-tanagra-dev.cmssynpuf_index_011523`.condition AS c WHERE (c.t_standard_path IS NOT NULL AND c.t_standard_path = '') ORDER BY c.t_count_person_standard DESC LIMIT 250")
-        .instances(instances), HttpStatus.OK);
+    return new ResponseEntity<>(
+        new InstanceList()
+            .sql(
+                "SELECT c.concept_code AS concept_code, c.id AS id, c.name AS name, c.standard_concept AS standard_concept, c.t_count_person AS t_count_person, c.t_count_person_standard AS t_count_person_standard, c.t_display_standard_concept AS t_display_standard_concept, c.t_display_vocabulary AS t_display_vocabulary, c.t_standard_num_children AS t_standard_num_children, c.t_standard_path AS t_standard_path, c.vocabulary AS vocabulary FROM `broad-tanagra-dev.cmssynpuf_index_011523`.condition AS c WHERE (c.t_standard_path IS NOT NULL AND c.t_standard_path = '') ORDER BY c.t_count_person_standard DESC LIMIT 250")
+            .instances(instances),
+        HttpStatus.OK);
   }
 
   @Override
-  public ResponseEntity<ConceptSetList> listConceptSets(@RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
-                                                        @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
+  public ResponseEntity<ConceptSetList> listConceptSets(
+      @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
+      @RequestParam(value = "limit", required = false, defaultValue = "10") Integer limit) {
     ConceptSetList response = new ConceptSetList();
     response.add(generateStubConceptSet());
     return new ResponseEntity<>(response, HttpStatus.OK);
@@ -150,7 +221,8 @@ public class CohortBuilderApiController implements CohortBuilderApi {
   }
 
   @Override
-  public ResponseEntity<ConceptSet> updateConceptSet(String conceptSetId, ConceptSetUpdateInfo conceptSetUpdateInfo) {
+  public ResponseEntity<ConceptSet> updateConceptSet(
+      String conceptSetId, ConceptSetUpdateInfo conceptSetUpdateInfo) {
     return new ResponseEntity<>(generateStubConceptSet(), HttpStatus.OK);
   }
 
@@ -161,112 +233,194 @@ public class CohortBuilderApiController implements CohortBuilderApi {
 
   @Override
   public ResponseEntity<DisplayHintList> queryHints(String entityId, HintQuery hintQuery) {
-    DisplayHintList response = new DisplayHintList()
-        .addDisplayHintsItem(new DisplayHint()
-            .attribute(new Attribute()
-                .name("gender")
-                .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
-                .dataType(DataType.INT64)
-            ).displayHint(new DisplayHintDisplayHint()
-                .enumHint(new DisplayHintEnum().enumHintValues(List.of(
-                    new DisplayHintEnumEnumHintValues()
-                        .enumVal(new ValueDisplay().display("FEMALE").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8532L))))
-                        .count(1292861),
-                    new DisplayHintEnumEnumHintValues()
-                        .enumVal(new ValueDisplay().display("MALE").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8507L))))
-                        .count(1033995)
-                )))))
-        .addDisplayHintsItem(new DisplayHint()
-            .attribute(new Attribute()
-                .name("race")
-                .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
-                .dataType(DataType.INT64)
-            ).displayHint(new DisplayHintDisplayHint()
-                .enumHint(new DisplayHintEnum().enumHintValues(Arrays.asList(
-                    new DisplayHintEnumEnumHintValues()
-                        .enumVal(new ValueDisplay().display("Black or African American").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8516L))))
-                        .count(247723),
-                    new DisplayHintEnumEnumHintValues()
-                        .enumVal(new ValueDisplay().display("No matching concept").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(0L))))
-                        .count(152425),
-                    new DisplayHintEnumEnumHintValues()
-                        .enumVal(new ValueDisplay().display("White").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(8527L))))
-                        .count(1926708)
-                ))))
-        )
-        .addDisplayHintsItem(new DisplayHint()
-            .attribute(new Attribute()
-                .name("ethnicity")
-                .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
-                .dataType(DataType.INT64)
-            ).displayHint(new DisplayHintDisplayHint()
-                .enumHint(new DisplayHintEnum().enumHintValues(Arrays.asList(
-                    new DisplayHintEnumEnumHintValues()
-                        .enumVal(new ValueDisplay().display("Hispanic or Latino").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(38003563L))))
-                        .count(54453),
-                    new DisplayHintEnumEnumHintValues()
-                        .enumVal(new ValueDisplay().display("Not Hispanic or Latino").value(new Literal().dataType(DataType.INT64).valueUnion(new LiteralValueUnion().int64Val(38003564L))))
-                        .count(2272403)
-                ))))
-        )
-        .addDisplayHintsItem(new DisplayHint()
-            .attribute(new Attribute()
-                .name("year_of_birth")
-                .type(Attribute.TypeEnum.SIMPLE)
-                .dataType(DataType.INT64)
-            ).displayHint(new DisplayHintDisplayHint().numericRangeHint(new DisplayHintNumericRange().min(1909.0D).max(1983.0D)))
-        );
+    DisplayHintList response =
+        new DisplayHintList()
+            .addDisplayHintsItem(
+                new DisplayHint()
+                    .attribute(
+                        new Attribute()
+                            .name("gender")
+                            .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
+                            .dataType(DataType.INT64))
+                    .displayHint(
+                        new DisplayHintDisplayHint()
+                            .enumHint(
+                                new DisplayHintEnum()
+                                    .enumHintValues(
+                                        List.of(
+                                            new DisplayHintEnumEnumHintValues()
+                                                .enumVal(
+                                                    new ValueDisplay()
+                                                        .display("FEMALE")
+                                                        .value(
+                                                            new Literal()
+                                                                .dataType(DataType.INT64)
+                                                                .valueUnion(
+                                                                    new LiteralValueUnion()
+                                                                        .int64Val(8532L))))
+                                                .count(1292861),
+                                            new DisplayHintEnumEnumHintValues()
+                                                .enumVal(
+                                                    new ValueDisplay()
+                                                        .display("MALE")
+                                                        .value(
+                                                            new Literal()
+                                                                .dataType(DataType.INT64)
+                                                                .valueUnion(
+                                                                    new LiteralValueUnion()
+                                                                        .int64Val(8507L))))
+                                                .count(1033995))))))
+            .addDisplayHintsItem(
+                new DisplayHint()
+                    .attribute(
+                        new Attribute()
+                            .name("race")
+                            .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
+                            .dataType(DataType.INT64))
+                    .displayHint(
+                        new DisplayHintDisplayHint()
+                            .enumHint(
+                                new DisplayHintEnum()
+                                    .enumHintValues(
+                                        Arrays.asList(
+                                            new DisplayHintEnumEnumHintValues()
+                                                .enumVal(
+                                                    new ValueDisplay()
+                                                        .display("Black or African American")
+                                                        .value(
+                                                            new Literal()
+                                                                .dataType(DataType.INT64)
+                                                                .valueUnion(
+                                                                    new LiteralValueUnion()
+                                                                        .int64Val(8516L))))
+                                                .count(247723),
+                                            new DisplayHintEnumEnumHintValues()
+                                                .enumVal(
+                                                    new ValueDisplay()
+                                                        .display("No matching concept")
+                                                        .value(
+                                                            new Literal()
+                                                                .dataType(DataType.INT64)
+                                                                .valueUnion(
+                                                                    new LiteralValueUnion()
+                                                                        .int64Val(0L))))
+                                                .count(152425),
+                                            new DisplayHintEnumEnumHintValues()
+                                                .enumVal(
+                                                    new ValueDisplay()
+                                                        .display("White")
+                                                        .value(
+                                                            new Literal()
+                                                                .dataType(DataType.INT64)
+                                                                .valueUnion(
+                                                                    new LiteralValueUnion()
+                                                                        .int64Val(8527L))))
+                                                .count(1926708))))))
+            .addDisplayHintsItem(
+                new DisplayHint()
+                    .attribute(
+                        new Attribute()
+                            .name("ethnicity")
+                            .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
+                            .dataType(DataType.INT64))
+                    .displayHint(
+                        new DisplayHintDisplayHint()
+                            .enumHint(
+                                new DisplayHintEnum()
+                                    .enumHintValues(
+                                        Arrays.asList(
+                                            new DisplayHintEnumEnumHintValues()
+                                                .enumVal(
+                                                    new ValueDisplay()
+                                                        .display("Hispanic or Latino")
+                                                        .value(
+                                                            new Literal()
+                                                                .dataType(DataType.INT64)
+                                                                .valueUnion(
+                                                                    new LiteralValueUnion()
+                                                                        .int64Val(38003563L))))
+                                                .count(54453),
+                                            new DisplayHintEnumEnumHintValues()
+                                                .enumVal(
+                                                    new ValueDisplay()
+                                                        .display("Not Hispanic or Latino")
+                                                        .value(
+                                                            new Literal()
+                                                                .dataType(DataType.INT64)
+                                                                .valueUnion(
+                                                                    new LiteralValueUnion()
+                                                                        .int64Val(38003564L))))
+                                                .count(2272403))))))
+            .addDisplayHintsItem(
+                new DisplayHint()
+                    .attribute(
+                        new Attribute()
+                            .name("year_of_birth")
+                            .type(Attribute.TypeEnum.SIMPLE)
+                            .dataType(DataType.INT64))
+                    .displayHint(
+                        new DisplayHintDisplayHint()
+                            .numericRangeHint(
+                                new DisplayHintNumericRange().min(1909.0D).max(1983.0D))));
 
     return new ResponseEntity<>(new DisplayHintList(), HttpStatus.NOT_IMPLEMENTED);
   }
 
   // Our stubs have the same count for everything
-  private List<InstanceCount> createInstanceCountsYearGenderRace(List<ValueDisplay> genders, List<ValueDisplay> races, List<ValueDisplay> yearsOfBirth) {
+  private List<InstanceCount> createInstanceCountsYearGenderRace(
+      List<ValueDisplay> genders, List<ValueDisplay> races, List<ValueDisplay> yearsOfBirth) {
     List<InstanceCount> instanceCounts = new ArrayList<>();
-    genders.forEach((ValueDisplay gender) ->
-        races.forEach(race ->
-            yearsOfBirth.forEach((ValueDisplay yearOfBirth) -> {
-              instanceCounts.add(new InstanceCount().count(20000).attributes(Map.of(
-                  "gender", new ValueDisplay().value(gender.getValue()).display(gender.getDisplay()),
-                  "race", new ValueDisplay().value(race.getValue()).display(race.getDisplay()),
-                  "year_of_birth", new ValueDisplay().value(yearOfBirth.getValue()).display(yearOfBirth.getDisplay())
-              )));
-            })
-        )
-    );
+    genders.forEach(
+        (ValueDisplay gender) ->
+            races.forEach(
+                race ->
+                    yearsOfBirth.forEach(
+                        (ValueDisplay yearOfBirth) -> {
+                          instanceCounts.add(
+                              new InstanceCount()
+                                  .count(20000)
+                                  .attributes(
+                                      Map.of(
+                                          "gender",
+                                              new ValueDisplay()
+                                                  .value(gender.getValue())
+                                                  .display(gender.getDisplay()),
+                                          "race",
+                                              new ValueDisplay()
+                                                  .value(race.getValue())
+                                                  .display(race.getDisplay()),
+                                          "year_of_birth",
+                                              new ValueDisplay()
+                                                  .value(yearOfBirth.getValue())
+                                                  .display(yearOfBirth.getDisplay()))));
+                        })));
     return instanceCounts;
   }
 
   private Cohort generateStubCohort() {
     List<CriteriaGroup> criteriaGroups = new java.util.ArrayList<>();
     List<Criteria> criteria = new java.util.ArrayList<>();
-    criteria.add(new Criteria()
-        .id("Q1Ng787e")
-        .displayName("")
-        .pluginName("classification")
-        .selectionData("{\"selected\":[{\"key\":4047779,\"name\":\"Disorder by body site\"}]}")
-        .uiConfig("{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}"
-        ));
-    criteriaGroups.add(new CriteriaGroup()
-        .id("A3FJlc87")
-        .displayName("")
-        .criteria(
-            criteria
-        ));
-    return new Cohort()
-        .id("42VHg43VxA")
-        .displayName("My Cohort")
-        .criteriaGroups(criteriaGroups);
+    criteria.add(
+        new Criteria()
+            .id("Q1Ng787e")
+            .displayName("")
+            .pluginName("classification")
+            .selectionData("{\"selected\":[{\"key\":4047779,\"name\":\"Disorder by body site\"}]}")
+            .uiConfig(
+                "{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}"));
+    criteriaGroups.add(new CriteriaGroup().id("A3FJlc87").displayName("").criteria(criteria));
+    return new Cohort().id("42VHg43VxA").displayName("My Cohort").criteriaGroups(criteriaGroups);
   }
 
   private ConceptSet generateStubConceptSet() {
-    Criteria criteria = new Criteria()
-        .id("DrX3z0V9")
-        .displayName("")
-        .pluginName("classification")
-        .selectionData("{\"selected\":[{\"key\":441840,\"name\":\"Clinical finding\"}]}")
-        .uiConfig("{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}"
-        );
+    Criteria criteria =
+        new Criteria()
+            .id("DrX3z0V9")
+            .displayName("")
+            .pluginName("classification")
+            .selectionData("{\"selected\":[{\"key\":441840,\"name\":\"Clinical finding\"}]}")
+            .uiConfig(
+                "{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}");
     return new ConceptSet()
         .id("Mu6OSPzPdp")
         .entity("condition_occurrence")

--- a/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
+++ b/src/main/java/bio/terra/app/controller/CohortBuilderApiController.java
@@ -361,7 +361,7 @@ public class CohortBuilderApiController implements CohortBuilderApi {
                             .numericRangeHint(
                                 new DisplayHintNumericRange().min(1909.0D).max(1983.0D))));
 
-    return new ResponseEntity<>(new DisplayHintList(), HttpStatus.NOT_IMPLEMENTED);
+    return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   // Our stubs have the same count for everything

--- a/src/main/java/bio/terra/service/cohortbuilder/CohortService.java
+++ b/src/main/java/bio/terra/service/cohortbuilder/CohortService.java
@@ -1,0 +1,55 @@
+package bio.terra.service.cohortbuilder;
+
+import bio.terra.model.Cohort;
+import bio.terra.model.CohortCreateInfo;
+import bio.terra.model.CohortList;
+import bio.terra.model.CohortUpdateInfo;
+import bio.terra.model.Criteria;
+import bio.terra.model.CriteriaGroup;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CohortService {
+
+  public CohortList listCohorts(Integer offset, Integer limit) {
+    CohortList cohortList = new CohortList();
+    cohortList.add(generateStubCohort());
+    return cohortList;
+  }
+
+  public Cohort createCohort(CohortCreateInfo cohortCreateInfo) {
+    return generateStubCohort();
+  }
+
+  public Cohort getCohort(String cohortId) {
+    return generateStubCohort();
+  }
+
+  public Cohort updateCohort(String cohortId, CohortUpdateInfo cohortUpdateInfo) {
+    return generateStubCohort();
+  }
+
+  public void deleteCohort(String cohortId) {}
+
+  private Cohort generateStubCohort() {
+    return new Cohort()
+        .id("42VHg43VxA")
+        .displayName("My Cohort")
+        .criteriaGroups(
+            List.of(
+                new CriteriaGroup()
+                    .id("A3FJlc87")
+                    .displayName("")
+                    .criteria(
+                        List.of(
+                            new Criteria()
+                                .id("Q1Ng787e")
+                                .displayName("")
+                                .pluginName("classification")
+                                .selectionData(
+                                    "{\"selected\":[{\"key\":4047779,\"name\":\"Disorder by body site\"}]}")
+                                .uiConfig(
+                                    "{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}")))));
+  }
+}

--- a/src/main/java/bio/terra/service/cohortbuilder/ConceptSetService.java
+++ b/src/main/java/bio/terra/service/cohortbuilder/ConceptSetService.java
@@ -1,0 +1,51 @@
+package bio.terra.service.cohortbuilder;
+
+import bio.terra.model.ConceptSet;
+import bio.terra.model.ConceptSetCreateInfo;
+import bio.terra.model.ConceptSetList;
+import bio.terra.model.ConceptSetUpdateInfo;
+import bio.terra.model.Criteria;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConceptSetService {
+
+  public ConceptSetList listConceptSets(Integer offset, Integer limit) {
+    ConceptSetList conceptSetList = new ConceptSetList();
+    conceptSetList.add(generateStubConceptSet());
+    return conceptSetList;
+  }
+
+  public ConceptSet createConceptSet(ConceptSetCreateInfo conceptSetCreateInfo) {
+    return generateStubConceptSet();
+  }
+
+  public ConceptSet getConceptSet(String ConceptSetId) {
+    return generateStubConceptSet();
+  }
+
+  public ConceptSet updateConceptSet(
+      String conceptSetId, ConceptSetUpdateInfo conceptSetUpdateInfo) {
+    return generateStubConceptSet();
+  }
+
+  public void deleteConceptSet(String conceptSetId) {}
+
+  private ConceptSet generateStubConceptSet() {
+    return new ConceptSet()
+        .id("Mu6OSPzPdp")
+        .entity("condition_occurrence")
+        .created(OffsetDateTime.now())
+        .lastModified(OffsetDateTime.now())
+        .criteria(
+            new Criteria()
+                .id("DrX3z0V9")
+                .displayName("")
+                .pluginName("classification")
+                .selectionData("{\"selected\":[{\"key\":441840,\"name\":\"Clinical finding\"}]}")
+                .uiConfig(
+                    "{\"type\":\"classification\",\"id\":\"tanagra-conditions\",\"title\":\"Condition\",\"conceptSet\":true,\"category\":\"Domains\",\"columns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Concept name\"},{\"key\":\"id\",\"width\":100,\"title\":\"Concept ID\"},{\"key\":\"standard_concept\",\"width\":120,\"title\":\"Source/standard\"},{\"key\":\"vocabulary_t_value\",\"width\":120,\"title\":\"Vocab\"},{\"key\":\"concept_code\",\"width\":120,\"title\":\"Code\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"hierarchyColumns\":[{\"key\":\"name\",\"width\":\"100%\",\"title\":\"Condition\"},{\"key\":\"id\",\"width\":120,\"title\":\"Concept ID\"},{\"key\":\"t_rollup_count\",\"width\":120,\"title\":\"Roll-up count\"}],\"occurrence\":\"condition_occurrence\",\"classification\":\"condition\"}"))
+        .createdBy("authentication-disabled");
+  }
+}

--- a/src/main/java/bio/terra/service/cohortbuilder/HintsService.java
+++ b/src/main/java/bio/terra/service/cohortbuilder/HintsService.java
@@ -1,0 +1,151 @@
+package bio.terra.service.cohortbuilder;
+
+import bio.terra.model.Attribute;
+import bio.terra.model.DataType;
+import bio.terra.model.DisplayHint;
+import bio.terra.model.DisplayHintDisplayHint;
+import bio.terra.model.DisplayHintEnum;
+import bio.terra.model.DisplayHintEnumEnumHintValues;
+import bio.terra.model.DisplayHintList;
+import bio.terra.model.DisplayHintNumericRange;
+import bio.terra.model.HintQuery;
+import bio.terra.model.Literal;
+import bio.terra.model.LiteralValueUnion;
+import bio.terra.model.ValueDisplay;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HintsService {
+  public DisplayHintList queryHints(String entityId, HintQuery hintQuery) {
+    return new DisplayHintList()
+        .addDisplayHintsItem(
+            new DisplayHint()
+                .attribute(
+                    new Attribute()
+                        .name("gender")
+                        .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
+                        .dataType(DataType.INT64))
+                .displayHint(
+                    new DisplayHintDisplayHint()
+                        .enumHint(
+                            new DisplayHintEnum()
+                                .enumHintValues(
+                                    List.of(
+                                        new DisplayHintEnumEnumHintValues()
+                                            .enumVal(
+                                                new ValueDisplay()
+                                                    .display("FEMALE")
+                                                    .value(
+                                                        new Literal()
+                                                            .dataType(DataType.INT64)
+                                                            .valueUnion(
+                                                                new LiteralValueUnion()
+                                                                    .int64Val(8532L))))
+                                            .count(1292861),
+                                        new DisplayHintEnumEnumHintValues()
+                                            .enumVal(
+                                                new ValueDisplay()
+                                                    .display("MALE")
+                                                    .value(
+                                                        new Literal()
+                                                            .dataType(DataType.INT64)
+                                                            .valueUnion(
+                                                                new LiteralValueUnion()
+                                                                    .int64Val(8507L))))
+                                            .count(1033995))))))
+        .addDisplayHintsItem(
+            new DisplayHint()
+                .attribute(
+                    new Attribute()
+                        .name("race")
+                        .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
+                        .dataType(DataType.INT64))
+                .displayHint(
+                    new DisplayHintDisplayHint()
+                        .enumHint(
+                            new DisplayHintEnum()
+                                .enumHintValues(
+                                    Arrays.asList(
+                                        new DisplayHintEnumEnumHintValues()
+                                            .enumVal(
+                                                new ValueDisplay()
+                                                    .display("Black or African American")
+                                                    .value(
+                                                        new Literal()
+                                                            .dataType(DataType.INT64)
+                                                            .valueUnion(
+                                                                new LiteralValueUnion()
+                                                                    .int64Val(8516L))))
+                                            .count(247723),
+                                        new DisplayHintEnumEnumHintValues()
+                                            .enumVal(
+                                                new ValueDisplay()
+                                                    .display("No matching concept")
+                                                    .value(
+                                                        new Literal()
+                                                            .dataType(DataType.INT64)
+                                                            .valueUnion(
+                                                                new LiteralValueUnion()
+                                                                    .int64Val(0L))))
+                                            .count(152425),
+                                        new DisplayHintEnumEnumHintValues()
+                                            .enumVal(
+                                                new ValueDisplay()
+                                                    .display("White")
+                                                    .value(
+                                                        new Literal()
+                                                            .dataType(DataType.INT64)
+                                                            .valueUnion(
+                                                                new LiteralValueUnion()
+                                                                    .int64Val(8527L))))
+                                            .count(1926708))))))
+        .addDisplayHintsItem(
+            new DisplayHint()
+                .attribute(
+                    new Attribute()
+                        .name("ethnicity")
+                        .type(Attribute.TypeEnum.KEY_AND_DISPLAY)
+                        .dataType(DataType.INT64))
+                .displayHint(
+                    new DisplayHintDisplayHint()
+                        .enumHint(
+                            new DisplayHintEnum()
+                                .enumHintValues(
+                                    Arrays.asList(
+                                        new DisplayHintEnumEnumHintValues()
+                                            .enumVal(
+                                                new ValueDisplay()
+                                                    .display("Hispanic or Latino")
+                                                    .value(
+                                                        new Literal()
+                                                            .dataType(DataType.INT64)
+                                                            .valueUnion(
+                                                                new LiteralValueUnion()
+                                                                    .int64Val(38003563L))))
+                                            .count(54453),
+                                        new DisplayHintEnumEnumHintValues()
+                                            .enumVal(
+                                                new ValueDisplay()
+                                                    .display("Not Hispanic or Latino")
+                                                    .value(
+                                                        new Literal()
+                                                            .dataType(DataType.INT64)
+                                                            .valueUnion(
+                                                                new LiteralValueUnion()
+                                                                    .int64Val(38003564L))))
+                                            .count(2272403))))))
+        .addDisplayHintsItem(
+            new DisplayHint()
+                .attribute(
+                    new Attribute()
+                        .name("year_of_birth")
+                        .type(Attribute.TypeEnum.SIMPLE)
+                        .dataType(DataType.INT64))
+                .displayHint(
+                    new DisplayHintDisplayHint()
+                        .numericRangeHint(
+                            new DisplayHintNumericRange().min(1909.0D).max(1983.0D))));
+  }
+}

--- a/src/main/java/bio/terra/service/cohortbuilder/InstancesService.java
+++ b/src/main/java/bio/terra/service/cohortbuilder/InstancesService.java
@@ -1,0 +1,149 @@
+package bio.terra.service.cohortbuilder;
+
+import bio.terra.model.CountQuery;
+import bio.terra.model.DataType;
+import bio.terra.model.Instance;
+import bio.terra.model.InstanceCount;
+import bio.terra.model.InstanceCountList;
+import bio.terra.model.InstanceHierarchyFields;
+import bio.terra.model.InstanceList;
+import bio.terra.model.InstanceRelationshipFields;
+import bio.terra.model.Literal;
+import bio.terra.model.LiteralValueUnion;
+import bio.terra.model.Query;
+import bio.terra.model.ValueDisplay;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InstancesService {
+
+  public InstanceCountList countInstances(String entityName, CountQuery countQuery) {
+    return new InstanceCountList()
+        .sql("SQL goes here")
+        .instanceCounts(
+            createInstanceCountsYearGenderRace(
+                // Stub values based on what the API synthetic data returns in the other API -
+                // not representative of life
+                List.of(
+                    new ValueDisplay()
+                        .value(
+                            new Literal()
+                                .dataType(DataType.INT64)
+                                .valueUnion(new LiteralValueUnion().int64Val(8507L)))
+                        .display("MALE"),
+                    new ValueDisplay()
+                        .value(
+                            new Literal()
+                                .dataType(DataType.INT64)
+                                .valueUnion(new LiteralValueUnion().int64Val(8532L)))
+                        .display("FEMALE")),
+                List.of(
+                    new ValueDisplay()
+                        .value(
+                            new Literal()
+                                .dataType(DataType.INT64)
+                                .valueUnion(new LiteralValueUnion().int64Val(0L)))
+                        .display("No matching concept"),
+                    new ValueDisplay()
+                        .value(
+                            new Literal()
+                                .dataType(DataType.INT64)
+                                .valueUnion(new LiteralValueUnion().int64Val(8516L)))
+                        .display("Black or African American"),
+                    new ValueDisplay()
+                        .value(
+                            new Literal()
+                                .dataType(DataType.INT64)
+                                .valueUnion(new LiteralValueUnion().int64Val(8527L)))
+                        .display("White")),
+                LongStream.range(1909, 1984)
+                    .mapToObj(
+                        yearOfBirth ->
+                            new ValueDisplay()
+                                .value(
+                                    new Literal()
+                                        .dataType(DataType.INT64)
+                                        .valueUnion(new LiteralValueUnion().int64Val(yearOfBirth))))
+                    .collect(Collectors.toList())));
+  }
+
+  public InstanceList queryInstances(String entityName, Query query) {
+    List<InstanceRelationshipFields> relationshipFields =
+        List.of(
+            new InstanceRelationshipFields()
+                .relatedEntity("person")
+                .hierarchy("standard")
+                .count(1970071),
+            new InstanceRelationshipFields().relatedEntity("person").count(0));
+
+    List<InstanceHierarchyFields> hierarchyFields =
+        List.of(new InstanceHierarchyFields().hierarchy("standard").path("").numChildren(29));
+
+    Map<String, ValueDisplay> attributes =
+        Map.of(
+            "standard_concept",
+            new ValueDisplay()
+                .display("Standard")
+                .value(
+                    new Literal()
+                        .dataType(DataType.STRING)
+                        .valueUnion(new LiteralValueUnion().stringVal("S"))),
+            "vocabulary",
+            new ValueDisplay()
+                .display("Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO)")
+                .value(
+                    new Literal()
+                        .dataType(DataType.STRING)
+                        .valueUnion(new LiteralValueUnion().stringVal("SNOMED"))),
+            "name",
+            new ValueDisplay()
+                .value(
+                    new Literal()
+                        .dataType(DataType.STRING)
+                        .valueUnion(new LiteralValueUnion().stringVal("Clinical finding"))),
+            "concept_code",
+            new ValueDisplay()
+                .value(
+                    new Literal()
+                        .dataType(DataType.STRING)
+                        .valueUnion(new LiteralValueUnion().stringVal("404684003"))),
+            "id",
+            new ValueDisplay()
+                .value(
+                    new Literal()
+                        .dataType(DataType.INT64)
+                        .valueUnion(new LiteralValueUnion().int64Val(441840L))));
+
+    List<Instance> instances =
+        List.of(
+            new Instance()
+                .relationshipFields(relationshipFields)
+                .hierarchyFields(hierarchyFields)
+                .attributes(attributes));
+    return new InstanceList().sql("SQL Goes here").instances(instances);
+  }
+
+  // Our stubs have the same count for everything
+  private List<InstanceCount> createInstanceCountsYearGenderRace(
+      List<ValueDisplay> genders, List<ValueDisplay> races, List<ValueDisplay> yearsOfBirth) {
+    record GR(ValueDisplay gender, ValueDisplay race) {}
+    record GRY(ValueDisplay gender, ValueDisplay race, ValueDisplay year) {}
+
+    return genders.stream()
+        .flatMap(gender -> races.stream().map(race -> new GR(gender, race)))
+        .flatMap(
+            gr ->
+                yearsOfBirth.stream().map(yearOfBirth -> new GRY(gr.gender, gr.race, yearOfBirth)))
+        .map(
+            gry ->
+                new InstanceCount()
+                    .count(20000)
+                    .attributes(
+                        Map.of("gender", gry.gender, "race", gry.race, "year_of_birth", gry.year)))
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3102,6 +3102,287 @@ paths:
                 $ref: '#/components/schemas/ErrorModel'
       x-codegen-request-body-name: upgrade
 
+  # -- Cohort Builder Endpoints --
+
+  '/api/repository/v1/cohort-builder/entities/{entityName}/hints':
+    parameters:
+      - $ref: '#/parameters/EntityName'
+    post:
+      summary: Query entity display hints
+      operationId: queryHints
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HintQuery'
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/DisplayHintList'
+        404:
+          $ref: '#/definitions/ErrorModel'
+        500:
+          $ref: '#/definitions/ErrorModel'
+
+  '/api/repository/v1/cohort-builder/concept-sets':
+    get:
+      parameters:
+        - name: offset
+          in: query
+          description: The number of entries to skip before when retrieving the next
+            page
+          schema:
+            type: integer
+            default: 0
+        - name: limit
+          in: query
+          description: The numbers of items to return.
+          schema:
+            type: integer
+            default: 10
+      summary: List all concept sets in a study
+      operationId: listConceptSets
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/ConceptSetList'
+        500:
+          $ref: '#/definitions/ErrorModel'
+    post:
+      summary: Create a new concept set
+      operationId: createConceptSet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/ConceptSetCreateInfo'
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/ConceptSet'
+        500:
+          $ref: '#/definitions/ErrorModel'
+
+  '/api/repository/v1/cohort-builder/concept-sets/{conceptSetId}':
+    parameters:
+      - $ref: '#/parameters/ConceptSetId'
+    get:
+      summary: Get an existing concept set
+      operationId: getConceptSet
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/ConceptSet'
+        404:
+          $ref: '#/definitions/ErrorModel'
+        500:
+          $ref: '#/definitions/ErrorModel'
+    patch:
+      parameters:
+      summary: Update an existing concept set
+      operationId: updateConceptSet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/ConceptSetUpdateInfo'
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/ConceptSet'
+        404:
+          $ref: '#/definitions/ErrorModel'
+        500:
+          $ref: '#/definitions/ErrorModel'
+    delete:
+      summary: Delete a concept set
+      operationId: deleteConceptSet
+      tags:
+        - repository
+      responses:
+        204:
+          description: OK
+        404:
+          $ref: '#/definitions/ErrorModel'
+        500:
+          $ref: '#/definitions/ErrorModel'
+
+  '/api/repository/v1/cohort-builder/entities/{entityName}/counts':
+    parameters:
+      - $ref: '#/parameters/EntityName'
+    post:
+      summary: Count entity instances
+      operationId: countInstances
+      tags:
+        - repository
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/CountQuery'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/InstanceCountList'
+        404:
+          $ref: '#/definitions/ErrorModel'
+        500:
+          $ref: '#/definitions/ErrorModel'
+
+  '/api/repository/v1/cohort-builder/entities/{entityName}/instances':
+    parameters:
+      - $ref: '#/parameters/EntityName'
+    post:
+      summary: Query entity instances
+      operationId: queryInstances
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/Query'
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/InstanceList'
+        404:
+          $ref: '#/definitions/ErrorModel'
+        500:
+          $ref: '#/definitions/ErrorModel'
+
+  '/api/repository/v1/cohort-builder/cohorts':
+    get:
+      parameters:
+        - in: query
+          name: offset
+          description: The number of items to skip before starting to collect the result set.
+          schema:
+            type: integer
+            default: 0
+        - in: query
+          name: limit
+          description: The numbers of items to return.
+          schema:
+            type: integer
+            default: 10
+      summary: List all user cohorts
+      operationId: listCohorts
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/CohortList'
+        500:
+          $ref: '#/definitions/ErrorModel'
+    post:
+      summary: Create a new cohort
+      operationId: createCohort
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/CohortCreateInfo'
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/Cohort'
+        500:
+          $ref: '#/definitions/ErrorModel'
+
+  '/api/repository/v1/cohort-builder/cohorts/{cohortId}':
+    parameters:
+      - $ref: '#/parameters/CohortId'
+    get:
+      summary: Get an existing cohort
+      operationId: getCohort
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/Cohort'
+        404:
+          $ref: '#/definitions/ErrorModel'
+        500:
+          $ref: '#/definitions/ErrorModel'
+    patch:
+      summary: Update an existing cohort
+      operationId: updateCohort
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/CohortUpdateInfo'
+      tags:
+        - repository
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/Cohort'
+        404:
+          $ref: '#/definitions/ErrorModel'
+        500:
+          $ref: '#/definitions/ErrorModel'
+    delete:
+      summary: Delete a cohort
+      operationId: deleteCohort
+      tags:
+        - repository
+      responses:
+        204:
+          description: OK
+        404:
+          $ref: '#/definitions/ErrorModel'
+        500:
+          $ref: '#/definitions/ErrorModel'
+
 ##############################################################################
 ## SEARCH API STANDARD ENDPOINTS
 ##############################################################################

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3101,12 +3101,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
       x-codegen-request-body-name: upgrade
-
-  # -- Cohort Builder Endpoints --
-
+  #################################################################
+  #####                  COHORT BUILDER ROUTES
+  #################################################################
   '/api/repository/v1/cohort-builder/entities/{entityName}/hints':
     parameters:
-      - $ref: '#/parameters/EntityName'
+      - $ref: '#/components/parameters/EntityName'
     post:
       summary: Query entity display hints
       operationId: queryHints
@@ -3116,6 +3116,7 @@ paths:
             schema:
               $ref: '#/components/schemas/HintQuery'
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3123,11 +3124,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/DisplayHintList'
+                $ref: '#/components/schemas/DisplayHintList'
         404:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
 
   '/api/repository/v1/cohort-builder/concept-sets':
     get:
@@ -3148,6 +3149,7 @@ paths:
       summary: List all concept sets in a study
       operationId: listConceptSets
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3155,9 +3157,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/ConceptSetList'
+                $ref: '#/components/schemas/ConceptSetList'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
     post:
       summary: Create a new concept set
       operationId: createConceptSet
@@ -3165,8 +3167,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/ConceptSetCreateInfo'
+              $ref: '#/components/schemas/ConceptSetCreateInfo'
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3174,17 +3177,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/ConceptSet'
+                $ref: '#/components/schemas/ConceptSet'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
 
   '/api/repository/v1/cohort-builder/concept-sets/{conceptSetId}':
     parameters:
-      - $ref: '#/parameters/ConceptSetId'
+      - $ref: '#/components/parameters/ConceptSetId'
     get:
       summary: Get an existing concept set
       operationId: getConceptSet
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3192,21 +3196,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/ConceptSet'
+                $ref: '#/components/schemas/ConceptSet'
         404:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
     patch:
-      parameters:
       summary: Update an existing concept set
       operationId: updateConceptSet
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/ConceptSetUpdateInfo'
+              $ref: '#/components/schemas/ConceptSetUpdateInfo'
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3214,52 +3218,54 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/ConceptSet'
+                $ref: '#/components/schemas/ConceptSet'
         404:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
     delete:
       summary: Delete a concept set
       operationId: deleteConceptSet
       tags:
+        - cohort-builder
         - repository
       responses:
         204:
           description: OK
         404:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
 
   '/api/repository/v1/cohort-builder/entities/{entityName}/counts':
     parameters:
-      - $ref: '#/parameters/EntityName'
+      - $ref: '#/components/parameters/EntityName'
     post:
       summary: Count entity instances
       operationId: countInstances
       tags:
+        - cohort-builder
         - repository
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/CountQuery'
+              $ref: '#/components/schemas/CountQuery'
       responses:
         200:
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/definitions/InstanceCountList'
+                $ref: '#/components/schemas/InstanceCountList'
         404:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
 
   '/api/repository/v1/cohort-builder/entities/{entityName}/instances':
     parameters:
-      - $ref: '#/parameters/EntityName'
+      - $ref: '#/components/parameters/EntityName'
     post:
       summary: Query entity instances
       operationId: queryInstances
@@ -3267,8 +3273,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/Query'
+              $ref: '#/components/schemas/Query'
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3276,11 +3283,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/InstanceList'
+                $ref: '#/components/schemas/InstanceList'
         404:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
 
   '/api/repository/v1/cohort-builder/cohorts':
     get:
@@ -3300,6 +3307,7 @@ paths:
       summary: List all user cohorts
       operationId: listCohorts
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3307,9 +3315,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/CohortList'
+                $ref: '#/components/schemas/CohortList'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
     post:
       summary: Create a new cohort
       operationId: createCohort
@@ -3317,8 +3325,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/CohortCreateInfo'
+              $ref: '#/components/schemas/CohortCreateInfo'
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3326,17 +3335,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/Cohort'
+                $ref: '#/components/schemas/Cohort'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
 
   '/api/repository/v1/cohort-builder/cohorts/{cohortId}':
     parameters:
-      - $ref: '#/parameters/CohortId'
+      - $ref: '#/components/parameters/CohortId'
     get:
       summary: Get an existing cohort
       operationId: getCohort
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3344,11 +3354,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/Cohort'
+                $ref: '#/components/schemas/Cohort'
         404:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
     patch:
       summary: Update an existing cohort
       operationId: updateCohort
@@ -3356,8 +3366,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/definitions/CohortUpdateInfo'
+              $ref: '#/components/schemas/CohortUpdateInfo'
       tags:
+        - cohort-builder
         - repository
       responses:
         200:
@@ -3365,23 +3376,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/definitions/Cohort'
+                $ref: '#/components/schemas/Cohort'
         404:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
     delete:
       summary: Delete a cohort
       operationId: deleteCohort
       tags:
+        - cohort-builder
         - repository
       responses:
         204:
           description: OK
         404:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
         500:
-          $ref: '#/definitions/ErrorModel'
+          $ref: '#/components/schemas/ErrorModel'
 
 ##############################################################################
 ## SEARCH API STANDARD ENDPOINTS
@@ -6404,6 +6416,564 @@ components:
             which token to send via other means. It is strongly recommended that the caller
             validate that it is appropriate to send the requested token to the DRS server to mitigate attacks
             by malicious DRS servers requesting credentials they should not have.
+    #################################################################
+    #####                  COHORT BUILDER MODELS
+    #################################################################
+    Attribute:
+      type: object
+      description: Entity attribute
+      properties:
+        name:
+          description: Name
+          type: string
+        type:
+          description: Attribute type
+          type: string
+          enum: [ 'SIMPLE', 'KEY_AND_DISPLAY' ]
+        dataType:
+          $ref: '#/components/schemas/DataType'
+
+    EntityName:
+      type: string
+      description: Name of the entity (e.g. condition_occurrence)
+
+    ConceptSetDisplayName:
+      type: string
+      description: Human readable name of the concept set
+
+    ConceptSetDescription:
+      type: string
+      description: Description of the concept set
+
+    ConceptSetList:
+      type: array
+      items:
+        $ref: '#/components/schemas/ConceptSet'
+
+    DisplayHint:
+      type: object
+      description: Display hint for entity attribute
+      properties:
+        attribute:
+          $ref: '#/components/schemas/Attribute'
+        displayHint:
+          type: object
+          description: Display hint calculated from source data
+          properties:
+            enumHint:
+              $ref: '#/components/schemas/DisplayHintEnum'
+            numericRangeHint:
+              $ref: '#/components/schemas/DisplayHintNumericRange'
+
+    DisplayHintEnum:
+      type: object
+      description: Enumeration of possible values, display strings, and counts
+      properties:
+        enumHintValues:
+          type: array
+          items:
+            type: object
+            description: Enum value and count
+            properties:
+              enumVal:
+                $ref: '#/components/schemas/ValueDisplay'
+              count:
+                type: integer
+
+    DisplayHintNumericRange:
+      type: object
+      description: Maximum and minimum values
+      properties:
+        min:
+          description: Max value
+          type: number
+          format: double
+        max:
+          description: Min value
+          type: number
+          format: double
+
+    DisplayHintList:
+      type: object
+      description: List of display hints
+      properties:
+        sql:
+          type: string
+        displayHints:
+          type: array
+          items:
+            $ref: '#/components/schemas/DisplayHint'
+
+    HintQuery:
+      type: object
+      description: Get display hints
+      properties:
+        relatedEntity:
+          description: |
+            Optional related entity.
+            If specified, then we return hints computed across related instances (e.g. condition occurrences where condition id=11).
+            Otherwise, we return hints computed across all instances (e.g. all persons).
+          type: object
+          properties:
+            name:
+              type: string
+              description: Related entity name
+            id:
+              $ref: '#/components/schemas/Literal'
+
+    ConceptSet:
+      type: object
+      properties:
+        id:
+          description: ID of the concept set, immutable
+          type: string
+        entity:
+          $ref: '#/components/schemas/EntityName'
+        displayName:
+          $ref: '#/components/schemas/ConceptSetDisplayName'
+        description:
+          $ref: '#/components/schemas/ConceptSetDescription'
+        criteria:
+          $ref: '#/components/schemas/Criteria'
+        created:
+          description: Timestamp of when the concept set was created
+          type: string
+          format: date-time
+        createdBy:
+          description: Email of user who created the concept set
+          type: string
+        lastModified:
+          description: Timestamp of when the concept set was last modified
+          type: string
+          format: date-time
+      required:
+        - id
+        - entity
+        - displayName
+        - criteria
+        - created
+        - createdBy
+        - lastModified
+
+    ConceptSetCreateInfo:
+      type: object
+      properties:
+        entity:
+          $ref: '#/components/schemas/EntityName'
+        displayName:
+          $ref: '#/components/schemas/ConceptSetDisplayName'
+        description:
+          $ref: '#/components/schemas/ConceptSetDescription'
+        criteria:
+          $ref: '#/components/schemas/Criteria'
+
+    ConceptSetUpdateInfo:
+      type: object
+      properties:
+        entity:
+          $ref: '#/components/schemas/EntityName'
+        displayName:
+          $ref: '#/components/schemas/ConceptSetDisplayName'
+        description:
+          $ref: '#/components/schemas/ConceptSetDescription'
+        criteria:
+          $ref: '#/components/schemas/Criteria'
+
+    OrderByDirection:
+      type: string
+      description: Defaults to ascending
+      enum: [ 'ASCENDING', 'DESCENDING' ]
+
+    Limit:
+      type: integer
+      description: Maximum number of results to return. Defaults to 250.
+      default: 250
+
+    Query:
+      type: object
+      description: Query for entity instances
+      properties:
+        includeAttributes:
+          description: Attributes to include in the returned instances
+          type: array
+          items:
+            type: string
+        includeHierarchyFields:
+          description: Hierarchy fields to include in the returned instances. All fields will be returned for each hierarchy specified.
+          type: object
+          properties:
+            hierarchies:
+              type: array
+              description: Hierarchy names
+              items:
+                type: string
+            fields:
+              type: array
+              items:
+                type: string
+                enum: [ 'IS_MEMBER', 'PATH', 'NUM_CHILDREN', 'IS_ROOT' ]
+        includeRelationshipFields:
+          description: Relationship (count) fields to include in the returned instances.
+          type: array
+          items:
+            type: object
+            description: Related entity and optional hierarchies. Per-node rollups are always returned.
+            properties:
+              relatedEntity:
+                type: string
+              hierarchies:
+                type: array
+                description: Hierarchy names
+                items:
+                  type: string
+        filter:
+          $ref: '#/components/schemas/Filter'
+        orderBys:
+          type: array
+          description: Attributes and direction to order the results by
+          items:
+            type: object
+            description: Attribute or relationship (count) field and the direction
+            properties:
+              attribute:
+                type: string
+              relationshipField:
+                type: object
+                properties:
+                  relatedEntity:
+                    type: string
+                  hierarchy:
+                    type: string
+              direction:
+                $ref: '#/components/schemas/OrderByDirection'
+        limit:
+          $ref: '#/components/schemas/Limit'
+
+    InstanceList:
+      type: object
+      description: List of instances
+      properties:
+        sql:
+          type: string
+        instances:
+          type: array
+          items:
+            $ref: '#/components/schemas/Instance'
+
+    Instance:
+      type: object
+      properties:
+        attributes:
+          description: A map of entity attribute names to their value for this instance. Only the attributes requested are populated.
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ValueDisplay'
+        hierarchyFields:
+          description: Hierarchy field values for this instance. One set of values per hierarchy. Only the values requested are populated.
+          type: array
+          items:
+            type: object
+            properties:
+              hierarchy:
+                type: string
+              isMember:
+                type: boolean
+              path:
+                type: string
+              numChildren:
+                type: integer
+              isRoot:
+                type: boolean
+        relationshipFields:
+          description: Relationship field values for this instance. Only the values requested are populated.
+          type: array
+          items:
+            type: object
+            properties:
+              relatedEntity:
+                type: string
+              hierarchy:
+                type: string
+              count:
+                type: integer
+              displayHints:
+                type: string
+
+    InstanceCountList:
+      type: object
+      description: List of instance counts
+      properties:
+        sql:
+          type: string
+        instanceCounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/InstanceCount'
+
+    InstanceCount:
+      type: object
+      properties:
+        count:
+          type: integer
+        attributes:
+          description: A map of entity attribute names to their value for this group
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ValueDisplay'
+
+    ValueDisplay:
+      type: object
+      description: Attribute value and optional display string
+      properties:
+        value:
+          $ref: '#/components/schemas/Literal'
+        display:
+          type: string
+          description: Optional display string
+
+    CountQuery:
+      type: object
+      description: Count entity instances
+      properties:
+        attributes:
+          description: |
+            Attributes to group by. One count will be returned for each possible combination of attribute values
+            (e.g. [gender, hair_color] will return counts for man+red, man+black, woman+red, woman+black).
+          type: array
+          items:
+            type: string
+        filter:
+          $ref: '#/components/schemas/Filter'
+
+    DataType:
+      type: string
+      enum: [ 'INT64', 'STRING', 'BOOLEAN', 'DATE' ]
+
+    Literal:
+      type: object
+      description: Union of references to each value type. Exactly one will be populated based on the dataType.
+      properties:
+        dataType:
+          $ref: '#/components/schemas/DataType'
+        valueUnion:
+          type: object
+          properties:
+            boolVal:
+              type: boolean
+            int64Val:
+              type: integer
+              format: int64
+            stringVal:
+              type: string
+            dateVal:
+              type: string
+              description: Format YYYY-MM-DD
+
+    Filter:
+      type: object
+      description: Union of references to each filter type. Exactly one should be specified based on the filterType.
+      properties:
+        filterType:
+          type: string
+          enum: [ 'ATTRIBUTE', 'TEXT', 'HIERARCHY', 'RELATIONSHIP', 'BOOLEAN_LOGIC' ]
+        filterUnion:
+          type: object
+          properties:
+            attributeFilter:
+              $ref: '#/components/schemas/AttributeFilter'
+            textFilter:
+              $ref: '#/components/schemas/TextFilter'
+            hierarchyFilter:
+              $ref: '#/components/schemas/HierarchyFilter'
+            relationshipFilter:
+              $ref: '#/components/schemas/RelationshipFilter'
+            booleanLogicFilter:
+              $ref: '#/components/schemas/BooleanLogicFilter'
+
+    AttributeFilter:
+      type: object
+      description: Filter on an attribute value (e.g. color=red)
+      properties:
+        attribute:
+          type: string
+        operator:
+          type: string
+          enum: [ 'EQUALS', 'NOT_EQUALS', 'LESS_THAN', 'GREATER_THAN' ]
+        value:
+          $ref: '#/components/schemas/Literal'
+
+    TextFilter:
+      type: object
+      description: Filter on a text search (e.g. person sounds like Joe)
+      properties:
+        matchType:
+          type: string
+          enum: [ 'EXACT_MATCH', 'FUZZY_MATCH' ]
+        attribute:
+          type: string
+          description: |
+            Attribute to match on. If not specified, then we match on whatever is specified in the text search mapping config.
+            Currently, fuzzy match only works on a single attribute (i.e. you must specify this field for fuzzy match).
+        text:
+          type: string
+
+    HierarchyFilter:
+      type: object
+      description: Filter on a hierarchy (e.g. descendant of id=12)
+      properties:
+        hierarchy:
+          description: Name of the hierarchy
+          type: string
+        operator:
+          type: string
+          enum: [ 'CHILD_OF', 'DESCENDANT_OF_INCLUSIVE', 'IS_ROOT', 'IS_MEMBER' ]
+        value:
+          $ref: '#/components/schemas/Literal'
+
+    RelationshipFilter:
+      type: object
+      description: Filter on a relationship between entities (e.g. condition occurrences where condition=diabetes)
+      properties:
+        entity:
+          type: string
+        subfilter:
+          $ref: '#/components/schemas/Filter'
+
+    BooleanLogicFilter:
+      type: object
+      description: |
+        Compose multiple filters (e.g. color=red AND capacity=3, NOT color=red).
+        The NOT operator only allows a single subfilter. The OR and AND operators require more than one subfilter.
+      properties:
+        operator:
+          type: string
+          enum: [ 'AND', 'OR', 'NOT' ]
+        subfilters:
+          type: array
+          items:
+            $ref: '#/components/schemas/Filter'
+
+    Cohort:
+      type: object
+      properties:
+        id:
+          description: ID of the cohort, immutable
+          type: string
+        displayName:
+          $ref: '#/components/schemas/CohortDisplayName'
+        description:
+          $ref: '#/components/schemas/CohortDescription'
+        criteriaGroups:
+          type: array
+          description: Groups of criteria that define the entity filter
+          items:
+            $ref: '#/components/schemas/CriteriaGroup'
+        created:
+          description: Timestamp of when the cohort was created
+          type: string
+          format: date-time
+        createdBy:
+          description: Email of user who created cohort
+          type: string
+        lastModified:
+          description: Timestamp of when the cohort was last modified
+          type: string
+          format: date-time
+      required:
+        - id
+        - displayName
+        - criteriaGroups
+        - created
+        - createdBy
+        - lastModified
+
+    CohortList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Cohort'
+
+    CohortCreateInfo:
+      type: object
+      properties:
+        displayName:
+          $ref: '#/components/schemas/CohortDisplayName'
+        description:
+          $ref: '#/components/schemas/CohortDescription'
+
+    CohortUpdateInfo:
+      type: object
+      properties:
+        displayName:
+          $ref: '#/components/schemas/CohortDisplayName'
+        description:
+          $ref: '#/components/schemas/CohortDescription'
+        criteriaGroups:
+          type: array
+          description: Groups of criteria that define the entity filter
+          items:
+            $ref: '#/components/schemas/CriteriaGroup'
+
+    CohortDisplayName:
+      type: string
+      description: Human readable name of the cohort
+
+    CohortDescription:
+      type: string
+      description: Description of the cohort
+
+    CriteriaGroup:
+      type: object
+      description: Group of criteria for a cohort definition
+      properties:
+        id:
+          type: string
+          description: ID of the group, immutable
+        displayName:
+          type: string
+          description: Name of the group
+        criteria:
+          type: array
+          description: Set of criteria in the group
+          items:
+            $ref: '#/components/schemas/Criteria'
+        operator:
+          type: string
+          description: Operator to use when combining the criteria in the group
+          enum: [ 'AND', 'OR' ]
+        excluded:
+          type: boolean
+          description: True to exclude the group, false to include it
+      required:
+        - id
+        - displayName
+        - criteria
+        - operator
+        - excluded
+
+    Criteria:
+      type: object
+      description: Single criteria for a cohort or concept set definition
+      properties:
+        id:
+          type: string
+          description: ID of the criteria, immutable
+        displayName:
+          type: string
+          description: Name of the criteria
+        pluginName:
+          type: string
+          description: Name of the plugin that generated this criteria
+        selectionData:
+          type: string # JSON formatted
+          description: Serialized plugin-specific representation of the user's selection
+        uiConfig:
+          type: string # JSON formatted
+          description: Serialized plugin-specific UI configuration for the criteria
+      required:
+        - id
+        - displayName
+        - pluginName
+        - selectionData
 #################################################################
 #####                  JOURNAL MODELS
 #################################################################
@@ -6539,6 +7109,27 @@ components:
       schema:
         type: string
         format: uuid
+    CohortId:
+      name: cohortId
+      description: A UUID to used to identify an object in the repository
+      required: true
+      schema:
+        type: string
+      in: path
+    EntityName:
+      name: entityName
+      in: path
+      description: Name of the entity
+      required: true
+      schema:
+        type: string
+    ConceptSetId:
+      name: conceptSetId
+      in: path
+      description: ID of the concept set
+      required: true
+      schema:
+        type: string
   securitySchemes:
     googleoauth:
       type: oauth2
@@ -6560,3 +7151,4 @@ components:
             openid: open id authorization
             email: email authorization
             profile: profile authorization
+


### PR DESCRIPTION
This adds stub apis for the cohort builder. I copied over the yaml definitions from Tanagra https://github.com/DataBiosphere/tanagra

The stubs are there so that we can use this to power an equivalent feature branch in the Tanagra UI. This code will not go into the dev branch until after implementation, and likely some work to productionize the code. https://github.com/DataBiosphere/tanagra/pull/354