### PR TITLE
DR-2935 Add upgrade method to convert random file ids to predicable file ids

### DIFF
--- a/src/main/java/bio/terra/common/PdaoConstant.java
+++ b/src/main/java/bio/terra/common/PdaoConstant.java
@@ -29,6 +29,9 @@ public final class PdaoConstant {
       PDAO_PREFIX + "transaction_terminated_by";
   public static final String PDAO_LOAD_HISTORY_STAGING_TABLE_PREFIX =
       PDAO_LOAD_HISTORY_TABLE + "_staging_";
+  public static final String PDAO_FILE_ID_STAGING_TABLE = PDAO_PREFIX + "file_id_staging";
+  public static final String PDAO_FILE_ID_STAGING_ORIG_ID = "orig_id";
+  public static final String PDAO_FILE_ID_STAGING_NEW_ID = "new_id";
   public static final String PDAO_INGESTED_BY_COLUMN = "ingested_by";
   public static final String PDAO_INGEST_TIME_COLUMN = "ingest_time";
   public static final String PDAO_LOAD_TAG_COLUMN = "load_tag";

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -768,6 +768,31 @@ public class DatasetDao {
   }
 
   /**
+   * Update a dataset's predictableFileIds flag
+   *
+   * @param id dataset UUID
+   * @param predictableFileIds sets the predictableFileIds flag in the dataset
+   * @return whether the dataset record was updated
+   */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public boolean setPredictableFileId(UUID id, boolean predictableFileIds) {
+    String sql =
+        """
+        UPDATE dataset SET predictable_file_ids = :predictable_file_ids
+        WHERE id = :id
+        """;
+
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("predictable_file_ids", predictableFileIds)
+            .addValue("id", id);
+
+    int rowsAffected = jdbcTemplate.update(sql, params);
+
+    return (rowsAffected == 1);
+  }
+
+  /**
    * Probe to see if can access database
    *
    * @return status and if failure, exception message in RepositoryStatusModelSystems model

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -322,6 +322,11 @@ public class DatasetService {
     return datasetDao.retrieveSummaryById(id).toModel();
   }
 
+  public DatasetSummaryModel setPredictableFileIds(UUID id, boolean predictableFileIds) {
+    datasetDao.setPredictableFileId(id, predictableFileIds);
+    return datasetDao.retrieveSummaryById(id).toModel();
+  }
+
   public String ingestDataset(
       String id, IngestRequestModel ingestRequestModel, AuthenticatedUserRequest userReq) {
     // Fill in a default load id if the caller did not provide one in the ingest request.

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertFileIdUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertFileIdUtils.java
@@ -11,6 +11,8 @@ public class ConvertFileIdUtils {
   private ConvertFileIdUtils() {}
 
   public static final String FILE_ID_MAPPINGS_FIELD = "flightIdMappings";
+  public static final String DATASET_USES_PREDICTABLE_IDS_AT_START =
+      "datasetUsesPredictableIdsAtStart";
 
   public static Map<UUID, UUID> readFlightMappings(FlightMap workingMap) {
     return workingMap

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertFileIdUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertFileIdUtils.java
@@ -1,0 +1,23 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.stairway.FlightMap;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class ConvertFileIdUtils {
+
+  private ConvertFileIdUtils() {}
+
+  public static final String FILE_ID_MAPPINGS_FIELD = "flightIdMappings";
+
+  public static Map<UUID, UUID> readFlightMappings(FlightMap workingMap) {
+    return workingMap
+        .get(FILE_ID_MAPPINGS_FIELD, new TypeReference<Map<String, String>>() {})
+        .entrySet()
+        .stream()
+        .collect(
+            Collectors.toMap(e -> UUID.fromString(e.getKey()), e -> UUID.fromString(e.getValue())));
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqCreateStageTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqCreateStageTableStep.java
@@ -1,0 +1,64 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConvertToPredictableFileIdsBqCreateStageTableStep implements Step {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ConvertToPredictableFileIdsBqCreateStageTableStep.class);
+
+  private final UUID datasetId;
+  private final DatasetService datasetService;
+  private final BigQueryDatasetPdao bigQueryDatasetPdao;
+
+  public ConvertToPredictableFileIdsBqCreateStageTableStep(
+      UUID datasetId, DatasetService datasetService, BigQueryDatasetPdao bigQueryDatasetPdao) {
+    this.datasetId = datasetId;
+    this.datasetService = datasetService;
+    this.bigQueryDatasetPdao = bigQueryDatasetPdao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+
+    Map<UUID, UUID> oldToNewMappings =
+        ConvertFileIdUtils.readFlightMappings(context.getWorkingMap());
+
+    if (oldToNewMappings.isEmpty()) {
+      logger.info("No file ids to migrate");
+      return StepResult.getStepResultSuccess();
+    }
+
+    // Create the table
+    bigQueryDatasetPdao.createStagingFileIdMappingTable(dataset);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+    Map<UUID, UUID> oldToNewMappings =
+        ConvertFileIdUtils.readFlightMappings(context.getWorkingMap());
+
+    if (oldToNewMappings.isEmpty()) {
+      logger.info("No file ids to migrate");
+      return StepResult.getStepResultSuccess();
+    }
+
+    // Delete the table
+    bigQueryDatasetPdao.deleteStagingFileIdMappingTable(dataset);
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqDropStageTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqDropStageTableStep.java
@@ -1,0 +1,43 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConvertToPredictableFileIdsBqDropStageTableStep implements Step {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ConvertToPredictableFileIdsBqDropStageTableStep.class);
+
+  private final UUID datasetId;
+  private final DatasetService datasetService;
+  private final BigQueryDatasetPdao bigQueryDatasetPdao;
+
+  public ConvertToPredictableFileIdsBqDropStageTableStep(
+      UUID datasetId, DatasetService datasetService, BigQueryDatasetPdao bigQueryDatasetPdao) {
+    this.datasetId = datasetId;
+    this.datasetService = datasetService;
+    this.bigQueryDatasetPdao = bigQueryDatasetPdao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+
+    // Drop the table
+    bigQueryDatasetPdao.deleteStagingFileIdMappingTable(dataset);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqDropStageTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqDropStageTableStep.java
@@ -2,16 +2,16 @@ package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
 
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConvertToPredictableFileIdsBqDropStageTableStep implements Step {
+public class ConvertToPredictableFileIdsBqDropStageTableStep extends DefaultUndoStep {
   private static final Logger logger =
       LoggerFactory.getLogger(ConvertToPredictableFileIdsBqDropStageTableStep.class);
 
@@ -33,11 +33,6 @@ public class ConvertToPredictableFileIdsBqDropStageTableStep implements Step {
     // Drop the table
     bigQueryDatasetPdao.deleteStagingFileIdMappingTable(dataset);
 
-    return StepResult.getStepResultSuccess();
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqStageDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqStageDataStep.java
@@ -2,9 +2,9 @@ package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
 
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.Map;
@@ -12,7 +12,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConvertToPredictableFileIdsBqStageDataStep implements Step {
+public class ConvertToPredictableFileIdsBqStageDataStep extends DefaultUndoStep {
   private static final Logger logger =
       LoggerFactory.getLogger(ConvertToPredictableFileIdsBqStageDataStep.class);
 
@@ -34,17 +34,14 @@ public class ConvertToPredictableFileIdsBqStageDataStep implements Step {
         ConvertFileIdUtils.readFlightMappings(context.getWorkingMap());
 
     if (oldToNewMappings.isEmpty()) {
+      // Note: this situation might arise if either the file ids were already converted or if there
+      // are no fileids in this particular dataset
       logger.info("No file ids to migrate");
       return StepResult.getStepResultSuccess();
     }
     // Load file ids into the table
     bigQueryDatasetPdao.fileIdMappingToStagingTable(dataset, oldToNewMappings);
 
-    return StepResult.getStepResultSuccess();
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqStageDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqStageDataStep.java
@@ -1,0 +1,50 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConvertToPredictableFileIdsBqStageDataStep implements Step {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ConvertToPredictableFileIdsBqStageDataStep.class);
+
+  private final UUID datasetId;
+  private final DatasetService datasetService;
+  private final BigQueryDatasetPdao bigQueryDatasetPdao;
+
+  public ConvertToPredictableFileIdsBqStageDataStep(
+      UUID datasetId, DatasetService datasetService, BigQueryDatasetPdao bigQueryDatasetPdao) {
+    this.datasetId = datasetId;
+    this.datasetService = datasetService;
+    this.bigQueryDatasetPdao = bigQueryDatasetPdao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+    Map<UUID, UUID> oldToNewMappings =
+        ConvertFileIdUtils.readFlightMappings(context.getWorkingMap());
+
+    if (oldToNewMappings.isEmpty()) {
+      logger.info("No file ids to migrate");
+      return StepResult.getStepResultSuccess();
+    }
+    // Load file ids into the table
+    bigQueryDatasetPdao.fileIdMappingToStagingTable(dataset, oldToNewMappings);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqUpdateRowsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqUpdateRowsStep.java
@@ -1,0 +1,67 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.common.Column;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.flight.transactions.TransactionUtils;
+import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConvertToPredictableFileIdsBqUpdateRowsStep implements Step {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ConvertToPredictableFileIdsBqUpdateRowsStep.class);
+
+  private final UUID datasetId;
+  private final DatasetService datasetService;
+  private final BigQueryDatasetPdao bigQueryDatasetPdao;
+  private final AuthenticatedUserRequest authedUser;
+
+  public ConvertToPredictableFileIdsBqUpdateRowsStep(
+      UUID datasetId,
+      DatasetService datasetService,
+      BigQueryDatasetPdao bigQueryDatasetPdao,
+      AuthenticatedUserRequest authedUser) {
+    this.datasetId = datasetId;
+    this.datasetService = datasetService;
+    this.bigQueryDatasetPdao = bigQueryDatasetPdao;
+    this.authedUser = authedUser;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+    UUID transactionId = TransactionUtils.getTransactionId(context);
+    Map<UUID, UUID> oldToNewMappings =
+        ConvertFileIdUtils.readFlightMappings(context.getWorkingMap());
+
+    if (oldToNewMappings.isEmpty()) {
+      logger.info("No file ids to migrate");
+      return StepResult.getStepResultSuccess();
+    }
+    // Load file ids into the table
+    for (DatasetTable table : dataset.getTables()) {
+      logger.info("Migrating table {}", table.getName());
+
+      if (table.getColumns().stream().anyMatch(Column::isFileOrDirRef)) {
+        bigQueryDatasetPdao.insertNewFileIdsIntoDatasetTable(
+            dataset, table, transactionId, context.getFlightId(), authedUser);
+      }
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqUpdateRowsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqUpdateRowsStep.java
@@ -6,9 +6,9 @@ import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.dataset.flight.transactions.TransactionUtils;
+import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.Map;
@@ -16,7 +16,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConvertToPredictableFileIdsBqUpdateRowsStep implements Step {
+public class ConvertToPredictableFileIdsBqUpdateRowsStep extends DefaultUndoStep {
   private static final Logger logger =
       LoggerFactory.getLogger(ConvertToPredictableFileIdsBqUpdateRowsStep.class);
 
@@ -57,11 +57,6 @@ public class ConvertToPredictableFileIdsBqUpdateRowsStep implements Step {
       }
     }
 
-    return StepResult.getStepResultSuccess();
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsFlight.java
@@ -1,0 +1,107 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.common.JournalRecordUpdateEntryStep;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.flight.LockDatasetStep;
+import bio.terra.service.dataset.flight.UnlockDatasetStep;
+import bio.terra.service.dataset.flight.transactions.TransactionCommitStep;
+import bio.terra.service.dataset.flight.transactions.TransactionOpenStep;
+import bio.terra.service.filedata.FileIdService;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.journal.JournalService;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
+import bio.terra.service.tabulardata.google.bigquery.BigQueryTransactionPdao;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.RetryRuleRandomBackoff;
+import java.util.UUID;
+import org.springframework.context.ApplicationContext;
+
+public class ConvertToPredictableFileIdsFlight extends Flight {
+
+  public ConvertToPredictableFileIdsFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+    // get the required daos to pass into the steps
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+
+    ApplicationConfiguration appConfig = appContext.getBean(ApplicationConfiguration.class);
+    DatasetService datasetService = appContext.getBean(DatasetService.class);
+    SnapshotService snapshotService = appContext.getBean(SnapshotService.class);
+    FireStoreDao fileDao = appContext.getBean(FireStoreDao.class);
+    FileIdService fileIdService = appContext.getBean(FileIdService.class);
+    BigQueryTransactionPdao bigQueryTransactionPdao =
+        appContext.getBean(BigQueryTransactionPdao.class);
+    BigQueryDatasetPdao bigQueryDatasetPdao = appContext.getBean(BigQueryDatasetPdao.class);
+    JournalService journalService = appContext.getBean(JournalService.class);
+    AuthenticatedUserRequest userReq =
+        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+
+    UUID datasetId = inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), UUID.class);
+
+    RetryRuleRandomBackoff retryRule =
+        getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
+    addStep(new LockDatasetStep(datasetService, datasetId, false));
+
+    // Verify dataset can be upgraded
+    addStep(new ConvertToPredictableFileIdsVerifyDatasetStep(datasetId, snapshotService, userReq));
+
+    // Firestore steps
+    addStep(
+        new ConvertToPredictableFileIdsGetIdsStep(
+            datasetId, datasetService, fileDao, fileIdService),
+        retryRule);
+    addStep(
+        new ConvertToPredictableFileIdsUpdateFirestoreCollectionsStep(
+            datasetId, datasetService, fileDao),
+        retryRule);
+
+    // BQ steps
+    String transactionDesc = "Autocommit transaction";
+    addStep(
+        new TransactionOpenStep(
+            datasetService, bigQueryTransactionPdao, userReq, transactionDesc, false, false),
+        retryRule);
+    addStep(
+        new ConvertToPredictableFileIdsBqCreateStageTableStep(
+            datasetId, datasetService, bigQueryDatasetPdao));
+    addStep(
+        new ConvertToPredictableFileIdsBqStageDataStep(
+            datasetId, datasetService, bigQueryDatasetPdao),
+        retryRule);
+    addStep(
+        new ConvertToPredictableFileIdsBqUpdateRowsStep(
+            datasetId, datasetService, bigQueryDatasetPdao, userReq),
+        retryRule);
+    addStep(
+        new TransactionCommitStep(datasetService, bigQueryTransactionPdao, userReq, false, null),
+        retryRule);
+
+    // Update metadata
+    addStep(new ConvertToPredictableFileIdsUpdateMetadataStep(datasetId, datasetService));
+
+    // Record log message
+    addStep(new ConvertToPredictableFileIdsSetResponseStep(datasetId, datasetService));
+
+    // Cleanup steps
+    addStep(
+        new ConvertToPredictableFileIdsBqDropStageTableStep(
+            datasetId, datasetService, bigQueryDatasetPdao));
+
+    addStep(
+        new JournalRecordUpdateEntryStep(
+            journalService,
+            userReq,
+            datasetId,
+            IamResourceType.DATASET,
+            "FileIds converted to predictable ids on dataset."));
+    addStep(new UnlockDatasetStep(datasetService, datasetId, false));
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsGetIdsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsGetIdsStep.java
@@ -6,8 +6,8 @@ import bio.terra.service.filedata.FSFile;
 import bio.terra.service.filedata.FileIdService;
 import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.filedata.google.firestore.FireStoreUtils;
+import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.ArrayList;
@@ -21,7 +21,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConvertToPredictableFileIdsGetIdsStep implements Step {
+public class ConvertToPredictableFileIdsGetIdsStep extends DefaultUndoStep {
   private static final Logger logger =
       LoggerFactory.getLogger(ConvertToPredictableFileIdsGetIdsStep.class);
 
@@ -65,11 +65,6 @@ public class ConvertToPredictableFileIdsGetIdsStep implements Step {
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
     context.getWorkingMap().put(ConvertFileIdUtils.FILE_ID_MAPPINGS_FIELD, oldToNewMappings);
-    return StepResult.getStepResultSuccess();
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsGetIdsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsGetIdsStep.java
@@ -1,0 +1,75 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.FSFile;
+import bio.terra.service.filedata.FileIdService;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.firestore.FireStoreUtils;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.ListUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConvertToPredictableFileIdsGetIdsStep implements Step {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ConvertToPredictableFileIdsGetIdsStep.class);
+
+  private final UUID datasetId;
+  private final DatasetService datasetService;
+  private final FireStoreDao fileDao;
+  private final FileIdService fileIdService;
+
+  public ConvertToPredictableFileIdsGetIdsStep(
+      UUID datasetId,
+      DatasetService datasetService,
+      FireStoreDao fileDao,
+      FileIdService fileIdService) {
+    this.datasetId = datasetId;
+    this.datasetService = datasetService;
+    this.fileDao = fileDao;
+    this.fileIdService = fileIdService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+
+    // Retrieve existing file ids
+    List<String> existingFileIds = fileDao.retrieveAllFileIds(dataset, false);
+    List<FSFile> fsFiles = new ArrayList<>(existingFileIds.size());
+    for (var fileIdBatch :
+        ListUtils.partition(existingFileIds, FireStoreUtils.MAX_FIRESTORE_BATCH_SIZE)) {
+      fsFiles.addAll(fileDao.batchRetrieveById(dataset, fileIdBatch, 0));
+    }
+
+    // Calculate new file ids (and store as strings to avoid serialization issues)
+    Map<String, String> oldToNewMappings =
+        fsFiles.stream()
+            .map(
+                f ->
+                    Map.entry(
+                        f.getFileId().toString(),
+                        fileIdService.calculateFileId(true, f).toString()))
+            .filter(e -> !Objects.equals(e.getKey(), e.getValue()))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    context.getWorkingMap().put(ConvertFileIdUtils.FILE_ID_MAPPINGS_FIELD, oldToNewMappings);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsGetIdsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsGetIdsStep.java
@@ -65,6 +65,11 @@ public class ConvertToPredictableFileIdsGetIdsStep extends DefaultUndoStep {
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
     context.getWorkingMap().put(ConvertFileIdUtils.FILE_ID_MAPPINGS_FIELD, oldToNewMappings);
+    context
+        .getWorkingMap()
+        .put(
+            ConvertFileIdUtils.DATASET_USES_PREDICTABLE_IDS_AT_START,
+            dataset.hasPredictableFileIds());
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsSetResponseStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsSetResponseStep.java
@@ -1,0 +1,44 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.common.Column;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.Map;
+import java.util.UUID;
+
+public class ConvertToPredictableFileIdsSetResponseStep extends DefaultUndoStep {
+
+  private final UUID datasetId;
+  private final DatasetService datasetService;
+
+  public ConvertToPredictableFileIdsSetResponseStep(UUID datasetId, DatasetService datasetService) {
+    this.datasetId = datasetId;
+    this.datasetService = datasetService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+    Map<UUID, UUID> oldToNewMappings =
+        ConvertFileIdUtils.readFlightMappings(context.getWorkingMap());
+    long numTables = dataset.getTables().size();
+    long numTablesConverted =
+        dataset.getTables().stream()
+            .filter(t -> t.getColumns().stream().anyMatch(Column::isFileOrDirRef))
+            .count();
+    String responseMessage =
+        "Migrated dataset %s: %s file Ids updated across %s of %s tables"
+            .formatted(
+                dataset.toLogString(),
+                oldToNewMappings.keySet().size(),
+                numTablesConverted,
+                numTables);
+    context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), responseMessage);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateFirestoreCollectionsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateFirestoreCollectionsStep.java
@@ -40,11 +40,11 @@ public class ConvertToPredictableFileIdsUpdateFirestoreCollectionsStep implement
   public StepResult undoStep(FlightContext context) throws InterruptedException {
     Dataset dataset = datasetService.retrieve(datasetId);
     // Reverse the id mapping to revert
-    Map<UUID, UUID> oldToNewMappings =
+    Map<UUID, UUID> newToOldMappings =
         ConvertFileIdUtils.readFlightMappings(context.getWorkingMap()).entrySet().stream()
             .collect(Collectors.toMap(Entry::getValue, Entry::getKey));
 
-    fileDao.moveFileMetadata(dataset, oldToNewMappings);
+    fileDao.moveFileMetadata(dataset, newToOldMappings);
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateFirestoreCollectionsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateFirestoreCollectionsStep.java
@@ -1,0 +1,50 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class ConvertToPredictableFileIdsUpdateFirestoreCollectionsStep implements Step {
+
+  private final UUID datasetId;
+  private final DatasetService datasetService;
+  private final FireStoreDao fileDao;
+
+  public ConvertToPredictableFileIdsUpdateFirestoreCollectionsStep(
+      UUID datasetId, DatasetService datasetService, FireStoreDao fileDao) {
+    this.datasetId = datasetId;
+    this.datasetService = datasetService;
+    this.fileDao = fileDao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+    Map<UUID, UUID> oldToNewMappings =
+        ConvertFileIdUtils.readFlightMappings(context.getWorkingMap());
+
+    fileDao.moveFileMetadata(dataset, oldToNewMappings);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+    // Reverse the id mapping to revert
+    Map<UUID, UUID> oldToNewMappings =
+        ConvertFileIdUtils.readFlightMappings(context.getWorkingMap()).entrySet().stream()
+            .collect(Collectors.toMap(Entry::getValue, Entry::getKey));
+
+    fileDao.moveFileMetadata(dataset, oldToNewMappings);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMetadataStep.java
@@ -1,13 +1,13 @@
 package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
 
 import bio.terra.service.dataset.DatasetService;
-import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
 
-public class ConvertToPredictableFileIdsUpdateMetadataStep extends DefaultUndoStep {
+public class ConvertToPredictableFileIdsUpdateMetadataStep implements Step {
 
   private final UUID datasetId;
   private final DatasetService datasetService;
@@ -20,7 +20,20 @@ public class ConvertToPredictableFileIdsUpdateMetadataStep extends DefaultUndoSt
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+
     datasetService.setPredictableFileIds(datasetId, true);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    Boolean usesPredictableIdsAtStart =
+        context
+            .getWorkingMap()
+            .get(ConvertFileIdUtils.DATASET_USES_PREDICTABLE_IDS_AT_START, Boolean.class);
+    if (!usesPredictableIdsAtStart) {
+      datasetService.setPredictableFileIds(datasetId, false);
+    }
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMetadataStep.java
@@ -1,0 +1,26 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+
+public class ConvertToPredictableFileIdsUpdateMetadataStep extends DefaultUndoStep {
+
+  private final UUID datasetId;
+  private final DatasetService datasetService;
+
+  public ConvertToPredictableFileIdsUpdateMetadataStep(
+      UUID datasetId, DatasetService datasetService) {
+    this.datasetId = datasetId;
+    this.datasetService = datasetService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    datasetService.setPredictableFileIds(datasetId, true);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsVerifyDatasetStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsVerifyDatasetStep.java
@@ -1,0 +1,47 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.EnumerateSortByParam;
+import bio.terra.model.SqlSortDirection;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.List;
+import java.util.UUID;
+
+public class ConvertToPredictableFileIdsVerifyDatasetStep extends DefaultUndoStep {
+
+  private final UUID datasetId;
+  private final SnapshotService snapshotService;
+  private final AuthenticatedUserRequest userReq;
+
+  public ConvertToPredictableFileIdsVerifyDatasetStep(
+      UUID datasetId, SnapshotService snapshotService, AuthenticatedUserRequest userReq) {
+    this.datasetId = datasetId;
+    this.snapshotService = snapshotService;
+    this.userReq = userReq;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    long numSnapshotsFromDataset =
+        snapshotService
+            .enumerateSnapshots(
+                userReq,
+                0,
+                1,
+                EnumerateSortByParam.CREATED_DATE,
+                SqlSortDirection.DESC,
+                null,
+                null,
+                List.of(datasetId))
+            .getFilteredTotal();
+    if (numSnapshotsFromDataset > 0) {
+      throw new IllegalArgumentException(
+          "Dataset file ids cannot be migrated when a snapshot has been created from it");
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsGcpStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotRecordFileIdsGcpStep.java
@@ -25,6 +25,6 @@ public class SnapshotRecordFileIdsGcpStep extends SnapshotRecordFileIdsStep {
 
   @Override
   List<String> getFileIds(FlightContext context, Snapshot snapshot) throws InterruptedException {
-    return fireStoreDao.retrieveAllFileIds(snapshot);
+    return fireStoreDao.retrieveAllFileIds(snapshot, true);
   }
 }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryDatasetPdao.java
@@ -385,14 +385,14 @@ public class BigQueryDatasetPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(insertLoadHistoryToStagingTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("stagingTable", PDAO_LOAD_HISTORY_STAGING_TABLE_PREFIX + tableName_FlightId);
-
-    sqlTemplate.add("load_history_array", loadHistoryArray);
-    sqlTemplate.add("load_tag", loadTag);
-    sqlTemplate.add("load_time", loadTime);
+    ST sqlTemplate =
+        new ST(insertLoadHistoryToStagingTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("stagingTable", PDAO_LOAD_HISTORY_STAGING_TABLE_PREFIX + tableName_FlightId)
+            .add("load_history_array", loadHistoryArray)
+            .add("load_tag", loadTag)
+            .add("load_time", loadTime);
 
     bigQueryProject.query(sqlTemplate.render());
   }
@@ -419,11 +419,12 @@ public class BigQueryDatasetPdao {
       bigQueryProject.createTable(datasetName, PDAO_LOAD_HISTORY_TABLE, buildLoadDatasetSchema());
     }
 
-    ST sqlTemplate = new ST(mergeLoadHistoryStagingTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", datasetName);
-    sqlTemplate.add("stagingTable", PDAO_LOAD_HISTORY_STAGING_TABLE_PREFIX + flightId);
-    sqlTemplate.add("loadTable", PDAO_LOAD_HISTORY_TABLE);
+    ST sqlTemplate =
+        new ST(mergeLoadHistoryStagingTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", datasetName)
+            .add("stagingTable", PDAO_LOAD_HISTORY_STAGING_TABLE_PREFIX + flightId)
+            .add("loadTable", PDAO_LOAD_HISTORY_TABLE);
 
     try {
       bigQueryProject.query(sqlTemplate.render());
@@ -447,12 +448,13 @@ public class BigQueryDatasetPdao {
       Dataset dataset, String loadTag, int offset, int limit) {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
     String datasetName = BigQueryPdao.prefixName(dataset.getName());
-    var sqlTemplate = new ST(getLoadHistoryTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", datasetName);
-    sqlTemplate.add("loadTable", PDAO_LOAD_HISTORY_TABLE);
-    sqlTemplate.add("limit", limit);
-    sqlTemplate.add("offset", offset);
+    var sqlTemplate =
+        new ST(getLoadHistoryTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", datasetName)
+            .add("loadTable", PDAO_LOAD_HISTORY_TABLE)
+            .add("limit", limit)
+            .add("offset", offset);
 
     var query = sqlTemplate.render();
     QueryJobConfiguration queryConfig =
@@ -532,15 +534,16 @@ public class BigQueryDatasetPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(insertFileIdToStagingTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("stagingTable", PDAO_FILE_ID_STAGING_TABLE);
+    ST sqlTemplate =
+        new ST(insertFileIdToStagingTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("stagingTable", PDAO_FILE_ID_STAGING_TABLE);
 
     List<FileIdMapping> fileIdArray =
         oldToNewMappings.entrySet().stream()
             .map(e -> new FileIdMapping(e.getKey(), e.getValue()))
-            .collect(Collectors.toList());
+            .toList();
     sqlTemplate.add("file_id_array", fileIdArray);
 
     bigQueryProject.query(sqlTemplate.render());
@@ -584,12 +587,13 @@ public class BigQueryDatasetPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(getRefIdsTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("table", tableName);
-    sqlTemplate.add("refCol", refColumn.getName());
-    sqlTemplate.add("array", refColumn.isArrayOf());
+    ST sqlTemplate =
+        new ST(getRefIdsTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("table", tableName)
+            .add("refCol", refColumn.getName())
+            .add("array", refColumn.isArrayOf());
 
     TableResult result = bigQueryProject.query(sqlTemplate.render());
     List<String> refIdArray = new ArrayList<>();
@@ -612,13 +616,14 @@ public class BigQueryDatasetPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(insertIntoDatasetTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("targetTable", targetTable.getRawTableName());
-    sqlTemplate.add("stagingTable", stagingTableName);
-    sqlTemplate.add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN);
-    sqlTemplate.add("columns", PDAO_ROW_ID_COLUMN);
+    ST sqlTemplate =
+        new ST(insertIntoDatasetTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("targetTable", targetTable.getRawTableName())
+            .add("stagingTable", stagingTableName)
+            .add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN)
+            .add("columns", PDAO_ROW_ID_COLUMN);
     targetTable.getColumns().forEach(column -> sqlTemplate.add("columns", column.getName()));
 
     bigQueryProject.query(
@@ -659,21 +664,22 @@ public class BigQueryDatasetPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(insertNewFileIdsIntoDatasetTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("softDeleteTable", targetTable.getSoftDeleteTableName());
-    sqlTemplate.add("flightIdColumn", PDAO_FLIGHT_ID_COLUMN);
-    sqlTemplate.add("deletedAtColumn", PDAO_DELETED_AT_COLUMN);
-    sqlTemplate.add("deletedByColumn", PDAO_DELETED_BY_COLUMN);
-    sqlTemplate.add("targetTable", targetTable.getRawTableName());
-    sqlTemplate.add("liveTable", targetTable.getName());
-    sqlTemplate.add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN);
-    sqlTemplate.add("rowIdColumn", PDAO_ROW_ID_COLUMN);
-    sqlTemplate.add("fileIdMappingTable", PDAO_FILE_ID_STAGING_TABLE);
-    sqlTemplate.add("origIdColumn", PDAO_FILE_ID_STAGING_ORIG_ID);
-    sqlTemplate.add("newIdColumn", PDAO_FILE_ID_STAGING_NEW_ID);
-    sqlTemplate.add("columns", targetTable.getColumns());
+    ST sqlTemplate =
+        new ST(insertNewFileIdsIntoDatasetTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("softDeleteTable", targetTable.getSoftDeleteTableName())
+            .add("flightIdColumn", PDAO_FLIGHT_ID_COLUMN)
+            .add("deletedAtColumn", PDAO_DELETED_AT_COLUMN)
+            .add("deletedByColumn", PDAO_DELETED_BY_COLUMN)
+            .add("targetTable", targetTable.getRawTableName())
+            .add("liveTable", targetTable.getName())
+            .add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN)
+            .add("rowIdColumn", PDAO_ROW_ID_COLUMN)
+            .add("fileIdMappingTable", PDAO_FILE_ID_STAGING_TABLE)
+            .add("origIdColumn", PDAO_FILE_ID_STAGING_ORIG_ID)
+            .add("newIdColumn", PDAO_FILE_ID_STAGING_NEW_ID)
+            .add("columns", targetTable.getColumns());
 
     bigQueryProject.query(
         sqlTemplate.render(),
@@ -703,17 +709,18 @@ public class BigQueryDatasetPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(insertIntoMetadataTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("metadataTable", metadataTableName);
-    sqlTemplate.add("stagingTable", stagingTableName);
-    sqlTemplate.add("rowIdColumn", PDAO_ROW_ID_COLUMN);
-    sqlTemplate.add("ingestEmail", email);
-    sqlTemplate.add("ingestByColumn", PDAO_INGESTED_BY_COLUMN);
-    sqlTemplate.add("ingestTimeColumn", PDAO_INGEST_TIME_COLUMN);
-    sqlTemplate.add("loadTag", loadTag);
-    sqlTemplate.add("loadTagColumn", PDAO_LOAD_TAG_COLUMN);
+    ST sqlTemplate =
+        new ST(insertIntoMetadataTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("metadataTable", metadataTableName)
+            .add("stagingTable", stagingTableName)
+            .add("rowIdColumn", PDAO_ROW_ID_COLUMN)
+            .add("ingestEmail", email)
+            .add("ingestByColumn", PDAO_INGESTED_BY_COLUMN)
+            .add("ingestTimeColumn", PDAO_INGEST_TIME_COLUMN)
+            .add("loadTag", loadTag)
+            .add("loadTagColumn", PDAO_LOAD_TAG_COLUMN);
 
     bigQueryProject.query(sqlTemplate.render());
   }
@@ -763,20 +770,21 @@ public class BigQueryDatasetPdao {
             targetTable,
             transactId,
             null);
-    ST sqlTemplate = new ST(insertIntoSoftDeleteDatasetTable(datasetLiveViewSql));
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("softDeleteTable", targetTable.getSoftDeleteTableName());
-    sqlTemplate.add("targetTable", targetTable.getRawTableName());
-    sqlTemplate.add("targetTableName", targetTable.getName());
-    sqlTemplate.add("stagingTable", stagingTableName);
-    sqlTemplate.add("rowIdColumn", PDAO_ROW_ID_COLUMN);
-    sqlTemplate.add("deleteAtColumn", PDAO_DELETED_AT_COLUMN);
-    sqlTemplate.add("deleteByColumn", PDAO_DELETED_BY_COLUMN);
-    sqlTemplate.add("loadTagColumn", PDAO_LOAD_TAG_COLUMN);
-    sqlTemplate.add("flightIdColumn", PDAO_FLIGHT_ID_COLUMN);
-    sqlTemplate.add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN);
-    sqlTemplate.add("pkColumns", targetTable.getPrimaryKey());
+    ST sqlTemplate =
+        new ST(insertIntoSoftDeleteDatasetTable(datasetLiveViewSql))
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("softDeleteTable", targetTable.getSoftDeleteTableName())
+            .add("targetTable", targetTable.getRawTableName())
+            .add("targetTableName", targetTable.getName())
+            .add("stagingTable", stagingTableName)
+            .add("rowIdColumn", PDAO_ROW_ID_COLUMN)
+            .add("deleteAtColumn", PDAO_DELETED_AT_COLUMN)
+            .add("deleteByColumn", PDAO_DELETED_BY_COLUMN)
+            .add("loadTagColumn", PDAO_LOAD_TAG_COLUMN)
+            .add("flightIdColumn", PDAO_FLIGHT_ID_COLUMN)
+            .add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN)
+            .add("pkColumns", targetTable.getPrimaryKey());
 
     bigQueryProject.query(
         sqlTemplate.render(),
@@ -994,14 +1002,15 @@ public class BigQueryDatasetPdao {
     String datasetLiveViewSql =
         renderDatasetLiveViewSql(projectId, datasetName, targetTable, transactionId, null);
 
-    ST sqlTemplate = new ST(stagingRowsWithoutSingleTargetRowMatchTemplate(datasetLiveViewSql));
-    sqlTemplate.add("count", PDAO_COUNT_ALIAS);
-    sqlTemplate.add("project", projectId);
-    sqlTemplate.add("dataset", datasetName);
-    sqlTemplate.add("targetTable", targetTable.getRawTableName());
-    sqlTemplate.add("stagingTable", stagingTableName);
-    sqlTemplate.add("pkColumns", targetTable.getPrimaryKey());
-    sqlTemplate.add("rowIdColumn", PDAO_ROW_ID_COLUMN);
+    ST sqlTemplate =
+        new ST(stagingRowsWithoutSingleTargetRowMatchTemplate(datasetLiveViewSql))
+            .add("count", PDAO_COUNT_ALIAS)
+            .add("project", projectId)
+            .add("dataset", datasetName)
+            .add("targetTable", targetTable.getRawTableName())
+            .add("stagingTable", stagingTableName)
+            .add("pkColumns", targetTable.getPrimaryKey())
+            .add("rowIdColumn", PDAO_ROW_ID_COLUMN);
 
     return bigQueryProject.query(
         sqlTemplate.render(),
@@ -1052,13 +1061,14 @@ public class BigQueryDatasetPdao {
     String datasetLiveViewSql =
         renderDatasetLiveViewSql(projectId, datasetName, targetTable, transactionId, null);
 
-    ST sqlTemplate = new ST(mergeIngestTemplate(datasetLiveViewSql));
-    sqlTemplate.add("project", projectId);
-    sqlTemplate.add("dataset", datasetName);
-    sqlTemplate.add("targetTable", targetTable.getRawTableName());
-    sqlTemplate.add("stagingTable", stagingTableName);
-    sqlTemplate.add("columns", targetTable.getColumns());
-    sqlTemplate.add("pkColumns", targetTable.getPrimaryKey());
+    ST sqlTemplate =
+        new ST(mergeIngestTemplate(datasetLiveViewSql))
+            .add("project", projectId)
+            .add("dataset", datasetName)
+            .add("targetTable", targetTable.getRawTableName())
+            .add("stagingTable", stagingTableName)
+            .add("columns", targetTable.getColumns())
+            .add("pkColumns", targetTable.getPrimaryKey());
 
     bigQueryProject.query(
         sqlTemplate.render(),
@@ -1109,26 +1119,27 @@ public class BigQueryDatasetPdao {
       DatasetTable table,
       UUID transactionId,
       Instant filterBefore) {
-    ST datasetLiveViewSql = new ST(liveViewTemplate(transactionId, filterBefore));
-    datasetLiveViewSql.add("project", bigQueryProject);
-    datasetLiveViewSql.add("dataset", datasetName);
-    datasetLiveViewSql.add("rawTable", table.getRawTableName());
-    datasetLiveViewSql.add("sdTable", table.getSoftDeleteTableName());
-    datasetLiveViewSql.add("transactionTable", PDAO_TRANSACTIONS_TABLE);
-    datasetLiveViewSql.add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN);
-    datasetLiveViewSql.add("transactStatusCol", PDAO_TRANSACTION_STATUS_COLUMN);
-    datasetLiveViewSql.add("partitionDateCol", PDAO_INGEST_DATE_COLUMN_ALIAS);
-    datasetLiveViewSql.add("transactionTerminatedAtCol", PDAO_TRANSACTION_TERMINATED_AT_COLUMN);
-    datasetLiveViewSql.add("transactStatusVal", TransactionModel.StatusEnum.ACTIVE);
-
-    datasetLiveViewSql.add("columns", PDAO_ROW_ID_COLUMN);
-    datasetLiveViewSql.add(
-        "columns", table.getColumns().stream().map(Column::getName).collect(Collectors.toList()));
-    datasetLiveViewSql.add(
-        "partitionByDate",
-        table.getBigQueryPartitionConfig() != null
-            && table.getBigQueryPartitionConfig().getMode()
-                == BigQueryPartitionConfigV1.Mode.INGEST_DATE);
+    ST datasetLiveViewSql =
+        new ST(liveViewTemplate(transactionId, filterBefore))
+            .add("project", bigQueryProject)
+            .add("dataset", datasetName)
+            .add("rawTable", table.getRawTableName())
+            .add("sdTable", table.getSoftDeleteTableName())
+            .add("transactionTable", PDAO_TRANSACTIONS_TABLE)
+            .add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN)
+            .add("transactStatusCol", PDAO_TRANSACTION_STATUS_COLUMN)
+            .add("partitionDateCol", PDAO_INGEST_DATE_COLUMN_ALIAS)
+            .add("transactionTerminatedAtCol", PDAO_TRANSACTION_TERMINATED_AT_COLUMN)
+            .add("transactStatusVal", TransactionModel.StatusEnum.ACTIVE)
+            .add("columns", PDAO_ROW_ID_COLUMN)
+            .add(
+                "columns",
+                table.getColumns().stream().map(Column::getName).collect(Collectors.toList()))
+            .add(
+                "partitionByDate",
+                table.getBigQueryPartitionConfig() != null
+                    && table.getBigQueryPartitionConfig().getMode()
+                        == BigQueryPartitionConfigV1.Mode.INGEST_DATE);
     return datasetLiveViewSql.render();
   }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -55,12 +55,13 @@ public abstract class BigQueryPdao {
 
     String bqDatasetName = prefixContainerName(container);
 
-    ST sqlTemplate = new ST(selectHasDuplicateStagingIdsTemplate);
-    sqlTemplate.add("count", PDAO_COUNT_ALIAS);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", bqDatasetName);
-    sqlTemplate.add("tableName", tableName);
-    sqlTemplate.add("pkColumns", pkColumns);
+    ST sqlTemplate =
+        new ST(selectHasDuplicateStagingIdsTemplate)
+            .add("count", PDAO_COUNT_ALIAS)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", bqDatasetName)
+            .add("tableName", tableName)
+            .add("pkColumns", pkColumns);
 
     return bigQueryProject.query(sqlTemplate.render());
   }

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQuerySnapshotPdao.java
@@ -139,22 +139,24 @@ public class BigQuerySnapshotPdao {
     UUID rootTableId = rootTable.getId();
 
     if (rowIds.size() > 0) {
-      ST sqlTemplate = new ST(loadRootRowIdsTemplate);
-      sqlTemplate.add("project", snapshotProjectId);
-      sqlTemplate.add("snapshot", snapshotName);
-      sqlTemplate.add("dataset", datasetBqDatasetName);
-      sqlTemplate.add("tableId", rootTableId);
-      sqlTemplate.add("rowIds", rowIds);
+      ST sqlTemplate =
+          new ST(loadRootRowIdsTemplate)
+              .add("project", snapshotProjectId)
+              .add("snapshot", snapshotName)
+              .add("dataset", datasetBqDatasetName)
+              .add("tableId", rootTableId)
+              .add("rowIds", rowIds);
       snapshotBigQueryProject.query(sqlTemplate.render());
     }
 
     String datasetLiveViewSql =
         BigQueryDatasetPdao.renderDatasetLiveViewSql(
             datasetProjectId, datasetBqDatasetName, rootTable, null, filterBefore);
-    ST sqlTemplate = new ST(validateRowIdsForRootTemplate);
-    sqlTemplate.add("snapshotProject", snapshotProjectId);
-    sqlTemplate.add("snapshot", snapshotName);
-    sqlTemplate.add("datasetLiveViewSql", datasetLiveViewSql);
+    ST sqlTemplate =
+        new ST(validateRowIdsForRootTemplate)
+            .add("snapshotProject", snapshotProjectId)
+            .add("snapshot", snapshotName)
+            .add("datasetLiveViewSql", datasetLiveViewSql);
 
     TableResult result =
         snapshotBigQueryProject.query(
@@ -259,22 +261,23 @@ public class BigQuerySnapshotPdao {
 
     for (DatasetTable table : tables) {
 
-      ST sqlTableTemplate = new ST(getLiveViewTableTemplate);
-      sqlTableTemplate.add("tableId", table.getId());
-      sqlTableTemplate.add("dataRepoRowId", PDAO_ROW_ID_COLUMN);
-      sqlTableTemplate.add(
-          "datasetLiveViewSql",
-          BigQueryDatasetPdao.renderDatasetLiveViewSql(
-              datasetBigQueryProject.getProjectId(),
-              datasetBqDatasetName,
-              table,
-              null,
-              creationStart));
+      ST sqlTableTemplate =
+          new ST(getLiveViewTableTemplate)
+              .add("tableId", table.getId())
+              .add("dataRepoRowId", PDAO_ROW_ID_COLUMN)
+              .add(
+                  "datasetLiveViewSql",
+                  BigQueryDatasetPdao.renderDatasetLiveViewSql(
+                      datasetBigQueryProject.getProjectId(),
+                      datasetBqDatasetName,
+                      table,
+                      null,
+                      creationStart));
 
       selectStatements.add(sqlTableTemplate.render());
     }
-    ST sqlMergeTablesTemplate = new ST(mergeLiveViewTablesTemplate);
-    sqlMergeTablesTemplate.add("selectStatements", selectStatements);
+    ST sqlMergeTablesTemplate =
+        new ST(mergeLiveViewTablesTemplate).add("selectStatements", selectStatements);
     return sqlMergeTablesTemplate.render();
   }
 
@@ -306,13 +309,14 @@ public class BigQuerySnapshotPdao {
           createSnapshotTableFromLiveViews(
               datasetBigQueryProject, tablesBatch, datasetBqDatasetName, filterBefore);
 
-      ST sqlTemplate = new ST(insertAllLiveViewDataTemplate);
-      sqlTemplate.add("snapshotProject", snapshotProjectId);
-      sqlTemplate.add("snapshot", snapshotName);
-      sqlTemplate.add("dataRepoTable", PDAO_ROW_ID_TABLE);
-      sqlTemplate.add("dataRepoTableId", PDAO_TABLE_ID_COLUMN);
-      sqlTemplate.add("dataRepoRowId", PDAO_ROW_ID_COLUMN);
-      sqlTemplate.add("liveViewTables", liveViewTables);
+      ST sqlTemplate =
+          new ST(insertAllLiveViewDataTemplate)
+              .add("snapshotProject", snapshotProjectId)
+              .add("snapshot", snapshotName)
+              .add("dataRepoTable", PDAO_ROW_ID_TABLE)
+              .add("dataRepoTableId", PDAO_TABLE_ID_COLUMN)
+              .add("dataRepoRowId", PDAO_ROW_ID_COLUMN)
+              .add("liveViewTables", liveViewTables);
 
       snapshotBigQueryProject.query(
           sqlTemplate.render(),
@@ -321,11 +325,12 @@ public class BigQuerySnapshotPdao {
               QueryParameterValue.timestamp(DateTimeUtils.toEpochMicros(filterBefore))));
     }
 
-    ST sqlValidateSnapshotTemplate = new ST(validateSnapshotSizeTemplate);
-    sqlValidateSnapshotTemplate.add("rowId", PDAO_ROW_ID_COLUMN);
-    sqlValidateSnapshotTemplate.add("snapshotProject", snapshotProjectId);
-    sqlValidateSnapshotTemplate.add("snapshot", snapshotName);
-    sqlValidateSnapshotTemplate.add("dataRepoTable", PDAO_ROW_ID_TABLE);
+    ST sqlValidateSnapshotTemplate =
+        new ST(validateSnapshotSizeTemplate)
+            .add("rowId", PDAO_ROW_ID_COLUMN)
+            .add("snapshotProject", snapshotProjectId)
+            .add("snapshot", snapshotName)
+            .add("dataRepoTable", PDAO_ROW_ID_TABLE);
 
     TableResult result = snapshotBigQueryProject.query(sqlValidateSnapshotTemplate.render());
     if (result.getTotalRows() <= 0) {
@@ -391,22 +396,24 @@ public class BigQuerySnapshotPdao {
 
         for (List<UUID> rowIdChunk :
             rowIdChunks) { // each loop will load a chunk of rowIds as an INSERT
-          ST sqlTemplate = new ST(loadRootRowIdsTemplate);
-          sqlTemplate.add("project", snapshotProjectId);
-          sqlTemplate.add("snapshot", snapshotName);
-          sqlTemplate.add("dataset", datasetBqDatasetName);
-          sqlTemplate.add("tableId", sourceTable.getId().toString());
-          sqlTemplate.add("rowIds", rowIdChunk);
+          ST sqlTemplate =
+              new ST(loadRootRowIdsTemplate)
+                  .add("project", snapshotProjectId)
+                  .add("snapshot", snapshotName)
+                  .add("dataset", datasetBqDatasetName)
+                  .add("tableId", sourceTable.getId().toString())
+                  .add("rowIds", rowIdChunk);
           snapshotBigQueryProject.query(sqlTemplate.render());
         }
       }
       String datasetLiveViewSql =
           BigQueryDatasetPdao.renderDatasetLiveViewSql(
               datasetProjectId, datasetBqDatasetName, datasetTable, null, filterBefore);
-      ST sqlTemplate = new ST(validateRowIdsForRootTemplate);
-      sqlTemplate.add("snapshotProject", snapshotProjectId);
-      sqlTemplate.add("snapshot", snapshotName);
-      sqlTemplate.add("datasetLiveViewSql", datasetLiveViewSql);
+      ST sqlTemplate =
+          new ST(validateRowIdsForRootTemplate)
+              .add("snapshotProject", snapshotProjectId)
+              .add("snapshot", snapshotName)
+              .add("datasetLiveViewSql", datasetLiveViewSql);
 
       TableResult result =
           snapshotBigQueryProject.query(
@@ -486,10 +493,11 @@ public class BigQuerySnapshotPdao {
             datasetTable,
             null,
             filterBefore);
-    ST sqlTemplate = new ST(mapValuesToRowsTemplate);
-    sqlTemplate.add("datasetLiveViewSql", datasetLiveViewSql);
-    sqlTemplate.add("column", column.getName());
-    sqlTemplate.add("inputVals", inputValues);
+    ST sqlTemplate =
+        new ST(mapValuesToRowsTemplate)
+            .add("datasetLiveViewSql", datasetLiveViewSql)
+            .add("column", column.getName())
+            .add("inputVals", inputValues);
 
     // Execute the query building the row id match structure that tracks the matching
     // ids and the mismatched ids
@@ -539,15 +547,16 @@ public class BigQuerySnapshotPdao {
     BigQueryProject datasetBigQueryProject = BigQueryProject.from(dataset);
     BigQueryProject snapshotBigQueryProject = BigQueryProject.from(snapshot);
 
-    ST sqlTemplate = new ST(getSnapshotRefIdsTemplate);
-    sqlTemplate.add("datasetProject", datasetBigQueryProject.getProjectId());
-    sqlTemplate.add("snapshotProject", snapshotBigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("snapshot", snapshot.getName());
-    sqlTemplate.add("table", tableName);
-    sqlTemplate.add("tableId", tableId);
-    sqlTemplate.add("refCol", refColumn.getName());
-    sqlTemplate.add("array", refColumn.isArrayOf());
+    ST sqlTemplate =
+        new ST(getSnapshotRefIdsTemplate)
+            .add("datasetProject", datasetBigQueryProject.getProjectId())
+            .add("snapshotProject", snapshotBigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("snapshot", snapshot.getName())
+            .add("table", tableName)
+            .add("tableId", tableId)
+            .add("refCol", refColumn.getName())
+            .add("array", refColumn.isArrayOf());
 
     TableResult result = snapshotBigQueryProject.query(sqlTemplate.render());
     List<String> refIdArray = new ArrayList<>();
@@ -618,15 +627,16 @@ public class BigQuerySnapshotPdao {
       DatasetTable rootTable = rootAssetTable.getTable();
       UUID rootTableId = rootTable.getId();
 
-      ST sqlTemplate = new ST(joinTablesToTestForMissingRowIds);
-      sqlTemplate.add("snapshotProject", snapshotProjectId);
-      sqlTemplate.add("snapshotDatasetName", snapshotName);
-      sqlTemplate.add("tempTable", PDAO_TEMP_TABLE);
-      sqlTemplate.add(
-          "datasetLiveViewSql",
-          BigQueryDatasetPdao.renderDatasetLiveViewSql(
-              datasetProjectId, datasetBqDatasetName, rootTable, null, filterBefore));
-      sqlTemplate.add("commonColumn", PDAO_ROW_ID_COLUMN);
+      ST sqlTemplate =
+          new ST(joinTablesToTestForMissingRowIds)
+              .add("snapshotProject", snapshotProjectId)
+              .add("snapshotDatasetName", snapshotName)
+              .add("tempTable", PDAO_TEMP_TABLE)
+              .add(
+                  "datasetLiveViewSql",
+                  BigQueryDatasetPdao.renderDatasetLiveViewSql(
+                      datasetProjectId, datasetBqDatasetName, rootTable, null, filterBefore))
+              .add("commonColumn", PDAO_ROW_ID_COLUMN);
 
       TableResult result =
           snapshotBigQueryProject.query(
@@ -649,14 +659,14 @@ public class BigQuerySnapshotPdao {
 
       // insert into the PDAO_ROW_ID_TABLE the literal that is the table id
       // and then all the row ids from the temp table
-      ST sqlLoadTemplate = new ST(loadRootRowIdsFromTempTableTemplate);
-      sqlLoadTemplate.add("snapshotProject", snapshotProjectId);
-      sqlLoadTemplate.add("snapshot", snapshotName);
-      sqlLoadTemplate.add("dataset", datasetBqDatasetName);
-      sqlLoadTemplate.add("tableId", rootTableId);
-      sqlLoadTemplate.add(
-          "commonColumn", PDAO_ROW_ID_COLUMN); // this is the disc from classic asset
-      sqlLoadTemplate.add("tempTable", PDAO_TEMP_TABLE);
+      ST sqlLoadTemplate =
+          new ST(loadRootRowIdsFromTempTableTemplate)
+              .add("snapshotProject", snapshotProjectId)
+              .add("snapshot", snapshotName)
+              .add("dataset", datasetBqDatasetName)
+              .add("tableId", rootTableId)
+              .add("commonColumn", PDAO_ROW_ID_COLUMN) // this is the disc from classic asset
+              .add("tempTable", PDAO_TEMP_TABLE);
       snapshotBigQueryProject.query(sqlLoadTemplate.render());
 
       // ST sqlValidateTemplate = new ST(validateRowIdsForRootTemplate);
@@ -733,10 +743,12 @@ public class BigQuerySnapshotPdao {
               datasetTable,
               null,
               filterBefore);
-      ST sqlTemplate = new ST(mapValuesToRowsTemplate); // This query fails w >100k rows
-      sqlTemplate.add("datasetLiveViewSql", datasetLiveViewSql);
-      sqlTemplate.add("column", rowIdColumn.getName());
-      sqlTemplate.add("inputVals", rowIdChunk);
+      // This query fails w >100k rows
+      ST sqlTemplate =
+          new ST(mapValuesToRowsTemplate)
+              .add("datasetLiveViewSql", datasetLiveViewSql)
+              .add("column", rowIdColumn.getName())
+              .add("inputVals", rowIdChunk);
 
       String sql = sqlTemplate.render();
       logger.debug("mapValuesToRows sql: " + sql);
@@ -1000,17 +1012,18 @@ public class BigQuerySnapshotPdao {
     fromTableTableSelect.add("tableSelect", liveViewSqlFrom);
     toTableTableSelect.add("tableSelect", liveViewSqlTo);
 
-    ST sqlTemplate = new ST(storeRowIdsForRelatedTableTemplate);
-    sqlTemplate.add("snapshotProject", snapshotProjectId);
-    sqlTemplate.add("datasetProject", datasetProjectId);
-    sqlTemplate.add("dataset", datasetBqDatasetName);
-    sqlTemplate.add("snapshot", snapshot.getName());
-    sqlTemplate.add("fromTableId", relationship.getFromTableId());
-    sqlTemplate.add("toTableId", relationship.getToTableId());
-    sqlTemplate.add("fromTableTableSelect", fromTableTableSelect.render());
-    sqlTemplate.add("toTableTableSelect", toTableTableSelect.render());
-    sqlTemplate.add("fromCol", fromCol);
-    sqlTemplate.add("toCol", toCol);
+    ST sqlTemplate =
+        new ST(storeRowIdsForRelatedTableTemplate)
+            .add("snapshotProject", snapshotProjectId)
+            .add("datasetProject", datasetProjectId)
+            .add("dataset", datasetBqDatasetName)
+            .add("snapshot", snapshot.getName())
+            .add("fromTableId", relationship.getFromTableId())
+            .add("toTableId", relationship.getToTableId())
+            .add("fromTableTableSelect", fromTableTableSelect.render())
+            .add("toTableTableSelect", toTableTableSelect.render())
+            .add("fromCol", fromCol)
+            .add("toCol", toCol);
 
     QueryJobConfiguration queryConfig =
         QueryJobConfiguration.newBuilder(sqlTemplate.render())
@@ -1076,13 +1089,14 @@ public class BigQuerySnapshotPdao {
                 throw new PdaoException(
                     "No matching map table for snapshot table " + table.getName());
               }
-              ST sqlTemplate = new ST(createViewsTemplate);
-              sqlTemplate.add("datasetProject", datasetProjectId);
-              sqlTemplate.add("snapshotProject", snapshotProjectId);
-              sqlTemplate.add("dataset", datasetBqDatasetName);
-              sqlTemplate.add("snapshot", snapshotName);
-              sqlTemplate.add("mapTable", mapTable.getFromTable().getRawTableName());
-              sqlTemplate.add("tableId", mapTable.getFromTable().getId().toString());
+              ST sqlTemplate =
+                  new ST(createViewsTemplate)
+                      .add("datasetProject", datasetProjectId)
+                      .add("snapshotProject", snapshotProjectId)
+                      .add("dataset", datasetBqDatasetName)
+                      .add("snapshot", snapshotName)
+                      .add("mapTable", mapTable.getFromTable().getRawTableName())
+                      .add("tableId", mapTable.getFromTable().getId().toString());
               table
                   .getColumns()
                   .forEach(

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryTransactionPdao.java
@@ -62,17 +62,17 @@ public class BigQueryTransactionPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(insertIntoTransactionTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("transactionTable", PDAO_TRANSACTIONS_TABLE);
-
-    sqlTemplate.add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN);
-    sqlTemplate.add("transactStatusCol", PDAO_TRANSACTION_STATUS_COLUMN);
-    sqlTemplate.add("transactLockCol", PDAO_TRANSACTION_LOCK_COLUMN);
-    sqlTemplate.add("transactDescriptionCol", PDAO_TRANSACTION_DESCRIPTION_COLUMN);
-    sqlTemplate.add("transactCreatedAtCol", PDAO_TRANSACTION_CREATED_AT_COLUMN);
-    sqlTemplate.add("transactCreatedByCol", PDAO_TRANSACTION_CREATED_BY_COLUMN);
+    ST sqlTemplate =
+        new ST(insertIntoTransactionTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("transactionTable", PDAO_TRANSACTIONS_TABLE)
+            .add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN)
+            .add("transactStatusCol", PDAO_TRANSACTION_STATUS_COLUMN)
+            .add("transactLockCol", PDAO_TRANSACTION_LOCK_COLUMN)
+            .add("transactDescriptionCol", PDAO_TRANSACTION_DESCRIPTION_COLUMN)
+            .add("transactCreatedAtCol", PDAO_TRANSACTION_CREATED_AT_COLUMN)
+            .add("transactCreatedByCol", PDAO_TRANSACTION_CREATED_BY_COLUMN);
 
     Instant filterBefore = Instant.now();
     TransactionModel transaction =
@@ -115,12 +115,12 @@ public class BigQueryTransactionPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(deleteFromTransactionTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("transactionTable", PDAO_TRANSACTIONS_TABLE);
-
-    sqlTemplate.add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN);
+    ST sqlTemplate =
+        new ST(deleteFromTransactionTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("transactionTable", PDAO_TRANSACTIONS_TABLE)
+            .add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN);
 
     bigQueryProject.query(
         sqlTemplate.render(),
@@ -145,15 +145,15 @@ public class BigQueryTransactionPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(updateTransactionTableLockTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("transactionTable", PDAO_TRANSACTIONS_TABLE);
-
-    sqlTemplate.add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN);
-    sqlTemplate.add("transactLockCol", PDAO_TRANSACTION_LOCK_COLUMN);
-    sqlTemplate.add("transactTerminatedAtCol", PDAO_TRANSACTION_TERMINATED_AT_COLUMN);
-    sqlTemplate.add("createdByCol", PDAO_TRANSACTION_CREATED_BY_COLUMN);
+    ST sqlTemplate =
+        new ST(updateTransactionTableLockTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("transactionTable", PDAO_TRANSACTIONS_TABLE)
+            .add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN)
+            .add("transactLockCol", PDAO_TRANSACTION_LOCK_COLUMN)
+            .add("transactTerminatedAtCol", PDAO_TRANSACTION_TERMINATED_AT_COLUMN)
+            .add("createdByCol", PDAO_TRANSACTION_CREATED_BY_COLUMN);
 
     String lockErrorMessage = "Transaction already locked or was created by another user";
     sqlTemplate.add("lockErrorMessage", lockErrorMessage);
@@ -194,15 +194,15 @@ public class BigQueryTransactionPdao {
     }
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(updateTransactionTableStatusTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("transactionTable", PDAO_TRANSACTIONS_TABLE);
-
-    sqlTemplate.add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN);
-    sqlTemplate.add("transactStatusCol", PDAO_TRANSACTION_STATUS_COLUMN);
-    sqlTemplate.add("transactTerminatedAtCol", PDAO_TRANSACTION_TERMINATED_AT_COLUMN);
-    sqlTemplate.add("transactTerminatedByCol", PDAO_TRANSACTION_TERMINATED_BY_COLUMN);
+    ST sqlTemplate =
+        new ST(updateTransactionTableStatusTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("transactionTable", PDAO_TRANSACTIONS_TABLE)
+            .add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN)
+            .add("transactStatusCol", PDAO_TRANSACTION_STATUS_COLUMN)
+            .add("transactTerminatedAtCol", PDAO_TRANSACTION_TERMINATED_AT_COLUMN)
+            .add("transactTerminatedByCol", PDAO_TRANSACTION_TERMINATED_BY_COLUMN);
 
     Instant terminatedAt = Instant.now();
 
@@ -238,14 +238,14 @@ public class BigQueryTransactionPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(enumerateTransactionsTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("transactionTable", PDAO_TRANSACTIONS_TABLE);
-
-    sqlTemplate.add("limit", limit);
-    sqlTemplate.add("offset", offset);
-    sqlTemplate.add("transactCreatedAtCol", PDAO_TRANSACTION_CREATED_AT_COLUMN);
+    ST sqlTemplate =
+        new ST(enumerateTransactionsTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("transactionTable", PDAO_TRANSACTIONS_TABLE)
+            .add("limit", limit)
+            .add("offset", offset)
+            .add("transactCreatedAtCol", PDAO_TRANSACTION_CREATED_AT_COLUMN);
 
     return StreamSupport.stream(
             bigQueryProject.query(sqlTemplate.render()).getValues().spliterator(), false)
@@ -260,12 +260,12 @@ public class BigQueryTransactionPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(retrieveTransactionTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("transactionTable", PDAO_TRANSACTIONS_TABLE);
-
-    sqlTemplate.add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN);
+    ST sqlTemplate =
+        new ST(retrieveTransactionTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("transactionTable", PDAO_TRANSACTIONS_TABLE)
+            .add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN);
 
     TableResult result =
         bigQueryProject.query(
@@ -303,20 +303,20 @@ public class BigQueryTransactionPdao {
       throws InterruptedException {
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(verifyTransactionTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("targetTable", datasetTable.getName());
-    sqlTemplate.add("metadataTable", datasetTable.getRowMetadataTableName());
-    sqlTemplate.add("rawDataTable", datasetTable.getRawTableName());
-    sqlTemplate.add("transactionTable", PDAO_TRANSACTIONS_TABLE);
-
-    sqlTemplate.add("rowIdColumn", PDAO_ROW_ID_COLUMN);
-    sqlTemplate.add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN);
-    sqlTemplate.add("transactStatusCol", PDAO_TRANSACTION_STATUS_COLUMN);
-    sqlTemplate.add("transactTerminatedAtCol", PDAO_TRANSACTION_TERMINATED_AT_COLUMN);
-    sqlTemplate.add("transactCreatedAtCol", PDAO_TRANSACTION_CREATED_AT_COLUMN);
-    sqlTemplate.add("pkColumns", datasetTable.getPrimaryKey());
+    ST sqlTemplate =
+        new ST(verifyTransactionTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("targetTable", datasetTable.getName())
+            .add("metadataTable", datasetTable.getRowMetadataTableName())
+            .add("rawDataTable", datasetTable.getRawTableName())
+            .add("transactionTable", PDAO_TRANSACTIONS_TABLE)
+            .add("rowIdColumn", PDAO_ROW_ID_COLUMN)
+            .add("transactIdCol", PDAO_TRANSACTION_ID_COLUMN)
+            .add("transactStatusCol", PDAO_TRANSACTION_STATUS_COLUMN)
+            .add("transactTerminatedAtCol", PDAO_TRANSACTION_TERMINATED_AT_COLUMN)
+            .add("transactCreatedAtCol", PDAO_TRANSACTION_CREATED_AT_COLUMN)
+            .add("pkColumns", datasetTable.getPrimaryKey());
 
     TableResult result =
         bigQueryProject.query(
@@ -346,11 +346,12 @@ public class BigQueryTransactionPdao {
     }
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(rollbackDatasetTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("targetTable", targetTableName);
-    sqlTemplate.add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN);
+    ST sqlTemplate =
+        new ST(rollbackDatasetTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("targetTable", targetTableName)
+            .add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN);
 
     bigQueryProject.query(
         sqlTemplate.render(),
@@ -371,13 +372,14 @@ public class BigQueryTransactionPdao {
     }
     BigQueryProject bigQueryProject = BigQueryProject.from(dataset);
 
-    ST sqlTemplate = new ST(rollbackDatasetMetadataTableTemplate);
-    sqlTemplate.add("project", bigQueryProject.getProjectId());
-    sqlTemplate.add("dataset", BigQueryPdao.prefixName(dataset.getName()));
-    sqlTemplate.add("metadataTable", targetTable.getRowMetadataTableName());
-    sqlTemplate.add("targetTable", targetTable.getRawTableName());
-    sqlTemplate.add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN);
-    sqlTemplate.add("datarepoIdCol", PDAO_ROW_ID_COLUMN);
+    ST sqlTemplate =
+        new ST(rollbackDatasetMetadataTableTemplate)
+            .add("project", bigQueryProject.getProjectId())
+            .add("dataset", BigQueryPdao.prefixName(dataset.getName()))
+            .add("metadataTable", targetTable.getRowMetadataTableName())
+            .add("targetTable", targetTable.getRawTableName())
+            .add("transactIdColumn", PDAO_TRANSACTION_ID_COLUMN)
+            .add("datarepoIdCol", PDAO_ROW_ID_COLUMN);
 
     bigQueryProject.query(
         sqlTemplate.render(),

--- a/src/main/java/bio/terra/service/upgrade/UpgradeService.java
+++ b/src/main/java/bio/terra/service/upgrade/UpgradeService.java
@@ -1,6 +1,7 @@
 package bio.terra.service.upgrade;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.ValidationUtils;
 import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.UpgradeModel;
@@ -8,9 +9,17 @@ import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.flight.transactions.upgrade.TransactionUpgradeFlight;
+import bio.terra.service.dataset.flight.upgrade.predictableFileIds.ConvertToPredictableFileIdsFlight;
+import bio.terra.service.job.JobBuilder;
+import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.job.JobService;
 import bio.terra.service.upgrade.exception.InvalidCustomNameException;
 import bio.terra.stairway.Flight;
+import com.google.common.base.Preconditions;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -19,12 +28,32 @@ public class UpgradeService {
 
   private enum CustomFlight {
     PLACEHOLDER(null),
-    TRANSACTION_SUPPORT(TransactionUpgradeFlight.class);
+    TRANSACTION_SUPPORT(TransactionUpgradeFlight.class),
+    CONVERT_DATASET_FILE_IDS(
+        ConvertToPredictableFileIdsFlight.class,
+        request -> {
+          Preconditions.checkArgument(
+              request.getCustomArgs().size() == 1,
+              "Custom argument must have a single row: a valid dataset id");
 
+          Optional<UUID> datasetId = ValidationUtils.convertToUuid(request.getCustomArgs().get(0));
+          Preconditions.checkArgument(
+              datasetId.isPresent(), "Custom argument's single value is not a valid UUID");
+
+          return Map.of(JobMapKeys.DATASET_ID.getKeyName(), datasetId.get());
+        });
     private final Class<? extends Flight> flightClass;
+    private final Function<UpgradeModel, Map<String, Object>> inputParameterSupplier;
 
     CustomFlight(Class<? extends Flight> flightClass) {
+      this(flightClass, request -> Map.of());
+    }
+
+    CustomFlight(
+        Class<? extends Flight> flightClass,
+        Function<UpgradeModel, Map<String, Object>> inputParameterSupplier) {
       this.flightClass = flightClass;
+      this.inputParameterSupplier = inputParameterSupplier;
     }
   }
 
@@ -65,8 +94,11 @@ public class UpgradeService {
           "Invalid custom name provided to upgrade: " + request.getCustomName());
     }
 
-    return jobService
-        .newJob(request.getCustomName(), customFlight.flightClass, request, user)
-        .submit();
+    JobBuilder jobBuilder =
+        jobService.newJob(request.getCustomName(), customFlight.flightClass, request, user);
+
+    customFlight.inputParameterSupplier.apply(request).forEach(jobBuilder::addParameter);
+
+    return jobBuilder.submit();
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -905,6 +905,19 @@ public class DatasetDaoTest {
   }
 
   @Test
+  public void updatePredictableFileIdsFlag() throws Exception {
+    UUID datasetId = createDataset("dataset-minimal.json");
+    assertFalse(
+        "predictable file ids flag is false",
+        datasetDao.retrieve(datasetId).hasPredictableFileIds());
+    datasetDao.setPredictableFileId(datasetId, true);
+    assertTrue(
+        "predictable file ids flag is false",
+        datasetDao.retrieve(datasetId).hasPredictableFileIds());
+    datasetDao.delete(datasetId, TEST_USER);
+  }
+
+  @Test
   public void patchDatasetProperties() throws Exception {
     UUID datasetId = createDataset("dataset-create-test.json");
     String defaultDesc = datasetDao.retrieve(datasetId).getDescription();

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -82,6 +82,7 @@ public class DatasetDaoTest {
 
   private BillingProfileModel billingProfile;
   private UUID projectId;
+  private final List<UUID> datasetIdsToDelete = new ArrayList<>();
 
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticatedUserRequest.builder()
@@ -106,6 +107,7 @@ public class DatasetDaoTest {
     dataset.id(datasetId);
     datasetDao.createAndLock(dataset, createFlightId, TEST_USER);
     datasetDao.unlockExclusive(dataset.getId(), createFlightId);
+    datasetIdsToDelete.add(datasetId);
     return datasetId;
   }
 
@@ -122,10 +124,12 @@ public class DatasetDaoTest {
 
     GoogleProjectResource projectResource = ResourceFixtures.randomProjectResource(billingProfile);
     projectId = resourceDao.createProject(projectResource);
+    datasetIdsToDelete.clear();
   }
 
   @After
   public void teardown() {
+    datasetIdsToDelete.forEach(i -> datasetDao.delete(i, TEST_USER));
     resourceDao.deleteProject(projectId);
     profileDao.deleteBillingProfileById(billingProfile.getId());
   }
@@ -278,9 +282,6 @@ public class DatasetDaoTest {
             .allMatch(
                 datasetSummary ->
                     datasetSummary.datasetStorageContainsRegion(GoogleRegion.US_EAST1)));
-
-    datasetDao.delete(dataset1, TEST_USER);
-    datasetDao.delete(dataset2, TEST_USER);
   }
 
   @Test
@@ -291,53 +292,46 @@ public class DatasetDaoTest {
 
     GoogleRegion testSettingRegion = GoogleRegion.ASIA_NORTHEAST1;
     UUID datasetId = createDataset(request, expectedName, testSettingRegion);
-    try {
-      Dataset fromDB = datasetDao.retrieve(datasetId);
+    Dataset fromDB = datasetDao.retrieve(datasetId);
 
-      assertThat("dataset name is set correctly", fromDB.getName(), equalTo(expectedName));
+    assertThat("dataset name is set correctly", fromDB.getName(), equalTo(expectedName));
 
-      // verify tables
+    // verify tables
+    assertThat(
+        "correct number of tables created for dataset", fromDB.getTables().size(), equalTo(2));
+    fromDB.getTables().forEach(this::assertDatasetTable);
+
+    assertThat(
+        "correct number of relationships are created for dataset",
+        fromDB.getRelationships().size(),
+        equalTo(2));
+
+    assertTablesInRelationship(fromDB);
+
+    // verify assets
+    assertThat(
+        "correct number of assets created for dataset",
+        fromDB.getAssetSpecifications().size(),
+        equalTo(2));
+    fromDB.getAssetSpecifications().forEach(this::assertAssetSpecs);
+
+    for (GoogleCloudResource resource : GoogleCloudResource.values()) {
+      CloudRegion region = fromDB.getDatasetSummary().getStorageResourceRegion(resource);
       assertThat(
-          "correct number of tables created for dataset", fromDB.getTables().size(), equalTo(2));
-      fromDB.getTables().forEach(this::assertDatasetTable);
-
-      assertThat(
-          "correct number of relationships are created for dataset",
-          fromDB.getRelationships().size(),
-          equalTo(2));
-
-      assertTablesInRelationship(fromDB);
-
-      // verify assets
-      assertThat(
-          "correct number of assets created for dataset",
-          fromDB.getAssetSpecifications().size(),
-          equalTo(2));
-      fromDB.getAssetSpecifications().forEach(this::assertAssetSpecs);
-
-      for (GoogleCloudResource resource : GoogleCloudResource.values()) {
-        CloudRegion region = fromDB.getDatasetSummary().getStorageResourceRegion(resource);
-        assertThat(
-            String.format("dataset %s region is set", resource),
-            region,
-            equalTo(testSettingRegion));
-      }
-
-      assertThat(
-          "dataset has billing profiles returned from the database",
-          fromDB.getDatasetSummary().getBillingProfiles(),
-          is(not(empty())));
-
-      assertThat(
-          "dataset default Billing Profile matches default profile id",
-          fromDB.getDatasetSummary().getDefaultBillingProfile().getId(),
-          equalTo(fromDB.getDatasetSummary().getDefaultProfileId()));
-
-      assertThat(
-          "Cloud platform is returned", fromDB.getCloudPlatform(), equalTo(CloudPlatform.GCP));
-    } finally {
-      datasetDao.delete(datasetId, TEST_USER);
+          String.format("dataset %s region is set", resource), region, equalTo(testSettingRegion));
     }
+
+    assertThat(
+        "dataset has billing profiles returned from the database",
+        fromDB.getDatasetSummary().getBillingProfiles(),
+        is(not(empty())));
+
+    assertThat(
+        "dataset default Billing Profile matches default profile id",
+        fromDB.getDatasetSummary().getDefaultBillingProfile().getId(),
+        equalTo(fromDB.getDatasetSummary().getDefaultProfileId()));
+
+    assertThat("Cloud platform is returned", fromDB.getCloudPlatform(), equalTo(CloudPlatform.GCP));
   }
 
   @Test
@@ -347,81 +341,68 @@ public class DatasetDaoTest {
     String expectedName = request.getName() + UUID.randomUUID().toString();
 
     UUID datasetId = createDataset(request, expectedName, GoogleRegion.US);
-    try {
-      Dataset fromDB = datasetDao.retrieve(datasetId);
+    Dataset fromDB = datasetDao.retrieve(datasetId);
 
-      for (GoogleCloudResource resource : GoogleCloudResource.values()) {
-        CloudRegion region =
-            (GoogleRegion) fromDB.getDatasetSummary().getStorageResourceRegion(resource);
-        GoogleRegion expectedRegion =
-            (resource == GoogleCloudResource.BIGQUERY) ? GoogleRegion.US : GoogleRegion.US_EAST4;
-        assertThat(
-            String.format("dataset %s region is set to %s", resource, region.name()),
-            region,
-            equalTo(expectedRegion));
-      }
-    } finally {
-      datasetDao.delete(datasetId, TEST_USER);
+    for (GoogleCloudResource resource : GoogleCloudResource.values()) {
+      CloudRegion region =
+          (GoogleRegion) fromDB.getDatasetSummary().getStorageResourceRegion(resource);
+      GoogleRegion expectedRegion =
+          (resource == GoogleCloudResource.BIGQUERY) ? GoogleRegion.US : GoogleRegion.US_EAST4;
+      assertThat(
+          String.format("dataset %s region is set to %s", resource, region.name()),
+          region,
+          equalTo(expectedRegion));
     }
   }
 
   @Test
   public void partitionTest() throws Exception {
     UUID datasetId = createDataset("ingest-test-partitioned-dataset.json");
-    try {
-      Dataset fromDB = datasetDao.retrieve(datasetId);
-      DatasetTable participants =
-          fromDB.getTableByName("participant").orElseThrow(IllegalStateException::new);
-      DatasetTable samples =
-          fromDB.getTableByName("sample").orElseThrow(IllegalStateException::new);
-      DatasetTable files = fromDB.getTableByName("file").orElseThrow(IllegalStateException::new);
+    Dataset fromDB = datasetDao.retrieve(datasetId);
+    DatasetTable participants =
+        fromDB.getTableByName("participant").orElseThrow(IllegalStateException::new);
+    DatasetTable samples = fromDB.getTableByName("sample").orElseThrow(IllegalStateException::new);
+    DatasetTable files = fromDB.getTableByName("file").orElseThrow(IllegalStateException::new);
 
-      assertThat(
-          "int-range partition settings are persisted",
-          participants.getBigQueryPartitionConfig(),
-          equalTo(BigQueryPartitionConfigV1.intRange("age", 0, 120, 1)));
-      assertThat(
-          "date partition settings are persisted",
-          samples.getBigQueryPartitionConfig(),
-          equalTo(BigQueryPartitionConfigV1.date("date_collected")));
-      assertThat(
-          "ingest-time partition settings are persisted",
-          files.getBigQueryPartitionConfig(),
-          equalTo(BigQueryPartitionConfigV1.ingestDate()));
-    } finally {
-      datasetDao.delete(datasetId, TEST_USER);
-    }
+    assertThat(
+        "int-range partition settings are persisted",
+        participants.getBigQueryPartitionConfig(),
+        equalTo(BigQueryPartitionConfigV1.intRange("age", 0, 120, 1)));
+    assertThat(
+        "date partition settings are persisted",
+        samples.getBigQueryPartitionConfig(),
+        equalTo(BigQueryPartitionConfigV1.date("date_collected")));
+    assertThat(
+        "ingest-time partition settings are persisted",
+        files.getBigQueryPartitionConfig(),
+        equalTo(BigQueryPartitionConfigV1.ingestDate()));
   }
 
   @Test
   public void primaryKeyTest() throws Exception {
     UUID datasetId = createDataset("dataset-primary-key.json");
-    try {
-      Dataset fromDB = datasetDao.retrieve(datasetId);
-      DatasetTable variants =
-          fromDB.getTableByName("variant").orElseThrow(IllegalStateException::new);
-      DatasetTable freqAnalysis =
-          fromDB.getTableByName("frequency_analysis").orElseThrow(IllegalStateException::new);
-      DatasetTable metaAnalysis =
-          fromDB.getTableByName("meta_analysis").orElseThrow(IllegalStateException::new);
+    Dataset fromDB = datasetDao.retrieve(datasetId);
+    DatasetTable variants =
+        fromDB.getTableByName("variant").orElseThrow(IllegalStateException::new);
+    DatasetTable freqAnalysis =
+        fromDB.getTableByName("frequency_analysis").orElseThrow(IllegalStateException::new);
+    DatasetTable metaAnalysis =
+        fromDB.getTableByName("meta_analysis").orElseThrow(IllegalStateException::new);
 
-      assertThat(
-          "single-column primary keys are set correctly",
-          variants.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()),
-          equalTo(Collections.singletonList("id")));
+    assertThat(
+        "single-column primary keys are set correctly",
+        variants.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()),
+        equalTo(Collections.singletonList("id")));
 
-      assertThat(
-          "dual-column primary keys are set correctly",
-          metaAnalysis.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()),
-          equalTo(Arrays.asList("variant_id", "phenotype")));
+    assertThat(
+        "dual-column primary keys are set correctly",
+        metaAnalysis.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()),
+        equalTo(Arrays.asList("variant_id", "phenotype")));
 
-      assertThat(
-          "many-column primary keys are set correctly",
-          freqAnalysis.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()),
-          equalTo(Arrays.asList("variant_id", "ancestry", "phenotype")));
-    } finally {
-      datasetDao.delete(datasetId, TEST_USER);
-    }
+    assertThat(
+        "many-column primary keys are set correctly",
+        freqAnalysis.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()),
+        equalTo(Arrays.asList("variant_id", "ancestry", "phenotype")));
   }
 
   protected void assertTablesInRelationship(Dataset dataset) {
@@ -481,255 +462,235 @@ public class DatasetDaoTest {
   @Test
   public void mixingSharedAndExclusiveLocksTest() throws Exception {
     UUID datasetId = createDataset("dataset-primary-key.json");
+    // check that there are no outstanding locks
+    String exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after creation", exclusiveLock);
+    String[] sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after creation", 0, sharedLocks.length);
+
+    // 1. take out a shared lock
+    // confirm that there are no exclusive locks and one shared lock
+    datasetDao.lockShared(datasetId, "flightid1");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after step 1", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("one shared lock after step 1", 1, sharedLocks.length);
+    assertEquals("flightid1 has shared lock after step 1", "flightid1", sharedLocks[0]);
+
+    // 2. take out another shared lock
+    // confirm that there are no exclusive locks and two shared locks
+    datasetDao.lockShared(datasetId, "flightid2");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after step 2", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("two shared locks after step 2", 2, sharedLocks.length);
+    assertTrue(
+        "flightid2 has shared lock after step 2", Arrays.asList(sharedLocks).contains("flightid2"));
+
+    // 3. try to take out an exclusive lock
+    // confirm that it fails with a DatasetLockException
+    boolean threwLockException = false;
     try {
-      // check that there are no outstanding locks
-      String exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after creation", exclusiveLock);
-      String[] sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after creation", 0, sharedLocks.length);
-
-      // 1. take out a shared lock
-      // confirm that there are no exclusive locks and one shared lock
-      datasetDao.lockShared(datasetId, "flightid1");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after step 1", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("one shared lock after step 1", 1, sharedLocks.length);
-      assertEquals("flightid1 has shared lock after step 1", "flightid1", sharedLocks[0]);
-
-      // 2. take out another shared lock
-      // confirm that there are no exclusive locks and two shared locks
-      datasetDao.lockShared(datasetId, "flightid2");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after step 2", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("two shared locks after step 2", 2, sharedLocks.length);
-      assertTrue(
-          "flightid2 has shared lock after step 2",
-          Arrays.asList(sharedLocks).contains("flightid2"));
-
-      // 3. try to take out an exclusive lock
-      // confirm that it fails with a DatasetLockException
-      boolean threwLockException = false;
-      try {
-        datasetDao.lockExclusive(datasetId, "flightid3");
-      } catch (DatasetLockException dlEx) {
-        threwLockException = true;
-      }
-      assertTrue("exclusive lock threw exception in step 3", threwLockException);
-
-      // 4. release the first shared lock
-      // confirm that there are no exclusive locks and one shared lock
-      datasetDao.unlockShared(datasetId, "flightid1");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after step 4", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("one shared lock after step 4", 1, sharedLocks.length);
-      assertFalse(
-          "flightid1 no longer has shared lock after step 4",
-          Arrays.asList(sharedLocks).contains("flightid1"));
-
-      // 5. try to take out an exclusive lock
-      // confirm that it fails with a DatasetLockException
-      threwLockException = false;
-      try {
-        datasetDao.lockExclusive(datasetId, "flightid4");
-      } catch (DatasetLockException dlEx) {
-        threwLockException = true;
-      }
-      assertTrue("exclusive lock threw exception in step 5", threwLockException);
-
-      // 6. take out five shared locks
-      // confirm that there are no exclusive locks and six shared locks
-      datasetDao.lockShared(datasetId, "flightid5");
-      datasetDao.lockShared(datasetId, "flightid6");
-      datasetDao.lockShared(datasetId, "flightid7");
-      datasetDao.lockShared(datasetId, "flightid8");
-      datasetDao.lockShared(datasetId, "flightid9");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after step 6", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("six shared locks after step 6", 6, sharedLocks.length);
-      assertTrue(
-          "flightid2 has shared lock after step 6",
-          Arrays.asList(sharedLocks).contains("flightid2"));
-      assertTrue(
-          "flightid5 has shared lock after step 6",
-          Arrays.asList(sharedLocks).contains("flightid5"));
-      assertTrue(
-          "flightid6 has shared lock after step 6",
-          Arrays.asList(sharedLocks).contains("flightid6"));
-      assertTrue(
-          "flightid7 has shared lock after step 6",
-          Arrays.asList(sharedLocks).contains("flightid7"));
-      assertTrue(
-          "flightid8 has shared lock after step 6",
-          Arrays.asList(sharedLocks).contains("flightid8"));
-      assertTrue(
-          "flightid9 has shared lock after step 6",
-          Arrays.asList(sharedLocks).contains("flightid9"));
-
-      // 7. release all the shared locks
-      // confirm that there are no outstanding locks
-      datasetDao.unlockShared(datasetId, "flightid2");
-      datasetDao.unlockShared(datasetId, "flightid5");
-      datasetDao.unlockShared(datasetId, "flightid6");
-      datasetDao.unlockShared(datasetId, "flightid7");
-      datasetDao.unlockShared(datasetId, "flightid8");
-      datasetDao.unlockShared(datasetId, "flightid9");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after step 7", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 7", 0, sharedLocks.length);
-
-      // 8. take out an exclusive lock
-      // confirm that there is an exclusive lock and no shared locks
-      datasetDao.lockExclusive(datasetId, "flightid10");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertEquals("exclusive lock taken out after step 8", "flightid10", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 8", 0, sharedLocks.length);
-
-      // 9. try to take out a shared lock
-      // confirm that it fails with a DatasetLockException
-      threwLockException = false;
-      try {
-        datasetDao.lockShared(datasetId, "flightid11");
-      } catch (DatasetLockException dlEx) {
-        threwLockException = true;
-      }
-      assertTrue("shared lock threw exception in step 9", threwLockException);
-
-      // 10. release the exclusive lock
-      // confirm that there are no outstanding locks
-      datasetDao.unlockExclusive(datasetId, "flightid10");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("exclusive lock taken out after step 10", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 10", 0, sharedLocks.length);
-
-    } finally {
-      datasetDao.delete(datasetId, TEST_USER);
+      datasetDao.lockExclusive(datasetId, "flightid3");
+    } catch (DatasetLockException dlEx) {
+      threwLockException = true;
     }
+    assertTrue("exclusive lock threw exception in step 3", threwLockException);
+
+    // 4. release the first shared lock
+    // confirm that there are no exclusive locks and one shared lock
+    datasetDao.unlockShared(datasetId, "flightid1");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after step 4", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("one shared lock after step 4", 1, sharedLocks.length);
+    assertFalse(
+        "flightid1 no longer has shared lock after step 4",
+        Arrays.asList(sharedLocks).contains("flightid1"));
+
+    // 5. try to take out an exclusive lock
+    // confirm that it fails with a DatasetLockException
+    threwLockException = false;
+    try {
+      datasetDao.lockExclusive(datasetId, "flightid4");
+    } catch (DatasetLockException dlEx) {
+      threwLockException = true;
+    }
+    assertTrue("exclusive lock threw exception in step 5", threwLockException);
+
+    // 6. take out five shared locks
+    // confirm that there are no exclusive locks and six shared locks
+    datasetDao.lockShared(datasetId, "flightid5");
+    datasetDao.lockShared(datasetId, "flightid6");
+    datasetDao.lockShared(datasetId, "flightid7");
+    datasetDao.lockShared(datasetId, "flightid8");
+    datasetDao.lockShared(datasetId, "flightid9");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after step 6", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("six shared locks after step 6", 6, sharedLocks.length);
+    assertTrue(
+        "flightid2 has shared lock after step 6", Arrays.asList(sharedLocks).contains("flightid2"));
+    assertTrue(
+        "flightid5 has shared lock after step 6", Arrays.asList(sharedLocks).contains("flightid5"));
+    assertTrue(
+        "flightid6 has shared lock after step 6", Arrays.asList(sharedLocks).contains("flightid6"));
+    assertTrue(
+        "flightid7 has shared lock after step 6", Arrays.asList(sharedLocks).contains("flightid7"));
+    assertTrue(
+        "flightid8 has shared lock after step 6", Arrays.asList(sharedLocks).contains("flightid8"));
+    assertTrue(
+        "flightid9 has shared lock after step 6", Arrays.asList(sharedLocks).contains("flightid9"));
+
+    // 7. release all the shared locks
+    // confirm that there are no outstanding locks
+    datasetDao.unlockShared(datasetId, "flightid2");
+    datasetDao.unlockShared(datasetId, "flightid5");
+    datasetDao.unlockShared(datasetId, "flightid6");
+    datasetDao.unlockShared(datasetId, "flightid7");
+    datasetDao.unlockShared(datasetId, "flightid8");
+    datasetDao.unlockShared(datasetId, "flightid9");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after step 7", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 7", 0, sharedLocks.length);
+
+    // 8. take out an exclusive lock
+    // confirm that there is an exclusive lock and no shared locks
+    datasetDao.lockExclusive(datasetId, "flightid10");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertEquals("exclusive lock taken out after step 8", "flightid10", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 8", 0, sharedLocks.length);
+
+    // 9. try to take out a shared lock
+    // confirm that it fails with a DatasetLockException
+    threwLockException = false;
+    try {
+      datasetDao.lockShared(datasetId, "flightid11");
+    } catch (DatasetLockException dlEx) {
+      threwLockException = true;
+    }
+    assertTrue("shared lock threw exception in step 9", threwLockException);
+
+    // 10. release the exclusive lock
+    // confirm that there are no outstanding locks
+    datasetDao.unlockExclusive(datasetId, "flightid10");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("exclusive lock taken out after step 10", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 10", 0, sharedLocks.length);
   }
 
   @Test
   public void duplicateCallsForExclusiveLockTest() throws Exception {
     UUID datasetId = createDataset("dataset-primary-key.json");
-    try {
-      // check that there are no outstanding locks
-      String exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after creation", exclusiveLock);
-      String[] sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after creation", 0, sharedLocks.length);
+    // check that there are no outstanding locks
+    String exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after creation", exclusiveLock);
+    String[] sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after creation", 0, sharedLocks.length);
 
-      // 1. take out an exclusive lock
-      // confirm that there is an exclusive lock and no shared locks
-      datasetDao.lockExclusive(datasetId, "flightid20");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertEquals("exclusive lock taken out after step 1", "flightid20", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 1", 0, sharedLocks.length);
+    // 1. take out an exclusive lock
+    // confirm that there is an exclusive lock and no shared locks
+    datasetDao.lockExclusive(datasetId, "flightid20");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertEquals("exclusive lock taken out after step 1", "flightid20", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 1", 0, sharedLocks.length);
 
-      // 2. try to take out an exclusive lock again with the same flightid
-      // confirm that the exclusive lock is still there and there are no shared locks
-      datasetDao.lockExclusive(datasetId, "flightid20");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertEquals("exclusive lock taken out after step 2", "flightid20", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 2", 0, sharedLocks.length);
+    // 2. try to take out an exclusive lock again with the same flightid
+    // confirm that the exclusive lock is still there and there are no shared locks
+    datasetDao.lockExclusive(datasetId, "flightid20");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertEquals("exclusive lock taken out after step 2", "flightid20", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 2", 0, sharedLocks.length);
 
-      // 3. try to unlock the exclusive lock with a different flightid
-      // confirm that the exclusive lock is still there and there are no shared locks
-      boolean rowUnlocked = datasetDao.unlockExclusive(datasetId, "flightid21");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertFalse(
-          "no rows updated on call to unlock with different flightid after step 3", rowUnlocked);
-      assertEquals("exclusive lock still taken out after step 3", "flightid20", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 3", 0, sharedLocks.length);
+    // 3. try to unlock the exclusive lock with a different flightid
+    // confirm that the exclusive lock is still there and there are no shared locks
+    boolean rowUnlocked = datasetDao.unlockExclusive(datasetId, "flightid21");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertFalse(
+        "no rows updated on call to unlock with different flightid after step 3", rowUnlocked);
+    assertEquals("exclusive lock still taken out after step 3", "flightid20", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 3", 0, sharedLocks.length);
 
-      // 4. unlock the exclusive lock
-      // confirm that there are no outstanding exclusive or shared locks
-      rowUnlocked = datasetDao.unlockExclusive(datasetId, "flightid20");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertTrue("row was updated on first call to unlock after step 4", rowUnlocked);
-      assertNull("no exclusive lock after step 4", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 4", 0, sharedLocks.length);
+    // 4. unlock the exclusive lock
+    // confirm that there are no outstanding exclusive or shared locks
+    rowUnlocked = datasetDao.unlockExclusive(datasetId, "flightid20");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertTrue("row was updated on first call to unlock after step 4", rowUnlocked);
+    assertNull("no exclusive lock after step 4", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 4", 0, sharedLocks.length);
 
-      // 5. unlock the exclusive lock again with the same flightid
-      // confirm that there are still no oustanding exclusive or shared locks
-      rowUnlocked = datasetDao.unlockExclusive(datasetId, "flightid20");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertFalse("no rows updated on second call to unlock after step 5", rowUnlocked);
-      assertNull("no exclusive lock after step 5", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 5", 0, sharedLocks.length);
-    } finally {
-      datasetDao.delete(datasetId, TEST_USER);
-    }
+    // 5. unlock the exclusive lock again with the same flightid
+    // confirm that there are still no oustanding exclusive or shared locks
+    rowUnlocked = datasetDao.unlockExclusive(datasetId, "flightid20");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertFalse("no rows updated on second call to unlock after step 5", rowUnlocked);
+    assertNull("no exclusive lock after step 5", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 5", 0, sharedLocks.length);
   }
 
   @Test
   public void duplicateCallsForSharedLockTest() throws Exception {
     UUID datasetId = createDataset("dataset-primary-key.json");
-    try {
-      // check that there are no outstanding locks
-      String exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after creation", exclusiveLock);
-      String[] sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after creation", 0, sharedLocks.length);
+    // check that there are no outstanding locks
+    String exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after creation", exclusiveLock);
+    String[] sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after creation", 0, sharedLocks.length);
 
-      // 1. take out a shared lock
-      // confirm that there is no exclusive lock and one shared lock
-      datasetDao.lockShared(datasetId, "flightid30");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after step 1", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("one shared lock after step 1", 1, sharedLocks.length);
-      assertEquals("flightid30 has shared lock after step 1", "flightid30", sharedLocks[0]);
+    // 1. take out a shared lock
+    // confirm that there is no exclusive lock and one shared lock
+    datasetDao.lockShared(datasetId, "flightid30");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after step 1", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("one shared lock after step 1", 1, sharedLocks.length);
+    assertEquals("flightid30 has shared lock after step 1", "flightid30", sharedLocks[0]);
 
-      // 2. try to take out a shared lock again with the same flightid
-      // confirm that the shared lock is still there and there is no exclusive lock
-      datasetDao.lockShared(datasetId, "flightid30");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertNull("no exclusive lock after step 2", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("one shared lock after step 2", 1, sharedLocks.length);
-      assertEquals("flightid30 has shared lock after step 2", "flightid30", sharedLocks[0]);
+    // 2. try to take out a shared lock again with the same flightid
+    // confirm that the shared lock is still there and there is no exclusive lock
+    datasetDao.lockShared(datasetId, "flightid30");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertNull("no exclusive lock after step 2", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("one shared lock after step 2", 1, sharedLocks.length);
+    assertEquals("flightid30 has shared lock after step 2", "flightid30", sharedLocks[0]);
 
-      // 3. try to unlock the shared lock with a different flightid
-      // confirm that the shared lock is still there and there is no exclusive lock
-      boolean rowUnlocked = datasetDao.unlockShared(datasetId, "flightid31");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertFalse(
-          "no rows updated on call to unlock with different flightid after step 3", rowUnlocked);
-      assertNull("no exclusive lock after step 3", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("one shared lock still taken out after step 3", 1, sharedLocks.length);
-      assertEquals("flightid30 still has shared lock after step 3", "flightid30", sharedLocks[0]);
+    // 3. try to unlock the shared lock with a different flightid
+    // confirm that the shared lock is still there and there is no exclusive lock
+    boolean rowUnlocked = datasetDao.unlockShared(datasetId, "flightid31");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertFalse(
+        "no rows updated on call to unlock with different flightid after step 3", rowUnlocked);
+    assertNull("no exclusive lock after step 3", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("one shared lock still taken out after step 3", 1, sharedLocks.length);
+    assertEquals("flightid30 still has shared lock after step 3", "flightid30", sharedLocks[0]);
 
-      // 4. unlock the shared lock
-      // confirm that there are no outstanding exclusive or shared locks
-      rowUnlocked = datasetDao.unlockShared(datasetId, "flightid30");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertTrue("row was updated on first call to unlock after step 4", rowUnlocked);
-      assertNull("no exclusive lock after step 4", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 4", 0, sharedLocks.length);
+    // 4. unlock the shared lock
+    // confirm that there are no outstanding exclusive or shared locks
+    rowUnlocked = datasetDao.unlockShared(datasetId, "flightid30");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertTrue("row was updated on first call to unlock after step 4", rowUnlocked);
+    assertNull("no exclusive lock after step 4", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 4", 0, sharedLocks.length);
 
-      // 5. unlock the exclusive lock again with the same flightid
-      // confirm that there are still no oustanding exclusive or shared locks
-      rowUnlocked = datasetDao.unlockShared(datasetId, "flightid30");
-      exclusiveLock = datasetDao.getExclusiveLock(datasetId);
-      assertFalse("no rows updated on second call to unlock after step 5", rowUnlocked);
-      assertNull("no exclusive lock after step 5", exclusiveLock);
-      sharedLocks = datasetDao.getSharedLocks(datasetId);
-      assertEquals("no shared locks after step 5", 0, sharedLocks.length);
-    } finally {
-      datasetDao.delete(datasetId, TEST_USER);
-    }
+    // 5. unlock the exclusive lock again with the same flightid
+    // confirm that there are still no oustanding exclusive or shared locks
+    rowUnlocked = datasetDao.unlockShared(datasetId, "flightid30");
+    exclusiveLock = datasetDao.getExclusiveLock(datasetId);
+    assertFalse("no rows updated on second call to unlock after step 5", rowUnlocked);
+    assertNull("no exclusive lock after step 5", exclusiveLock);
+    sharedLocks = datasetDao.getSharedLocks(datasetId);
+    assertEquals("no shared locks after step 5", 0, sharedLocks.length);
   }
 
   @Test
@@ -779,7 +740,6 @@ public class DatasetDaoTest {
                     "can retrieve row metadata table name",
                     t.getRowMetadataTableName(),
                     containsString("row_metadata")));
-    datasetDao.delete(datasetId, TEST_USER);
   }
 
   @Test
@@ -844,9 +804,6 @@ public class DatasetDaoTest {
             .map(Column::getName)
             .collect(Collectors.toList()),
         contains("c3", "c2", "c1"));
-
-    datasetDao.delete(dataset1Id, TEST_USER);
-    datasetDao.delete(dataset2Id, TEST_USER);
   }
 
   @Test
@@ -887,8 +844,6 @@ public class DatasetDaoTest {
         "dataset's PHS ID is set to empty string from patch",
         datasetDao.retrieve(datasetId).getPhsId(),
         equalTo(""));
-
-    datasetDao.delete(datasetId, TEST_USER);
   }
 
   @Test
@@ -901,7 +856,6 @@ public class DatasetDaoTest {
         "dataset properties are set",
         datasetDao.retrieve(datasetId).getProperties(),
         equalTo(request.getProperties()));
-    datasetDao.delete(datasetId, TEST_USER);
   }
 
   @Test
@@ -912,9 +866,8 @@ public class DatasetDaoTest {
         datasetDao.retrieve(datasetId).hasPredictableFileIds());
     datasetDao.setPredictableFileId(datasetId, true);
     assertTrue(
-        "predictable file ids flag is false",
+        "predictable file ids flag is true",
         datasetDao.retrieve(datasetId).hasPredictableFileIds());
-    datasetDao.delete(datasetId, TEST_USER);
   }
 
   @Test
@@ -994,6 +947,5 @@ public class DatasetDaoTest {
         "dataset properties is set to empty",
         datasetDao.retrieve(datasetId).getProperties(),
         equalTo(unsetDatasetProperties));
-    datasetDao.delete(datasetId, TEST_USER);
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -7,12 +7,16 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.app.usermetrics.UserLoggingMetrics;
 import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.category.Unit;
 import bio.terra.model.DatasetPatchRequestModel;
+import bio.terra.model.DatasetSummaryModel;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
@@ -109,5 +113,16 @@ public class DatasetServiceUnitTest {
         datasetService.patchDatasetIamActions(
             new DatasetPatchRequestModel().description("an updated description")),
         containsInAnyOrder(IamAction.MANAGE_SCHEMA));
+  }
+
+  @Test
+  public void updatePredictableIdsFlag() {
+    UUID datasetId = UUID.randomUUID();
+    DatasetSummary summary = mock(DatasetSummary.class);
+    when(summary.toModel()).thenReturn(new DatasetSummaryModel().id(datasetId));
+    when(datasetDao.retrieveSummaryById(datasetId)).thenReturn(summary);
+    datasetService.setPredictableFileIds(datasetId, true);
+    verify(datasetDao, times(1)).setPredictableFileId(eq(datasetId), eq(true));
+    verify(datasetDao, times(1)).retrieveSummaryById(eq(datasetId));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -122,7 +121,7 @@ public class DatasetServiceUnitTest {
     when(summary.toModel()).thenReturn(new DatasetSummaryModel().id(datasetId));
     when(datasetDao.retrieveSummaryById(datasetId)).thenReturn(summary);
     datasetService.setPredictableFileIds(datasetId, true);
-    verify(datasetDao, times(1)).setPredictableFileId(eq(datasetId), eq(true));
-    verify(datasetDao, times(1)).retrieveSummaryById(eq(datasetId));
+    verify(datasetDao).setPredictableFileId(datasetId, true);
+    verify(datasetDao).retrieveSummaryById(datasetId);
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.filedata.google.firestore;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -14,7 +15,9 @@ import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FileMetadataUtils;
 import bio.terra.service.filedata.SnapshotCompute;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.snapshot.Snapshot;
 import com.google.cloud.firestore.Firestore;
+import com.google.common.collect.Streams;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -53,23 +56,21 @@ public class FireStoreDaoTest {
   @Autowired private FireStoreDependencyDao fireStoreDependencyDao;
 
   private Firestore firestore;
-  private String pretendDatasetId;
-  private String collectionId;
-  private String snapshotId;
+  private UUID datasetId;
+  private UUID snapshotId;
 
   @Before
   public void setup() throws Exception {
     firestore = TestFirestoreProvider.getFirestore();
-    pretendDatasetId = UUID.randomUUID().toString();
-    collectionId = "fsdaoDset_" + pretendDatasetId;
-    snapshotId = "fsdaoSnap_" + pretendDatasetId;
+    datasetId = UUID.randomUUID();
+    snapshotId = UUID.randomUUID();
   }
 
   @After
   public void cleanup() throws Exception {
-    directoryDao.deleteDirectoryEntriesFromCollection(firestore, snapshotId);
-    directoryDao.deleteDirectoryEntriesFromCollection(firestore, collectionId);
-    fileDao.deleteFilesFromDataset(firestore, collectionId, i -> {});
+    directoryDao.deleteDirectoryEntriesFromCollection(firestore, snapshotId.toString());
+    directoryDao.deleteDirectoryEntriesFromCollection(firestore, datasetId.toString());
+    fileDao.deleteFilesFromDataset(firestore, datasetId.toString(), i -> {});
   }
 
   // Test for snapshot file system
@@ -82,44 +83,51 @@ public class FireStoreDaoTest {
   @Test
   @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
   public void snapshotTest() throws Exception {
-    String collectionId = "fsdaoDset_" + pretendDatasetId;
-    String snapshotId = "fsdaoSnap_" + pretendDatasetId;
     GoogleProjectResource projectResource =
         new GoogleProjectResource().googleProjectId(System.getenv("GOOGLE_CLOUD_DATA_PROJECT"));
-    Dataset dataset =
-        new Dataset().id(UUID.fromString(pretendDatasetId)).projectResource(projectResource);
-
+    Dataset dataset = new Dataset().id(datasetId).projectResource(projectResource);
+    Snapshot snapshot = new Snapshot().id(snapshotId).projectResource(projectResource);
     // Make files that will be in the snapshot
     List<FireStoreDirectoryEntry> snapObjects = new ArrayList<>();
-    snapObjects.add(makeFileObject(collectionId, "/adir/A1", 1));
-    snapObjects.add(makeFileObject(collectionId, "/adir/bdir/B1", 2));
-    snapObjects.add(makeFileObject(collectionId, "/adir/bdir/cdir/C1", 4));
-    snapObjects.add(makeFileObject(collectionId, "/adir/bdir/cdir/C2", 8));
+    snapObjects.add(makeFileObject(datasetId.toString(), "/adir/A1", 1));
+    snapObjects.add(makeFileObject(datasetId.toString(), "/adir/bdir/B1", 2));
+    snapObjects.add(makeFileObject(datasetId.toString(), "/adir/bdir/cdir/C1", 4));
+    snapObjects.add(makeFileObject(datasetId.toString(), "/adir/bdir/cdir/C2", 8));
 
     // And some files that won't be in the snapshot
     List<FireStoreDirectoryEntry> dsetObjects = new ArrayList<>();
-    dsetObjects.add(makeFileObject(collectionId, "/adir/bdir/B2", 16));
-    dsetObjects.add(makeFileObject(collectionId, "/adir/A2", 32));
+    dsetObjects.add(makeFileObject(datasetId.toString(), "/adir/bdir/B2", 16));
+    dsetObjects.add(makeFileObject(datasetId.toString(), "/adir/A2", 32));
+
+    List<String> dsfileIdList =
+        Streams.concat(
+                dsetObjects.stream().map(FireStoreDirectoryEntry::getFileId),
+                snapObjects.stream().map(FireStoreDirectoryEntry::getFileId))
+            .toList();
 
     // Make the dataset file system
     List<FireStoreDirectoryEntry> fileObjects = new ArrayList<>(snapObjects);
     fileObjects.addAll(dsetObjects);
     for (FireStoreDirectoryEntry fireStoreDirectoryEntry : fileObjects) {
-      directoryDao.createDirectoryEntry(firestore, collectionId, fireStoreDirectoryEntry);
+      directoryDao.createDirectoryEntry(firestore, datasetId.toString(), fireStoreDirectoryEntry);
     }
 
     // Make the snapshot file system
-    List<String> fileIdList = new ArrayList<>();
-    for (FireStoreDirectoryEntry fireStoreDirectoryEntry : snapObjects) {
-      fileIdList.add(fireStoreDirectoryEntry.getFileId());
-    }
+    List<String> snapfileIdList =
+        snapObjects.stream().map(FireStoreDirectoryEntry::getFileId).toList();
     directoryDao.addEntriesToSnapshot(
-        firestore, collectionId, "dataset", firestore, snapshotId, fileIdList, false);
+        firestore,
+        datasetId.toString(),
+        "dataset",
+        firestore,
+        snapshotId.toString(),
+        snapfileIdList,
+        false);
 
     // Validate we can lookup files in the snapshot
     for (FireStoreDirectoryEntry dsetObject : snapObjects) {
       FireStoreDirectoryEntry snapObject =
-          directoryDao.retrieveById(firestore, snapshotId, dsetObject.getFileId());
+          directoryDao.retrieveById(firestore, snapshotId.toString(), dsetObject.getFileId());
       assertNotNull("object found in snapshot", snapObject);
       assertThat("objectId matches", snapObject.getFileId(), equalTo(dsetObject.getFileId()));
       assertThat("path does not match", snapObject.getPath(), not(equalTo(dsetObject.getPath())));
@@ -132,7 +140,8 @@ public class FireStoreDaoTest {
     assertFalse("Dataset should not yet have dependencies", noDependencies);
 
     // Create dependency file system
-    fireStoreDependencyDao.storeSnapshotFileDependencies(dataset, snapshotId, fileIdList);
+    fireStoreDependencyDao.storeSnapshotFileDependencies(
+        dataset, snapshotId.toString(), snapfileIdList);
 
     // Snapshot and File Dependency should now exist for dataset
     boolean hasReference = fireStoreDependencyDao.datasetHasSnapshotReference(dataset);
@@ -150,21 +159,42 @@ public class FireStoreDaoTest {
     // Validate we cannot lookup dataset files in the snapshot
     for (FireStoreDirectoryEntry dsetObject : dsetObjects) {
       FireStoreDirectoryEntry snapObject =
-          directoryDao.retrieveById(firestore, snapshotId, dsetObject.getFileId());
+          directoryDao.retrieveById(firestore, snapshotId.toString(), dsetObject.getFileId());
       assertNull("object not found in snapshot", snapObject);
     }
 
     // Compute the size and checksums
-    FireStoreDirectoryEntry topDir = directoryDao.retrieveByPath(firestore, snapshotId, "/");
+    FireStoreDirectoryEntry topDir =
+        directoryDao.retrieveByPath(firestore, snapshotId.toString(), "/");
     List<FireStoreDirectoryEntry> updateBatch = new ArrayList<>();
-    FireStoreDao.FirestoreComputeHelper helper = dao.getHelper(firestore, firestore, snapshotId);
+    FireStoreDao.FirestoreComputeHelper helper =
+        dao.getHelper(firestore, firestore, snapshotId.toString());
     SnapshotCompute.computeDirectory(helper, topDir, updateBatch);
-    directoryDao.batchStoreDirectoryEntry(firestore, snapshotId, updateBatch);
+    directoryDao.batchStoreDirectoryEntry(firestore, snapshotId.toString(), updateBatch);
 
     // Check the accumulated size on the root dir
-    FireStoreDirectoryEntry snapObject = directoryDao.retrieveByPath(firestore, snapshotId, "/");
+    FireStoreDirectoryEntry snapObject =
+        directoryDao.retrieveByPath(firestore, snapshotId.toString(), "/");
     assertNotNull("root exists", snapObject);
     assertThat("Total size is correct", snapObject.getSize(), equalTo(15L));
+
+    // Check that we can retrieve all with or without directories
+    assertThat(
+        "all dataset files and directories can be returned",
+        dao.retrieveAllFileIds(dataset, true),
+        hasSize(10));
+    assertThat(
+        "all dataset files (only) can be returned",
+        dao.retrieveAllFileIds(dataset, false).stream().sorted().toList(),
+        equalTo(dsfileIdList.stream().sorted().toList()));
+    assertThat(
+        "all snapshot files and directories can be returned",
+        dao.retrieveAllFileIds(snapshot, true),
+        hasSize(9));
+    assertThat(
+        "all snapshot files (only) can be returned",
+        dao.retrieveAllFileIds(snapshot, false).stream().sorted().toList(),
+        equalTo(snapfileIdList.stream().sorted().toList()));
   }
 
   private FireStoreDirectoryEntry makeFileObject(String datasetId, String fullPath, long size)
@@ -192,7 +222,7 @@ public class FireStoreDaoTest {
         .isFileRef(true)
         .path(FileMetadataUtils.getDirectoryPath(fullPath))
         .name(FileMetadataUtils.getName(fullPath))
-        .datasetId(collectionId)
+        .datasetId(datasetId)
         .size(size)
         .checksumCrc32c(SnapshotCompute.computeCrc32c(fullPath))
         .checksumMd5(SnapshotCompute.computeMd5(fullPath));

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -108,6 +108,9 @@ public class BigQueryPdaoTest {
 
   private final Storage storage = StorageOptions.getDefaultInstance().getService();
 
+  private final List<UUID> datasetIdsToDelete = new ArrayList<>();
+  private final List<Dataset> bqDatasetsToDelete = new ArrayList<>();
+
   @Rule public ExpectedException exceptionGrabber = ExpectedException.none();
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticatedUserRequest.builder()
@@ -185,7 +188,6 @@ public class BigQueryPdaoTest {
   @Test
   public void nonStringAssetRootTest() throws Exception {
     Dataset dataset = readDataset("ingest-test-dataset.json");
-    connectedOperations.addDataset(dataset.getId());
 
     // Stage tabular data for ingest.
     String targetPath = "scratch/file" + UUID.randomUUID() + "/";
@@ -605,6 +607,7 @@ public class BigQueryPdaoTest {
     dataset.id(datasetId);
     datasetDao.createAndLock(dataset, createFlightId, TEST_USER);
     datasetDao.unlockExclusive(dataset.getId(), createFlightId);
+    connectedOperations.addDataset(dataset.getId());
     return dataset;
   }
 


### PR DESCRIPTION
Adds an upgrade utility method that will update the file ids from random ids to predictable ids by:
- Obtaining the existing ids
- Determining the new ones
- Storing the difference in Firestore
- Updating the BigQuery data with pointers to files by:
  - soft deleting existing rows (for tables with at least one file or directory ref)
  - adding new rows with new ids (for tables with at least one file or directory ref)
 

All while enforcing that no snapshot must exist on the dataset

Note: most testing was done manually though connected tests added to verify the trickier pieces.

To call the upgrade, you invoke:
```
curl -X 'POST' \
  'https://<hostname>/api/repository/v1/upgrade' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer xxx' \
  -H 'Content-Type: application/json' \
  -d '{
  "upgradeName": "CONVERT_DATASET_FILE_IDS",
  "upgradeType": "custom",
  "customName": "CONVERT_DATASET_FILE_IDS",
  "customArgs": [
    "<your dataset id>"
  ]
}'
```