### PR TITLE
[DR-3042] Share common HTTP clients

### DIFF
--- a/src/main/java/bio/terra/service/rawls/RawlsClient.java
+++ b/src/main/java/bio/terra/service/rawls/RawlsClient.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -27,10 +26,9 @@ public class RawlsClient {
   private final HttpHeaders headers;
 
   @Autowired
-  public RawlsClient(RawlsConfiguration rawlsConfiguration) {
+  public RawlsClient(RawlsConfiguration rawlsConfiguration, RestTemplate restTemplate) {
     this.rawlsConfiguration = rawlsConfiguration;
-    this.restTemplate = new RestTemplate();
-    restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+    this.restTemplate = restTemplate;
     this.headers = new HttpHeaders();
     headers.setAccept(List.of(MediaType.APPLICATION_JSON));
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
@@ -6,7 +6,6 @@ import bio.terra.buffer.api.UnauthenticatedApi;
 import bio.terra.buffer.client.ApiClient;
 import bio.terra.buffer.client.ApiException;
 import bio.terra.buffer.model.HandoutRequestBody;
-import bio.terra.buffer.model.PoolInfo;
 import bio.terra.buffer.model.ResourceInfo;
 import bio.terra.buffer.model.SystemStatus;
 import bio.terra.buffer.model.SystemStatusSystems;
@@ -22,6 +21,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Map;
 import java.util.UUID;
+import javax.ws.rs.client.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +38,8 @@ public class BufferService {
   private final ResourceBufferServiceConfiguration bufferServiceConfiguration;
   private final GoogleResourceConfiguration googleConfig;
   private final GoogleResourceManagerService googleResourceManagerService;
+  /** Clients should be shared among requests to reduce latency and save memory * */
+  private final Client sharedHttpClient;
 
   @Autowired
   public BufferService(
@@ -47,51 +49,23 @@ public class BufferService {
     this.bufferServiceConfiguration = bufferServiceConfiguration;
     this.googleConfig = googleConfig;
     this.googleResourceManagerService = googleResourceManagerService;
+    this.sharedHttpClient = new ApiClient().getHttpClient();
   }
 
-  private ApiClient getApiClient(String accessToken) {
-    ApiClient client = new ApiClient();
+  private ApiClient createUnauthApiClient() {
+    return new ApiClient()
+        .setHttpClient(sharedHttpClient)
+        .setBasePath(bufferServiceConfiguration.getInstanceUrl());
+  }
+
+  private ApiClient createApiClient(String accessToken) {
+    ApiClient client = createUnauthApiClient();
     client.setAccessToken(accessToken);
-    client.setBasePath(bufferServiceConfiguration.getInstanceUrl());
     return client;
   }
 
-  private ApiClient getUnAuthApiClient() {
-    ApiClient client = new ApiClient();
-    client.setBasePath(bufferServiceConfiguration.getInstanceUrl());
-    return client;
-  }
-
-  private BufferApi bufferApi(String instanceUrl) throws IOException {
-    return new BufferApi(
-        getApiClient(bufferServiceConfiguration.getAccessToken()).setBasePath(instanceUrl));
-  }
-
-  /**
-   * Return the PoolInfo object for the ResourceBuffer pool that we are using to create Google Cloud
-   * projects. Note that this is configured once per Workspace Manager instance (both the instance
-   * of RBS to use and which pool) so no configuration happens here.
-   *
-   * @return PoolInfo
-   */
-  public PoolInfo getPoolInfo() {
-    try {
-      BufferApi bufferApi = bufferApi(bufferServiceConfiguration.getInstanceUrl());
-      PoolInfo info = bufferApi.getPoolInfo(bufferServiceConfiguration.getPoolId());
-      logger.info(
-          "Retrieved pool {} on Buffer Service instance {}",
-          bufferServiceConfiguration.getPoolId(),
-          bufferServiceConfiguration.getInstanceUrl());
-      return info;
-    } catch (IOException e) {
-      throw new BufferServiceAuthorizationException("Error reading or parsing credentials file", e);
-    } catch (ApiException e) {
-      if (e.getCode() == HttpStatus.UNAUTHORIZED.value()) {
-        throw new BufferServiceAuthorizationException("Not authorized to access Buffer Service", e);
-      } else {
-        throw new BufferServiceAPIException(e);
-      }
-    }
+  private BufferApi bufferApi() throws IOException {
+    return new BufferApi(createApiClient(bufferServiceConfiguration.getAccessToken()));
   }
 
   /**
@@ -105,7 +79,7 @@ public class BufferService {
     logger.info("Using request ID: {} to get project from RBS", handoutRequestId);
     HandoutRequestBody requestBody = new HandoutRequestBody().handoutRequestId(handoutRequestId);
     try {
-      BufferApi bufferApi = bufferApi(bufferServiceConfiguration.getInstanceUrl());
+      BufferApi bufferApi = bufferApi();
       ResourceInfo info =
           bufferApi.handoutResource(requestBody, bufferServiceConfiguration.getPoolId());
       logger.info(
@@ -156,7 +130,7 @@ public class BufferService {
   }
 
   public RepositoryStatusModelSystems status() {
-    UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(getUnAuthApiClient());
+    UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(createUnauthApiClient());
     try {
       SystemStatus status = unauthenticatedApi.serviceStatus();
       Map<String, SystemStatusSystems> subsystemStatusMap = status.getSystems();

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -13,7 +13,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -52,7 +52,7 @@ public class DataRepoClient {
 
     headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
-    headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON));
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
   }
 
   // -- RepositoryController Client --

--- a/src/test/java/bio/terra/integration/SamFixtures.java
+++ b/src/test/java/bio/terra/integration/SamFixtures.java
@@ -3,7 +3,6 @@ package bio.terra.integration;
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.configuration.TestConfiguration;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
@@ -34,7 +33,7 @@ public class SamFixtures {
   public SamFixtures() {
     headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
-    headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON));
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 
     restTemplate = new RestTemplate();
     restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamApiServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamApiServiceTest.java
@@ -2,63 +2,81 @@ package bio.terra.service.auth.iam.sam;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.when;
 
 import bio.terra.app.configuration.SamConfiguration;
-import bio.terra.common.category.Unit;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import okhttp3.ConnectionPool;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.test.context.ActiveProfiles;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
 public class SamApiServiceTest {
 
   @Mock private SamConfiguration samConfig;
   @Mock private ConfigurationService configurationService;
   private SamApiService samApiService;
+  private Map<String, ApiClient> unauthorizedApiClients;
+  private Map<String, ApiClient> authorizedApiClients;
 
   private static final String TOKEN = "some-access-token";
   private static final int OPERATION_TIMEOUT_SECONDS = 123;
   private static final int OPERATION_TIMEOUT_MILLIS = OPERATION_TIMEOUT_SECONDS * 1000;
 
-  @Before
-  public void setUp() throws Exception {
-    samApiService = new SamApiService(samConfig, configurationService);
-
+  @BeforeEach
+  void setUp() {
     when(configurationService.getParameterValue(ConfigEnum.SAM_OPERATION_TIMEOUT_SECONDS))
         .thenReturn(OPERATION_TIMEOUT_SECONDS);
-  }
-
-  @Test
-  public void testSamApiClientReadTimeouts() {
-    // We only have one unauthorized Sam API -- StatusApi -- and this is unlikely to change.
-    assertThat(
-        "StatusApi keeps default read timeout",
-        samApiService.statusApi().getApiClient().getReadTimeout(),
-        equalTo(new ApiClient().getReadTimeout()));
-
-    var authorizedApiClients =
+    samApiService = new SamApiService(samConfig, configurationService);
+    unauthorizedApiClients = Map.of("StatusApi", samApiService.statusApi().getApiClient());
+    authorizedApiClients =
         Map.of(
             "ResourcesApi", samApiService.resourcesApi(TOKEN).getApiClient(),
             "GoogleApi", samApiService.googleApi(TOKEN).getApiClient(),
             "UsersApi", samApiService.usersApi(TOKEN).getApiClient(),
             "TermsOfServiceApi", samApiService.termsOfServiceApi(TOKEN).getApiClient(),
             "GroupApi", samApiService.groupApi(TOKEN).getApiClient());
+  }
+
+  @Test
+  void testSamApiClientReadTimeouts() {
+    unauthorizedApiClients.forEach(
+        (name, client) ->
+            assertThat(
+                name + " keeps default read timeout",
+                client.getReadTimeout(),
+                equalTo(new ApiClient().getReadTimeout())));
     authorizedApiClients.forEach(
         (name, client) ->
             assertThat(
                 name + " has expected read timeout",
                 client.getReadTimeout(),
                 equalTo(OPERATION_TIMEOUT_MILLIS)));
+  }
+
+  @Test
+  void testSamApiClientsShareHttpClient() {
+    List<ApiClient> apiClients = new ArrayList<>();
+    apiClients.addAll(unauthorizedApiClients.values());
+    apiClients.addAll(authorizedApiClients.values());
+
+    // Our intention is that all Sam ApiClients share a common HttpClient, but under the covers
+    // we could have many HttpClients built to support different configuration that all reuse the
+    // same connection pool.
+    // As a proxy check, we make sure that the same connection pool is reused.
+    List<ConnectionPool> connectionPools =
+        apiClients.stream().map(ac -> ac.getHttpClient().connectionPool()).distinct().toList();
+    assertThat("All Sam ApiClients share a connection pool", connectionPools, hasSize(1));
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3042

While investigating recurring memory leaks in TDR, I found that we are not following best practices when constructing HTTP clients.  Visualization of a recent memory leak in a TDR prod API pod:

<img width="1196" alt="Screenshot 2023-05-18 at 12 07 24 PM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/277334fd-5bf8-46da-a895-284c33e7cbbb">

Timely discussion in Slack: https://broadinstitute.slack.com/archives/C03T815L316/p1684422897621399

A few instances of DSP projects which presently share clients safely:
- https://github.com/DataBiosphere/terra-workspace-manager/blob/3970810228cb235d507dcdb4a3c54f33fff5c463/service/src/main/java/bio/terra/workspace/service/iam/SamService.java#L106
- https://github.com/DataBiosphere/terra-data-catalog/blob/main/common/src/main/java/bio/terra/catalog/rawls/RawlsClient.java 

My developer environment is up to date with these latest changes:
- UI https://jade-ok.datarepo-dev.broadinstitute.org/
- Overview of my API deployment https://console.cloud.google.com/kubernetes/deployment/us-central1/dev-master/ok/ok-jade-datarepo-api/overview?authuser=1&project=broad-jade-dev
- 
  It's certainly lower traffic than other environments and my changes haven't been on there long, so it's hard to draw sweeping conclusions.  But I do see that the TDR dev API pods show signs of memory leaks, so if we were to merge this in we'd likely get an early indication of its impact before it made it to prod:

<img width="1477" alt="Screenshot 2023-05-18 at 5 46 13 PM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/a951b0c8-9d0c-4a6a-bbb5-085e8fc23ed8">

**Sam**

[OkHttpClient docs](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/) used for Sam calls:
> OkHttp performs best when you create a single OkHttpClient instance and reuse it for all of your HTTP calls. This is because each client holds its own connection pool and thread pools. Reusing connections and threads reduces latency and saves memory. Conversely, creating a client for each request wastes resources on idle pools.

We did not follow those recommendations and implicitly constructed new `OkHttpClient`s on every call.

Now, Sam APIs share a common `OkHttpClient`.  Tokens are stored on the wrapper `ApiClient` and not the shared `Client`.  Sam APIs may build new `OkHttpClient`s to handle custom configuration, but they will all share common connection pools and thread pools.

**RBS**

[Oracle Client docs](https://docs.oracle.com/javaee/7/api/javax/ws/rs/client/Client.html) used for RBS calls:
> Clients are heavy-weight objects that manage the client-side communication infrastructure. Initialization as well as disposal of a Client instance may be a rather expensive operation. It is therefore advised to construct only a small number of Client instances in the application. Client instances must be properly closed before being disposed to avoid leaking resources.

We did not follow those recommendations and implicitly constructed new Clients on every call without closing them.

Now, RBS APIs share a common `Client`, though we don't bother to close it as it will be closed on app shut-down anyway.  Tokens are stored on the wrapper `ApiClient` and not the shared `Client`.

**Others**

I also found several instances where we were not using the shared `RestTemplate` bean, but could have been.  I flagged swaps that I wasn't confident in for reviewers.

**Follow-On Work**

I may not get to these in time for the next release train, so I think if we're comfortable with these current changes we shouldn't hold the PR and instead pursue a follow-on for the rest and any further improvements.

- [x] `PolicyApiService` should use a shared `Client`
- [x] `Oauth2ApiController` can use `RestTemplate` bean
- [ ] `OpenIDConnectConfiguration` can use `RestTemplate` bean (actually will hold off, looking at this I think it might need its own?)