### PR TITLE
DR-2937 Refactor azure storage

### DIFF
--- a/src/main/java/bio/terra/grammar/azure/SynapseVisitor.java
+++ b/src/main/java/bio/terra/grammar/azure/SynapseVisitor.java
@@ -3,6 +3,7 @@ package bio.terra.grammar.azure;
 import bio.terra.grammar.DatasetAwareVisitor;
 import bio.terra.grammar.SQLParser;
 import bio.terra.model.DatasetModel;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import java.util.Map;
 import java.util.Objects;
 
@@ -24,11 +25,14 @@ public class SynapseVisitor extends DatasetAwareVisitor {
     String alias = generateAlias(tableName);
     return """
       OPENROWSET(
-        BULK 'parquet/%s/*/*.parquet',
+        BULK '%s',
         DATA_SOURCE = '%s',
         FORMAT = 'parquet') AS %s
       """
-        .formatted(tableName, sourceDatasetDatasource, alias);
+        .formatted(
+            FolderType.METADATA.getPath("parquet/%s/*/*.parquet".formatted(tableName)),
+            sourceDatasetDatasource,
+            alias);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/common/azure/StorageTableName.java
+++ b/src/main/java/bio/terra/service/common/azure/StorageTableName.java
@@ -1,6 +1,5 @@
 package bio.terra.service.common.azure;
 
-import bio.terra.common.exception.FeatureNotImplementedException;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -8,29 +7,8 @@ public enum StorageTableName {
   SNAPSHOT("snapshot"),
   LOAD_HISTORY("loadHistory"),
   DEPENDENCIES("dependencies"),
-  DATASET("dataset") {
-    // TODO - With DR-2127, move remove special case for dataset
-    @Override
-    public String toTableName(UUID resourceId) {
-      throw new FeatureNotImplementedException(
-          "Dataset storage table names are not unique per resource. Use DATASET_TABLE.toTableName() instead.");
-    }
-
-    public String toTableName() {
-      return label;
-    }
-  },
-  FILES_TABLE("files") {
-    @Override
-    public String toTableName(UUID resourceId) {
-      throw new FeatureNotImplementedException(
-          "Files storage table names are not unique per resource. Use FILES_TABLE.toTableName() instead.");
-    }
-
-    public String toTableName() {
-      return label;
-    }
-  };
+  DATASET("dataset"),
+  FILES_TABLE("files");
 
   public final String label;
 
@@ -47,10 +25,5 @@ public enum StorageTableName {
   public String toTableName(UUID resourceId) {
     Objects.requireNonNull(resourceId, "Resource Id must be provided for this storage table type.");
     return "datarepo" + resourceId.toString().replaceAll("-", "") + label;
-  }
-
-  // TODO - With DR-2127, move remove special case for dataset
-  public String toTableName() {
-    throw new IllegalArgumentException("Resource Id must be provided for this storage table type.");
   }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -34,7 +34,8 @@ public final class DatasetJsonConversion {
   // only allow use of static methods
   private DatasetJsonConversion() {}
 
-  public static Dataset datasetRequestToDataset(DatasetRequestModel datasetRequest) {
+  public static Dataset datasetRequestToDataset(
+      DatasetRequestModel datasetRequest, UUID datasetId) {
     Map<String, DatasetTable> tablesMap = new HashMap<>();
     Map<String, Relationship> relationshipsMap = new HashMap<>();
     List<AssetSpecification> assetSpecifications = new ArrayList<>();
@@ -71,6 +72,7 @@ public final class DatasetJsonConversion {
 
     return new Dataset(
             new DatasetSummary()
+                .id(datasetId)
                 .name(datasetRequest.getName())
                 .description(datasetRequest.getDescription())
                 .storage(storageResources)

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -667,7 +667,6 @@ public class DatasetService {
               profile,
               storageAccount,
               tempFilePath,
-              AzureStorageAccountResource.ContainerType.SCRATCH,
               new BlobSasTokenOptions(
                   Duration.ofHours(1),
                   new BlobSasPermission().setReadPermission(true).setWritePermission(true),

--- a/src/main/java/bio/terra/service/dataset/DatasetUtils.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetUtils.java
@@ -52,7 +52,7 @@ public final class DatasetUtils {
    * method twice on the same request will produce different results.
    */
   public static Dataset convertRequestWithGeneratedNames(DatasetRequestModel request) {
-    Dataset baseDataset = DatasetJsonConversion.datasetRequestToDataset(request);
+    Dataset baseDataset = DatasetJsonConversion.datasetRequestToDataset(request, null);
     fillGeneratedTableNames(baseDataset.getTables());
     return baseDataset;
   }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
@@ -3,6 +3,7 @@ package bio.terra.service.dataset.flight.create;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.service.dataset.DatasetJsonConversion;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
@@ -11,6 +12,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,33 +22,31 @@ public class CreateDatasetGetOrCreateContainerStep implements Step {
   private final ResourceService resourceService;
   private final DatasetRequestModel datasetRequestModel;
   private final AzureContainerPdao azureContainerPdao;
-  private final AzureStorageAccountResource.ContainerType containerType;
 
   public CreateDatasetGetOrCreateContainerStep(
       ResourceService resourceService,
       DatasetRequestModel datasetRequestModel,
-      AzureContainerPdao azureContainerPdao,
-      AzureStorageAccountResource.ContainerType containerType) {
+      AzureContainerPdao azureContainerPdao) {
     this.resourceService = resourceService;
     this.datasetRequestModel = datasetRequestModel;
     this.azureContainerPdao = azureContainerPdao;
-    this.containerType = containerType;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
-    logger.info("Creating a {} container for an Azure backed dataset", containerType);
+    logger.info("Creating a container for an Azure backed dataset");
     FlightMap workingMap = context.getWorkingMap();
     BillingProfileModel profileModel =
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
 
     AzureStorageAccountResource storageAccount =
         resourceService.getOrCreateDatasetStorageAccount(
-            DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel),
+            DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel, datasetId),
             profileModel,
             context.getFlightId());
 
-    azureContainerPdao.getOrCreateContainer(profileModel, storageAccount, containerType);
+    azureContainerPdao.getOrCreateContainer(profileModel, storageAccount);
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateStorageAccountStep.java
@@ -12,6 +12,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,10 +38,11 @@ public class CreateDatasetGetOrCreateStorageAccountStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     BillingProfileModel profileModel =
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
 
     AzureStorageAccountResource storageAccount =
         resourceService.getOrCreateDatasetStorageAccount(
-            DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel),
+            DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel, datasetId),
             profileModel,
             context.getFlightId());
 

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -26,7 +26,6 @@ import bio.terra.service.profile.google.GoogleBillingService;
 import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.Flight;
@@ -105,15 +104,10 @@ public class DatasetCreateFlight extends Flight {
           new CreateDatasetGetOrCreateStorageAccountStep(
               resourceService, datasetRequest, azureBlobStorePdao));
 
-      // Create the metadata container
+      // Create the top level container
       addStep(
           new CreateDatasetGetOrCreateContainerStep(
-              resourceService, datasetRequest, azureContainerPdao, ContainerType.METADATA));
-
-      // Create the data container
-      addStep(
-          new CreateDatasetGetOrCreateContainerStep(
-              resourceService, datasetRequest, azureContainerPdao, ContainerType.DATA));
+              resourceService, datasetRequest, azureContainerPdao));
     }
 
     // Create dataset metadata objects in postgres and lock the dataset

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DatasetDeleteFlight.java
@@ -28,6 +28,7 @@ import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
 import bio.terra.service.snapshot.SnapshotDao;
+import bio.terra.service.tabulardata.azure.StorageTableService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -60,6 +61,7 @@ public class DatasetDeleteFlight extends Flight {
     TableDependencyDao tableDependencyDao = appContext.getBean(TableDependencyDao.class);
     AzureAuthService azureAuthService = appContext.getBean(AzureAuthService.class);
     JournalService journalService = appContext.getBean(JournalService.class);
+    StorageTableService storageTableService = appContext.getBean(StorageTableService.class);
 
     // get data from inputs that steps need
     UUID datasetId =
@@ -116,6 +118,9 @@ public class DatasetDeleteFlight extends Flight {
               profileDao,
               userReq),
           primaryDataDeleteRetry);
+      addStep(
+          new DeleteDatasetLoadHistoryStorageTableStep(
+              storageTableService, datasetService, datasetId));
       addStep(
           new DeleteDatasetDeleteStorageAccountsStep(resourceService, datasetService, datasetId));
     }

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetAzurePrimaryDataStep.java
@@ -64,7 +64,7 @@ public class DeleteDatasetAzurePrimaryDataStep implements Step {
             "No Azure storage auth info found");
 
     tableDao.deleteFilesFromDataset(
-        storageAuthInfo, f -> azureBlobStorePdao.deleteFile(f, userRequest));
+        storageAuthInfo, datasetId, f -> azureBlobStorePdao.deleteFile(f, userRequest));
 
     // this fault is used by the DatasetConnectedTest > testOverlappingDeletes
     if (configService.testInsertFault(ConfigEnum.DATASET_DELETE_LOCK_CONFLICT_STOP_FAULT)) {

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetDeleteStorageAccountsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetDeleteStorageAccountsStep.java
@@ -28,7 +28,7 @@ public class DeleteDatasetDeleteStorageAccountsStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Dataset dataset = datasetService.retrieve(datasetId);
     logger.info("Deleting a storage account for Azure backed dataset");
-    resourceService.deleteStorageAccount(dataset, context.getFlightId());
+    resourceService.deleteStorageContainer(dataset, context.getFlightId());
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetLoadHistoryStorageTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/delete/DeleteDatasetLoadHistoryStorageTableStep.java
@@ -1,0 +1,35 @@
+package bio.terra.service.dataset.flight.delete;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.tabulardata.azure.StorageTableService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteDatasetLoadHistoryStorageTableStep extends DefaultUndoStep {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(DeleteDatasetLoadHistoryStorageTableStep.class);
+
+  private final StorageTableService storageTableService;
+  private final DatasetService datasetService;
+  private final UUID datasetId;
+
+  public DeleteDatasetLoadHistoryStorageTableStep(
+      StorageTableService storageTableService, DatasetService datasetService, UUID datasetId) {
+    this.storageTableService = storageTableService;
+    this.datasetService = datasetService;
+    this.datasetId = datasetId;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+    storageTableService.dropLoadHistoryTable(dataset);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -56,7 +56,6 @@ import bio.terra.service.profile.google.GoogleBillingService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import bio.terra.service.resourcemanagement.google.GoogleProjectService;
 import bio.terra.service.tabulardata.azure.StorageTableService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
@@ -248,12 +247,7 @@ public class DatasetIngestFlight extends Flight {
       addStep(
           new IngestCreateIngestRequestDataSourceStep(
               azureSynapsePdao, azureBlobStorePdao, userReq));
-      addStep(
-          new IngestCreateTargetDataSourceStep(
-              azureSynapsePdao, azureBlobStorePdao, ContainerType.METADATA, userReq));
-      addStep(
-          new IngestCreateTargetDataSourceStep(
-              azureSynapsePdao, azureBlobStorePdao, ContainerType.SCRATCH, userReq));
+      addStep(new IngestCreateTargetDataSourceStep(azureSynapsePdao, azureBlobStorePdao, userReq));
       addStep(
           new IngestCreateScratchParquetFilesStep(
               azureSynapsePdao, azureBlobStorePdao, datasetService, userReq));

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCleanAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCleanAzureStep.java
@@ -5,6 +5,7 @@ import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -35,19 +36,18 @@ public class IngestCleanAzureStep implements Step {
             IngestUtils.getSynapseIngestTableName(context.getFlightId())));
     azureSynapsePdao.dropDataSources(
         List.of(
-            IngestUtils.getScratchDataSourceName(context.getFlightId()),
             IngestUtils.getTargetDataSourceName(context.getFlightId()),
             IngestUtils.getIngestRequestDataSourceName(context.getFlightId())));
     azureSynapsePdao.dropScopedCredentials(
         List.of(
-            IngestUtils.getScratchScopedCredentialName(context.getFlightId()),
             IngestUtils.getTargetScopedCredentialName(context.getFlightId()),
             IngestUtils.getIngestRequestScopedCredentialName(context.getFlightId())));
 
     AzureStorageAccountResource storageAccountResource =
         workingMap.get(
             CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
-    String scratchParquetFile = workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class);
+    String scratchParquetFile =
+        FolderType.SCRATCH.getPath(workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class));
     azureBlobStorePdao.deleteScratchParquet(
         scratchParquetFile, storageAccountResource, userRequest);
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateIngestRequestDataSourceStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateIngestRequestDataSourceStep.java
@@ -48,7 +48,7 @@ public class IngestCreateIngestRequestDataSourceStep implements Step {
               CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
       signedBlobUrlParts =
           azureBlobStorePdao.getOrSignUrlForTargetFactory(
-              path, billingProfileModel, storageAccount, ContainerType.SCRATCH, userRequest);
+              path, billingProfileModel, storageAccount, userRequest);
     } else {
       signedBlobUrlParts =
           azureBlobStorePdao.getOrSignUrlForSourceFactory(

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStep.java
@@ -8,7 +8,7 @@ import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.job.JobMapKeys;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -32,7 +32,8 @@ public class IngestCreateParquetFilesStep implements Step {
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
     Dataset dataset = IngestUtils.getDataset(context, datasetService);
-    String parquetFilePath = workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class);
+    String parquetFilePath =
+        FolderType.METADATA.getPath(workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class));
     DatasetTable datasetTable = IngestUtils.getDatasetTable(context, dataset);
 
     int failedRowCount = workingMap.get(IngestMapKeys.AZURE_ROWS_FAILED_VALIDATION, Integer.class);
@@ -43,7 +44,7 @@ public class IngestCreateParquetFilesStep implements Step {
           azureSynapsePdao.createFinalParquetFiles(
               IngestUtils.getSynapseIngestTableName(context.getFlightId()),
               parquetFilePath,
-              IngestUtils.getDataSourceName(ContainerType.METADATA, context.getFlightId()),
+              IngestUtils.getTargetDataSourceName(context.getFlightId()),
               IngestUtils.getSynapseScratchTableName(context.getFlightId()),
               datasetTable);
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateScratchParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateScratchParquetFilesStep.java
@@ -9,7 +9,7 @@ import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -43,7 +43,8 @@ public class IngestCreateScratchParquetFilesStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     Dataset dataset = IngestUtils.getDataset(context, datasetService);
     DatasetTable targetTable = IngestUtils.getDatasetTable(context, dataset);
-    String parquetFilePath = workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class);
+    String parquetFilePath =
+        FolderType.SCRATCH.getPath(workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class));
     final BlobUrlParts ingestBlob;
     if (IngestUtils.isCombinedFileIngest(context)) {
       ingestBlob =
@@ -58,7 +59,7 @@ public class IngestCreateScratchParquetFilesStep implements Step {
           targetTable,
           ingestBlob.getBlobName(),
           parquetFilePath,
-          IngestUtils.getDataSourceName(ContainerType.SCRATCH, context.getFlightId()),
+          IngestUtils.getTargetDataSourceName(context.getFlightId()),
           IngestUtils.getIngestRequestDataSourceName(context.getFlightId()),
           IngestUtils.getSynapseScratchTableName(context.getFlightId()),
           ingestRequestModel.getCsvSkipLeadingRows(),
@@ -81,7 +82,8 @@ public class IngestCreateScratchParquetFilesStep implements Step {
     AzureStorageAccountResource storageAccountResource =
         workingMap.get(
             CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
-    String scratchParquetFile = workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class);
+    String scratchParquetFile =
+        FolderType.SCRATCH.getPath(workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class));
     azureBlobStorePdao.deleteScratchParquet(
         scratchParquetFile, storageAccountResource, userRequest);
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLandingFileDeleteAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLandingFileDeleteAzureStep.java
@@ -56,8 +56,7 @@ public class IngestLandingFileDeleteAzureStep implements Step {
     String pathToLandingFile = ingestRequestModel.getPath();
 
     BlobContainerClient containerClient =
-        azureContainerPdao.getOrCreateContainer(
-            profile, storageAccount, AzureStorageAccountResource.ContainerType.SCRATCH);
+        azureContainerPdao.getOrCreateContainer(profile, storageAccount);
 
     String blobName = BlobUrlParts.parse(pathToLandingFile).getBlobName();
     containerClient.getBlobClient(blobName).delete();

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -373,13 +373,11 @@ public final class IngestUtils {
    * Returns wildcard path that can be used to retrieve all data for a snapshot table A snapshot
    * table can be represented by multiple parquet files in a snapshot table directory
    *
-   * @param snapshotId
    * @param targetTableName
    * @return
    */
-  public static String getSnapshotParquetFilePathForQuery(UUID snapshotId, String targetTableName) {
-    return FolderType.METADATA.getPath(
-        "parquet/" + snapshotId + "/" + targetTableName + "/*.parquet/*");
+  public static String getSnapshotParquetFilePathForQuery(String targetTableName) {
+    return FolderType.METADATA.getPath("parquet/" + targetTableName + "/*.parquet/*");
   }
 
   /**
@@ -387,15 +385,14 @@ public final class IngestUtils {
    * multiple slices/parquet files per snapshot table. All parquet files within the table directory
    * represent the data in a snapshot table.
    *
-   * @param snapshotId
    * @param targetTableName Snapshot table name that will be used as a directory
    * @param snapshotSliceName Name of parquet file
    * @return
    */
   public static String getSnapshotSliceParquetFilePath(
-      UUID snapshotId, String targetTableName, String snapshotSliceName) {
+      String targetTableName, String snapshotSliceName) {
     return FolderType.METADATA.getPath(
-        "parquet/" + snapshotId + "/" + targetTableName + "/" + snapshotSliceName + ".parquet");
+        "parquet/" + targetTableName + "/" + snapshotSliceName + ".parquet");
   }
 
   public static String getSourceDatasetParquetFilePath(String tableName) {

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -15,14 +15,13 @@ import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.dataset.exception.InvalidBlobURLException;
-import bio.terra.service.dataset.exception.InvalidIngestStrategyException;
 import bio.terra.service.dataset.exception.TableNotFoundException;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.filedata.CloudFileReader;
 import bio.terra.service.filedata.exception.BlobAccessNotAuthorizedException;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.job.JobMapKeys;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -51,11 +50,9 @@ public final class IngestUtils {
       "source_dataset_scoped_credential_";
   private static final String SOURCE_SCOPED_CREDENTIAL_PREFIX = "source_scoped_credential_";
   private static final String TARGET_SCOPED_CREDENTIAL_PREFIX = "target_scoped_credential_";
-  private static final String SCRATCH_SCOPED_CREDENTIAL_PREFIX = "scratch_scoped_credential_";
   private static final String SOURCE_DATASET_DATA_SOURCE_PREFIX = "source_dataset_data_source_";
   private static final String SOURCE_DATA_SOURCE_PREFIX = "source_data_source_";
   private static final String TARGET_DATA_SOURCE_PREFIX = "target_data_source_";
-  private static final String SCRATCH_DATA_SOURCE_PREFIX = "scratch_data_source_";
   private static final String INGEST_TABLE_NAME_PREFIX = "ingest_";
   private static final String SCRATCH_TABLE_NAME_PREFIX = "scratch_";
 
@@ -351,27 +348,7 @@ public final class IngestUtils {
         .collect(Collectors.toList());
   }
 
-  public static void checkForLargeIngestRequests(long numLines, long maxIngestRows) {
-    if (numLines > maxIngestRows) {
-      throw new InvalidIngestStrategyException(
-          String.format(
-              "The combined file ingest and metadata ingest workflow is limited to "
-                  + "%s files for ingest. This request had %s files.",
-              maxIngestRows, numLines));
-    }
-  }
-
-  public static String getParquetBlobUrl(
-      AzureStorageAccountResource storageAccountResource,
-      AzureStorageAccountResource.ContainerType containerType,
-      String path) {
-    return String.format(
-        "%s/%s/%s",
-        storageAccountResource.getStorageAccountUrl(),
-        storageAccountResource.determineContainer(containerType),
-        path);
-  }
-
+  // Note: this is the unqualified path (e.g. it gets used in metadata and scratch directories)
   public static String getParquetFilePath(String targetTableName, String flightId) {
     return "parquet/" + targetTableName + "/" + flightId + ".parquet";
   }
@@ -385,7 +362,8 @@ public final class IngestUtils {
    * @return
    */
   public static String getSnapshotParquetFilePathForQuery(UUID snapshotId, String targetTableName) {
-    return "parquet/" + snapshotId + "/" + targetTableName + "/*.parquet/*";
+    return FolderType.METADATA.getPath(
+        "parquet/" + snapshotId + "/" + targetTableName + "/*.parquet/*");
   }
 
   /**
@@ -400,11 +378,12 @@ public final class IngestUtils {
    */
   public static String getSnapshotSliceParquetFilePath(
       UUID snapshotId, String targetTableName, String snapshotSliceName) {
-    return "parquet/" + snapshotId + "/" + targetTableName + "/" + snapshotSliceName + ".parquet";
+    return FolderType.METADATA.getPath(
+        "parquet/" + snapshotId + "/" + targetTableName + "/" + snapshotSliceName + ".parquet");
   }
 
   public static String getSourceDatasetParquetFilePath(String tableName) {
-    return "parquet/" + tableName + "/*/*.parquet";
+    return FolderType.METADATA.getPath("parquet/" + tableName + "/*/*.parquet");
   }
 
   public static String formatSnapshotTableName(UUID snapshotId, String tableName) {
@@ -431,16 +410,8 @@ public final class IngestUtils {
     return TARGET_DATA_SOURCE_PREFIX + flightId;
   }
 
-  public static String getScratchDataSourceName(String flightId) {
-    return SCRATCH_DATA_SOURCE_PREFIX + flightId;
-  }
-
   public static String getTargetScopedCredentialName(String flightId) {
     return TARGET_SCOPED_CREDENTIAL_PREFIX + flightId;
-  }
-
-  public static String getScratchScopedCredentialName(String flightId) {
-    return SCRATCH_SCOPED_CREDENTIAL_PREFIX + flightId;
   }
 
   public static String getSynapseIngestTableName(String flightId) {
@@ -500,31 +471,11 @@ public final class IngestUtils {
     }
   }
 
-  public static String getDataSourceName(
-      AzureStorageAccountResource.ContainerType containerType, String flightId) {
-    switch (containerType) {
-      case METADATA:
-        return IngestUtils.getTargetDataSourceName(flightId);
-      case SCRATCH:
-        return IngestUtils.getScratchDataSourceName(flightId);
-      default:
-        throw new IllegalArgumentException(
-            String.format(
-                "Cannot get data source name for %s ContainerType", containerType.name()));
-    }
+  public static String getDataSourceName(String flightId) {
+    return IngestUtils.getTargetDataSourceName(flightId);
   }
 
-  public static String getScopedCredentialName(
-      AzureStorageAccountResource.ContainerType containerType, String flightId) {
-    switch (containerType) {
-      case METADATA:
-        return IngestUtils.getTargetScopedCredentialName(flightId);
-      case SCRATCH:
-        return IngestUtils.getScratchScopedCredentialName(flightId);
-      default:
-        throw new IllegalArgumentException(
-            String.format(
-                "Cannot get data source name for %s ContainerType", containerType.name()));
-    }
+  public static String getScopedCredentialName(String flightId) {
+    return IngestUtils.getTargetScopedCredentialName(flightId);
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateAzureRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateAzureRefsStep.java
@@ -56,7 +56,9 @@ public class IngestValidateAzureRefsStep extends IngestValidateRefsStep {
                 column -> {
                   List<String> refIdArray =
                       azureSynapsePdao.getRefIds(tableName, column, dataset.getCollectionType());
-                  return tableDirectoryDao.validateRefIds(tableServiceClient, refIdArray).stream()
+                  return tableDirectoryDao
+                      .validateRefIds(tableServiceClient, dataset.getId(), refIdArray)
+                      .stream()
                       .map(id -> new InvalidRefId(id, column.getName()));
                 })
             .collect(Collectors.toSet());

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
@@ -31,8 +31,7 @@ public class CreateScratchFileForAzureStep extends DefaultUndoStep {
         workingMap.get(
             CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
     BlobContainerClient containerClient =
-        azureContainerPdao.getOrCreateContainer(
-            billingProfile, storageAccount, AzureStorageAccountResource.ContainerType.SCRATCH);
+        azureContainerPdao.getOrCreateContainer(billingProfile, storageAccount);
 
     String path =
         containerClient

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -587,11 +587,14 @@ public class DrsService {
                 ACCESS_ID_PREFIX_AZURE + ACCESS_ID_PREFIX_PASSPORT,
                 azureRegion,
                 passportAuth,
-                billingSnapshot);
+                cachedSnapshot.globalFileIds ? billingSnapshot : null);
       } else {
         accessMethods =
             getDrsSignedURLAccessMethods(
-                ACCESS_ID_PREFIX_AZURE, azureRegion, passportAuth, billingSnapshot);
+                ACCESS_ID_PREFIX_AZURE,
+                azureRegion,
+                passportAuth,
+                cachedSnapshot.globalFileIds ? billingSnapshot : null);
       }
     } else {
       throw new InvalidCloudPlatformException();

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -36,7 +36,6 @@ import bio.terra.service.filedata.google.gcs.GcsProjectFactory;
 import bio.terra.service.job.JobService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotProject;
@@ -517,7 +516,6 @@ public class DrsService {
                 profileModel,
                 storageAccountResource,
                 ((FSFile) fsItem).getCloudPath(),
-                ContainerType.DATA,
                 new BlobSasTokenOptions(
                     URL_TTL,
                     new BlobSasPermission().setReadPermission(true),
@@ -589,10 +587,11 @@ public class DrsService {
                 ACCESS_ID_PREFIX_AZURE + ACCESS_ID_PREFIX_PASSPORT,
                 azureRegion,
                 passportAuth,
-                null);
+                billingSnapshot);
       } else {
         accessMethods =
-            getDrsSignedURLAccessMethods(ACCESS_ID_PREFIX_AZURE, azureRegion, passportAuth, null);
+            getDrsSignedURLAccessMethods(
+                ACCESS_ID_PREFIX_AZURE, azureRegion, passportAuth, billingSnapshot);
       }
     } else {
       throw new InvalidCloudPlatformException();

--- a/src/main/java/bio/terra/service/filedata/FileService.java
+++ b/src/main/java/bio/terra/service/filedata/FileService.java
@@ -252,6 +252,7 @@ public class FileService {
       return tableDao.retrieveById(
           CollectionType.DATASET,
           UUID.fromString(datasetId),
+          UUID.fromString(datasetId),
           fileId,
           depth,
           storageAuthInfo,
@@ -345,6 +346,7 @@ public class FileService {
 
       return tableDao.retrieveById(
           CollectionType.SNAPSHOT,
+          dataset.getId(),
           snapshot.getId(),
           fileId,
           depth,

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -1104,12 +1104,12 @@ public class AzureSynapsePdao {
             });
   }
 
-  public static String getCredentialName(UUID id, String email) {
-    return "cred-%s-%s".formatted(id, email);
+  public static String getCredentialName(UUID collectionId, String email) {
+    return "cred-%s-%s".formatted(collectionId, email);
   }
 
-  public static String getDataSourceName(UUID id, String email) {
-    return "ds-%s-%s".formatted(id, email);
+  public static String getDataSourceName(UUID collectionId, String email) {
+    return "ds-%s-%s".formatted(collectionId, email);
   }
 
   private String sanitizeStringForSql(String value) {

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -517,7 +517,7 @@ public class AzureSynapsePdao {
             table.getName());
       } else if (tableRowCounts.get(table.getName()) > 0) {
         String snapshotParquetFileName =
-            IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, table.getName());
+            IngestUtils.getSnapshotParquetFilePathForQuery(table.getName());
 
         ST sqlTableTemplate =
             new ST(getLiveViewTableTemplate)
@@ -538,8 +538,7 @@ public class AzureSynapsePdao {
     // Create row id table
     String rowIdTableName = IngestUtils.formatSnapshotTableName(snapshotId, PDAO_ROW_ID_TABLE);
     String rowIdParquetFile =
-        IngestUtils.getSnapshotSliceParquetFilePath(
-            snapshotId, PDAO_ROW_ID_TABLE, PDAO_ROW_ID_PARQUET_NAME);
+        IngestUtils.getSnapshotSliceParquetFilePath(PDAO_ROW_ID_TABLE, PDAO_ROW_ID_PARQUET_NAME);
     ST sqlCreateRowIdTable =
         new ST(createSnapshotRowIdTableTemplate)
             .add("tableName", rowIdTableName)
@@ -571,7 +570,7 @@ public class AzureSynapsePdao {
             IngestUtils.getSourceDatasetParquetFilePath(rootTable.getTable().getName()),
             rootTable.getTable().getName(),
             snapshotId,
-            IngestUtils.getSnapshotSliceParquetFilePath(snapshotId, rootTableName, "root"),
+            IngestUtils.getSnapshotSliceParquetFilePath(rootTableName, "root"),
             datasetDataSourceName,
             snapshotDataSourceName,
             rootTable.getSynapseColumns(),
@@ -648,7 +647,7 @@ public class AzureSynapsePdao {
             IngestUtils.getSourceDatasetParquetFilePath(rootTable.getTable().getName()),
             rootTable.getTable().getName(),
             snapshotId,
-            IngestUtils.getSnapshotSliceParquetFilePath(snapshotId, rootTableName, "root"),
+            IngestUtils.getSnapshotSliceParquetFilePath(rootTableName, "root"),
             datasetDataSourceName,
             snapshotDataSourceName,
             rootTable.getSynapseColumns(),
@@ -791,9 +790,7 @@ public class AzureSynapsePdao {
             toTableName,
             snapshotId,
             IngestUtils.getSnapshotSliceParquetFilePath(
-                snapshotId,
-                toTableName,
-                String.format("%s_%s_relationship", fromTableName, toTableName)),
+                toTableName, String.format("%s_%s_relationship", fromTableName, toTableName)),
             datasetDataSourceName,
             snapshotDataSourceName,
             toAssetTable.getSynapseColumns(),
@@ -816,11 +813,10 @@ public class AzureSynapsePdao {
     queryTemplate.add("fromTableColumn", relationship.getFromColumnName());
     queryTemplate.add(
         "fromTableParquetFileLocation",
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, fromTableName));
+        IngestUtils.getSnapshotParquetFilePathForQuery(fromTableName));
     queryTemplate.add("snapshotDataSource", snapshotDataSourceName);
     queryTemplate.add(
-        "toTableParquetFileLocation",
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, toTableName));
+        "toTableParquetFileLocation", IngestUtils.getSnapshotParquetFilePathForQuery(toTableName));
     String sql = queryTemplate.render();
     int rows = 0;
     try {
@@ -891,8 +887,7 @@ public class AzureSynapsePdao {
                     IngestUtils.getSourceDatasetParquetFilePath(table.getName()),
                     table.getName(),
                     snapshotId,
-                    IngestUtils.getSnapshotSliceParquetFilePath(
-                        snapshotId, table.getName(), table.getName()),
+                    IngestUtils.getSnapshotSliceParquetFilePath(table.getName(), table.getName()),
                     datasetDataSourceName,
                     snapshotDataSourceName,
                     columns,
@@ -937,8 +932,7 @@ public class AzureSynapsePdao {
                   IngestUtils.getSourceDatasetParquetFilePath(table.getName()),
                   table.getName(),
                   snapshotId,
-                  IngestUtils.getSnapshotSliceParquetFilePath(
-                      snapshotId, table.getName(), table.getName()),
+                  IngestUtils.getSnapshotSliceParquetFilePath(table.getName(), table.getName()),
                   datasetDataSourceName,
                   snapshotDataSourceName,
                   table.getSynapseColumns(),

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -30,6 +30,7 @@ import bio.terra.service.filedata.DrsId;
 import bio.terra.service.filedata.DrsIdService;
 import bio.terra.service.filedata.DrsService;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import bio.terra.service.resourcemanagement.exception.AzureResourceException;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotTable;
@@ -277,7 +278,7 @@ public class AzureSynapsePdao {
       SELECT <columns:{c|tbl.[<c>]}; separator=",">
         FROM (SELECT row_number() over (order by <sort> <direction>) AS datarepo_row_number,
                      <columns:{c|rows.[<c>]}; separator=",">
-                FROM OPENROWSET(BULK 'parquet/*/<tableName>/*.parquet/*',
+                FROM OPENROWSET(BULK '<filePath>',
                                 DATA_SOURCE = '<datasource>',
                                 FORMAT='PARQUET') AS rows
                 WHERE (<userFilter>)
@@ -1038,11 +1039,13 @@ public class AzureSynapsePdao {
             List.of(new Column().name(PDAO_ROW_ID_COLUMN).type(TableDataType.STRING)),
             table.getColumns());
 
+    String filePath = FolderType.METADATA.getPath("parquet/*/" + tableName + "/*.parquet/*");
+
     final String sql =
         new ST(queryFromDatasourceTemplate)
             .add("columns", columns.stream().map(Column::getName).toList())
             .add("datasource", getDataSourceName(snapshot, userRequest.getEmail()))
-            .add("tableName", tableName)
+            .add("filePath", filePath)
             .add("sort", sort)
             .add("direction", direction)
             .add("userFilter", userFilter)

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -111,7 +111,6 @@ public class AzureBlobStorePdao implements CloudFileReader {
         getTargetDataClientFactory(
             profileModel,
             storageAccountResource,
-            ContainerType.DATA,
             new BlobSasTokenOptions(
                 DEFAULT_SAS_TOKEN_EXPIRATION,
                 new BlobSasPermission()
@@ -271,7 +270,6 @@ public class AzureBlobStorePdao implements CloudFileReader {
         getTargetDataClientFactory(
             profileModel,
             storageAccountResource,
-            ContainerType.DATA,
             new BlobSasTokenOptions(
                 DEFAULT_SAS_TOKEN_EXPIRATION,
                 new BlobSasPermission().setReadPermission(true).setDeletePermission(true),
@@ -292,7 +290,6 @@ public class AzureBlobStorePdao implements CloudFileReader {
         getTargetDataClientFactory(
             profileModel,
             storageAccountResource,
-            ContainerType.DATA,
             new BlobSasTokenOptions(
                 DEFAULT_SAS_TOKEN_EXPIRATION,
                 new BlobSasPermission().setReadPermission(true).setDeletePermission(true),
@@ -336,7 +333,6 @@ public class AzureBlobStorePdao implements CloudFileReader {
         getTargetDataClientFactory(
             profileModel,
             storageAccountResource,
-            ContainerType.SCRATCH,
             new BlobSasTokenOptions(
                 DEFAULT_SAS_TOKEN_EXPIRATION,
                 new BlobSasPermission()
@@ -376,11 +372,9 @@ public class AzureBlobStorePdao implements CloudFileReader {
       BillingProfileModel profileModel,
       AzureStorageAccountResource storageAccountResource,
       String url,
-      ContainerType containerType,
       BlobSasTokenOptions blobSasTokenOptions) {
     BlobContainerClientFactory destinationClientFactory =
-        getTargetDataClientFactory(
-            profileModel, storageAccountResource, containerType, blobSasTokenOptions);
+        getTargetDataClientFactory(profileModel, storageAccountResource, blobSasTokenOptions);
 
     BlobUrlParts blobParts = BlobUrlParts.parse(url);
     if (!blobParts.getAccountName().equals(storageAccountResource.getName())) {
@@ -422,12 +416,11 @@ public class AzureBlobStorePdao implements CloudFileReader {
   public BlobContainerClientFactory getTargetDataClientFactory(
       BillingProfileModel profileModel,
       AzureStorageAccountResource storageAccountResource,
-      ContainerType containerType,
       BlobSasTokenOptions blobSasTokenOptions) {
 
     return new BlobContainerClientFactory(
         azureContainerPdao.getDestinationContainerSignedUrl(
-            profileModel, storageAccountResource, containerType, blobSasTokenOptions),
+            profileModel, storageAccountResource, blobSasTokenOptions),
         getRetryOptions());
   }
 
@@ -490,7 +483,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
             userRequest.getEmail());
 
     BlobContainerClientFactory targetDataClientFactory =
-        getTargetDataClientFactory(profileModel, storageAccount, containerType, options);
+        getTargetDataClientFactory(profileModel, storageAccount, options);
 
     return targetDataClientFactory.getBlobSasUrlFactory().createSasUrlForBlob(blobName, options);
   }
@@ -522,6 +515,6 @@ public class AzureBlobStorePdao implements CloudFileReader {
   }
 
   private String getBlobName(String fileId, String fileName) {
-    return String.format("%s/%s", fileId, fileName);
+    return String.format("%s/%s/%s", ContainerType.DATA.name().toLowerCase(), fileId, fileName);
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -25,7 +25,7 @@ import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import bio.terra.service.resourcemanagement.azure.AzureResourceDao;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import bio.terra.service.resourcemanagement.exception.AzureResourceException;
 import com.azure.core.credential.TokenCredential;
 import com.azure.storage.blob.BlobUrlParts;
@@ -321,10 +321,8 @@ public class AzureBlobStorePdao implements CloudFileReader {
 
     String blobUrl =
         String.format(
-            "%s/%s/%s",
-            storageAccountResource.getStorageAccountUrl(),
-            storageAccountResource.determineContainer(ContainerType.SCRATCH),
-            blobPath);
+            "%s/%s",
+            storageAccountResource.getStorageAccountUrl(), FolderType.SCRATCH.getPath(blobPath));
     BlobUrlParts blobParts = BlobUrlParts.parse(blobUrl);
 
     BillingProfileModel profileModel =
@@ -456,18 +454,16 @@ public class AzureBlobStorePdao implements CloudFileReader {
       String dataSourceUrl,
       BillingProfileModel profileModel,
       AzureStorageAccountResource storageAccount,
-      ContainerType containerType,
       AuthenticatedUserRequest userRequest) {
     return BlobUrlParts.parse(
         getOrSignUrlStringForTargetFactory(
-            dataSourceUrl, profileModel, storageAccount, containerType, userRequest));
+            dataSourceUrl, profileModel, storageAccount, userRequest));
   }
 
   public String getOrSignUrlStringForTargetFactory(
       String dataSourceUrl,
       BillingProfileModel profileModel,
       AzureStorageAccountResource storageAccount,
-      ContainerType containerType,
       AuthenticatedUserRequest userRequest) {
     BlobUrlParts ingestControlFileBlobUrl = BlobUrlParts.parse(dataSourceUrl);
     String blobName = ingestControlFileBlobUrl.getBlobName();
@@ -515,6 +511,6 @@ public class AzureBlobStorePdao implements CloudFileReader {
   }
 
   private String getBlobName(String fileId, String fileName) {
-    return String.format("%s/%s/%s", ContainerType.DATA.name().toLowerCase(), fileId, fileName);
+    return FolderType.DATA.getPath("%s/%s".formatted(fileId, fileName));
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
@@ -11,6 +11,7 @@ import com.azure.data.tables.models.TableItem;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class TableServiceClientUtils {
@@ -55,13 +56,13 @@ public class TableServiceClientUtils {
   }
 
   public static List<TableEntity> batchRetrieveFiles(
-      TableServiceClient tableServiceClient, List<String> fileIdArray) {
+      TableServiceClient tableServiceClient, UUID datasetId, List<String> fileIdArray) {
     String filter =
         fileIdArray.stream()
-            // maybe wrap or cause in parenthesis
+            // maybe wrap or cause in parentheses
             .map(refId -> String.format("fileId eq '%s'", refId))
             .collect(Collectors.joining(" or "));
-    return filterTable(tableServiceClient, StorageTableName.DATASET.toTableName(), filter);
+    return filterTable(tableServiceClient, StorageTableName.DATASET.toTableName(datasetId), filter);
   }
 
   /**

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureDirectoryStep.java
@@ -30,7 +30,10 @@ public class DeleteFileAzureDirectoryStep implements Step {
     try {
       boolean found =
           tableDao.deleteDirectoryEntry(
-              fileId, storageAuthInfo, dataset.getId(), StorageTableName.DATASET.toTableName());
+              fileId,
+              storageAuthInfo,
+              dataset.getId(),
+              StorageTableName.DATASET.toTableName(dataset.getId()));
       DeleteResponseModel.ObjectStateEnum state =
           (found)
               ? DeleteResponseModel.ObjectStateEnum.DELETED

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureLookupStep.java
@@ -70,7 +70,7 @@ public class DeleteFileAzureLookupStep implements Step {
       workingMap.put(CommonMapKeys.DATASET_STORAGE_AUTH_INFO, storageAuthInfo);
 
       if (fireStoreFile == null) {
-        fireStoreFile = tableDao.lookupFile(fileId, storageAuthInfo);
+        fireStoreFile = tableDao.lookupFile(dataset.getId().toString(), fileId, storageAuthInfo);
         if (fireStoreFile != null) {
           workingMap.put(FileMapKeys.FIRESTORE_FILE, fireStoreFile);
         }

--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureMetadataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileAzureMetadataStep.java
@@ -24,7 +24,7 @@ public class DeleteFileAzureMetadataStep implements Step {
     AzureStorageAuthInfo storageAuthInfo =
         workingMap.get(CommonMapKeys.DATASET_STORAGE_AUTH_INFO, AzureStorageAuthInfo.class);
     try {
-      tableDao.deleteFileMetadata(fileId, storageAuthInfo);
+      tableDao.deleteFileMetadata(dataset.getId().toString(), fileId, storageAuthInfo);
     } catch (FileSystemAbortTransactionException rex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
     }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileAzureStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileAzureStep.java
@@ -65,10 +65,9 @@ public class IngestBuildAndWriteScratchLoadFileAzureStep
         workingMap.get(
             CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
     BlobContainerClient containerClient =
-        azureContainerPdao.getOrCreateContainer(
-            billingProfile, storageAccount, AzureStorageAccountResource.ContainerType.SCRATCH);
+        azureContainerPdao.getOrCreateContainer(billingProfile, storageAccount);
     return containerClient
-        .getBlobClient(flightContext.getFlightId() + "/ingest-scratch.json")
+        .getBlobClient("scratch/" + flightContext.getFlightId() + "/ingest-scratch.json")
         .getBlobUrl();
   }
 
@@ -85,7 +84,6 @@ public class IngestBuildAndWriteScratchLoadFileAzureStep
             billingProfile,
             storageAccount,
             path,
-            AzureStorageAccountResource.ContainerType.SCRATCH,
             new BlobSasTokenOptions(
                 Duration.ofHours(1),
                 new BlobSasPermission().setReadPermission(true).setWritePermission(true),

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureDirectoryStep.java
@@ -81,7 +81,7 @@ public class IngestFileAzureDirectoryStep implements Step {
                 .datasetId(datasetId.toString())
                 .loadTag(loadModel.getLoadTag());
         tableDao.createDirectoryEntry(
-            newEntry, storageAuthInfo, datasetId, StorageTableName.DATASET.toTableName());
+            newEntry, storageAuthInfo, datasetId, StorageTableName.DATASET.toTableName(datasetId));
       } else if (ingestFileAction.equals(ValidateIngestFileDirectoryStep.CHECK_ENTRY_ACTION)) {
         FireStoreDirectoryEntry existingEntry =
             workingMap.get(FileMapKeys.FIRESTORE_DIRECTORY_ENTRY, FireStoreDirectoryEntry.class);
@@ -89,7 +89,8 @@ public class IngestFileAzureDirectoryStep implements Step {
           // (b) We are in a re-run of a load job. Try to get the file entry.
           fileId = existingEntry.getFileId();
           workingMap.put(FileMapKeys.FILE_ID, fileId);
-          FireStoreFile fileEntry = tableDao.lookupFile(fileId, storageAuthInfo);
+          FireStoreFile fileEntry =
+              tableDao.lookupFile(datasetId.toString(), fileId, storageAuthInfo);
           if (fileEntry != null) {
             // (b)(i) We successfully loaded this file already
             workingMap.put(FileMapKeys.LOAD_COMPLETED, true);
@@ -116,7 +117,10 @@ public class IngestFileAzureDirectoryStep implements Step {
     if (ingestFileAction.equals(ValidateIngestFileDirectoryStep.CREATE_ENTRY_ACTION)) {
       try {
         tableDao.deleteDirectoryEntry(
-            fileId, storageAuthInfo, dataset.getId(), StorageTableName.DATASET.toTableName());
+            fileId,
+            storageAuthInfo,
+            dataset.getId(),
+            StorageTableName.DATASET.toTableName(dataset.getId()));
       } catch (TableServiceException rex) {
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
       }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzureFileStep.java
@@ -62,11 +62,12 @@ public class IngestFileAzureFileStep implements Step {
               .loadTag(fileLoadModel.getLoadTag());
 
       try {
-        tableDao.createFileMetadata(newFile, storageAuthInfo);
+        tableDao.createFileMetadata(dataset.getId().toString(), newFile, storageAuthInfo);
         // Retrieve to build the complete FSItem
         FSItem fsItem =
             tableDao.retrieveById(
                 CollectionType.DATASET,
+                dataset.getId(),
                 dataset.getId(),
                 fileId,
                 1,
@@ -90,7 +91,7 @@ public class IngestFileAzureFileStep implements Step {
             context, CommonMapKeys.DATASET_STORAGE_AUTH_INFO, AzureStorageAuthInfo.class);
 
     try {
-      tableDao.deleteFileMetadata(itemId, storageAuthInfo);
+      tableDao.deleteFileMetadata(dataset.getId().toString(), itemId, storageAuthInfo);
     } catch (TableServiceException rex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, rex);
     }

--- a/src/main/java/bio/terra/service/resourcemanagement/AzureDataLocationSelector.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/AzureDataLocationSelector.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.model.BillingProfileModel;
 import java.nio.charset.StandardCharsets;
@@ -13,10 +14,10 @@ import org.springframework.stereotype.Component;
 public class AzureDataLocationSelector {
 
   public String createStorageAccountName(
-      String prefix, String collectionName, BillingProfileModel billingProfile) {
+      String prefix, AzureRegion region, BillingProfileModel billingProfile) {
     int maxStorageAccountNameLength = 24;
     int randomLength = maxStorageAccountNameLength - prefix.length();
-    return prefix + armUniqueString(collectionName + billingProfile.toString(), randomLength);
+    return prefix + armUniqueString(region.getValue() + billingProfile.toString(), randomLength);
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -17,7 +17,6 @@ import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.azure.util.BlobSasTokenOptions;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotTable;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryPdao;
@@ -186,7 +185,6 @@ public final class MetadataDataAccessUtils {
             profileModel,
             storageAccountResource,
             unsignedUrl,
-            ContainerType.METADATA,
             blobSasTokenOptions);
 
     UrlParts urlParts = UrlParts.fromUrl(signedURL);
@@ -216,7 +214,6 @@ public final class MetadataDataAccessUtils {
                                   profileModel,
                                   storageAccountResource,
                                   unsignedTableUrl,
-                                  ContainerType.METADATA,
                                   blobSasTokenOptions);
                           UrlParts tableUrlParts = UrlParts.fromUrl(tableUrl);
                           return new AccessInfoParquetModelTable()

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -182,10 +182,7 @@ public final class MetadataDataAccessUtils {
             .render();
     String signedURL =
         azureBlobStorePdao.signFile(
-            profileModel,
-            storageAccountResource,
-            unsignedUrl,
-            blobSasTokenOptions);
+            profileModel, storageAccountResource, unsignedUrl, blobSasTokenOptions);
 
     UrlParts urlParts = UrlParts.fromUrl(signedURL);
     accessInfoModel.parquet(

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -1,7 +1,6 @@
 package bio.terra.service.resourcemanagement;
 
 import bio.terra.common.CloudPlatformWrapper;
-import bio.terra.common.CollectionType;
 import bio.terra.common.Table;
 import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -47,10 +46,7 @@ public final class MetadataDataAccessUtils {
 
   private static final String AZURE_PARQUET_LINK =
       "https://<storageAccount>.blob.core.windows.net/<container>/<blob>";
-  private static final String AZURE_BLOB_TEMPLATE_DATASET =
-      FolderType.METADATA.getPath("parquet/<table>");
-  private static final String AZURE_BLOB_TEMPLATE_SNAPSHOT =
-      FolderType.METADATA.getPath("parquet/<collectionId>/<table>");
+  private static final String AZURE_BLOB_TEMPLATE = FolderType.METADATA.getPath("parquet/<table>");
   private static final String AZURE_DATASET_ID = "<storageAccount>.<dataset>";
 
   private static final String DEPLOYED_APPLICATION_RESOURCE_ID =
@@ -159,24 +155,9 @@ public final class MetadataDataAccessUtils {
             new BlobSasPermission().setReadPermission(true).setListPermission(true),
             userRequest.getEmail());
 
-    String blobName;
-    BiFunction<FSContainerInterface, Table, String> tableBlobGenerator;
-    if (collection.getCollectionType() == CollectionType.DATASET) {
-      blobName = FolderType.METADATA.getPath("parquet");
-      tableBlobGenerator =
-          (c, t) -> new ST(AZURE_BLOB_TEMPLATE_DATASET).add("table", t.getName()).render();
-    } else if (collection.getCollectionType() == CollectionType.SNAPSHOT) {
-      blobName = FolderType.METADATA.getPath("parquet/" + collection.getId());
-      tableBlobGenerator =
-          (c, t) ->
-              new ST(AZURE_BLOB_TEMPLATE_SNAPSHOT)
-                  .add("collectionId", c.getId())
-                  .add("table", t.getName())
-                  .render();
-    } else {
-      throw new IllegalArgumentException(
-          String.format("Invalid collection type: %s", collection.getClass().getName()));
-    }
+    String blobName = FolderType.METADATA.getPath("parquet");
+    BiFunction<FSContainerInterface, Table, String> tableBlobGenerator =
+        (c, t) -> new ST(AZURE_BLOB_TEMPLATE).add("table", t.getName()).render();
 
     String unsignedUrl =
         new ST(AZURE_PARQUET_LINK)

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
@@ -2,7 +2,6 @@ package bio.terra.service.resourcemanagement.azure;
 
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.filedata.azure.util.BlobSasTokenOptions;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import com.azure.storage.common.sas.SasProtocol;
@@ -27,18 +26,13 @@ public class AzureContainerPdao {
    * @param profileModel The profile that describes information needed to access the storage account
    * @param storageAccountResource Metadata describing the storage account that contains the
    *     container
-   * @param containerType The nature of the container
    * @return A client connection object that can be used to create folders and files
    */
   public BlobContainerClient getOrCreateContainer(
-      BillingProfileModel profileModel,
-      AzureStorageAccountResource storageAccountResource,
-      AzureStorageAccountResource.ContainerType containerType) {
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
     BlobContainerClient blobContainerClient =
         authService.getBlobContainerClient(
-            profileModel,
-            storageAccountResource,
-            storageAccountResource.determineContainer(containerType));
+            profileModel, storageAccountResource, storageAccountResource.getTopLevelContainer());
 
     if (!blobContainerClient.exists()) {
       blobContainerClient.create();
@@ -49,7 +43,6 @@ public class AzureContainerPdao {
   public String getDestinationContainerSignedUrl(
       BillingProfileModel profileModel,
       AzureStorageAccountResource storageAccountResource,
-      ContainerType containerType,
       BlobSasTokenOptions blobSasTokenOptions) {
 
     OffsetDateTime expiryTime = OffsetDateTime.now().plus(blobSasTokenOptions.getDuration());
@@ -68,7 +61,7 @@ public class AzureContainerPdao {
     }
 
     BlobContainerClient containerClient =
-        getOrCreateContainer(profileModel, storageAccountResource, containerType);
+        getOrCreateContainer(profileModel, storageAccountResource);
     return String.format(
         "%s?%s",
         containerClient.getBlobContainerUrl(), containerClient.generateSas(sasSignatureValues));

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
@@ -296,7 +296,7 @@ public class AzureResourceDao {
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public AzureStorageAccountResource createAndLockStorage(
       String storageAccountName,
-      String containerId,
+      String collectionId,
       AzureApplicationDeploymentResource applicationResource,
       AzureRegion region,
       String flightId) {
@@ -317,7 +317,7 @@ public class AzureResourceDao {
         new MapSqlParameterSource()
             .addValue("application_resource_id", applicationResource.getId())
             .addValue("name", storageAccountName)
-            .addValue("toplevelcontainer", containerId)
+            .addValue("toplevelcontainer", collectionId)
             .addValue("datacontainer", "data")
             .addValue("metadatacontainer", "metadata")
             .addValue("dbname", storageAccountName)
@@ -332,7 +332,7 @@ public class AzureResourceDao {
           .profileId(applicationResource.getProfileId())
           .applicationResource(applicationResource)
           .name(storageAccountName)
-          .topLevelContainer(containerId)
+          .topLevelContainer(collectionId)
           .dataContainer("data")
           .metadataContainer("metadata")
           .dbName(storageAccountName)
@@ -348,6 +348,7 @@ public class AzureResourceDao {
    * an error
    *
    * @param storageAccountName storage account to unlock
+   * @param collectionId the id of the dataset or snapshot to unlock the storage account for
    * @param flightId flight trying to unlock it
    */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
@@ -12,6 +12,7 @@ public class AzureStorageAccountResource {
   private UUID profileId;
   private AzureApplicationDeploymentResource applicationResource;
   private String name;
+  private String topLevelContainer;
   private String dataContainer;
   private String metadataContainer;
   private String dbName;
@@ -62,6 +63,15 @@ public class AzureStorageAccountResource {
 
   public AzureStorageAccountResource name(String name) {
     this.name = name;
+    return this;
+  }
+
+  public String getTopLevelContainer() {
+    return topLevelContainer;
+  }
+
+  public AzureStorageAccountResource topLevelContainer(String topLevelContainer) {
+    this.topLevelContainer = topLevelContainer;
     return this;
   }
 
@@ -163,6 +173,11 @@ public class AzureStorageAccountResource {
   }
 
   public enum ContainerType {
+    TOPLEVEL() {
+      String getContainer(AzureStorageAccountResource account) {
+        return account.getTopLevelContainer();
+      }
+    },
     DATA() {
       String getContainer(AzureStorageAccountResource account) {
         return account.getDataContainer();

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
@@ -111,10 +111,6 @@ public class AzureStorageAccountResource {
     return this;
   }
 
-  public String determineContainer(ContainerType containerType) {
-    return containerType.getContainer(this);
-  }
-
   public String getStorageAccountUrl() {
     String storageAccountURLTemplate = "https://<storageAccount>.blob.core.windows.net";
 
@@ -172,28 +168,29 @@ public class AzureStorageAccountResource {
         .toString();
   }
 
-  public enum ContainerType {
-    TOPLEVEL() {
-      String getContainer(AzureStorageAccountResource account) {
-        return account.getTopLevelContainer();
-      }
-    },
+  public enum FolderType {
     DATA() {
-      String getContainer(AzureStorageAccountResource account) {
-        return account.getDataContainer();
+      public String getPath(String path) {
+        return "data/" + path;
       }
     },
     METADATA() {
-      String getContainer(AzureStorageAccountResource account) {
-        return account.getMetadataContainer();
+      public String getPath(String path) {
+        return "metadata/" + path;
       }
     },
     SCRATCH() {
-      String getContainer(AzureStorageAccountResource accountResource) {
-        return "ingest-scratch-container";
+      public String getPath(String path) {
+        return "scratch/" + path;
       }
     };
 
-    abstract String getContainer(AzureStorageAccountResource account);
+    /**
+     * Given a blob path, will prepend the correct top level directory
+     *
+     * @param path the blob path to qualify
+     * @return the path with the proper folder path prepended
+     */
+    public abstract String getPath(String path);
   }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -122,6 +122,7 @@ public class AzureStorageAccountService {
    * steps.
    *
    * @param storageAccountName name for a new or existing storage account
+   * @param collectionId id of the collection (e.g. dataset or snapshot)
    * @param applicationResource application deployment in which the storage account should be
    *     retrieved or created
    * @param region location of the storage account
@@ -133,7 +134,7 @@ public class AzureStorageAccountService {
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public AzureStorageAccountResource getOrCreateStorageAccount(
       String storageAccountName,
-      String containerId,
+      String collectionId,
       AzureApplicationDeploymentResource applicationResource,
       AzureRegion region,
       String flightId)
@@ -145,7 +146,7 @@ public class AzureStorageAccountService {
     AzureStorageAccountResource storageAccountResource =
         resourceDao.getStorageAccount(
             storageAccountName,
-            containerId,
+            collectionId,
             applicationResource.getAzureApplicationDeploymentName());
     StorageAccount storageAccount = getCloudStorageAccount(profileModel, storageAccountResource);
 
@@ -162,7 +163,7 @@ public class AzureStorageAccountService {
           throw storageAccountLockException(flightId);
         }
         // CASE 3: we have the flight locked, but we did all of the creating.
-        return createFinish(flightId, storageAccountResource, containerId);
+        return createFinish(flightId, storageAccountResource, collectionId);
       } else {
         // CASE 4: This code as currently implemented is unreachable since an empty resource make it
         // impossible
@@ -188,11 +189,11 @@ public class AzureStorageAccountService {
         // CASE 7: this flight has the metadata locked, but didn't finish creating the storage
         // account
         return createCloudStorageAccount(
-            profileModel, storageAccountResource, containerId, flightId);
+            profileModel, storageAccountResource, collectionId, flightId);
       } else {
         // CASE 8: no storage account and no record
         return createMetadataRecord(
-            profileModel, storageAccountName, containerId, applicationResource, region, flightId);
+            profileModel, storageAccountName, collectionId, applicationResource, region, flightId);
       }
     }
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -252,7 +252,7 @@ public class AzureStorageAccountService {
     // If the storage account doesn't exist, create it
     StorageAccount storageAccount = getCloudStorageAccount(profileModel, storageAccountResource);
     if (storageAccount == null) {
-      storageAccount = newCloudStorageAccount(profileModel, storageAccountResource);
+      newCloudStorageAccount(profileModel, storageAccountResource);
     }
 
     return createFinish(flightId, storageAccountResource, containerId);

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -202,13 +202,6 @@ public class AzureStorageAccountService {
     return resourceDao.retrieveStorageAccountById(storageAccountId);
   }
 
-  public void deleteCloudStorageAccount(AzureStorageAccountResource storageAccountResource) {
-    BillingProfileModel profileModel =
-        profileDao.getBillingProfileById(storageAccountResource.getProfileId());
-    logger.info("Deleting Azure storage account");
-    deleteCloudStorageAccount(profileModel, storageAccountResource);
-  }
-
   public void deleteCloudStorageAccountMetadata(
       String storageAccountResourceName, String topLevelContainer, String flightId) {
     logger.info(

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -133,6 +133,7 @@ public class AzureStorageAccountService {
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public AzureStorageAccountResource getOrCreateStorageAccount(
       String storageAccountName,
+      String containerId,
       AzureApplicationDeploymentResource applicationResource,
       AzureRegion region,
       String flightId)
@@ -143,7 +144,9 @@ public class AzureStorageAccountService {
         profileDao.getBillingProfileById(applicationResource.getProfileId());
     AzureStorageAccountResource storageAccountResource =
         resourceDao.getStorageAccount(
-            storageAccountName, applicationResource.getAzureApplicationDeploymentName());
+            storageAccountName,
+            containerId,
+            applicationResource.getAzureApplicationDeploymentName());
     StorageAccount storageAccount = getCloudStorageAccount(profileModel, storageAccountResource);
 
     // Test all of the cases
@@ -159,7 +162,7 @@ public class AzureStorageAccountService {
           throw storageAccountLockException(flightId);
         }
         // CASE 3: we have the flight locked, but we did all of the creating.
-        return createFinish(storageAccount, flightId, storageAccountResource);
+        return createFinish(flightId, storageAccountResource, containerId);
       } else {
         // CASE 4: This code as currently implemented is unreachable since an empty resource make it
         // impossible
@@ -184,11 +187,12 @@ public class AzureStorageAccountService {
         }
         // CASE 7: this flight has the metadata locked, but didn't finish creating the storage
         // account
-        return createCloudStorageAccount(profileModel, storageAccountResource, flightId);
+        return createCloudStorageAccount(
+            profileModel, storageAccountResource, containerId, flightId);
       } else {
         // CASE 8: no storage account and no record
         return createMetadataRecord(
-            profileModel, storageAccountName, applicationResource, region, flightId);
+            profileModel, storageAccountName, containerId, applicationResource, region, flightId);
       }
     }
   }
@@ -206,10 +210,14 @@ public class AzureStorageAccountService {
   }
 
   public void deleteCloudStorageAccountMetadata(
-      String storageAccountResourceName, String flightId) {
-    logger.info("Deleting Azure storage account metadata");
+      String storageAccountResourceName, String topLevelContainer, String flightId) {
+    logger.info(
+        "Deleting Azure storage account metadata named {} with top level container {}",
+        storageAccountResourceName,
+        topLevelContainer);
     boolean deleted =
-        resourceDao.deleteStorageAccountMetadata(storageAccountResourceName, flightId);
+        resourceDao.deleteStorageAccountMetadata(
+            storageAccountResourceName, topLevelContainer, flightId);
     logger.info("Metadata removed: {}", deleted);
   }
 
@@ -221,6 +229,7 @@ public class AzureStorageAccountService {
   private AzureStorageAccountResource createMetadataRecord(
       BillingProfileModel profileModel,
       String storageAccountName,
+      String containerId,
       AzureApplicationDeploymentResource applicationResource,
       AzureRegion region,
       String flightId)
@@ -231,35 +240,35 @@ public class AzureStorageAccountService {
         Optional.ofNullable(region).orElse(applicationResource.getDefaultRegion());
 
     AzureStorageAccountResource storageAccountResource =
-        resourceDao.createAndLockStorageAccount(
-            storageAccountName, applicationResource, regionToUse, flightId);
+        resourceDao.createAndLockStorage(
+            storageAccountName, containerId, applicationResource, regionToUse, flightId);
     if (storageAccountResource == null) {
       // We tried and failed to get the lock. So we ended up in CASE 2 after all.
       throw storageAccountLockException(flightId);
     }
 
-    return createCloudStorageAccount(profileModel, storageAccountResource, flightId);
+    return createCloudStorageAccount(profileModel, storageAccountResource, containerId, flightId);
   }
 
   // Step 2 of creating a new storage account
   private AzureStorageAccountResource createCloudStorageAccount(
       BillingProfileModel profileModel,
       AzureStorageAccountResource storageAccountResource,
+      String containerId,
       String flightId) {
     // If the storage account doesn't exist, create it
     StorageAccount storageAccount = getCloudStorageAccount(profileModel, storageAccountResource);
     if (storageAccount == null) {
       storageAccount = newCloudStorageAccount(profileModel, storageAccountResource);
     }
-    return createFinish(storageAccount, flightId, storageAccountResource);
+
+    return createFinish(flightId, storageAccountResource, containerId);
   }
 
   // Step 3 (last) of creating a new storage account
   private AzureStorageAccountResource createFinish(
-      StorageAccount storageAccount,
-      String flightId,
-      AzureStorageAccountResource storageAccountResource) {
-    resourceDao.unlockStorageAccount(storageAccountResource.getName(), flightId);
+      String flightId, AzureStorageAccountResource storageAccountResource, String containerId) {
+    resourceDao.unlockStorageAccount(storageAccountResource.getName(), containerId, flightId);
 
     return storageAccountResource;
   }
@@ -321,21 +330,5 @@ public class AzureStorageAccountService {
     } catch (Exception e) {
       throw new AzureResourceException("Could not check storage account existence", e);
     }
-  }
-
-  /**
-   * Delete a storage account cloud resource
-   *
-   * @param profileModel the TDR billing profile associated with this storage account
-   * @param storageAccountResource storage account resource to look up storage account.
-   */
-  void deleteCloudStorageAccount(
-      BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
-    resourceConfiguration
-        .getClient(profileModel.getSubscriptionId())
-        .storageAccounts()
-        .deleteByResourceGroup(
-            storageAccountResource.getApplicationResource().getAzureResourceGroupName(),
-            storageAccountResource.getName());
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -820,7 +820,7 @@ public class SnapshotService {
               table,
               tableName,
               datasourceName,
-              IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, tableName),
+              IngestUtils.getSnapshotParquetFilePathForQuery(tableName),
               limit,
               offset,
               sort,

--- a/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
@@ -9,6 +9,7 @@ public final class SnapshotWorkingMapKeys extends ProjectCreatingFlightKeys {
   public static final String SNAPSHOT_ID = "snapshotId";
   public static final String POLICY_MAP = "policyMap";
   public static final String PROJECT_RESOURCE_ID = "projectResourceId";
+  public static final String PROFILE_ID = "profileId";
   public static final String PROJECTS_MARKED_FOR_DELETE = "projectsMarkedForDelete";
   public static final String TABLE_ROW_COUNT_MAP = "tableRowCountMap";
   public static final String SNAPSHOT_EXISTS = "snapshotExists";
@@ -16,6 +17,8 @@ public final class SnapshotWorkingMapKeys extends ProjectCreatingFlightKeys {
   public static final String SNAPSHOT_HAS_AZURE_STORAGE_ACCOUNT = "snapshotHasStorageAccount";
   public static final String DATASET_EXISTS = "datasetExists";
   public static final String STORAGE_ACCOUNT_RESOURCE_NAME = "storageAccountResourceName";
+  public static final String STORAGE_ACCOUNT_RESOURCE_TLC = "storageAccountResourceTlc";
+  public static final String STORAGE_ACCOUNT_RESOURCE_ID = "storageAccountResourceId";
   public static final String SNAPSHOT_EXPORT_BUCKET = "snapshotExportBucket";
   public static final String SNAPSHOT_EXPORT_PARQUET_PATHS = "snapshotExportParquetPaths";
   public static final String SNAPSHOT_EXPORT_MANIFEST_PATH = "snapshotExportManifestPath";

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureStorageAccountStep.java
@@ -1,7 +1,6 @@
 package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.model.BillingProfileModel;
-import bio.terra.model.SnapshotRequestModel;
 import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.common.CreateAzureStorageAccountStep;
 import bio.terra.service.dataset.Dataset;
@@ -18,14 +17,12 @@ import java.util.UUID;
 public class CreateSnapshotCreateAzureStorageAccountStep extends CreateAzureStorageAccountStep {
   private final ResourceService resourceService;
   private final Dataset dataset;
-  private final SnapshotRequestModel snapshotRequestModel;
 
   public CreateSnapshotCreateAzureStorageAccountStep(
-      ResourceService resourceService, Dataset dataset, SnapshotRequestModel snapshotRequestModel) {
+      ResourceService resourceService, Dataset dataset) {
     super(resourceService, dataset);
     this.resourceService = resourceService;
     this.dataset = dataset;
-    this.snapshotRequestModel = snapshotRequestModel;
   }
 
   @Override
@@ -45,11 +42,7 @@ public class CreateSnapshotCreateAzureStorageAccountStep extends CreateAzureStor
 
     AzureStorageAccountResource storageAccountResource =
         resourceService.createSnapshotStorageAccount(
-            snapshotRequestModel.getName(),
-            snapshotId,
-            dataset.getStorageAccountRegion(),
-            billingProfile,
-            flightId);
+            snapshotId, dataset.getStorageAccountRegion(), billingProfile, flightId);
     workingMap.put(CommonMapKeys.SNAPSHOT_STORAGE_ACCOUNT_RESOURCE, storageAccountResource);
 
     AzureStorageAuthInfo storageAuthInfo =

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotSourceDatasetDataSourceAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotSourceDatasetDataSourceAzureStep.java
@@ -46,7 +46,6 @@ public class CreateSnapshotSourceDatasetDataSourceAzureStep implements Step {
             parquetDatasetSourceLocation,
             billingProfile,
             datasetAzureStorageAccountResource,
-            AzureStorageAccountResource.ContainerType.METADATA,
             userRequest);
     try {
       azureSynapsePdao.getOrCreateExternalDataSource(

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotTargetDataSourceAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotTargetDataSourceAzureStep.java
@@ -48,7 +48,6 @@ public class CreateSnapshotTargetDataSourceAzureStep implements Step {
             snapshotParquetTargetLocation,
             billingProfile,
             snapshotAzureStorageAccountResource,
-            AzureStorageAccountResource.ContainerType.METADATA,
             userRequest);
     try {
       azureSynapsePdao.getOrCreateExternalDataSource(

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -126,8 +126,7 @@ public class SnapshotCreateFlight extends Flight {
 
     if (platform.isAzure()) {
       addStep(
-          new CreateSnapshotCreateAzureStorageAccountStep(
-              resourceService, sourceDataset, snapshotReq));
+          new CreateSnapshotCreateAzureStorageAccountStep(resourceService, sourceDataset));
       addStep(
           new CreateSnapshotSourceDatasetDataSourceAzureStep(
               azureSynapsePdao, azureBlobStorePdao, userReq));

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -125,8 +125,7 @@ public class SnapshotCreateFlight extends Flight {
         getDefaultExponentialBackoffRetryRule());
 
     if (platform.isAzure()) {
-      addStep(
-          new CreateSnapshotCreateAzureStorageAccountStep(resourceService, sourceDataset));
+      addStep(new CreateSnapshotCreateAzureStorageAccountStep(resourceService, sourceDataset));
       addStep(
           new CreateSnapshotSourceDatasetDataSourceAzureStep(
               azureSynapsePdao, azureBlobStorePdao, userReq));

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsAzureStep.java
@@ -39,6 +39,6 @@ public class SnapshotRecordFileIdsAzureStep extends SnapshotRecordFileIdsStep {
     TableServiceClient snapshotTableServiceClient =
         azureAuthService.getTableServiceClient(snapshotStorageAuthInfo);
 
-    return tableDao.retrieveAllFileIds(snapshotTableServiceClient);
+    return tableDao.retrieveAllFileIds(snapshotTableServiceClient, snapshot.getId());
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteStorageAccountStep.java
@@ -12,6 +12,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.UUID;
 
 public class DeleteSnapshotDeleteStorageAccountStep implements Step {
@@ -33,6 +34,9 @@ public class DeleteSnapshotDeleteStorageAccountStep implements Step {
   }
 
   @Override
+  @SuppressFBWarnings(
+      value = "RCN",
+      justification = "Spotbugs doesn't believe snapshotStorageAccountResource can be null")
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
 

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteStorageAccountStep.java
@@ -1,8 +1,11 @@
 package bio.terra.service.snapshot.flight.delete;
 
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAuthInfo;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -15,23 +18,36 @@ public class DeleteSnapshotDeleteStorageAccountStep implements Step {
 
   private final UUID snapshotId;
   private final ResourceService resourceService;
-  private final AzureStorageAccountService storageAccountService;
+  private final TableDao tableDao;
+  private final ProfileService profileService;
 
   public DeleteSnapshotDeleteStorageAccountStep(
       UUID snapshotId,
       ResourceService resourceService,
-      AzureStorageAccountService storageAccountService) {
+      TableDao tableDao,
+      ProfileService profileService) {
     this.snapshotId = snapshotId;
     this.resourceService = resourceService;
-    this.storageAccountService = storageAccountService;
+    this.tableDao = tableDao;
+    this.profileService = profileService;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
 
+    UUID profileId = workingMap.get(SnapshotWorkingMapKeys.PROFILE_ID, UUID.class);
+    UUID storageResourceId =
+        workingMap.get(SnapshotWorkingMapKeys.STORAGE_ACCOUNT_RESOURCE_ID, UUID.class);
+
+    BillingProfileModel snapshotBillingProfile = profileService.getProfileByIdNoCheck(profileId);
+
     AzureStorageAccountResource snapshotStorageAccountResource =
-        resourceService.getSnapshotStorageAccount(snapshotId).orElse(null);
+        resourceService.lookupStorageAccount(storageResourceId);
+
+    AzureStorageAuthInfo snapshotAzureStorageAuthInfo =
+        AzureStorageAuthInfo.azureStorageAuthInfoBuilder(
+            snapshotBillingProfile, snapshotStorageAccountResource);
 
     // If we do not find the storage account, we assume things are already clean
     if (snapshotStorageAccountResource == null) {
@@ -43,8 +59,14 @@ public class DeleteSnapshotDeleteStorageAccountStep implements Step {
     workingMap.put(
         SnapshotWorkingMapKeys.STORAGE_ACCOUNT_RESOURCE_NAME,
         snapshotStorageAccountResource.getName());
+    workingMap.put(
+        SnapshotWorkingMapKeys.STORAGE_ACCOUNT_RESOURCE_TLC,
+        snapshotStorageAccountResource.getTopLevelContainer());
 
-    storageAccountService.deleteCloudStorageAccount(snapshotStorageAccountResource);
+    resourceService.deleteStorageContainer(storageResourceId, profileId, context.getFlightId());
+
+    // Delete the directory entries for the snapshot
+    tableDao.deleteFilesFromSnapshot(snapshotAzureStorageAuthInfo, snapshotId);
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataAzureStep.java
@@ -21,9 +21,11 @@ public class DeleteSnapshotMetadataAzureStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     String storageAccountResourceName =
         workingMap.get(SnapshotWorkingMapKeys.STORAGE_ACCOUNT_RESOURCE_NAME, String.class);
+    String storageAccountResourceTopLevelContainer =
+        workingMap.get(SnapshotWorkingMapKeys.STORAGE_ACCOUNT_RESOURCE_TLC, String.class);
 
     storageAccountService.deleteCloudStorageAccountMetadata(
-        storageAccountResourceName, context.getFlightId());
+        storageAccountResourceName, storageAccountResourceTopLevelContainer, context.getFlightId());
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotStoreAzureIdsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotStoreAzureIdsStep.java
@@ -1,0 +1,39 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+
+public class DeleteSnapshotStoreAzureIdsStep implements Step {
+  private final UUID snapshotId;
+  private final SnapshotService snapshotService;
+
+  public DeleteSnapshotStoreAzureIdsStep(UUID snapshotId, SnapshotService snapshotService) {
+    this.snapshotId = snapshotId;
+    this.snapshotService = snapshotService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Snapshot snapshot = snapshotService.retrieve(snapshotId);
+    UUID profileId = snapshot.getProfileId();
+    UUID storageResourceId = snapshot.getStorageAccountResource().getResourceId();
+
+    FlightMap workingMap = context.getWorkingMap();
+    workingMap.put(SnapshotWorkingMapKeys.PROFILE_ID, profileId);
+    workingMap.put(SnapshotWorkingMapKeys.STORAGE_ACCOUNT_RESOURCE_ID, storageResourceId);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
@@ -16,7 +16,7 @@ import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -66,7 +66,6 @@ public class SnapshotExportWriteManifestAzureStep extends DefaultUndoStep {
 
     Map<String, List<String>> paths =
         FlightUtils.getTyped(workingMap, SnapshotWorkingMapKeys.SNAPSHOT_EXPORT_PARQUET_PATHS);
-    ContainerType containerType = ContainerType.METADATA;
 
     UUID billingProfileId = workingMap.get(JobMapKeys.BILLING_ID.getKeyName(), UUID.class);
     BillingProfileModel billingProfile = profileService.getProfileById(billingProfileId, userReq);
@@ -78,10 +77,12 @@ public class SnapshotExportWriteManifestAzureStep extends DefaultUndoStep {
     String fullExportManifestPath =
         "%s/%s/%s"
             .formatted(
-                storageAccountResource.getStorageAccountUrl(), containerType, exportManifestPath);
+                storageAccountResource.getStorageAccountUrl(),
+                storageAccountResource.getTopLevelContainer(),
+                FolderType.METADATA.getPath(exportManifestPath));
     BlobUrlParts snapshotSignedUrlBlob =
         azureBlobStorePdao.getOrSignUrlForTargetFactory(
-            fullExportManifestPath, billingProfile, storageAccountResource, containerType, userReq);
+            fullExportManifestPath, billingProfile, storageAccountResource, userReq);
 
     List<SnapshotExportResponseModelFormatParquetLocationTables> tables =
         paths.entrySet().stream()

--- a/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/AzureStorageTablePdao.java
@@ -129,6 +129,12 @@ public class AzureStorageTablePdao {
         .collect(Collectors.toList());
   }
 
+  public void dropLoadHistoryTable(TableServiceClient tableServiceClient, UUID datasetId) {
+    tableServiceClient
+        .getTableClient(StorageTableName.LOAD_HISTORY.toTableName(datasetId))
+        .deleteTable();
+  }
+
   private static TableEntity bulkFileLoadModelToStorageTableEntity(
       StorageTableLoadHistoryEntity entity, String loadTag, Instant loadTime) {
     var model = entity.model;

--- a/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
+++ b/src/main/java/bio/terra/service/tabulardata/azure/StorageTableService.java
@@ -58,4 +58,15 @@ public class StorageTableService {
     return storageTableDao.getLoadHistory(
         tableServiceClient, dataset.getId(), loadTag, offset, limit);
   }
+
+  public void dropLoadHistoryTable(Dataset dataset) {
+    var billingProfile = dataset.getDatasetSummary().getDefaultBillingProfile();
+    var storageAccountResource = resourceService.getDatasetStorageAccount(dataset, billingProfile);
+    TableServiceClient tableServiceClient =
+        azureAuthService.getTableServiceClient(
+            billingProfile.getSubscriptionId(),
+            storageAccountResource.getApplicationResource().getAzureResourceGroupName(),
+            storageAccountResource.getName());
+    storageTableDao.dropLoadHistoryTable(tableServiceClient, dataset.getId());
+  }
 }

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -70,4 +70,5 @@
     <include file="changesets/20221104_v2drsids.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20230208_gcpautoclassbucket.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20230307_shedlock.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20230307_sharestorageaccounts.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20230307_sharestorageaccounts.yaml
+++ b/src/main/resources/db/changesets/20230307_sharestorageaccounts.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: sharestorageaccounts
+      author: nm
+      changes:
+        - addColumn:
+            tableName: storage_account_resource
+            columns:
+              name: toplevelcontainer
+              type: text
+        - dropUniqueConstraint:
+            tableName: storage_account_resource
+            constraintName: storage_account_resource_name_key
+        - addUniqueConstraint:
+            tableName: storage_account_resource
+            columnNames: name, toplevelcontainer

--- a/src/test/java/bio/terra/common/SynapseUtils.java
+++ b/src/test/java/bio/terra/common/SynapseUtils.java
@@ -487,7 +487,8 @@ public class SynapseUtils {
     jsonLoader.loadObject("ingest-test-dataset-table-all-data-types.json", DatasetTable.class);
 
     String scratchParquetFile =
-        "parquet/scratch_" + destinationTable.getName() + "/" + randomFlightId + ".parquet";
+        FolderType.SCRATCH.getPath(
+            "parquet/scratch_" + destinationTable.getName() + "/" + randomFlightId + ".parquet");
     addParquetFileName(scratchParquetFile, datasetStorageAccountResource);
     addParquetFileName(
         IngestUtils.getParquetFilePath(destinationTable.getName(), randomFlightId),
@@ -496,7 +497,8 @@ public class SynapseUtils {
     // Check that the parquet files were successfully created.
     List<String> firstNames =
         readParquetFileStringColumn(
-            IngestUtils.getParquetFilePath(destinationTable.getName(), randomFlightId),
+            FolderType.METADATA.getPath(
+                IngestUtils.getParquetFilePath(destinationTable.getName(), randomFlightId)),
             IngestUtils.getTargetDataSourceName(randomFlightId),
             "first_name",
             true);

--- a/src/test/java/bio/terra/common/SynapseUtils.java
+++ b/src/test/java/bio/terra/common/SynapseUtils.java
@@ -334,10 +334,7 @@ public class SynapseUtils {
       BlobSasTokenOptions blobSasTokenOptions) {
     BlobContainerClientFactory targetDataClientFactory =
         azureBlobStorePdao.getTargetDataClientFactory(
-            profileModel,
-            storageAccount,
-            AzureStorageAccountResource.ContainerType.METADATA,
-            blobSasTokenOptions);
+            profileModel, storageAccount, blobSasTokenOptions);
 
     var result =
         targetDataClientFactory

--- a/src/test/java/bio/terra/common/configuration/TestConfiguration.java
+++ b/src/test/java/bio/terra/common/configuration/TestConfiguration.java
@@ -29,6 +29,7 @@ public class TestConfiguration {
   private UUID targetTenantId;
   private UUID targetSubscriptionId;
   private String targetResourceGroupName;
+  private String targetManagedResourceGroupName;
   private String targetApplicationName;
   private String sourceStorageAccountName;
   private String ingestRequestContainer;
@@ -150,6 +151,14 @@ public class TestConfiguration {
 
   public void setTargetResourceGroupName(String targetResourceGroupName) {
     this.targetResourceGroupName = targetResourceGroupName;
+  }
+
+  public String getTargetManagedResourceGroupName() {
+    return targetManagedResourceGroupName;
+  }
+
+  public void setTargetManagedResourceGroupName(String targetManagedResourceGroupName) {
+    this.targetManagedResourceGroupName = targetManagedResourceGroupName;
   }
 
   public String getTargetApplicationName() {

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -439,6 +439,9 @@ public class AzureIntegrationTest extends UsersBase {
     AccessInfoParquetModel datasetParquetAccessInfo =
         datasetModel.getAccessInformation().getParquet();
 
+    // record the storage account
+    storageAccounts.add(getStorageAccountName(datasetParquetAccessInfo));
+
     DatasetSpecificationModel datasetSchema = datasetModel.getSchema();
     // dataset ingest
     // Ingest Metadata - 1 row from JSON file
@@ -561,12 +564,6 @@ public class AzureIntegrationTest extends UsersBase {
         "Correct row is returned",
         ((LinkedHashMap) filteredVocabRows.get(0)).get("vocabulary_id").toString(),
         equalTo("1"));
-
-    AccessInfoParquetModel datasetParquetAccessInfo =
-        datasetModel.getAccessInformation().getParquet();
-
-    // record the storage account
-    storageAccounts.add(getStorageAccountName(datasetParquetAccessInfo));
 
     // test handling of empty dataset table
     List<Object> emptyTable =

--- a/src/test/java/bio/terra/service/common/azure/StorageTableNameTest.java
+++ b/src/test/java/bio/terra/service/common/azure/StorageTableNameTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.common.category.Unit;
-import bio.terra.common.exception.NotImplementedException;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -14,11 +13,6 @@ import org.springframework.test.context.ActiveProfiles;
 @Category(Unit.class)
 public class StorageTableNameTest {
 
-  @Test(expected = IllegalArgumentException.class)
-  public void snapshotToTableNameNoParam() {
-    StorageTableName.SNAPSHOT.toTableName();
-  }
-
   @Test
   public void snapshotToTableNameWithParam() {
     UUID snapshotId = UUID.randomUUID();
@@ -26,16 +20,5 @@ public class StorageTableNameTest {
     String snapshotTableName = StorageTableName.SNAPSHOT.toTableName(snapshotId);
     assertThat(
         "expected snapshot table name should match", snapshotTableName, equalTo(expectedTableName));
-  }
-
-  @Test
-  public void datasetToTableNameNoParam() {
-    String datasetTableName = StorageTableName.DATASET.toTableName();
-    assertThat("expected snapshot table name should match", datasetTableName, equalTo("dataset"));
-  }
-
-  @Test(expected = NotImplementedException.class)
-  public void datasetToTableNameWithParam() {
-    StorageTableName.DATASET.toTableName(UUID.randomUUID());
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -283,7 +283,7 @@ public class DatasetJsonConversionTest {
                                             .required(true)
                                             .arrayOf(false))))));
 
-    var dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel);
+    var dataset = DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel, DATASET_ID);
     var columnMap = dataset.getTables().get(0).getColumnsMap();
     var pkColumn = columnMap.get(DATASET_COLUMN_NAME);
     var defaultColumn = columnMap.get(defaultColumnName);

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -599,15 +599,8 @@ public class DatasetServiceTest {
     when(storageAccountResource.getApplicationResource()).thenReturn(applicationResource);
     when(resourceService.getOrCreateDatasetStorageAccount(any(), any(), any()))
         .thenReturn(storageAccountResource);
-    when(azureContainerPdao.getOrCreateContainer(
-            any(), any(), eq(AzureStorageAccountResource.ContainerType.SCRATCH)))
-        .thenReturn(containerClient);
-    when(azureBlobStorePdao.signFile(
-            any(),
-            eq(storageAccountResource),
-            eq(filePath),
-            eq(AzureStorageAccountResource.ContainerType.SCRATCH),
-            any()))
+    when(azureContainerPdao.getOrCreateContainer(any(), any())).thenReturn(containerClient);
+    when(azureBlobStorePdao.signFile(any(), eq(storageAccountResource), eq(filePath), any()))
         .thenReturn(signedPath);
     IngestRequestModel ingestRequestModel =
         new IngestRequestModel()

--- a/src/test/java/bio/terra/service/dataset/DatasetStorageAccountDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetStorageAccountDaoTest.java
@@ -106,8 +106,12 @@ public class DatasetStorageAccountDaoTest {
     datasetIds.add(datasetId);
 
     AzureStorageAccountResource storageAccount =
-        azureResourceDao.createAndLockStorageAccount(
-            "sa", applicationResource, AzureRegion.ASIA_PACIFIC, ShortUUID.get());
+        azureResourceDao.createAndLockStorage(
+            "sa",
+            datasetId.toString(),
+            applicationResource,
+            AzureRegion.ASIA_PACIFIC,
+            ShortUUID.get());
     storageAccountResourceIds.add(storageAccount.getResourceId());
     datasetStorageAccountDao.createDatasetStorageAccountLink(
         datasetId, storageAccount.getResourceId(), false);

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -652,6 +652,8 @@ public class DrsServiceTest {
     UUID defaultProfileModelId = UUID.randomUUID();
     Snapshot snapshot =
         mockSnapshot(snapshotId, defaultProfileModelId, CloudPlatform.AZURE, "google-project");
+    // Make this a global file id snapshot to test access ids
+    snapshot.globalFileIds(true);
     DrsId drsId = drsIdService.fromObjectId(azureDrsObjectId);
     when(snapshotService.retrieve(UUID.fromString(drsId.getSnapshotId()))).thenReturn(snapshot);
     AzureStorageAccountResource storageAccountResource =

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -662,7 +662,8 @@ public class DrsServiceTest {
     when(azureBlobStorePdao.signFile(any(), any(), any(), any())).thenReturn(urlString);
 
     DRSAccessURL result =
-        drsService.getAccessUrlForObjectId(authUser, azureDrsObjectId, "az-centralus");
+        drsService.getAccessUrlForObjectId(
+            authUser, azureDrsObjectId, "az-centralus*" + snapshotId);
     assertEquals(urlString, result.getUrl());
   }
 

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -659,7 +659,7 @@ public class DrsServiceTest {
     when(fileService.lookupSnapshotFSItem(any(), any(), eq(1))).thenReturn(azureFsFile);
     when(resourceService.lookupStorageAccountMetadata(any())).thenReturn(storageAccountResource);
     String urlString = "https://blahblah.core.windows.com/data/file.json";
-    when(azureBlobStorePdao.signFile(any(), any(), any(), any(), any())).thenReturn(urlString);
+    when(azureBlobStorePdao.signFile(any(), any(), any(), any())).thenReturn(urlString);
 
     DRSAccessURL result =
         drsService.getAccessUrlForObjectId(authUser, azureDrsObjectId, "az-centralus");

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -134,8 +134,7 @@ public class AzureIngestFileConnectedTest {
             .resourceId(storageAccountId)
             .name(testConfig.getSourceStorageAccountName())
             .applicationResource(applicationResource)
-            .metadataContainer("metadata")
-            .dataContainer("data");
+            .topLevelContainer(datasetId.toString());
 
     storageAuthInfo =
         AzureStorageAuthInfo.azureStorageAuthInfoBuilder(billingProfile, storageAccountResource);

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -26,6 +26,7 @@ import bio.terra.service.filedata.DrsId;
 import bio.terra.service.filedata.DrsIdService;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotTable;
@@ -187,7 +188,8 @@ public class AzureSynapsePdaoConnectedTest {
 
     List<String> textCols =
         synapseUtils.readParquetFileStringColumn(
-            IngestUtils.getParquetFilePath("all_data_types", randomFlightId),
+            FolderType.METADATA.getPath(
+                IngestUtils.getParquetFilePath("all_data_types", randomFlightId)),
             IngestUtils.getTargetDataSourceName(randomFlightId),
             "textCol",
             true);

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -245,7 +245,7 @@ public class AzureSynapsePdaoConnectedTest {
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "all_data_types"));
     // Test that parquet files are correctly generated
     String snapshotParquetFileName =
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, destinationTable.getName());
+        IngestUtils.getSnapshotParquetFilePathForQuery(destinationTable.getName());
     List<String> snapshotFirstNames =
         synapseUtils.readParquetFileStringColumn(
             snapshotParquetFileName, snapshotDataSourceName, "first_name", true);
@@ -265,7 +265,7 @@ public class AzureSynapsePdaoConnectedTest {
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, PDAO_ROW_ID_TABLE));
     // Test that parquet files are correctly generated
     String snapshotRowIdsParquetFileName =
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, PDAO_ROW_ID_TABLE);
+        IngestUtils.getSnapshotParquetFilePathForQuery(PDAO_ROW_ID_TABLE);
     synapseUtils.addParquetFileName(snapshotRowIdsParquetFileName, snapshotStorageAccountResource);
     List<String> snapshotRowIds =
         synapseUtils.readParquetFileStringColumn(
@@ -297,7 +297,7 @@ public class AzureSynapsePdaoConnectedTest {
                 snapshotTable,
                 snapshotTable.getName(),
                 snapshotQueryDataSourceName,
-                IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, snapshotTable.getName()),
+                IngestUtils.getSnapshotParquetFilePathForQuery(snapshotTable.getName()),
                 10,
                 0,
                 "first_name",
@@ -316,7 +316,7 @@ public class AzureSynapsePdaoConnectedTest {
                 snapshotTable,
                 snapshotTable.getName(),
                 snapshotQueryDataSourceName,
-                IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, snapshotTable.getName()),
+                IngestUtils.getSnapshotParquetFilePathForQuery(snapshotTable.getName()),
                 10,
                 0,
                 "first_name",
@@ -335,7 +335,7 @@ public class AzureSynapsePdaoConnectedTest {
                 snapshotTable,
                 snapshotTable.getName(),
                 snapshotQueryDataSourceName,
-                IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, snapshotTable.getName()),
+                IngestUtils.getSnapshotParquetFilePathForQuery(snapshotTable.getName()),
                 10,
                 0,
                 "first_name",

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
@@ -192,7 +192,7 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "sample"));
 
     String snapshotParquetFileName =
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, participantTable.getName());
+        IngestUtils.getSnapshotParquetFilePathForQuery(participantTable.getName());
     synapseUtils.addParquetFileName(snapshotParquetFileName, snapshotStorageAccountResource);
     List<String> snapshotFirstNames =
         synapseUtils.readParquetFileStringColumn(
@@ -369,8 +369,7 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
 
   private void validateFourTableSnapshot(String rootTableName, Map<String, Long> tableRowCounts) {
     // Check correct row included for root table
-    String snapshotParquetFileName =
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, rootTableName);
+    String snapshotParquetFileName = IngestUtils.getSnapshotParquetFilePathForQuery(rootTableName);
     synapseUtils.addParquetFileName(snapshotParquetFileName, snapshotStorageAccountResource);
     List<String> snapshotFirstNames =
         synapseUtils.readParquetFileStringColumn(
@@ -385,7 +384,7 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
         equalTo(1L));
     // Check correct row included for date of birth table, participant_id
     String dobParquetFileName =
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, dateOfBirthTable.getName());
+        IngestUtils.getSnapshotParquetFilePathForQuery(dateOfBirthTable.getName());
     synapseUtils.addParquetFileName(dobParquetFileName, snapshotStorageAccountResource);
     List<String> participantIds =
         synapseUtils.readParquetFileStringColumn(
@@ -400,7 +399,7 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
         equalTo(1L));
     // Check correct row included for all_data_types, first_name Sally
     String adtParquetFileName =
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, allDataTypesTable.getName());
+        IngestUtils.getSnapshotParquetFilePathForQuery(allDataTypesTable.getName());
     synapseUtils.addParquetFileName(adtParquetFileName, snapshotStorageAccountResource);
     List<String> firstNames =
         synapseUtils.readParquetFileStringColumn(
@@ -415,7 +414,7 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
         equalTo(1L));
     // Check correct row included for sample, participant_id "1"
     String sampleParquetFileName =
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, sampleTable.getName());
+        IngestUtils.getSnapshotParquetFilePathForQuery(sampleTable.getName());
     synapseUtils.addParquetFileName(sampleParquetFileName, snapshotStorageAccountResource);
     List<String> ids =
         synapseUtils.readParquetFileStringColumn(
@@ -436,7 +435,7 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
         snapshot.getTables(), snapshotId, snapshotDataSourceName, tableRowCounts);
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, PDAO_ROW_ID_TABLE));
     String snapshotRowIdsParquetFileName =
-        IngestUtils.getSnapshotParquetFilePathForQuery(snapshotId, PDAO_ROW_ID_TABLE);
+        IngestUtils.getSnapshotParquetFilePathForQuery(PDAO_ROW_ID_TABLE);
     synapseUtils.addParquetFileName(snapshotRowIdsParquetFileName, snapshotStorageAccountResource);
     List<String> snapshotRowIds =
         synapseUtils.readParquetFileStringColumn(

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -128,9 +128,7 @@ public class AzureBlobStorePdaoTest {
     targetBlobContainerFactory = mock(BlobContainerClientFactory.class);
     sourceBlobContainerFactory = mock(BlobContainerClientFactory.class);
     blobCrl = mock(BlobCrl.class);
-    doReturn(targetBlobContainerFactory)
-        .when(dao)
-        .getTargetDataClientFactory(any(), any(), any(), any());
+    doReturn(targetBlobContainerFactory).when(dao).getTargetDataClientFactory(any(), any(), any());
     doReturn(sourceBlobContainerFactory)
         .when(dao)
         .getSourceClientFactory(anyString(), any(), anyString());

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -179,7 +179,7 @@ public class AzureBlobStorePdaoTest {
   public void testDeleteFile() {
     UUID fileId = UUID.randomUUID();
     FSFileInfo fsFileInfo = mockFileCopy(fileId);
-    when(blobCrl.deleteBlob(fileId + "/" + SOURCE_FILE_NAME)).thenReturn(true);
+    when(blobCrl.deleteBlob("data/" + fileId + "/" + SOURCE_FILE_NAME)).thenReturn(true);
 
     FireStoreFile fileToDelete =
         new FireStoreFile()
@@ -193,7 +193,7 @@ public class AzureBlobStorePdaoTest {
   public void testDeleteFileNotFound() {
     UUID fileId = UUID.randomUUID();
     FSFileInfo fsFileInfo = mockFileCopy(fileId);
-    when(blobCrl.deleteBlob(fileId + "/" + SOURCE_FILE_NAME)).thenReturn(false);
+    when(blobCrl.deleteBlob("data/" + fileId + "/" + SOURCE_FILE_NAME)).thenReturn(false);
 
     FireStoreFile fileToDelete =
         new FireStoreFile()
@@ -225,7 +225,7 @@ public class AzureBlobStorePdaoTest {
   public void testDeleteFileById() {
     UUID fileId = UUID.randomUUID();
     mockFileCopy(fileId);
-    when(blobCrl.deleteBlob(fileId + "/" + SOURCE_FILE_NAME)).thenReturn(true);
+    when(blobCrl.deleteBlob("data/" + fileId + "/" + SOURCE_FILE_NAME)).thenReturn(true);
 
     assertThat(
         dao.deleteDataFileById(
@@ -237,7 +237,7 @@ public class AzureBlobStorePdaoTest {
   public void testDeleteFileByIdNotFound() {
     UUID fileId = UUID.randomUUID();
     mockFileCopy(fileId);
-    when(blobCrl.deleteBlob(fileId + "/" + SOURCE_FILE_NAME)).thenReturn(false);
+    when(blobCrl.deleteBlob("data/" + fileId + "/" + SOURCE_FILE_NAME)).thenReturn(false);
 
     assertThat(
         dao.deleteDataFileById(
@@ -289,7 +289,7 @@ public class AzureBlobStorePdaoTest {
     when(blobProperties.getContentMd5()).thenReturn(BLOB_CONTENT_MD5);
     when(copier.beginCopyOperation()).thenReturn(poller);
     when(blobCrl.createBlobContainerCopier(any(), anyString(), anyString())).thenReturn(copier);
-    String targetBlobName = fileId + "/" + SOURCE_FILE_NAME;
+    String targetBlobName = "data/" + fileId + "/" + SOURCE_FILE_NAME;
     when(blobCrl.getBlobProperties(targetBlobName)).thenReturn(blobProperties);
     BlobContainerClient sourceBlobContainerClient = mock(BlobContainerClient.class);
     BlobClient blobClient = mock(BlobClient.class);

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
@@ -85,7 +85,7 @@ public class TableDirectoryDaoConnectedTest {
     for (String entry : directoryEntriesToCleanup) {
       try {
         tableDirectoryDao.deleteDirectoryEntry(
-            tableServiceClient, datasetId, StorageTableName.DATASET.toTableName(), entry);
+            tableServiceClient, datasetId, StorageTableName.DATASET.toTableName(datasetId), entry);
       } catch (Exception ex) {
         logger.debug("Directory entry either already deleted or unable to delete {}", entry, ex);
       }
@@ -156,14 +156,14 @@ public class TableDirectoryDaoConnectedTest {
         tableDirectoryDao.deleteDirectoryEntry(
             tableServiceClient,
             datasetId,
-            StorageTableName.DATASET.toTableName(),
+            StorageTableName.DATASET.toTableName(datasetId),
             fileEntry1.getFileId());
     assertThat("Delete Entry 1", deleteEntry, equalTo(true));
     FireStoreDirectoryEntry shouldbeNull =
         tableDirectoryDao.retrieveByPath(
             tableServiceClient,
             datasetId,
-            StorageTableName.DATASET.toTableName(),
+            StorageTableName.DATASET.toTableName(datasetId),
             sharedTargetPath + fileName1);
     assertThat("File1 reference no longer exists", shouldbeNull, equalTo(null));
 
@@ -171,7 +171,7 @@ public class TableDirectoryDaoConnectedTest {
         tableDirectoryDao.retrieveByPath(
             tableServiceClient,
             datasetId,
-            StorageTableName.DATASET.toTableName(),
+            StorageTableName.DATASET.toTableName(datasetId),
             sharedTargetPath + fileName2);
     assertThat(
         "File2's directory still exists",
@@ -183,7 +183,7 @@ public class TableDirectoryDaoConnectedTest {
         tableDirectoryDao.retrieveByPath(
             tableServiceClient,
             datasetId,
-            StorageTableName.DATASET.toTableName(),
+            StorageTableName.DATASET.toTableName(datasetId),
             sharedTargetPath);
     assertThat(
         String.format(
@@ -194,7 +194,10 @@ public class TableDirectoryDaoConnectedTest {
 
     FireStoreDirectoryEntry parentEntryStillPresent =
         tableDirectoryDao.retrieveByPath(
-            tableServiceClient, datasetId, StorageTableName.DATASET.toTableName(), sharedParentDir);
+            tableServiceClient,
+            datasetId,
+            StorageTableName.DATASET.toTableName(datasetId),
+            sharedParentDir);
     assertThat(
         String.format(
             "Shared subdirectory '/%s' should still exist after single file delete",
@@ -204,7 +207,7 @@ public class TableDirectoryDaoConnectedTest {
 
     FireStoreDirectoryEntry blankEntryStillPresent =
         tableDirectoryDao.retrieveByPath(
-            tableServiceClient, datasetId, StorageTableName.DATASET.toTableName(), "/");
+            tableServiceClient, datasetId, StorageTableName.DATASET.toTableName(datasetId), "/");
     assertThat(
         "Shared subdirectory should still exist after single file delete",
         blankEntryStillPresent.getPath(),
@@ -215,14 +218,14 @@ public class TableDirectoryDaoConnectedTest {
         tableDirectoryDao.deleteDirectoryEntry(
             tableServiceClient,
             datasetId,
-            StorageTableName.DATASET.toTableName(),
+            StorageTableName.DATASET.toTableName(datasetId),
             fileEntry2.getFileId());
     assertThat("Delete Entry 2", deleteEntry2, equalTo(true));
     FireStoreDirectoryEntry file2ShouldbeNull =
         tableDirectoryDao.retrieveByPath(
             tableServiceClient,
             datasetId,
-            StorageTableName.DATASET.toTableName(),
+            StorageTableName.DATASET.toTableName(datasetId),
             sharedTargetPath + fileName2);
     assertThat("File2 reference no longer exists", file2ShouldbeNull, equalTo(null));
 
@@ -230,7 +233,7 @@ public class TableDirectoryDaoConnectedTest {
         tableDirectoryDao.retrieveByPath(
             tableServiceClient,
             datasetId,
-            StorageTableName.DATASET.toTableName(),
+            StorageTableName.DATASET.toTableName(datasetId),
             sharedTargetPath);
     assertNull(
         String.format(
@@ -239,7 +242,10 @@ public class TableDirectoryDaoConnectedTest {
         testEntryNotPresent);
     FireStoreDirectoryEntry parentEntryNotPresent =
         tableDirectoryDao.retrieveByPath(
-            tableServiceClient, datasetId, StorageTableName.DATASET.toTableName(), sharedParentDir);
+            tableServiceClient,
+            datasetId,
+            StorageTableName.DATASET.toTableName(datasetId),
+            sharedParentDir);
     assertNull(
         String.format(
             "Shared subdirectory '/%s' should not exist after remaining file delete",
@@ -264,14 +270,14 @@ public class TableDirectoryDaoConnectedTest {
             .datasetId(datasetId.toString())
             .loadTag(loadTag);
     tableDirectoryDao.createDirectoryEntry(
-        tableServiceClient, datasetId, StorageTableName.DATASET.toTableName(), newEntry);
+        tableServiceClient, datasetId, StorageTableName.DATASET.toTableName(datasetId), newEntry);
     directoryEntriesToCleanup.add(fileId.toString());
 
     // test that directory entry now exists
     return tableDirectoryDao.retrieveByPath(
         tableServiceClient,
         datasetId,
-        StorageTableName.DATASET.toTableName(),
+        StorageTableName.DATASET.toTableName(datasetId),
         sharedTargetPath + fileName);
   }
 

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
@@ -96,7 +96,10 @@ public class TableDirectoryDaoTest {
     when(tableClient.getEntity(PARTITION_KEY, ROW_KEY)).thenReturn(entity);
     FireStoreDirectoryEntry response =
         dao.retrieveByPath(
-            tableServiceClient, DATASET_ID, StorageTableName.DATASET.toTableName(), FULL_PATH);
+            tableServiceClient,
+            DATASET_ID,
+            StorageTableName.DATASET.toTableName(DATASET_ID),
+            FULL_PATH);
     assertEquals("The same entry is returned", directoryEntry, response);
 
     when(tableClient.getEntity(PARTITION_KEY, NONEXISTENT_ROW_KEY))
@@ -105,7 +108,7 @@ public class TableDirectoryDaoTest {
         dao.retrieveByPath(
             tableServiceClient,
             DATASET_ID,
-            StorageTableName.DATASET.toTableName(),
+            StorageTableName.DATASET.toTableName(DATASET_ID),
             NONEXISTENT_PATH);
     assertNull("The entry does not exist", nonExistentEntry);
   }
@@ -127,7 +130,8 @@ public class TableDirectoryDaoTest {
           .when(() -> TableServiceClientUtils.tableHasSingleEntry(any(), any(), any()))
           .thenReturn(true);
       FireStoreDirectoryEntry response =
-          dao.retrieveById(tableServiceClient, StorageTableName.DATASET.toTableName(), FILE_ID);
+          dao.retrieveById(
+              tableServiceClient, StorageTableName.DATASET.toTableName(DATASET_ID), FILE_ID);
       assertThat(
           "retrieveById returns the correct directory entry", response, equalTo(directoryEntry));
     }
@@ -143,7 +147,7 @@ public class TableDirectoryDaoTest {
 
     FireStoreDirectoryEntry response =
         dao.retrieveById(
-            tableServiceClient, StorageTableName.DATASET.toTableName(), "nonexistentId");
+            tableServiceClient, StorageTableName.DATASET.toTableName(DATASET_ID), "nonexistentId");
     assertNull("The entry does not exist", response);
   }
 
@@ -157,7 +161,7 @@ public class TableDirectoryDaoTest {
 
     String missingId = UUID.randomUUID().toString();
     List<String> refIds = List.of(missingId);
-    List<String> response = dao.validateRefIds(tableServiceClient, refIds);
+    List<String> response = dao.validateRefIds(tableServiceClient, DATASET_ID, refIds);
     assertEquals(response.get(0), missingId);
   }
 
@@ -169,7 +173,8 @@ public class TableDirectoryDaoTest {
     when(tableClient.listEntities(any(), any(), any())).thenReturn(mockPagedIterable);
 
     List<FireStoreDirectoryEntry> response =
-        dao.enumerateDirectory(tableServiceClient, StorageTableName.DATASET.toTableName(), FILE_ID);
+        dao.enumerateDirectory(
+            tableServiceClient, StorageTableName.DATASET.toTableName(DATASET_ID), FILE_ID);
     assertEquals(response.get(0), directoryEntry);
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
@@ -40,6 +40,7 @@ public class TableFileConnectedTest {
   private TableServiceClient tableServiceClient;
 
   private static final String PARTITION_KEY = "partitionKey";
+  private static final String DATASET_ID = UUID.randomUUID().toString();
   private static final String FILE_ID = UUID.randomUUID().toString();
   private final TableEntity entity =
       new TableEntity(PARTITION_KEY, FILE_ID)
@@ -72,16 +73,16 @@ public class TableFileConnectedTest {
   @Test
   public void testCreateDeleteEntry() {
     FireStoreFile fireStoreFile = FireStoreFile.fromTableEntity(entity);
-    tableFileDao.createFileMetadata(tableServiceClient, fireStoreFile);
-    FireStoreFile file = tableFileDao.retrieveFileMetadata(tableServiceClient, FILE_ID);
+    tableFileDao.createFileMetadata(tableServiceClient, DATASET_ID, fireStoreFile);
+    FireStoreFile file = tableFileDao.retrieveFileMetadata(tableServiceClient, DATASET_ID, FILE_ID);
     assertEquals("The same file is retrieved", file, fireStoreFile);
 
     // Delete an entry
-    boolean isDeleted = tableFileDao.deleteFileMetadata(tableServiceClient, FILE_ID);
+    boolean isDeleted = tableFileDao.deleteFileMetadata(tableServiceClient, DATASET_ID, FILE_ID);
     assertTrue("File record is deleted", isDeleted);
 
     // Try to delete the entry again
-    boolean isNotDeleted = tableFileDao.deleteFileMetadata(tableServiceClient, FILE_ID);
+    boolean isNotDeleted = tableFileDao.deleteFileMetadata(tableServiceClient, DATASET_ID, FILE_ID);
     assertFalse("File record was already deleted", isNotDeleted);
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableFileDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableFileDaoTest.java
@@ -40,6 +40,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @EmbeddedDatabaseTest
 public class TableFileDaoTest {
   private static final String PARTITION_KEY = "partitionKey";
+  private static final String DATASET_ID = UUID.randomUUID().toString();
   private static final String FILE_ID = UUID.randomUUID().toString();
   private final TableEntity entity =
       new TableEntity(PARTITION_KEY, FILE_ID)
@@ -77,16 +78,16 @@ public class TableFileDaoTest {
 
   @Test
   public void testRetrieveFileMetadata() {
-    FireStoreFile fileMetadata = dao.retrieveFileMetadata(tableServiceClient, FILE_ID);
+    FireStoreFile fileMetadata = dao.retrieveFileMetadata(tableServiceClient, DATASET_ID, FILE_ID);
     FireStoreFile expected = FireStoreFile.fromTableEntity(entity);
     assertEquals("The same object is returned", fileMetadata, expected);
   }
 
   @Test
   public void testDeleteFileMetadata() {
-    boolean exists = dao.deleteFileMetadata(tableServiceClient, FILE_ID);
+    boolean exists = dao.deleteFileMetadata(tableServiceClient, DATASET_ID, FILE_ID);
     assertTrue("Existing row is deleted", exists);
-    boolean result = dao.deleteFileMetadata(tableServiceClient, "nonexistentFile");
+    boolean result = dao.deleteFileMetadata(tableServiceClient, DATASET_ID, "nonexistentFile");
     assertFalse("Non-existent row is not deleted", result);
   }
 
@@ -95,7 +96,8 @@ public class TableFileDaoTest {
     FireStoreDirectoryEntry fsDirectoryEntry = new FireStoreDirectoryEntry().fileId(FILE_ID);
     List<FireStoreDirectoryEntry> directoryEntries = List.of(fsDirectoryEntry);
     List<FireStoreFile> expectedFiles = List.of(FireStoreFile.fromTableEntity(entity));
-    List<FireStoreFile> files = dao.batchRetrieveFileMetadata(tableServiceClient, directoryEntries);
+    List<FireStoreFile> files =
+        dao.batchRetrieveFileMetadata(tableServiceClient, DATASET_ID, directoryEntries);
     assertEquals(
         "A file record is found for each directory entry", files.size(), expectedFiles.size());
     assertEquals("The same object is returned", files.get(0), expectedFiles.get(0));

--- a/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
@@ -79,22 +79,26 @@ public class MetadataDataAccessUtilsTest {
   @Test
   public void testAzureAccessInfo() {
     AzureStorageAccountResource storageAccountResource =
-        new AzureStorageAccountResource().resourceId(UUID.randomUUID()).name("michaelstorage");
+        new AzureStorageAccountResource()
+            .resourceId(UUID.randomUUID())
+            .name("michaelstorage")
+            .topLevelContainer("tlc");
     when(resourceService.getDatasetStorageAccount(any(), any())).thenReturn(storageAccountResource);
 
     when(azureBlobStorePdao.signFile(
             any(),
             any(),
-            eq("https://michaelstorage.blob.core.windows.net/metadata/parquet"),
+            eq("https://michaelstorage.blob.core.windows.net/tlc/metadata/parquet"),
             any()))
-        .thenReturn("https://michaelstorage.blob.core.windows.net/metadata/parquet/signedUrl?sast");
+        .thenReturn(
+            "https://michaelstorage.blob.core.windows.net/tlc/metadata/parquet/signedUrl?sast");
     when(azureBlobStorePdao.signFile(
             any(),
             any(),
-            eq("https://michaelstorage.blob.core.windows.net/metadata/parquet/sample"),
+            eq("https://michaelstorage.blob.core.windows.net/tlc/metadata/parquet/sample"),
             any()))
         .thenReturn(
-            "https://michaelstorage.blob.core.windows.net/metadata/parquet/sample/signedUrl?sast");
+            "https://michaelstorage.blob.core.windows.net/tlc/metadata/parquet/sample/signedUrl?sast");
 
     AccessInfoParquetModel infoModel =
         metadataDataAccessUtils.accessInfoFromDataset(azureDataset, TEST_USER).getParquet();
@@ -103,7 +107,7 @@ public class MetadataDataAccessUtilsTest {
     assertThat(infoModel.getDatasetId(), equalTo("michaelstorage.test-dataset"));
     assertThat(
         infoModel.getUrl(),
-        equalTo("https://michaelstorage.blob.core.windows.net/metadata/parquet/signedUrl"));
+        equalTo("https://michaelstorage.blob.core.windows.net/tlc/metadata/parquet/signedUrl"));
     assertThat(infoModel.getSasToken(), equalTo("sast"));
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
@@ -19,7 +19,6 @@ import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import java.util.List;
 import java.util.UUID;
 import org.junit.Before;
@@ -87,14 +86,12 @@ public class MetadataDataAccessUtilsTest {
             any(),
             any(),
             eq("https://michaelstorage.blob.core.windows.net/metadata/parquet"),
-            eq(ContainerType.METADATA),
             any()))
         .thenReturn("https://michaelstorage.blob.core.windows.net/metadata/parquet/signedUrl?sast");
     when(azureBlobStorePdao.signFile(
             any(),
             any(),
             eq("https://michaelstorage.blob.core.windows.net/metadata/parquet/sample"),
-            eq(ContainerType.METADATA),
             any()))
         .thenReturn(
             "https://michaelstorage.blob.core.windows.net/metadata/parquet/sample/signedUrl?sast");

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
 import bio.terra.model.BillingProfileModel;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.ContainerType;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobContainerProperties;
 import org.junit.Before;
@@ -57,9 +56,7 @@ public class AzureContainerPdaoTest {
 
     assertThat(
         "same object is returned",
-        dao.getOrCreateContainer(billingProfile, storageAccountResource, ContainerType.DATA)
-            .getProperties()
-            .getETag(),
+        dao.getOrCreateContainer(billingProfile, storageAccountResource).getProperties().getETag(),
         equalTo("TAG"));
 
     verify(blobContainerClient, times(0)).create();
@@ -74,9 +71,7 @@ public class AzureContainerPdaoTest {
 
     assertThat(
         "same object is returned",
-        dao.getOrCreateContainer(billingProfile, storageAccountResource, ContainerType.DATA)
-            .getProperties()
-            .getETag(),
+        dao.getOrCreateContainer(billingProfile, storageAccountResource).getProperties().getETag(),
         equalTo("TAG"));
 
     verify(blobContainerClient, times(1)).create();

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
@@ -41,9 +41,9 @@ public class AzureContainerPdaoTest {
         new AzureStorageAccountResource()
             .name("mystorageaccount")
             .metadataContainer("md")
-            .dataContainer("d");
-    when(authService.getBlobContainerClient(any(), any(), eq("d"))).thenReturn(blobContainerClient);
-    when(authService.getBlobContainerClient(any(), any(), eq("md")))
+            .dataContainer("d")
+            .topLevelContainer("tld");
+    when(authService.getBlobContainerClient(any(), any(), eq("tld")))
         .thenReturn(blobContainerClient);
     dao = new AzureContainerPdao(authService);
   }

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceDaoTest.java
@@ -58,7 +58,7 @@ public class AzureResourceDaoTest {
     applicationDeployments.add(appDeployment);
 
     var sa1 =
-        azureResourceDao.createAndLockStorageAccount(
+        azureResourceDao.createAndLockStorage(
             ProfileFixtures.randomizeName("sa1"),
             appDeployment,
             AzureRegion.DEFAULT_AZURE_REGION,
@@ -66,7 +66,7 @@ public class AzureResourceDaoTest {
     storageAccounts.add(sa1);
 
     var sa2 =
-        azureResourceDao.createAndLockStorageAccount(
+        azureResourceDao.createAndLockStorage(
             ProfileFixtures.randomizeName("sa2"),
             appDeployment,
             AzureRegion.DEFAULT_AZURE_REGION,
@@ -78,7 +78,10 @@ public class AzureResourceDaoTest {
   public void teardown() {
     boolean allStorageDeleted =
         storageAccounts.stream()
-            .allMatch(sa -> azureResourceDao.deleteStorageAccountMetadata(sa.getName(), null));
+            .allMatch(
+                sa ->
+                    azureResourceDao.deleteStorageAccountMetadata(
+                        sa.getName(), sa.getTopLevelContainer(), null));
 
     azureResourceDao.markUnusedApplicationDeploymentsForDelete(billingProfile.getId());
     azureResourceDao.deleteApplicationDeploymentMetadata(

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceDaoTest.java
@@ -13,6 +13,7 @@ import bio.terra.service.profile.ProfileDao;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
@@ -43,6 +44,9 @@ public class AzureResourceDaoTest {
 
   @Before
   public void setup() throws IOException, InterruptedException {
+    UUID datasetId = UUID.randomUUID();
+    UUID snapshotId = UUID.randomUUID();
+
     // Initialize list;
     applicationDeployments = new ArrayList<>();
     storageAccounts = new ArrayList<>();
@@ -60,6 +64,7 @@ public class AzureResourceDaoTest {
     var sa1 =
         azureResourceDao.createAndLockStorage(
             ProfileFixtures.randomizeName("sa1"),
+            datasetId.toString(),
             appDeployment,
             AzureRegion.DEFAULT_AZURE_REGION,
             null);
@@ -68,6 +73,7 @@ public class AzureResourceDaoTest {
     var sa2 =
         azureResourceDao.createAndLockStorage(
             ProfileFixtures.randomizeName("sa2"),
+            snapshotId.toString(),
             appDeployment,
             AzureRegion.DEFAULT_AZURE_REGION,
             null);
@@ -125,9 +131,11 @@ public class AzureResourceDaoTest {
               azureResourceDao.retrieveStorageAccountById(sa.getResourceId()),
               equalTo(sa));
           assertThat(
-              "Can fetch storage account by name",
+              "Can fetch storage account by name and container",
               azureResourceDao.getStorageAccount(
-                  sa.getName(), sa.getApplicationResource().getAzureApplicationDeploymentName()),
+                  sa.getName(),
+                  sa.getTopLevelContainer(),
+                  sa.getApplicationResource().getAzureApplicationDeploymentName()),
               equalTo(sa));
         });
   }

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountServiceTest.java
@@ -47,6 +47,7 @@ public class AzureStorageAccountServiceTest {
   private static final String MANAGED_GROUP_NAME = "mgd-grp-1";
   private static final String STORAGE_ACCOUNT_NAME = "sa1";
   private static final String APPLICATION_DEPLOYMENT_NAME = "appdeployment";
+  private static final String COLLECTION_ID = UUID.randomUUID().toString();
   private static final AzureRegion REGION = AzureRegion.CENTRAL_US;
   private static final AzureStorageAccountSkuType STORAGE_SKU_TYPE =
       AzureStorageAccountSkuType.STANDARD_LRS;
@@ -125,7 +126,8 @@ public class AzureStorageAccountServiceTest {
   @Test
   public void tesGetOrCreateStorageAccountCase1() throws InterruptedException {
     String flight = ShortUUID.get();
-    when(resourceDao.getStorageAccount(STORAGE_ACCOUNT_NAME, APPLICATION_DEPLOYMENT_NAME))
+    when(resourceDao.getStorageAccount(
+            STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
         .thenReturn(
             new AzureStorageAccountResource()
                 .name(STORAGE_ACCOUNT_NAME)
@@ -134,16 +136,18 @@ public class AzureStorageAccountServiceTest {
     when(storageAccounts.getByResourceGroup(MANAGED_GROUP_NAME, STORAGE_ACCOUNT_NAME))
         .thenReturn(storageAccount);
 
-    service.getOrCreateStorageAccount(STORAGE_ACCOUNT_NAME, applicationResource, REGION, flight);
+    service.getOrCreateStorageAccount(
+        STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
 
     // Create finish doesn't get called
-    verify(resourceDao, never()).unlockStorageAccount(any(), any());
+    verify(resourceDao, never()).unlockStorageAccount(any(), any(), any());
   }
 
   @Test
   public void tesGetOrCreateStorageAccountCase2() {
     String flight = ShortUUID.get();
-    when(resourceDao.getStorageAccount(STORAGE_ACCOUNT_NAME, APPLICATION_DEPLOYMENT_NAME))
+    when(resourceDao.getStorageAccount(
+            STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
         .thenReturn(
             new AzureStorageAccountResource()
                 .name(STORAGE_ACCOUNT_NAME)
@@ -159,7 +163,7 @@ public class AzureStorageAccountServiceTest {
         () -> {
           try {
             service.getOrCreateStorageAccount(
-                STORAGE_ACCOUNT_NAME, applicationResource, REGION, flight);
+                STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
           } catch (InterruptedException e) {
             throw new RuntimeException(e);
           }
@@ -170,7 +174,8 @@ public class AzureStorageAccountServiceTest {
   @Test
   public void tesGetOrCreateStorageAccountCase3() throws InterruptedException {
     String flight = ShortUUID.get();
-    when(resourceDao.getStorageAccount(STORAGE_ACCOUNT_NAME, APPLICATION_DEPLOYMENT_NAME))
+    when(resourceDao.getStorageAccount(
+            STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
         .thenReturn(
             new AzureStorageAccountResource()
                 .name(STORAGE_ACCOUNT_NAME)
@@ -180,10 +185,11 @@ public class AzureStorageAccountServiceTest {
     when(storageAccounts.getByResourceGroup(MANAGED_GROUP_NAME, STORAGE_ACCOUNT_NAME))
         .thenReturn(storageAccount);
 
-    service.getOrCreateStorageAccount(STORAGE_ACCOUNT_NAME, applicationResource, REGION, flight);
+    service.getOrCreateStorageAccount(
+        STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
 
     // Called by createFinish
-    verify(resourceDao, times(1)).unlockStorageAccount(STORAGE_ACCOUNT_NAME, flight);
+    verify(resourceDao, times(1)).unlockStorageAccount(STORAGE_ACCOUNT_NAME, COLLECTION_ID, flight);
   }
 
   @Test
@@ -194,7 +200,8 @@ public class AzureStorageAccountServiceTest {
   @Test
   public void tesGetOrCreateStorageAccountCase5() {
     String flight = ShortUUID.get();
-    when(resourceDao.getStorageAccount(STORAGE_ACCOUNT_NAME, APPLICATION_DEPLOYMENT_NAME))
+    when(resourceDao.getStorageAccount(
+            STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
         .thenReturn(
             new AzureStorageAccountResource()
                 .name(STORAGE_ACCOUNT_NAME)
@@ -207,7 +214,7 @@ public class AzureStorageAccountServiceTest {
         () -> {
           try {
             service.getOrCreateStorageAccount(
-                STORAGE_ACCOUNT_NAME, applicationResource, REGION, flight);
+                STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
           } catch (InterruptedException e) {
             throw new RuntimeException(e);
           }
@@ -219,7 +226,8 @@ public class AzureStorageAccountServiceTest {
   @Test
   public void tesGetOrCreateStorageAccountCase6() {
     String flight = ShortUUID.get();
-    when(resourceDao.getStorageAccount(STORAGE_ACCOUNT_NAME, APPLICATION_DEPLOYMENT_NAME))
+    when(resourceDao.getStorageAccount(
+            STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
         .thenReturn(
             new AzureStorageAccountResource()
                 .name(STORAGE_ACCOUNT_NAME)
@@ -234,7 +242,7 @@ public class AzureStorageAccountServiceTest {
         () -> {
           try {
             service.getOrCreateStorageAccount(
-                STORAGE_ACCOUNT_NAME, applicationResource, REGION, flight);
+                STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
           } catch (InterruptedException e) {
             throw new RuntimeException(e);
           }
@@ -245,7 +253,8 @@ public class AzureStorageAccountServiceTest {
   @Test
   public void tesGetOrCreateStorageAccountCase7() throws InterruptedException {
     String flight = ShortUUID.get();
-    when(resourceDao.getStorageAccount(STORAGE_ACCOUNT_NAME, APPLICATION_DEPLOYMENT_NAME))
+    when(resourceDao.getStorageAccount(
+            STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
         .thenReturn(
             new AzureStorageAccountResource()
                 .name(STORAGE_ACCOUNT_NAME)
@@ -257,22 +266,24 @@ public class AzureStorageAccountServiceTest {
     mockStorageAccountNotFound();
     mockStorageAccountCreation();
 
-    service.getOrCreateStorageAccount(STORAGE_ACCOUNT_NAME, applicationResource, REGION, flight);
+    service.getOrCreateStorageAccount(
+        STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
 
     // Called by createFinish
-    verify(resourceDao, times(1)).unlockStorageAccount(STORAGE_ACCOUNT_NAME, flight);
+    verify(resourceDao, times(1)).unlockStorageAccount(STORAGE_ACCOUNT_NAME, COLLECTION_ID, flight);
   }
 
   @Test
   public void tesGetOrCreateStorageAccountCase8() throws InterruptedException {
     String flight = ShortUUID.get();
-    when(resourceDao.getStorageAccount(STORAGE_ACCOUNT_NAME, APPLICATION_DEPLOYMENT_NAME))
+    when(resourceDao.getStorageAccount(
+            STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
         .thenReturn(null);
     mockStorageAccountNotFound();
     mockStorageAccountCreation();
     // Mock creating the metadata record
-    when(resourceDao.createAndLockStorageAccount(
-            STORAGE_ACCOUNT_NAME, applicationResource, REGION, flight))
+    when(resourceDao.createAndLockStorage(
+            STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight))
         .thenReturn(
             new AzureStorageAccountResource()
                 .name(STORAGE_ACCOUNT_NAME)
@@ -280,10 +291,11 @@ public class AzureStorageAccountServiceTest {
                 .region(REGION)
                 // Locked by this flight flight
                 .flightId(flight));
-    service.getOrCreateStorageAccount(STORAGE_ACCOUNT_NAME, applicationResource, REGION, flight);
+    service.getOrCreateStorageAccount(
+        STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
 
     // Called by createFinish
-    verify(resourceDao, times(1)).unlockStorageAccount(STORAGE_ACCOUNT_NAME, flight);
+    verify(resourceDao, times(1)).unlockStorageAccount(STORAGE_ACCOUNT_NAME, COLLECTION_ID, flight);
   }
 
   private void mockStorageAccountNotFound() {

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceUnitTest.java
@@ -119,7 +119,7 @@ public class ResourceServiceUnitTest {
 
   @Test
   public void testGetOrCreateStorageAccount() throws Exception {
-    when(storageAccountService.getOrCreateStorageAccount(any(), any(), any(), any()))
+    when(storageAccountService.getOrCreateStorageAccount(any(), any(), any(), any(), any()))
         .thenReturn(storageAccountResource);
     when(storageAccountService.getStorageAccountResourceById(storageAccountId, true))
         .thenReturn(storageAccountResource);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotStorageAccountDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotStorageAccountDaoTest.java
@@ -87,7 +87,7 @@ public class SnapshotStorageAccountDaoTest {
                 .id(azureApplicationDeploymentResourceId)
                 .profileId(billingProfileId)
                 .storageAccountPrefix("tdr"));
-    when(storageAccountService.getOrCreateStorageAccount(any(), any(), any(), any()))
+    when(storageAccountService.getOrCreateStorageAccount(any(), any(), any(), any(), any()))
         .thenReturn(
             new AzureStorageAccountResource()
                 .region(AzureRegion.DEFAULT_AZURE_REGION)
@@ -97,11 +97,7 @@ public class SnapshotStorageAccountDaoTest {
 
     AzureStorageAccountResource azureStorageAccountResource =
         resourceService.createSnapshotStorageAccount(
-            snapshot.getName(),
-            snapshotId,
-            dataset.getStorageAccountRegion(),
-            billingProfile,
-            flightId);
+            snapshotId, dataset.getStorageAccountRegion(), billingProfile, flightId);
 
     assertThat(
         "Returns the new storage account resource", azureStorageAccountResource, notNullValue());

--- a/src/test/java/bio/terra/service/snapshot/SnapshotStorageAccountDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotStorageAccountDaoTest.java
@@ -65,13 +65,6 @@ public class SnapshotStorageAccountDaoTest {
                         AzureCloudResource.STORAGE_ACCOUNT,
                         AzureRegion.DEFAULT_AZURE_REGION)));
     Dataset dataset = new Dataset(summary);
-    Snapshot snapshot =
-        new Snapshot()
-            .id(snapshotId)
-            .profileId(billingProfileId)
-            .name("snapshotName")
-            .snapshotSources(
-                List.of(new SnapshotSource().dataset(new Dataset(summary).id(datasetId))));
     when(snapshotStorageAccountDao.getStorageAccountResourceIdForSnapshotId(snapshotId))
         .thenReturn(Optional.of(azureStorageAccountResourceId));
     when(storageAccountService.getStorageAccountResourceById(any(), anyBoolean()))

--- a/src/test/resources/application-integrationtest.properties
+++ b/src/test/resources/application-integrationtest.properties
@@ -8,6 +8,7 @@ it.ingestbucket=jade-testdata
 it.googleBillingAccountId=00708C-45D19D-27AAFA
 it.targetTenantId=efc08443-0082-4d6c-8931-c5794c156abd
 it.targetResourceGroupName=TDR_integration
+it.targetManagedResourceGroupName=mrg-tdr-dev-preview-20210622121222
 it.targetSubscriptionId=71d52ec1-5886-480a-9d6e-ed98cbf1f69f
 it.targetApplicationName=integrationapp
 it.sourceStorageAccountName=tdrintegrationsrc1


### PR DESCRIPTION
Doc describing the general approach of the change is here:
https://docs.google.com/document/d/1CmVQXpZ6_ZC9dJwglrtXes6PFigABX4l599TbeOu95g/edit#

The main idea with this PR is to change how many storage accounts we create when creating snapshots/datasets.

Today, we create a storage account for each dataset and snapshot and that quickly runs into the limit of storage accounts per subscription (250).  Given that we have some projects coming up that require creating hundreds (low thousands) of datasets/snapshots, this is no good.  This PR changes it so that a storage account is created per billing account + region combo and all of the Azure artifacts are pushed down a level. E.g.:
- The storage accounts per dataset/snapshot are now going to be containers
- The metadata/data/scratch containers are now going to be folders and storage account
- The storage account tables (those that weren't already) were renamed to use the ids of the datasets and snapshots instead of constants

I didn't really add a ton of new testing but rather modified the the Azure Integration test to count the number of storage accounts created (should be just one) and then explicitly delete the storage accounts (since we'll no longer do that in order to preserve logs)

A few notes:
- I didn't create a migration since so few users are impacted.  We'll have to go in and manually remove the existing Azure datasets and snapshots and re-create
- I made a drive by change for Azure snapshots to include the snapshot id in our access ids for global snapshots (we already do this for Google)