### PR TITLE
[DR-3014] Register Policy in Snapshot Create Flight

### DIFF
--- a/src/main/java/bio/terra/service/policy/PolicyService.java
+++ b/src/main/java/bio/terra/service/policy/PolicyService.java
@@ -74,7 +74,7 @@ public class PolicyService {
     } catch (ApiException e) {
       // Ignore the exception if the policy object being deleted does not exist
       RuntimeException exception = convertApiException(e);
-      if (!PolicyServiceNotFoundException.class.isAssignableFrom(exception.getClass())) {
+      if (!(exception instanceof PolicyServiceNotFoundException)) {
         throw exception;
       }
     }

--- a/src/main/java/bio/terra/service/policy/PolicyService.java
+++ b/src/main/java/bio/terra/service/policy/PolicyService.java
@@ -9,6 +9,7 @@ import bio.terra.policy.client.ApiException;
 import bio.terra.policy.model.TpsComponent;
 import bio.terra.policy.model.TpsObjectType;
 import bio.terra.policy.model.TpsPaoCreateRequest;
+import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.policy.exception.PolicyConflictException;
 import bio.terra.service.policy.exception.PolicyServiceApiException;
@@ -26,6 +27,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class PolicyService {
+  public static final String POLICY_NAMESPACE = "terra";
+  public static final String PROTECTED_DATA_POLICY_NAME = "protected-data";
   private static final Logger logger = LoggerFactory.getLogger(PolicyService.class);
   private final PolicyServiceConfiguration policyServiceConfiguration;
   private final PolicyApiService policyApiService;
@@ -37,6 +40,10 @@ public class PolicyService {
   }
 
   // -- Policy Attribute Object Interface --
+  public static TpsPolicyInput getProtectedDataPolicyInput() {
+    return new TpsPolicyInput().namespace(POLICY_NAMESPACE).name(PROTECTED_DATA_POLICY_NAME);
+  }
+
   public void createSnapshotPao(UUID snapshotId, @Nullable TpsPolicyInputs policyInputs) {
     createPao(snapshotId, TpsObjectType.SNAPSHOT, policyInputs);
   }

--- a/src/main/java/bio/terra/service/policy/PolicyService.java
+++ b/src/main/java/bio/terra/service/policy/PolicyService.java
@@ -72,8 +72,9 @@ public class PolicyService {
     try {
       tpsApi.deletePao(resourceId);
     } catch (ApiException e) {
+      // Ignore the exception if the policy object being deleted does not exist
       RuntimeException exception = convertApiException(e);
-      if (PolicyServiceNotFoundException.class.isAssignableFrom(exception.getClass())) {
+      if (!PolicyServiceNotFoundException.class.isAssignableFrom(exception.getClass())) {
         throw exception;
       }
     }

--- a/src/main/java/bio/terra/service/policy/exception/PolicyConflictException.java
+++ b/src/main/java/bio/terra/service/policy/exception/PolicyConflictException.java
@@ -4,6 +4,10 @@ import bio.terra.common.exception.ConflictException;
 
 public class PolicyConflictException extends ConflictException {
 
+  public PolicyConflictException(String message) {
+    super(message);
+  }
+
   public PolicyConflictException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
@@ -1,0 +1,46 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.policy.model.TpsPolicyInput;
+import bio.terra.policy.model.TpsPolicyInputs;
+import bio.terra.service.policy.PolicyService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+
+public class CreateSnapshotPolicyStep implements Step {
+
+  private final PolicyService policyService;
+  private final boolean enableSecureMonitoring;
+
+  public CreateSnapshotPolicyStep(PolicyService policyService, boolean enableSecureMonitoring) {
+    this.policyService = policyService;
+    this.enableSecureMonitoring = enableSecureMonitoring;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    if (enableSecureMonitoring) {
+      FlightMap flightMap = flightContext.getWorkingMap();
+      UUID snapshotId = flightMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
+      TpsPolicyInput protectedDataPolicy = PolicyService.getProtectedDataPolicyInput();
+      TpsPolicyInputs policyInputs = new TpsPolicyInputs().addInputsItem(protectedDataPolicy);
+      policyService.createSnapshotPao(snapshotId, policyInputs);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    if (enableSecureMonitoring) {
+      FlightMap flightMap = flightContext.getWorkingMap();
+      UUID snapshotId = flightMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
+      policyService.deletePao(snapshotId);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.snapshot.flight.create;
 
+import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.policy.PolicyService;
@@ -37,6 +38,8 @@ public class CreateSnapshotPolicyStep implements Step {
         policyService.createSnapshotPao(snapshotId, policyInputs);
       } catch (PolicyConflictException ex) {
         logger.warn("Policy access object already exists for snapshot {}", snapshotId);
+      } catch (FeatureNotImplementedException ex) {
+        logger.info("Terra Policy Service is not enabled");
       }
     }
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -26,6 +26,7 @@ import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.journal.JournalService;
+import bio.terra.service.policy.PolicyService;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.service.profile.flight.AuthorizeBillingProfileUseStep;
 import bio.terra.service.profile.flight.VerifyBillingAccountAccessStep;
@@ -87,6 +88,7 @@ public class SnapshotCreateFlight extends Flight {
     DrsService drsService = appContext.getBean(DrsService.class);
     DuosDao duosDao = appContext.getBean(DuosDao.class);
     DuosService duosService = appContext.getBean(DuosService.class);
+    PolicyService policyService = appContext.getBean(PolicyService.class);
 
     SnapshotRequestModel snapshotReq =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), SnapshotRequestModel.class);
@@ -327,5 +329,6 @@ public class SnapshotCreateFlight extends Flight {
             datasetId,
             IamResourceType.DATASET,
             "A snapshot was created from this dataset."));
+    addStep(new CreateSnapshotPolicyStep(policyService, sourceDataset.isSecureMonitoringEnabled()));
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -319,6 +319,8 @@ public class SnapshotCreateFlight extends Flight {
       addStep(new CreateSnapshotCleanSynapseAzureStep(azureSynapsePdao, snapshotService));
     }
 
+    addStep(new CreateSnapshotPolicyStep(policyService, sourceDataset.isSecureMonitoringEnabled()));
+
     // unlock the snapshot metadata row
     addStep(new UnlockSnapshotStep(snapshotDao, null));
     addStep(new CreateSnapshotJournalEntryStep(journalService, userReq));
@@ -329,6 +331,5 @@ public class SnapshotCreateFlight extends Flight {
             datasetId,
             IamResourceType.DATASET,
             "A snapshot was created from this dataset."));
-    addStep(new CreateSnapshotPolicyStep(policyService, sourceDataset.isSecureMonitoringEnabled()));
   }
 }

--- a/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
+++ b/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
@@ -61,6 +62,16 @@ public class PolicyServiceTest {
 
   private void mockUnauthPolicyApi() {
     when(policyApiService.getUnauthPolicyApi()).thenReturn(tpsUnauthApi);
+  }
+
+  @Test
+  void testGetProtectedDataPolicyInput() {
+    TpsPolicyInput actualPolicy = PolicyService.getProtectedDataPolicyInput();
+    TpsPolicyInput expectedPolicy =
+        new TpsPolicyInput()
+            .namespace(PolicyService.POLICY_NAMESPACE)
+            .name(PolicyService.PROTECTED_DATA_POLICY_NAME);
+    assertEquals(actualPolicy, expectedPolicy);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
+++ b/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
@@ -91,6 +91,24 @@ public class PolicyServiceTest {
   }
 
   @Test
+  void testDeleteSnapshotDao() throws Exception {
+    mockPolicyApi();
+    UUID snapshotId = UUID.randomUUID();
+    policyService.deletePao(snapshotId);
+    verify(tpsApi).deletePao(snapshotId);
+  }
+
+  @Test
+  void testDeleteSnapshotDaoIgnoresNotFoundException() throws Exception {
+    mockPolicyApi();
+    UUID snapshotId = UUID.randomUUID();
+    var exception = new ApiException(HttpStatus.NOT_FOUND.value(), "Policy object not found");
+    doThrow(exception).when(tpsApi).deletePao(snapshotId);
+    policyService.deletePao(snapshotId);
+    verify(tpsApi).deletePao(snapshotId);
+  }
+
+  @Test
   void testConvertApiException() {
     var unauthorizedException = new ApiException(HttpStatus.UNAUTHORIZED.value(), "unauthorized");
     assertThat(

--- a/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.policy.flight;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.policy.PolicyService;
+import bio.terra.service.policy.exception.PolicyConflictException;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.service.snapshot.flight.create.CreateSnapshotPolicyStep;
 import bio.terra.stairway.FlightContext;
@@ -50,6 +52,17 @@ public class CreateSnapshotPolicyStepTest {
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verify(policyService).deletePao(SNAPSHOT_ID);
+  }
+
+  @Test
+  void testProtectedDataPolicyAlreadyExists() throws Exception {
+    mockFlightMap();
+    CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, true);
+    var exception = new PolicyConflictException("Policy access object already exists");
+    doThrow(exception).when(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
@@ -1,0 +1,65 @@
+package bio.terra.service.policy.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.policy.model.TpsPolicyInput;
+import bio.terra.policy.model.TpsPolicyInputs;
+import bio.terra.service.policy.PolicyService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.service.snapshot.flight.create.CreateSnapshotPolicyStep;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
+public class CreateSnapshotPolicyStepTest {
+  @Mock private PolicyService policyService;
+  @Mock private FlightContext flightContext;
+
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final TpsPolicyInput protectedDataPolicy =
+      PolicyService.getProtectedDataPolicyInput();
+  private static final TpsPolicyInputs policies =
+      new TpsPolicyInputs().addInputsItem(protectedDataPolicy);
+
+  private void mockFlightMap() {
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_ID, SNAPSHOT_ID);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void testProtectedDataPolicyDoUndo() throws Exception {
+    mockFlightMap();
+    CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, true);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService).deletePao(SNAPSHOT_ID);
+  }
+
+  @Test
+  void testNoPolicyDoUndo() throws Exception {
+    CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, false);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService, never()).createSnapshotPao(SNAPSHOT_ID, policies);
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService, never()).deletePao(SNAPSHOT_ID);
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3014

If a snapshot's parent dataset has `secureMonitoringEnabled`, register a "protected-data" policy in the Terra Policy Service. The "terra" namespace and policy names (e.g.  "protected-data") are defined [here](https://github.com/DataBiosphere/terra-policy-service/blob/17001cab3fe1e594ae03dbabe286070d9b1aeb27/service/src/main/java/bio/terra/policy/common/model/Constants.java). When we allow users to specify other restrictions, such as an authDomain/allow-list of users, we can expand this step to create those policies too.