### PR TITLE
Idea: what if all Steps were Java records?

### DIFF
--- a/src/main/java/bio/terra/service/common/CreateAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/common/CreateAzureStorageAccountStep.java
@@ -10,25 +10,19 @@ import bio.terra.service.resourcemanagement.azure.AzureStorageAuthInfo;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 
-public abstract class CreateAzureStorageAccountStep extends DefaultUndoStep {
+public interface CreateAzureStorageAccountStep extends DefaultUndoStep {
+  ResourceService resourceService();
 
-  private final ResourceService resourceService;
-  private final Dataset dataset;
+  Dataset dataset();
 
-  public CreateAzureStorageAccountStep(ResourceService resourceService, Dataset dataset) {
-    this.resourceService = resourceService;
-    this.dataset = dataset;
-  }
-
-  protected void getOrCreateDatasetStorageAccount(FlightContext context)
-      throws InterruptedException {
+  default void getOrCreateDatasetStorageAccount(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
     String flightId = context.getFlightId();
     BillingProfileModel billingProfile =
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
 
     AzureStorageAccountResource storageAccountResource =
-        resourceService.getOrCreateDatasetStorageAccount(dataset, billingProfile, flightId);
+        resourceService().getOrCreateDatasetStorageAccount(dataset(), billingProfile, flightId);
     workingMap.put(CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, storageAccountResource);
 
     AzureStorageAuthInfo storageAuthInfo =

--- a/src/main/java/bio/terra/service/dataset/flight/LockDatasetStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/LockDatasetStep.java
@@ -13,37 +13,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.TransactionSystemException;
 
-public class LockDatasetStep implements Step {
-
-  private static final Logger logger = LoggerFactory.getLogger(LockDatasetStep.class);
-
-  private final DatasetService datasetService;
-  private final UUID datasetId;
-  private final boolean sharedLock; // default to false
-  private final boolean suppressNotFoundException; // default to false
-
-  public LockDatasetStep(DatasetService datasetService, UUID datasetId, boolean sharedLock) {
-    this(datasetService, datasetId, sharedLock, false);
-  }
-
-  public LockDatasetStep(
-      DatasetService datasetService,
-      UUID datasetId,
-      boolean sharedLock,
-      boolean suppressNotFoundException) {
-    this.datasetService = datasetService;
-    this.datasetId = datasetId;
-
+public record LockDatasetStep(
+    DatasetService datasetService,
+    UUID datasetId,
     // this will be set to true for a shared lock, false for an exclusive lock
-    this.sharedLock = sharedLock;
-
+    boolean sharedLock,
     // this will be set to true in cases where we don't want to fail if the dataset metadata record
     // doesn't exist.
     // for example, dataset deletion. we want multiple deletes to succeed, not throw a lock or
     // notfound exception.
     // for most cases, this should be set to false because we expect the dataset metadata record to
     // exist.
-    this.suppressNotFoundException = suppressNotFoundException;
+    boolean suppressNotFoundException)
+    implements Step {
+
+  private static final Logger logger = LoggerFactory.getLogger(LockDatasetStep.class);
+
+  public LockDatasetStep(DatasetService datasetService, UUID datasetId, boolean sharedLock) {
+    this(datasetService, datasetId, sharedLock, false);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/CombinedFileIngestOptionalStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/CombinedFileIngestOptionalStep.java
@@ -5,11 +5,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import java.util.Objects;
 
-public class CombinedFileIngestOptionalStep extends OptionalStep {
-  public CombinedFileIngestOptionalStep(Step step) {
-    super(step);
-  }
-
+public record CombinedFileIngestOptionalStep(Step step) implements OptionalStep {
   @Override
   public boolean isEnabled(FlightContext context) {
     return IngestUtils.isCombinedFileIngest(context);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestBulkMapResponseStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestBulkMapResponseStep.java
@@ -15,15 +15,8 @@ import java.util.UUID;
 // It expects the following working map data:
 // - LOAD_ID - load id we are working on
 //
-public class IngestBulkMapResponseStep extends DefaultUndoStep {
-
-  private final LoadService loadService;
-  private final String loadTag;
-
-  public IngestBulkMapResponseStep(LoadService loadService, String loadTag) {
-    this.loadService = loadService;
-    this.loadTag = loadTag;
-  }
+public record IngestBulkMapResponseStep(LoadService loadService, String loadTag)
+    implements DefaultUndoStep {
 
   @Override
   public StepResult doStep(FlightContext context) {

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCopyControlFileStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCopyControlFileStep.java
@@ -14,16 +14,8 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import com.google.cloud.storage.BlobId;
 
-public class IngestCopyControlFileStep extends DefaultUndoStep {
-
-  private final DatasetService datasetService;
-  private final GcsPdao gcsPdao;
-
-  public IngestCopyControlFileStep(DatasetService datasetService, GcsPdao gcsPdao) {
-    this.datasetService = datasetService;
-    this.gcsPdao = gcsPdao;
-  }
-
+public record IngestCopyControlFileStep(DatasetService datasetService, GcsPdao gcsPdao)
+    implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     FlightMap workingMap = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateAzureRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateAzureRefsStep.java
@@ -14,24 +14,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class IngestValidateAzureRefsStep extends IngestValidateRefsStep {
-
-  private final AzureAuthService azureAuthService;
-  private final DatasetService datasetService;
-  private final AzureSynapsePdao azureSynapsePdao;
-  private final TableDirectoryDao tableDirectoryDao;
-
-  public IngestValidateAzureRefsStep(
-      AzureAuthService azureAuthService,
-      DatasetService datasetService,
-      AzureSynapsePdao azureSynapsePdao,
-      TableDirectoryDao tableDirectoryDao) {
-    this.azureAuthService = azureAuthService;
-    this.datasetService = datasetService;
-    this.azureSynapsePdao = azureSynapsePdao;
-    this.tableDirectoryDao = tableDirectoryDao;
-  }
-
+public record IngestValidateAzureRefsStep(
+    AzureAuthService azureAuthService,
+    DatasetService datasetService,
+    AzureSynapsePdao azureSynapsePdao,
+    TableDirectoryDao tableDirectoryDao)
+    implements IngestValidateRefsStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     var workingMap = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateGcpRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateGcpRefsStep.java
@@ -12,21 +12,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class IngestValidateGcpRefsStep extends IngestValidateRefsStep {
-
-  private final DatasetService datasetService;
-  private final BigQueryDatasetPdao bigQueryDatasetPdao;
-  private final FireStoreDao fileDao;
-
-  public IngestValidateGcpRefsStep(
-      DatasetService datasetService,
-      BigQueryDatasetPdao bigQueryDatasetPdao,
-      FireStoreDao fileDao) {
-    this.datasetService = datasetService;
-    this.bigQueryDatasetPdao = bigQueryDatasetPdao;
-    this.fileDao = fileDao;
-  }
-
+public record IngestValidateGcpRefsStep(
+    DatasetService datasetService, BigQueryDatasetPdao bigQueryDatasetPdao, FireStoreDao fileDao)
+    implements IngestValidateRefsStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Dataset dataset = IngestUtils.getDataset(context, datasetService);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateRefsStep.java
@@ -6,17 +6,16 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
-public abstract class IngestValidateRefsStep implements Step {
-  private static final int MAX_ERROR_REF_IDS = 20;
+public interface IngestValidateRefsStep extends Step {
+  int MAX_ERROR_REF_IDS = 20;
 
-  public StepResult handleInvalidRefs(Set<InvalidRefId> invalidRefIds) {
+  default StepResult handleInvalidRefs(Set<InvalidRefId> invalidRefIds) {
     int invalidIdCount = invalidRefIds.size();
     if (invalidIdCount != 0) {
       // Made a string buffer to appease findbugs; it saw + in the loop and said "bad!"
-      StringBuffer errorMessage = new StringBuffer("Invalid file ids found during ingest (");
+      StringBuilder errorMessage = new StringBuilder("Invalid file ids found during ingest (");
 
       List<String> errorDetails = new ArrayList<>();
       int count = 0;
@@ -28,7 +27,7 @@ public abstract class IngestValidateRefsStep implements Step {
         errorDetails.add(badId.toString());
         count++;
       }
-      errorMessage.append(invalidIdCount + " returned in details)");
+      errorMessage.append(invalidIdCount).append(" returned in details)");
       throw new InvalidFileRefException(errorMessage.toString(), errorDetails);
     }
 
@@ -36,36 +35,10 @@ public abstract class IngestValidateRefsStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext context) {
+  public default StepResult undoStep(FlightContext context) {
     // The update will update row ids that are null, so it can be restarted on failure.
     return StepResult.getStepResultSuccess();
   }
 
-  public static class InvalidRefId {
-    public final String refId;
-    public final String columnName;
-
-    public InvalidRefId(String refId, String columnName) {
-      this.refId = refId;
-      this.columnName = columnName;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      InvalidRefId that = (InvalidRefId) o;
-      return Objects.equals(refId, that.refId) && Objects.equals(columnName, that.columnName);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(refId, columnName);
-    }
-
-    @Override
-    public String toString() {
-      return "{" + "refId: " + refId + ", " + "columnName: " + columnName + "}";
-    }
-  }
+  record InvalidRefId(String refId, String columnName) {}
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/NonCombinedFileIngestOptionalStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/NonCombinedFileIngestOptionalStep.java
@@ -4,11 +4,7 @@ import bio.terra.service.job.OptionalStep;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 
-public class NonCombinedFileIngestOptionalStep extends OptionalStep {
-  public NonCombinedFileIngestOptionalStep(Step step) {
-    super(step);
-  }
-
+public record NonCombinedFileIngestOptionalStep(Step step) implements OptionalStep {
   @Override
   public boolean isEnabled(FlightContext context) {
     return !IngestUtils.isCombinedFileIngest(context);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/PerformPayloadIngestStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/PerformPayloadIngestStep.java
@@ -4,11 +4,7 @@ import bio.terra.service.job.OptionalStep;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 
-public class PerformPayloadIngestStep extends OptionalStep {
-  public PerformPayloadIngestStep(Step step) {
-    super(step);
-  }
-
+public record PerformPayloadIngestStep(Step step) implements OptionalStep {
   @Override
   public boolean isEnabled(FlightContext context) {
     return IngestUtils.isIngestFromPayload(context.getInputParameters());

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
@@ -13,13 +13,8 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import com.azure.storage.blob.BlobContainerClient;
 
-public class CreateScratchFileForAzureStep extends DefaultUndoStep {
-
-  private final AzureContainerPdao azureContainerPdao;
-
-  public CreateScratchFileForAzureStep(AzureContainerPdao azureContainerPdao) {
-    this.azureContainerPdao = azureContainerPdao;
-  }
+public record CreateScratchFileForAzureStep(AzureContainerPdao azureContainerPdao)
+    implements DefaultUndoStep {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
@@ -40,11 +35,6 @@ public class CreateScratchFileForAzureStep extends DefaultUndoStep {
             .getBlobUrl();
 
     context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), path);
-    return StepResult.getStepResultSuccess();
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForGCPStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForGCPStep.java
@@ -12,10 +12,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import com.google.cloud.storage.BlobId;
 
-public class CreateScratchFileForGCPStep extends DefaultUndoStep {
-
-  public CreateScratchFileForGCPStep() {}
-
+public class CreateScratchFileForGCPStep implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
@@ -29,11 +26,6 @@ public class CreateScratchFileForGCPStep extends DefaultUndoStep {
     String path = GcsUriUtils.getGsPathFromBlob(scratchFilePath);
 
     context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), path);
-    return StepResult.getStepResultSuccess();
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqDropStageTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqDropStageTableStep.java
@@ -8,24 +8,10 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class ConvertToPredictableFileIdsBqDropStageTableStep extends DefaultUndoStep {
-  private static final Logger logger =
-      LoggerFactory.getLogger(ConvertToPredictableFileIdsBqDropStageTableStep.class);
-
-  private final UUID datasetId;
-  private final DatasetService datasetService;
-  private final BigQueryDatasetPdao bigQueryDatasetPdao;
-
-  public ConvertToPredictableFileIdsBqDropStageTableStep(
-      UUID datasetId, DatasetService datasetService, BigQueryDatasetPdao bigQueryDatasetPdao) {
-    this.datasetId = datasetId;
-    this.datasetService = datasetService;
-    this.bigQueryDatasetPdao = bigQueryDatasetPdao;
-  }
-
+public record ConvertToPredictableFileIdsBqDropStageTableStep(
+    UUID datasetId, DatasetService datasetService, BigQueryDatasetPdao bigQueryDatasetPdao)
+    implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     Dataset dataset = datasetService.retrieve(datasetId);

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqStageDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqStageDataStep.java
@@ -12,20 +12,11 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConvertToPredictableFileIdsBqStageDataStep extends DefaultUndoStep {
+public record ConvertToPredictableFileIdsBqStageDataStep(
+    UUID datasetId, DatasetService datasetService, BigQueryDatasetPdao bigQueryDatasetPdao)
+    implements DefaultUndoStep {
   private static final Logger logger =
       LoggerFactory.getLogger(ConvertToPredictableFileIdsBqStageDataStep.class);
-
-  private final UUID datasetId;
-  private final DatasetService datasetService;
-  private final BigQueryDatasetPdao bigQueryDatasetPdao;
-
-  public ConvertToPredictableFileIdsBqStageDataStep(
-      UUID datasetId, DatasetService datasetService, BigQueryDatasetPdao bigQueryDatasetPdao) {
-    this.datasetId = datasetId;
-    this.datasetService = datasetService;
-    this.bigQueryDatasetPdao = bigQueryDatasetPdao;
-  }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqUpdateRowsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqUpdateRowsStep.java
@@ -16,25 +16,14 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConvertToPredictableFileIdsBqUpdateRowsStep extends DefaultUndoStep {
+public record ConvertToPredictableFileIdsBqUpdateRowsStep(
+    UUID datasetId,
+    DatasetService datasetService,
+    BigQueryDatasetPdao bigQueryDatasetPdao,
+    AuthenticatedUserRequest authedUser)
+    implements DefaultUndoStep {
   private static final Logger logger =
       LoggerFactory.getLogger(ConvertToPredictableFileIdsBqUpdateRowsStep.class);
-
-  private final UUID datasetId;
-  private final DatasetService datasetService;
-  private final BigQueryDatasetPdao bigQueryDatasetPdao;
-  private final AuthenticatedUserRequest authedUser;
-
-  public ConvertToPredictableFileIdsBqUpdateRowsStep(
-      UUID datasetId,
-      DatasetService datasetService,
-      BigQueryDatasetPdao bigQueryDatasetPdao,
-      AuthenticatedUserRequest authedUser) {
-    this.datasetId = datasetId;
-    this.datasetService = datasetService;
-    this.bigQueryDatasetPdao = bigQueryDatasetPdao;
-    this.authedUser = authedUser;
-  }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsGetIdsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsGetIdsStep.java
@@ -18,29 +18,13 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class ConvertToPredictableFileIdsGetIdsStep extends DefaultUndoStep {
-  private static final Logger logger =
-      LoggerFactory.getLogger(ConvertToPredictableFileIdsGetIdsStep.class);
-
-  private final UUID datasetId;
-  private final DatasetService datasetService;
-  private final FireStoreDao fileDao;
-  private final FileIdService fileIdService;
-
-  public ConvertToPredictableFileIdsGetIdsStep(
-      UUID datasetId,
-      DatasetService datasetService,
-      FireStoreDao fileDao,
-      FileIdService fileIdService) {
-    this.datasetId = datasetId;
-    this.datasetService = datasetService;
-    this.fileDao = fileDao;
-    this.fileIdService = fileIdService;
-  }
-
+public record ConvertToPredictableFileIdsGetIdsStep(
+    UUID datasetId,
+    DatasetService datasetService,
+    FireStoreDao fileDao,
+    FileIdService fileIdService)
+    implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     Dataset dataset = datasetService.retrieve(datasetId);

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsSetResponseStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsSetResponseStep.java
@@ -11,16 +11,8 @@ import bio.terra.stairway.exception.RetryException;
 import java.util.Map;
 import java.util.UUID;
 
-public class ConvertToPredictableFileIdsSetResponseStep extends DefaultUndoStep {
-
-  private final UUID datasetId;
-  private final DatasetService datasetService;
-
-  public ConvertToPredictableFileIdsSetResponseStep(UUID datasetId, DatasetService datasetService) {
-    this.datasetId = datasetId;
-    this.datasetService = datasetService;
-  }
-
+public record ConvertToPredictableFileIdsSetResponseStep(
+    UUID datasetId, DatasetService datasetService) implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     Dataset dataset = datasetService.retrieve(datasetId);

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsVerifyDatasetStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsVerifyDatasetStep.java
@@ -11,19 +11,9 @@ import bio.terra.stairway.exception.RetryException;
 import java.util.List;
 import java.util.UUID;
 
-public class ConvertToPredictableFileIdsVerifyDatasetStep extends DefaultUndoStep {
-
-  private final UUID datasetId;
-  private final SnapshotService snapshotService;
-  private final AuthenticatedUserRequest userReq;
-
-  public ConvertToPredictableFileIdsVerifyDatasetStep(
-      UUID datasetId, SnapshotService snapshotService, AuthenticatedUserRequest userReq) {
-    this.datasetId = datasetId;
-    this.snapshotService = snapshotService;
-    this.userReq = userReq;
-  }
-
+public record ConvertToPredictableFileIdsVerifyDatasetStep(
+    UUID datasetId, SnapshotService snapshotService, AuthenticatedUserRequest userReq)
+    implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     long numSnapshotsFromDataset =

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/CreateBucketForBigQueryScratchStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/CreateBucketForBigQueryScratchStep.java
@@ -15,16 +15,8 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.UUID;
 
-public class CreateBucketForBigQueryScratchStep extends DefaultUndoStep {
-
-  private final ResourceService resourceService;
-  private final DatasetService datasetService;
-
-  public CreateBucketForBigQueryScratchStep(
-      ResourceService resourceService, DatasetService datasetService) {
-    this.resourceService = resourceService;
-    this.datasetService = datasetService;
-  }
+public record CreateBucketForBigQueryScratchStep(
+    ResourceService resourceService, DatasetService datasetService) implements DefaultUndoStep {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileAzureStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileAzureStep.java
@@ -21,27 +21,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.stream.Stream;
 
-public class IngestBuildAndWriteScratchLoadFileAzureStep
-    extends IngestBuildAndWriteScratchLoadFileStep {
-  private final AzureBlobStorePdao azureBlobStorePdao;
-  private final AzureContainerPdao azureContainerPdao;
-  private final AuthenticatedUserRequest userRequest;
-
-  public IngestBuildAndWriteScratchLoadFileAzureStep(
-      ObjectMapper objectMapper,
-      AzureBlobStorePdao azureBlobStorePdao,
-      AzureContainerPdao azureContainerPdao,
-      Dataset dataset,
-      AuthenticatedUserRequest userRequest,
-      int maxBadLoadFileLineErrorsReported) {
-    super(objectMapper, dataset, maxBadLoadFileLineErrorsReported);
-    this.azureBlobStorePdao = azureBlobStorePdao;
-    this.azureContainerPdao = azureContainerPdao;
-    this.userRequest = userRequest;
-  }
-
+public record IngestBuildAndWriteScratchLoadFileAzureStep(
+    ObjectMapper objectMapper,
+    AzureBlobStorePdao azureBlobStorePdao,
+    AzureContainerPdao azureContainerPdao,
+    Dataset dataset,
+    AuthenticatedUserRequest userRequest,
+    int maxBadLoadFileLineErrorsReported)
+    implements IngestBuildAndWriteScratchLoadFileStep {
   @Override
-  Stream<JsonNode> getJsonNodesFromCloudFile(
+  public Stream<JsonNode> getJsonNodesFromCloudFile(
       IngestRequestModel ingestRequest, ErrorCollector errorCollector) {
     String tenantId =
         IngestUtils.getIngestBillingProfileFromDataset(dataset, ingestRequest)
@@ -57,7 +46,7 @@ public class IngestBuildAndWriteScratchLoadFileAzureStep
   }
 
   @Override
-  String getOutputFilePath(FlightContext flightContext) {
+  public String getOutputFilePath(FlightContext flightContext) {
     FlightMap workingMap = flightContext.getWorkingMap();
     BillingProfileModel billingProfile =
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
@@ -73,7 +62,7 @@ public class IngestBuildAndWriteScratchLoadFileAzureStep
   }
 
   @Override
-  void writeCloudFile(FlightContext flightContext, String path, Stream<String> lines) {
+  public void writeCloudFile(FlightContext flightContext, String path, Stream<String> lines) {
     FlightMap workingMap = flightContext.getWorkingMap();
     BillingProfileModel billingProfile =
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBuildAndWriteScratchLoadFileGcpStep.java
@@ -15,24 +15,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.stream.Stream;
 
-public class IngestBuildAndWriteScratchLoadFileGcpStep
-    extends IngestBuildAndWriteScratchLoadFileStep {
-  private final GcsPdao gcsPdao;
-  private final AuthenticatedUserRequest userRequest;
-
-  public IngestBuildAndWriteScratchLoadFileGcpStep(
-      ObjectMapper objectMapper,
-      GcsPdao gcsPdao,
-      Dataset dataset,
-      AuthenticatedUserRequest userRequest,
-      int maxBadLoadFileLineErrorsReported) {
-    super(objectMapper, dataset, maxBadLoadFileLineErrorsReported);
-    this.gcsPdao = gcsPdao;
-    this.userRequest = userRequest;
-  }
-
+public record IngestBuildAndWriteScratchLoadFileGcpStep(
+    ObjectMapper objectMapper,
+    GcsPdao gcsPdao,
+    Dataset dataset,
+    AuthenticatedUserRequest userRequest,
+    int maxBadLoadFileLineErrorsReported)
+    implements IngestBuildAndWriteScratchLoadFileStep {
   @Override
-  Stream<JsonNode> getJsonNodesFromCloudFile(
+  public Stream<JsonNode> getJsonNodesFromCloudFile(
       IngestRequestModel ingestRequest, ErrorCollector errorCollector) {
     return IngestUtils.getJsonNodesStreamFromFile(
         gcsPdao,
@@ -44,7 +35,7 @@ public class IngestBuildAndWriteScratchLoadFileGcpStep
   }
 
   @Override
-  String getOutputFilePath(FlightContext flightContext) {
+  public String getOutputFilePath(FlightContext flightContext) {
     GoogleBucketResource bucket =
         flightContext
             .getWorkingMap()
@@ -55,7 +46,7 @@ public class IngestBuildAndWriteScratchLoadFileGcpStep
   }
 
   @Override
-  void writeCloudFile(FlightContext flightContext, String path, Stream<String> lines) {
+  public void writeCloudFile(FlightContext flightContext, String path, Stream<String> lines) {
     GoogleBucketResource bucket =
         flightContext
             .getWorkingMap()

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
@@ -12,14 +12,9 @@ import org.apache.commons.collections4.CollectionUtils;
 // It expects the following working map data:
 // - BULK_LOAD_RESULT - a BulkLoadArrayResultModel object
 //
-public class IngestBulkBulkModeResponseStep extends DefaultUndoStep {
+public record IngestBulkBulkModeResponseStep(boolean isArrayMode) implements DefaultUndoStep {
 
   private static final int MAX_FILE_RESULTS = 1000;
-  private final boolean isArrayMode;
-
-  public IngestBulkBulkModeResponseStep(boolean isArrayMode) {
-    this.isArrayMode = isArrayMode;
-  }
 
   @Override
   public StepResult doStep(FlightContext context) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
@@ -53,9 +53,9 @@ import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class IngestBulkGcpStep extends DefaultUndoStep {
+public abstract class IngestBulkGcpStep implements DefaultUndoStep {
 
-  private Logger logger = LoggerFactory.getLogger(IngestBulkGcpStep.class);
+  private static final Logger logger = LoggerFactory.getLogger(IngestBulkGcpStep.class);
 
   protected final String loadTag;
   protected final UUID profileId;

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCleanFileStateStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCleanFileStateStep.java
@@ -9,14 +9,7 @@ import bio.terra.stairway.StepResult;
 import java.util.UUID;
 
 // Populate the files to be loaded from the incoming array
-public class IngestCleanFileStateStep extends DefaultUndoStep {
-
-  private final LoadService loadService;
-
-  public IngestCleanFileStateStep(LoadService loadService) {
-    this.loadService = loadService;
-  }
-
+public record IngestCleanFileStateStep(LoadService loadService) implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) {
     FlightMap workingMap = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCreateAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCreateAzureStorageAccountStep.java
@@ -6,12 +6,8 @@ import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 
-public class IngestCreateAzureStorageAccountStep extends CreateAzureStorageAccountStep {
-
-  public IngestCreateAzureStorageAccountStep(ResourceService resourceService, Dataset dataset) {
-    super(resourceService, dataset);
-  }
-
+public record IngestCreateAzureStorageAccountStep(ResourceService resourceService, Dataset dataset)
+    implements CreateAzureStorageAccountStep {
   @Override
   public StepResult doStep(FlightContext flightContext) throws InterruptedException {
     getOrCreateDatasetStorageAccount(flightContext);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -58,42 +58,19 @@ import org.slf4j.LoggerFactory;
 // - BUCKET_INFO is a GoogleBucketResource
 // - STORAGE_ACCOUNT_RESOURCE is a AzureStorageAccountResource
 //
-public class IngestDriverStep extends DefaultUndoStep {
+public record IngestDriverStep(
+    LoadService loadService,
+    ConfigurationService configurationService,
+    JobService jobService,
+    String datasetId,
+    String loadTag,
+    int maxFailedFileLoads,
+    int driverWaitSeconds,
+    UUID profileId,
+    CloudPlatform platform,
+    AuthenticatedUserRequest userReq)
+    implements DefaultUndoStep {
   private static final Logger logger = LoggerFactory.getLogger(IngestDriverStep.class);
-
-  private final LoadService loadService;
-  private final ConfigurationService configurationService;
-  private final JobService jobService;
-  private final String datasetId;
-  private final String loadTag;
-  private final int maxFailedFileLoads;
-  private final int driverWaitSeconds;
-  private final UUID profileId;
-  private final CloudPlatform platform;
-  private final AuthenticatedUserRequest userReq;
-
-  public IngestDriverStep(
-      LoadService loadService,
-      ConfigurationService configurationService,
-      JobService jobService,
-      String datasetId,
-      String loadTag,
-      int maxFailedFileLoads,
-      int driverWaitSeconds,
-      UUID profileId,
-      CloudPlatform platform,
-      AuthenticatedUserRequest userReq) {
-    this.loadService = loadService;
-    this.configurationService = configurationService;
-    this.jobService = jobService;
-    this.datasetId = datasetId;
-    this.loadTag = loadTag;
-    this.maxFailedFileLoads = maxFailedFileLoads;
-    this.driverWaitSeconds = driverWaitSeconds;
-    this.profileId = profileId;
-    this.platform = platform;
-    this.userReq = userReq;
-  }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataLocationStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataLocationStep.java
@@ -8,12 +8,8 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 
-public class IngestFileAzurePrimaryDataLocationStep extends CreateAzureStorageAccountStep {
-
-  public IngestFileAzurePrimaryDataLocationStep(ResourceService resourceService, Dataset dataset) {
-    super(resourceService, dataset);
-  }
-
+public record IngestFileAzurePrimaryDataLocationStep(
+    ResourceService resourceService, Dataset dataset) implements CreateAzureStorageAccountStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileGetProjectStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileGetProjectStep.java
@@ -11,15 +11,8 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 
 /** Requests a Google project from the Resource Buffer Service and puts it in the working map. */
-public class IngestFileGetProjectStep extends DefaultUndoStep {
-  private final Dataset dataset;
-  private final GoogleProjectService googleProjectService;
-
-  public IngestFileGetProjectStep(Dataset dataset, GoogleProjectService googleProjectService) {
-    this.dataset = dataset;
-    this.googleProjectService = googleProjectService;
-  }
-
+public record IngestFileGetProjectStep(Dataset dataset, GoogleProjectService googleProjectService)
+    implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) {
     // Requests a google project from RBS and puts it in the working map

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileInitializeProjectStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileInitializeProjectStep.java
@@ -14,15 +14,8 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 
-public class IngestFileInitializeProjectStep extends DefaultUndoStep {
-  private final ResourceService resourceService;
-  private final Dataset dataset;
-
-  public IngestFileInitializeProjectStep(ResourceService resourceService, Dataset dataset) {
-    this.resourceService = resourceService;
-    this.dataset = dataset;
-  }
-
+public record IngestFileInitializeProjectStep(ResourceService resourceService, Dataset dataset)
+    implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/ValidateIngestFileAzureDirectoryStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/ValidateIngestFileAzureDirectoryStep.java
@@ -18,17 +18,10 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.azure.core.management.exception.ManagementException;
 
-public class ValidateIngestFileAzureDirectoryStep extends DefaultUndoStep {
+public record ValidateIngestFileAzureDirectoryStep(TableDao tableDao, Dataset dataset)
+    implements DefaultUndoStep {
   public static final String CREATE_ENTRY_ACTION = "createEntry";
   public static final String CHECK_ENTRY_ACTION = "checkEntry";
-
-  private final TableDao tableDao;
-  private final Dataset dataset;
-
-  public ValidateIngestFileAzureDirectoryStep(TableDao tableDao, Dataset dataset) {
-    this.tableDao = tableDao;
-    this.dataset = dataset;
-  }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {

--- a/src/main/java/bio/terra/service/job/DefaultUndoStep.java
+++ b/src/main/java/bio/terra/service/job/DefaultUndoStep.java
@@ -5,9 +5,9 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 
 /** A subclass of Step that provides a default implementation of undo that returns success. */
-public abstract class DefaultUndoStep implements Step {
+public interface DefaultUndoStep extends Step {
   @Override
-  public StepResult undoStep(FlightContext context) {
+  default StepResult undoStep(FlightContext context) {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/load/flight/LoadUnlockStep.java
+++ b/src/main/java/bio/terra/service/load/flight/LoadUnlockStep.java
@@ -8,13 +8,7 @@ import bio.terra.stairway.StepResult;
 // This step is meant to be shared by dataset and filesystem flights for locking the load tag.
 // It expects to find LoadMapKeys.LOAD_TAG in the working map.
 
-public class LoadUnlockStep extends DefaultUndoStep {
-  private final LoadService loadService;
-
-  public LoadUnlockStep(LoadService loadService) {
-    this.loadService = loadService;
-  }
-
+public record LoadUnlockStep(LoadService loadService) implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) {
     String loadTag = loadService.getLoadTag(context);

--- a/src/main/java/bio/terra/service/profile/flight/AuthorizeBillingProfileUseStep.java
+++ b/src/main/java/bio/terra/service/profile/flight/AuthorizeBillingProfileUseStep.java
@@ -18,18 +18,9 @@ import java.util.UUID;
  * is stored in the working map of the flight in the ProfileMapKeys.PROFILE_MODEL entry. On failure,
  * exception is thrown and the flight will fail.
  */
-public class AuthorizeBillingProfileUseStep extends DefaultUndoStep {
-  private final ProfileService profileService;
-  private final UUID profileId;
-  private final AuthenticatedUserRequest user;
-
-  public AuthorizeBillingProfileUseStep(
-      ProfileService profileService, UUID profileId, AuthenticatedUserRequest user) {
-    this.profileService = profileService;
-    this.profileId = profileId;
-    this.user = user;
-  }
-
+public record AuthorizeBillingProfileUseStep(
+    ProfileService profileService, UUID profileId, AuthenticatedUserRequest user)
+    implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) {
     BillingProfileModel profileModel = profileService.authorizeLinking(profileId, user);

--- a/src/main/java/bio/terra/service/snapshot/flight/UnlockSnapshotStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/UnlockSnapshotStep.java
@@ -10,17 +10,10 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UnlockSnapshotStep extends DefaultUndoStep {
-
-  private final SnapshotDao snapshotDao;
-  private final UUID snapshotId;
+public record UnlockSnapshotStep(SnapshotDao snapshotDao, UUID snapshotId)
+    implements DefaultUndoStep {
 
   private static final Logger logger = LoggerFactory.getLogger(UnlockSnapshotStep.class);
-
-  public UnlockSnapshotStep(SnapshotDao snapshotDao, UUID snapshotId) {
-    this.snapshotDao = snapshotDao;
-    this.snapshotId = snapshotId;
-  }
 
   @Override
   public StepResult doStep(FlightContext context) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStep.java
@@ -10,20 +10,11 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.Map;
 
-public class CountSnapshotTableRowsStep implements Step {
-
-  private final BigQuerySnapshotPdao bigQuerySnapshotPdao;
-  private final SnapshotDao snapshotDao;
-  private final SnapshotRequestModel snapshotReq;
-
-  public CountSnapshotTableRowsStep(
-      BigQuerySnapshotPdao bigQuerySnapshotPdao,
-      SnapshotDao snapshotDao,
-      SnapshotRequestModel snapshotReq) {
-    this.bigQuerySnapshotPdao = bigQuerySnapshotPdao;
-    this.snapshotDao = snapshotDao;
-    this.snapshotReq = snapshotReq;
-  }
+public record CountSnapshotTableRowsStep(
+    BigQuerySnapshotPdao bigQuerySnapshotPdao,
+    SnapshotDao snapshotDao,
+    SnapshotRequestModel snapshotReq)
+    implements Step {
 
   @Override
   public StepResult doStep(FlightContext flightContext)

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByAssetParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByAssetParquetFilesAzureStep.java
@@ -18,18 +18,11 @@ import bio.terra.stairway.StepStatus;
 import java.sql.SQLException;
 import java.util.Map;
 
-public class CreateSnapshotByAssetParquetFilesAzureStep
-    extends CreateSnapshotParquetFilesAzureStep {
-  private final SnapshotRequestModel snapshotReq;
-
-  public CreateSnapshotByAssetParquetFilesAzureStep(
-      AzureSynapsePdao azureSynapsePdao,
-      SnapshotService snapshotService,
-      SnapshotRequestModel snapshotReq) {
-    super(azureSynapsePdao, snapshotService);
-    this.snapshotReq = snapshotReq;
-  }
-
+public record CreateSnapshotByAssetParquetFilesAzureStep(
+    AzureSynapsePdao azureSynapsePdao,
+    SnapshotService snapshotService,
+    SnapshotRequestModel snapshotReq)
+    implements CreateSnapshotParquetFilesAzureStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByFullViewParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByFullViewParquetFilesAzureStep.java
@@ -15,19 +15,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public class CreateSnapshotByFullViewParquetFilesAzureStep
-    extends CreateSnapshotParquetFilesAzureStep {
-
-  private final SnapshotRequestModel snapshotReq;
-
-  public CreateSnapshotByFullViewParquetFilesAzureStep(
-      AzureSynapsePdao azureSynapsePdao,
-      SnapshotService snapshotService,
-      SnapshotRequestModel snapshotReq) {
-    super(azureSynapsePdao, snapshotService);
-    this.snapshotReq = snapshotReq;
-  }
-
+public record CreateSnapshotByFullViewParquetFilesAzureStep(
+    AzureSynapsePdao azureSynapsePdao,
+    SnapshotService snapshotService,
+    SnapshotRequestModel snapshotReq)
+    implements CreateSnapshotParquetFilesAzureStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByQueryParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByQueryParquetFilesAzureStep.java
@@ -24,9 +24,11 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 
-public class CreateSnapshotByQueryParquetFilesAzureStep extends CreateSnapshotParquetFilesAzureStep
-    implements CreateSnapshotPrimaryDataQueryInterface {
+public class CreateSnapshotByQueryParquetFilesAzureStep
+    implements CreateSnapshotParquetFilesAzureStep, CreateSnapshotPrimaryDataQueryInterface {
 
+  private final AzureSynapsePdao azureSynapsePdao;
+  private final SnapshotService snapshotService;
   private final SnapshotDao snapshotDao;
   private final SnapshotRequestModel snapshotReq;
   private final DatasetService datasetService;
@@ -41,11 +43,22 @@ public class CreateSnapshotByQueryParquetFilesAzureStep extends CreateSnapshotPa
       SnapshotRequestModel snapshotReq,
       DatasetService datasetService,
       AuthenticatedUserRequest userRequest) {
-    super(azureSynapsePdao, snapshotService);
+    this.azureSynapsePdao = azureSynapsePdao;
+    this.snapshotService = snapshotService;
     this.snapshotReq = snapshotReq;
     this.snapshotDao = snapshotDao;
     this.datasetService = datasetService;
     this.userRequest = userRequest;
+  }
+
+  @Override
+  public AzureSynapsePdao azureSynapsePdao() {
+    return azureSynapsePdao;
+  }
+
+  @Override
+  public SnapshotService snapshotService() {
+    return snapshotService;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRowIdParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRowIdParquetFilesAzureStep.java
@@ -18,18 +18,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public class CreateSnapshotByRowIdParquetFilesAzureStep
-    extends CreateSnapshotParquetFilesAzureStep {
-  private final SnapshotRequestModel snapshotRequestModel;
-
-  public CreateSnapshotByRowIdParquetFilesAzureStep(
-      AzureSynapsePdao azureSynapsePdao,
-      SnapshotService snapshotService,
-      SnapshotRequestModel snapshotRequestModel) {
-    super(azureSynapsePdao, snapshotService);
-    this.snapshotRequestModel = snapshotRequestModel;
-  }
-
+public record CreateSnapshotByRowIdParquetFilesAzureStep(
+    AzureSynapsePdao azureSynapsePdao,
+    SnapshotService snapshotService,
+    SnapshotRequestModel snapshotRequestModel)
+    implements CreateSnapshotParquetFilesAzureStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     SnapshotRequestContentsModel contentsModel = snapshotRequestModel.getContents().get(0);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCleanSynapseAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCleanSynapseAzureStep.java
@@ -15,16 +15,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class CreateSnapshotCleanSynapseAzureStep implements Step {
-
-  private AzureSynapsePdao azureSynapsePdao;
-  private SnapshotService snapshotService;
-
-  public CreateSnapshotCleanSynapseAzureStep(
-      AzureSynapsePdao azureSynapsePdao, SnapshotService snapshotService) {
-    this.azureSynapsePdao = azureSynapsePdao;
-    this.snapshotService = snapshotService;
-  }
+public record CreateSnapshotCleanSynapseAzureStep(
+    AzureSynapsePdao azureSynapsePdao, SnapshotService snapshotService) implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
@@ -13,20 +13,9 @@ import bio.terra.stairway.exception.RetryException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CreateSnapshotCountTableRowsAzureStep implements Step {
-
-  private final AzureSynapsePdao azureSynapsePdao;
-  private final SnapshotDao snapshotDao;
-  private final SnapshotRequestModel snapshotReq;
-
-  public CreateSnapshotCountTableRowsAzureStep(
-      AzureSynapsePdao azureSynapsePdao,
-      SnapshotDao snapshotDao,
-      SnapshotRequestModel snapshotReq) {
-    this.azureSynapsePdao = azureSynapsePdao;
-    this.snapshotDao = snapshotDao;
-    this.snapshotReq = snapshotReq;
-  }
+public record CreateSnapshotCountTableRowsAzureStep(
+    AzureSynapsePdao azureSynapsePdao, SnapshotDao snapshotDao, SnapshotRequestModel snapshotReq)
+    implements Step {
 
   @Override
   public StepResult doStep(FlightContext flightContext)

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureStorageAccountStep.java
@@ -15,19 +15,9 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import java.util.UUID;
 
-public class CreateSnapshotCreateAzureStorageAccountStep extends CreateAzureStorageAccountStep {
-  private final ResourceService resourceService;
-  private final Dataset dataset;
-  private final SnapshotRequestModel snapshotRequestModel;
-
-  public CreateSnapshotCreateAzureStorageAccountStep(
-      ResourceService resourceService, Dataset dataset, SnapshotRequestModel snapshotRequestModel) {
-    super(resourceService, dataset);
-    this.resourceService = resourceService;
-    this.dataset = dataset;
-    this.snapshotRequestModel = snapshotRequestModel;
-  }
-
+public record CreateSnapshotCreateAzureStorageAccountStep(
+    ResourceService resourceService, Dataset dataset, SnapshotRequestModel snapshotRequestModel)
+    implements CreateAzureStorageAccountStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     getOrCreateDatasetStorageAccount(context);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateRowIdParquetFileStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateRowIdParquetFileStep.java
@@ -13,33 +13,21 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class CreateSnapshotCreateRowIdParquetFileStep implements Step {
-  private Logger logger = LoggerFactory.getLogger(CreateSnapshotCreateRowIdParquetFileStep.class);
-
-  private final AzureSynapsePdao azureSynapsePdao;
-  private final SnapshotService snapshotService;
-
-  public CreateSnapshotCreateRowIdParquetFileStep(
-      AzureSynapsePdao azureSynapsePdao, SnapshotService snapshotService) {
-    this.azureSynapsePdao = azureSynapsePdao;
-    this.snapshotService = snapshotService;
-  }
-
+public record CreateSnapshotCreateRowIdParquetFileStep(
+    AzureSynapsePdao azureSynapsePdao, SnapshotService snapshotService) implements Step {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
     FlightMap workingMap = flightContext.getWorkingMap();
     UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
     Map<String, Long> tableRowCounts =
-        workingMap.get(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, HashMap.class);
+        workingMap.get(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, new TypeReference<>() {});
     List<SnapshotTable> tables = snapshotService.retrieveTables(snapshotId);
     try {
       azureSynapsePdao.createSnapshotRowIdsParquetFile(

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreComputeStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreComputeStep.java
@@ -10,19 +10,9 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 
-public class CreateSnapshotFireStoreComputeStep implements Step {
-
-  private SnapshotService snapshotService;
-  private SnapshotRequestModel snapshotReq;
-  private FireStoreDao fileDao;
-
-  public CreateSnapshotFireStoreComputeStep(
-      SnapshotService snapshotService, SnapshotRequestModel snapshotReq, FireStoreDao fileDao) {
-    this.snapshotService = snapshotService;
-    this.snapshotReq = snapshotReq;
-    this.fileDao = fileDao;
-  }
-
+public record CreateSnapshotFireStoreComputeStep(
+    SnapshotService snapshotService, SnapshotRequestModel snapshotReq, FireStoreDao fileDao)
+    implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Snapshot snapshot = snapshotService.retrieveByName(snapshotReq.getName());

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotFireStoreDataStep.java
@@ -23,34 +23,17 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CreateSnapshotFireStoreDataStep implements Step {
+public record CreateSnapshotFireStoreDataStep(
+    BigQuerySnapshotPdao bigQuerySnapshotPdao,
+    SnapshotService snapshotService,
+    FireStoreDependencyDao dependencyDao,
+    DatasetService datasetService,
+    SnapshotRequestModel snapshotReq,
+    FireStoreDao fileDao,
+    PerformanceLogger performanceLogger)
+    implements Step {
   private static final Logger logger =
       LoggerFactory.getLogger(CreateSnapshotFireStoreDataStep.class);
-
-  private final BigQuerySnapshotPdao bigQuerySnapshotPdao;
-  private final SnapshotService snapshotService;
-  private final FireStoreDependencyDao dependencyDao;
-  private final DatasetService datasetService;
-  private final SnapshotRequestModel snapshotReq;
-  private final FireStoreDao fileDao;
-  private final PerformanceLogger performanceLogger;
-
-  public CreateSnapshotFireStoreDataStep(
-      BigQuerySnapshotPdao bigQuerySnapshotPdao,
-      SnapshotService snapshotService,
-      FireStoreDependencyDao dependencyDao,
-      DatasetService datasetService,
-      SnapshotRequestModel snapshotReq,
-      FireStoreDao fileDao,
-      PerformanceLogger performanceLogger) {
-    this.bigQuerySnapshotPdao = bigQuerySnapshotPdao;
-    this.snapshotService = snapshotService;
-    this.dependencyDao = dependencyDao;
-    this.datasetService = datasetService;
-    this.snapshotReq = snapshotReq;
-    this.fileDao = fileDao;
-    this.performanceLogger = performanceLogger;
-  }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotIdStep.java
@@ -9,18 +9,8 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class CreateSnapshotIdStep implements Step {
-  private final SnapshotRequestModel snapshotReq;
-
-  private static Logger logger = LoggerFactory.getLogger(CreateSnapshotIdStep.class);
-
-  public CreateSnapshotIdStep(SnapshotRequestModel snapshotReq) {
-    this.snapshotReq = snapshotReq;
-  }
-
+public record CreateSnapshotIdStep(SnapshotRequestModel snapshotReq) implements Step {
   @Override
   public StepResult doStep(FlightContext context) {
     try {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotInitializeProjectStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotInitializeProjectStep.java
@@ -14,18 +14,9 @@ import bio.terra.stairway.StepStatus;
 import java.util.List;
 import java.util.UUID;
 
-public class CreateSnapshotInitializeProjectStep implements Step {
-  private final ResourceService resourceService;
-  private final List<Dataset> sourceDatasets;
-  private final String snapshotName;
-
-  public CreateSnapshotInitializeProjectStep(
-      ResourceService resourceService, List<Dataset> sourceDatasets, String snapshotName) {
-    this.resourceService = resourceService;
-    this.sourceDatasets = sourceDatasets;
-    this.snapshotName = snapshotName;
-  }
-
+public record CreateSnapshotInitializeProjectStep(
+    ResourceService resourceService, List<Dataset> sourceDatasets, String snapshotName)
+    implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -22,24 +22,13 @@ import org.springframework.dao.CannotSerializeTransactionException;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.TransactionSystemException;
 
-public class CreateSnapshotMetadataStep implements Step {
-  private final SnapshotDao snapshotDao;
-  private final SnapshotService snapshotService;
-  private final SnapshotRequestModel snapshotReq;
-
+public record CreateSnapshotMetadataStep(
+    SnapshotDao snapshotDao,
+    SnapshotService snapshotService,
+    SnapshotRequestModel snapshotReq,
+    AuthenticatedUserRequest userReq)
+    implements Step {
   private static final Logger logger = LoggerFactory.getLogger(CreateSnapshotMetadataStep.class);
-  private final AuthenticatedUserRequest userReq;
-
-  public CreateSnapshotMetadataStep(
-      SnapshotDao snapshotDao,
-      SnapshotService snapshotService,
-      SnapshotRequestModel snapshotReq,
-      AuthenticatedUserRequest userReq) {
-    this.snapshotDao = snapshotDao;
-    this.snapshotService = snapshotService;
-    this.snapshotReq = snapshotReq;
-    this.userReq = userReq;
-  }
 
   @Override
   public StepResult doStep(FlightContext context) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotParquetFilesAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotParquetFilesAzureStep.java
@@ -12,35 +12,24 @@ import bio.terra.stairway.StepResult;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.NotImplementedException;
 
-public class CreateSnapshotParquetFilesAzureStep implements Step {
+public interface CreateSnapshotParquetFilesAzureStep extends Step {
 
-  protected AzureSynapsePdao azureSynapsePdao;
-  protected SnapshotService snapshotService;
+  AzureSynapsePdao azureSynapsePdao();
 
-  public CreateSnapshotParquetFilesAzureStep(
-      AzureSynapsePdao azureSynapsePdao, SnapshotService snapshotService) {
-    this.azureSynapsePdao = azureSynapsePdao;
-    this.snapshotService = snapshotService;
-  }
+  SnapshotService snapshotService();
 
   @Override
-  public StepResult doStep(FlightContext context) throws InterruptedException {
-    throw new NotImplementedException(
-        "doStep should be implemented by Snapshot Type Specific Steps");
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext context) {
+  default StepResult undoStep(FlightContext context) {
     FlightMap workingMap = context.getWorkingMap();
     UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-    List<SnapshotTable> tables = snapshotService.retrieveTables(snapshotId);
+    List<SnapshotTable> tables = snapshotService().retrieveTables(snapshotId);
 
-    azureSynapsePdao.dropTables(
-        tables.stream()
-            .map(table -> IngestUtils.formatSnapshotTableName(snapshotId, table.getName()))
-            .collect(Collectors.toList()));
+    azureSynapsePdao()
+        .dropTables(
+            tables.stream()
+                .map(table -> IngestUtils.formatSnapshotTableName(snapshotId, table.getName()))
+                .collect(Collectors.toList()));
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/PerformAzureDatasetDependencyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/PerformAzureDatasetDependencyStep.java
@@ -6,11 +6,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 
-public class PerformAzureDatasetDependencyStep extends OptionalStep {
-  public PerformAzureDatasetDependencyStep(Step step) {
-    super(step);
-  }
-
+public record PerformAzureDatasetDependencyStep(Step step) implements OptionalStep {
   @Override
   public boolean isEnabled(FlightContext context) {
     FlightMap map = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/PerformAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/PerformAzureStep.java
@@ -6,12 +6,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 
-public class PerformAzureStep extends OptionalStep {
-
-  public PerformAzureStep(Step step) {
-    super(step);
-  }
-
+public record PerformAzureStep(Step step) implements OptionalStep {
   @Override
   public boolean isEnabled(FlightContext context) {
     FlightMap map = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/PerformDatasetStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/PerformDatasetStep.java
@@ -5,11 +5,7 @@ import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 
-public class PerformDatasetStep extends OptionalStep {
-  public PerformDatasetStep(Step step) {
-    super(step);
-  }
-
+public record PerformDatasetStep(Step step) implements OptionalStep {
   @Override
   public boolean isEnabled(FlightContext context) {
     return context.getWorkingMap().get(SnapshotWorkingMapKeys.DATASET_EXISTS, boolean.class);

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/PerformGCPDatasetDependencyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/PerformGCPDatasetDependencyStep.java
@@ -6,11 +6,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 
-public class PerformGCPDatasetDependencyStep extends OptionalStep {
-  public PerformGCPDatasetDependencyStep(Step step) {
-    super(step);
-  }
-
+public record PerformGCPDatasetDependencyStep(Step step) implements OptionalStep {
   @Override
   public boolean isEnabled(FlightContext context) {
     FlightMap map = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/PerformGcpStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/PerformGcpStep.java
@@ -6,11 +6,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 
-public class PerformGcpStep extends OptionalStep {
-  public PerformGcpStep(Step step) {
-    super(step);
-  }
-
+public record PerformGcpStep(Step step) implements OptionalStep {
   @Override
   public boolean isEnabled(FlightContext context) {
     FlightMap map = context.getWorkingMap();

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/PerformSnapshotStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/PerformSnapshotStep.java
@@ -5,11 +5,7 @@ import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 
-public class PerformSnapshotStep extends OptionalStep {
-  public PerformSnapshotStep(Step step) {
-    super(step);
-  }
-
+public record PerformSnapshotStep(Step step) implements OptionalStep {
   @Override
   public boolean isEnabled(FlightContext context) {
     return context.getWorkingMap().get(SnapshotWorkingMapKeys.SNAPSHOT_EXISTS, boolean.class);

--- a/src/main/java/bio/terra/service/snapshot/flight/duos/IfNoGroupRetrievedStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/duos/IfNoGroupRetrievedStep.java
@@ -5,10 +5,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 
-public class IfNoGroupRetrievedStep extends OptionalStep {
-  public IfNoGroupRetrievedStep(Step step) {
-    super(step);
-  }
+public record IfNoGroupRetrievedStep(Step step) implements OptionalStep {
 
   @Override
   public boolean isEnabled(FlightContext context) {

--- a/src/main/java/bio/terra/service/snapshot/flight/duos/SyncDuosFirecloudGroupStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/duos/SyncDuosFirecloudGroupStep.java
@@ -7,16 +7,8 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 
-public class SyncDuosFirecloudGroupStep extends DefaultUndoStep {
-
-  private final DuosService duosService;
-  private final String duosId;
-
-  public SyncDuosFirecloudGroupStep(DuosService duosService, String duosId) {
-    this.duosService = duosService;
-    this.duosId = duosId;
-  }
-
+public record SyncDuosFirecloudGroupStep(DuosService duosService, String duosId)
+    implements DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
     DuosFirecloudGroupModel synced = duosService.syncDuosDatasetAuthorizedUsers(duosId);

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportCreateBucketStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportCreateBucketStep.java
@@ -15,18 +15,9 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
 
-public class SnapshotExportCreateBucketStep extends DefaultUndoStep {
-
-  private final ResourceService resourceService;
-  private final SnapshotService snapshotService;
-  private final UUID snapshotId;
-
-  public SnapshotExportCreateBucketStep(
-      ResourceService resourceService, SnapshotService snapshotService, UUID snapshotId) {
-    this.resourceService = resourceService;
-    this.snapshotService = snapshotService;
-    this.snapshotId = snapshotId;
-  }
+public record SnapshotExportCreateBucketStep(
+    ResourceService resourceService, SnapshotService snapshotService, UUID snapshotId)
+    implements DefaultUndoStep {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportCreateParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportCreateParquetFilesStep.java
@@ -17,26 +17,13 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class SnapshotExportCreateParquetFilesStep extends DefaultUndoStep {
-
-  private final BigQueryExportPdao bigQueryExportPdao;
-  private final GcsPdao gcsPdao;
-  private final SnapshotService snapshotService;
-  private final UUID snapshotId;
-  private final boolean exportGsPaths;
-
-  public SnapshotExportCreateParquetFilesStep(
-      BigQueryExportPdao bigQueryExportPdao,
-      GcsPdao gcsPdao,
-      SnapshotService snapshotService,
-      UUID snapshotId,
-      boolean exportGsPaths) {
-    this.bigQueryExportPdao = bigQueryExportPdao;
-    this.gcsPdao = gcsPdao;
-    this.snapshotService = snapshotService;
-    this.snapshotId = snapshotId;
-    this.exportGsPaths = exportGsPaths;
-  }
+public record SnapshotExportCreateParquetFilesStep(
+    BigQueryExportPdao bigQueryExportPdao,
+    GcsPdao gcsPdao,
+    SnapshotService snapshotService,
+    UUID snapshotId,
+    boolean exportGsPaths)
+    implements DefaultUndoStep {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportListAzureParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportListAzureParquetFilesStep.java
@@ -18,23 +18,12 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class SnapshotExportListAzureParquetFilesStep extends DefaultUndoStep {
-
-  private final SnapshotService snapshotService;
-  private final UUID snapshotId;
-  private final AzureBlobStorePdao azureBlobStorePdao;
-  private final AuthenticatedUserRequest userReq;
-
-  public SnapshotExportListAzureParquetFilesStep(
-      SnapshotService snapshotService,
-      UUID snapshotId,
-      AzureBlobStorePdao azureBlobStorePdao,
-      AuthenticatedUserRequest userReq) {
-    this.snapshotService = snapshotService;
-    this.snapshotId = snapshotId;
-    this.azureBlobStorePdao = azureBlobStorePdao;
-    this.userReq = userReq;
-  }
+public record SnapshotExportListAzureParquetFilesStep(
+    SnapshotService snapshotService,
+    UUID snapshotId,
+    AzureBlobStorePdao azureBlobStorePdao,
+    AuthenticatedUserRequest userReq)
+    implements DefaultUndoStep {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
@@ -33,32 +33,15 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class SnapshotExportWriteManifestAzureStep extends DefaultUndoStep {
-
-  private final UUID snapshotId;
-  private final SnapshotService snapshotService;
-  private final ObjectMapper objectMapper;
-  private final AzureBlobStorePdao azureBlobStorePdao;
-  private final ResourceService resourceService;
-  private ProfileService profileService;
-  private final AuthenticatedUserRequest userReq;
-
-  public SnapshotExportWriteManifestAzureStep(
-      UUID snapshotId,
-      SnapshotService snapshotService,
-      ObjectMapper objectMapper,
-      AzureBlobStorePdao azureBlobStorePdao,
-      ResourceService resourceService,
-      ProfileService profileService,
-      AuthenticatedUserRequest userReq) {
-    this.snapshotId = snapshotId;
-    this.snapshotService = snapshotService;
-    this.objectMapper = objectMapper;
-    this.azureBlobStorePdao = azureBlobStorePdao;
-    this.resourceService = resourceService;
-    this.profileService = profileService;
-    this.userReq = userReq;
-  }
+public record SnapshotExportWriteManifestAzureStep(
+    UUID snapshotId,
+    SnapshotService snapshotService,
+    ObjectMapper objectMapper,
+    AzureBlobStorePdao azureBlobStorePdao,
+    ResourceService resourceService,
+    ProfileService profileService,
+    AuthenticatedUserRequest userReq)
+    implements DefaultUndoStep {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestStep.java
@@ -28,29 +28,14 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class SnapshotExportWriteManifestStep extends DefaultUndoStep {
-
-  private final UUID snapshotId;
-  private final SnapshotService snapshotService;
-  private final GcsPdao gcsPdao;
-  private final ObjectMapper objectMapper;
-  private final AuthenticatedUserRequest userReq;
-  private final boolean validatePrimaryKeyUniqueness;
-
-  public SnapshotExportWriteManifestStep(
-      UUID snapshotId,
-      SnapshotService snapshotService,
-      GcsPdao gcsPdao,
-      ObjectMapper objectMapper,
-      AuthenticatedUserRequest userReq,
-      boolean validatePrimaryKeyUniqueness) {
-    this.snapshotId = snapshotId;
-    this.snapshotService = snapshotService;
-    this.gcsPdao = gcsPdao;
-    this.objectMapper = objectMapper;
-    this.userReq = userReq;
-    this.validatePrimaryKeyUniqueness = validatePrimaryKeyUniqueness;
-  }
+public record SnapshotExportWriteManifestStep(
+    UUID snapshotId,
+    SnapshotService snapshotService,
+    GcsPdao gcsPdao,
+    ObjectMapper objectMapper,
+    AuthenticatedUserRequest userReq,
+    boolean validatePrimaryKeyUniqueness)
+    implements DefaultUndoStep {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {

--- a/src/test/java/bio/terra/service/snapshot/flight/duos/SnapshotUpdateDuosDatasetFlightTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/duos/SnapshotUpdateDuosDatasetFlightTest.java
@@ -112,7 +112,7 @@ public class SnapshotUpdateDuosDatasetFlightTest {
   private List<String> getFlightOptionalStepNames(SnapshotUpdateDuosDatasetFlight flight) {
     return flight.getSteps().stream()
         .filter(step -> step instanceof OptionalStep)
-        .map(step -> ((OptionalStep) step).getStep().getClass().getSimpleName())
+        .map(step -> ((OptionalStep) step).step().getClass().getSimpleName())
         .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
I didn't convert all steps but did a lot of them. Doing this means using `default` in any intermediate `Step` subclass (since they now must be an `interface`). It's less code overall and seems OK to me but may not be a big win.