### PR TITLE
adds sherlock reporting for api PR and semver builds

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -21,6 +21,8 @@ on:
       - '.swagger-codegen-ignore'
 jobs:
   update_image:
+    outputs:
+      api_image_tag: ${{ steps.bumperstep.outputs.tag }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -89,8 +91,18 @@ jobs:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
-          alpharelease: ${{ steps.bumperstep.outputs.tag }}
+          alpharelease: ${{ steps.bumperstep.outputs.tag }} # creates gcr build with semver tag
           gcr_google_project: 'broad-jade-dev'
+  report-to-sherlock:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs:
+      - update_image
+    with:
+      new-version: ${{ needs.update_image.outputs.api_image_tag }}
+      chart-name: 'datarepo'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
   helm_tag_bumper:
     needs: update_image
     uses: ./.github/workflows/helmtagbumper.yaml

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -140,6 +140,7 @@ jobs:
     name: "Run integration and smoke tests"
     outputs:
       job-status: ${{ job.status }}
+      api_image_tag: ${{ steps.configuration.outputs.git_hash }}
     timeout-minutes: 300
     needs: test_check
     strategy:
@@ -190,7 +191,7 @@ jobs:
       - name: "Build docker container via Gradle"
         uses: broadinstitute/datarepo-actions/actions/main@0.68.0
         with:
-          actions_subcommand: 'gradlebuild'
+          actions_subcommand: 'gradlebuild' # creates gcr build with git_hash tag
       - name: "Deploy to cluster with Helm"
         uses: broadinstitute/datarepo-actions/actions/main@0.68.0
         with:
@@ -232,6 +233,15 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.68.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
+  report-to-sherlock:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: deploy_test_integration
+    with:
+      new-version: ${{ needs.deploy_test_integration.outputs.api_image_tag }}
+      chart-name: 'datarepo'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
   publish_test_reports:
     name: "Save execution reports and notify"
     timeout-minutes: 60

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -236,6 +236,8 @@ jobs:
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: deploy_test_integration
+    # Always attempt to run, as we want to report the appVersion even if the tests fail.
+    if: always()
     with:
       new-version: ${{ needs.deploy_test_integration.outputs.api_image_tag }}
       chart-name: 'datarepo'


### PR DESCRIPTION
Adds sherlock reporting for api at two points:
- int-and-connected-test-run.yaml - this gener
- dev-image-update.yaml 

Does NOT:
- report the dev build that does to the `dev` instance of datarepo, this build appears to be identical to the alpha/semver as they both get built in the dev-image-update workflow
- touch anything with datarepo-ui 
  - It looks like datarepo-ui does get checked out before the alpha semver build, no idea if this affects anything. tbd.

Follow Ups:
- recording app versions lets us a bit more smartly target release testing for smoke tests
  - targeting arbitrary environment for smoke tests is up next.
- recording the PR versions allows us to test against BEEs instead of integration (w/ some more massaging)