### PR TITLE
[DR-2975] GCP datasets with dedicated SAs don't need to check file perms

### DIFF
--- a/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
+++ b/src/main/java/bio/terra/common/ValidateBucketAccessStep.java
@@ -35,9 +35,8 @@ import org.slf4j.LoggerFactory;
  * <p>GCS files specified indirectly -- i.e. referenced in a control file -- do not have their
  * access validated in this step.
  *
- * <p>Since GCS files can be ingested to Azure-backed datasets, this step should be added
- * unconditionally to flights which take in user-specified files no matter the platform of the
- * destination dataset.
+ * <p>This step should be added to flights when GCS files could be specified directly in the
+ * request, which could include instances where the destination dataset is backed by Azure.
  */
 public class ValidateBucketAccessStep extends DefaultUndoStep {
   private static final Logger logger = LoggerFactory.getLogger(ValidateBucketAccessStep.class);
@@ -98,6 +97,7 @@ public class ValidateBucketAccessStep extends DefaultUndoStep {
     } else {
       throw new IllegalArgumentException("Invalid request type");
     }
+    // The destination dataset may be Azure-based, and thus would not have a Google project ID
     String cloudEncapsulationId =
         Optional.ofNullable(dataset.getProjectResource())
             .map(GoogleProjectResource::getGoogleProjectId)

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -289,28 +289,12 @@ public class Dataset implements FSContainerInterface, LogPrintable {
   }
 
   /**
-   * When ingesting to a GCP dataset, TDR can bypass the costly permission checking of all ingested
-   * files if the dataset has a dedicated service account, as such accounts are unique to the
-   * dataset and ingests will correctly fail if it lacks needed permission on the files.
-   *
-   * <p>Otherwise, we must preserve this check to ensure that a user cannot ingest files
-   * inaccessible to them, but accessible to the general TDR service account.
-   *
-   * <p>This check is not needed for Azure datasets because we use signed URLS that by default check
-   * permissions.
-   *
-   * @return whether TDR should verify that the ingester has access to the files they're trying to
-   *     ingest.
+   * @return whether this dataset has a dedicated GCP service account
    */
-  public boolean shouldValidateIngesterFileAccess() {
-    if (getCloudPlatform() == CloudPlatform.AZURE) {
-      return false;
-    }
-    boolean hasDedicatedServiceAccount =
-        Optional.ofNullable(projectResource)
-            .map(GoogleProjectResource::hasDedicatedServiceAccount)
-            .orElse(false);
-    return !hasDedicatedServiceAccount;
+  public boolean hasDedicatedGcpServiceAccount() {
+    return Optional.ofNullable(projectResource)
+        .map(GoogleProjectResource::hasDedicatedServiceAccount)
+        .orElse(false);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
@@ -31,8 +31,7 @@ public class IngestRequestValidator implements Validator {
       value = "UC_USELESS_VOID_METHOD",
       justification = "FB mistake - this clearly validates and returns data in errors")
   public void validate(@NotNull Object target, Errors errors) {
-    if (target instanceof IngestRequestModel) {
-      IngestRequestModel ingestRequest = (IngestRequestModel) target;
+    if (target instanceof IngestRequestModel ingestRequest) {
       validateTableName(ingestRequest.getTable(), errors);
       boolean isPayloadIngest =
           ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY);
@@ -57,8 +56,7 @@ public class IngestRequestValidator implements Validator {
             "DataPayloadIsPresent",
             "Records should not be specified when ingesting from a path");
       }
-    } else if (target instanceof FileLoadModel) {
-      FileLoadModel fileLoadModel = (FileLoadModel) target;
+    } else if (target instanceof FileLoadModel fileLoadModel) {
       if (fileLoadModel.getProfileId() == null) {
         errors.rejectValue("profileId", "ProfileIdMissing", "File ingest requires a profile id.");
       }

--- a/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/datadelete/DatasetDataDeleteFlight.java
@@ -73,7 +73,7 @@ public class DatasetDataDeleteFlight extends Flight {
     if (request.getSpecType() == DataDeletionRequest.SpecTypeEnum.GCSFILE) {
       addStep(
           new ValidateBucketAccessStep(
-              gcsPdao, UUID.fromString(datasetId), datasetService, userReq),
+              gcsPdao, userReq, datasetService.retrieveAvailable(UUID.fromString(datasetId))),
           getDefaultExponentialBackoffRetryRule());
     }
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -340,8 +340,7 @@ public class DatasetIngestFlight extends Flight {
 
     // Verify that the user is allowed to access the bucket where the control file lives
     addStep(
-        new ValidateBucketAccessStep(
-            gcsPdao, dataset.getProjectResource().getGoogleProjectId(), userReq),
+        new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
         getDefaultExponentialBackoffRetryRule());
 
     // Parse the JSON file and see if there's actually any files to load.

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -24,6 +24,7 @@ import bio.terra.service.dataset.flight.transactions.TransactionCommitStep;
 import bio.terra.service.dataset.flight.transactions.TransactionLockStep;
 import bio.terra.service.dataset.flight.transactions.TransactionOpenStep;
 import bio.terra.service.dataset.flight.transactions.TransactionUnlockStep;
+import bio.terra.service.filedata.CloudFileReader;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
@@ -155,6 +156,13 @@ public class DatasetIngestFlight extends Flight {
     }
 
     addStep(new IngestSetupStep(datasetService, configService, cloudPlatform));
+
+    CloudFileReader cloudFileReader = (cloudPlatform.isGcp()) ? gcsPdao : azureBlobStorePdao;
+    // Verify that the user is allowed to access the bucket where a control file lives:
+    // the step will figure out if this is necessary depending on ingest type and cloud platform.
+    addStep(
+        new ValidateBucketAccessStep(cloudFileReader, userReq, dataset),
+        getDefaultExponentialBackoffRetryRule());
 
     if (IngestUtils.isJsonTypeIngest(inputParameters)) {
       int driverWaitSeconds = configService.getParameterValue(ConfigEnum.LOAD_DRIVER_WAIT_SECONDS);
@@ -337,11 +345,6 @@ public class DatasetIngestFlight extends Flight {
     ExecutorService executor = appContext.getBean("performanceThreadpool", ExecutorService.class);
 
     var platform = CloudPlatform.GCP;
-
-    // Verify that the user is allowed to access the bucket where the control file lives
-    addStep(
-        new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
-        getDefaultExponentialBackoffRetryRule());
 
     // Parse the JSON file and see if there's actually any files to load.
     // If there are no files to load, then SkippableSteps taking the `ingestSkipCondition`

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupAzureStep.java
@@ -36,7 +36,7 @@ public class IngestJsonFileSetupAzureStep extends IngestJsonFileSetupStep {
         IngestUtils.getIngestBillingProfileFromDataset(dataset, ingestRequest)
             .getTenantId()
             .toString();
-    return IngestUtils.countAndValidateBulkFileLoadModelsFromPath(
+    return IngestUtils.validateAndCountBulkFileLoadModelsFromPath(
         azureBlobStorePdao,
         objectMapper,
         ingestRequest,

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupAzureStep.java
@@ -43,6 +43,7 @@ public class IngestJsonFileSetupAzureStep extends IngestJsonFileSetupStep {
         userRequest,
         tenantId,
         fileRefColumns,
-        errorCollector);
+        errorCollector,
+        dataset);
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupGcpStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupGcpStep.java
@@ -32,7 +32,7 @@ public class IngestJsonFileSetupGcpStep extends IngestJsonFileSetupStep {
       IngestRequestModel ingestRequest,
       List<Column> fileRefColumns,
       ErrorCollector errorCollector) {
-    return IngestUtils.countAndValidateBulkFileLoadModelsFromPath(
+    return IngestUtils.validateAndCountBulkFileLoadModelsFromPath(
         gcsPdao,
         objectMapper,
         ingestRequest,

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupGcpStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupGcpStep.java
@@ -39,6 +39,7 @@ public class IngestJsonFileSetupGcpStep extends IngestJsonFileSetupStep {
         userRequest,
         dataset.getProjectResource().getGoogleProjectId(),
         fileRefColumns,
-        errorCollector);
+        errorCollector,
+        dataset);
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestJsonFileSetupStep.java
@@ -4,14 +4,14 @@ import bio.terra.common.Column;
 import bio.terra.common.ErrorCollector;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.service.dataset.Dataset;
+import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import java.util.List;
 
-public abstract class IngestJsonFileSetupStep implements Step {
+public abstract class IngestJsonFileSetupStep extends DefaultUndoStep {
 
   final Dataset dataset;
   final int maxBadLoadFileLineErrorsReported;
@@ -51,11 +51,6 @@ public abstract class IngestJsonFileSetupStep implements Step {
 
     workingMap.put(IngestMapKeys.NUM_BULK_LOAD_FILE_MODELS, fileModelsCount);
 
-    return StepResult.getStepResultSuccess();
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -283,7 +283,8 @@ public final class IngestUtils {
       AuthenticatedUserRequest userRequest,
       String cloudEncapsulationId,
       List<Column> fileRefColumns,
-      ErrorCollector errorCollector) {
+      ErrorCollector errorCollector,
+      Dataset dataset) {
     try (var nodesStream =
         IngestUtils.getBulkFileLoadModelsStream(
             cloudFileReader,
@@ -299,7 +300,10 @@ public final class IngestUtils {
                 try {
                   validateBulkLoadFileModel(loadFileModel);
                   cloudFileReader.validateUserCanRead(
-                      List.of(loadFileModel.getSourcePath()), cloudEncapsulationId, userRequest);
+                      List.of(loadFileModel.getSourcePath()),
+                      cloudEncapsulationId,
+                      userRequest,
+                      dataset);
                 } catch (BlobAccessNotAuthorizedException
                     | BadRequestException
                     | IllegalArgumentException

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -287,7 +287,6 @@ public final class IngestUtils {
       AuthenticatedUserRequest userRequest,
       ErrorCollector errorCollector,
       Dataset dataset) {
-    logger.info("START validateBulkFileLoadModelsFromStream");
     return nodesStream.peek(
         loadFileModel -> {
           try {

--- a/src/main/java/bio/terra/service/filedata/CloudFileReader.java
+++ b/src/main/java/bio/terra/service/filedata/CloudFileReader.java
@@ -1,6 +1,7 @@
 package bio.terra.service.filedata;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.dataset.Dataset;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -10,5 +11,8 @@ public interface CloudFileReader {
       String blobUrl, String cloudEncapsulationId, AuthenticatedUserRequest userRequest);
 
   void validateUserCanRead(
-      List<String> sourcePaths, String cloudEncapsulationId, AuthenticatedUserRequest user);
+      List<String> sourcePaths,
+      String cloudEncapsulationId,
+      AuthenticatedUserRequest user,
+      Dataset dataset);
 }

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -208,11 +208,12 @@ public class AzureBlobStorePdao implements CloudFileReader {
 
   @Override
   public void validateUserCanRead(
-      List<String> sourcePaths, String cloudEncapsulationId, AuthenticatedUserRequest user) {
-    // This checked is not needed for Azure because we use signed URLS that by default check
-    // permissions
-    // Keeping this method because we do need to do this check for GCP in code that is shared
-    // between gcp and azure [See CloudFileReader]
+      List<String> sourcePaths,
+      String cloudEncapsulationId,
+      AuthenticatedUserRequest user,
+      Dataset dataset) {
+    // This check is not needed for Azure because we use signed URLS that by default check
+    // permissions.
   }
 
   public void writeBlobLines(String signedPath, List<String> lines) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -173,6 +173,9 @@ public class FileIngestBulkFlight extends Flight {
             randomBackoffRetry);
         addStep(new IngestFileMakeBucketLinkStep(datasetBucketDao, dataset), randomBackoffRetry);
       }
+      addStep(
+          new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
+          getDefaultExponentialBackoffRetryRule());
     } else if (platform.isAzure()) {
       addStep(
           new IngestFileAzurePrimaryDataLocationStep(resourceService, dataset), randomBackoffRetry);
@@ -198,7 +201,6 @@ public class FileIngestBulkFlight extends Flight {
                 executor,
                 appConfig.getMaxPerformanceThreadQueueSize()));
       } else {
-        // TODO: also validate file access for non-array bulk ingest.
         addStep(
             new IngestBulkGcpBulkFileStep(
                 loadTag,
@@ -220,9 +222,6 @@ public class FileIngestBulkFlight extends Flight {
         addStep(new IngestPopulateFileStateFromArrayStep(loadService));
       } else {
         if (platform.isGcp()) {
-          addStep(
-              new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
-              getDefaultExponentialBackoffRetryRule());
           addStep(
               new IngestPopulateFileStateFromFileGcpStep(
                   loadService,

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -163,6 +163,9 @@ public class FileIngestBulkFlight extends Flight {
     if (!isBulkMode) {
       addStep(new LoadLockStep(loadService));
     }
+    addStep(
+        new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
+        getDefaultExponentialBackoffRetryRule());
     if (platform.isGcp()) {
       addStep(new VerifyBillingAccountAccessStep(googleBillingService));
       if (!dataset.isSelfHosted()) {
@@ -173,9 +176,6 @@ public class FileIngestBulkFlight extends Flight {
             randomBackoffRetry);
         addStep(new IngestFileMakeBucketLinkStep(datasetBucketDao, dataset), randomBackoffRetry);
       }
-      addStep(
-          new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
-          getDefaultExponentialBackoffRetryRule());
     } else if (platform.isAzure()) {
       addStep(
           new IngestFileAzurePrimaryDataLocationStep(resourceService, dataset), randomBackoffRetry);

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -17,6 +17,7 @@ import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetStorageAccountDao;
 import bio.terra.service.dataset.flight.LockDatasetStep;
 import bio.terra.service.dataset.flight.UnlockDatasetStep;
+import bio.terra.service.filedata.CloudFileReader;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.google.firestore.FireStoreDao;
@@ -163,8 +164,9 @@ public class FileIngestBulkFlight extends Flight {
     if (!isBulkMode) {
       addStep(new LoadLockStep(loadService));
     }
+    CloudFileReader cloudFileReader = (platform.isGcp()) ? gcsPdao : azureBlobStorePdao;
     addStep(
-        new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
+        new ValidateBucketAccessStep(cloudFileReader, userReq, dataset),
         getDefaultExponentialBackoffRetryRule());
     if (platform.isGcp()) {
       addStep(new VerifyBillingAccountAccessStep(googleBillingService));

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -198,6 +198,7 @@ public class FileIngestBulkFlight extends Flight {
                 executor,
                 appConfig.getMaxPerformanceThreadQueueSize()));
       } else {
+        // TODO: also validate file access for non-array bulk ingest.
         addStep(
             new IngestBulkGcpBulkFileStep(
                 loadTag,
@@ -220,8 +221,7 @@ public class FileIngestBulkFlight extends Flight {
       } else {
         if (platform.isGcp()) {
           addStep(
-              new ValidateBucketAccessStep(
-                  gcsPdao, dataset.getProjectResource().getGoogleProjectId(), userReq),
+              new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
               getDefaultExponentialBackoffRetryRule());
           addStep(
               new IngestPopulateFileStateFromFileGcpStep(
@@ -242,7 +242,8 @@ public class FileIngestBulkFlight extends Flight {
                   azureBlobStorePdao,
                   bulkLoadObjectMapper,
                   executor,
-                  userReq));
+                  userReq,
+                  dataset));
         }
       }
       addStep(

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -136,8 +136,7 @@ public class FileIngestFlight extends FileIngestTypeFlight {
     if (platform.isGcp()) {
       addStep(new VerifyBillingAccountAccessStep(googleBillingService));
       addStep(
-          new ValidateBucketAccessStep(
-              gcsPdao, dataset.getProjectResource().getGoogleProjectId(), userReq),
+          new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
           getDefaultExponentialBackoffRetryRule());
       addStep(new ValidateIngestFileDirectoryStep(fileDao, dataset));
       if (!dataset.isSelfHosted()) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -132,12 +132,12 @@ public class FileIngestFlight extends FileIngestTypeFlight {
     addStep(new LockDatasetStep(datasetService, datasetId, true), randomBackoffRetry);
     addStep(new LoadLockStep(loadService));
     addStep(new IngestFileIdStep(configService));
+    addStep(
+        new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
+        getDefaultExponentialBackoffRetryRule());
 
     if (platform.isGcp()) {
       addStep(new VerifyBillingAccountAccessStep(googleBillingService));
-      addStep(
-          new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
-          getDefaultExponentialBackoffRetryRule());
       addStep(new ValidateIngestFileDirectoryStep(fileDao, dataset));
       if (!dataset.isSelfHosted()) {
         addStep(new IngestFileGetProjectStep(dataset, googleProjectService));

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -16,6 +16,7 @@ import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetStorageAccountDao;
 import bio.terra.service.dataset.flight.LockDatasetStep;
 import bio.terra.service.dataset.flight.UnlockDatasetStep;
+import bio.terra.service.filedata.CloudFileReader;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.azure.tables.TableDao;
@@ -132,8 +133,10 @@ public class FileIngestFlight extends FileIngestTypeFlight {
     addStep(new LockDatasetStep(datasetService, datasetId, true), randomBackoffRetry);
     addStep(new LoadLockStep(loadService));
     addStep(new IngestFileIdStep(configService));
+
+    CloudFileReader cloudFileReader = (platform.isGcp()) ? gcsPdao : azureBlobStorePdao;
     addStep(
-        new ValidateBucketAccessStep(gcsPdao, userReq, dataset),
+        new ValidateBucketAccessStep(cloudFileReader, userReq, dataset),
         getDefaultExponentialBackoffRetryRule());
 
     if (platform.isGcp()) {

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpBulkFileStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpBulkFileStep.java
@@ -60,14 +60,19 @@ public class IngestBulkGcpBulkFileStep extends IngestBulkGcpStep {
                 + ingestRequest.getLoadControlFile()
                 + " could not be processed");
 
-    return IngestUtils.getStreamFromFile(
-        gcsPdao,
-        objectMapper,
-        ingestRequest.getLoadControlFile(),
-        userReq,
-        dataset.getProjectResource().getGoogleProjectId(),
-        errorCollector,
-        // Casting explicitly since it's losing the type downstream
-        new TypeReference<BulkLoadFileModel>() {});
+    var cloudEncapsulationId = dataset.getProjectResource().getGoogleProjectId();
+    try (var nodesStream =
+        IngestUtils.getStreamFromFile(
+            gcsPdao,
+            objectMapper,
+            ingestRequest.getLoadControlFile(),
+            userReq,
+            cloudEncapsulationId,
+            errorCollector,
+            // Casting explicitly since it's losing the type downstream
+            new TypeReference<BulkLoadFileModel>() {})) {
+      return IngestUtils.validateBulkFileLoadModelsFromStream(
+          nodesStream, gcsPdao, cloudEncapsulationId, userReq, errorCollector, dataset);
+    }
   }
 }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileAzureStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileAzureStep.java
@@ -3,6 +3,7 @@ package bio.terra.service.filedata.flight.ingest;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.filedata.azure.util.AzureBlobStoreBufferedReader;
@@ -30,7 +31,8 @@ public class IngestPopulateFileStateFromFileAzureStep extends IngestPopulateFile
       AzureBlobStorePdao azureBlobStorePdao,
       ObjectMapper bulkLoadObjectMapper,
       ExecutorService executor,
-      AuthenticatedUserRequest userRequest) {
+      AuthenticatedUserRequest userRequest,
+      Dataset dataset) {
     super(
         loadService,
         maxBadLoadFileLineErrorsReported,
@@ -38,7 +40,8 @@ public class IngestPopulateFileStateFromFileAzureStep extends IngestPopulateFile
         bulkLoadObjectMapper,
         azureBlobStorePdao,
         executor,
-        userRequest);
+        userRequest,
+        dataset);
     this.azureBlobStorePdao = azureBlobStorePdao;
     this.userRequest = userRequest;
   }

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestPopulateFileStateFromFileGcpStep.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ExecutorService;
 // Populate the files to be loaded from the incoming array
 public class IngestPopulateFileStateFromFileGcpStep extends IngestPopulateFileStateFromFileStep {
   private final GcsPdao gcsPdao;
-  private final Dataset dataset;
 
   public IngestPopulateFileStateFromFileGcpStep(
       LoadService loadService,
@@ -35,9 +34,15 @@ public class IngestPopulateFileStateFromFileGcpStep extends IngestPopulateFileSt
       AuthenticatedUserRequest userRequest,
       Dataset dataset) {
     super(
-        loadService, maxBadLines, batchSize, bulkLoadObjectMapper, gcsPdao, executor, userRequest);
+        loadService,
+        maxBadLines,
+        batchSize,
+        bulkLoadObjectMapper,
+        gcsPdao,
+        executor,
+        userRequest,
+        dataset);
     this.gcsPdao = gcsPdao;
-    this.dataset = dataset;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -291,21 +291,30 @@ public class GcsPdao implements CloudFileReader {
   }
 
   /**
-   * Given a list a source paths, validate that the specified user has a pat service account with
-   * read permissions
+   * Given a list of source paths, validate that the specified user has a pet service account with
+   * read permissions. This method is a no-op if the destination dataset does not necessitate access
+   * validation.
    *
    * @param sourcePaths A list of gs:// formatted paths
    * @param cloudEncapsulationId The dataset project to bill to if any of the source buckets are
    *     configured to use requester pays
    * @param user An authenticated user
+   * @param dataset destination dataset for this ingestion
    * @throws BlobAccessNotAuthorizedException if the user does not have an authorized pet
    * @throws IllegalArgumentException if the source path is not a valid blob url
    */
   public void validateUserCanRead(
-      List<String> sourcePaths, String cloudEncapsulationId, AuthenticatedUserRequest user) {
+      List<String> sourcePaths,
+      String cloudEncapsulationId,
+      AuthenticatedUserRequest user,
+      Dataset dataset) {
     // If the connected profile is used, skip this check since we don't specify users when mocking
     // requests
     if (List.of(environment.getActiveProfiles()).contains("connectedtest")) {
+      return;
+    }
+    // If destination dataset doesn't necessitate access validation, skip this check.
+    if (!dataset.shouldValidateIngesterFileAccess()) {
       return;
     }
     // Obtain a token for the user's pet service account that can verify that it is allowed to read

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectResource.java
@@ -8,6 +8,7 @@ public class GoogleProjectResource {
   private String googleProjectId; // google's user specified, globally unique id of the project
   private String googleProjectNumber; // google's auto generated numeric id of the project
   private String serviceAccount; // service account associated with this project
+  private boolean dedicatedServiceAccount; // whether this project has a dedicated service account
 
   // Default constructor for JSON serdes
   public GoogleProjectResource() {}
@@ -54,6 +55,15 @@ public class GoogleProjectResource {
 
   public GoogleProjectResource serviceAccount(String serviceAccount) {
     this.serviceAccount = serviceAccount;
+    return this;
+  }
+
+  public boolean hasDedicatedServiceAccount() {
+    return dedicatedServiceAccount;
+  }
+
+  public GoogleProjectResource dedicatedServiceAccount(boolean dedicatedServiceAccount) {
+    this.dedicatedServiceAccount = dedicatedServiceAccount;
     return this;
   }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -319,15 +320,18 @@ public class GoogleResourceDao {
     return jdbcTemplate.query(
         sql,
         params,
-        (rs, rowNum) ->
-            new GoogleProjectResource()
-                .id(rs.getObject("id", UUID.class))
-                .profileId(rs.getObject("profile_id", UUID.class))
-                .googleProjectId(rs.getString("google_project_id"))
-                .googleProjectNumber(rs.getString("google_project_number"))
-                .serviceAccount(
-                    Optional.ofNullable(rs.getString("service_account"))
-                        .orElse(tdrServiceAccountEmail)));
+        (rs, rowNum) -> {
+          String serviceAccount = rs.getString("service_account");
+          return new GoogleProjectResource()
+              .id(rs.getObject("id", UUID.class))
+              .profileId(rs.getObject("profile_id", UUID.class))
+              .googleProjectId(rs.getString("google_project_id"))
+              .googleProjectNumber(rs.getString("google_project_number"))
+              .serviceAccount(Optional.ofNullable(serviceAccount).orElse(tdrServiceAccountEmail))
+              .dedicatedServiceAccount(
+                  StringUtils.isNotEmpty(serviceAccount)
+                      && !StringUtils.equalsIgnoreCase(serviceAccount, tdrServiceAccountEmail));
+        });
   }
 
   // -- bucket resource methods --

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4072,7 +4072,8 @@ components:
         ingestServiceAccount:
           type: string
           description: >
-            Google service account to grant storage.object.get access on source Google storage buckets to in order to ingest files
+            Google service account which must be granted `storage.objects.get` permissions on any
+            source buckets that TDR will ingest data from.
         predictableFileIds:
           type: boolean
           default: false
@@ -4173,17 +4174,34 @@ components:
           type: boolean
           default: false
           description: >
-            If true, for GCP-backed datasets, a service account will be created in the dataset's primary GCP project.
-            This service account must be granted `storage.objects.get` permissions on any source buckets that TDR will ingest data from.
-            The service account can be obtained when retrieving the dataset.  If this value is false and the dataset
-            is a GCP-backed dataset, then the global service account must be granted `storage.objects.get` permissions to source buckets.
+            This field is only relevant for GCP-backed datasets. If true, a unique service account
+            will be created in the dataset's primary GCP project, registered in Terra, and used to
+            facilitate ingests. If false, TDR's general service account will be used.
 
-            Note: this can be done by granting the "Storage Object Viewer", "Storage Legacy Object Reader", or "Storage Legacy Object Owner"
-            role to the source buckets
 
-            This might be useful to set as a security improvement since this provides a dedicated account that explicitly
-            does not have access to any other buckets.  It's also recommended if you need to authorize a large number of buckets
-            since the main service account could run into Google group membership quota violations.
+            The dataset's service account can be found when retrieving the dataset.  Whether it is
+            dedicated or general, it must be granted `storage.objects.get` permissions on any source
+            buckets that TDR will ingest data from.
+            This can be done by giving the service account the "Storage Object Viewer", "Storage
+            Legacy Object Reader", or "Storage Legacy Object Owner" role on the source buckets.
+
+
+            TDR recommends that this be set to true:
+
+
+            - A dedicated account that explicitly does not have access to other buckets is more
+              secure and isolated from issues that could impact the general account.
+            - Up to 2.5x speed improvements when ingesting files. TDR can bypass the costly
+              permission checking of all user-specified GCP files to ingest if the dataset has a
+              dedicated service account. Such accounts are unique to the dataset and ingests will
+              correctly fail if they lack needed permission on the files. Otherwise, we must
+              perform this check to ensure that a user cannot ingest files inaccessible to them, but
+              accessible to the general TDR service account.
+            - Only the dataset's dedicated account must be granted permissions on source ingest
+              buckets.  When using the general account, you must also grant permissions to the Terra
+              proxy user groups for any users triggering ingests.
+            - A dedicated service account is less likely to encounter Google group membership quota
+              violations, which is relevant if you need to authorize a large number of buckets.
         experimentalPredictableFileIds:
           type: boolean
           default: false

--- a/src/test/java/bio/terra/common/FlightTestUtils.java
+++ b/src/test/java/bio/terra/common/FlightTestUtils.java
@@ -1,6 +1,5 @@
 package bio.terra.common;
 
-import bio.terra.service.job.OptionalStep;
 import bio.terra.stairway.Flight;
 import java.util.List;
 

--- a/src/test/java/bio/terra/common/FlightTestUtils.java
+++ b/src/test/java/bio/terra/common/FlightTestUtils.java
@@ -1,0 +1,12 @@
+package bio.terra.common;
+
+import bio.terra.service.job.OptionalStep;
+import bio.terra.stairway.Flight;
+import java.util.List;
+
+public class FlightTestUtils {
+
+  public static List<String> getStepNames(Flight flight) {
+    return flight.getSteps().stream().map(step -> step.getClass().getSimpleName()).toList();
+  }
+}

--- a/src/test/java/bio/terra/common/ValidateBucketAccessStepTest.java
+++ b/src/test/java/bio/terra/common/ValidateBucketAccessStepTest.java
@@ -1,0 +1,186 @@
+package bio.terra.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.BulkLoadArrayRequestModel;
+import bio.terra.model.BulkLoadFileModel;
+import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.model.DataDeletionGcsFileModel;
+import bio.terra.model.DataDeletionRequest;
+import bio.terra.model.DataDeletionTableModel;
+import bio.terra.model.FileLoadModel;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.model.IngestRequestModel.FormatEnum;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.google.cloud.storage.StorageException;
+import java.util.List;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.context.ActiveProfiles;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ActiveProfiles({"unittest"})
+@Category(Unit.class)
+public class ValidateBucketAccessStepTest {
+  @Mock private GcsPdao gcsPdao;
+  @Mock private Dataset dataset;
+  @Mock private FlightContext flightContext;
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private static final String PROJECT_ID = "googleProjectId";
+
+  private ValidateBucketAccessStep step;
+  private FlightMap inputParameters;
+
+  @Before
+  public void setup() {
+    step = new ValidateBucketAccessStep(gcsPdao, TEST_USER, dataset);
+    inputParameters = new FlightMap();
+
+    when(dataset.getProjectResource())
+        .thenReturn(new GoogleProjectResource().googleProjectId(PROJECT_ID));
+    when(flightContext.getInputParameters()).thenReturn(inputParameters);
+  }
+
+  @Test
+  public void testValidateSingleFileIngest() throws InterruptedException {
+    var sourcePath = "singleFileSourcePath";
+    var request = new FileLoadModel().sourcePath(sourcePath);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(gcsPdao).validateUserCanRead(List.of(sourcePath), PROJECT_ID, TEST_USER, dataset);
+  }
+
+  @Test
+  public void testValidateBulkFileJsonIngest() throws InterruptedException {
+    var controlPath = "bulkFileControlPath";
+    var request = new BulkLoadRequestModel().loadControlFile(controlPath);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(gcsPdao).validateUserCanRead(List.of(controlPath), PROJECT_ID, TEST_USER, dataset);
+  }
+
+  @Test
+  public void testValidateBulkFileArrayIngest() throws InterruptedException {
+    var sourcePaths = List.of("a", "b", "c");
+    var files = sourcePaths.stream().map(this::createBulkFileLoadModel).toList();
+    var request = new BulkLoadArrayRequestModel().loadArray(files);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(gcsPdao).validateUserCanRead(sourcePaths, PROJECT_ID, TEST_USER, dataset);
+  }
+
+  private BulkLoadFileModel createBulkFileLoadModel(String sourcePath) {
+    return new BulkLoadFileModel().sourcePath(sourcePath);
+  }
+
+  @Test
+  public void testValidateCombinedArrayIngest() throws InterruptedException {
+    var controlPath = "tdrGeneratedArrayControlPath";
+    var request = new IngestRequestModel().format(FormatEnum.ARRAY).path(controlPath);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(gcsPdao).validateUserCanRead(List.of(), PROJECT_ID, TEST_USER, dataset);
+  }
+
+  @Test
+  public void testValidateCombinedJsonIngest() throws InterruptedException {
+    var controlPath = "userProvidedJsonControlPath";
+    var request = new IngestRequestModel().format(FormatEnum.JSON).path(controlPath);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(gcsPdao).validateUserCanRead(List.of(controlPath), PROJECT_ID, TEST_USER, dataset);
+  }
+
+  @Test
+  public void testValidateCombinedCsvIngest() throws InterruptedException {
+    var controlPath = "userProvidedCsvControlPath";
+    var request = new IngestRequestModel().format(FormatEnum.CSV).path(controlPath);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(gcsPdao).validateUserCanRead(List.of(controlPath), PROJECT_ID, TEST_USER, dataset);
+  }
+
+  @Test
+  public void testValidateSoftDeletes() throws InterruptedException {
+    var paths = List.of("a", "b", "c");
+    var tables = paths.stream().map(this::createDataDeletionTableModel).toList();
+    var request = new DataDeletionRequest().tables(tables);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(gcsPdao).validateUserCanRead(paths, PROJECT_ID, TEST_USER, dataset);
+  }
+
+  private DataDeletionTableModel createDataDeletionTableModel(String path) {
+    return new DataDeletionTableModel().gcsFileSpec(new DataDeletionGcsFileModel().path(path));
+  }
+
+  @Test
+  public void testStepThrowsOnUnhandledRequestType() {
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), "Strings are not supported request types");
+    assertThrows(IllegalArgumentException.class, () -> step.doStep(flightContext));
+  }
+
+  @Test
+  public void testStepFailsOnGeneralStorageException() throws InterruptedException {
+    var sourcePath = "singleFileSourcePath";
+    var request = new FileLoadModel().sourcePath(sourcePath);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+
+    var retryException =
+        new StorageException(
+            HttpStatus.SC_FORBIDDEN, ValidateBucketAccessStep.PET_PROPAGATION_ERROR_MSG);
+    var fatalException = new StorageException(HttpStatus.SC_FORBIDDEN, "fatal");
+
+    doThrow(retryException, fatalException)
+        .when(gcsPdao)
+        .validateUserCanRead(List.of(sourcePath), PROJECT_ID, TEST_USER, dataset);
+
+    // First attempt: retry exception
+    StepResult retryResult = step.doStep(flightContext);
+    assertThat(retryResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+    verify(gcsPdao).validateUserCanRead(List.of(sourcePath), PROJECT_ID, TEST_USER, dataset);
+
+    // Second attempt: fatal exception
+    StepResult fatalResult = step.doStep(flightContext);
+    assertThat(fatalResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    verify(gcsPdao, times(2))
+        .validateUserCanRead(List.of(sourcePath), PROJECT_ID, TEST_USER, dataset);
+  }
+}

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -111,7 +111,8 @@ public class DataRepoFixtures {
           + "<if(hasFlightId)>jsonPayload.flightId=\"<flightId>\"<endif>";
 
   /** Roles which must be held by a dataset's SA to facilitate an ingestion * */
-  private static final List<Role> INGEST_ROLES = List.of(StorageRoles.objectViewer());
+  private static final List<Role> INGEST_ROLES =
+      List.of(StorageRoles.objectViewer(), StorageRoles.legacyBucketReader());
 
   @Autowired private JsonLoader jsonLoader;
 

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -68,8 +68,10 @@ import bio.terra.service.filedata.DrsService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.Role;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.StorageRoles;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -89,6 +91,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.stringtemplate.v4.ST;
@@ -107,11 +110,20 @@ public class DataRepoFixtures {
           + "labels.k8s-pod/component=\"integration-<intNumber>-jade-datarepo-api\"\n"
           + "<if(hasFlightId)>jsonPayload.flightId=\"<flightId>\"<endif>";
 
+  /** Roles which must be held by a dataset's SA to facilitate an ingestion * */
+  private static final List<Role> INGEST_ROLES = List.of(StorageRoles.objectViewer());
+
   @Autowired private JsonLoader jsonLoader;
 
   @Autowired private DataRepoClient dataRepoClient;
 
   @Autowired private TestConfiguration testConfig;
+
+  @Autowired private SamFixtures samFixtures;
+
+  @Autowired
+  @Qualifier("tdrServiceAccountEmail")
+  private String tdrServiceAccountEmail;
 
   // Create a Billing Profile model: expect successful creation
   public BillingProfileModel createBillingProfile(TestConfiguration.User user) throws Exception {
@@ -322,6 +334,25 @@ public class DataRepoFixtures {
     assertTrue("dataset create error response is present", response.getErrorObject().isPresent());
   }
 
+  private boolean isDedicatedServiceAccount(String serviceAccount) {
+    return StringUtils.isNotEmpty(serviceAccount)
+        && !StringUtils.equalsIgnoreCase(serviceAccount, tdrServiceAccountEmail);
+  }
+
+  /**
+   * If the dataset has its own service account, grant it the roles it needs to ingest data from the
+   * specified ingest bucket.
+   */
+  public void grantIngestBucketPermissionsToDedicatedSa(DatasetModel dataset, String ingestBucket) {
+    String serviceAccount = dataset.getIngestServiceAccount();
+    if (ingestBucket != null && isDedicatedServiceAccount(serviceAccount)) {
+      for (var role : INGEST_ROLES) {
+        GcsFixtures.addServiceAccountRoleToBucket(
+            ingestBucket, serviceAccount, role, dataset.getDataProject());
+      }
+    }
+  }
+
   public DataRepoResponse<JobModel> deleteDataRaw(
       TestConfiguration.User user, UUID datasetId, DataDeletionRequest request) throws Exception {
     String url = String.format("/api/repository/v1/datasets/%s/deletes", datasetId);
@@ -346,6 +377,25 @@ public class DataRepoFixtures {
   public void deleteDataset(TestConfiguration.User user, UUID datasetId) throws Exception {
     DataRepoResponse<DeleteResponseModel> deleteResponse = deleteDatasetLog(user, datasetId);
     assertGoodDeleteResponse(deleteResponse);
+  }
+
+  /**
+   * Delete the dataset, first performing any resource clean-up necessary if the dataset has its own
+   * dedicated ingest service account (revoking ingest bucket permissions and deleting the SA from
+   * Terra).
+   */
+  public void deleteDataset(TestConfiguration.User user, UUID datasetId, String ingestBucket)
+      throws Exception {
+    DatasetModel dataset = getDataset(user, datasetId);
+    String serviceAccount = dataset.getIngestServiceAccount();
+    if (ingestBucket != null && isDedicatedServiceAccount(serviceAccount)) {
+      for (var role : INGEST_ROLES) {
+        GcsFixtures.removeServiceAccountRoleFromBucket(
+            ingestBucket, serviceAccount, role, dataset.getDataProject());
+      }
+      samFixtures.deleteServiceAccountFromTerra(user, serviceAccount);
+    }
+    deleteDataset(user, datasetId);
   }
 
   public void deleteDatasetShouldFail(TestConfiguration.User user, UUID datasetId)

--- a/src/test/java/bio/terra/integration/GcsFixtures.java
+++ b/src/test/java/bio/terra/integration/GcsFixtures.java
@@ -1,11 +1,18 @@
 package bio.terra.integration;
 
 import com.google.auth.Credentials;
+import com.google.cloud.Identity;
+import com.google.cloud.Policy;
+import com.google.cloud.Role;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class GcsFixtures {
+  private static final Logger logger = LoggerFactory.getLogger(GcsFixtures.class);
   private static final int connectTimeoutSeconds = 100;
   private static final int readTimeoutSeconds = 100;
 
@@ -22,5 +29,36 @@ public final class GcsFixtures {
         .setCredentials(credentials)
         .build()
         .getService();
+  }
+
+  static void addServiceAccountRoleToBucket(
+      String bucket, String serviceAccount, Role role, String userProject) {
+    logger.info("Granting role {} to {} on bucket {}", role, serviceAccount, bucket);
+    Storage storage = StorageOptions.getDefaultInstance().getService();
+    Storage.BucketSourceOption[] options =
+        Optional.ofNullable(userProject)
+            .map(p -> new Storage.BucketSourceOption[] {Storage.BucketSourceOption.userProject(p)})
+            .orElseGet(() -> new Storage.BucketSourceOption[0]);
+
+    Policy iamPolicy = storage.getIamPolicy(bucket, options);
+    storage.setIamPolicy(
+        bucket,
+        iamPolicy.toBuilder().addIdentity(role, Identity.serviceAccount(serviceAccount)).build(),
+        options);
+  }
+
+  static void removeServiceAccountRoleFromBucket(
+      String bucket, String serviceAccount, Role role, String userProject) {
+    logger.info("Revoking role {} from {} on bucket {}", role, serviceAccount, bucket);
+    Storage storage = StorageOptions.getDefaultInstance().getService();
+    Storage.BucketSourceOption[] options =
+        Optional.ofNullable(userProject)
+            .map(p -> new Storage.BucketSourceOption[] {Storage.BucketSourceOption.userProject(p)})
+            .orElseGet(() -> new Storage.BucketSourceOption[0]);
+    Policy iamPolicy = storage.getIamPolicy(bucket, options);
+    storage.setIamPolicy(
+        bucket,
+        iamPolicy.toBuilder().removeIdentity(role, Identity.serviceAccount(serviceAccount)).build(),
+        options);
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -40,14 +40,10 @@ import bio.terra.model.StorageResourceModel;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
-import com.google.cloud.Identity;
-import com.google.cloud.Policy;
-import com.google.cloud.Role;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobWriteOption;
-import com.google.cloud.storage.Storage.BucketSourceOption;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Charsets;
 import java.io.IOException;
@@ -480,34 +476,5 @@ public class DatasetIntegrationTest extends UsersBase {
       }
     }
     return String.format("gs://%s/%s", blob.getBucket(), targetPath);
-  }
-
-  static void addServiceAccountRoleToBucket(
-      String bucket, String serviceAccount, Role role, String userProject) {
-    Storage storage = StorageOptions.getDefaultInstance().getService();
-    BucketSourceOption[] options =
-        Optional.ofNullable(userProject)
-            .map(p -> new BucketSourceOption[] {BucketSourceOption.userProject(p)})
-            .orElseGet(() -> new BucketSourceOption[0]);
-
-    Policy iamPolicy = storage.getIamPolicy(bucket, options);
-    storage.setIamPolicy(
-        bucket,
-        iamPolicy.toBuilder().addIdentity(role, Identity.serviceAccount(serviceAccount)).build(),
-        options);
-  }
-
-  static void removeServiceAccountRoleFromBucket(
-      String bucket, String serviceAccount, Role role, String userProject) {
-    Storage storage = StorageOptions.getDefaultInstance().getService();
-    BucketSourceOption[] options =
-        Optional.ofNullable(userProject)
-            .map(p -> new BucketSourceOption[] {BucketSourceOption.userProject(p)})
-            .orElseGet(() -> new BucketSourceOption[0]);
-    Policy iamPolicy = storage.getIamPolicy(bucket, options);
-    storage.setIamPolicy(
-        bucket,
-        iamPolicy.toBuilder().removeIdentity(role, Identity.serviceAccount(serviceAccount)).build(),
-        options);
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetTest.java
@@ -13,29 +13,29 @@ import org.junit.experimental.categories.Category;
 public class DatasetTest {
 
   @Test
-  public void testShouldValidateIngesterFileAccess() {
+  public void testHasDedicatedGcpServiceAccount() {
     var datasetSummary = new DatasetSummary();
     var projectResource = new GoogleProjectResource();
     var dataset = new Dataset(datasetSummary).projectResource(projectResource);
 
     datasetSummary.cloudPlatform(CloudPlatform.AZURE);
     assertFalse(
-        "Azure datasets do not validate that user can access ingested files",
-        dataset.shouldValidateIngesterFileAccess());
+        "Azure datasets do not have a dedicated GCP service account",
+        dataset.hasDedicatedGcpServiceAccount());
 
     datasetSummary.cloudPlatform(CloudPlatform.GCP);
-    assertTrue(
-        "GCP datasets by default validate that user can access ingested files",
-        dataset.shouldValidateIngesterFileAccess());
+    assertFalse(
+        "GCP datasets by default use the general TDR service account",
+        dataset.hasDedicatedGcpServiceAccount());
 
     projectResource.dedicatedServiceAccount(false);
-    assertTrue(
-        "GCP datasets with the general TDR SA validate that user can access ingested files",
-        dataset.shouldValidateIngesterFileAccess());
+    assertFalse(
+        "GCP dataset uses the general TDR service account",
+        dataset.hasDedicatedGcpServiceAccount());
 
     projectResource.dedicatedServiceAccount(true);
-    assertFalse(
-        "GCP datasets with dedicated SAs do not validate that user can access ingested files",
-        dataset.shouldValidateIngesterFileAccess());
+    assertTrue(
+        "GCP datasets uses a dedicated GCP service account",
+        dataset.hasDedicatedGcpServiceAccount());
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetTest.java
@@ -3,17 +3,16 @@ package bio.terra.service.dataset;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import bio.terra.common.category.Unit;
 import bio.terra.model.CloudPlatform;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Unit.class)
+@Tag("bio.terra.common.category.Unit")
 public class DatasetTest {
 
   @Test
-  public void testHasDedicatedGcpServiceAccount() {
+  void testHasDedicatedGcpServiceAccount() {
     var datasetSummary = new DatasetSummary();
     var projectResource = new GoogleProjectResource();
     var dataset = new Dataset(datasetSummary).projectResource(projectResource);

--- a/src/test/java/bio/terra/service/dataset/DatasetTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetTest.java
@@ -1,0 +1,41 @@
+package bio.terra.service.dataset;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.CloudPlatform;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Unit.class)
+public class DatasetTest {
+
+  @Test
+  public void testShouldValidateIngesterFileAccess() {
+    var datasetSummary = new DatasetSummary();
+    var projectResource = new GoogleProjectResource();
+    var dataset = new Dataset(datasetSummary).projectResource(projectResource);
+
+    datasetSummary.cloudPlatform(CloudPlatform.AZURE);
+    assertFalse(
+        "Azure datasets do not validate that user can access ingested files",
+        dataset.shouldValidateIngesterFileAccess());
+
+    datasetSummary.cloudPlatform(CloudPlatform.GCP);
+    assertTrue(
+        "GCP datasets by default validate that user can access ingested files",
+        dataset.shouldValidateIngesterFileAccess());
+
+    projectResource.dedicatedServiceAccount(false);
+    assertTrue(
+        "GCP datasets with the general TDR SA validate that user can access ingested files",
+        dataset.shouldValidateIngesterFileAccess());
+
+    projectResource.dedicatedServiceAccount(true);
+    assertFalse(
+        "GCP datasets with dedicated SAs do not validate that user can access ingested files",
+        dataset.shouldValidateIngesterFileAccess());
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/DatasetTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetTest.java
@@ -35,7 +35,7 @@ public class DatasetTest {
 
     projectResource.dedicatedServiceAccount(true);
     assertTrue(
-        "GCP datasets uses a dedicated GCP service account",
+        "GCP dataset uses a dedicated GCP service account",
         dataset.hasDedicatedGcpServiceAccount());
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
@@ -3,35 +3,46 @@ package bio.terra.service.dataset.flight.ingest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import bio.terra.common.category.Unit;
 import bio.terra.model.IngestRequestModel;
-import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.model.IngestRequestModel.FormatEnum;
 import bio.terra.service.dataset.exception.InvalidBlobURLException;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightMap;
 import com.azure.storage.blob.BlobUrlParts;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
-@AutoConfigureMockMvc
-@ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
+@Tag("bio.terra.common.category.Unit")
 public class IngestUtilsTest {
 
-  @Mock ConfigurationService configurationService;
+  @ParameterizedTest
+  @EnumSource(names = {"CSV", "ARRAY", "JSON"})
+  void testJsonTypeIngest(FormatEnum format) {
+    FlightMap inputParameters = new FlightMap();
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), new IngestRequestModel().format(format));
+    if (format == FormatEnum.CSV) {
+      assertFalse(
+          format + " ingest is not considered json-type",
+          IngestUtils.isJsonTypeIngest(inputParameters));
+    } else {
+      assertTrue(
+          format + " ingest is considered json-type",
+          IngestUtils.isJsonTypeIngest(inputParameters));
+    }
+  }
 
   @Test
-  public void testParseValidBlobURL() {
+  void testParseValidBlobURL() {
     BlobUrlParts blobUrlParts =
         IngestUtils.validateBlobAzureBlobFileURL(
             "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/azure-simple-dataset-ingest-request.csv");
@@ -48,46 +59,48 @@ public class IngestUtilsTest {
         equalTo("test/azure-simple-dataset-ingest-request.csv"));
   }
 
-  public void testValidURLWithSpecialCharacterBlobPaths() {
-    String urlPrefix = "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata";
-    IngestUtils.validateBlobAzureBlobFileURL(urlPrefix + "/test/azure_simple_dataset_ingest.csv");
-    IngestUtils.validateBlobAzureBlobFileURL(urlPrefix + "/test/AZURE_SIMPLE_DATASET_INGEST.CSV");
-    IngestUtils.validateBlobAzureBlobFileURL(urlPrefix + "/test/----.json");
-    IngestUtils.validateBlobAzureBlobFileURL(urlPrefix + "/test/nested/0_o.json");
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/test/azure_simple_dataset_ingest.csv",
+        "/test/----.json",
+        "/test/nested/0_o.json"
+      })
+  void testValidURLWithSpecialCharacterBlobPaths(String urlSuffix) {
+    IngestUtils.validateBlobAzureBlobFileURL(
+        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata" + urlSuffix);
   }
 
-  @Test(expected = InvalidBlobURLException.class)
-  public void testInvalidScheme() {
-    IngestUtils.validateBlobAzureBlobFileURL(
-        "gs://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/azure-simple-dataset-ingest-request.csv");
+  @ParameterizedTest
+  @MethodSource
+  void testInvalidBlobUrl(String invalidFeature, String url) {
+    assertThrows(
+        "Blob URL with " + invalidFeature + " is invalid",
+        InvalidBlobURLException.class,
+        () -> IngestUtils.validateBlobAzureBlobFileURL(url));
   }
 
-  @Test(expected = InvalidBlobURLException.class)
-  public void testInvalidHost() {
-    IngestUtils.validateBlobAzureBlobFileURL(
-        "https://tdrconnectedsrc1/synapsetestdata/test/azure-simple-dataset-ingest-request.csv");
-  }
-
-  @Test(expected = InvalidBlobURLException.class)
-  public void testInvalidFileExtension() {
-    IngestUtils.validateBlobAzureBlobFileURL(
-        "https://tdrconnectedsrc1.blob.core.windows.net/test/azure-simple-dataset-ingest-request");
-  }
-
-  @Test(expected = InvalidBlobURLException.class)
-  public void testNoDoubleDash() {
-    IngestUtils.validateBlobAzureBlobFileURL(
-        "https://tdrconnectedsrc1.blob.core.windows.net/synapsetest--data/test/azure-simple-dataset-ingest-request.csv");
-  }
-
-  @Test(expected = InvalidBlobURLException.class)
-  public void testNoUpperCase() {
-    IngestUtils.validateBlobAzureBlobFileURL(
-        "https://tdrconnectedsrc1.blob.core.windows.net/SYNAPSETEST/test/azure-simple-dataset-ingest-request.csv");
+  private static Stream<Arguments> testInvalidBlobUrl() {
+    return Stream.of(
+        arguments(
+            "invalid scheme",
+            "gs://tdrconnectedsrc1.blob.core.windows.net/synapsetestdata/test/azure-simple-dataset-ingest-request.csv"),
+        arguments(
+            "invalid host",
+            "https://tdrconnectedsrc1/synapsetestdata/test/azure-simple-dataset-ingest-request.csv"),
+        arguments(
+            "invalid file extension",
+            "https://tdrconnectedsrc1.blob.core.windows.net/test/azure-simple-dataset-ingest-request"),
+        arguments(
+            "illegal double dash",
+            "https://tdrconnectedsrc1.blob.core.windows.net/synapsetest--data/test/azure-simple-dataset-ingest-request.csv"),
+        arguments(
+            "illegal uppercase",
+            "https://tdrconnectedsrc1.blob.core.windows.net/SYNAPSETEST/test/azure-simple-dataset-ingest-request.csv"));
   }
 
   @Test
-  public void testShouldIgnoreUserSpecifiedRowIds() {
+  void testShouldIgnoreUserSpecifiedRowIds() {
     // We should not find ourselves here: ingests default to append mode if unspecified.
     FlightMap flightMapNoUpdateStrategy = createFlightMap(null);
     assertFalse(

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/DatasetIngestFlightTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/DatasetIngestFlightTest.java
@@ -1,0 +1,124 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.common.FlightTestUtils;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.model.IngestRequestModel.FormatEnum;
+import bio.terra.service.configuration.ConfigEnum;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.DatasetSummary;
+import bio.terra.service.dataset.flight.ingest.DatasetIngestFlight;
+import bio.terra.service.dataset.flight.ingest.IngestUtils;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
+public class DatasetIngestFlightTest {
+  @Mock private ApplicationContext context;
+  @Mock private DatasetSummary datasetSummary;
+  @Mock private ConfigurationService configurationService;
+  private FlightMap inputParameters;
+  private static final UUID DATASET_ID = UUID.randomUUID();
+
+  @BeforeEach
+  void beforeEach() {
+    DatasetService datasetService = mock(DatasetService.class);
+    when(datasetService.retrieve(DATASET_ID)).thenReturn(new Dataset(datasetSummary));
+
+    ApplicationConfiguration appConfig = mock(ApplicationConfiguration.class);
+    when(appConfig.getMaxStairwayThreads()).thenReturn(1);
+
+    when(context.getBean(any(Class.class))).thenReturn(null);
+    // Beans that are interacted with directly in flight construction rather than simply passed
+    // to steps need to be added to our context mock.
+    when(context.getBean(DatasetService.class)).thenReturn(datasetService);
+    when(context.getBean(ApplicationConfiguration.class)).thenReturn(appConfig);
+    when(context.getBean(ConfigurationService.class)).thenReturn(configurationService);
+
+    inputParameters = new FlightMap();
+    inputParameters.put(JobMapKeys.DATASET_ID.getKeyName(), DATASET_ID.toString());
+  }
+
+  void initJsonTypeIngestMocks() {
+    when(datasetSummary.getId()).thenReturn(DATASET_ID);
+    when(configurationService.getParameterValue(ConfigEnum.LOAD_DRIVER_WAIT_SECONDS)).thenReturn(1);
+    when(configurationService.getParameterValue(ConfigEnum.LOAD_HISTORY_WAIT_SECONDS))
+        .thenReturn(1);
+    when(configurationService.getParameterValue(ConfigEnum.LOAD_HISTORY_COPY_CHUNK_SIZE))
+        .thenReturn(1);
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testDatasetIngestValidatesFileAccess(
+      CloudPlatform cloudPlatform, FormatEnum format, boolean bulkMode) {
+    when(datasetSummary.getStorageCloudPlatform()).thenReturn(cloudPlatform);
+
+    var request =
+        new IngestRequestModel().format(format).bulkMode(bulkMode).profileId(UUID.randomUUID());
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+
+    boolean jsonTypeIngest = IngestUtils.isJsonTypeIngest(inputParameters);
+    if (jsonTypeIngest) {
+      initJsonTypeIngestMocks();
+    }
+
+    var flight = new DatasetIngestFlight(inputParameters, context);
+    List<String> stepNames = FlightTestUtils.getStepNames(flight);
+
+    assertThat(
+        "Combined %s ingest to %s dataset (bulk mode = %b) validates accessibility of directly specified files"
+            .formatted(format, cloudPlatform, bulkMode),
+        stepNames,
+        hasItems("ValidateBucketAccessStep"));
+    if (jsonTypeIngest) {
+      // CSV ingests can only be run for metadata, not files
+      String expectedIndirectFileValidationStep =
+          CloudPlatformWrapper.of(cloudPlatform).isGcp()
+              ? "IngestJsonFileSetupGcpStep"
+              : "IngestJsonFileSetupAzureStep";
+      assertThat(
+          "Combined %s ingest to %s dataset (bulk mode = %b) validates accessibility of indirectly specified files"
+              .formatted(format, cloudPlatform, bulkMode),
+          stepNames,
+          hasItems(expectedIndirectFileValidationStep));
+    }
+  }
+
+  private static Stream<Arguments> testDatasetIngestValidatesFileAccess() {
+    List<Arguments> arguments = new ArrayList<>();
+    for (var platform : CloudPlatform.values()) {
+      for (var format : FormatEnum.values()) {
+        for (var bulkMode : List.of(false, true)) {
+          arguments.add(arguments(platform, format, bulkMode));
+        }
+      }
+    }
+    return arguments.stream();
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlightTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlightTest.java
@@ -1,0 +1,114 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.FlightTestUtils;
+import bio.terra.model.BulkLoadArrayRequestModel;
+import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.model.CloudPlatform;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.DatasetSummary;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.load.flight.LoadMapKeys;
+import bio.terra.stairway.FlightMap;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
+public class FileIngestBulkFlightTest {
+  @Mock private ApplicationContext context;
+  @Mock private DatasetSummary datasetSummary;
+  private FlightMap inputParameters;
+
+  @BeforeEach
+  void beforeEach() {
+    UUID datasetId = UUID.randomUUID();
+
+    DatasetService datasetService = mock(DatasetService.class);
+    when(datasetService.retrieve(datasetId)).thenReturn(new Dataset(datasetSummary));
+
+    ApplicationConfiguration appConfig = mock(ApplicationConfiguration.class);
+    when(appConfig.getMaxStairwayThreads()).thenReturn(1);
+
+    when(context.getBean(any(Class.class))).thenReturn(null);
+    // Beans that are interacted with directly in flight construction rather than simply passed
+    // to steps need to be added to our context mock.
+    when(context.getBean(DatasetService.class)).thenReturn(datasetService);
+    when(context.getBean(ApplicationConfiguration.class)).thenReturn(appConfig);
+
+    inputParameters = new FlightMap();
+    inputParameters.put(JobMapKeys.DATASET_ID.getKeyName(), datasetId.toString());
+    inputParameters.put(LoadMapKeys.DRIVER_WAIT_SECONDS, 1);
+    inputParameters.put(LoadMapKeys.LOAD_HISTORY_WAIT_SECONDS, 1);
+    inputParameters.put(LoadMapKeys.LOAD_HISTORY_COPY_CHUNK_SIZE, 1);
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testFileIngestBulkArrayFlightValidatesFileAccess(
+      CloudPlatform cloudPlatform, boolean bulkMode) {
+    when(datasetSummary.getStorageCloudPlatform()).thenReturn(cloudPlatform);
+
+    var request = new BulkLoadArrayRequestModel().bulkMode(bulkMode);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+    inputParameters.put(LoadMapKeys.IS_ARRAY, true);
+
+    var flight = new FileIngestBulkFlight(inputParameters, context);
+    assertThat(
+        "Bulk array file access validation performed for %s dataset (bulk mode = %b)"
+            .formatted(cloudPlatform, bulkMode),
+        FlightTestUtils.getStepNames(flight),
+        hasItems("ValidateBucketAccessStep"));
+  }
+
+  private static Stream<Arguments> testFileIngestBulkArrayFlightValidatesFileAccess() {
+    return Stream.of(
+        arguments(CloudPlatform.GCP, false),
+        arguments(CloudPlatform.GCP, true),
+        arguments(CloudPlatform.AZURE, false),
+        arguments(CloudPlatform.AZURE, true));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testFileIngestBulkJsonFlightValidatesFileAccess(
+      CloudPlatform cloudPlatform, boolean bulkMode, String expectedIndirectFileValidationStep) {
+    when(datasetSummary.getStorageCloudPlatform()).thenReturn(cloudPlatform);
+
+    var request = new BulkLoadRequestModel().bulkMode(bulkMode);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), request);
+    inputParameters.put(LoadMapKeys.IS_ARRAY, false);
+
+    var flight = new FileIngestBulkFlight(inputParameters, context);
+    assertThat(
+        "Bulk JSON file access validation performed for %s dataset (bulk mode = %b)"
+            .formatted(cloudPlatform, bulkMode),
+        FlightTestUtils.getStepNames(flight),
+        hasItems("ValidateBucketAccessStep", expectedIndirectFileValidationStep));
+  }
+
+  private static Stream<Arguments> testFileIngestBulkJsonFlightValidatesFileAccess() {
+    return Stream.of(
+        arguments(CloudPlatform.GCP, false, "IngestPopulateFileStateFromFileGcpStep"),
+        arguments(CloudPlatform.GCP, true, "IngestBulkGcpBulkFileStep"),
+        arguments(CloudPlatform.AZURE, false, "IngestPopulateFileStateFromFileAzureStep"),
+        arguments(CloudPlatform.AZURE, true, "IngestBulkGcpBulkFileStep"));
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/FileIngestFlightTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/FileIngestFlightTest.java
@@ -1,0 +1,67 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.FlightTestUtils;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.FileLoadModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.DatasetSummary;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightMap;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
+public class FileIngestFlightTest {
+  @Mock private ApplicationContext context;
+  @Mock private DatasetSummary datasetSummary;
+  private FlightMap inputParameters;
+
+  @BeforeEach
+  void beforeEach() {
+    UUID datasetId = UUID.randomUUID();
+
+    DatasetService datasetService = mock(DatasetService.class);
+    when(datasetService.retrieve(datasetId)).thenReturn(new Dataset(datasetSummary));
+
+    ApplicationConfiguration appConfig = mock(ApplicationConfiguration.class);
+    when(appConfig.getMaxStairwayThreads()).thenReturn(1);
+
+    when(context.getBean(any(Class.class))).thenReturn(null);
+    // Beans that are interacted with directly in flight construction rather than simply passed
+    // to steps need to be added to our context mock.
+    when(context.getBean(DatasetService.class)).thenReturn(datasetService);
+    when(context.getBean(ApplicationConfiguration.class)).thenReturn(appConfig);
+
+    inputParameters = new FlightMap();
+    inputParameters.put(JobMapKeys.DATASET_ID.getKeyName(), datasetId.toString());
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), new FileLoadModel());
+  }
+
+  @ParameterizedTest
+  @EnumSource(names = {"GCP", "AZURE"})
+  void testFileIngestFlightValidatesFileAccess(CloudPlatform cloudPlatform) {
+    when(datasetSummary.getStorageCloudPlatform()).thenReturn(cloudPlatform);
+
+    var flight = new FileIngestFlight(inputParameters, context);
+    assertThat(
+        "File access validation performed for %s dataset".formatted(cloudPlatform),
+        FlightTestUtils.getStepNames(flight),
+        hasItems("ValidateBucketAccessStep"));
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleResourceDaoUnitTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleResourceDaoUnitTest.java
@@ -2,9 +2,14 @@ package bio.terra.service.resourcemanagement.google;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.fixtures.DaoOperations;
 import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.common.fixtures.ResourceFixtures;
@@ -13,20 +18,25 @@ import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.filedata.google.gcs.GcsConfiguration;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.exception.GoogleResourceNotFoundException;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -42,25 +52,27 @@ public class GoogleResourceDaoUnitTest {
 
   @Autowired private DatasetDao datasetDao;
 
-  @Autowired private GoogleResourceDao googleResourceDao;
-
   @Autowired private DaoOperations daoOperations;
 
+  @Autowired private NamedParameterJdbcTemplate jdbcTemplate;
+  @Mock private GcsConfiguration gcsConfiguration;
+  @Mock private GoogleResourceConfiguration googleResourceConfiguration;
+  private static final String TDR_SERVICE_ACCOUNT_EMAIL = "tdr-sa@a.com";
+  private GoogleResourceDao googleResourceDao;
+
   private BillingProfileModel billingProfile;
-  private List<GoogleProjectResource> projects;
   private List<UUID> projectResourceIds;
   private List<UUID> datasetIds;
   private static final AuthenticatedUserRequest TEST_USER =
-      AuthenticatedUserRequest.builder()
-          .setSubjectId("DatasetUnit")
-          .setEmail("dataset@unit.com")
-          .setToken("token")
-          .build();
+      AuthenticationFixtures.randomUserRequest();
 
   @Before
-  public void setup() throws IOException, InterruptedException {
-    // Initialize list;
-    projects = new ArrayList<>();
+  public void setup() throws IOException, InterruptedException, SQLException {
+    googleResourceDao =
+        new GoogleResourceDao(
+            jdbcTemplate, gcsConfiguration, googleResourceConfiguration, TDR_SERVICE_ACCOUNT_EMAIL);
+
+    // Initialize lists
     projectResourceIds = new ArrayList<>();
     datasetIds = new ArrayList<>();
 
@@ -68,18 +80,14 @@ public class GoogleResourceDaoUnitTest {
     BillingProfileRequestModel profileRequest = ProfileFixtures.randomBillingProfileRequest();
     billingProfile = profileDao.createBillingProfile(profileRequest, "testUser");
 
-    // two google project resources
-    GoogleProjectResource projectResource1 = ResourceFixtures.randomProjectResource(billingProfile);
-    UUID projectId = googleResourceDao.createProject(projectResource1);
-    projectResource1.id(projectId);
-    projectResourceIds.add(projectId);
-    projects.add(projectResource1);
-
-    GoogleProjectResource projectResource2 = ResourceFixtures.randomProjectResource(billingProfile);
-    UUID projectId2 = googleResourceDao.createProject(projectResource2);
-    projectResource2.id(projectId2);
-    projectResourceIds.add(projectId2);
-    projects.add(projectResource2);
+    // Two google project resources
+    IntStream.range(0, 2)
+        .forEach(
+            i -> {
+              GoogleProjectResource project =
+                  ResourceFixtures.randomProjectResource(billingProfile);
+              projectResourceIds.add(googleResourceDao.createProject(project));
+            });
   }
 
   @After
@@ -87,10 +95,18 @@ public class GoogleResourceDaoUnitTest {
     for (UUID datasetId : datasetIds) {
       datasetDao.delete(datasetId, TEST_USER);
     }
-    for (GoogleProjectResource project : projects) {
-      googleResourceDao.deleteProject(project.getId());
+    for (UUID projectResourceId : projectResourceIds) {
+      googleResourceDao.deleteProject(projectResourceId);
     }
     profileDao.deleteBillingProfileById(billingProfile.getId());
+  }
+
+  /* Helper method to create a minimal dataset and register its ID for cleanup */
+  private Dataset createDataset(UUID projectResourceId) throws IOException {
+    Dataset dataset =
+        daoOperations.createMinimalDataset(billingProfile.getId(), projectResourceId, TEST_USER);
+    datasetIds.add(dataset.getId());
+    return dataset;
   }
 
   @Test
@@ -98,58 +114,64 @@ public class GoogleResourceDaoUnitTest {
     List<GoogleProjectResource> retrievedProjects =
         googleResourceDao.retrieveProjectsByBillingProfileId(billingProfile.getId());
 
-    assertThat("Project Count should be 2", retrievedProjects.size(), equalTo(2));
+    assertThat("Project Count should be 2", retrievedProjects, hasSize(2));
+    retrievedProjects.forEach(
+        project ->
+            assertFalse(
+                "Projects by default use the general TDR SA",
+                project.hasDedicatedServiceAccount()));
+
+    UUID projectId1 = projectResourceIds.get(0);
+    UUID projectId2 = projectResourceIds.get(1);
+    String dedicatedSa = "dedicated-sa@gmail.com";
+    googleResourceDao.updateProjectResourceServiceAccount(projectId1, dedicatedSa);
+    assertTrue(
+        "Dedicated service account is detected",
+        googleResourceDao.retrieveProjectById(projectId1).hasDedicatedServiceAccount());
+    assertFalse(
+        "Unaltered project still uses the general TDR SA",
+        googleResourceDao.retrieveProjectById(projectId2).hasDedicatedServiceAccount());
+
+    googleResourceDao.updateProjectResourceServiceAccount(projectId1, TDR_SERVICE_ACCOUNT_EMAIL);
+    assertFalse(
+        "Project explicitly using general TDR SA is registered as such",
+        googleResourceDao.retrieveProjectById(projectId1).hasDedicatedServiceAccount());
   }
 
   @Test
   public void testMarkForDelete() {
-    UUID project1Id = projects.get(0).getId();
-    UUID project2Id = projects.get(1).getId();
+    projectResourceIds.forEach(this::confirmNotFoundByDelete);
 
-    confirmNotFoundByDelete(project1Id);
-    confirmNotFoundByDelete(project2Id);
-
-    // mark the two projects for delete
+    // mark the projects for delete
     // They're not used for any resources, so this should succeed
     googleResourceDao.markUnusedProjectsForDelete(projectResourceIds);
 
-    assertThat(
-        "Should be able to retrieve the project 1 'for delete' since it was marked for delete",
-        googleResourceDao.retrieveProjectByIdForDelete(project1Id).getId(),
-        equalTo(project1Id));
-    assertThat(
-        "Should be able to retrieve the project 2 'for delete' since it was marked for delete",
-        googleResourceDao.retrieveProjectByIdForDelete(project2Id).getId(),
-        equalTo(project2Id));
+    projectResourceIds.forEach(
+        projectResourceId ->
+            assertThat(
+                "Should be able to retrieve project 'for delete' since it was marked for delete",
+                googleResourceDao.retrieveProjectByIdForDelete(projectResourceId).getId(),
+                equalTo(projectResourceId)));
   }
 
   @Test
   public void testMarkForDeleteWhenProjectInUse() throws IOException {
-    UUID project1Id = projects.get(0).getId();
-    UUID project2Id = projects.get(1).getId();
-    Dataset dataset =
-        daoOperations.createMinimalDataset(billingProfile.getId(), project1Id, TEST_USER);
-    datasetIds.add(dataset.getId());
+    createDataset(projectResourceIds.get(0));
     googleResourceDao.markUnusedProjectsForDelete(projectResourceIds);
 
     // Since project1 is in use by dataset1, we should not mark it for delete
-    confirmNotFoundByDelete(project1Id);
+    confirmNotFoundByDelete(projectResourceIds.get(0));
     // Project 2 is not in use, so we should have still marked it for delete
     assertThat(
         "Should be able to retrieve the project 2 'for delete' since it was marked for delete",
-        googleResourceDao.retrieveProjectByIdForDelete(project2Id).getId(),
-        equalTo(project2Id));
+        googleResourceDao.retrieveProjectByIdForDelete(projectResourceIds.get(1)).getId(),
+        equalTo(projectResourceIds.get(1)));
   }
 
   private void confirmNotFoundByDelete(UUID projectResourceId) {
-    boolean errorCaught = false;
-    try {
-      googleResourceDao.retrieveProjectByIdForDelete(projectResourceId);
-    } catch (GoogleResourceNotFoundException ex) {
-      errorCaught = true;
-    }
-    assertThat(
+    assertThrows(
         "Should not be able to retrieve project 'for delete' b/c it hasn't been marked for delete",
-        errorCaught);
+        GoogleResourceNotFoundException.class,
+        () -> googleResourceDao.retrieveProjectByIdForDelete(projectResourceId));
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2975

### Security Protections for User-Specified GCS Files

We have a number of flights which take user-specified GCS files within their requests.  TDR must validate that the caller has access to all such files to span a security hole for datasets which use the generic TDR service account for ingestion.  If the generic TDR SA has access to a file but the caller initiating the flight does not (possible if it was meant to be ingested to another dataset), we should fail the flight.

In simpler terms, we shouldn't let users ingest files that they don't have access to.

Note that files can be specified **directly** in an ingest as well as **indirectly** in some cases (i.e. as a reference in a control file).  Indirect file references additionally benefit from validation of their formatting.  Formatting of direct file references already takes place as part of our OpenAPI specification.

### Objectives

#### Initial

The initial aim of this ticket was to improve performance of ingests to datasets with dedicated service accounts without compromising security.  If a dataset has a dedicated (unique) service account, then TDR can bypass the costly permission checking of all user-specified GCS files.  Such service accounts are unique to the dataset: flights will correctly fail if they lack needed file permissions, and they will fail fast if the caller does not have permission to initiate the flight in question.

#### Expanded

While working on the places I found instances where we were not checking file permissions but should have been. 

There were a few red herrings too: places where we were rightfully not checking file permissions (TDR-generated control file for combined array ingest), or places where it wasn't clear that we were checking file permissions (combined array ingest files).  I tried to make this behavior more clear via comments and unit testing, but the many flavors of ingest mean that it continues to be easy to misstep when trying to enforce a universal behavior.  But a more substantial refactor was a greater undertaking than we wanted to take on right now.

After I first raised the PR, another PR was merged to allow GCS files to be ingested to Azure datasets. This necessitated some additional work as we could no longer assume that the destination dataset’s platform would match that of files ingested.  There were also additional spots where we were not validating file permissions.

### Accounting of Flight Validation by Format

**Single File Ingest**

Validate that the user can access the singular file specified directly in the request.

**Bulk File Ingest**

- Array
  - Validate that the user can access the files specified directly in the request
- JSON
  - Validate that the user can access the control file
  - Validate that the user can access the files specified in the control file, and that their request bodies are valid

Bulk file ingest does not support CSV format.

**Combined Metadata and File Ingest**

- Array
  - TDR generates a control file on behalf of the user, so we don't need to validate that they can access it.  (Such a validation would fail.)
  - Validate that the user can access the files specified in the request array, achieved by treating this ingest as a "JSON-type" ingest.
- CSV
  - Validate that the user can access the control file
  - Files to ingest cannot be specified CSV-formatted ingests
- JSON
  - Validate that the user can access the control file
  - Validate that the user can access the files specified in the control file, and that their request bodies are valid
  
**Soft Deletes**

Validate that the user can access any files directly in the request.  Such files are targets for soft deletion.

### Benchmarking

On my [developer environment](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/) I conducted bulk file ingests with the following shared settings:

- Platform: GCP
- Format: JSON
- Self-hosted dataset
- File count: 50k

The ingest to a dataset with a dedicated SA ran in **36m**:
```
{
  "id": "lL62y-NpTGuwzM1y_mk8Jg",
  "description": "Bulk ingest from control file: gs://jade-testdata-uswestregion/scratch/file-test-control.1683661352761.json  LoadTag: longtest8f488384_9a8e_4456_95f0_9bb420e12bd8",
  "job_status": "succeeded",
  "status_code": 200,
  "submitted": "2023-05-09T19:42:33.818939Z",
  "completed": "2023-05-09T20:18:25.064953Z",
  "class_name": "bio.terra.service.filedata.flight.ingest.FileIngestBulkFlight"
}
```

The ingest to a dataset with the general SA ran in **1h 29m**:
```
{
  "id": "u7_rKv9HRo6EPyj_LC6b6A",
  "description": "Bulk ingest from control file: gs://jade-testdata-uswestregion/scratch/file-test-control.1683682163050.json  LoadTag: longtest09886f02_d524_467e_be51_7aa5fd4e24a9",
  "job_status": "succeeded",
  "status_code": 200,
  "submitted": "2023-05-10T01:29:24.601536Z",
  "completed": "2023-05-10T02:58:52.872540Z",
  "class_name": "bio.terra.service.filedata.flight.ingest.FileIngestBulkFlight"
}
```

This amounted to a **2.5x speed improvement**.

### To Do

- [x] Expand unit testing to verify that flights which allow user-specified GCS files are including the necessary step(s) to validate access 
- [ ] Flag / audit opportunities for code consolidation in file verification (ex. I noticed there's a utility where we validate files in sequence, but in another step we do very similar work but parallelized)
- [x] update documentation, error logs to indicate that dedicated SA datasets don't need the user's pet to be a reader of the files, just the dedicated SA requires this permission