### PR TITLE
[DR-2844] Allow a snapshot to be linked to a DUOS dataset on creation

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -182,8 +182,8 @@ public class SnapshotDao {
 
     String sql =
         """
-        INSERT INTO snapshot (name, description, profile_id, project_resource_id, id, consent_code, flightid, creation_information, properties, global_file_ids, compact_id_prefix)
-        VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb, :properties::jsonb, :global_file_ids, :compact_id_prefix)
+        INSERT INTO snapshot (name, description, profile_id, project_resource_id, id, consent_code, flightid, creation_information, properties, global_file_ids, compact_id_prefix, duos_firecloud_group_id)
+        VALUES (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid, :creation_information::jsonb, :properties::jsonb, :global_file_ids, :compact_id_prefix, :duos_firecloud_group_id)
         """;
     String creationInfo;
     try {
@@ -205,7 +205,8 @@ public class SnapshotDao {
             .addValue(
                 "properties", DaoUtils.propertiesToString(objectMapper, snapshot.getProperties()))
             .addValue("global_file_ids", snapshot.hasGlobalFileIds())
-            .addValue("compact_id_prefix", snapshot.getCompactIdPrefix());
+            .addValue("compact_id_prefix", snapshot.getCompactIdPrefix())
+            .addValue("duos_firecloud_group_id", snapshot.getDuosFirecloudGroupId());
     try {
       jdbcTemplate.update(sql, params);
     } catch (DuplicateKeyException dkEx) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -167,6 +167,11 @@ public class SnapshotService {
           snapshotRequestModel.getName(),
           dataset.getDefaultProfileId());
     }
+    String duosId = snapshotRequestModel.getDuosId();
+    if (duosId != null) {
+      // We fetch the DUOS dataset to confirm its existence, but do not need the returned value.
+      duosClient.getDataset(duosId, userReq);
+    }
     return jobService
         .newJob(description, SnapshotCreateFlight.class, snapshotRequestModel, userReq)
         .addParameter(CommonMapKeys.CREATED_AT, Instant.now().toEpochMilli())

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -2,6 +2,7 @@ package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.common.FlightUtils;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.DuosFirecloudGroupModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.snapshot.Snapshot;
@@ -10,6 +11,7 @@ import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.exception.InvalidSnapshotException;
 import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.service.snapshot.flight.duos.SnapshotDuosFlightUtils;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
@@ -54,6 +56,13 @@ public class CreateSnapshotMetadataStep implements Step {
               .makeSnapshotFromSnapshotRequest(snapshotReq)
               .id(snapshotId)
               .projectResourceId(projectResourceId);
+      if (snapshotReq.getDuosId() != null) {
+        DuosFirecloudGroupModel duosFirecloudGroup =
+            SnapshotDuosFlightUtils.getFirecloudGroup(context);
+        UUID duosFirecloudGroupId =
+            SnapshotDuosFlightUtils.getDuosFirecloudGroupId(duosFirecloudGroup);
+        snapshot.duosFirecloudGroupId(duosFirecloudGroupId);
+      }
       snapshotDao.createAndLock(snapshot, context.getFlightId(), userReq);
 
       SnapshotSummaryModel response = snapshotService.retrieveSnapshotSummary(snapshotId);

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4833,6 +4833,8 @@ components:
           description: Description of the snapshot
         consentCode:
           $ref: '#/components/schemas/ConsentCode'
+        duosId:
+          $ref: '#/components/schemas/DuosId'
         contents:
           type: array
           items:

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -870,7 +870,7 @@ public class SnapshotServiceTest {
     verify(ecmService).validatePassport(any());
   }
 
-  private SnapshotRequestModel getDUOSSnapshotRequestModel(String duosId) {
+  private SnapshotRequestModel getDuosSnapshotRequestModel(String duosId) {
     String sourceDatasetName = "TestSourceDataset";
     Dataset sourceDataset = new Dataset().name(sourceDatasetName);
     when(datasetService.retrieveByName(sourceDatasetName)).thenReturn(sourceDataset);
@@ -882,8 +882,8 @@ public class SnapshotServiceTest {
   }
 
   @Test
-  public void testCreateSnapshotDuosDataset() {
-    SnapshotRequestModel request = getDUOSSnapshotRequestModel(null);
+  public void testCreateSnapshotWithoutDuosDataset() {
+    SnapshotRequestModel request = getDuosSnapshotRequestModel(null);
     JobBuilder jobBuilder = mock(JobBuilder.class);
     when(jobService.newJob(anyString(), eq(SnapshotCreateFlight.class), eq(request), eq(TEST_USER)))
         .thenReturn(jobBuilder);
@@ -899,7 +899,7 @@ public class SnapshotServiceTest {
 
   @Test
   public void testCreateSnapshotWithDuosDataset() {
-    SnapshotRequestModel request = getDUOSSnapshotRequestModel(DUOS_ID);
+    SnapshotRequestModel request = getDuosSnapshotRequestModel(DUOS_ID);
     JobBuilder jobBuilder = mock(JobBuilder.class);
     when(jobService.newJob(anyString(), eq(SnapshotCreateFlight.class), eq(request), eq(TEST_USER)))
         .thenReturn(jobBuilder);
@@ -915,7 +915,7 @@ public class SnapshotServiceTest {
 
   @Test
   public void testCreateSnapshotThrowsWhenDuosClientThrows() {
-    SnapshotRequestModel request = getDUOSSnapshotRequestModel(DUOS_ID);
+    SnapshotRequestModel request = getDuosSnapshotRequestModel(DUOS_ID);
     HttpClientErrorException expectedEx = new HttpClientErrorException(HttpStatus.I_AM_A_TEAPOT);
     when(duosClient.getDataset(DUOS_ID, TEST_USER)).thenThrow(expectedEx);
     assertThrows(HttpClientErrorException.class, () -> service.createSnapshot(request, TEST_USER));

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -49,6 +49,7 @@ import bio.terra.model.SnapshotLinkDuosDatasetResponse;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotPatchRequestModel;
 import bio.terra.model.SnapshotRequestContentsModel;
+import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRetrieveIncludeModel;
 import bio.terra.model.SnapshotSourceModel;
 import bio.terra.model.SnapshotSummaryModel;
@@ -82,6 +83,7 @@ import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.SnapshotService.SnapshotAccessibleResult;
 import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
+import bio.terra.service.snapshot.flight.create.SnapshotCreateFlight;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
 import bio.terra.service.snapshot.flight.duos.SnapshotUpdateDuosDatasetFlight;
 import bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao;
@@ -866,6 +868,59 @@ public class SnapshotServiceTest {
 
     verify(ecmService).getRasProviderPassport(TEST_USER);
     verify(ecmService).validatePassport(any());
+  }
+
+  private SnapshotRequestModel getDUOSSnapshotRequestModel(String duosId) {
+    String sourceDatasetName = "TestSourceDataset";
+    Dataset sourceDataset = new Dataset().name(sourceDatasetName);
+    when(datasetService.retrieveByName(sourceDatasetName)).thenReturn(sourceDataset);
+    return new SnapshotRequestModel()
+        .name("TestSnapshot")
+        .profileId(UUID.randomUUID())
+        .duosId(duosId)
+        .contents(List.of(new SnapshotRequestContentsModel().datasetName(sourceDatasetName)));
+  }
+
+  @Test
+  public void testCreateSnapshotDuosDataset() {
+    SnapshotRequestModel request = getDUOSSnapshotRequestModel(null);
+    JobBuilder jobBuilder = mock(JobBuilder.class);
+    when(jobService.newJob(anyString(), eq(SnapshotCreateFlight.class), eq(request), eq(TEST_USER)))
+        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(any(), any())).thenReturn(jobBuilder);
+    String jobId = String.valueOf(UUID.randomUUID());
+    when(jobBuilder.submit()).thenReturn(jobId);
+
+    String result = service.createSnapshot(request, TEST_USER);
+    assertThat("Job is submitted and id returned", result, equalTo(jobId));
+    verify(duosClient, never()).getDataset(DUOS_ID, TEST_USER);
+    verify(jobBuilder).submit();
+  }
+
+  @Test
+  public void testCreateSnapshotWithDuosDataset() {
+    SnapshotRequestModel request = getDUOSSnapshotRequestModel(DUOS_ID);
+    JobBuilder jobBuilder = mock(JobBuilder.class);
+    when(jobService.newJob(anyString(), eq(SnapshotCreateFlight.class), eq(request), eq(TEST_USER)))
+        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(any(), any())).thenReturn(jobBuilder);
+    String jobId = String.valueOf(UUID.randomUUID());
+    when(jobBuilder.submit()).thenReturn(jobId);
+
+    String result = service.createSnapshot(request, TEST_USER);
+    assertThat("Job is submitted and id returned", result, equalTo(jobId));
+    verify(duosClient).getDataset(DUOS_ID, TEST_USER);
+    verify(jobBuilder).submit();
+  }
+
+  @Test
+  public void testCreateSnapshotThrowsWhenDuosClientThrows() {
+    SnapshotRequestModel request = getDUOSSnapshotRequestModel(DUOS_ID);
+    HttpClientErrorException expectedEx = new HttpClientErrorException(HttpStatus.I_AM_A_TEAPOT);
+    when(duosClient.getDataset(DUOS_ID, TEST_USER)).thenThrow(expectedEx);
+    assertThrows(HttpClientErrorException.class, () -> service.createSnapshot(request, TEST_USER));
+    JobBuilder jobBuilder = mock(JobBuilder.class);
+    verifyNoInteractions(jobBuilder);
   }
 
   private void mockSnapshotWithDuosDataset() {

--- a/src/test/java/bio/terra/service/snapshot/flight/snapshot/CreateSnapshotMetadataStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/snapshot/CreateSnapshotMetadataStepTest.java
@@ -37,7 +37,7 @@ import org.springframework.test.context.ActiveProfiles;
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 @ActiveProfiles({"google", "unittest"})
 @Category(Unit.class)
-public class CreateSnapshotMetadataTest {
+public class CreateSnapshotMetadataStepTest {
 
   @Mock private SnapshotDao snapshotDao;
   @Mock private SnapshotService snapshotService;

--- a/src/test/java/bio/terra/service/snapshot/flight/snapshot/CreateSnapshotMetadataTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/snapshot/CreateSnapshotMetadataTest.java
@@ -1,0 +1,116 @@
+package bio.terra.service.snapshot.flight.snapshot;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.fixtures.DuosFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.DuosFirecloudGroupModel;
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotDao;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.service.snapshot.flight.create.CreateSnapshotMetadataStep;
+import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.context.ActiveProfiles;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class CreateSnapshotMetadataTest {
+
+  @Mock private SnapshotDao snapshotDao;
+  @Mock private SnapshotService snapshotService;
+  @Mock private FlightContext flightContext;
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private static final String FLIGHT_ID = String.valueOf(UUID.randomUUID());
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final UUID PROJECT_RESOURCE_ID = UUID.randomUUID();
+  private static final String DUOS_ID = "DUOS-123456";
+  private static final DuosFirecloudGroupModel DUOS_FIRECLOUD_GROUP =
+      DuosFixtures.createDbFirecloudGroup(DUOS_ID);
+
+  private CreateSnapshotMetadataStep step;
+  private FlightMap workingMap;
+  private SnapshotRequestModel snapshotRequestModel;
+  private Dataset dataset;
+  private Snapshot snapshot;
+
+  @Before
+  public void setup() {
+    workingMap = new FlightMap();
+    workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_ID, SNAPSHOT_ID);
+    workingMap.put(SnapshotWorkingMapKeys.PROJECT_RESOURCE_ID, PROJECT_RESOURCE_ID);
+    when(flightContext.getFlightId()).thenReturn(FLIGHT_ID);
+
+    snapshotRequestModel = new SnapshotRequestModel();
+    snapshot = new Snapshot();
+    when(snapshotService.makeSnapshotFromSnapshotRequest(snapshotRequestModel))
+        .thenReturn(snapshot);
+  }
+
+  @Test
+  public void testDoAndUndoStep() throws InterruptedException {
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    step =
+        new CreateSnapshotMetadataStep(
+            snapshotDao, snapshotService, snapshotRequestModel, TEST_USER);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    snapshot.id(UUID.randomUUID()).projectResourceId(PROJECT_RESOURCE_ID);
+    ArgumentCaptor<Snapshot> argument = ArgumentCaptor.forClass(Snapshot.class);
+    verify(snapshotDao).createAndLock(argument.capture(), eq(FLIGHT_ID), eq(TEST_USER));
+    assertNull(argument.getValue().getDuosFirecloudGroupId());
+
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(snapshotDao).delete(SNAPSHOT_ID, TEST_USER);
+  }
+
+  @Test
+  public void testDoAndUndoStepWithDUOS() throws InterruptedException {
+    workingMap.put(SnapshotDuosMapKeys.FIRECLOUD_GROUP, DUOS_FIRECLOUD_GROUP);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    snapshotRequestModel.duosId(DUOS_ID);
+
+    step =
+        new CreateSnapshotMetadataStep(
+            snapshotDao, snapshotService, snapshotRequestModel, TEST_USER);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    snapshot
+        .id(SNAPSHOT_ID)
+        .projectResourceId(PROJECT_RESOURCE_ID)
+        .duosFirecloudGroupId(DUOS_FIRECLOUD_GROUP.getId());
+    ArgumentCaptor<Snapshot> argument = ArgumentCaptor.forClass(Snapshot.class);
+    verify(snapshotDao).createAndLock(argument.capture(), eq(FLIGHT_ID), eq(TEST_USER));
+    assertEquals(argument.getValue().getDuosFirecloudGroupId(), DUOS_FIRECLOUD_GROUP.getId());
+
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(snapshotDao).delete(SNAPSHOT_ID, TEST_USER);
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/flight/snapshot/CreateSnapshotMetadataTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/snapshot/CreateSnapshotMetadataTest.java
@@ -14,7 +14,6 @@ import bio.terra.common.fixtures.DuosFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.DuosFirecloudGroupModel;
 import bio.terra.model.SnapshotRequestModel;
-import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
@@ -56,7 +55,6 @@ public class CreateSnapshotMetadataTest {
   private CreateSnapshotMetadataStep step;
   private FlightMap workingMap;
   private SnapshotRequestModel snapshotRequestModel;
-  private Dataset dataset;
   private Snapshot snapshot;
 
   @Before

--- a/src/test/java/bio/terra/service/snapshot/flight/snapshot/SnapshotAuthzIamStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/snapshot/SnapshotAuthzIamStepTest.java
@@ -1,0 +1,107 @@
+package bio.terra.service.snapshot.flight.snapshot;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.fixtures.DuosFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.DuosFirecloudGroupModel;
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.model.SnapshotRequestModelPolicies;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.service.snapshot.flight.create.SnapshotAuthzIamStep;
+import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.context.ActiveProfiles;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class SnapshotAuthzIamStepTest {
+  @Mock private IamService iamService;
+  @Mock private SnapshotService snapshotService;
+  @Mock private FlightContext flightContext;
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final String DUOS_ID = "DUOS-123456";
+  private static final DuosFirecloudGroupModel DUOS_FIRECLOUD_GROUP =
+      DuosFixtures.createDbFirecloudGroup(DUOS_ID);
+
+  private SnapshotAuthzIamStep step;
+  private FlightMap workingMap;
+  private SnapshotRequestModel snapshotRequestModel;
+
+  @Before
+  public void setup() {
+    workingMap = new FlightMap();
+    workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_ID, SNAPSHOT_ID);
+    snapshotRequestModel = new SnapshotRequestModel();
+    when(iamService.deriveSnapshotPolicies(snapshotRequestModel))
+        .thenReturn(new SnapshotRequestModelPolicies().readers(new ArrayList<>()));
+  }
+
+  @Test
+  public void testDoAndUndoStep() throws InterruptedException {
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    step = new SnapshotAuthzIamStep(iamService, snapshotService, snapshotRequestModel, TEST_USER);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+
+    ArgumentCaptor<SnapshotRequestModelPolicies> argument =
+        ArgumentCaptor.forClass(SnapshotRequestModelPolicies.class);
+    verify(iamService).createSnapshotResource(eq(TEST_USER), eq(SNAPSHOT_ID), argument.capture());
+    List<String> readers = argument.getValue().getReaders();
+    assertFalse(readers.contains(DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail()));
+
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(iamService).deleteSnapshotResource(TEST_USER, SNAPSHOT_ID);
+  }
+
+  @Test
+  public void testDoAndUndoStepWithDUOS() throws InterruptedException {
+    workingMap.put(SnapshotDuosMapKeys.FIRECLOUD_GROUP, DUOS_FIRECLOUD_GROUP);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+
+    snapshotRequestModel.duosId(DUOS_ID);
+    step = new SnapshotAuthzIamStep(iamService, snapshotService, snapshotRequestModel, TEST_USER);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+
+    SnapshotRequestModelPolicies policies = iamService.deriveSnapshotPolicies(snapshotRequestModel);
+    policies.addReadersItem(DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail());
+    ArgumentCaptor<SnapshotRequestModelPolicies> argument =
+        ArgumentCaptor.forClass(SnapshotRequestModelPolicies.class);
+    verify(iamService).createSnapshotResource(eq(TEST_USER), eq(SNAPSHOT_ID), argument.capture());
+    List<String> readers = argument.getValue().getReaders();
+    assertTrue(readers.contains(DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail()));
+
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(iamService).deleteSnapshotResource(TEST_USER, SNAPSHOT_ID);
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2844

Currently a user can link/unlink a DUOS dataset to a snapshot that already exists. This PR allows users to specify a DUOS dataset to link when creating a new snapshot.

**Changes:**
The snapshot request model now has an optional `duos_id` field. If there is no DUOS dataset associated with that id, the request will fail before launching a job.

The `SnapshotCreateFlight` includes the following changes:
* The DUOS Firecloud group is retrieved/created using the same steps from `SnapshotUpdateDuosDatasetFlight`
* The Firecloud group is stored as part of the snapshot metadata in `CreateSnapshotMetadataStep`
* The Firecloud group email is added as a reader in `SnapshotAuthzIamStep`

**Testing:**
- Based on how the link/unlink functionality was tested https://github.com/DataBiosphere/jade-data-repo/pull/1368, I created unit tests for the`CreateSnapshotMetadataStep` and `SnapshotAuthzIamStep`, as well as validating that the flight is only launched when the duosId is associated with a dataset.
- The changes are deployed in: https://jade-se.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/createSnapshot. I used the following payload for manual testing (I added the data repo admins group to the dataset and billing profile):
```
{
  "name": "TestSnapshotWithDUOS",
  "description": "Test PR to add DUOS id on snapshot create",
  "duosId": "DUOS-000003",
  "contents": [
    {
      "datasetName": "it_dataset_omop3a0aa2cf_2b47_40dc_894d_ea6200a3a387",
      "mode": "byFullView"
    }],
  "profileId": "794c3c51-25f2-4485-b3aa-89b1f08aa8cc"
}
```