### PR TITLE
[DR-2997] Journal entries are retrieved in descending order

### DIFF
--- a/src/main/java/bio/terra/service/journal/JournalDao.java
+++ b/src/main/java/bio/terra/service/journal/JournalDao.java
@@ -118,27 +118,24 @@ public class JournalDao {
       isolation = Isolation.SERIALIZABLE,
       readOnly = true)
   public List<JournalEntryModel> retrieveEntriesByIdAndType(
-      UUID resource_key, @NotNull IamResourceType resourceType, long offset, int limit) {
+      UUID resourceKey, @NotNull IamResourceType resourceType, long offset, int limit) {
     String sql =
-        "SELECT "
-            + summaryQueryColumns
-            + "FROM "
-            + TABLE_NAME
-            + " "
-            + "WHERE "
-            + "resource_key = :resource_key "
-            + "AND "
-            + "resource_type = :resourceType "
-            + "ORDER BY entry_timestamp ASC "
-            + "OFFSET :offset LIMIT :limit";
+        """
+            SELECT %s FROM %s
+            WHERE resource_key = :resource_key
+            AND resource_type = :resource_type
+            ORDER BY entry_timestamp DESC
+            OFFSET :offset LIMIT :limit
+            """
+            .formatted(summaryQueryColumns, TABLE_NAME);
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
-            .addValue("resource_key", resource_key)
-            .addValue("resourceType", resourceType.toString())
+            .addValue("resource_key", resourceKey)
+            .addValue("resource_type", resourceType.toString())
             .addValue("offset", offset)
             .addValue("limit", limit);
-    return jdbcTemplate.query(sql, params, new JournalDao.JournalEntryMapper());
+    return jdbcTemplate.query(sql, params, new JournalEntryMapper());
   }
 
   private class JournalEntryMapper implements RowMapper<JournalEntryModel> {

--- a/src/main/java/bio/terra/service/journal/JournalService.java
+++ b/src/main/java/bio/terra/service/journal/JournalService.java
@@ -113,7 +113,8 @@ public class JournalService {
   }
 
   /**
-   * Return an ordered list of {@code JournalEntryModel}s sorted ascending by when they were created
+   * Return an ordered list of {@code JournalEntryModel}s sorted descending by when they were
+   * created
    *
    * @param resourceKey The domain object key of the resource
    * @param resourceType The {@code IamResourceType} that maps to the domain object the journal

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3802,7 +3802,8 @@ paths:
       tags:
         - journal
       description: >
-        Returns a list of journal entries for an object the caller has access to
+        Returns a list of journal entries for an object the caller has access to, in descending
+        order of entry creation.
       operationId: retrieveJournalEntries
       parameters:
         - in: path
@@ -3827,7 +3828,7 @@ paths:
             default: 0
         - name: limit
           in: query
-          description: The numbers entries to retrieve and return.
+          description: The number of entries to retrieve and return.
           schema:
             type: integer
             default: 10
@@ -3865,7 +3866,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
         500:
-          description: An unexpected error occurred - dataset was not updated.
+          description: An unexpected error occurred.
           content:
             application/json:
               schema:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2997

This change makes it so that fetched journal entries are returned in **descending** creation order (most recent entries first).  Previously they were returned in ascending creation order which was confusing for users and inconsistent with our other enumerations.

My developer environment has been updated with these changes.  As an example, this [dataset](https://jade-ok.datarepo-dev.broadinstitute.org/datasets/e9899643-4ba7-4c73-9101-13c50ad79788) has 13 corresponding journal entries and we see them returned in descending creation order:

https://user-images.githubusercontent.com/79769153/233163722-44c6384a-d87d-43a6-a300-2e5a83139802.mov

I updated our unit tests to verify this new behavior.
