### PR TITLE
DR-2998 Chunk inserts into BQ during file id migration

### DIFF
--- a/src/main/java/bio/terra/common/MapUtils.java
+++ b/src/main/java/bio/terra/common/MapUtils.java
@@ -1,0 +1,27 @@
+package bio.terra.common;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.apache.arrow.util.Preconditions;
+import org.apache.commons.collections4.ListUtils;
+
+public class MapUtils {
+
+  private MapUtils() {}
+
+  /**
+   * Partition a map into chunks of maximum size
+   *
+   * @param map The map to partition
+   * @param chunkSize The maximum size of the partitions
+   * @return A list of partitioned maps
+   */
+  public static <K, V> List<Map<K, V>> partitionMap(Map<K, V> map, int chunkSize) {
+    Preconditions.checkArgument(chunkSize > 0, "chunk size must be greater than zero");
+    return ListUtils.partition(List.copyOf(map.entrySet()), chunkSize).stream()
+        .map(l -> l.stream().collect(Collectors.toMap(Entry::getKey, Entry::getValue)))
+        .toList();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqStageDataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsBqStageDataStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
 
+import bio.terra.common.MapUtils;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.job.DefaultUndoStep;
@@ -7,6 +8,7 @@ import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -15,6 +17,8 @@ import org.slf4j.LoggerFactory;
 public class ConvertToPredictableFileIdsBqStageDataStep extends DefaultUndoStep {
   private static final Logger logger =
       LoggerFactory.getLogger(ConvertToPredictableFileIdsBqStageDataStep.class);
+
+  private static final int INSERT_CHUNK_SIZE = 1000;
 
   private final UUID datasetId;
   private final DatasetService datasetService;
@@ -40,7 +44,15 @@ public class ConvertToPredictableFileIdsBqStageDataStep extends DefaultUndoStep 
       return StepResult.getStepResultSuccess();
     }
     // Load file ids into the table
-    bigQueryDatasetPdao.fileIdMappingToStagingTable(dataset, oldToNewMappings);
+    // Chunk the writes to avoid overwhelming BigQuery
+    List<Map<UUID, UUID>> chunkedOldToNewMappings =
+        MapUtils.partitionMap(oldToNewMappings, INSERT_CHUNK_SIZE);
+
+    int i = 0;
+    for (Map<UUID, UUID> chunk : chunkedOldToNewMappings) {
+      logger.info("inserting chunk {} of {}", ++i, chunkedOldToNewMappings.size());
+      bigQueryDatasetPdao.fileIdMappingToStagingTable(dataset, chunk);
+    }
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/test/java/bio/terra/common/MapUtilsTest.java
+++ b/src/test/java/bio/terra/common/MapUtilsTest.java
@@ -1,0 +1,55 @@
+package bio.terra.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import bio.terra.common.category.Unit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Unit.class)
+public class MapUtilsTest {
+
+  private static final Map<String, Integer> BASE_MAP =
+      Map.of(
+          "zero", 0,
+          "one", 1,
+          "two", 2);
+
+  @Test
+  public void testPartitionMap() {
+    List<Map<String, Integer>> partitionedMap = MapUtils.partitionMap(BASE_MAP, 2);
+    assertThat("two chunks were created", partitionedMap, hasSize(2));
+    Map<String, Integer> reconstitutedMap = new HashMap<>();
+    partitionedMap.forEach(reconstitutedMap::putAll);
+    assertThat(
+        "can reconstitute the partitioned map and it equals the original",
+        reconstitutedMap,
+        equalTo(BASE_MAP));
+  }
+
+  @Test
+  public void testPartitionMapBiggerChunkSize() {
+    List<Map<String, Integer>> partitionedMap = MapUtils.partitionMap(BASE_MAP, 20);
+    assertThat("one chunk was created", partitionedMap, hasSize(1));
+    assertThat(
+        "can reconstitute the partitioned map and it equals the original",
+        partitionedMap.get(0),
+        equalTo(BASE_MAP));
+  }
+
+  @Test
+  public void testPartitionMapEmptyMap() {
+    List<Map<String, Integer>> partitionedMap = MapUtils.partitionMap(Map.of(), 10);
+    assertThat("no chunks were created", partitionedMap, hasSize(0));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPartitionMapInvalidChunkSize() {
+    MapUtils.partitionMap(BASE_MAP, -1);
+  }
+}


### PR DESCRIPTION
This came up when migrating datasets with more files (more than 1000).  This PR chunks the file ids into 1K bits that BQ can handle