### PR TITLE
DR-2966 Add support for compact DRS ids

### DIFF
--- a/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
@@ -12,6 +12,8 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -123,7 +125,7 @@ public class ApplicationConfiguration {
    * having each such task create its own threadpool, this property is used to create a globally
    * accessible pool that should be used by all such operations.
    *
-   * <p>Note: this is different than than the flight threadpool.
+   * <p>Note: this is different than the flight threadpool.
    */
   private int numPerformanceThreads;
 
@@ -132,6 +134,12 @@ public class ApplicationConfiguration {
    * submit: maxPerformanceThreadQueueSize + numPerformanceThreads before you get an exception
    */
   private int maxPerformanceThreadQueueSize;
+
+  /**
+   * List of compact id prefixes that are allowed. TODO<DR-2985> This should be in addition to any
+   * prefix registered at identifiers.org that points back to this dnsName value
+   */
+  private List<String> compactIdPrefixAllowList = new ArrayList<>();
 
   public String getUserEmail() {
     return userEmail;
@@ -335,6 +343,14 @@ public class ApplicationConfiguration {
 
   public void setMaxPerformanceThreadQueueSize(int maxPerformanceThreadQueueSize) {
     this.maxPerformanceThreadQueueSize = maxPerformanceThreadQueueSize;
+  }
+
+  public List<String> getCompactIdPrefixAllowList() {
+    return compactIdPrefixAllowList;
+  }
+
+  public void setCompactIdPrefixAllowList(List<String> compactIdPrefixAllowList) {
+    this.compactIdPrefixAllowList = compactIdPrefixAllowList;
   }
 
   @Primary

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -27,7 +27,6 @@ import bio.terra.service.dataset.exception.TableNotFoundException;
 import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.filedata.DrsId;
 import bio.terra.service.filedata.DrsIdService;
-import bio.terra.service.filedata.DrsService;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import bio.terra.service.resourcemanagement.exception.AzureResourceException;
 import bio.terra.service.snapshot.Snapshot;
@@ -42,7 +41,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
 import com.microsoft.sqlserver.jdbc.SQLServerException;
-import java.net.URI;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -111,15 +109,15 @@ public class AzureSynapsePdao {
                     <if(c.isFileType)>
                        <if(c.arrayOf)>
                          <if(isGlobalFileIds)>
-                           (SELECT '[' + STRING_AGG('"drs://<hostname>/v2_' + [file_id] + '"', ',') + ']' FROM OPENJSON([<c.name>]) WITH ([file_id] VARCHAR(36) '$') WHERE [<c.name>] != '') AS [<c.name>]
+                           (SELECT '[' + STRING_AGG('"drs://<drsLocator>v2_' + [file_id] + '"', ',') + ']' FROM OPENJSON([<c.name>]) WITH ([file_id] VARCHAR(36) '$') WHERE [<c.name>] != '') AS [<c.name>]
                          <else>
-                           (SELECT '[' + STRING_AGG('"drs://<hostname>/v1_<snapshotId>_' + [file_id] + '"', ',') + ']' FROM OPENJSON([<c.name>]) WITH ([file_id] VARCHAR(36) '$') WHERE [<c.name>] != '') AS [<c.name>]
+                           (SELECT '[' + STRING_AGG('"drs://<drsLocator>v1_<snapshotId>_' + [file_id] + '"', ',') + ']' FROM OPENJSON([<c.name>]) WITH ([file_id] VARCHAR(36) '$') WHERE [<c.name>] != '') AS [<c.name>]
                          <endif>
                        <else>
                          <if(isGlobalFileIds)>
-                           'drs://<hostname>/v2_' + [<c.name>] AS [<c.name>]
+                           'drs://<drsLocator>v2_' + [<c.name>] AS [<c.name>]
                          <else>
-                           'drs://<hostname>/v1_<snapshotId>_' + [<c.name>] AS [<c.name>]
+                           'drs://<drsLocator>v1_<snapshotId>_' + [<c.name>] AS [<c.name>]
                          <endif>
                        <endif>
                     <else>
@@ -352,10 +350,7 @@ public class AzureSynapsePdao {
     if (StringUtils.isEmpty(drsUri)) {
       return Optional.empty();
     }
-    URI uri = URI.create(drsUri);
-    String fileName = DrsService.getLastNameFromPath(uri.getPath());
-    DrsId drsId = drsIdService.fromObjectId(fileName);
-
+    DrsId drsId = DrsIdService.fromUri(drsUri);
     return Optional.of(drsId.getFsObjectId());
   }
 
@@ -556,7 +551,8 @@ public class AzureSynapsePdao {
       String datasetDataSourceName,
       String snapshotDataSourceName,
       String translatedQuery,
-      boolean isGlobalFieldIds)
+      boolean isGlobalFieldIds,
+      String compactIdPrefix)
       throws SQLException, PdaoException {
     Map<String, Long> tableRowCounts = new HashMap<>();
 
@@ -575,7 +571,8 @@ public class AzureSynapsePdao {
             datasetDataSourceName,
             snapshotDataSourceName,
             rootTable.getSynapseColumns(),
-            isGlobalFieldIds);
+            isGlobalFieldIds,
+            compactIdPrefix);
 
     queryTemplate.add("query", translatedQuery);
     int rows;
@@ -606,7 +603,8 @@ public class AzureSynapsePdao {
         rootTableId,
         walkRelationships,
         tableRowCounts,
-        isGlobalFieldIds);
+        isGlobalFieldIds,
+        compactIdPrefix);
 
     return tableRowCounts;
   }
@@ -633,7 +631,8 @@ public class AzureSynapsePdao {
       String datasetDataSourceName,
       String snapshotDataSourceName,
       SnapshotRequestAssetModel requestModel,
-      boolean isGlobalFieldIds)
+      boolean isGlobalFieldIds,
+      String compactIdPrefix)
       throws SQLException, PdaoException {
     Map<String, Long> tableRowCounts = new HashMap<>();
 
@@ -652,7 +651,8 @@ public class AzureSynapsePdao {
             datasetDataSourceName,
             snapshotDataSourceName,
             rootTable.getSynapseColumns(),
-            isGlobalFieldIds);
+            isGlobalFieldIds,
+            compactIdPrefix);
 
     AssetColumn rootColumn = assetSpec.getRootColumn();
 
@@ -693,7 +693,8 @@ public class AzureSynapsePdao {
         rootTableId,
         walkRelationships,
         tableRowCounts,
-        isGlobalFieldIds);
+        isGlobalFieldIds,
+        compactIdPrefix);
 
     return tableRowCounts;
   }
@@ -706,7 +707,8 @@ public class AzureSynapsePdao {
       UUID startTableId,
       List<WalkRelationship> walkRelationships,
       Map<String, Long> tableRowCounts,
-      boolean isGlobalFieldIds) {
+      boolean isGlobalFieldIds,
+      String compactIdPrefix) {
     for (WalkRelationship relationship : walkRelationships) {
       if (relationship.visitRelationship(startTableId)) {
         createSnapshotParquetFilesByRelationship(
@@ -716,7 +718,8 @@ public class AzureSynapsePdao {
             datasetDataSourceName,
             snapshotDataSourceName,
             tableRowCounts,
-            isGlobalFieldIds);
+            isGlobalFieldIds,
+            compactIdPrefix);
         walkRelationships(
             snapshotId,
             assetSpec,
@@ -725,7 +728,8 @@ public class AzureSynapsePdao {
             relationship.getToTableId(),
             walkRelationships,
             tableRowCounts,
-            isGlobalFieldIds);
+            isGlobalFieldIds,
+            compactIdPrefix);
       }
     }
   }
@@ -747,6 +751,8 @@ public class AzureSynapsePdao {
    * @param datasetDataSourceName Azure data source associated with parent dataset
    * @param snapshotDataSourceName Azure data source associated with destination snapshot
    * @param tableRowCounts Map tracking the number of rows included in each table of the snapshot
+   * @param isGlobalFieldIds If true, configure query to use the global drs id format
+   * @param compactIdPrefix If specified, configure the query to use a compact drs id format
    * @throws SQLException
    */
   public void createSnapshotParquetFilesByRelationship(
@@ -756,7 +762,8 @@ public class AzureSynapsePdao {
       String datasetDataSourceName,
       String snapshotDataSourceName,
       Map<String, Long> tableRowCounts,
-      boolean isGlobalFieldIds) {
+      boolean isGlobalFieldIds,
+      String compactIdPrefix) {
     String fromTableName = relationship.getFromTableName();
     String toTableName = relationship.getToTableName();
     AssetTable toAssetTable = assetSpecification.getAssetTableByName(toTableName);
@@ -797,7 +804,8 @@ public class AzureSynapsePdao {
             datasetDataSourceName,
             snapshotDataSourceName,
             toAssetTable.getSynapseColumns(),
-            isGlobalFieldIds);
+            isGlobalFieldIds,
+            compactIdPrefix);
 
     queryTemplate.add("rootColumn", relationship.getToColumnName());
     queryTemplate.add("isRootColumnArray", toTableColumn.getDatasetColumn().isArrayOf());
@@ -862,7 +870,8 @@ public class AzureSynapsePdao {
       String datasetDataSourceName,
       String snapshotDataSourceName,
       SnapshotRequestRowIdModel rowIdModel,
-      boolean isGlobalFileIds)
+      boolean isGlobalFileIds,
+      String compactIdPrefix)
       throws SQLException, PdaoException {
     Map<String, Long> tableRowCounts = new HashMap<>();
 
@@ -896,7 +905,8 @@ public class AzureSynapsePdao {
                     datasetDataSourceName,
                     snapshotDataSourceName,
                     columns,
-                    isGlobalFileIds)
+                    isGlobalFileIds,
+                    compactIdPrefix)
                 .render();
 
         List<UUID> rowIds = rowIdTableModel.get().getRowIds();
@@ -924,7 +934,8 @@ public class AzureSynapsePdao {
       UUID snapshotId,
       String datasetDataSourceName,
       String snapshotDataSourceName,
-      boolean isGlobalFileIds)
+      boolean isGlobalFileIds,
+      String compactIdPrefix)
       throws SQLException {
     Map<String, Long> tableRowCounts = new HashMap<>();
 
@@ -942,7 +953,8 @@ public class AzureSynapsePdao {
                   datasetDataSourceName,
                   snapshotDataSourceName,
                   table.getSynapseColumns(),
-                  isGlobalFileIds)
+                  isGlobalFileIds,
+                  compactIdPrefix)
               .render();
       int rows = 0;
       try {
@@ -968,9 +980,16 @@ public class AzureSynapsePdao {
       String datasetDataSourceName,
       String snapshotDataSourceName,
       List<SynapseColumn> columns,
-      boolean isGlobalFileIds) {
+      boolean isGlobalFileIds,
+      String compactIdPrefix) {
     String snapshotTableName = IngestUtils.formatSnapshotTableName(snapshotId, tableName);
 
+    String drsLocator;
+    if (StringUtils.isEmpty(compactIdPrefix)) {
+      drsLocator = applicationConfiguration.getDnsName() + "/";
+    } else {
+      drsLocator = compactIdPrefix + ":";
+    }
     sqlCreateSnapshotTableTemplate
         .add("columns", columns)
         .add("tableName", snapshotTableName)
@@ -979,7 +998,7 @@ public class AzureSynapsePdao {
         .add("fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName())
         .add("ingestFileName", datasetParquetFileName)
         .add("ingestFileDataSourceName", datasetDataSourceName)
-        .add("hostname", applicationConfiguration.getDnsName())
+        .add("drsLocator", drsLocator)
         .add("snapshotId", snapshotId)
         .add("isGlobalFileIds", isGlobalFileIds);
 

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -42,6 +42,7 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
   private UUID duosFirecloudGroupId;
   private DuosFirecloudGroupModel duosFirecloudGroup;
   private boolean globalFileIds;
+  private String compactIdPrefix;
 
   @Override
   public CollectionType getCollectionType() {
@@ -257,6 +258,15 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
 
   public Snapshot globalFileIds(boolean globalFileIds) {
     this.globalFileIds = globalFileIds;
+    return this;
+  }
+
+  public String getCompactIdPrefix() {
+    return compactIdPrefix;
+  }
+
+  public Snapshot compactIdPrefix(String compactIdPrefix) {
+    this.compactIdPrefix = compactIdPrefix;
     return this;
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -181,8 +181,10 @@ public class SnapshotDao {
     logger.debug("createAndLock snapshot " + snapshot.getName());
 
     String sql =
-        "INSERT INTO snapshot (name, description, profile_id, project_resource_id, id, consent_code, flightid, creation_information, properties, global_file_ids) "
-            + "VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb, :properties::jsonb, :global_file_ids) ";
+        """
+        INSERT INTO snapshot (name, description, profile_id, project_resource_id, id, consent_code, flightid, creation_information, properties, global_file_ids, compact_id_prefix)
+        VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb, :properties::jsonb, :global_file_ids, :compact_id_prefix)
+        """;
     String creationInfo;
     try {
       creationInfo = objectMapper.writeValueAsString(snapshot.getCreationInformation());
@@ -202,7 +204,8 @@ public class SnapshotDao {
             .addValue("creation_information", creationInfo)
             .addValue(
                 "properties", DaoUtils.propertiesToString(objectMapper, snapshot.getProperties()))
-            .addValue("global_file_ids", snapshot.hasGlobalFileIds());
+            .addValue("global_file_ids", snapshot.hasGlobalFileIds())
+            .addValue("compact_id_prefix", snapshot.getCompactIdPrefix());
     try {
       jdbcTemplate.update(sql, params);
     } catch (DuplicateKeyException dkEx) {
@@ -416,6 +419,7 @@ public class SnapshotDao {
                               rs.getString("creation_information")))
                       .consentCode(rs.getString("consent_code"))
                       .globalFileIds(rs.getBoolean("global_file_ids"))
+                      .compactIdPrefix(rs.getString("compact_id_prefix"))
                       .properties(
                           DaoUtils.stringToProperties(objectMapper, rs.getString("properties")))
                       .duosFirecloudGroupId(rs.getObject("duos_firecloud_group_id", UUID.class)));

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -573,7 +573,8 @@ public class SnapshotService {
         .creationInformation(requestContents)
         .consentCode(snapshotRequestModel.getConsentCode())
         .properties(snapshotRequestModel.getProperties())
-        .globalFileIds(snapshotRequestModel.isGlobalFileIds());
+        .globalFileIds(snapshotRequestModel.isGlobalFileIds())
+        .compactIdPrefix(snapshotRequestModel.getCompactIdPrefix());
   }
 
   public List<UUID> getSourceDatasetIdsFromSnapshotRequest(
@@ -1058,7 +1059,8 @@ public class SnapshotService {
             .createdDate(snapshot.getCreatedDate().toString())
             .consentCode(snapshot.getConsentCode())
             .cloudPlatform(snapshot.getCloudPlatform())
-            .globalFileIds(snapshot.hasGlobalFileIds());
+            .globalFileIds(snapshot.hasGlobalFileIds())
+            .compactIdPrefix(snapshot.getCompactIdPrefix());
 
     // In case NONE is specified, this should supersede any other value being passed in
     if (include.contains(SnapshotRetrieveIncludeModel.NONE)) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByAssetParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByAssetParquetFilesAzureStep.java
@@ -49,7 +49,8 @@ public class CreateSnapshotByAssetParquetFilesAzureStep
               IngestUtils.getSourceDatasetDataSourceName(context.getFlightId()),
               IngestUtils.getTargetDataSourceName(context.getFlightId()),
               assetModel,
-              snapshotReq.isGlobalFileIds());
+              snapshotReq.isGlobalFileIds(),
+              snapshotReq.getCompactIdPrefix());
       workingMap.put(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, tableRowCounts);
     } catch (SQLException | PdaoException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByFullViewParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByFullViewParquetFilesAzureStep.java
@@ -41,7 +41,8 @@ public class CreateSnapshotByFullViewParquetFilesAzureStep
               snapshotId,
               IngestUtils.getSourceDatasetDataSourceName(context.getFlightId()),
               IngestUtils.getTargetDataSourceName(context.getFlightId()),
-              snapshotReq.isGlobalFileIds());
+              snapshotReq.isGlobalFileIds(),
+              snapshotReq.getCompactIdPrefix());
       workingMap.put(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, tableRowCounts);
     } catch (SQLException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByQueryParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByQueryParquetFilesAzureStep.java
@@ -72,7 +72,8 @@ public class CreateSnapshotByQueryParquetFilesAzureStep extends CreateSnapshotPa
               sourceDatasetDataSourceName,
               targetDataSourceName,
               sqlQuery,
-              snapshotReq.isGlobalFileIds());
+              snapshotReq.isGlobalFileIds(),
+              snapshot.getCompactIdPrefix());
       workingMap.put(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, tableRowCounts);
     } catch (SQLException | PdaoException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRowIdParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRowIdParquetFilesAzureStep.java
@@ -46,7 +46,8 @@ public class CreateSnapshotByRowIdParquetFilesAzureStep
               IngestUtils.getSourceDatasetDataSourceName(context.getFlightId()),
               IngestUtils.getTargetDataSourceName(context.getFlightId()),
               rowIdModel,
-              snapshotRequestModel.isGlobalFileIds());
+              snapshotRequestModel.isGlobalFileIds(),
+              snapshotRequestModel.getCompactIdPrefix());
       workingMap.put(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, tableRowCounts);
     } catch (SQLException | PdaoException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
@@ -1149,12 +1149,17 @@ public class BigQuerySnapshotPdao {
       String mapName = mapColumn.getFromColumn().getName();
 
       if (mapColumn.getFromColumn().isFileOrDirRef()) {
-
-        String drsPrefix;
+        String drsIdPrefix;
         if (snapshot.hasGlobalFileIds()) {
-          drsPrefix = "'drs://" + datarepoDnsName + "/v2_'";
+          drsIdPrefix = "v2_";
         } else {
-          drsPrefix = "'drs://" + datarepoDnsName + "/v1_" + snapshot.getId() + "_'";
+          drsIdPrefix = "v1_" + snapshot.getId() + "_";
+        }
+        String drsPrefix;
+        if (StringUtils.isEmpty(snapshot.getCompactIdPrefix())) {
+          drsPrefix = "'drs://" + datarepoDnsName + "/" + drsIdPrefix + "'";
+        } else {
+          drsPrefix = "'drs://" + snapshot.getCompactIdPrefix() + ":" + drsIdPrefix + "'";
         }
 
         if (targetColumn.isArrayOf()) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4872,6 +4872,8 @@ components:
           description: >
             if false, the drs ids will be in the format: v1_<snapshotid>_<fileid>
             if true, drs ids will be in the format: v2_<fileid>
+        compactIdPrefix:
+          $ref: '#/components/schemas/CompactIdPrefix'
       description: >
         Request for creating a snapshot.
         For now, the API only supports snapshots defined as a single dataset asset and
@@ -5133,6 +5135,8 @@ components:
           description: >
             if false, the drs ids will be in the format: v1_<snapshotid>_<fileid>
             if true, drs ids will be in the format: v2_<fileid>
+        compactIdPrefix:
+          $ref: '#/components/schemas/CompactIdPrefix'
       description: >
         SnapshotModel returns detailed data about an existing snapshot.
     SnapshotExportResponseModel:
@@ -5775,6 +5779,14 @@ components:
       enum: [ gcp, azure ]
       default: gcp
       description: Cloud platforms supported by TDR.
+
+    CompactIdPrefix:
+      type: string
+      description: >
+        if present, the drs URIs will be rendered using the compact id format (drs://<compactIdPrefix>:<drsId>)
+        instead of the original format (drs://<hostname>/<drsId>).  The format is [A-Za-z0-9._] and the prefix
+        must be registered at identifiers.org
+      example: drs.42
 
     PhsId:
       type: string

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,6 +83,7 @@ datarepo.bq.rateLimitRetries=3
 datarepo.bq.rateLimitRetryWaitMs=500
 datarepo.numPerformanceThreads=50
 datarepo.maxPerformanceThreadQueueSize=1000
+#datarepo.compactIdPrefixAllowList[0]=<compact id allowed to point back to TDR>
 sam.basePath=https://sam.dsde-dev.broadinstitute.org
 sam.stewardsGroupEmail=JadeStewards-dev@dev.test.firecloud.org
 sam.adminsGroupEmail=DataRepoAdmins@dev.test.firecloud.org

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -70,4 +70,5 @@
     <include file="changesets/20221104_v2drsids.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20230208_gcpautoclassbucket.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20230307_shedlock.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20230323_compactdrsids.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20230323_compactdrsids.yaml
+++ b/src/main/resources/db/changesets/20230323_compactdrsids.yaml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - changeSet:
+      id: compactdrsids
+      author: nm
+      changes:
+        - addColumn:
+            tableName: snapshot
+            columns:
+              name: compact_id_prefix
+              type: varchar(256)

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -282,8 +282,17 @@ public class ConnectedOperations {
   public SnapshotSummaryModel createSnapshot(
       DatasetSummaryModel datasetSummaryModel, String resourcePath, String infix) throws Exception {
 
+    SnapshotRequestModel snapshotRequest =
+        jsonLoader.loadObject(resourcePath, SnapshotRequestModel.class);
+    return createSnapshot(datasetSummaryModel, snapshotRequest, infix);
+  }
+
+  public SnapshotSummaryModel createSnapshot(
+      DatasetSummaryModel datasetSummaryModel, SnapshotRequestModel snapshotRequest, String infix)
+      throws Exception {
+
     MockHttpServletResponse response =
-        launchCreateSnapshot(datasetSummaryModel, resourcePath, infix);
+        launchCreateSnapshot(datasetSummaryModel, snapshotRequest, infix);
     SnapshotSummaryModel snapshotSummary = handleCreateSnapshotSuccessCase(response);
 
     return snapshotSummary;
@@ -305,6 +314,12 @@ public class ConnectedOperations {
       DatasetSummaryModel datasetSummaryModel, String resourcePath, String infix) throws Exception {
     SnapshotRequestModel snapshotRequest =
         jsonLoader.loadObject(resourcePath, SnapshotRequestModel.class);
+    return launchCreateSnapshot(datasetSummaryModel, snapshotRequest, infix);
+  }
+
+  public MockHttpServletResponse launchCreateSnapshot(
+      DatasetSummaryModel datasetSummaryModel, SnapshotRequestModel snapshotRequest, String infix)
+      throws Exception {
     String snapshotName = Names.randomizeNameInfix(snapshotRequest.getName(), infix);
 
     return launchCreateSnapshotName(datasetSummaryModel, snapshotRequest, snapshotName);

--- a/src/test/java/bio/terra/service/filedata/DrsIdTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsIdTest.java
@@ -43,6 +43,18 @@ public class DrsIdTest {
     assertThat("drsid toObjectId works", drsId.toDrsObjectId(), equalTo("v2_file"));
   }
 
+  @Test
+  public void testCompactDrsURI() {
+    DrsId drsId =
+        DrsId.builder().dnsname("dns").version("v2").fsObjectId("file").compactId(true).build();
+
+    assertThat("drsid constructor succeeds - dnsname", drsId.getDnsname(), equalTo("dns"));
+    assertThat("drsid constructor succeeds - version", drsId.getVersion(), equalTo("v2"));
+    assertThat("drsid constructor succeeds - fileId", drsId.getFsObjectId(), equalTo("file"));
+    assertThat("drsid toDrsUri works", drsId.toDrsUri(), equalTo("drs://dns:v2_file"));
+    assertThat("drsid toObjectId works", drsId.toDrsObjectId(), equalTo("v2_file"));
+  }
+
   @Test(expected = InvalidDrsIdException.class)
   public void testBadUri() {
     DrsId drsId =

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -157,11 +157,11 @@ public class DrsServiceTest {
     String bucketResourceId = UUID.randomUUID().toString();
     String storageAccountResourceId = UUID.randomUUID().toString();
     googleFileId = UUID.randomUUID();
-    DrsId googleDrsId = new DrsId("", "v1", snapshotId.toString(), googleFileId.toString());
+    DrsId googleDrsId = new DrsId("", "v1", snapshotId.toString(), googleFileId.toString(), false);
     googleDrsObjectId = googleDrsId.toDrsObjectId();
 
     UUID azureFileId = UUID.randomUUID();
-    DrsId azureDrsId = new DrsId("", "v1", snapshotId.toString(), azureFileId.toString());
+    DrsId azureDrsId = new DrsId("", "v1", snapshotId.toString(), azureFileId.toString(), false);
     azureDrsObjectId = azureDrsId.toDrsObjectId();
 
     googleFsFile =
@@ -278,7 +278,7 @@ public class DrsServiceTest {
         .thenReturn(bucketA);
     when(resourceService.lookupBucketMetadata(bucketB.getResourceId().toString()))
         .thenReturn(bucketB);
-    DrsId drsId = new DrsId("", "v2", null, googleFileId.toString());
+    DrsId drsId = new DrsId("", "v2", null, googleFileId.toString(), false);
     when(drsIdDao.retrieveReferencedSnapshotIds(any()))
         .thenReturn(List.of(snpId1, snpId2, snpId3, snpId4));
 
@@ -371,7 +371,7 @@ public class DrsServiceTest {
         .thenReturn(bucketA);
     when(resourceService.lookupStorageAccountMetadata(bucketB.getResourceId().toString()))
         .thenReturn(bucketB);
-    DrsId drsId = new DrsId("", "v2", null, googleFileId.toString());
+    DrsId drsId = new DrsId("", "v2", null, googleFileId.toString(), false);
     when(drsIdDao.retrieveReferencedSnapshotIds(any())).thenReturn(List.of(snpId1, snpId2));
 
     // Mock the files returned from the various snapshots
@@ -462,7 +462,7 @@ public class DrsServiceTest {
     UUID randomSnapshotId = UUID.randomUUID();
     when(snapshotService.retrieve(randomSnapshotId)).thenThrow(SnapshotNotFoundException.class);
     DrsId drsIdWithInvalidSnapshotId =
-        new DrsId("", "v1", randomSnapshotId.toString(), googleFileId.toString());
+        new DrsId("", "v1", randomSnapshotId.toString(), googleFileId.toString(), false);
     String drsObjectIdWithInvalidSnapshotId = drsIdWithInvalidSnapshotId.toDrsObjectId();
     assertThrows(
         DrsObjectNotFoundException.class,
@@ -674,7 +674,7 @@ public class DrsServiceTest {
                 i -> {
                   UUID googleFileId = UUID.randomUUID();
                   DrsId googleDrsId =
-                      new DrsId("", "v1", snapshotId.toString(), googleFileId.toString());
+                      new DrsId("", "v1", snapshotId.toString(), googleFileId.toString(), false);
                   return googleDrsId.toDrsObjectId();
                 })
             .toList();
@@ -692,7 +692,7 @@ public class DrsServiceTest {
                 i -> {
                   UUID azureFileId = UUID.randomUUID();
                   DrsId azureDrsId =
-                      new DrsId("", "v1", snapshotId.toString(), azureFileId.toString());
+                      new DrsId("", "v1", snapshotId.toString(), azureFileId.toString(), false);
                   return azureDrsId.toDrsObjectId();
                 })
             .toList();

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -160,7 +160,11 @@ public class AzureSynapsePdaoConnectedTest {
     IngestRequestModel ingestRequestModel =
         new IngestRequestModel().format(FormatEnum.CSV).csvSkipLeadingRows(2);
     testSynapseQuery(
-        ingestRequestModel, "azure-simple-dataset-ingest-request.csv", SAMPLE_DATA_CSV, false);
+        ingestRequestModel,
+        "azure-simple-dataset-ingest-request.csv",
+        SAMPLE_DATA_CSV,
+        false,
+        null);
   }
 
   @Test
@@ -183,7 +187,8 @@ public class AzureSynapsePdaoConnectedTest {
         nonStandardIngestRequestModel,
         "azure-simple-dataset-ingest-request-non-standard.csv",
         testData,
-        false);
+        false,
+        null);
 
     List<String> textCols =
         synapseUtils.readParquetFileStringColumn(
@@ -199,20 +204,27 @@ public class AzureSynapsePdaoConnectedTest {
   @Test
   public void testSynapseQueryJSON() throws Exception {
     IngestRequestModel ingestRequestModel = new IngestRequestModel().format(FormatEnum.JSON);
-    testSynapseQuery(ingestRequestModel, "azure-ingest-request.json", SAMPLE_DATA, false);
+    testSynapseQuery(ingestRequestModel, "azure-ingest-request.json", SAMPLE_DATA, false, null);
   }
 
   @Test
   public void testSynapseQueryJSONWithGlobalFileIds() throws Exception {
     IngestRequestModel ingestRequestModel = new IngestRequestModel().format(FormatEnum.JSON);
-    testSynapseQuery(ingestRequestModel, "azure-ingest-request.json", SAMPLE_DATA, true);
+    testSynapseQuery(ingestRequestModel, "azure-ingest-request.json", SAMPLE_DATA, true, null);
+  }
+
+  @Test
+  public void testSynapseQueryJSONWithGlobalFileIdsAndCompactIds() throws Exception {
+    IngestRequestModel ingestRequestModel = new IngestRequestModel().format(FormatEnum.JSON);
+    testSynapseQuery(ingestRequestModel, "azure-ingest-request.json", SAMPLE_DATA, true, "foo.0");
   }
 
   private void testSynapseQuery(
       IngestRequestModel ingestRequestModel,
       String ingestFileLocation,
       List<Map<String, Optional<Object>>> expectedData,
-      boolean isGlobalFileIds)
+      boolean isGlobalFileIds,
+      String compactIdPrefix)
       throws Exception {
     // ---- part 1 - ingest metadata into parquet files associated with dataset
     DatasetTable destinationTable =
@@ -239,7 +251,8 @@ public class AzureSynapsePdaoConnectedTest {
             snapshotId,
             sourceDatasetDataSourceName,
             snapshotDataSourceName,
-            isGlobalFileIds);
+            isGlobalFileIds,
+            compactIdPrefix);
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "all_data_types"));
     // Test that parquet files are correctly generated
     String snapshotParquetFileName =

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
@@ -141,7 +141,8 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
         sourceDatasetDataSourceName,
         snapshotDataSourceName,
         new SnapshotRequestAssetModel().assetName(assetName).addRootValuesItem(rootValue),
-        false);
+        false,
+        null);
   }
 
   @Test
@@ -187,7 +188,8 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
             sourceDatasetDataSourceName,
             snapshotDataSourceName,
             new SnapshotRequestAssetModel().assetName(assetName).addRootValuesItem(rootValue),
-            false);
+            false,
+            null);
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "participant"));
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "sample"));
 
@@ -228,7 +230,8 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
             sourceDatasetDataSourceName,
             snapshotDataSourceName,
             new SnapshotRequestAssetModel().assetName(assetName).addRootValuesItem(rootValue),
-            false);
+            false,
+            null);
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "participant"));
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "date_of_birth"));
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "all_data_types"));
@@ -279,7 +282,8 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
             sourceDatasetDataSourceName,
             snapshotDataSourceName,
             translatedQuery,
-            false);
+            false,
+            null);
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "participant"));
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "date_of_birth"));
     synapseUtils.addTableName(IngestUtils.formatSnapshotTableName(snapshotId, "all_data_types"));

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoUnitTest.java
@@ -83,7 +83,8 @@ public class AzureSynapsePdaoUnitTest {
             "datasetDataSource1",
             "snapshotDataSource1",
             requestAssetModel,
-            false);
+            false,
+            null);
     assertThat(
         "Table has 2 rows",
         tableRowCounts.get(assetSpec.getRootTable().getTable().getName()),
@@ -106,7 +107,8 @@ public class AzureSynapsePdaoUnitTest {
         "datasetDataSource1",
         "snapshotDataSource1",
         requestAssetModel,
-        false);
+        false,
+        null);
   }
 
   @Test(expected = PdaoException.class)
@@ -124,7 +126,8 @@ public class AzureSynapsePdaoUnitTest {
         "datasetDataSource1",
         "snapshotDataSource1",
         requestAssetModel,
-        false);
+        false,
+        null);
   }
 
   @Test
@@ -141,7 +144,8 @@ public class AzureSynapsePdaoUnitTest {
         "datasetDataSourceName1",
         "snapshotDataSourceName1",
         tableRowCounts,
-        false);
+        false,
+        null);
     assertThat(
         "Correct row count returned for sample table", tableRowCounts.get("sample"), equalTo(3L));
   }
@@ -158,7 +162,8 @@ public class AzureSynapsePdaoUnitTest {
         "datasetDataSourceName1",
         "snapshotDataSourceName1",
         tableRowCounts,
-        false);
+        false,
+        null);
     assertThat(
         "'FROM' table was not in tableRowCounts, so no rows were added",
         tableRowCounts.get("sample"),
@@ -228,7 +233,8 @@ public class AzureSynapsePdaoUnitTest {
         "datasetDataSourceName1",
         "snapshotDataSourceName1",
         new SnapshotRequestRowIdModel(),
-        false);
+        false,
+        null);
   }
 
   @Test
@@ -247,7 +253,8 @@ public class AzureSynapsePdaoUnitTest {
             "datasetDataSourceName1",
             "snapshotDataSourceName1",
             requestRowIdModel,
-            false);
+            false,
+            null);
     assertThat("Table has 2 rows", tableRowCounts.get("table1"), equalTo(2L));
   }
 
@@ -269,7 +276,8 @@ public class AzureSynapsePdaoUnitTest {
             "datasetDataSourceName1",
             "snapshotDataSourceName1",
             requestRowIdModel,
-            false);
+            false,
+            null);
     assertThat(
         "Table should have thrown exception, should should be set to 0 rows",
         tableRowCounts.get("table1"),
@@ -284,7 +292,12 @@ public class AzureSynapsePdaoUnitTest {
 
     Map<String, Long> tableRowCounts =
         azureSynapsePdaoSpy.createSnapshotParquetFiles(
-            tables, UUID.randomUUID(), "datasetDataSourceName1", "snapshotDataSourceName1", false);
+            tables,
+            UUID.randomUUID(),
+            "datasetDataSourceName1",
+            "snapshotDataSourceName1",
+            false,
+            null);
     assertThat("Table has 3 rows", tableRowCounts.get("table1"), equalTo(3L));
   }
 
@@ -296,7 +309,12 @@ public class AzureSynapsePdaoUnitTest {
 
     Map<String, Long> tableRowCounts =
         azureSynapsePdaoSpy.createSnapshotParquetFiles(
-            tables, UUID.randomUUID(), "datasetDataSourceName1", "snapshotDataSourceName1", false);
+            tables,
+            UUID.randomUUID(),
+            "datasetDataSourceName1",
+            "snapshotDataSourceName1",
+            false,
+            null);
     assertThat("Table has 0 rows", tableRowCounts.get("table1"), equalTo(0L));
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotFileLookupConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotFileLookupConnectedTest.java
@@ -26,6 +26,7 @@ import bio.terra.model.FileLoadModel;
 import bio.terra.model.FileModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.SnapshotModel;
+import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.auth.ras.EcmService;
@@ -266,7 +267,7 @@ public class SnapshotFileLookupConnectedTest {
      * WARNING: if making any changes to this test make sure to notify the #dsp-batch channel! Describe the change
      * and any consequences downstream to DRS clients.
      */
-    String fileUri = getFileRefIdFromSnapshot(snapshotSummary);
+    String fileUri = getFileRefIdFromSnapshot(snapshotSummary, "file_ref");
     DrsId drsId = drsIdService.fromUri(fileUri);
     DRSObject drsObject = connectedOperations.drsGetObjectSuccess(drsId.toDrsObjectId(), false);
     String filePath = drsObject.getAliases().get(0);
@@ -384,8 +385,7 @@ public class SnapshotFileLookupConnectedTest {
 
     // load a JSON file that contains the table rows to load into the test bucket
     String jsonFileName = "this-array-better-pass.json";
-    String dirInCloud =
-        "scratch/testExcludeLockedFromSnapshotFileLookups/" + UUID.randomUUID().toString();
+    String dirInCloud = "scratch/testExcludeLockedFromSnapshotFileLookups/" + UUID.randomUUID();
     BlobInfo ingestTableBlob =
         BlobInfo.newBuilder(testConfig.getIngestbucket(), dirInCloud + "/" + jsonFileName).build();
     Storage storage = StorageOptions.getDefaultInstance().getService();
@@ -416,7 +416,7 @@ public class SnapshotFileLookupConnectedTest {
      * WARNING: if making any changes to this test make sure to notify the #dsp-batch channel! Describe the change
      * and any consequences downstream to DRS clients.
      */
-    String fileUri = getFileRefIdFromSnapshot(snapshotSummary);
+    String fileUri = getFileRefIdFromSnapshot(snapshotSummary, "file_ref");
     DrsId drsId = drsIdService.fromUri(fileUri);
     DRSObject drsObject = connectedOperations.drsGetObjectSuccess(drsId.toDrsObjectId(), false);
     String filePath = drsObject.getAliases().get(0);
@@ -442,12 +442,83 @@ public class SnapshotFileLookupConnectedTest {
         "Retrieve snapshot file objects match", fsObjById, CoreMatchers.equalTo(fsObjByPath));
   }
 
+  // Note: the standard DRS URI mode gets tested with most DRS access methods
+  @Test
+  public void testDrsWithCompactId() throws Exception {
+    // create a dataset
+    DatasetSummaryModel datasetRefSummary =
+        SnapshotConnectedTestUtils.createTestDataset(
+            connectedOperations,
+            billingProfile,
+            "simple-with-array-and-single-filerefs-dataset.json");
+
+    // ingest a file
+    URI sourceUri = new URI("gs", "jade-testdata", "/fileloadprofiletest/1KBfile.txt", null, null);
+    String targetFilePath =
+        "/mm/" + Names.randomizeName("testdir") + "/testExcludeLockedFromSnapshotFileLookups.txt";
+    FileLoadModel fileLoadModel =
+        new FileLoadModel()
+            .sourcePath(sourceUri.toString())
+            .description("testExcludeLockedFromSnapshotFileLookups")
+            .mimeType("text/plain")
+            .targetPath(targetFilePath)
+            .profileId(billingProfile.getId());
+    FileModel fileModel =
+        connectedOperations.ingestFileSuccess(datasetRefSummary.getId(), fileLoadModel);
+
+    // generate a JSON file with the filerefs
+    String jsonLine =
+        "{\"name\":\"name1\", \"file_ref\":\"%s\", \"file_ref_a\": [\"%s\"]}\n"
+            .formatted(fileModel.getFileId(), fileModel.getFileId());
+
+    // load a JSON file that contains the table rows to load into the test bucket
+    String jsonFileName = "this-better-pass.json";
+    String dirInCloud =
+        "scratch/testExcludeLockedFromSnapshotFileLookups/" + UUID.randomUUID().toString();
+    BlobInfo ingestTableBlob =
+        BlobInfo.newBuilder(testConfig.getIngestbucket(), dirInCloud + "/" + jsonFileName).build();
+    Storage storage = StorageOptions.getDefaultInstance().getService();
+    storage.create(ingestTableBlob, jsonLine.getBytes(StandardCharsets.UTF_8));
+
+    // make sure the JSON file gets cleaned up on test teardown
+    connectedOperations.addScratchFile(dirInCloud + "/" + jsonFileName);
+
+    // ingest the tabular data from the JSON file we just generated
+    String gsPath = "gs://" + testConfig.getIngestbucket() + "/" + dirInCloud + "/" + jsonFileName;
+    IngestRequestModel ingestRequest1 =
+        new IngestRequestModel()
+            .format(IngestRequestModel.FormatEnum.JSON)
+            .table("tableA")
+            .path(gsPath);
+    connectedOperations.ingestTableSuccess(datasetRefSummary.getId(), ingestRequest1);
+
+    SnapshotRequestModel snapshotRequest =
+        jsonLoader
+            .loadObject("simple-with-filerefs-snapshot.json", SnapshotRequestModel.class)
+            .compactIdPrefix("foo.0");
+    // create a snapshot
+    SnapshotSummaryModel snapshotSummary =
+        connectedOperations.createSnapshot(datasetRefSummary, snapshotRequest, "");
+
+    // Iterate over file fields to verify DRS ids are valid
+    for (String fieldName : List.of("file_ref", "file_ref_a")) {
+      String fileUri = getFileRefIdFromSnapshot(snapshotSummary, fieldName);
+      DrsId drsId = DrsIdService.fromUri(fileUri);
+      DRSObject drsObject = connectedOperations.drsGetObjectSuccess(drsId.toDrsObjectId(), false);
+
+      assertEquals(
+          "Retrieve snapshot file by DRS id matches desc",
+          drsObject.getDescription(),
+          fileLoadModel.getDescription());
+    }
+  }
+
   private static final String queryForRefIdTemplate =
-      "SELECT file_ref FROM `<project>.<snapshot>.<table>` WHERE file_ref IS NOT NULL";
+      "SELECT <fieldName> FROM `<project>.<snapshot>.<table>` WHERE file_ref IS NOT NULL";
 
   // Technically a helper method, but so specific to testExcludeLockedFromSnapshotFileLookups,
   // likely not re-useable
-  private String getFileRefIdFromSnapshot(SnapshotSummaryModel snapshotSummary)
+  private String getFileRefIdFromSnapshot(SnapshotSummaryModel snapshotSummary, String fieldName)
       throws InterruptedException {
     Snapshot snapshot = snapshotDao.retrieveSnapshotByName(snapshotSummary.getName());
     BigQueryProject bigQueryProject =
@@ -458,6 +529,7 @@ public class SnapshotFileLookupConnectedTest {
     sqlTemplate.add("project", snapshot.getProjectResource().getGoogleProjectId());
     sqlTemplate.add("snapshot", snapshot.getName());
     sqlTemplate.add("table", "tableA");
+    sqlTemplate.add("fieldName", fieldName);
 
     QueryJobConfiguration queryConfig =
         QueryJobConfiguration.newBuilder(sqlTemplate.render()).build();

--- a/src/test/resources/application-connectedtest.properties
+++ b/src/test/resources/application-connectedtest.properties
@@ -1,4 +1,5 @@
 datarepo.testWithEmbeddedDatabase=true
+datarepo.compactIdPrefixAllowList[0]=foo.0
 
 # ct for connected test
 ct.ingestBucket=jade-testdata

--- a/src/test/resources/simple-with-array-and-single-filerefs-dataset.json
+++ b/src/test/resources/simple-with-array-and-single-filerefs-dataset.json
@@ -1,0 +1,27 @@
+{
+  "name":        "SimpleWithArrayAndSingleFilerefs",
+  "description": "This is a sample dataset definition with filerefs",
+  "schema":      {
+    "tables":        [
+      {
+        "name":    "tableA",
+        "columns": [
+          {"name": "name", "datatype": "string"},
+          {"name": "file_ref", "datatype": "fileref", "array_of": false },
+          {"name": "file_ref_a", "datatype": "fileref", "array_of": true }
+        ]
+      }
+    ],
+    "assets":
+    [
+      {
+        "name":   "simpleasset",
+        "rootTable": "tableA",
+        "rootColumn": "name",
+        "tables": [
+          {"name": "tableA", "columns": []}
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Introduces a field in the Snapshot creation request `compactIdPrefix` that, if specified, will cause the displayed drs URLs in a snapshots BigQuery or Parquet files to use the compact id format.  E.g. DRS URLs that would have looked like:
`drs://data.terra.bio/v2_<fileid>`
will now look like:
`drs://<compact id prefix>:v2_<fileid>`

This values is also returned as part of the snapshot detail object.

A note on verification.

There is a follow-on ticket to allow for verifying the prefix with the central identifiers.org site.  The challenge there is that we're still working on how to register with them and, more importantly, this approach makes it harder to test.  As a result, this PR adds a new configuration option which allows the application to have an allowlist for valid comact id prefixes (e.g. without needing to validate with the central site)

This PR is best reviewed commit by commit

Oh, and you can see it in action here!
https://jade-nm.datarepo-dev.broadinstitute.org/snapshots/4aee8d01-4f91-4df0-a921-5a319195b7a3/data