### PR TITLE
DR-3000 Add fixup Firestore file metadata collections on migration

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep.java
@@ -1,0 +1,69 @@
+package bio.terra.service.dataset.flight.upgrade.predictableFileIds;
+
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.filedata.google.gcs.GcsProjectFactory;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import java.util.List;
+import java.util.UUID;
+import liquibase.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep extends DefaultUndoStep {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep.class);
+
+  private final UUID datasetId;
+  private final DatasetService datasetService;
+  private final FireStoreDao fileDao;
+  private final GcsProjectFactory gcsProjectFactory;
+
+  public ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep(
+      UUID datasetId,
+      DatasetService datasetService,
+      FireStoreDao fileDao,
+      GcsProjectFactory gcsProjectFactory) {
+    this.datasetId = datasetId;
+    this.datasetService = datasetService;
+    this.fileDao = fileDao;
+    this.gcsProjectFactory = gcsProjectFactory;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    Dataset dataset = datasetService.retrieve(datasetId);
+
+    // Retrieve files with null MD5s
+    List<FireStoreFile> noMd5Files = fileDao.retrieveAllWithEmptyField(dataset, "checksumMd5");
+    if (noMd5Files.isEmpty()) {
+      return StepResult.getStepResultSuccess();
+    }
+    logger.info("{} files will have md5s updated", noMd5Files.size());
+    String projectId = dataset.getProjectResource().getGoogleProjectId();
+    Storage storage = gcsProjectFactory.getStorage(projectId);
+
+    // Add md5s
+    noMd5Files.forEach(
+        f -> {
+          Blob sourceBlob = GcsPdao.getBlobFromGsPath(storage, f.getGspath(), projectId);
+          f.checksumMd5(sourceBlob.getMd5ToHexString());
+          if (StringUtils.isEmpty(f.getChecksumMd5())) {
+            logger.warn("File {} has no MD5", f.getGspath());
+          }
+        });
+
+    // Re-add files with md5s
+    fileDao.upsertFileMetadata(dataset, noMd5Files);
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
@@ -417,7 +417,7 @@ public abstract class IngestBulkGcpStep extends DefaultUndoStep {
     for (var writeBatch : writeBatches) {
       i++;
       logger.info("Writing batch {} of {}", i, writeBatches.size());
-      fileDao.createFileMetadata(dataset, writeBatch);
+      fileDao.upsertFileMetadata(dataset, writeBatch);
     }
     // Retrieve documents from to build the complete FSItems
     List<FSFile> fsItems = new ArrayList<>(fileIdsByPath.size());

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileFileStep.java
@@ -54,7 +54,7 @@ public class IngestFileFileStep implements Step {
               .loadTag(fileLoadModel.getLoadTag());
 
       try {
-        fileDao.createFileMetadata(dataset, newFile);
+        fileDao.upsertFileMetadata(dataset, newFile);
         // Retrieve to build the complete FSItem
         FSItem fsItem = fileDao.retrieveById(dataset, fileId, 1);
         workingMap.put(JobMapKeys.RESPONSE.getKeyName(), fileService.fileModelFromFSItem(fsItem));

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -147,24 +147,24 @@ public class FireStoreDao {
    * Upserts a file metadata object into Firestore (e.g. this is the metadata that contains size,
    * checksum, cloud location etc.) of a file, as opposed to the path information for the file
    */
-  public void createFileMetadata(Dataset dataset, FireStoreFile newFile)
+  public void upsertFileMetadata(Dataset dataset, FireStoreFile newFile)
       throws InterruptedException {
     Firestore firestore =
         FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
     String datasetId = dataset.getId().toString();
-    fileDao.createFileMetadata(firestore, datasetId, newFile);
+    fileDao.upsertFileMetadata(firestore, datasetId, newFile);
   }
 
   /**
    * Upserts file metadata objects into Firestore (e.g. this is the metadata that contains size,
    * checksum, cloud location etc.) of a file, as opposed to the path information for the file
    */
-  public void createFileMetadata(Dataset dataset, List<FireStoreFile> newFiles)
+  public void upsertFileMetadata(Dataset dataset, List<FireStoreFile> newFiles)
       throws InterruptedException {
     Firestore firestore =
         FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
     String datasetId = dataset.getId().toString();
-    fileDao.createFileMetadata(firestore, datasetId, newFiles);
+    fileDao.upsertFileMetadata(firestore, datasetId, newFiles);
   }
 
   /** Updates the ID of a file's metadata (effectively, this is a move operation) */
@@ -512,6 +512,13 @@ public class FireStoreDao {
           .map(FireStoreFile::getFileId)
           .toList();
     }
+  }
+
+  public List<FireStoreFile> retrieveAllWithEmptyField(Dataset dataset, String fieldName)
+      throws InterruptedException {
+    Firestore firestore =
+        FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
+    return fileDao.enumerateAllWithEmptyField(firestore, dataset.getId().toString(), fieldName);
   }
 
   // -- private methods --

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -215,7 +215,7 @@ public class FireStoreDaoTest {
             .userSpecifiedMd5(false)
             .size(size);
 
-    fileDao.createFileMetadata(firestore, datasetId, newFile);
+    fileDao.upsertFileMetadata(firestore, datasetId, newFile);
 
     return new FireStoreDirectoryEntry()
         .fileId(fileId)


### PR DESCRIPTION
Today for AnVIL datasets, some files are stored with no MD5 value in Firestore.  This is because they had no MD5 at the time of ingest.  Since then, Nate's team has calculated and stored MD5s on the files on the actual files in the buckets but in Firestore they're still null.  This was causing migrations to fail

The quickest approach for this (especially given that the migration of datasets to use predictable file ids is limited to AnVIL datasets) was to add a step to the migration that:
- Looks up any file entries that have a null value for the file
- For any of those, look at the source file and see if there's an MD5 and set it in Firestore
- Proceed as normal

The testing is handled at the connected test level, which is exercising the code that will live on beyond the migration.