### PR TITLE
DDO-2815 add bump to datarepo-latest + test code

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -103,6 +103,19 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+  set-app-version-in-environment:
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs:
+      - update_image
+      - report-to-sherlock
+    with:
+      new-version: ${{ needs.update_image.outputs.api_image_tag }}
+      chart-name: 'datarepo'
+      environment-name: 'datarepo-latest'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'
   helm_tag_bumper:
     needs: update_image
     uses: ./.github/workflows/helmtagbumper.yaml

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -244,19 +244,6 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-  set-app-version-in-environment:
-    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs:
-      - deploy_test_integration
-      - report-to-sherlock
-    with:
-      new-version: ${{ needs.deploy_test_integration.outputs.api_image_tag }}
-      chart-name: 'datarepo'
-      environment-name: 'datarepo-latest'
-    secrets:
-      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
-    permissions:
-      id-token: 'write'
   publish_test_reports:
     name: "Save execution reports and notify"
     timeout-minutes: 60

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -244,6 +244,19 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+  set-app-version-in-environment:
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs:
+      - deploy_test_integration
+      - report-to-sherlock
+    with:
+      new-version: ${{ needs.deploy_test_integration.outputs.api_image_tag }}
+      chart-name: 'datarepo'
+      environment-name: 'datarepo-latest'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'
   publish_test_reports:
     name: "Save execution reports and notify"
     timeout-minutes: 60


### PR DESCRIPTION
Adds another step to the datarepo api update process:
update datarepo-latest template with the newest semver, this is required for immediate release of new code because 

1) datarepo develop is not managed by devops and doesn't share the same versions as terra (semantic versioning)alpha is 2) only deployed to once a day so does not work for up-to-date constant testing.

tested here: https://github.com/DataBiosphere/jade-data-repo/actions/runs/4885874733?pr=1452

confirmed in a pr test run that app version set to `8348105` which can only happen from pr builds.