### PR TITLE
DR-2938: GCP Column Statistics Endpoint

### DIFF
--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -16,7 +16,7 @@ select_statement: SELECT (ALL | DISTINCT)?
 
 from_statement : FROM from_item (',' from_item )* ;
 
-from_item : (fully_qualified_table_expr | table_expr) (AS? alias_name)?  (FOR SYSTEM TIME AS OF string)?
+from_item : table_expr (AS? alias_name)?  (FOR SYSTEM TIME AS OF string)?
     | from_item join_type? JOIN from_item (on_clause | using_clause)
     | '(' query_expr ')' (AS? alias_name)?
     | UNNEST'(' array_expr ')' (AS? alias_name)? (WITH OFFSET (AS? alias_name))?
@@ -110,9 +110,7 @@ function_name : name;
 join_name : name;
 member_name : name;
 struct_name : name;
-project_id : name;
 table_name : name;
-fully_qualified_table_expr: '`'project_id '.' table_expr'`';
 table_expr : dataset_name '.' table_name;
 
 number : integer_type | float_type ;

--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -16,7 +16,7 @@ select_statement: SELECT (ALL | DISTINCT)?
 
 from_statement : FROM from_item (',' from_item )* ;
 
-from_item : table_expr (AS? alias_name)?  (FOR SYSTEM TIME AS OF string)?
+from_item : (fully_qualified_table_expr | table_expr) (AS? alias_name)?  (FOR SYSTEM TIME AS OF string)?
     | from_item join_type? JOIN from_item (on_clause | using_clause)
     | '(' query_expr ')' (AS? alias_name)?
     | UNNEST'(' array_expr ')' (AS? alias_name)? (WITH OFFSET (AS? alias_name))?
@@ -110,7 +110,9 @@ function_name : name;
 join_name : name;
 member_name : name;
 struct_name : name;
+project_id : name;
 table_name : name;
+fully_qualified_table_expr: '`'project_id '.' table_expr'`';
 table_expr : dataset_name '.' table_name;
 
 number : integer_type | float_type ;

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -197,10 +197,10 @@ public class DatasetsApiController implements DatasetsApi {
 
   @Override
   public ResponseEntity<ColumnStatisticsModel> lookupDatasetColumnStatisticsById(
-      UUID id, String table, String column) {
+      UUID id, String table, String column, String filter) {
     datasetService.verifyDatasetReadable(id, getAuthenticatedInfo());
     ColumnStatisticsModel columnStatisticsModel =
-        datasetService.retrieveColumnStatistics(getAuthenticatedInfo(), id, table, column);
+        datasetService.retrieveColumnStatistics(getAuthenticatedInfo(), id, table, column, filter);
     return ResponseEntity.ok(columnStatisticsModel);
   }
 

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -15,6 +15,7 @@ import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadHistoryModel;
 import bio.terra.model.BulkLoadHistoryModelList;
 import bio.terra.model.BulkLoadRequestModel;
+import bio.terra.model.ColumnStatisticsModel;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DatasetDataModel;
 import bio.terra.model.DatasetModel;
@@ -192,6 +193,15 @@ public class DatasetsApiController implements DatasetsApi {
         datasetService.retrieveData(
             getAuthenticatedInfo(), id, table, limit, offset, sort, sortDirection, filter);
     return ResponseEntity.ok(previewModel);
+  }
+
+  @Override
+  public ResponseEntity<ColumnStatisticsModel> lookupDatasetColumnStatisticsById(
+      UUID id, String table, String column) {
+    datasetService.verifyDatasetReadable(id, getAuthenticatedInfo());
+    ColumnStatisticsModel columnStatisticsModel =
+        datasetService.retrieveColumnStatistics(getAuthenticatedInfo(), id, table, column);
+    return ResponseEntity.ok(columnStatisticsModel);
   }
 
   @Override

--- a/src/main/java/bio/terra/common/Column.java
+++ b/src/main/java/bio/terra/common/Column.java
@@ -86,36 +86,24 @@ public class Column {
   }
 
   public boolean isTextType() {
-    switch (this.type) {
-      case TEXT:
-      case STRING:
-      case DIRREF:
-      case FILEREF:
-        return true;
-      default:
-        return false;
-    }
+    return switch (this.type) {
+      case TEXT, STRING, DIRREF, FILEREF -> true;
+      default -> false;
+    };
   }
 
   public boolean isDoubleType() {
-    switch (this.type) {
-      case NUMERIC:
-      case FLOAT:
-      case FLOAT64:
-        return true;
-      default:
-        return false;
-    }
+    return switch (this.type) {
+      case NUMERIC, FLOAT, FLOAT64 -> true;
+      default -> false;
+    };
   }
 
   public boolean isIntType() {
-    switch (this.type) {
-      case INT64:
-      case INTEGER:
-        return true;
-      default:
-        return false;
-    }
+    return switch (this.type) {
+      case INT64, INTEGER -> true;
+      default -> false;
+    };
   }
 
   public boolean isArrayOf() {

--- a/src/main/java/bio/terra/common/Column.java
+++ b/src/main/java/bio/terra/common/Column.java
@@ -85,6 +85,31 @@ public class Column {
     return this;
   }
 
+  public boolean isTextType() {
+    switch (this.type) {
+      case TEXT:
+      case STRING:
+      case DIRREF:
+      case FILEREF:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public boolean isNumericType() {
+    switch (this.type) {
+      case NUMERIC:
+      case FLOAT:
+      case FLOAT64:
+      case INT64:
+      case INTEGER:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public boolean isArrayOf() {
     return arrayOf;
   }

--- a/src/main/java/bio/terra/common/Column.java
+++ b/src/main/java/bio/terra/common/Column.java
@@ -97,11 +97,19 @@ public class Column {
     }
   }
 
-  public boolean isNumericType() {
+  public boolean isDoubleType() {
     switch (this.type) {
       case NUMERIC:
       case FLOAT:
       case FLOAT64:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public boolean isIntType() {
+    switch (this.type) {
       case INT64:
       case INTEGER:
         return true;

--- a/src/main/java/bio/terra/common/PdaoConstant.java
+++ b/src/main/java/bio/terra/common/PdaoConstant.java
@@ -44,4 +44,5 @@ public final class PdaoConstant {
   public static final String PDAO_FIRESTORE_DUMP_GSPATH_KEY = "gs_path";
   public static final String PDAO_GS_MAPPING_TABLE = PDAO_PREFIX + "gs_path_mapping";
   public static final String PDAO_COUNT_ALIAS = "count";
+  public static final String PDAO_COUNT_COLUMN_NAME = "count_column";
 }

--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -47,6 +47,16 @@ public class Dataset implements FSContainerInterface, LogPrintable {
     return CollectionType.DATASET;
   }
 
+  @Override
+  public boolean isSnapshot() {
+    return false;
+  }
+
+  @Override
+  public boolean isDataset() {
+    return true;
+  }
+
   public List<DatasetTable> getTables() {
     return Collections.unmodifiableList(tables);
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -46,6 +46,8 @@ import bio.terra.service.auth.iam.exception.IamForbiddenException;
 import bio.terra.service.dataset.exception.DatasetDataException;
 import bio.terra.service.dataset.exception.DatasetNotFoundException;
 import bio.terra.service.dataset.exception.IngestFailureException;
+import bio.terra.service.dataset.exception.InvalidColumnException;
+import bio.terra.service.dataset.exception.InvalidTableException;
 import bio.terra.service.dataset.flight.create.AddAssetSpecFlight;
 import bio.terra.service.dataset.flight.create.DatasetCreateFlight;
 import bio.terra.service.dataset.flight.datadelete.DatasetDataDeleteFlight;
@@ -615,17 +617,16 @@ public class DatasetService {
       String filter) {
     Dataset dataset = retrieve(datasetId);
 
-    // TODO - create new exception instead of DatasetDataException
     Column column =
         dataset
             .getTableByName(tableName)
             .orElseThrow(
                 () ->
-                    new DatasetDataException("No dataset table exists with the name: " + tableName))
+                    new InvalidTableException("No dataset table exists with the name: " + tableName))
             .getColumnByName(columnName)
             .orElseThrow(
                 () ->
-                    new DatasetDataException(
+                    new InvalidColumnException(
                         "No column exists in table "
                             + tableName
                             + " with column name "

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -640,8 +640,7 @@ public class DatasetService {
           return BigQueryPdao.getStatsForNumericColumn(
               dataset, bqFormattedTableName, columnName, filter);
         } else if (column.isTextType()) {
-          return BigQueryPdao.getStatsForTextColumn(
-              dataset, bqFormattedTableName, columnName, filter);
+          return BigQueryPdao.getStatsForTextColumn(dataset, bqFormattedTableName, column, filter);
         }
         return new ColumnStatisticsModel();
       } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -636,9 +636,11 @@ public class DatasetService {
     if (cloudPlatformWrapper.isGcp()) {
       try {
         String bqFormattedTableName = PDAO_PREFIX + dataset.getName() + "." + tableName;
-        if (column.isNumericType()) {
-          return BigQueryPdao.getStatsForNumericColumn(
+        if (column.isDoubleType()) {
+          return BigQueryPdao.getStatsForDoubleColumn(
               dataset, bqFormattedTableName, column, filter);
+        } else if (column.isIntType()) {
+          return BigQueryPdao.getStatsForIntColumn(dataset, bqFormattedTableName, column, filter);
         } else if (column.isTextType()) {
           return BigQueryPdao.getStatsForTextColumn(
               dataset, bqFormattedTableName, tableName, column, filter);
@@ -666,9 +668,11 @@ public class DatasetService {
         throw new RuntimeException("Could not configure external datasource", e);
       }
 
-      if (column.isNumericType()) {
-        return azureSynapsePdao.getStatsForNumericColumn(
+      if (column.isDoubleType()) {
+        return azureSynapsePdao.getStatsForDoubleColumn(
             column, datasourceName, sourceParquetFilePath);
+      } else if (column.isIntType()) {
+        return azureSynapsePdao.getStatsForIntColumn(column, datasourceName, sourceParquetFilePath);
       } else if (column.isTextType()) {
         return azureSynapsePdao.getStatsForTextColumn(
             column, datasourceName, sourceParquetFilePath);

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -622,7 +622,8 @@ public class DatasetService {
             .getTableByName(tableName)
             .orElseThrow(
                 () ->
-                    new InvalidTableException("No dataset table exists with the name: " + tableName))
+                    new InvalidTableException(
+                        "No dataset table exists with the name: " + tableName))
             .getColumnByName(columnName)
             .orElseThrow(
                 () ->

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -638,7 +638,7 @@ public class DatasetService {
         String bqFormattedTableName = PDAO_PREFIX + dataset.getName() + "." + tableName;
         if (column.isNumericType()) {
           return BigQueryPdao.getStatsForNumericColumn(
-              dataset, bqFormattedTableName, columnName, filter);
+              dataset, bqFormattedTableName, column, filter);
         } else if (column.isTextType()) {
           return BigQueryPdao.getStatsForTextColumn(dataset, bqFormattedTableName, column, filter);
         }

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -563,7 +563,6 @@ public class DatasetService {
                     : values.get(0).getTotalCount())
             .filteredRowCount(values.isEmpty() ? 0 : values.get(0).getFilteredCount());
       } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
         throw new DatasetDataException("Error retrieving data for dataset " + dataset.getName(), e);
       }
     } else if (cloudPlatformWrapper.isAzure()) {
@@ -649,7 +648,6 @@ public class DatasetService {
         }
         return new ColumnStatisticsModel();
       } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
         throw new DatasetDataException("Error retrieving data for dataset " + dataset.getName(), e);
       }
     } else if (cloudPlatformWrapper.isAzure()) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -630,7 +630,7 @@ public class DatasetService {
                     new InvalidColumnException(
                         "No column exists in table "
                             + tableName
-                            + " with column name "
+                            + " with column name: "
                             + columnName));
 
     var cloudPlatformWrapper = CloudPlatformWrapper.of(dataset.getCloudPlatform());

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -608,7 +608,11 @@ public class DatasetService {
   }
 
   public ColumnStatisticsModel retrieveColumnStatistics(
-      AuthenticatedUserRequest userRequest, UUID datasetId, String tableName, String columnName) {
+      AuthenticatedUserRequest userRequest,
+      UUID datasetId,
+      String tableName,
+      String columnName,
+      String filter) {
     Dataset dataset = retrieve(datasetId);
 
     // TODO - create new exception instead of DatasetDataException
@@ -633,9 +637,11 @@ public class DatasetService {
       try {
         String bqFormattedTableName = PDAO_PREFIX + dataset.getName() + "." + tableName;
         if (column.isNumericType()) {
-          return BigQueryPdao.getStatsForNumericColumn(dataset, bqFormattedTableName, columnName);
+          return BigQueryPdao.getStatsForNumericColumn(
+              dataset, bqFormattedTableName, columnName, filter);
         } else if (column.isTextType()) {
-          return BigQueryPdao.getStatsForTextColumn(dataset, bqFormattedTableName, columnName);
+          return BigQueryPdao.getStatsForTextColumn(
+              dataset, bqFormattedTableName, columnName, filter);
         }
         return new ColumnStatisticsModel();
       } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -1,6 +1,5 @@
 package bio.terra.service.dataset;
 
-import static bio.terra.common.PdaoConstant.PDAO_PREFIX;
 import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_COLUMN;
 import static bio.terra.service.filedata.azure.AzureSynapsePdao.getDataSourceName;
 
@@ -550,16 +549,15 @@ public class DatasetService {
     if (cloudPlatformWrapper.isGcp()) {
       try {
         List<String> columns = datasetTableDao.retrieveColumnNames(table, true);
-        String bqFormattedTableName = PDAO_PREFIX + dataset.getName() + "." + tableName;
         List<BigQueryDataResultModel> values =
             BigQueryPdao.getTable(
-                dataset, bqFormattedTableName, columns, limit, offset, sort, direction, filter);
+                dataset, tableName, columns, limit, offset, sort, direction, filter);
         return new DatasetDataModel()
             .result(
                 List.copyOf(values.stream().map(BigQueryDataResultModel::getRowResult).toList()))
             .totalRowCount(
                 values.isEmpty()
-                    ? BigQueryPdao.getTableTotalRowCount(dataset, bqFormattedTableName)
+                    ? BigQueryPdao.getTableTotalRowCount(dataset, tableName)
                     : values.get(0).getTotalCount())
             .filteredRowCount(values.isEmpty() ? 0 : values.get(0).getFilteredCount());
       } catch (InterruptedException e) {
@@ -636,15 +634,12 @@ public class DatasetService {
 
     if (cloudPlatformWrapper.isGcp()) {
       try {
-        String bqFormattedTableName = PDAO_PREFIX + dataset.getName() + "." + tableName;
         if (column.isDoubleType()) {
-          return BigQueryPdao.getStatsForDoubleColumn(
-              dataset, bqFormattedTableName, column, filter);
+          return BigQueryPdao.getStatsForDoubleColumn(dataset, tableName, column, filter);
         } else if (column.isIntType()) {
-          return BigQueryPdao.getStatsForIntColumn(dataset, bqFormattedTableName, column, filter);
+          return BigQueryPdao.getStatsForIntColumn(dataset, tableName, column, filter);
         } else if (column.isTextType()) {
-          return BigQueryPdao.getStatsForTextColumn(
-              dataset, bqFormattedTableName, tableName, column, filter);
+          return BigQueryPdao.getStatsForTextColumn(dataset, tableName, column, filter);
         }
         return new ColumnStatisticsModel();
       } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -640,7 +640,8 @@ public class DatasetService {
           return BigQueryPdao.getStatsForNumericColumn(
               dataset, bqFormattedTableName, column, filter);
         } else if (column.isTextType()) {
-          return BigQueryPdao.getStatsForTextColumn(dataset, bqFormattedTableName, column, filter);
+          return BigQueryPdao.getStatsForTextColumn(
+              dataset, bqFormattedTableName, tableName, column, filter);
         }
         return new ColumnStatisticsModel();
       } catch (InterruptedException e) {

--- a/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
+++ b/src/main/java/bio/terra/service/filedata/FSContainerInterface.java
@@ -20,4 +20,8 @@ public interface FSContainerInterface {
   CollectionType getCollectionType();
 
   CloudPlatform getCloudPlatform();
+
+  boolean isDataset();
+
+  boolean isSnapshot();
 }

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -14,6 +14,8 @@ import bio.terra.common.SynapseColumn;
 import bio.terra.common.Table;
 import bio.terra.common.exception.PdaoException;
 import bio.terra.grammar.Query;
+import bio.terra.model.ColumnStatisticsNumericModel;
+import bio.terra.model.ColumnStatisticsTextModel;
 import bio.terra.model.IngestRequestModel.FormatEnum;
 import bio.terra.model.SnapshotRequestAssetModel;
 import bio.terra.model.SnapshotRequestRowIdModel;
@@ -1043,6 +1045,16 @@ public class AzureSynapsePdao {
           ex);
       return 0;
     }
+  }
+
+  public static ColumnStatisticsNumericModel getStatsForNumericColumn(
+      Column column, String dataSourceName, String parquetFileLocation) {
+    return new ColumnStatisticsNumericModel();
+  }
+
+  public static ColumnStatisticsTextModel getStatsForTextColumn(
+      Column column, String dataSourceName, String parquetFileLocation) {
+    return new ColumnStatisticsTextModel();
   }
 
   public List<SynapseDataResultModel> getTableData(

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -12,6 +12,7 @@ import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
 import bio.terra.common.SynapseColumn;
 import bio.terra.common.Table;
+import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.common.exception.PdaoException;
 import bio.terra.grammar.Query;
 import bio.terra.model.ColumnStatisticsNumericModel;
@@ -1049,12 +1050,14 @@ public class AzureSynapsePdao {
 
   public static ColumnStatisticsNumericModel getStatsForNumericColumn(
       Column column, String dataSourceName, String parquetFileLocation) {
-    return new ColumnStatisticsNumericModel();
+    throw new FeatureNotImplementedException("This feature is not yet supported for Azure-backed datasets.");
+//    return new ColumnStatisticsNumericModel();
   }
 
   public static ColumnStatisticsTextModel getStatsForTextColumn(
       Column column, String dataSourceName, String parquetFileLocation) {
-    return new ColumnStatisticsTextModel();
+    throw new FeatureNotImplementedException("This feature is not yet supported for Azure-backed datasets.");
+//    return new ColumnStatisticsTextModel();
   }
 
   public List<SynapseDataResultModel> getTableData(

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -1050,14 +1050,16 @@ public class AzureSynapsePdao {
 
   public static ColumnStatisticsNumericModel getStatsForNumericColumn(
       Column column, String dataSourceName, String parquetFileLocation) {
-    throw new FeatureNotImplementedException("This feature is not yet supported for Azure-backed datasets.");
-//    return new ColumnStatisticsNumericModel();
+    throw new FeatureNotImplementedException(
+        "This feature is not yet supported for Azure-backed datasets.");
+    //    return new ColumnStatisticsNumericModel();
   }
 
   public static ColumnStatisticsTextModel getStatsForTextColumn(
       Column column, String dataSourceName, String parquetFileLocation) {
-    throw new FeatureNotImplementedException("This feature is not yet supported for Azure-backed datasets.");
-//    return new ColumnStatisticsTextModel();
+    throw new FeatureNotImplementedException(
+        "This feature is not yet supported for Azure-backed datasets.");
+    //    return new ColumnStatisticsTextModel();
   }
 
   public List<SynapseDataResultModel> getTableData(

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -15,7 +15,8 @@ import bio.terra.common.Table;
 import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.common.exception.PdaoException;
 import bio.terra.grammar.Query;
-import bio.terra.model.ColumnStatisticsNumericModel;
+import bio.terra.model.ColumnStatisticsDoubleModel;
+import bio.terra.model.ColumnStatisticsIntModel;
 import bio.terra.model.ColumnStatisticsTextModel;
 import bio.terra.model.IngestRequestModel.FormatEnum;
 import bio.terra.model.SnapshotRequestAssetModel;
@@ -1048,7 +1049,14 @@ public class AzureSynapsePdao {
     }
   }
 
-  public static ColumnStatisticsNumericModel getStatsForNumericColumn(
+  public static ColumnStatisticsDoubleModel getStatsForDoubleColumn(
+      Column column, String dataSourceName, String parquetFileLocation) {
+    throw new FeatureNotImplementedException(
+        "This feature is not yet supported for Azure-backed datasets.");
+    //    return new ColumnStatisticsNumericModel();
+  }
+
+  public static ColumnStatisticsIntModel getStatsForIntColumn(
       Column column, String dataSourceName, String parquetFileLocation) {
     throw new FeatureNotImplementedException(
         "This feature is not yet supported for Azure-backed datasets.");

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -1049,21 +1049,21 @@ public class AzureSynapsePdao {
     }
   }
 
-  public static ColumnStatisticsDoubleModel getStatsForDoubleColumn(
+  public ColumnStatisticsDoubleModel getStatsForDoubleColumn(
       Column column, String dataSourceName, String parquetFileLocation) {
     throw new FeatureNotImplementedException(
         "This feature is not yet supported for Azure-backed datasets.");
     //    return new ColumnStatisticsNumericModel();
   }
 
-  public static ColumnStatisticsIntModel getStatsForIntColumn(
+  public ColumnStatisticsIntModel getStatsForIntColumn(
       Column column, String dataSourceName, String parquetFileLocation) {
     throw new FeatureNotImplementedException(
         "This feature is not yet supported for Azure-backed datasets.");
     //    return new ColumnStatisticsNumericModel();
   }
 
-  public static ColumnStatisticsTextModel getStatsForTextColumn(
+  public ColumnStatisticsTextModel getStatsForTextColumn(
       Column column, String dataSourceName, String parquetFileLocation) {
     throw new FeatureNotImplementedException(
         "This feature is not yet supported for Azure-backed datasets.");

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -289,4 +289,14 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
   public String toLogString() {
     return String.format("%s (%s)", this.getName(), this.getId());
   }
+
+  @Override
+  public boolean isSnapshot() {
+    return true;
+  }
+
+  @Override
+  public boolean isDataset() {
+    return false;
+  }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -821,10 +821,9 @@ public class SnapshotService {
       try {
         List<String> columns =
             snapshotTableDao.retrieveColumns(table).stream().map(Column::getName).toList();
-        String bqFormattedTableName = snapshot.getName() + "." + tableName;
         List<BigQueryDataResultModel> values =
             BigQueryPdao.getTable(
-                snapshot, bqFormattedTableName, columns, limit, offset, sort, direction, filter);
+                snapshot, tableName, columns, limit, offset, sort, direction, filter);
         return new SnapshotPreviewModel()
             .result(
                 List.copyOf(values.stream().map(BigQueryDataResultModel::getRowResult).toList()))

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -311,7 +311,10 @@ public abstract class BigQueryPdao {
         .forEach(
             rows -> {
               ColumnStatisticsTextValue val = new ColumnStatisticsTextValue();
-              val.value(rows.get(column).getStringValue());
+              FieldValue fieldValue = rows.get(column);
+              // getStringValue() throws NPE if value of field is null; getValue() does not
+              Object rowValue = fieldValue.getValue();
+              val.value(rowValue != null ? fieldValue.getStringValue() : null);
               val.count((int) (rows.get(PDAO_COUNT_COLUMN_NAME).getLongValue()));
               values.add(val);
               // I don't _think_ we need to handle array fields b/c we flatten them

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -14,7 +14,6 @@ import bio.terra.common.exception.PdaoException;
 import bio.terra.grammar.Query;
 import bio.terra.model.ColumnStatisticsDoubleModel;
 import bio.terra.model.ColumnStatisticsIntModel;
-import bio.terra.model.ColumnStatisticsModel;
 import bio.terra.model.ColumnStatisticsTextModel;
 import bio.terra.model.ColumnStatisticsTextValue;
 import bio.terra.model.SqlSortDirection;
@@ -277,7 +276,7 @@ public abstract class BigQueryPdao {
         SELECT MIN(<column>) AS min, MAX(<column>) AS max FROM <table> <whereClause>
       """;
 
-  public static ColumnStatisticsModel getStatsForTextColumn(
+  public static ColumnStatisticsTextModel getStatsForTextColumn(
       FSContainerInterface tdrResource,
       String bqFormattedTableName,
       String tableName,
@@ -301,9 +300,10 @@ public abstract class BigQueryPdao {
             .render();
     final TableResult result = bigQueryProject.query(bigQuerySQL);
 
-    return new ColumnStatisticsTextModel()
-        .values(aggregateTextColumnStats(result, columnName))
-        .dataType(column.getType().toString());
+    return (ColumnStatisticsTextModel)
+        new ColumnStatisticsTextModel()
+            .values(aggregateTextColumnStats(result, columnName))
+            .dataType(column.getType().toString());
   }
 
   static List<ColumnStatisticsTextValue> aggregateTextColumnStats(
@@ -324,28 +324,30 @@ public abstract class BigQueryPdao {
     return values;
   }
 
-  public static ColumnStatisticsModel getStatsForDoubleColumn(
+  public static ColumnStatisticsDoubleModel getStatsForDoubleColumn(
       FSContainerInterface tdrResource, String bqFormattedTableName, Column column, String filter)
       throws InterruptedException {
 
     final TableResult result =
         retrieveNumericColumnStats(tdrResource, bqFormattedTableName, column, filter);
-    return new ColumnStatisticsDoubleModel()
-        .maxValue(getDoubleResult(result, "max"))
-        .minValue(getDoubleResult(result, "min"))
-        .dataType(column.getType().toString());
+    return (ColumnStatisticsDoubleModel)
+        new ColumnStatisticsDoubleModel()
+            .maxValue(getDoubleResult(result, "max"))
+            .minValue(getDoubleResult(result, "min"))
+            .dataType(column.getType().toString());
   }
 
-  public static ColumnStatisticsModel getStatsForIntColumn(
+  public static ColumnStatisticsIntModel getStatsForIntColumn(
       FSContainerInterface tdrResource, String bqFormattedTableName, Column column, String filter)
       throws InterruptedException {
 
     final TableResult result =
         retrieveNumericColumnStats(tdrResource, bqFormattedTableName, column, filter);
-    return new ColumnStatisticsIntModel()
-        .maxValue(getIntResult(result, "max"))
-        .minValue(getIntResult(result, "min"))
-        .dataType(column.getType().toString());
+    return (ColumnStatisticsIntModel)
+        new ColumnStatisticsIntModel()
+            .maxValue(getIntResult(result, "max"))
+            .minValue(getIntResult(result, "min"))
+            .dataType(column.getType().toString());
   }
 
   private static TableResult retrieveNumericColumnStats(

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -300,10 +300,10 @@ public abstract class BigQueryPdao {
             .render();
     final TableResult result = bigQueryProject.query(bigQuerySQL);
 
-    return new ColumnStatisticsTextModel().values(aggregateColumnStats(result, columnName));
+    return new ColumnStatisticsTextModel().values(aggregateTextColumnStats(result, columnName));
   }
 
-  private static List<ColumnStatisticsTextValue> aggregateColumnStats(
+  static List<ColumnStatisticsTextValue> aggregateTextColumnStats(
       TableResult result, String column) {
     List<ColumnStatisticsTextValue> values = new ArrayList<>();
     result
@@ -317,12 +317,6 @@ public abstract class BigQueryPdao {
               val.value(rowValue != null ? fieldValue.getStringValue() : null);
               val.count((int) (rows.get(PDAO_COUNT_COLUMN_NAME).getLongValue()));
               values.add(val);
-              // I don't _think_ we need to handle array fields b/c we flatten them
-              //              if (fieldValue.getAttribute() == FieldValue.Attribute.REPEATED) {
-              //                fieldValue.getRepeatedValue().stream()
-              //                    .forEach(val -> values.add(val.getStringValue()));
-              //              } else {
-
             });
     return values;
   }
@@ -332,7 +326,7 @@ public abstract class BigQueryPdao {
       throws InterruptedException {
 
     final TableResult result =
-        retrieveColumnStats(tdrResource, bqFormattedTableName, column, filter);
+        retrieveNumericColumnStats(tdrResource, bqFormattedTableName, column, filter);
     return new ColumnStatisticsDoubleModel()
         .maxValue(getDoubleResult(result, "max"))
         .minValue(getDoubleResult(result, "min"));
@@ -343,13 +337,13 @@ public abstract class BigQueryPdao {
       throws InterruptedException {
 
     final TableResult result =
-        retrieveColumnStats(tdrResource, bqFormattedTableName, column, filter);
+        retrieveNumericColumnStats(tdrResource, bqFormattedTableName, column, filter);
     return new ColumnStatisticsIntModel()
         .maxValue(getIntResult(result, "max"))
         .minValue(getIntResult(result, "min"));
   }
 
-  private static TableResult retrieveColumnStats(
+  private static TableResult retrieveNumericColumnStats(
       FSContainerInterface tdrResource, String bqFormattedTableName, Column column, String filter)
       throws InterruptedException {
     String whereClause = StringUtils.isNotEmpty(filter) ? filter : "";

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -154,8 +154,6 @@ public abstract class BigQueryPdao {
   }
 
   public static String bqTableName(FSContainerInterface tdrResource, String tableName) {
-    final BigQueryProject bigQueryProject = BigQueryProject.from(tdrResource);
-    final String projectId = bigQueryProject.getProjectId();
     return new ST(BQ_TABLE_NAME_TEMPLATE)
         .add("pdaoPrefix", tdrResource.isDataset() ? PDAO_PREFIX : "")
         .add("resourceName", tdrResource.getName())

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -255,8 +255,8 @@ public abstract class BigQueryPdao {
   // COLUMN STATS
   public static final String ARRAY_TEXT_COLUMN_STATS_TEMPLATE =
       """
-          WITH array_field AS (Select <column> FROM <table> <whereClause>)
-            Select flattened_array_field AS <column>, COUNT(*) AS <countColumn> FROM array_field CROSS JOIN UNNEST(array_field.<column>)
+          WITH array_field AS (SELECT <column> FROM <table> <whereClause>)
+            SELECT flattened_array_field AS <column>, COUNT(*) AS <countColumn> FROM array_field CROSS JOIN UNNEST(array_field.<column>)
             AS flattened_array_field GROUP BY flattened_array_field ORDER BY flattened_array_field <direction>
           """;
   public static final String TEXT_COLUMN_STATS_TEMPLATE =
@@ -266,8 +266,8 @@ public abstract class BigQueryPdao {
 
   public static final String ARRAY_NUMERIC_COLUMN_STATS_TEMPLATE =
       """
-          WITH array_field AS (Select <column> FROM <table> <whereClause>)
-            Select MIN(flattened_array_field) AS min, MAX(flattened_array_field) AS max FROM array_field CROSS JOIN UNNEST(array_field.<column>)
+          WITH array_field AS (SELECT <column> FROM <table> <whereClause>)
+            SELECT MIN(flattened_array_field) AS min, MAX(flattened_array_field) AS max FROM array_field CROSS JOIN UNNEST(array_field.<column>)
             AS flattened_array_field
           """;
 

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -14,6 +14,7 @@ import bio.terra.common.exception.PdaoException;
 import bio.terra.grammar.Query;
 import bio.terra.model.ColumnStatisticsDoubleModel;
 import bio.terra.model.ColumnStatisticsIntModel;
+import bio.terra.model.ColumnStatisticsModel;
 import bio.terra.model.ColumnStatisticsTextModel;
 import bio.terra.model.ColumnStatisticsTextValue;
 import bio.terra.model.SqlSortDirection;
@@ -276,7 +277,7 @@ public abstract class BigQueryPdao {
         SELECT MIN(<column>) AS min, MAX(<column>) AS max FROM <table> <whereClause>
       """;
 
-  public static ColumnStatisticsTextModel getStatsForTextColumn(
+  public static ColumnStatisticsModel getStatsForTextColumn(
       FSContainerInterface tdrResource,
       String bqFormattedTableName,
       String tableName,
@@ -300,7 +301,9 @@ public abstract class BigQueryPdao {
             .render();
     final TableResult result = bigQueryProject.query(bigQuerySQL);
 
-    return new ColumnStatisticsTextModel().values(aggregateTextColumnStats(result, columnName));
+    return new ColumnStatisticsTextModel()
+        .values(aggregateTextColumnStats(result, columnName))
+        .dataType(column.getType().toString());
   }
 
   static List<ColumnStatisticsTextValue> aggregateTextColumnStats(
@@ -321,7 +324,7 @@ public abstract class BigQueryPdao {
     return values;
   }
 
-  public static ColumnStatisticsDoubleModel getStatsForDoubleColumn(
+  public static ColumnStatisticsModel getStatsForDoubleColumn(
       FSContainerInterface tdrResource, String bqFormattedTableName, Column column, String filter)
       throws InterruptedException {
 
@@ -329,10 +332,11 @@ public abstract class BigQueryPdao {
         retrieveNumericColumnStats(tdrResource, bqFormattedTableName, column, filter);
     return new ColumnStatisticsDoubleModel()
         .maxValue(getDoubleResult(result, "max"))
-        .minValue(getDoubleResult(result, "min"));
+        .minValue(getDoubleResult(result, "min"))
+        .dataType(column.getType().toString());
   }
 
-  public static ColumnStatisticsIntModel getStatsForIntColumn(
+  public static ColumnStatisticsModel getStatsForIntColumn(
       FSContainerInterface tdrResource, String bqFormattedTableName, Column column, String filter)
       throws InterruptedException {
 
@@ -340,7 +344,8 @@ public abstract class BigQueryPdao {
         retrieveNumericColumnStats(tdrResource, bqFormattedTableName, column, filter);
     return new ColumnStatisticsIntModel()
         .maxValue(getIntResult(result, "max"))
-        .minValue(getIntResult(result, "min"));
+        .minValue(getIntResult(result, "min"))
+        .dataType(column.getType().toString());
   }
 
   private static TableResult retrieveNumericColumnStats(

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -11,6 +11,8 @@ import bio.terra.common.CollectionType;
 import bio.terra.common.Column;
 import bio.terra.common.exception.PdaoException;
 import bio.terra.grammar.Query;
+import bio.terra.model.ColumnStatisticsNumericModel;
+import bio.terra.model.ColumnStatisticsTextModel;
 import bio.terra.model.SqlSortDirection;
 import bio.terra.service.filedata.FSContainerInterface;
 import bio.terra.service.tabulardata.google.BigQueryProject;
@@ -156,6 +158,18 @@ public abstract class BigQueryPdao {
           ex);
       return 0;
     }
+  }
+
+  public static ColumnStatisticsNumericModel getStatsForNumericColumn(
+      FSContainerInterface tdrResource, String bqFormattedTableName, String column)
+      throws InterruptedException {
+    return new ColumnStatisticsNumericModel();
+  }
+
+  public static ColumnStatisticsTextModel getStatsForTextColumn(
+      FSContainerInterface tdrResource, String bqFormattedTableName, String column)
+      throws InterruptedException {
+    return new ColumnStatisticsTextModel();
   }
   /*
    * WARNING: Ensure input parameters are validated before executing this method!

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1849,6 +1849,7 @@ paths:
           description: >-
             A SQL WHERE clause to filter results included in column statistics.
 
+
             For GCP array string columns, if you wanted to include all rows that contain 'value1' in column1,
             the filter clause would look like 'WHERE 'value1' IN UNNEST(column1)'. Note that "count" value
             includes all occurrences of a value including duplicates of the same value in a single array.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1850,12 +1850,14 @@ paths:
             A SQL WHERE clause to filter results included in column statistics.
 
             For GCP array string columns, if you wanted to include all rows that contain 'value1' in column1,
-            the filter clause would look like 'WHERE 'value1' IN UNNEST(column1)'.
+            the filter clause would look like 'WHERE 'value1' IN UNNEST(column1)'. Note that "count" value
+            includes all occurrences of a value including duplicates of the same value in a single array.
+            i.e. if we had two rows in a table where the value for column1, row1 = ['value1', 'value1', 'value2'] and column1, row2 = ['value1'] the count for 'value1' would be 3.
           schema:
             type: string
       responses:
         200:
-          description: Returns the statistics about column from a dataset's table
+          description: Returns the statistics about a column from a dataset's table
           content:
             application/json:
               schema:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4773,8 +4773,14 @@ components:
             values:
               type: array
               items:
-                type: string
-              description: list
+                $ref: '#/components/schemas/ColumnStatisticsTextValue'
+    ColumnStatisticsTextValue:
+      type: object
+      properties:
+        value:
+          type: string
+        count:
+          type: integer
     ColumnStatisticsNumericModel:
       allOf:
         - $ref: '#/components/schemas/ColumnStatisticsModel'

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1824,6 +1824,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DatasetDataModel'
+  /api/repository/v1/datasets/{id}/data/{table}/statistics/{column}:
+    get:
+      tags:
+        - datasets
+      description: Retrieve statiscs about data for a column in a table in a dataset
+      operationId: lookupDatasetColumnStatisticsById
+      parameters:
+        - $ref: '#/components/parameters/Id'
+        - name: table
+          in: path
+          description: Name of table where column lives
+          required: true
+          schema:
+            type: string
+        - name: column
+          in: path
+          description: Name of column in the table to get statisitcs about
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Returns the statistics about column from a dataset's table
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ColumnStatisticsModel'
   /api/repository/v1/datasets/{id}/summary:
     get:
       tags:
@@ -4727,6 +4754,35 @@ components:
           type: integer
       description: >
         A preview of a snapshot table
+    ColumnStatisticsTextModel:
+      allOf:
+        - $ref: '#/components/schemas/ColumnStatisticsModel'
+        - type: object
+          required:
+            - values
+          properties:
+            values:
+              type: array
+              items:
+                type: string
+              description: list
+    ColumnStatisticsNumericModel:
+      allOf:
+        - $ref: '#/components/schemas/ColumnStatisticsModel'
+        - type: object
+          properties:
+            minValue:
+              type: number
+            maxValue:
+              type: number
+    ColumnStatisticsModel:
+      type: object
+      required:
+        - dataType
+      properties:
+        dataType:
+          type: string
+          description: Data type of column
     FileModel:
       type: object
       properties:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4781,9 +4781,9 @@ components:
         - type: object
           properties:
             minValue:
-              type: number
+              type: integer
             maxValue:
-              type: number
+              type: integer
     ColumnStatisticsModel:
       type: object
       required:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1844,6 +1844,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: filter
+          in: path
+          description: Filter down results included in the column statistics
+          schema:
+            type: string
       responses:
         200:
           description: Returns the statistics about column from a dataset's table

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1845,8 +1845,12 @@ paths:
           schema:
             type: string
         - name: filter
-          in: path
-          description: Filter down results included in the column statistics
+          in: query
+          description: >-
+            A SQL WHERE clause to filter results included in column statistics.
+
+            For GCP array string columns, if you wanted to include all rows that contain 'value1' in column1,
+            the filter clause would look like 'WHERE 'value1' IN UNNEST(column1)'.
           schema:
             type: string
       responses:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4781,7 +4781,7 @@ components:
           type: string
         count:
           type: integer
-    ColumnStatisticsNumericModel:
+    ColumnStatisticsIntModel:
       allOf:
         - $ref: '#/components/schemas/ColumnStatisticsModel'
         - type: object
@@ -4790,6 +4790,17 @@ components:
               type: integer
             maxValue:
               type: integer
+    ColumnStatisticsDoubleModel:
+      allOf:
+        - $ref: '#/components/schemas/ColumnStatisticsModel'
+        - type: object
+          properties:
+            minValue:
+              type: number
+              format: double
+            maxValue:
+              type: number
+              format: double
     ColumnStatisticsModel:
       type: object
       required:

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -567,8 +567,7 @@ public class ConnectedOperations {
 
   public void checkTableRowCount(
       FSContainerInterface tdrResource, String tableName, String prefix, int expectedRowCount) {
-    String participantBQFormattedTableName = prefix + tdrResource.getName() + "." + tableName;
-    int rowCount = BigQueryPdao.getTableTotalRowCount(tdrResource, participantBQFormattedTableName);
+    int rowCount = BigQueryPdao.getTableTotalRowCount(tdrResource, tableName);
     assertThat("Expected row count", rowCount, equalTo(expectedRowCount));
   }
 
@@ -579,11 +578,10 @@ public class ConnectedOperations {
       String tableName,
       int expectedRowCount)
       throws InterruptedException {
-    String participantBQFormattedTableName = prefix + tdrResource.getName() + "." + tableName;
     List<BigQueryDataResultModel> results =
         BigQueryPdao.getTable(
             tdrResource,
-            participantBQFormattedTableName,
+            tableName,
             columnNames,
             expectedRowCount + 1,
             0,

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -961,7 +961,15 @@ public class DataRepoFixtures {
         retrieveColumnStats(user, datasetId, tableName, columnName, null).getValues().stream()
             .filter(val -> val.getValue() != null ? val.getValue().equals(columnTextValue) : false)
             .findFirst()
-            .orElseThrow(() -> new Exception("Value " + columnTextValue + " not found in table " + tableName + " column " + columnName))
+            .orElseThrow(
+                () ->
+                    new Exception(
+                        "Value "
+                            + columnTextValue
+                            + " not found in table "
+                            + tableName
+                            + " column "
+                            + columnName))
             .getCount();
     assertThat(
         "Expected count for column value matches actual count", count, equalTo(expectedValueCount));

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -3,6 +3,7 @@ package bio.terra.integration;
 import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_COLUMN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -28,6 +29,7 @@ import bio.terra.model.BulkLoadRequestModel;
 import bio.terra.model.BulkLoadResultModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.ColumnModel;
+import bio.terra.model.ColumnStatisticsTextModel;
 import bio.terra.model.ConfigEnableModel;
 import bio.terra.model.ConfigGroupModel;
 import bio.terra.model.ConfigListModel;
@@ -936,6 +938,62 @@ public class DataRepoFixtures {
     }
     if (direction != null) {
       queryParams += "&direction=%s".formatted(direction);
+    }
+    return dataRepoClient.get(user, url + queryParams, new TypeReference<>() {});
+  }
+
+  public void assertColumnTextValueCount(
+      TestConfiguration.User user,
+      UUID datasetId,
+      String tableName,
+      String columnName,
+      String columnTextValue,
+      int expectedValueCount)
+      throws Exception {
+    if (expectedValueCount == 0) {
+      assertThat(
+          "Column value is not present",
+          retrieveColumnTextValues(user, datasetId, tableName, columnName),
+          not(hasItem(columnTextValue)));
+      return;
+    }
+    int count =
+        retrieveColumnStats(user, datasetId, tableName, columnName, null).getValues().stream()
+            .filter(val -> val.getValue() != null ? val.getValue().equals(columnTextValue) : false)
+            .findFirst()
+            .orElseThrow()
+            .getCount();
+    assertThat(
+        "Expected count for column value matches actual count", count, equalTo(expectedValueCount));
+  }
+
+  public List<String> retrieveColumnTextValues(
+      TestConfiguration.User user, UUID datasetId, String tableName, String columnName)
+      throws Exception {
+    return retrieveColumnStats(user, datasetId, tableName, columnName, null).getValues().stream()
+        .map(val -> val.getValue())
+        .toList();
+  }
+
+  public ColumnStatisticsTextModel retrieveColumnStats(
+      TestConfiguration.User user, UUID datasetId, String table, String columnName, String filter)
+      throws Exception {
+    DataRepoResponse<ColumnStatisticsTextModel> response =
+        retrieveColumnStatsTextRaw(user, datasetId, table, columnName, filter);
+    return validateResponse(response, "dataset column stats", HttpStatus.OK, null);
+  }
+
+  private DataRepoResponse<ColumnStatisticsTextModel> retrieveColumnStatsTextRaw(
+      TestConfiguration.User user, UUID datasetId, String table, String columnName, String filter)
+      throws Exception {
+    String url =
+        "/api/repository/v1/datasets/%s/data/%s/statistics/%s"
+            .formatted(datasetId, table, columnName);
+
+    String queryParams = "";
+
+    if (filter != null) {
+      queryParams += "&filter=%s".formatted(filter);
     }
     return dataRepoClient.get(user, url + queryParams, new TypeReference<>() {});
   }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -961,7 +961,7 @@ public class DataRepoFixtures {
         retrieveColumnStats(user, datasetId, tableName, columnName, null).getValues().stream()
             .filter(val -> val.getValue() != null ? val.getValue().equals(columnTextValue) : false)
             .findFirst()
-            .orElseThrow()
+            .orElseThrow(() -> new Exception("Value " + columnTextValue + " not found in table " + tableName + " column " + columnName))
             .getCount();
     assertThat(
         "Expected count for column value matches actual count", count, equalTo(expectedValueCount));

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -372,11 +372,11 @@ public class IngestTest extends UsersBase {
         dataRepoFixtures.ingestJsonData(steward(), datasetId, mergeIngestRequest);
     assertThat("correct merge sample row count", mergeIngestResponse.getRowCount(), equalTo(2L));
     assertSampleTableIdColumnRemainsUnchanged(dataset);
-    // Merge ingest request should overwrite value 'sample7' for column 'derived_from'
-    // TODO - This check is failing -- "sample7" is not being overwritten - Is this correct behavior
-    // if the user specifically sets a value to null?
-    //    dataRepoFixtures.assertColumnTextValueCount(
-    //        steward(), datasetId, "sample", "derived_from", "sample7", 0);
+    // We cannot "null-out" a value in a merge ingest request
+    // so the value remains 'sample7' for the 'derived_from' column despite being set to null in the
+    // request
+    dataRepoFixtures.assertColumnTextValueCount(
+        steward(), datasetId, "sample", "derived_from", "sample7", 1);
 
     // -------- Updating the same row again via merge ingest should succeed--------
     IngestRequestModel mergeAgainIngestRequest =
@@ -390,9 +390,6 @@ public class IngestTest extends UsersBase {
         mergeAgainIngestResponse.getRowCount(),
         equalTo(1L));
     assertSampleTableIdColumnRemainsUnchanged(dataset);
-    // Second merge ingest request should also not include value 'sample7' for column 'derived_from'
-    //    dataRepoFixtures.assertColumnTextValueCount(
-    //        steward(), datasetId, "sample", "derived_from", "sample7", 0);
   }
 
   private void assertSampleTableIdColumnRemainsUnchanged(DatasetModel dataset) throws Exception {

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -373,8 +373,10 @@ public class IngestTest extends UsersBase {
     assertThat("correct merge sample row count", mergeIngestResponse.getRowCount(), equalTo(2L));
     assertSampleTableIdColumnRemainsUnchanged(dataset);
     // Merge ingest request should overwrite value 'sample7' for column 'derived_from'
-    dataRepoFixtures.assertColumnTextValueCount(
-        steward(), datasetId, "sample", "derived_from", "sample7", 0);
+    // TODO - This check is failing -- "sample7" is not being overwritten - Is this correct behavior
+    // if the user specifically sets a value to null?
+    //    dataRepoFixtures.assertColumnTextValueCount(
+    //        steward(), datasetId, "sample", "derived_from", "sample7", 0);
 
     // -------- Updating the same row again via merge ingest should succeed--------
     IngestRequestModel mergeAgainIngestRequest =
@@ -389,8 +391,8 @@ public class IngestTest extends UsersBase {
         equalTo(1L));
     assertSampleTableIdColumnRemainsUnchanged(dataset);
     // Second merge ingest request should also not include value 'sample7' for column 'derived_from'
-    dataRepoFixtures.assertColumnTextValueCount(
-        steward(), datasetId, "sample", "derived_from", "sample7", 0);
+    //    dataRepoFixtures.assertColumnTextValueCount(
+    //        steward(), datasetId, "sample", "derived_from", "sample7", 0);
   }
 
   private void assertSampleTableIdColumnRemainsUnchanged(DatasetModel dataset) throws Exception {

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -346,12 +346,24 @@ public class IngestTest extends UsersBase {
 
   @Test
   public void ingestMergeHappyPathTest() throws Exception {
+    DatasetModel dataset =
+        dataRepoFixtures.getDataset(
+            steward(), datasetId, List.of(DatasetRequestAccessIncludeModel.ACCESS_INFORMATION));
+    // -------- Simple ingest with 7 rows --------
     IngestRequestModel ingestRequest =
         dataRepoFixtures.buildSimpleIngest("sample", "ingest-test/ingest-test-sample.json");
     IngestResponseModel ingestResponse =
         dataRepoFixtures.ingestJsonData(steward(), datasetId, ingestRequest);
     assertThat("correct sample row count", ingestResponse.getRowCount(), equalTo(7L));
+    assertSampleTableIdColumnRemainsUnchanged(dataset);
+    // Original ingest request should include value 'sample7' for column 'derived_from'
+    dataRepoFixtures.assertColumnTextValueCount(
+        steward(), datasetId, "sample", "derived_from", "sample7", 1);
+    // Test column stats endpoint's handling of array columns
+    dataRepoFixtures.assertColumnTextValueCount(
+        steward(), datasetId, "sample", "participant_ids", "participant_1", 1);
 
+    // Rows ingested via merge should not increase the existing live row count.
     IngestRequestModel mergeIngestRequest =
         dataRepoFixtures
             .buildSimpleIngest("sample", "ingest-test/merge/ingest-test-sample-merge.json")
@@ -359,49 +371,12 @@ public class IngestTest extends UsersBase {
     IngestResponseModel mergeIngestResponse =
         dataRepoFixtures.ingestJsonData(steward(), datasetId, mergeIngestRequest);
     assertThat("correct merge sample row count", mergeIngestResponse.getRowCount(), equalTo(2L));
+    assertSampleTableIdColumnRemainsUnchanged(dataset);
+    // Merge ingest request should overwrite value 'sample7' for column 'derived_from'
+    dataRepoFixtures.assertColumnTextValueCount(
+        steward(), datasetId, "sample", "derived_from", "sample7", 0);
 
-    // Rows ingested via merge should not increase the existing live row count.
-    // TODO: once the preview API GA and works for datasets, we should use that here
-    DatasetModel dataset =
-        dataRepoFixtures.getDataset(
-            steward(), datasetId, List.of(DatasetRequestAccessIncludeModel.ACCESS_INFORMATION));
-    BigQueryProject bigQueryProject =
-        BigQueryProject.get(dataset.getAccessInformation().getBigQuery().getProjectId());
-    AccessInfoBigQueryModelTable bqTableInfo =
-        dataset.getAccessInformation().getBigQuery().getTables().stream()
-            .filter(t -> t.getName().equals("sample"))
-            .findFirst()
-            .orElseThrow();
-    // Note: the sample query is just a formatted select * query against the table
-    TableResult bqQueryResult = bigQueryProject.query(bqTableInfo.getSampleQuery());
-    assertThat("Expected number of rows are present", bqQueryResult.getTotalRows(), equalTo(7L));
-
-    List<Map<String, Object>> results =
-        BQTestUtils.mapToList(
-            bqQueryResult, "id", "participant_ids", "date_collected", "derived_from");
-
-    List<Map<String, Object>> dataPostMerge =
-        jsonLoader.loadObjectAsStream(
-            "ingest-test/merge/ingest-test-sample-merge-expected.json", new TypeReference<>() {});
-    List<Map<String, Object>> dataOriginal =
-        jsonLoader.loadObjectAsStream("ingest-test-sample.json", new TypeReference<>() {});
-
-    assertThat(
-        "Only specified records and fields updated by first merge ingest",
-        results,
-        containsInAnyOrder(
-            // Updated rows
-            dataPostMerge.get(0), // ID = sample1
-            dataPostMerge.get(1), // ID = sample2
-            // Untouched rows
-            dataOriginal.get(2), // ID = sample3
-            dataOriginal.get(3), // ID = sample4
-            dataOriginal.get(4), // ID = sample5
-            dataOriginal.get(5), // ID = sample6
-            dataOriginal.get(6) // ID = sample7
-            ));
-
-    // Updating the same row again via merge ingest should succeed
+    // -------- Updating the same row again via merge ingest should succeed--------
     IngestRequestModel mergeAgainIngestRequest =
         dataRepoFixtures
             .buildSimpleIngest("sample", "ingest-test/merge/ingest-test-sample-merge-again.json")
@@ -412,34 +387,22 @@ public class IngestTest extends UsersBase {
         "correct merge again sample row count",
         mergeAgainIngestResponse.getRowCount(),
         equalTo(1L));
+    assertSampleTableIdColumnRemainsUnchanged(dataset);
+    // Second merge ingest request should also not include value 'sample7' for column 'derived_from'
+    dataRepoFixtures.assertColumnTextValueCount(
+        steward(), datasetId, "sample", "derived_from", "sample7", 0);
+  }
 
-    bqQueryResult = bigQueryProject.query(bqTableInfo.getSampleQuery());
-    assertThat("Expected number of rows are present", bqQueryResult.getTotalRows(), equalTo(7L));
-
-    results =
-        BQTestUtils.mapToList(
-            bqQueryResult, "id", "participant_ids", "date_collected", "derived_from");
-
-    List<Map<String, Object>> dataPostMergeAgain =
-        jsonLoader.loadObjectAsStream(
-            "ingest-test/merge/ingest-test-sample-merge-again-expected.json",
-            new TypeReference<>() {});
-
+  private void assertSampleTableIdColumnRemainsUnchanged(DatasetModel dataset) throws Exception {
+    int expectedNumRows = 7;
+    dataRepoFixtures.assertDatasetTableCount(steward(), dataset, "sample", expectedNumRows);
+    List<String> actualValues =
+        dataRepoFixtures.retrieveColumnTextValues(steward(), datasetId, "sample", "id");
     assertThat(
-        "Only specified records and fields updated by second merge ingest",
-        results,
+        "Expected values returned from column stats endpoint for sample id table",
+        actualValues,
         containsInAnyOrder(
-            // Newly updated row
-            dataPostMergeAgain.get(0), // ID = sample1
-            // Prior updated row
-            dataPostMerge.get(1), // ID = sample2
-            // Untouched rows
-            dataOriginal.get(2), // ID = sample3
-            dataOriginal.get(3), // ID = sample4
-            dataOriginal.get(4), // ID = sample5
-            dataOriginal.get(5), // ID = sample6
-            dataOriginal.get(6) // ID = sample7
-            ));
+            "sample1", "sample2", "sample3", "sample4", "sample5", "sample6", "sample7"));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -240,7 +240,7 @@ public class DatasetServiceUnitTest {
         new ColumnStatisticsTextValue().value("val1").count(2);
     try (MockedStatic<BigQueryPdao> utilities = Mockito.mockStatic(BigQueryPdao.class)) {
       utilities
-          .when(() -> BigQueryPdao.getStatsForTextColumn(any(), any(), any(), any(), any()))
+          .when(() -> BigQueryPdao.getStatsForTextColumn(any(), any(), any(), any()))
           .thenReturn(new ColumnStatisticsTextModel().values(List.of(expectedValue)));
       ColumnStatisticsTextModel statsModel =
           (ColumnStatisticsTextModel)

--- a/src/test/java/bio/terra/service/dataset/DatasetUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetUnitTest.java
@@ -1,0 +1,32 @@
+package bio.terra.service.dataset;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import bio.terra.common.category.Unit;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class DatasetUnitTest {
+  @Test
+  public void isSnapshot() {
+    Dataset dataset = new Dataset();
+    assertFalse(dataset.isSnapshot());
+  }
+
+  @Test
+  public void isDataset() {
+    Dataset dataset = new Dataset();
+    assertTrue(dataset.isDataset());
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/SnapshotUnitTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotUnitTest.java
@@ -1,0 +1,32 @@
+package bio.terra.service.snapshot;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import bio.terra.common.category.Unit;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class SnapshotUnitTest {
+  @Test
+  public void isSnapshot() {
+    Snapshot snapshot = new Snapshot();
+    assertTrue(snapshot.isSnapshot());
+  }
+
+  @Test
+  public void isDataset() {
+    Snapshot snapshot = new Snapshot();
+    assertFalse(snapshot.isDataset());
+  }
+}

--- a/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
@@ -1150,11 +1150,29 @@ public class BigQueryPdaoUnitTest {
   }
 
   @Test
-  public void testBQDatasetTableName() {
+  public void testBQDatasetFullyQualifiedTableName() {
     Dataset dataset = mockDataset();
     String tableName = "table";
     String expected =
         "`" + DATASET_PROJECT_ID + "." + PDAO_PREFIX + dataset.getName() + "." + tableName + "`";
+    String actual = BigQueryPdao.bqFullyQualifiedTableName(dataset, tableName);
+    assertThat("Dataset BQ table name is correctly formatted", expected, equalTo(actual));
+  }
+
+  @Test
+  public void testBQSnapshotFullyQualifiedTableName() {
+    Snapshot snapshot = mockSnapshot();
+    String tableName = "table";
+    String expected = "`" + SNAPSHOT_PROJECT_ID + "." + snapshot.getName() + "." + tableName + "`";
+    String actual = BigQueryPdao.bqFullyQualifiedTableName(snapshot, tableName);
+    assertThat("Snapshot BQ table name is correctly formatted", expected, equalTo(actual));
+  }
+
+  @Test
+  public void testBQDatasetTableName() {
+    Dataset dataset = mockDataset();
+    String tableName = "table";
+    String expected = PDAO_PREFIX + dataset.getName() + "." + tableName;
     String actual = BigQueryPdao.bqTableName(dataset, tableName);
     assertThat("Dataset BQ table name is correctly formatted", expected, equalTo(actual));
   }
@@ -1163,7 +1181,7 @@ public class BigQueryPdaoUnitTest {
   public void testBQSnapshotTableName() {
     Snapshot snapshot = mockSnapshot();
     String tableName = "table";
-    String expected = "`" + SNAPSHOT_PROJECT_ID + "." + snapshot.getName() + "." + tableName + "`";
+    String expected = snapshot.getName() + "." + tableName;
     String actual = BigQueryPdao.bqTableName(snapshot, tableName);
     assertThat("Snapshot BQ table name is correctly formatted", expected, equalTo(actual));
   }

--- a/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.tabulardata.google.bigquery;
 import static bio.terra.common.PdaoConstant.PDAO_COUNT_COLUMN_NAME;
 import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_STAGING_TABLE_PREFIX;
 import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_TABLE;
+import static bio.terra.common.PdaoConstant.PDAO_PREFIX;
 import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_COLUMN;
 import static bio.terra.common.PdaoConstant.PDAO_TABLE_ID_COLUMN;
 import static bio.terra.service.tabulardata.google.bigquery.BigQueryPdao.prefixName;
@@ -1146,6 +1147,25 @@ public class BigQueryPdaoUnitTest {
         "ColumnStatisticsTextValue should have the correct count",
         result.get(0).getCount(),
         equalTo(2));
+  }
+
+  @Test
+  public void testBQDatasetTableName() {
+    Dataset dataset = mockDataset();
+    String tableName = "table";
+    String expected =
+        "`" + DATASET_PROJECT_ID + "." + PDAO_PREFIX + dataset.getName() + "." + tableName + "`";
+    String actual = BigQueryPdao.bqTableName(dataset, tableName);
+    assertThat("Dataset BQ table name is correctly formatted", expected, equalTo(actual));
+  }
+
+  @Test
+  public void testBQSnapshotTableName() {
+    Snapshot snapshot = mockSnapshot();
+    String tableName = "table";
+    String expected = "`" + SNAPSHOT_PROJECT_ID + "." + snapshot.getName() + "." + tableName + "`";
+    String actual = BigQueryPdao.bqTableName(snapshot, tableName);
+    assertThat("Snapshot BQ table name is correctly formatted", expected, equalTo(actual));
   }
 
   private Dataset mockDataset() {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-2938
Changes are deployed to my personal dev instance: https://jade-sh.datarepo-dev.broadinstitute.org/
_____________________
### Background
In order to support snapshot create in the UI, we need aggregated data about each column in a dataset table. The data required depends on the data type of the column. 

### The Changes
 
New endpoint: lookupDatasetColumnStatisticsById: /api/repository/v1/datasets/{id}/data/{table}/statistics/{column}

This returns three different models, dependent on the data type:
- ColumnStatisticsTextModel - Data types: Text, string, dirref, fileref - Returns a list of values and their associated count.
- ColumnStatisticsIntModel - Data types: int, int64 - Returns the min and max value
- ColumnStatisticsDoubleModel - Data types: float, float64 - Returns the min and max value

All models inherit from the ColumnStatisticsModel, so they all return datatype. 

![image](https://github.com/DataBiosphere/jade-data-repo/assets/13254229/afff49bb-9a1d-4139-9a1e-9f1d86a91c08)

### Future Changes

- Implement equivalent for azure (Upcoming in DR-2939)
- Update how we count occurrences of string values in arrays
- Handle all data types - Right now, we only handle text and numeric fields. We should add handling for datetime and boolean fields.
- Include more statistics