### PR TITLE
DR-2971 - Missing global_file_ids field on retrieveSnapshotsForDataset

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -712,7 +712,7 @@ public class SnapshotDao {
     try {
       String sql =
           "SELECT snapshot.id, snapshot.name, snapshot.description, snapshot.created_date, snapshot.profile_id, "
-              + "dataset.secure_monitoring, snapshot.consent_code, dataset.phs_id, dataset.self_hosted,"
+              + "dataset.secure_monitoring, snapshot.consent_code, snapshot.global_file_ids, dataset.phs_id, dataset.self_hosted,"
               + summaryCloudPlatformQuery
               + snapshotSourceStorageQuery
               + "FROM snapshot "

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNull;
@@ -177,6 +178,20 @@ public class SnapshotDaoTest {
     snapshotDao.createAndLock(snapshot, flightId, TEST_USER);
     snapshotDao.unlock(snapshot.getId(), flightId);
     return snapshotDao.retrieveSnapshot(snapshot.getId());
+  }
+
+  @Test
+  public void testRetrieveSnapshotsForDataset() {
+    snapshotRequest.name(snapshotRequest.getName() + UUID.randomUUID());
+
+    Snapshot snapshot =
+        snapshotService
+            .makeSnapshotFromSnapshotRequest(snapshotRequest)
+            .projectResourceId(projectId)
+            .id(snapshotId);
+    Snapshot fromDB = insertAndRetrieveSnapshot(snapshot, "happyInOutTest_flightId");
+    List<SnapshotSummary> snapshots = snapshotDao.retrieveSnapshotsForDataset(datasetId);
+    assertThat("there should exist one snapshot", snapshots, hasSize(1));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -189,7 +189,9 @@ public class SnapshotDaoTest {
             .makeSnapshotFromSnapshotRequest(snapshotRequest)
             .projectResourceId(projectId)
             .id(snapshotId);
-    Snapshot fromDB = insertAndRetrieveSnapshot(snapshot, "happyInOutTest_flightId");
+    String flightId = "happyInOutTest_flightId";
+    snapshotDao.createAndLock(snapshot, flightId, TEST_USER);
+    snapshotDao.unlock(snapshot.getId(), flightId);
     List<SnapshotSummary> snapshots = snapshotDao.retrieveSnapshotsForDataset(datasetId);
     assertThat("there should exist one snapshot", snapshots, hasSize(1));
   }


### PR DESCRIPTION
The object mapper expects for the global_file_ids field to be present on the snapshot summary model. Therefore, the retrieveSnapshotsForDataset endpoint was not functional. (Encountered error "The column name global_file_ids was not found in this ResultSet" before this change).  

How did we not know about this bug?  retrieveSnapshotsForDataset() is only used on dataset delete and only returns any results when there are snapshots still associated with the dataset getting deleted. If any snapshot results are returned, the delete flight fails because we require that there are no associated snapshots before deleting a source dataset. There were no associated tests/unit tests.