### PR TITLE
[DR-3033] TPS should not be included in status check until enabled

### DIFF
--- a/src/main/java/bio/terra/service/status/StatusService.java
+++ b/src/main/java/bio/terra/service/status/StatusService.java
@@ -1,5 +1,6 @@
 package bio.terra.service.status;
 
+import bio.terra.app.configuration.PolicyServiceConfiguration;
 import bio.terra.model.RepositoryStatusModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.configuration.ConfigEnum;
@@ -23,6 +24,7 @@ public class StatusService {
   private final BufferService bufferService;
   private final DuosService duosService;
   private final PolicyService policyService;
+  private final PolicyServiceConfiguration policyServiceConfiguration;
 
   // Names of subservices included in status check
   public static final String POSTGRES = "Postgres";
@@ -38,13 +40,15 @@ public class StatusService {
       IamProviderInterface iamProviderInterface,
       BufferService bufferService,
       DuosService duosService,
-      PolicyService policyService) {
+      PolicyService policyService,
+      PolicyServiceConfiguration policyServiceConfiguration) {
     this.configurationService = configurationService;
     this.datasetDao = datasetDao;
     this.iamProviderInterface = iamProviderInterface;
     this.bufferService = bufferService;
     this.duosService = duosService;
     this.policyService = policyService;
+    this.policyServiceConfiguration = policyServiceConfiguration;
   }
 
   public RepositoryStatusModel getStatus() {
@@ -61,7 +65,9 @@ public class StatusService {
     statusModel.putSystemsItem(SAM, iamProviderInterface.samStatus().critical(true));
     statusModel.putSystemsItem(RBS, bufferService.status());
     statusModel.putSystemsItem(DUOS, duosService.status());
-    statusModel.putSystemsItem(TPS, policyService.status());
+    if (policyServiceConfiguration.getEnabled()) {
+      statusModel.putSystemsItem(TPS, policyService.status());
+    }
 
     // if all critical systems are ok, then isOk = true
     // if any one critical system is down, then isOk = false


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3033

While TPS isn't enabled, we may like to exclude it from TDR's status check.  This more closely mimics the behavior of our new TPS service, which only allows operations when enabled.

Previously, it was included as a non-critical resource.  @snf2ye noticed TPS errors in TDR dev's status check:
```
Terra Policy Service status check failed
javax.ws.rs.ProcessingException: org.apache.http.conn.ConnectTimeoutException: Connect to tps.dsde-dev.broadinstitute.org:443 [tps.dsde-dev.broadinstitute.org/34.160.219.143] failed: Connection timed out
```

When we originally filed this ticket, we thought that the TPS status check was consistently failing, but looking into GCS logs we found it to be more intermittent (15 occurrences over the last day):
https://cloudlogging.app.goo.gl/jeTU4BhN7VqzmXAc7

Since the other environments don't have their host overrides configured, all will include TPS Dev in their status check.  I am still in favor of this change, but I think it's less critical to get it in before the next release... we were worried about logging too many errors.