### PR TITLE
[DR-2984] Make maxFailedFileLoads and maxBadRecords non nullable

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4298,6 +4298,8 @@ components:
       required:
         - format
         - table
+        - max_bad_records
+        - max_failed_file_loads
       type: object
       properties:
         table:
@@ -4627,6 +4629,7 @@ components:
         - loadControlFile
         - loadTag
         - profileId
+        - maxFailedFileLoads
       type: object
       properties:
         profileId:
@@ -4667,6 +4670,7 @@ components:
         - loadArray
         - loadTag
         - profileId
+        - maxFailedFileLoads
       type: object
       properties:
         profileId:

--- a/src/test/java/bio/terra/service/dataset/DatasetIngestRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIngestRequestValidatorTest.java
@@ -1,0 +1,298 @@
+package bio.terra.service.dataset;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.common.TestUtils;
+import bio.terra.common.category.Unit;
+import bio.terra.model.BulkLoadArrayRequestModel;
+import bio.terra.model.BulkLoadFileModel;
+import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.ErrorModel;
+import bio.terra.model.IngestRequestModel;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class DatasetIngestRequestValidatorTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private DatasetService datasetService;
+
+  @Test
+  public void testAzureIngestRequestParameters() throws Exception {
+    Dataset dataset = mock(Dataset.class);
+    DatasetSummary datasetSummary = mock(DatasetSummary.class);
+    when(datasetSummary.getStorageCloudPlatform()).thenReturn(CloudPlatform.AZURE);
+    when(dataset.getDatasetSummary()).thenReturn(datasetSummary);
+    when(datasetService.retrieve(any())).thenReturn(dataset);
+
+    var nullIngest =
+        new IngestRequestModel()
+            .path("foo/bar")
+            .table("myTable")
+            .format(IngestRequestModel.FormatEnum.CSV)
+            .csvSkipLeadingRows(null)
+            .csvFieldDelimiter(null)
+            .csvQuote(null);
+
+    var nullResult =
+        mvc.perform(
+                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(nullIngest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+    MockHttpServletResponse nullResponse = nullResult.getResponse();
+    String nullResponseBody = nullResponse.getContentAsString();
+    ErrorModel nullErrorModel = TestUtils.mapFromJson(nullResponseBody, ErrorModel.class);
+    assertThat(
+        "Validation catches all null parameters", nullErrorModel.getErrorDetail(), hasSize(3));
+    for (String error : nullErrorModel.getErrorDetail()) {
+      assertThat("Validation catches null parameters", error, containsString("defined"));
+    }
+
+    var invalidIngest =
+        new IngestRequestModel()
+            .path("foo/bar")
+            .table("myTable")
+            .format(IngestRequestModel.FormatEnum.CSV)
+            .csvSkipLeadingRows(-1)
+            .csvFieldDelimiter("toolong")
+            .csvQuote("toolong");
+
+    var invalidResult =
+        mvc.perform(
+                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(invalidIngest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
+    String invalidResponseBody = invalidResponse.getContentAsString();
+    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
+    assertThat(
+        "Validation catches all invalid parameters",
+        invalidErrorModel.getErrorDetail(),
+        hasSize(3));
+    var csvSkipLeadingRowsError = invalidErrorModel.getErrorDetail().get(0);
+    var csvFieldDelimiterError = invalidErrorModel.getErrorDetail().get(1);
+    var csvQuoteError = invalidErrorModel.getErrorDetail().get(2);
+
+    assertThat(
+        "Validator catches invalid 'csvSkipLeadingRows'",
+        csvSkipLeadingRowsError,
+        containsString("'csvSkipLeadingRows' must be a positive integer, was '-1."));
+    assertThat(
+        "Validator catches invalid 'csvFieldDelimiter'",
+        csvFieldDelimiterError,
+        containsString("'csvFieldDelimiter' must be a single character, was 'toolong'."));
+    assertThat(
+        "Validator catches invalid 'csvQuote'",
+        csvQuoteError,
+        containsString("'csvQuote' must be a single character, was 'toolong'."));
+  }
+
+  @Test
+  public void testInvalidIngestByArray() throws Exception {
+    var invalidIngest =
+        new IngestRequestModel()
+            .path("foo/bar")
+            .table("myTable")
+            .format(IngestRequestModel.FormatEnum.ARRAY);
+
+    var invalidResult =
+        mvc.perform(
+                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(invalidIngest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
+    String invalidResponseBody = invalidResponse.getContentAsString();
+    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
+    assertThat(
+        "Validation catches all invalid parameters",
+        invalidErrorModel.getErrorDetail(),
+        hasSize(2));
+    var pathIsPresentError = invalidErrorModel.getErrorDetail().get(0);
+    var payloadIsMissingError = invalidErrorModel.getErrorDetail().get(1);
+
+    assertThat(
+        "Validator catches invalid 'path' and 'format' combo",
+        pathIsPresentError,
+        containsString("Path should not be specified when ingesting from an array"));
+    assertThat(
+        "Validator catches invalid 'format' and 'records' combo",
+        payloadIsMissingError,
+        containsString("Records is required when ingesting as an array"));
+  }
+
+  @Test
+  public void testInvalidIngestByPath() throws Exception {
+    var invalidIngest =
+        new IngestRequestModel()
+            .table("myTable")
+            .format(IngestRequestModel.FormatEnum.JSON)
+            .addRecordsItem(Map.of("foo", "bar"));
+
+    var invalidResult =
+        mvc.perform(
+                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(invalidIngest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
+    String invalidResponseBody = invalidResponse.getContentAsString();
+    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
+    assertThat(
+        "Validation catches all invalid parameters",
+        invalidErrorModel.getErrorDetail(),
+        hasSize(2));
+    var pathIsMissingError = invalidErrorModel.getErrorDetail().get(0);
+    var payloadIsPresentError = invalidErrorModel.getErrorDetail().get(1);
+
+    assertThat(
+        "Validator catches invalid 'path' and 'format' combo",
+        pathIsMissingError,
+        containsString("Path is required when ingesting from a cloud object"));
+    assertThat(
+        "Validator catches invalid 'records' and 'format' combo",
+        payloadIsPresentError,
+        containsString("Records should not be specified when ingesting from a path"));
+  }
+
+  @Test
+  public void testInvalidIngestWithNullIntFields() throws Exception {
+    var invalidIngest =
+        new IngestRequestModel()
+            .table("myTable")
+            .path("gs://foo/bar.json")
+            .format(IngestRequestModel.FormatEnum.JSON)
+            .maxBadRecords(null)
+            .maxFailedFileLoads(null);
+
+    var invalidResult =
+        mvc.perform(
+                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(invalidIngest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
+    String invalidResponseBody = invalidResponse.getContentAsString();
+    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
+    assertThat(
+        "Validation catches all invalid parameters",
+        invalidErrorModel.getErrorDetail(),
+        hasSize(2));
+    var maxBadRecordsError = invalidErrorModel.getErrorDetail().get(0);
+    var maxFailedFileLoadsError = invalidErrorModel.getErrorDetail().get(1);
+    assertThat(
+        "Validator catches null 'maxBadRecordsError'",
+        maxBadRecordsError,
+        containsString("maxBadRecords: 'NotNull'"));
+    assertThat(
+        "Validator catches null 'maxFailedFileLoadsError'",
+        maxFailedFileLoadsError,
+        containsString("maxFailedFileLoads: 'NotNull'"));
+  }
+
+  @Test
+  public void testInvalidBulkIngestWithNullIntFields() throws Exception {
+    var invalidIngest =
+        new BulkLoadRequestModel()
+            .loadControlFile("gs://foo/bar.json")
+            .loadTag("foo")
+            .profileId(UUID.randomUUID())
+            .maxFailedFileLoads(null);
+
+    var invalidResult =
+        mvc.perform(
+                post(String.format("/api/repository/v1/datasets/%s/files/bulk", UUID.randomUUID()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(invalidIngest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
+    String invalidResponseBody = invalidResponse.getContentAsString();
+    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
+    assertThat(
+        "Validation catches all invalid parameters",
+        invalidErrorModel.getErrorDetail(),
+        hasSize(1));
+    var maxFailedFileLoadsError = invalidErrorModel.getErrorDetail().get(0);
+    assertThat(
+        "Validator catches null 'maxFailedFileLoadsError'",
+        maxFailedFileLoadsError,
+        containsString("maxFailedFileLoads: 'NotNull'"));
+  }
+
+  @Test
+  public void testInvalidBulkArrayIngestWithNullIntFields() throws Exception {
+    var invalidIngest =
+        new BulkLoadArrayRequestModel()
+            .loadArray(
+                List.of(
+                    new BulkLoadFileModel()
+                        .sourcePath("gs://foo/source.txt")
+                        .targetPath("/foo/bar")))
+            .profileId(UUID.randomUUID())
+            .loadTag("foo")
+            .maxFailedFileLoads(null);
+
+    var invalidResult =
+        mvc.perform(
+                post(String.format(
+                        "/api/repository/v1/datasets/%s/files/bulk/array", UUID.randomUUID()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(invalidIngest)))
+            .andExpect(status().is4xxClientError())
+            .andReturn();
+
+    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
+    String invalidResponseBody = invalidResponse.getContentAsString();
+    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
+    assertThat(
+        "Validation catches all invalid parameters",
+        invalidErrorModel.getErrorDetail(),
+        hasSize(1));
+    var maxFailedFileLoadsError = invalidErrorModel.getErrorDetail().get(0);
+    assertThat(
+        "Validator catches null 'maxFailedFileLoadsError'",
+        maxFailedFileLoadsError,
+        containsString("maxFailedFileLoads: 'NotNull'"));
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/DatasetIngestRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIngestRequestValidatorTest.java
@@ -41,7 +41,6 @@ import org.springframework.test.web.servlet.MockMvc;
 public class DatasetIngestRequestValidatorTest {
 
   @Autowired private MockMvc mvc;
-
   @MockBean private DatasetService datasetService;
 
   @Test
@@ -217,16 +216,9 @@ public class DatasetIngestRequestValidatorTest {
         "Validation catches all invalid parameters",
         invalidErrorModel.getErrorDetail(),
         hasSize(2));
-    var maxBadRecordsError = invalidErrorModel.getErrorDetail().get(0);
-    var maxFailedFileLoadsError = invalidErrorModel.getErrorDetail().get(1);
-    assertThat(
-        "Validator catches null 'maxBadRecordsError'",
-        maxBadRecordsError,
-        containsString("maxBadRecords: 'NotNull'"));
-    assertThat(
-        "Validator catches null 'maxFailedFileLoadsError'",
-        maxFailedFileLoadsError,
-        containsString("maxFailedFileLoads: 'NotNull'"));
+    for (String error : invalidErrorModel.getErrorDetail()) {
+      assertThat("Validation catches null parameters", error, containsString("NotNull"));
+    }
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -7,15 +7,10 @@ import static bio.terra.common.fixtures.DatasetFixtures.buildDatasetRequest;
 import static bio.terra.common.fixtures.DatasetFixtures.buildParticipantSampleRelationship;
 import static bio.terra.common.fixtures.DatasetFixtures.buildSampleTerm;
 import static bio.terra.service.dataset.ValidatorTestUtils.checkValidationErrorModel;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -25,27 +20,19 @@ import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
-import bio.terra.model.BulkLoadArrayRequestModel;
-import bio.terra.model.BulkLoadFileModel;
-import bio.terra.model.BulkLoadRequestModel;
-import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatePartitionOptionsModel;
 import bio.terra.model.ErrorModel;
-import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IntPartitionOptionsModel;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -53,7 +40,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
@@ -69,11 +55,6 @@ import org.springframework.test.web.servlet.MvcResult;
 public class DatasetRequestValidatorTest {
 
   @Autowired private MockMvc mvc;
-
-  @Autowired private ObjectMapper objectMapper;
-
-  @MockBean private DatasetService datasetService;
-
   @Autowired private JsonLoader jsonLoader;
 
   private ErrorModel expectBadDatasetCreateRequest(DatasetRequestModel datasetRequest)
@@ -716,258 +697,6 @@ public class DatasetRequestValidatorTest {
         new String[] {
           "InvalidDatePartitionOptions", "InvalidIntPartitionOptions", "IncompleteSchemaDefinition"
         });
-  }
-
-  @Test
-  public void testAzureIngestRequestParameters() throws Exception {
-    Dataset dataset = mock(Dataset.class);
-    DatasetSummary datasetSummary = mock(DatasetSummary.class);
-    when(datasetSummary.getStorageCloudPlatform()).thenReturn(CloudPlatform.AZURE);
-    when(dataset.getDatasetSummary()).thenReturn(datasetSummary);
-    when(datasetService.retrieve(any())).thenReturn(dataset);
-
-    var nullIngest =
-        new IngestRequestModel()
-            .path("foo/bar")
-            .table("myTable")
-            .format(IngestRequestModel.FormatEnum.CSV)
-            .csvSkipLeadingRows(null)
-            .csvFieldDelimiter(null)
-            .csvQuote(null);
-
-    var nullResult =
-        mvc.perform(
-                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(TestUtils.mapToJson(nullIngest)))
-            .andExpect(status().is4xxClientError())
-            .andReturn();
-
-    MockHttpServletResponse nullResponse = nullResult.getResponse();
-    String nullResponseBody = nullResponse.getContentAsString();
-    ErrorModel nullErrorModel = TestUtils.mapFromJson(nullResponseBody, ErrorModel.class);
-    assertThat(
-        "Validation catches all null parameters", nullErrorModel.getErrorDetail(), hasSize(3));
-    for (String error : nullErrorModel.getErrorDetail()) {
-      assertThat("Validation catches null parameters", error, containsString("defined"));
-    }
-
-    var invalidIngest =
-        new IngestRequestModel()
-            .path("foo/bar")
-            .table("myTable")
-            .format(IngestRequestModel.FormatEnum.CSV)
-            .csvSkipLeadingRows(-1)
-            .csvFieldDelimiter("toolong")
-            .csvQuote("toolong");
-
-    var invalidResult =
-        mvc.perform(
-                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(TestUtils.mapToJson(invalidIngest)))
-            .andExpect(status().is4xxClientError())
-            .andReturn();
-
-    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
-    String invalidResponseBody = invalidResponse.getContentAsString();
-    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
-    assertThat(
-        "Validation catches all invalid parameters",
-        invalidErrorModel.getErrorDetail(),
-        hasSize(3));
-    var csvSkipLeadingRowsError = invalidErrorModel.getErrorDetail().get(0);
-    var csvFieldDelimiterError = invalidErrorModel.getErrorDetail().get(1);
-    var csvQuoteError = invalidErrorModel.getErrorDetail().get(2);
-
-    assertThat(
-        "Validator catches invalid 'csvSkipLeadingRows'",
-        csvSkipLeadingRowsError,
-        containsString("'csvSkipLeadingRows' must be a positive integer, was '-1."));
-    assertThat(
-        "Validator catches invalid 'csvFieldDelimiter'",
-        csvFieldDelimiterError,
-        containsString("'csvFieldDelimiter' must be a single character, was 'toolong'."));
-    assertThat(
-        "Validator catches invalid 'csvQuote'",
-        csvQuoteError,
-        containsString("'csvQuote' must be a single character, was 'toolong'."));
-  }
-
-  @Test
-  public void testInvalidIngestByArray() throws Exception {
-    var invalidIngest =
-        new IngestRequestModel()
-            .path("foo/bar")
-            .table("myTable")
-            .format(IngestRequestModel.FormatEnum.ARRAY);
-
-    var invalidResult =
-        mvc.perform(
-                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(TestUtils.mapToJson(invalidIngest)))
-            .andExpect(status().is4xxClientError())
-            .andReturn();
-
-    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
-    String invalidResponseBody = invalidResponse.getContentAsString();
-    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
-    assertThat(
-        "Validation catches all invalid parameters",
-        invalidErrorModel.getErrorDetail(),
-        hasSize(2));
-    var pathIsPresentError = invalidErrorModel.getErrorDetail().get(0);
-    var payloadIsMissingError = invalidErrorModel.getErrorDetail().get(1);
-
-    assertThat(
-        "Validator catches invalid 'path' and 'format' combo",
-        pathIsPresentError,
-        containsString("Path should not be specified when ingesting from an array"));
-    assertThat(
-        "Validator catches invalid 'format' and 'records' combo",
-        payloadIsMissingError,
-        containsString("Records is required when ingesting as an array"));
-  }
-
-  @Test
-  public void testInvalidIngestByPath() throws Exception {
-    var invalidIngest =
-        new IngestRequestModel()
-            .table("myTable")
-            .format(IngestRequestModel.FormatEnum.JSON)
-            .addRecordsItem(Map.of("foo", "bar"));
-
-    var invalidResult =
-        mvc.perform(
-                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(TestUtils.mapToJson(invalidIngest)))
-            .andExpect(status().is4xxClientError())
-            .andReturn();
-
-    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
-    String invalidResponseBody = invalidResponse.getContentAsString();
-    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
-    assertThat(
-        "Validation catches all invalid parameters",
-        invalidErrorModel.getErrorDetail(),
-        hasSize(2));
-    var pathIsMissingError = invalidErrorModel.getErrorDetail().get(0);
-    var payloadIsPresentError = invalidErrorModel.getErrorDetail().get(1);
-
-    assertThat(
-        "Validator catches invalid 'path' and 'format' combo",
-        pathIsMissingError,
-        containsString("Path is required when ingesting from a cloud object"));
-    assertThat(
-        "Validator catches invalid 'records' and 'format' combo",
-        payloadIsPresentError,
-        containsString("Records should not be specified when ingesting from a path"));
-  }
-
-  @Test
-  public void testInvalidIngestWithNullIntFields() throws Exception {
-    var invalidIngest =
-        new IngestRequestModel()
-            .table("myTable")
-            .path("gs://foo/bar.json")
-            .format(IngestRequestModel.FormatEnum.JSON)
-            .maxBadRecords(null)
-            .maxFailedFileLoads(null);
-
-    var invalidResult =
-        mvc.perform(
-                post(String.format("/api/repository/v1/datasets/%s/ingest", UUID.randomUUID()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(TestUtils.mapToJson(invalidIngest)))
-            .andExpect(status().is4xxClientError())
-            .andReturn();
-
-    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
-    String invalidResponseBody = invalidResponse.getContentAsString();
-    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
-    assertThat(
-        "Validation catches all invalid parameters",
-        invalidErrorModel.getErrorDetail(),
-        hasSize(2));
-    var maxBadRecordsError = invalidErrorModel.getErrorDetail().get(0);
-    var maxFailedFileLoadsError = invalidErrorModel.getErrorDetail().get(1);
-    assertThat(
-        "Validator catches null 'maxBadRecordsError'",
-        maxBadRecordsError,
-        containsString("maxBadRecords: 'NotNull'"));
-    assertThat(
-        "Validator catches null 'maxFailedFileLoadsError'",
-        maxFailedFileLoadsError,
-        containsString("maxFailedFileLoads: 'NotNull'"));
-  }
-
-  @Test
-  public void testInvalidBulkIngestWithNullIntFields() throws Exception {
-    var invalidIngest =
-        new BulkLoadRequestModel()
-            .loadControlFile("gs://foo/bar.json")
-            .loadTag("foo")
-            .profileId(UUID.randomUUID())
-            .maxFailedFileLoads(null);
-
-    var invalidResult =
-        mvc.perform(
-                post(String.format("/api/repository/v1/datasets/%s/files/bulk", UUID.randomUUID()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(TestUtils.mapToJson(invalidIngest)))
-            .andExpect(status().is4xxClientError())
-            .andReturn();
-
-    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
-    String invalidResponseBody = invalidResponse.getContentAsString();
-    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
-    assertThat(
-        "Validation catches all invalid parameters",
-        invalidErrorModel.getErrorDetail(),
-        hasSize(1));
-    var maxFailedFileLoadsError = invalidErrorModel.getErrorDetail().get(0);
-    assertThat(
-        "Validator catches null 'maxFailedFileLoadsError'",
-        maxFailedFileLoadsError,
-        containsString("maxFailedFileLoads: 'NotNull'"));
-  }
-
-  @Test
-  public void testInvalidBulkArrayIngestWithNullIntFields() throws Exception {
-    var invalidIngest =
-        new BulkLoadArrayRequestModel()
-            .loadArray(
-                List.of(
-                    new BulkLoadFileModel()
-                        .sourcePath("gs://foo/source.txt")
-                        .targetPath("/foo/bar")))
-            .profileId(UUID.randomUUID())
-            .loadTag("foo")
-            .maxFailedFileLoads(null);
-
-    var invalidResult =
-        mvc.perform(
-                post(String.format(
-                        "/api/repository/v1/datasets/%s/files/bulk/array", UUID.randomUUID()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(TestUtils.mapToJson(invalidIngest)))
-            .andExpect(status().is4xxClientError())
-            .andReturn();
-
-    MockHttpServletResponse invalidResponse = invalidResult.getResponse();
-    String invalidResponseBody = invalidResponse.getContentAsString();
-    ErrorModel invalidErrorModel = TestUtils.mapFromJson(invalidResponseBody, ErrorModel.class);
-    assertThat(
-        "Validation catches all invalid parameters",
-        invalidErrorModel.getErrorDetail(),
-        hasSize(1));
-    var maxFailedFileLoadsError = invalidErrorModel.getErrorDetail().get(0);
-    assertThat(
-        "Validator catches null 'maxFailedFileLoadsError'",
-        maxFailedFileLoadsError,
-        containsString("maxFailedFileLoads: 'NotNull'"));
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2984

Fields with the integer type in the open api spec get translated into the non-nullable Java integer data type, so if a user passes in a null value the flight creation will fail. This impacts several API endpoints:
- /api/repository/v1/datasets/{id}/ingest:
  - `max_bad_records`
  - `max_failed_file_loads`
- /api/repository/v1/datasets/{id}/files/bulk:
  - `maxFailedFileLoads`
- /api/repository/v1/datasets/{id}/files/bulk/array:
  - `maxFailedFileLoads`

**Changes:**
Optional fields are nullable in swagger, even if `nullable` is set to `False`. Because of this, I changed these fields to be required. If a user does not specify a value, the default 0 will be used. And if a user specifies a null value, they will get a validation error.

I moved the dataset ingest related tests into a separate file and did some refactoring to consolidate repeated code, so for this PR it will probably be easier to take a look at the individual commits.