### PR TITLE
[DR-2999] Column names cannot start with numbers

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3893,9 +3893,9 @@ components:
       pattern: ^[a-zA-Z0-9][_a-zA-Z0-9]*$
       type: string
       description: >
-        Table and column names follow this pattern. This should be used for the name of any object in the
+        Table names follow this pattern. This should be used for the name of any non-column object in the
         system. It enforces BigQuery naming rules except it disallows a leading underscore so we avoid collisions with
-        any extra columns the DR adds. For table and column names, this is shorter than what BigQuery allows.
+        any extra tables the DR adds. For table names, this is shorter than what BigQuery allows.
     DatasetSnapshotNameProperty:
       maxLength: 511
       minLength: 1
@@ -3904,6 +3904,15 @@ components:
       description: >
         Dataset and snapshot names follow this pattern. It is the same as ObjectNameProperty, but has
         a greater maxLength.
+    ColumnNameProperty:
+      maxLength: 63
+      minLength: 1
+      pattern: ^[a-zA-Z][_a-zA-Z0-9]*$
+      type: string
+      description: >
+        Column names follow this pattern. This should be used for the name of any column in the
+        system. It enforces BigQuery naming rules except it disallows a leading underscore so we avoid collisions with
+        any extra columns the DR adds. This is shorter than what BigQuery allows.
     UniqueIdProperty:
       type: string
       format: uuid
@@ -4251,7 +4260,7 @@ components:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/ColumnNameProperty'
         datatype:
           $ref: '#/components/schemas/TableDataType'
         array_of:
@@ -4277,9 +4286,9 @@ components:
         primaryKey:
           type: array
           items:
-            $ref: '#/components/schemas/ObjectNameProperty'
+            $ref: '#/components/schemas/ColumnNameProperty'
           description: >
-            Primary key columns names. Any columns listed as a primary key will be marked as required by default.
+            Primary key column names. Any columns listed as a primary key will be marked as required by default.
         partitionMode:
           type: string
           default: none
@@ -4300,7 +4309,7 @@ components:
       type: object
       properties:
         column:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/ColumnNameProperty'
       description: Describes how a date partition should be configured.
     IntPartitionOptionsModel:
       required:
@@ -4311,7 +4320,7 @@ components:
       type: object
       properties:
         column:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/ColumnNameProperty'
         min:
           type: integer
           description: >
@@ -4337,7 +4346,7 @@ components:
         table:
           $ref: '#/components/schemas/ObjectNameProperty'
         column:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/ColumnNameProperty'
       description: Describes a table and columns for a relationship
     RelationshipModel:
       required:
@@ -4367,7 +4376,7 @@ components:
         columns:
           type: array
           items:
-            $ref: '#/components/schemas/ObjectNameProperty'
+            $ref: '#/components/schemas/ColumnNameProperty'
       description: >
         Used in the asset definition to describe a table that is included in the asset. This is used to define
         the view of the asset table in the snapshot. Columns can be an empty array indicating that all columns
@@ -4390,7 +4399,7 @@ components:
         rootTable:
           $ref: '#/components/schemas/ObjectNameProperty'
         rootColumn:
-          $ref: '#/components/schemas/ObjectNameProperty'
+          $ref: '#/components/schemas/ColumnNameProperty'
         follow:
           type: array
           items:
@@ -5144,7 +5153,7 @@ components:
         columns:
           type: array
           items:
-            $ref: '#/components/schemas/ObjectNameProperty'
+            $ref: '#/components/schemas/ColumnNameProperty'
         rowIds:
           type: array
           items:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3919,10 +3919,10 @@ components:
       description: >
         Unique identifier for a dataset, snapshot, etc.
     ShortIdProperty:
-      pattern: '[A-za-z0-9_\\-]{22}'
+      pattern: '[A-Za-z0-9_\\-]{22}'
       type: string
       description: >
-        Unique identifier for a flights, jobs, etc.
+        Unique identifier for flights, jobs, etc.
     BillingProfileRequestModel:
       required:
         - biller

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -394,7 +394,7 @@ public class DatasetDaoTest {
     assertThat("dataset name is set correctly", fromDB.getName(), equalTo(expectedName));
 
     // verify tables
-    assertThat("correct number of tables created for dataset", fromDB.getTables(), hasSize(2));
+    assertThat("correct number of tables created for dataset", fromDB.getTables(), hasSize(3));
     fromDB.getTables().forEach(this::assertDatasetTable);
 
     assertThat(
@@ -525,11 +525,18 @@ public class DatasetDaoTest {
   }
 
   protected void assertDatasetTable(Table table) {
-    if (table.getName().equals("participant")) {
-      assertThat("participant table has 4 columns", table.getColumns(), hasSize(4));
-    } else {
-      assertThat("other table created is sample", table.getName(), equalTo("sample"));
-      assertThat("sample table has 3 columns", table.getColumns(), hasSize(3));
+    switch (table.getName()) {
+      case "participant":
+        assertThat("participant table has 4 columns", table.getColumns(), hasSize(4));
+        break;
+      case "sample":
+        assertThat("sample table has 3 columns", table.getColumns(), hasSize(3));
+        break;
+      case "123_leading_number":
+        assertThat("123_leading_number table has 1 column", table.getColumns(), hasSize(1));
+        break;
+      default:
+        throw new RuntimeException("Unexpected table " + table.getName());
     }
   }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -526,17 +526,12 @@ public class DatasetDaoTest {
 
   protected void assertDatasetTable(Table table) {
     switch (table.getName()) {
-      case "participant":
-        assertThat("participant table has 4 columns", table.getColumns(), hasSize(4));
-        break;
-      case "sample":
-        assertThat("sample table has 3 columns", table.getColumns(), hasSize(3));
-        break;
-      case "123_leading_number":
-        assertThat("123_leading_number table has 1 column", table.getColumns(), hasSize(1));
-        break;
-      default:
-        throw new RuntimeException("Unexpected table " + table.getName());
+      case "participant" -> assertThat(
+          "participant table has 4 columns", table.getColumns(), hasSize(4));
+      case "sample" -> assertThat("sample table has 3 columns", table.getColumns(), hasSize(3));
+      case "123_leading_number" -> assertThat(
+          "123_leading_number table has 1 column", table.getColumns(), hasSize(1));
+      default -> throw new RuntimeException("Unexpected table " + table.getName());
     }
   }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -178,8 +178,11 @@ public class DatasetRequestValidatorTest {
     DatasetRequestModel req = buildDatasetRequest();
 
     // Table names with leading underscores are invalid
-    checkValidationErrorModel(
-        expectBadDatasetCreateRequest(withNamedTable(req, "_")), new String[] {"Pattern"});
+    List<String> invalidPatternNames = List.of("_", "_a_column", "_1_column");
+    for (String name : invalidPatternNames) {
+      checkValidationErrorModel(
+          expectBadDatasetCreateRequest(withNamedTable(req, name)), new String[] {"Pattern"});
+    }
 
     // Table names over 63 characters are invalid
     checkValidationErrorModel(
@@ -267,13 +270,12 @@ public class DatasetRequestValidatorTest {
   public void testInvalidColumnName() throws Exception {
     DatasetRequestModel req = buildDatasetRequest();
 
-    // Column names with leading numbers are invalid
-    checkValidationErrorModel(
-        expectBadDatasetCreateRequest(withNamedColumn(req, "1")), new String[] {"Pattern"});
-
-    // Column names with leading underscores are invalid
-    checkValidationErrorModel(
-        expectBadDatasetCreateRequest(withNamedColumn(req, "_")), new String[] {"Pattern"});
+    // Table names with leading numbers or leading underscores are invalid
+    List<String> invalidPatternNames = List.of("_", "_a_column", "_1_column", "1", "1_column");
+    for (String name : invalidPatternNames) {
+      checkValidationErrorModel(
+          expectBadDatasetCreateRequest(withNamedColumn(req, name)), new String[] {"Pattern"});
+    }
 
     // Column names over 63 characters are invalid
     checkValidationErrorModel(

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,8 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -106,11 +103,7 @@ public class DatasetRequestValidatorTest {
     ErrorModel errorModel = TestUtils.mapFromJson(responseBody, ErrorModel.class);
     assertThat("correct error message", errorModel.getMessage(), equalTo(expectedMessage));
     List<String> responseErrors = errorModel.getErrorDetail();
-    if (errors == null || errors.isEmpty()) {
-      assertThat("No details expected", ListUtils.emptyIfNull(responseErrors), empty());
-    } else {
-      assertThat("Error details match", responseErrors, contains(errors.toArray()));
-    }
+    assertThat("Error details match", responseErrors, contains(errors.toArray()));
   }
 
   @Test
@@ -190,8 +183,7 @@ public class DatasetRequestValidatorTest {
 
     // Table names over 63 characters are invalid
     checkValidationErrorModel(
-        expectBadDatasetCreateRequest(withNamedTable(req, StringUtils.repeat("a", 64))),
-        new String[] {"Size"});
+        expectBadDatasetCreateRequest(withNamedTable(req, "a".repeat(64))), new String[] {"Size"});
   }
 
   @Test
@@ -285,8 +277,7 @@ public class DatasetRequestValidatorTest {
 
     // Column names over 63 characters are invalid
     checkValidationErrorModel(
-        expectBadDatasetCreateRequest(withNamedColumn(req, StringUtils.repeat("a", 64))),
-        new String[] {"Size"});
+        expectBadDatasetCreateRequest(withNamedColumn(req, "a".repeat(64))), new String[] {"Size"});
   }
 
   @Test
@@ -462,7 +453,7 @@ public class DatasetRequestValidatorTest {
     checkValidationErrorModel(errorModel, new String[] {"Size", "Pattern"});
 
     // Make a 512 character string, it should be considered too long by the validation.
-    String tooLong = StringUtils.repeat("a", 512);
+    String tooLong = "a".repeat(512);
     errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(tooLong));
     checkValidationErrorModel(errorModel, new String[] {"Size"});
   }

--- a/src/test/resources/dataset-create-test.json
+++ b/src/test/resources/dataset-create-test.json
@@ -20,6 +20,12 @@
           {"name": "participant_id", "datatype": "string"},
           {"name": "date_collected", "datatype": "date"}
         ]
+      },
+      {
+        "name":    "123_leading_number",
+        "columns": [
+          {"name": "id", "datatype": "string"}
+        ]
       }
     ],
     "relationships": [


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2999

Previously we reused shared pattern `ObjectNameProperty` for table, column, and most other object names.  This pattern meant to enforce BigQuery naming conventions along with some additional restrictions of our own.

In this PR I broke out `ColumnNameProperty` for column pattern checking only: [BigQuery does not allow you create columns starting with numbers](https://cloud.google.com/bigquery/docs/schemas#:~:text=A%20column%20name%20can%20contain,with%20a%20letter%20or%20underscore.), and this wasn't a restriction we wanted to overly impose on tables / other objects.  Places where we previously used `ObjectNameProperty` to specify a column name were switched over.

**Testing**

- Added unit tests to verify that illegal table and column names cause dataset creation to fail fast with expected messaging.
- `dataset-create-test.json` now includes a table with a leading number in the name: updated downstream unit tests accordingly.

My [developer environment](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/datasets/createDataset) is up to date with these changes.  When I tried to create a dataset with a column that started with a number, it failed on validation before flight creation with a 400 and the following error:

```
{
  "message": "Validation errors - see error details",
  "errorDetail": [
    "schema.tables[0].columns[1].name: 'Pattern' (must match \"^[a-zA-Z][_a-zA-Z0-9]*$\")"
  ]
}
```

I wish this messaging included the table and column name, but I didn't see a straightforward way to make that improvement.  Error handling here: https://github.com/DataBiosphere/jade-data-repo/blob/d42092b0da8ec0a75f2f3006d7251401fdd33048/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java#L92-L100

**Follow-On Work**

There are a few opportunities to enhance TDR UI's schema builder if we wish.  I see that we validate dataset names as the user works:
![Screenshot 2023-04-19 at 5 38 23 PM](https://user-images.githubusercontent.com/79769153/233206144-ca72f47c-871e-44e5-abfc-ce683818b5ac.png)

But not table or column names:
![Screenshot 2023-04-19 at 5 38 47 PM](https://user-images.githubusercontent.com/79769153/233206190-3ec9f073-53c7-4f44-ab9a-7acf24900265.png)