### PR TITLE
[DR-2959] Merge and replace ingest rows get new IDs

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -235,10 +235,11 @@ public class DatasetIngestFlight extends Flight {
             new IngestSoftDeleteExistingRowsStep(
                 datasetService, bigQueryTransactionPdao, bigQueryDatasetPdao, userReq, autocommit));
       }
-      // Only appended records may specify their own row IDs: if specified for other ingest types,
-      // they are ignored and new ones are generated
-      boolean unsetExistingRowIds = replaceIngest || mergeIngest;
-      addStep(new IngestRowIdsStep(datasetService, bigQueryDatasetPdao, unsetExistingRowIds));
+      addStep(
+          new IngestRowIdsStep(
+              datasetService,
+              bigQueryDatasetPdao,
+              IngestUtils.shouldUnsetExistingRowIds(inputParameters)));
       addStep(new IngestValidateGcpRefsStep(datasetService, bigQueryDatasetPdao, fileDao));
       // Loads data into the final target raw data table
       addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -235,7 +235,10 @@ public class DatasetIngestFlight extends Flight {
             new IngestSoftDeleteExistingRowsStep(
                 datasetService, bigQueryTransactionPdao, bigQueryDatasetPdao, userReq, autocommit));
       }
-      addStep(new IngestRowIdsStep(datasetService, bigQueryDatasetPdao));
+      // Only appended records may specify their own row IDs: if specified for other ingest types,
+      // they are ignored and new ones are generated
+      boolean unsetExistingRowIds = replaceIngest || mergeIngest;
+      addStep(new IngestRowIdsStep(datasetService, bigQueryDatasetPdao, unsetExistingRowIds));
       addStep(new IngestValidateGcpRefsStep(datasetService, bigQueryDatasetPdao, fileDao));
       // Loads data into the final target raw data table
       addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -239,7 +239,7 @@ public class DatasetIngestFlight extends Flight {
           new IngestRowIdsStep(
               datasetService,
               bigQueryDatasetPdao,
-              IngestUtils.shouldUnsetExistingRowIds(inputParameters)));
+              IngestUtils.shouldIgnoreUserSpecifiedRowIds(inputParameters)));
       addStep(new IngestValidateGcpRefsStep(datasetService, bigQueryDatasetPdao, fileDao));
       // Loads data into the final target raw data table
       addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestRowIdsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestRowIdsStep.java
@@ -10,22 +10,23 @@ import bio.terra.stairway.StepResult;
 public class IngestRowIdsStep implements Step {
   private DatasetService datasetService;
   private BigQueryDatasetPdao bigQueryDatasetPdao;
-  private boolean unsetExistingRowIds;
+  private boolean ignoreUserSpecifiedRowIds;
 
   public IngestRowIdsStep(
       DatasetService datasetService,
       BigQueryDatasetPdao bigQueryDatasetPdao,
-      boolean unsetExistingRowIds) {
+      boolean ignoreUserSpecifiedRowIds) {
     this.datasetService = datasetService;
     this.bigQueryDatasetPdao = bigQueryDatasetPdao;
-    this.unsetExistingRowIds = unsetExistingRowIds;
+    this.ignoreUserSpecifiedRowIds = ignoreUserSpecifiedRowIds;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Dataset dataset = IngestUtils.getDataset(context, datasetService);
     String stagingTableName = IngestUtils.getStagingTableName(context);
-    bigQueryDatasetPdao.addRowIdsToStagingTable(dataset, stagingTableName, unsetExistingRowIds);
+    bigQueryDatasetPdao.addRowIdsToStagingTable(
+        dataset, stagingTableName, ignoreUserSpecifiedRowIds);
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestRowIdsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestRowIdsStep.java
@@ -10,17 +10,22 @@ import bio.terra.stairway.StepResult;
 public class IngestRowIdsStep implements Step {
   private DatasetService datasetService;
   private BigQueryDatasetPdao bigQueryDatasetPdao;
+  private boolean unsetExistingRowIds;
 
-  public IngestRowIdsStep(DatasetService datasetService, BigQueryDatasetPdao bigQueryDatasetPdao) {
+  public IngestRowIdsStep(
+      DatasetService datasetService,
+      BigQueryDatasetPdao bigQueryDatasetPdao,
+      boolean unsetExistingRowIds) {
     this.datasetService = datasetService;
     this.bigQueryDatasetPdao = bigQueryDatasetPdao;
+    this.unsetExistingRowIds = unsetExistingRowIds;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Dataset dataset = IngestUtils.getDataset(context, datasetService);
     String stagingTableName = IngestUtils.getStagingTableName(context);
-    bigQueryDatasetPdao.addRowIdsToStagingTable(dataset, stagingTableName);
+    bigQueryDatasetPdao.addRowIdsToStagingTable(dataset, stagingTableName, unsetExistingRowIds);
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -224,7 +224,7 @@ public final class IngestUtils {
   /**
    * @return whether ingest should ignore any user-specified row IDs and generate new ones
    */
-  public static boolean shouldUnsetExistingRowIds(FlightMap inputParameters) {
+  public static boolean shouldIgnoreUserSpecifiedRowIds(FlightMap inputParameters) {
     var updateStrategy =
         inputParameters
             .get(JobMapKeys.REQUEST.getKeyName(), IngestRequestModel.class)

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.storage.StorageException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -218,6 +219,21 @@ public final class IngestUtils {
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), IngestRequestModel.class);
     return ingestRequestModel.getFormat() == IngestRequestModel.FormatEnum.JSON
         || ingestRequestModel.getFormat() == IngestRequestModel.FormatEnum.ARRAY;
+  }
+
+  /**
+   * @return whether ingest should ignore any user-specified row IDs and generate new ones
+   */
+  public static boolean shouldUnsetExistingRowIds(FlightMap inputParameters) {
+    var updateStrategy =
+        inputParameters
+            .get(JobMapKeys.REQUEST.getKeyName(), IngestRequestModel.class)
+            .getUpdateStrategy();
+    // For historical reasons, ingests in append mode may specify their own row IDs.
+    return EnumSet.of(
+            IngestRequestModel.UpdateStrategyEnum.REPLACE,
+            IngestRequestModel.UpdateStrategyEnum.MERGE)
+        .contains(updateStrategy);
   }
 
   public static Stream<JsonNode> getJsonNodesStreamFromFile(

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -482,21 +482,32 @@ public class BigQueryDatasetPdao {
         .error(bqStringValue(fieldValue, LoadHistoryUtil.ERROR_FIELD_NAME));
   }
 
-  private static final String addRowIdsToStagingTableTemplate =
-      "UPDATE `<project>.<dataset>.<stagingTable>` SET "
-          + PDAO_ROW_ID_COLUMN
-          + " = GENERATE_UUID() WHERE "
-          + PDAO_ROW_ID_COLUMN
-          + " IS NULL";
-
-  public void addRowIdsToStagingTable(Dataset dataset, String stagingTableName)
+  /**
+   * @param unsetExistingRowIds true if we should generate new row IDs for all staged records,
+   *     otherwise only generate row IDs where they don't already exist.
+   */
+  public void addRowIdsToStagingTable(
+      Dataset dataset, String stagingTableName, boolean unsetExistingRowIds)
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(addRowIdsToStagingTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("stagingTable", stagingTableName);
+    String addRowIdsToStagingTableTemplate =
+        """
+            UPDATE `<project>.<dataset>.<stagingTable>`
+            SET <pdaoRowIdColumn> = GENERATE_UUID()
+            WHERE <whereClause>
+            """;
+    // BigQuery updates require WHERE clauses to protect against erroneous full-table updates,
+    // but we intend to run a full-table update when generating all new row IDs.
+    String whereClause = (unsetExistingRowIds) ? "true" : PDAO_ROW_ID_COLUMN + " IS NULL";
+
+    ST sqlTemplate =
+        new ST(addRowIdsToStagingTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("stagingTable", stagingTableName)
+            .add("pdaoRowIdColumn", PDAO_ROW_ID_COLUMN)
+            .add("whereClause", whereClause);
 
     bigQueryProject.query(sqlTemplate.render());
   }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -483,11 +483,11 @@ public class BigQueryDatasetPdao {
   }
 
   /**
-   * @param unsetExistingRowIds true if we should generate new row IDs for all staged records,
+   * @param ignoreUserSpecifiedRowIds true if we should generate new row IDs for all staged records,
    *     otherwise only generate row IDs where they don't already exist.
    */
   public void addRowIdsToStagingTable(
-      Dataset dataset, String stagingTableName, boolean unsetExistingRowIds)
+      Dataset dataset, String stagingTableName, boolean ignoreUserSpecifiedRowIds)
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
@@ -499,7 +499,7 @@ public class BigQueryDatasetPdao {
             """;
     // BigQuery updates require WHERE clauses to protect against erroneous full-table updates,
     // but we intend to run a full-table update when generating all new row IDs.
-    String whereClause = (unsetExistingRowIds) ? "true" : PDAO_ROW_ID_COLUMN + " IS NULL";
+    String whereClause = (ignoreUserSpecifiedRowIds) ? "true" : PDAO_ROW_ID_COLUMN + " IS NULL";
 
     ST sqlTemplate =
         new ST(addRowIdsToStagingTableTemplate)

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4383,12 +4383,15 @@ components:
              * `append` - Default: only ever insert rows, regardless of whether or not the primary key value exists
              * `replace` - If a primary key is present on the table, treat rows with matching primary keys
                          as updates. If duplicate IDs are found in your ingest, the ingest job
-                         will fail. Note: the full new record must be specified.
+                         will fail. If your rows specify `datarepo_row_id`, it will be ignored and
+                         TDR will generate new row IDs for your new records. Note: the full new
+                         record must be specified.
              * `merge` - If a primary key is present on the table, treat rows with matching primary keys
                          as partial updates. Any fields specified will overwrite their current values
-                         in the matching table row.  Each ingest row must match exactly one table row,
-                         and no duplicate IDs should be found in your ingest, otherwise the ingest job
-                         will fail.
+                         in the matching table row. If your rows specify `datarepo_row_id`, it will
+                         be ignored and TDR will generate new row IDs for your new records. Each
+                         ingest row must match exactly one table row, and no duplicate IDs should be
+                         found in your ingest, otherwise the ingest job will fail.
         bulkMode:
           type: boolean
           default: false

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
@@ -2,10 +2,15 @@ package bio.terra.service.dataset.flight.ingest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import bio.terra.common.category.Unit;
+import bio.terra.model.IngestRequestModel;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.exception.InvalidBlobURLException;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightMap;
 import com.azure.storage.blob.BlobUrlParts;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -79,5 +84,40 @@ public class IngestUtilsTest {
   public void testNoUpperCase() {
     IngestUtils.validateBlobAzureBlobFileURL(
         "https://tdrconnectedsrc1.blob.core.windows.net/SYNAPSETEST/test/azure-simple-dataset-ingest-request.csv");
+  }
+
+  @Test
+  public void testShouldUnsetExistingRowIds() {
+    // We should not find ourselves here: ingests default to append mode if unspecified.
+    FlightMap flightMapNoUpdateStrategy = createFlightMap(null);
+    assertFalse(
+        "Ingests with unspecified update strategy can specify their own row IDs",
+        IngestUtils.shouldUnsetExistingRowIds(flightMapNoUpdateStrategy));
+
+    FlightMap flightMapAppend = createFlightMap(IngestRequestModel.UpdateStrategyEnum.APPEND);
+    assertFalse(
+        "Ingests in append mode can specify their own row IDs",
+        IngestUtils.shouldUnsetExistingRowIds(flightMapAppend));
+
+    FlightMap flightMapReplace = createFlightMap(IngestRequestModel.UpdateStrategyEnum.REPLACE);
+    assertTrue(
+        "Ingests in replace mode will have any specified row IDs unset",
+        IngestUtils.shouldUnsetExistingRowIds(flightMapReplace));
+
+    FlightMap flightMapMerge = createFlightMap(IngestRequestModel.UpdateStrategyEnum.MERGE);
+    assertTrue(
+        "Ingests in merge mode will have any specified row IDs unset",
+        IngestUtils.shouldUnsetExistingRowIds(flightMapMerge));
+  }
+
+  /**
+   * @param updateStrategy to specify on a new stub ingest request
+   * @return a new FlightMap whose ingest request contains the provided update strategy
+   */
+  private FlightMap createFlightMap(IngestRequestModel.UpdateStrategyEnum updateStrategy) {
+    FlightMap inputParameters = new FlightMap();
+    IngestRequestModel ingestRequest = new IngestRequestModel().updateStrategy(updateStrategy);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), ingestRequest);
+    return inputParameters;
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
@@ -87,27 +87,27 @@ public class IngestUtilsTest {
   }
 
   @Test
-  public void testShouldUnsetExistingRowIds() {
+  public void testShouldIgnoreUserSpecifiedRowIds() {
     // We should not find ourselves here: ingests default to append mode if unspecified.
     FlightMap flightMapNoUpdateStrategy = createFlightMap(null);
     assertFalse(
         "Ingests with unspecified update strategy can specify their own row IDs",
-        IngestUtils.shouldUnsetExistingRowIds(flightMapNoUpdateStrategy));
+        IngestUtils.shouldIgnoreUserSpecifiedRowIds(flightMapNoUpdateStrategy));
 
     FlightMap flightMapAppend = createFlightMap(IngestRequestModel.UpdateStrategyEnum.APPEND);
     assertFalse(
         "Ingests in append mode can specify their own row IDs",
-        IngestUtils.shouldUnsetExistingRowIds(flightMapAppend));
+        IngestUtils.shouldIgnoreUserSpecifiedRowIds(flightMapAppend));
 
     FlightMap flightMapReplace = createFlightMap(IngestRequestModel.UpdateStrategyEnum.REPLACE);
     assertTrue(
         "Ingests in replace mode will have any specified row IDs unset",
-        IngestUtils.shouldUnsetExistingRowIds(flightMapReplace));
+        IngestUtils.shouldIgnoreUserSpecifiedRowIds(flightMapReplace));
 
     FlightMap flightMapMerge = createFlightMap(IngestRequestModel.UpdateStrategyEnum.MERGE);
     assertTrue(
         "Ingests in merge mode will have any specified row IDs unset",
-        IngestUtils.shouldUnsetExistingRowIds(flightMapMerge));
+        IngestUtils.shouldIgnoreUserSpecifiedRowIds(flightMapMerge));
   }
 
   /**


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2959

Previously:
- Combined ingests with any update strategy would let the user specify their own row IDs.  If left unspecified, TDR would generate new row UUIDs on their behalf.

Bug:
- If `merge` or `replace` ingest requests specified row IDs which already existed in the target table, both existing and new records could be deleted in the course of facilitating the ingest.  This is because we soft-delete from a join on the raw and soft delete tables based on the row ID. 

Now:
- TDR will always generate new row UUIDs for  `merge` or `replace` ingests, even if the requests specify row IDs.  (This also matches the expected behavior from [Nate's perspective](https://broadinstitute.slack.com/archives/CD4HBRFMG/p1677855551333509?thread_ts=1677812999.587869&cid=CD4HBRFMG)).
- Behavior for `append` ingests remains unchanged: there are some historical but active use cases where `append` ingests expect to be able to specify their own row IDs.

I expanded documentation in the OpenAPI spec and added unit tests, but didn't modify integration tests.  Please let me know if you'd like me to do so, I was personally content with the coverage given by unit tests but don't mind revisiting.

**Demonstration**

My [developer environment](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/datasets/ingestDataset) is up to date with these changes.

I worked off existing dataset https://jade-ok.datarepo-dev.broadinstitute.org/datasets/786725ff-5822-4e51-9e71-50793c561d32

Initial state:
<img width="1398" alt="Screenshot 2023-03-20 at 4 22 22 PM" src="https://user-images.githubusercontent.com/79769153/226457336-09848f80-aa67-4aff-be92-939459057fd6.png">

Append a record with a row ID specified:
```
{
    "format": "array",
    "ignore_unknown_values": true,
    "load_tag": "person",
    "max_bad_records": 0,
    "records": [
    {"datarepo_row_id":"user_supplied_1","id":1,"first_name":"Jim","last_name":"Smith","email":"jimmy@yahoo.com","birth_date":"2002-01-20","samples": [1,2] }
    ],
    "resolve_existing_files": true,
    "table": "person",
    "updateStrategy": "append"
  }
```
<img width="1370" alt="Screenshot 2023-03-20 at 4 25 51 PM" src="https://user-images.githubusercontent.com/79769153/226459139-909cbf39-ae74-496b-99ea-a5b76a9727d8.png">

Replace 2 records.  One has a row ID specified matching a current row's ID, it is ignored:
```
{
    "format": "array",
    "ignore_unknown_values": true,
    "load_tag": "person",
    "max_bad_records": 0,
    "records": [
      {"datarepo_row_id":"user_supplied_1","id":1,"first_name":"JimReplace","last_name":"Smith","email":"jimmy@yahoo.com","birth_date":"2002-01-20","samples": [1,2] },
      {"id":2,"first_name":"AnnieReplace","last_name":"Jones","email":"annie123@aol.com","birth_date":"2002-02-20","samples": [3]}
    ],
    "resolve_existing_files": true,
    "table": "person",
    "updateStrategy": "replace"
  }
```
<img width="1435" alt="Screenshot 2023-03-20 at 4 27 55 PM" src="https://user-images.githubusercontent.com/79769153/226459421-44197d4b-648d-429c-af25-2ab595066497.png">

Apply 2 partial merge records.  One has a row ID specified matching a current row's ID, it is ignored:
```
{
    "format": "array",
    "ignore_unknown_values": true,
    "load_tag": "person",
    "max_bad_records": 0,
    "records": [
      {"datarepo_row_id":"aabc6f3e-ff86-4244-ae3a-a6ce50138868","id":1,"first_name":"JimMerge" },
      {"id":2,"first_name":"AnnieMerge" }
    ],
    "resolve_existing_files": true,
    "table": "person",
    "updateStrategy": "merge"
  }
```
<img width="1398" alt="Screenshot 2023-03-20 at 4 30 51 PM" src="https://user-images.githubusercontent.com/79769153/226459555-3a38341b-201f-42bb-a100-3d63b8719b37.png">
