### PR TITLE
[DR-2963] Handle partial bulk mode failures

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
@@ -180,17 +180,17 @@ public abstract class IngestBulkGcpStep extends DefaultUndoStep {
     // attempting re-copying files)
     // For the case where we use predictable file Ids, this is a noop
     if (!dataset.hasPredictableFileIds()) {
-      List<CopyResult> copyResults =
-          doFileCopy(workingMap, loadModels, fileIdsByPath, bucketResource);
-      copyResults.stream()
-          .filter(r -> r.error() == null && r.fsFileInfo() != null)
-          .map(CopyResult::fsFileInfo)
-          .forEach(fsFileInfos::add);
-      List<String> failedTargetPaths =
-          copyResults.stream()
-              .filter(r -> r.fsFileInfo() == null)
-              .map(CopyResult::targetPath)
-              .toList();
+      List<String> failedTargetPaths = new ArrayList<>();
+      doFileCopy(workingMap, loadModels, fileIdsByPath, bucketResource)
+          .forEach(
+              copyResult -> {
+                var fsFileInfo = copyResult.fsFileInfo();
+                if (copyResult.error() == null && fsFileInfo != null) {
+                  fsFileInfos.add(fsFileInfo);
+                } else {
+                  failedTargetPaths.add(copyResult.targetPath());
+                }
+              });
       successfulLoadModels =
           loadModels.stream().filter(m -> !failedTargetPaths.contains(m.getTargetPath())).toList();
       fileIdsByPath.entrySet().removeIf(item -> failedTargetPaths.contains(item.getKey()));

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -1191,6 +1191,19 @@ public class DataRepoFixtures {
     return assertSuccessful(response, "bulkLoadArray failed");
   }
 
+  public ErrorModel bulkLoadArrayFailure(
+      TestConfiguration.User user, UUID datasetId, BulkLoadArrayRequestModel requestModel)
+      throws Exception {
+
+    DataRepoResponse<JobModel> launchResponse = bulkLoadArrayRaw(user, datasetId, requestModel);
+
+    DataRepoResponse<BulkLoadArrayResultModel> response =
+        dataRepoClient.waitForResponse(user, launchResponse, new TypeReference<>() {});
+    assertFalse("bulk load array failed", response.getStatusCode().is2xxSuccessful());
+    assertTrue("bulk load array error response is present", response.getErrorObject().isPresent());
+    return response.getErrorObject().get();
+  }
+
   public DataRepoResponse<JobModel> bulkLoadRaw(
       TestConfiguration.User user, UUID datasetId, BulkLoadRequestModel requestModel)
       throws Exception {
@@ -1216,6 +1229,17 @@ public class DataRepoFixtures {
     DataRepoResponse<BulkLoadResultModel> response =
         dataRepoClient.waitForResponse(user, launchResponse, new TypeReference<>() {});
     return assertSuccessful(response, "bulkLoad failed");
+  }
+
+  public ErrorModel bulkLoadFailure(
+      TestConfiguration.User user, UUID datasetId, BulkLoadRequestModel requestModel)
+      throws Exception {
+    DataRepoResponse<JobModel> launchResponse = bulkLoadRaw(user, datasetId, requestModel);
+    DataRepoResponse<ErrorModel> response =
+        dataRepoClient.waitForResponse(user, launchResponse, new TypeReference<>() {});
+    assertFalse("bulk load failed", response.getStatusCode().is2xxSuccessful());
+    assertTrue("bulk load error response is present", response.getErrorObject().isPresent());
+    return response.getErrorObject().get();
   }
 
   public BulkLoadHistoryModelList getLoadHistory(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2963

When performing a bulk file ingest, if the number of file failures is less than or equal to the `maxFailedFileLoads`, the ingest should still succeed. However, if an ingest used the `bulkMode` option (and did not use `predictableFileIds`), if any file ingest failed the entire bulk ingest request would fail (no matter what the `maxFailedFileLoads` was).

**Changes:**
- Only call `doFireStoreFileIngest` on the files that loaded successfully

**Tests:**
- Test that a bulk file ingest (via array and json file) without predictable ids will succeed if the number of failed file ingests is less than or equal to `maxFailedFileLoads`
- Test that a bulk file ingest (via array and json file) without predictable ids will fail if the number of failed file ingests is greater than the `maxFailedFileLoads`