### PR TITLE
DDO-2815 update report to sherlock filter to only run on pull_request

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -36,6 +36,12 @@ on:
   schedule:
     - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
 jobs:
+  test_fail:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "test failure to see if we need always"
+      run: |-
+        failfailfail
   test_check:
     name: "Checkout, verify and run unit tests"
     outputs:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -36,12 +36,6 @@ on:
   schedule:
     - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
 jobs:
-  test_fail:
-    runs-on: ubuntu-latest
-    steps:
-    - name: "test failure to see if we need always"
-      run: |-
-        failfailfail
   test_check:
     name: "Checkout, verify and run unit tests"
     outputs:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -236,8 +236,9 @@ jobs:
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: deploy_test_integration
-    # Always attempt to run, as we want to report the appVersion even if the tests fail.
-    if: always()
+    # Always attempt to run if pull_request, as we want to report the appVersion even if the tests fail.
+    # never run on cron or other runs as we don't want extranaeous build reporting.
+    if: github.event_name == 'pull_request'
     with:
       new-version: ${{ needs.deploy_test_integration.outputs.api_image_tag }}
       chart-name: 'datarepo'


### PR DESCRIPTION
Did not realize the integration tests we being called by cron and workflow_dispatch, this updates the filter to always run on pullrequest but never on cron or other triggers

The cron runs was dirtying the "latest" version of datarepo available.