### PR TITLE
DR-2965 Allow moving self hosted files for predictable id datasets

### DIFF
--- a/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
+++ b/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
@@ -23,9 +23,12 @@ public class FileMetadataUtils {
   public FileMetadataUtils() {}
 
   public static String getDirectoryPath(String path) {
+    if (StringUtils.isEmpty(path)) {
+      return "";
+    }
     Path pathParts = Paths.get(path);
     Path parentDirectory = pathParts.getParent();
-    if (pathParts.getNameCount() <= 1) {
+    if (pathParts.getNameCount() == 0) {
       // We are at the root; no containing directory
       return StringUtils.EMPTY;
     }

--- a/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
+++ b/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
@@ -22,13 +22,12 @@ public class FileMetadataUtils {
 
   public FileMetadataUtils() {}
 
+  // TODO: this currently returns the directory as "" if you pass in a one-level deep item
+  // https://broadworkbench.atlassian.net/browse/DR-3005 is to fix (changing breaks tests badly)
   public static String getDirectoryPath(String path) {
-    if (StringUtils.isEmpty(path)) {
-      return "";
-    }
     Path pathParts = Paths.get(path);
     Path parentDirectory = pathParts.getParent();
-    if (pathParts.getNameCount() == 0) {
+    if (pathParts.getNameCount() <= 1) {
       // We are at the root; no containing directory
       return StringUtils.EMPTY;
     }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDao.java
@@ -170,14 +170,18 @@ public class FireStoreDirectoryDao {
                         // this load and that this is a recovery.  In that case, just leave the
                         // entry unchanged and return a mapping from the attempted fileId to the
                         // existing fileId so that the calling flight's working map can be updated
-                        if (Objects.equals(entry.getLoadTag(), existingEntry.getLoadTag())) {
+                        if (StringUtils.isEmpty(existingEntry.getLoadTag())
+                            || Objects.equals(entry.getLoadTag(), existingEntry.getLoadTag())) {
                           return new IdConflict(
                               UUID.fromString(entry.getFileId()),
                               UUID.fromString(documentSnapshot.get("fileId", String.class)));
                         } else {
                           throw new FileAlreadyExistsException(
-                              "Path already exists: %s with load tag %s"
-                                  .formatted(entry.getPath(), existingEntry.getLoadTag()));
+                              "Path already exists: %s/%s with load tag %s"
+                                  .formatted(
+                                      entry.getPath(),
+                                      entry.getName(),
+                                      existingEntry.getLoadTag()));
                         }
                       }
                       xn.set(docRef, entry);

--- a/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
@@ -211,10 +211,12 @@ public class FileMetadataUtilsTest {
     assertThat("root directory dir looks ok", FileMetadataUtils.getDirectoryPath("/"), equalTo(""));
     assertThat("root directory file looks ok", FileMetadataUtils.getName("/"), equalTo(""));
 
+    // It's admitedly strange that this is what we expect but changing the behavior causes untold
+    // chaos
     assertThat(
         "1st level directory dir looks ok",
         FileMetadataUtils.getDirectoryPath("/foo"),
-        equalTo("/"));
+        equalTo(""));
     assertThat(
         "1st level directory file looks ok", FileMetadataUtils.getName("/foo"), equalTo("foo"));
 

--- a/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
@@ -205,6 +205,27 @@ public class FileMetadataUtilsTest {
     assertThrows(IllegalArgumentException.class, () -> FileMetadataUtils.extractDirectoryPaths(""));
   }
 
+  @Test
+  public void pathParsingTest() {
+    assertThat("empty string returns empty", FileMetadataUtils.getDirectoryPath(""), equalTo(""));
+    assertThat("root directory dir looks ok", FileMetadataUtils.getDirectoryPath("/"), equalTo(""));
+    assertThat("root directory file looks ok", FileMetadataUtils.getName("/"), equalTo(""));
+
+    assertThat(
+        "1st level directory dir looks ok",
+        FileMetadataUtils.getDirectoryPath("/foo"),
+        equalTo("/"));
+    assertThat(
+        "1st level directory file looks ok", FileMetadataUtils.getName("/foo"), equalTo("foo"));
+
+    assertThat(
+        "2nd level directory dir looks ok",
+        FileMetadataUtils.getDirectoryPath("/foo/bar"),
+        equalTo("/foo"));
+    assertThat(
+        "2nd level directory file looks ok", FileMetadataUtils.getName("/foo/bar"), equalTo("bar"));
+  }
+
   private List<FireStoreDirectoryEntry> initTestEntries(int numDirectories) {
     List<FireStoreDirectoryEntry> testEntries = new ArrayList<>();
     // Add 4 files per different directory path


### PR DESCRIPTION
It turns out, we already support this so I added an explicit integration test that ingests then re-ingests with a different source path

Note: to use this, you do need to ingest with the same load tag as the file that was originally ingested and the file needs to have the same size and MD5 hash (or else the fileids would be different)

I also made a couple of small drive by changes:
- ~~Make sure that we properly store the parent directory for root level directories in Firestore (Fixes an issue where you can't enumerate the top level directories)~~ (I reverted this since it caused all sorts of other problems and created a ticket - [DR-3005](https://broadworkbench.atlassian.net/browse/DR-3005) - to address this
- Add some more accurate logging in the bulk loader

[DR-3005]: https://broadworkbench.atlassian.net/browse/DR-3005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ