### PR TITLE
[DR-3034] Delete policies in snapshot delete flight

### DIFF
--- a/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
@@ -1,6 +1,5 @@
 package bio.terra.app.configuration;
 
-import bio.terra.common.exception.FeatureNotImplementedException;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
@@ -42,11 +41,5 @@ public class PolicyServiceConfiguration {
         ServiceAccountCredentials.getApplicationDefault().createScoped(POLICY_SCOPES);
     AccessToken token = credentials.refreshAccessToken();
     return token.getTokenValue();
-  }
-
-  public void tpsEnabledCheck() {
-    if (!this.enabled) {
-      throw new FeatureNotImplementedException("Terra Policy Service is not enabled");
-    }
   }
 }

--- a/src/main/java/bio/terra/service/policy/PolicyService.java
+++ b/src/main/java/bio/terra/service/policy/PolicyService.java
@@ -11,6 +11,7 @@ import bio.terra.policy.model.TpsObjectType;
 import bio.terra.policy.model.TpsPaoCreateRequest;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
+import bio.terra.service.duos.exception.DuosDatasetNotFoundException;
 import bio.terra.service.policy.exception.PolicyConflictException;
 import bio.terra.service.policy.exception.PolicyServiceApiException;
 import bio.terra.service.policy.exception.PolicyServiceAuthorizationException;
@@ -66,13 +67,16 @@ public class PolicyService {
     }
   }
 
-  public void deletePao(UUID resourceId) {
+  /**
+   * Delete the policy access object by its id. If it does not exist in the policy service,
+   * ignore the PolicyServiceNotFoundException exception.
+   */
+  public void deletePaoIfExists(UUID resourceId) {
     policyServiceConfiguration.tpsEnabledCheck();
     TpsApi tpsApi = policyApiService.getPolicyApi();
     try {
       tpsApi.deletePao(resourceId);
     } catch (ApiException e) {
-      // Ignore the exception if the policy object being deleted does not exist
       RuntimeException exception = convertApiException(e);
       if (!(exception instanceof PolicyServiceNotFoundException)) {
         throw exception;

--- a/src/main/java/bio/terra/service/policy/PolicyService.java
+++ b/src/main/java/bio/terra/service/policy/PolicyService.java
@@ -11,7 +11,6 @@ import bio.terra.policy.model.TpsObjectType;
 import bio.terra.policy.model.TpsPaoCreateRequest;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
-import bio.terra.service.duos.exception.DuosDatasetNotFoundException;
 import bio.terra.service.policy.exception.PolicyConflictException;
 import bio.terra.service.policy.exception.PolicyServiceApiException;
 import bio.terra.service.policy.exception.PolicyServiceAuthorizationException;
@@ -51,7 +50,10 @@ public class PolicyService {
 
   public void createPao(
       UUID resourceId, TpsObjectType resourceType, @Nullable TpsPolicyInputs policyInputs) {
-    policyServiceConfiguration.tpsEnabledCheck();
+    if (!policyServiceConfiguration.getEnabled()) {
+      logger.info("Terra Policy Service is not enabled.");
+      return;
+    }
     TpsPolicyInputs inputs = (policyInputs == null) ? new TpsPolicyInputs() : policyInputs;
 
     TpsApi tpsApi = policyApiService.getPolicyApi();
@@ -68,11 +70,14 @@ public class PolicyService {
   }
 
   /**
-   * Delete the policy access object by its id. If it does not exist in the policy service,
-   * ignore the PolicyServiceNotFoundException exception.
+   * Delete the policy access object by its id. If it does not exist in the policy service, ignore
+   * the PolicyServiceNotFoundException exception.
    */
   public void deletePaoIfExists(UUID resourceId) {
-    policyServiceConfiguration.tpsEnabledCheck();
+    if (!policyServiceConfiguration.getEnabled()) {
+      logger.info("Terra Policy Service is not enabled.");
+      return;
+    }
     TpsApi tpsApi = policyApiService.getPolicyApi();
     try {
       tpsApi.deletePao(resourceId);

--- a/src/main/java/bio/terra/service/snapshot/flight/SnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/SnapshotPolicyStep.java
@@ -1,0 +1,48 @@
+package bio.terra.service.snapshot.flight;
+
+import bio.terra.policy.model.TpsPolicyInput;
+import bio.terra.policy.model.TpsPolicyInputs;
+import bio.terra.service.policy.PolicyService;
+import bio.terra.service.policy.exception.PolicyConflictException;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class SnapshotPolicyStep implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(SnapshotPolicyStep.class);
+
+  private final PolicyService policyService;
+
+  public SnapshotPolicyStep(PolicyService policyService) {
+    this.policyService = policyService;
+  }
+
+  public abstract boolean isSecureMonitoringEnabled(FlightContext context)
+      throws InterruptedException;
+
+  public abstract UUID getSnapshotId(FlightContext context) throws InterruptedException;
+
+  public StepResult createPaoStep(FlightContext flightContext) throws InterruptedException {
+    if (isSecureMonitoringEnabled(flightContext)) {
+      UUID snapshotId = getSnapshotId(flightContext);
+      TpsPolicyInput protectedDataPolicy = PolicyService.getProtectedDataPolicyInput();
+      TpsPolicyInputs policyInputs = new TpsPolicyInputs().addInputsItem(protectedDataPolicy);
+      try {
+        policyService.createSnapshotPao(snapshotId, policyInputs);
+      } catch (PolicyConflictException ex) {
+        logger.warn("Policy access object already exists for snapshot {}", snapshotId);
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  public StepResult deletePaoStep(FlightContext flightContext) throws InterruptedException {
+    if (isSecureMonitoringEnabled(flightContext)) {
+      policyService.deletePaoIfExists(getSnapshotId(flightContext));
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
@@ -1,54 +1,42 @@
 package bio.terra.service.snapshot.flight.create;
 
-import bio.terra.policy.model.TpsPolicyInput;
-import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.policy.PolicyService;
-import bio.terra.service.policy.exception.PolicyConflictException;
+import bio.terra.service.snapshot.flight.SnapshotPolicyStep;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class CreateSnapshotPolicyStep implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(CreateSnapshotPolicyStep.class);
+public class CreateSnapshotPolicyStep extends SnapshotPolicyStep {
 
-  private final PolicyService policyService;
   private final boolean enableSecureMonitoring;
 
   public CreateSnapshotPolicyStep(PolicyService policyService, boolean enableSecureMonitoring) {
-    this.policyService = policyService;
+    super(policyService);
     this.enableSecureMonitoring = enableSecureMonitoring;
+  }
+
+  @Override
+  public boolean isSecureMonitoringEnabled(FlightContext flightContext) {
+    return enableSecureMonitoring;
+  }
+
+  @Override
+  public UUID getSnapshotId(FlightContext flightContext) {
+    FlightMap flightMap = flightContext.getWorkingMap();
+    return flightMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    if (enableSecureMonitoring) {
-      FlightMap flightMap = flightContext.getWorkingMap();
-      UUID snapshotId = flightMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-      TpsPolicyInput protectedDataPolicy = PolicyService.getProtectedDataPolicyInput();
-      TpsPolicyInputs policyInputs = new TpsPolicyInputs().addInputsItem(protectedDataPolicy);
-      try {
-        policyService.createSnapshotPao(snapshotId, policyInputs);
-      } catch (PolicyConflictException ex) {
-        logger.warn("Policy access object already exists for snapshot {}", snapshotId);
-      }
-    }
-    return StepResult.getStepResultSuccess();
+    return createPaoStep(flightContext);
   }
 
   @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    if (enableSecureMonitoring) {
-      FlightMap flightMap = flightContext.getWorkingMap();
-      UUID snapshotId = flightMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-      policyService.deletePaoIfExists(snapshotId);
-    }
-    return StepResult.getStepResultSuccess();
+    return deletePaoStep(flightContext);
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
@@ -50,7 +50,11 @@ public class CreateSnapshotPolicyStep implements Step {
     if (enableSecureMonitoring) {
       FlightMap flightMap = flightContext.getWorkingMap();
       UUID snapshotId = flightMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-      policyService.deletePao(snapshotId);
+      try {
+        policyService.deletePao(snapshotId);
+      } catch (FeatureNotImplementedException ex) {
+        logger.info("Terra Policy Service is not enabled");
+      }
     }
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
@@ -51,7 +51,7 @@ public class CreateSnapshotPolicyStep implements Step {
       FlightMap flightMap = flightContext.getWorkingMap();
       UUID snapshotId = flightMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
       try {
-        policyService.deletePao(snapshotId);
+        policyService.deletePaoIfExists(snapshotId);
       } catch (FeatureNotImplementedException ex) {
         logger.info("Terra Policy Service is not enabled");
       }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotPolicyStep.java
@@ -1,6 +1,5 @@
 package bio.terra.service.snapshot.flight.create;
 
-import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.policy.PolicyService;
@@ -38,8 +37,6 @@ public class CreateSnapshotPolicyStep implements Step {
         policyService.createSnapshotPao(snapshotId, policyInputs);
       } catch (PolicyConflictException ex) {
         logger.warn("Policy access object already exists for snapshot {}", snapshotId);
-      } catch (FeatureNotImplementedException ex) {
-        logger.info("Terra Policy Service is not enabled");
       }
     }
     return StepResult.getStepResultSuccess();
@@ -50,11 +47,7 @@ public class CreateSnapshotPolicyStep implements Step {
     if (enableSecureMonitoring) {
       FlightMap flightMap = flightContext.getWorkingMap();
       UUID snapshotId = flightMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
-      try {
-        policyService.deletePaoIfExists(snapshotId);
-      } catch (FeatureNotImplementedException ex) {
-        logger.info("Terra Policy Service is not enabled");
-      }
+      policyService.deletePaoIfExists(snapshotId);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
@@ -1,6 +1,5 @@
 package bio.terra.service.snapshot.flight.delete;
 
-import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.dataset.Dataset;
@@ -37,11 +36,7 @@ public class DeleteSnapshotPolicyStep implements Step {
     UUID datasetId = map.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
     Dataset dataset = datasetService.retrieve(datasetId);
     if (dataset.isSecureMonitoringEnabled()) {
-      try {
-        policyService.deletePaoIfExists(snapshotId);
-      } catch (FeatureNotImplementedException ex) {
-        logger.info("Terra Policy Service is not enabled");
-      }
+      policyService.deletePaoIfExists(snapshotId);
     }
     return StepResult.getStepResultSuccess();
   }
@@ -59,8 +54,6 @@ public class DeleteSnapshotPolicyStep implements Step {
         policyService.createSnapshotPao(snapshotId, policyInputs);
       } catch (PolicyConflictException ex) {
         logger.warn("Policy access object already exists for snapshot {}", snapshotId);
-      } catch (FeatureNotImplementedException ex) {
-        logger.info("Terra Policy Service is not enabled");
       }
     }
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
@@ -1,20 +1,23 @@
 package bio.terra.service.snapshot.flight.delete;
 
 import bio.terra.common.exception.FeatureNotImplementedException;
+import bio.terra.policy.model.TpsPolicyInput;
+import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
-import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.policy.PolicyService;
+import bio.terra.service.policy.exception.PolicyConflictException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DeleteSnapshotPolicyStep extends DefaultUndoStep {
+public class DeleteSnapshotPolicyStep implements Step {
   private static final Logger logger = LoggerFactory.getLogger(DeleteSnapshotPolicyStep.class);
   private final DatasetService datasetService;
   private final PolicyService policyService;
@@ -36,6 +39,26 @@ public class DeleteSnapshotPolicyStep extends DefaultUndoStep {
     if (dataset.isSecureMonitoringEnabled()) {
       try {
         policyService.deletePao(snapshotId);
+      } catch (FeatureNotImplementedException ex) {
+        logger.info("Terra Policy Service is not enabled");
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    FlightMap map = flightContext.getWorkingMap();
+    UUID datasetId = map.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
+    Dataset dataset = datasetService.retrieve(datasetId);
+    if (dataset.isSecureMonitoringEnabled()) {
+      TpsPolicyInput protectedDataPolicy = PolicyService.getProtectedDataPolicyInput();
+      TpsPolicyInputs policyInputs = new TpsPolicyInputs().addInputsItem(protectedDataPolicy);
+      try {
+        policyService.createSnapshotPao(snapshotId, policyInputs);
+      } catch (PolicyConflictException ex) {
+        logger.warn("Policy access object already exists for snapshot {}", snapshotId);
       } catch (FeatureNotImplementedException ex) {
         logger.info("Terra Policy Service is not enabled");
       }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
@@ -1,9 +1,13 @@
 package bio.terra.service.snapshot.flight.delete;
 
 import bio.terra.common.exception.FeatureNotImplementedException;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.policy.PolicyService;
 import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
@@ -12,10 +16,13 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteSnapshotPolicyStep extends DefaultUndoStep {
   private static final Logger logger = LoggerFactory.getLogger(DeleteSnapshotPolicyStep.class);
+  private final DatasetService datasetService;
   private final PolicyService policyService;
   private final UUID snapshotId;
 
-  public DeleteSnapshotPolicyStep(PolicyService policyService, UUID snapshotId) {
+  public DeleteSnapshotPolicyStep(
+      DatasetService datasetService, PolicyService policyService, UUID snapshotId) {
+    this.datasetService = datasetService;
     this.policyService = policyService;
     this.snapshotId = snapshotId;
   }
@@ -23,10 +30,15 @@ public class DeleteSnapshotPolicyStep extends DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    try {
-      policyService.deletePao(snapshotId);
-    } catch (FeatureNotImplementedException ex) {
-      logger.info("Terra Policy Service is not enabled");
+    FlightMap map = flightContext.getWorkingMap();
+    UUID datasetId = map.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
+    Dataset dataset = datasetService.retrieve(datasetId);
+    if (dataset.isSecureMonitoringEnabled()) {
+      try {
+        policyService.deletePao(snapshotId);
+      } catch (FeatureNotImplementedException ex) {
+        logger.info("Terra Policy Service is not enabled");
+      }
     }
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
@@ -38,7 +38,7 @@ public class DeleteSnapshotPolicyStep implements Step {
     Dataset dataset = datasetService.retrieve(datasetId);
     if (dataset.isSecureMonitoringEnabled()) {
       try {
-        policyService.deletePao(snapshotId);
+        policyService.deletePaoIfExists(snapshotId);
       } catch (FeatureNotImplementedException ex) {
         logger.info("Terra Policy Service is not enabled");
       }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
@@ -1,61 +1,49 @@
 package bio.terra.service.snapshot.flight.delete;
 
-import bio.terra.policy.model.TpsPolicyInput;
-import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.policy.PolicyService;
-import bio.terra.service.policy.exception.PolicyConflictException;
+import bio.terra.service.snapshot.flight.SnapshotPolicyStep;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class DeleteSnapshotPolicyStep implements Step {
-  private static final Logger logger = LoggerFactory.getLogger(DeleteSnapshotPolicyStep.class);
+public class DeleteSnapshotPolicyStep extends SnapshotPolicyStep {
   private final DatasetService datasetService;
-  private final PolicyService policyService;
   private final UUID snapshotId;
 
   public DeleteSnapshotPolicyStep(
       DatasetService datasetService, PolicyService policyService, UUID snapshotId) {
+    super(policyService);
     this.datasetService = datasetService;
-    this.policyService = policyService;
     this.snapshotId = snapshotId;
+  }
+
+  @Override
+  public boolean isSecureMonitoringEnabled(FlightContext context) throws InterruptedException {
+    FlightMap map = context.getWorkingMap();
+    UUID datasetId = map.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
+    Dataset dataset = datasetService.retrieve(datasetId);
+    return dataset.isSecureMonitoringEnabled();
+  }
+
+  @Override
+  public UUID getSnapshotId(FlightContext flightContext) {
+    return snapshotId;
   }
 
   @Override
   public StepResult doStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    FlightMap map = flightContext.getWorkingMap();
-    UUID datasetId = map.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
-    Dataset dataset = datasetService.retrieve(datasetId);
-    if (dataset.isSecureMonitoringEnabled()) {
-      policyService.deletePaoIfExists(snapshotId);
-    }
-    return StepResult.getStepResultSuccess();
+    return deletePaoStep(flightContext);
   }
 
   @Override
   public StepResult undoStep(FlightContext flightContext)
       throws InterruptedException, RetryException {
-    FlightMap map = flightContext.getWorkingMap();
-    UUID datasetId = map.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
-    Dataset dataset = datasetService.retrieve(datasetId);
-    if (dataset.isSecureMonitoringEnabled()) {
-      TpsPolicyInput protectedDataPolicy = PolicyService.getProtectedDataPolicyInput();
-      TpsPolicyInputs policyInputs = new TpsPolicyInputs().addInputsItem(protectedDataPolicy);
-      try {
-        policyService.createSnapshotPao(snapshotId, policyInputs);
-      } catch (PolicyConflictException ex) {
-        logger.warn("Policy access object already exists for snapshot {}", snapshotId);
-      }
-    }
-    return StepResult.getStepResultSuccess();
+    return createPaoStep(flightContext);
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPolicyStep.java
@@ -1,0 +1,33 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import bio.terra.common.exception.FeatureNotImplementedException;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.policy.PolicyService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteSnapshotPolicyStep extends DefaultUndoStep {
+  private static final Logger logger = LoggerFactory.getLogger(DeleteSnapshotPolicyStep.class);
+  private final PolicyService policyService;
+  private final UUID snapshotId;
+
+  public DeleteSnapshotPolicyStep(PolicyService policyService, UUID snapshotId) {
+    this.policyService = policyService;
+    this.snapshotId = snapshotId;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    try {
+      policyService.deletePao(snapshotId);
+    } catch (FeatureNotImplementedException ex) {
+      logger.info("Terra Policy Service is not enabled");
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
@@ -153,7 +153,9 @@ public class SnapshotDeleteFlight extends Flight {
     addStep(new PerformGcpStep(new DeleteSnapshotProjectMetadataStep(resourceService)));
 
     // delete policy object in Terra Policy Service
-    addStep(new DeleteSnapshotPolicyStep(datasetService, policyService, snapshotId));
+    addStep(
+        new PerformDatasetStep(
+            new DeleteSnapshotPolicyStep(datasetService, policyService, snapshotId)));
 
     addStep(new PerformDatasetStep(new UnlockDatasetStep(datasetService, false)));
     addStep(

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
@@ -153,7 +153,7 @@ public class SnapshotDeleteFlight extends Flight {
     addStep(new PerformGcpStep(new DeleteSnapshotProjectMetadataStep(resourceService)));
 
     // delete policy object in Terra Policy Service
-    addStep(new DeleteSnapshotPolicyStep(policyService, snapshotId));
+    addStep(new DeleteSnapshotPolicyStep(datasetService, policyService, snapshotId));
 
     addStep(new PerformDatasetStep(new UnlockDatasetStep(datasetService, false)));
     addStep(

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
@@ -18,6 +18,7 @@ import bio.terra.service.filedata.google.firestore.FireStoreDao;
 import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.journal.JournalService;
+import bio.terra.service.policy.PolicyService;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
@@ -59,6 +60,7 @@ public class SnapshotDeleteFlight extends Flight {
     JournalService journalService = appContext.getBean(JournalService.class);
     DrsService drsService = appContext.getBean(DrsService.class);
     String tdrServiceAccountEmail = appContext.getBean("tdrServiceAccountEmail", String.class);
+    PolicyService policyService = appContext.getBean(PolicyService.class);
 
     RetryRule randomBackoffRetry =
         getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
@@ -149,6 +151,9 @@ public class SnapshotDeleteFlight extends Flight {
             new DeleteSnapshotMarkProjectStep(resourceService, snapshotId, snapshotService)));
     addStep(new PerformGcpStep(new DeleteSnapshotDeleteProjectStep(resourceService)));
     addStep(new PerformGcpStep(new DeleteSnapshotProjectMetadataStep(resourceService)));
+
+    // delete policy object in Terra Policy Service
+    addStep(new DeleteSnapshotPolicyStep(policyService, snapshotId));
 
     addStep(new PerformDatasetStep(new UnlockDatasetStep(datasetService, false)));
     addStep(

--- a/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
+++ b/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
@@ -94,7 +94,7 @@ public class PolicyServiceTest {
   void testDeleteSnapshotDao() throws Exception {
     mockPolicyApi();
     UUID snapshotId = UUID.randomUUID();
-    policyService.deletePao(snapshotId);
+    policyService.deletePaoIfExists(snapshotId);
     verify(tpsApi).deletePao(snapshotId);
   }
 
@@ -104,7 +104,7 @@ public class PolicyServiceTest {
     UUID snapshotId = UUID.randomUUID();
     var exception = new ApiException(HttpStatus.NOT_FOUND.value(), "Policy object not found");
     doThrow(exception).when(tpsApi).deletePao(snapshotId);
-    policyService.deletePao(snapshotId);
+    policyService.deletePaoIfExists(snapshotId);
     verify(tpsApi).deletePao(snapshotId);
   }
 

--- a/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
+++ b/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
@@ -80,7 +80,7 @@ public class PolicyServiceTest {
   }
 
   @Test
-  void testCreateSnapshotDao() throws Exception {
+  void testCreateSnapshotPao() throws Exception {
     mockPolicyServiceConfiguration();
     mockPolicyApi();
     policyService.createSnapshotPao(snapshotId, policies);
@@ -106,7 +106,7 @@ public class PolicyServiceTest {
   }
 
   @Test
-  void testDeleteSnapshotDao() throws Exception {
+  void testDeleteSnapshotPao() throws Exception {
     mockPolicyServiceConfiguration();
     mockPolicyApi();
     policyService.deletePaoIfExists(snapshotId);
@@ -120,7 +120,7 @@ public class PolicyServiceTest {
   }
 
   @Test
-  void testDeleteSnapshotDaoIgnoresNotFoundException() throws Exception {
+  void testDeleteSnapshotPaoIgnoresNotFoundException() throws Exception {
     mockPolicyServiceConfiguration();
     mockPolicyApi();
     var exception = new ApiException(HttpStatus.NOT_FOUND.value(), "Policy object not found");

--- a/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
+++ b/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,7 +46,11 @@ public class PolicyServiceTest {
   @Mock private PolicyApiService policyApiService;
   @Mock private TpsApi tpsApi;
   @Mock private PublicApi tpsUnauthApi;
+  private final UUID snapshotId = UUID.randomUUID();
   private PolicyService policyService;
+  private final TpsPolicyInput policy =
+      new TpsPolicyInput().namespace("terra").name("protected-data");
+  private final TpsPolicyInputs policies = new TpsPolicyInputs().addInputsItem(policy);
 
   @BeforeEach
   public void setup() throws Exception {
@@ -76,10 +81,8 @@ public class PolicyServiceTest {
 
   @Test
   void testCreateSnapshotDao() throws Exception {
+    mockPolicyServiceConfiguration();
     mockPolicyApi();
-    UUID snapshotId = UUID.randomUUID();
-    TpsPolicyInput policy = new TpsPolicyInput().namespace("terra").name("protected-data");
-    TpsPolicyInputs policies = new TpsPolicyInputs().addInputsItem(policy);
     policyService.createSnapshotPao(snapshotId, policies);
     verify(tpsApi)
         .createPao(
@@ -91,17 +94,35 @@ public class PolicyServiceTest {
   }
 
   @Test
+  void testCreatePaoPolicyServiceNotEnabled() throws Exception {
+    policyService.createSnapshotPao(snapshotId, policies);
+    verify(tpsApi, never())
+        .createPao(
+            new TpsPaoCreateRequest()
+                .objectId(snapshotId)
+                .component(TpsComponent.TDR)
+                .objectType(TpsObjectType.SNAPSHOT)
+                .attributes(policies));
+  }
+
+  @Test
   void testDeleteSnapshotDao() throws Exception {
+    mockPolicyServiceConfiguration();
     mockPolicyApi();
-    UUID snapshotId = UUID.randomUUID();
     policyService.deletePaoIfExists(snapshotId);
     verify(tpsApi).deletePao(snapshotId);
   }
 
   @Test
+  void testDeletePaoPolicyServiceNotEnabled() throws Exception {
+    policyService.deletePaoIfExists(snapshotId);
+    verify(tpsApi, never()).deletePao(snapshotId);
+  }
+
+  @Test
   void testDeleteSnapshotDaoIgnoresNotFoundException() throws Exception {
+    mockPolicyServiceConfiguration();
     mockPolicyApi();
-    UUID snapshotId = UUID.randomUUID();
     var exception = new ApiException(HttpStatus.NOT_FOUND.value(), "Policy object not found");
     doThrow(exception).when(tpsApi).deletePao(snapshotId);
     policyService.deletePaoIfExists(snapshotId);

--- a/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
@@ -52,7 +52,7 @@ public class CreateSnapshotPolicyStepTest {
     verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).deletePao(SNAPSHOT_ID);
+    verify(policyService).deletePaoIfExists(SNAPSHOT_ID);
   }
 
   @Test
@@ -74,7 +74,7 @@ public class CreateSnapshotPolicyStepTest {
     verify(policyService, never()).createSnapshotPao(SNAPSHOT_ID, policies);
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService, never()).deletePao(SNAPSHOT_ID);
+    verify(policyService, never()).deletePaoIfExists(SNAPSHOT_ID);
   }
 
   @Test
@@ -83,7 +83,7 @@ public class CreateSnapshotPolicyStepTest {
     CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, true);
     var exception = new FeatureNotImplementedException("Policy service is not enabled");
     doThrow(exception).when(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
-    doThrow(exception).when(policyService).deletePao(SNAPSHOT_ID);
+    doThrow(exception).when(policyService).deletePaoIfExists(SNAPSHOT_ID);
 
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
@@ -91,6 +91,6 @@ public class CreateSnapshotPolicyStepTest {
 
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).deletePao(SNAPSHOT_ID);
+    verify(policyService).deletePaoIfExists(SNAPSHOT_ID);
   }
 }

--- a/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.policy.PolicyService;
@@ -75,22 +74,5 @@ public class CreateSnapshotPolicyStepTest {
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verify(policyService, never()).deletePaoIfExists(SNAPSHOT_ID);
-  }
-
-  @Test
-  void testCreatePolicyServiceNotEnabled() throws Exception {
-    mockFlightMap();
-    CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, true);
-    var exception = new FeatureNotImplementedException("Policy service is not enabled");
-    doThrow(exception).when(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
-    doThrow(exception).when(policyService).deletePaoIfExists(SNAPSHOT_ID);
-
-    StepResult doResult = step.doStep(flightContext);
-    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
-
-    StepResult undoResult = step.undoStep(flightContext);
-    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).deletePaoIfExists(SNAPSHOT_ID);
   }
 }

--- a/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
@@ -83,6 +83,7 @@ public class CreateSnapshotPolicyStepTest {
     CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, true);
     var exception = new FeatureNotImplementedException("Policy service is not enabled");
     doThrow(exception).when(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
+    doThrow(exception).when(policyService).deletePao(SNAPSHOT_ID);
 
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));

--- a/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.policy.PolicyService;
@@ -74,5 +75,21 @@ public class CreateSnapshotPolicyStepTest {
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verify(policyService, never()).deletePao(SNAPSHOT_ID);
+  }
+
+  @Test
+  void testCreatePolicyServiceNotEnabled() throws Exception {
+    mockFlightMap();
+    CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, true);
+    var exception = new FeatureNotImplementedException("Policy service is not enabled");
+    doThrow(exception).when(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
+
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService).deletePao(SNAPSHOT_ID);
   }
 }

--- a/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
@@ -1,0 +1,54 @@
+package bio.terra.service.policy.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.*;
+
+import bio.terra.common.exception.FeatureNotImplementedException;
+import bio.terra.service.policy.PolicyService;
+import bio.terra.service.snapshot.flight.delete.DeleteSnapshotPolicyStep;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
+public class DeleteSnapshotPolicyStepTest {
+  @Mock private PolicyService policyService;
+  @Mock private FlightContext flightContext;
+
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private DeleteSnapshotPolicyStep step;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    step = new DeleteSnapshotPolicyStep(policyService, SNAPSHOT_ID);
+  }
+
+  @Test
+  void testDeletePolicyDoUndo() throws Exception {
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService).deletePao(SNAPSHOT_ID);
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void testDeletePolicyServiceNotEnabled() throws Exception {
+    var exception = new FeatureNotImplementedException("Policy service is not enabled");
+    doThrow(exception).when(policyService).deletePao(SNAPSHOT_ID);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService).deletePao(SNAPSHOT_ID);
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+}

--- a/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.*;
 
-import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.dataset.Dataset;
@@ -56,22 +55,6 @@ public class DeleteSnapshotPolicyStepTest {
   @Test
   void testDeletePolicyDoUndo() throws Exception {
     mockSecureMonitoringEnabledDataset();
-    StepResult doResult = step.doStep(flightContext);
-    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).deletePaoIfExists(SNAPSHOT_ID);
-
-    StepResult undoResult = step.undoStep(flightContext);
-    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
-  }
-
-  @Test
-  void testDeletePolicyServiceNotEnabled() throws Exception {
-    mockSecureMonitoringEnabledDataset();
-    var exception = new FeatureNotImplementedException("Policy service is not enabled");
-    doThrow(exception).when(policyService).deletePaoIfExists(SNAPSHOT_ID);
-    doThrow(exception).when(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
-
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verify(policyService).deletePaoIfExists(SNAPSHOT_ID);

--- a/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
@@ -58,7 +58,7 @@ public class DeleteSnapshotPolicyStepTest {
     mockSecureMonitoringEnabledDataset();
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).deletePao(SNAPSHOT_ID);
+    verify(policyService).deletePaoIfExists(SNAPSHOT_ID);
 
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
@@ -69,12 +69,12 @@ public class DeleteSnapshotPolicyStepTest {
   void testDeletePolicyServiceNotEnabled() throws Exception {
     mockSecureMonitoringEnabledDataset();
     var exception = new FeatureNotImplementedException("Policy service is not enabled");
-    doThrow(exception).when(policyService).deletePao(SNAPSHOT_ID);
+    doThrow(exception).when(policyService).deletePaoIfExists(SNAPSHOT_ID);
     doThrow(exception).when(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
 
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).deletePao(SNAPSHOT_ID);
+    verify(policyService).deletePaoIfExists(SNAPSHOT_ID);
 
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));

--- a/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.*;
 
 import bio.terra.common.exception.FeatureNotImplementedException;
+import bio.terra.policy.model.TpsPolicyInput;
+import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetSummary;
@@ -32,6 +34,10 @@ public class DeleteSnapshotPolicyStepTest {
 
   private static final UUID DATASET_ID = UUID.randomUUID();
   private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final TpsPolicyInput protectedDataPolicy =
+      PolicyService.getProtectedDataPolicyInput();
+  private static final TpsPolicyInputs policies =
+      new TpsPolicyInputs().addInputsItem(protectedDataPolicy);
   private DeleteSnapshotPolicyStep step;
 
   @BeforeEach
@@ -53,8 +59,10 @@ public class DeleteSnapshotPolicyStepTest {
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verify(policyService).deletePao(SNAPSHOT_ID);
+
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
   }
 
   @Test
@@ -62,11 +70,15 @@ public class DeleteSnapshotPolicyStepTest {
     mockSecureMonitoringEnabledDataset();
     var exception = new FeatureNotImplementedException("Policy service is not enabled");
     doThrow(exception).when(policyService).deletePao(SNAPSHOT_ID);
+    doThrow(exception).when(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
+
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verify(policyService).deletePao(SNAPSHOT_ID);
+
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
   }
 
   @Test
@@ -74,6 +86,8 @@ public class DeleteSnapshotPolicyStepTest {
     when(datasetService.retrieve(DATASET_ID)).thenReturn(new Dataset());
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verifyNoInteractions(policyService);
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3034

In `SnapshotDeleteFlight`, add a new step `DeleteSnapshotPolicyStep` that deletes the snapshot's policy from the Terra Policy Service if its parent dataset has `secureMonitoringEnabled`. TPS handles the case where the policy is still linked to a Terra workspace, so TDR does not need to perform that check before calling `policyService.deletePao`.