### PR TITLE
DR-2792 Add ability to specify Terra project to bill to when accessing DRS object

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,7 @@ dependencies {
     implementation "org.springframework.cloud:spring-cloud-starter-sleuth:3.0.2"
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-7bfd91d'
     implementation 'org.antlr:ST4:4.3'                          // String templating
-    implementation group: 'io.kubernetes', name: 'client-java', version: '10.0.0'
+    implementation group: 'io.kubernetes', name: 'client-java', version: '18.0.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'javax.servlet:jstl:1.2'
@@ -239,7 +239,7 @@ dependencies {
         implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
         implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.2'
     } else {
-        implementation ('bio.terra:terra-common-lib:0.0.55-SNAPSHOT') {
+        implementation ('bio.terra:terra-common-lib:0.0.89-SNAPSHOT') {
             exclude group: 'org.broadinstitute.dsde.workbench', module: 'sam-client_2.12'
         }
     }
@@ -249,6 +249,8 @@ dependencies {
     implementation group: "bio.terra", name: "externalcreds-client-resttemplate", version: "0.72.0-SNAPSHOT"
     implementation group: "org.glassfish.jersey.inject", name: "jersey-hk2", version: "2.30.1"
 
+    // Pin the version of the OkHttp client to avoid a conflict with the version used by the Sam client
+    implementation group: "com.squareup.okhttp3", name: "okhttp", version: "4.10.0"
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus:1.8.6'
 

--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ dependencies {
     implementation 'org.springframework:spring-jdbc:5.1.9.RELEASE'
     implementation 'org.springframework.cloud:spring-cloud-gcp-starter-logging:1.2.8.RELEASE'
     implementation "org.springframework.cloud:spring-cloud-starter-sleuth:3.0.2"
-    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-c53306a-SNAP'
+    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-7bfd91d'
     implementation 'org.antlr:ST4:4.3'                          // String templating
     implementation group: 'io.kubernetes', name: 'client-java', version: '10.0.0'
 

--- a/datarepo-clienttests/src/main/java/scripts/utils/tdrwrapper/DataRepoWrap.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/tdrwrapper/DataRepoWrap.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import runner.config.ServerSpecification;

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -29,9 +29,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @Api(tags = {"DataRepositoryService"})
@@ -130,26 +127,27 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
 
   @Override
   public ResponseEntity<DRSAccessURL> getAccessURL(
-      @PathVariable("object_id") String objectId, @PathVariable("access_id") String accessId) {
+      String objectId, String accessId, String userProject) {
     AuthenticatedUserRequest authUser = getAuthenticatedInfo();
-    DRSAccessURL accessURL = drsService.getAccessUrlForObjectId(authUser, objectId, accessId);
+    DRSAccessURL accessURL =
+        drsService.getAccessUrlForObjectId(authUser, objectId, accessId, userProject);
     return new ResponseEntity<>(accessURL, HttpStatus.OK);
   }
 
   @Override
   public ResponseEntity<DRSAccessURL> postAccessURL(
-      @PathVariable("object_id") String objectId,
-      @PathVariable("access_id") String accessId,
-      @RequestBody DRSPassportRequestModel drsPassportRequestModel) {
+      String objectId,
+      String accessId,
+      DRSPassportRequestModel drsPassportRequestModel,
+      String userProject) {
     DRSAccessURL accessURL =
-        drsService.postAccessUrlForObjectId(objectId, accessId, drsPassportRequestModel);
+        drsService.postAccessUrlForObjectId(
+            objectId, accessId, drsPassportRequestModel, userProject);
     return new ResponseEntity<>(accessURL, HttpStatus.OK);
   }
 
   @Override
-  public ResponseEntity<DRSObject> getObject(
-      @PathVariable("object_id") String objectId,
-      @RequestParam(value = "expand", required = false, defaultValue = "false") Boolean expand) {
+  public ResponseEntity<DRSObject> getObject(String objectId, Boolean expand) {
     // The incoming object id is a DRS object id, not a file id.
     AuthenticatedUserRequest authUser = getAuthenticatedInfo();
     DRSObject drsObject = drsService.lookupObjectByDrsId(authUser, objectId, expand);
@@ -164,8 +162,7 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
 
   @Override
   public ResponseEntity<DRSObject> postObject(
-      @PathVariable("object_id") String objectId,
-      @RequestBody DRSPassportRequestModel drsPassportRequestModel) {
+      String objectId, DRSPassportRequestModel drsPassportRequestModel) {
     DRSObject drsObject = drsService.lookupObjectByDrsIdPassport(objectId, drsPassportRequestModel);
     return new ResponseEntity<>(drsObject, HttpStatus.OK);
   }

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -8,6 +8,7 @@ import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.model.UserStatusInfo;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -240,4 +241,20 @@ public interface IamProviderInterface {
    * @param groupName name of Firecloud managed group to delete
    */
   void deleteGroup(String accessToken, String groupName) throws InterruptedException;
+
+  /**
+   * Gets a signed URL for the given blob, signed by the Pet Service account of the calling user.
+   * The signed URL is scoped to the permissions of the signing Pet Service Account. Will provide a
+   * signed URL for any object path, even if that object does not exist.
+   *
+   * @param userReq authenticated user
+   * @param project Google project to use to sign blob
+   * @param path path to blob to sign
+   * @param duration duration of the signed URL
+   * @return signed URL containing the project as well as the email address of the user who
+   *     requested the URL for auditing purposes
+   */
+  String signUrlForBlob(
+      AuthenticatedUserRequest userReq, String project, String path, Duration duration)
+      throws InterruptedException;
 }

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -413,4 +413,21 @@ public class IamService {
     String tdrSaAccessToken = googleCredentialsService.getApplicationDefaultAccessToken(SCOPES);
     callProvider(() -> iamProvider.deleteGroup(tdrSaAccessToken, groupName));
   }
+
+  /**
+   * Gets a signed URL for the given blob, signed by the Pet Service account of the calling user.
+   * The signed URL is scoped to the permissions of the signing Pet Service Account. Will provide a
+   * signed URL for any object path, even if that object does not exist.
+   *
+   * @param userReq authenticated user
+   * @param project Google project to use to sign blob
+   * @param path path to blob to sign
+   * @param duration duration of the signed URL
+   * @return signed URL containing the project as well as the email address of the user who
+   *     requested the URL for auditing purposes
+   */
+  public String signUrlForBlob(
+      AuthenticatedUserRequest userReq, String project, String path, Duration duration) {
+    return callProvider(() -> iamProvider.signUrlForBlob(userReq, project, path, duration));
+  }
 }

--- a/src/main/java/bio/terra/service/auth/iam/LocalAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/service/auth/iam/LocalAuthenticatedUserRequestFactory.java
@@ -8,7 +8,7 @@ import bio.terra.service.auth.oauth2.exceptions.OauthTokeninfoRetrieveException;
 import com.google.api.services.oauth2.model.Tokeninfo;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -237,6 +237,7 @@ public class SamIam implements IamProviderInterface {
         IamRole.SNAPSHOT_CREATOR.toString(),
         createAccessPolicyV2(IamRole.SNAPSHOT_CREATOR, policies.getSnapshotCreators()));
 
+    req.authDomain(List.of());
     logger.debug("SAM request: " + req);
     return req;
   }

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -22,11 +22,15 @@ import bio.terra.service.auth.iam.exception.IamForbiddenException;
 import bio.terra.service.auth.iam.exception.IamInternalServerErrorException;
 import bio.terra.service.auth.iam.exception.IamNotFoundException;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
+import bio.terra.service.common.gcs.GcsUriUtils;
 import bio.terra.service.configuration.ConfigurationService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.cloud.storage.BlobId;
 import com.google.common.annotations.VisibleForTesting;
+import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,6 +54,8 @@ import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEn
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
+import org.broadinstitute.dsde.workbench.client.sam.model.SignedUrlRequest;
+import org.broadinstitute.dsde.workbench.client.sam.model.SyncReportEntry;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatus;
 import org.slf4j.Logger;
@@ -297,6 +303,7 @@ public class SamIam implements IamProviderInterface {
         IamRole.DISCOVERER.toString(),
         createAccessPolicyV2(IamRole.DISCOVERER, policies.getDiscoverers()));
 
+    req.authDomain(List.of());
     logger.debug("SAM request: " + req);
     return req;
   }
@@ -315,10 +322,10 @@ public class SamIam implements IamProviderInterface {
   private String syncOnePolicy(
       AuthenticatedUserRequest userReq, IamResourceType resourceType, UUID id, IamRole role)
       throws ApiException {
-    Map<String, List<Object>> results =
+    Map<String, List<SyncReportEntry>> results =
         samApiService
             .googleApi(userReq.getToken())
-            .syncPolicy(resourceType.toString(), id.toString(), role.toString());
+            .syncPolicy(resourceType.toString(), id.toString(), role.toString(), null);
     String policyEmail = getPolicyGroupEmailFromResponse(results);
     logger.debug(
         "Policy Group Resource: {} Role: {} Email:  {} ",
@@ -346,6 +353,7 @@ public class SamIam implements IamProviderInterface {
         IamRole.OWNER.toString(),
         createAccessPolicyOneV2(IamRole.OWNER, userStatusInfo.getUserEmail()));
     req.putPoliciesItem(IamRole.USER.toString(), createAccessPolicyV2(IamRole.USER, null));
+    req.authDomain(List.of());
 
     ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
     logger.debug("SAM request: " + req);
@@ -398,7 +406,9 @@ public class SamIam implements IamProviderInterface {
                       .name(entry.getPolicyName())
                       .members(entry.getPolicy().getMemberEmails())
                       .memberPolicies(
-                          entry.getPolicy().getMemberPolicies().stream()
+                          Optional.ofNullable(entry.getPolicy().getMemberPolicies())
+                              .orElseGet(List::of)
+                              .stream()
                               .map(
                                   pid ->
                                       new ResourcePolicyModel()
@@ -465,7 +475,7 @@ public class SamIam implements IamProviderInterface {
         policyName,
         userEmail);
     samResourceApi.addUserToPolicyV2(
-        iamResourceType.toString(), resourceId.toString(), policyName, userEmail);
+        iamResourceType.toString(), resourceId.toString(), policyName, userEmail, null);
   }
 
   @Override
@@ -561,7 +571,7 @@ public class SamIam implements IamProviderInterface {
         () -> {
           try {
             logger.info("Running the registration process");
-            samApiService.usersApi(accessToken).createUserV2();
+            samApiService.usersApi(accessToken).createUserV2(null);
           } catch (ApiException e) {
             // This conflict could happen if the request timed out originally.
             // In that case, it's ok to assume that this is a success and move on
@@ -586,7 +596,7 @@ public class SamIam implements IamProviderInterface {
   }
 
   private void createGroupInner(String accessToken, String groupName) throws ApiException {
-    samApiService.groupApi(accessToken).postGroup(groupName);
+    samApiService.groupApi(accessToken).postGroup(groupName, null);
   }
 
   private String getGroupEmail(String accessToken, String groupName) throws ApiException {
@@ -660,7 +670,8 @@ public class SamIam implements IamProviderInterface {
    * @param syncPolicyResponse map with one key that is an email
    * @return the policy group email
    */
-  private String getPolicyGroupEmailFromResponse(Map<String, List<Object>> syncPolicyResponse) {
+  private String getPolicyGroupEmailFromResponse(
+      Map<String, List<SyncReportEntry>> syncPolicyResponse) {
     if (syncPolicyResponse.size() != 1) {
       throw new IllegalArgumentException(
           "Expecting syncPolicyResponse to be an object with one key");

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestPopulateFileStateFromFlightMapStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestPopulateFileStateFromFlightMapStep.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public abstract class IngestPopulateFileStateFromFlightMapStep implements Step {
 

--- a/src/main/java/bio/terra/service/dataset/flight/transactions/TransactionVerifyStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/transactions/TransactionVerifyStep.java
@@ -12,7 +12,7 @@ import bio.terra.stairway.StepResult;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -993,13 +993,13 @@ public class DrsService {
   @VisibleForTesting
   static class SnapshotCacheResult {
     private final UUID id;
-    private final Boolean isSelfHosted;
+    private final boolean isSelfHosted;
     private final BillingProfileModel datasetBillingProfileModel;
     private final UUID snapshotBillingProfileId;
     private final CloudPlatform cloudPlatform;
     private final String googleProjectId;
     private final String datasetProjectId;
-    private final Boolean globalFileIds;
+    private final boolean globalFileIds;
 
     public SnapshotCacheResult(Snapshot snapshot) {
       this.id = snapshot.getId();

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -62,7 +62,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -108,7 +108,7 @@ public class GcsPdao implements CloudFileReader {
       "roles/serviceusage.serviceUsageConsumer";
 
   private static final String PSA_SEPARATOR = "|";
-  // Cache of pet service account tokens keys on a given user's actual access_token + separator +
+  // Cache of pet service account tokens keyed on a given user's actual access_token + separator +
   // projectid combo
   private final Map<String, Tokeninfo> petAccountTokens =
       Collections.synchronizedMap(new PassiveExpiringMap<>(30, TimeUnit.MINUTES));

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -11,7 +11,7 @@ import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.models.StorageAccount;
 import java.util.Optional;
 import java.util.UUID;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -8,7 +8,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class SnapshotSummary {
   private UUID id;

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzFileAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzFileAclStep.java
@@ -23,7 +23,7 @@ import com.google.cloud.storage.StorageException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3732,6 +3732,15 @@ paths:
           required: true
           schema:
             type: string
+        - name: x-user-project
+          in: header
+          description: >
+            For GCP hosted files, this will indicate the user project to bill when accessing the
+            signed url.  This value must be a valid Terra billing project ID that the caller has
+            access to and only applies to GCP hosted data.
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: The access URL was found successfully.
@@ -3806,6 +3815,15 @@ paths:
           in: path
           description: An `access_id` from the `access_methods` list of a Data Object
           required: true
+          schema:
+            type: string
+        - name: x-user-project
+          in: header
+          description: >
+            For GCP hosted files, this will indicate the user project to bill when accessing the
+            signed url.  This value must be a valid Terra billing project ID that the caller has
+            access to and only applies to GCP hosted data.
+          required: false
           schema:
             type: string
       requestBody:

--- a/src/test/java/bio/terra/common/TestUtils.java
+++ b/src/test/java/bio/terra/common/TestUtils.java
@@ -60,6 +60,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.junit.function.ThrowingRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.stringtemplate.v4.ST;
 
 public final class TestUtils {
@@ -345,5 +346,20 @@ public final class TestUtils {
       ThrowingRunnable runnable) {
     Throwable throwable = assertThrows("expect a failure", expectedThrowable, runnable);
     assertThat(throwable.getMessage(), containsString(expectedMessage));
+  }
+
+  /**
+   * Given an object with a private field, extract the value of that field and return it. Note: this
+   * should not be used for classes that we control but for third party library classes that aren't
+   * easily mocked (e.g. certain Google client SDK configuration classes)
+   *
+   * @param object The object to extract the value from
+   * @param fieldName The name of the field to extract
+   * @return A typed object containing the value of the field
+   * @param <T> The expected type of the field
+   */
+  public static <T> T extractValueFromPrivateObject(Object object, String fieldName) {
+    return objectMapper.convertValue(
+        ReflectionTestUtils.getField(object, fieldName), new TypeReference<>() {});
   }
 }

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -75,7 +75,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.CoreMatchers;
 import org.slf4j.Logger;

--- a/src/test/java/bio/terra/service/auth/iam/AccessTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/AccessTest.java
@@ -44,7 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -37,6 +37,8 @@ import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import com.google.api.client.http.HttpStatusCodes;
+import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,6 +56,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEn
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
+import org.broadinstitute.dsde.workbench.client.sam.model.SignedUrlRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.SubsystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserInfo;
@@ -742,5 +745,22 @@ public class SamIamTest {
         IamNotFoundException.class,
         () -> samIam.deleteGroup(accessToken, groupName));
     verify(samGroupApi).deleteGroup(groupName);
+  }
+
+  @Test
+  public void testSignUrl() throws InterruptedException, ApiException {
+    String project = "myProject";
+    String path = "gs://bucket/path/to/file";
+    Duration duration = Duration.ofMinutes(15);
+    samIam.signUrlForBlob(TEST_USER, project, path, duration);
+
+    // Verify the arguments are properly parsed and passed through
+    verify(samGoogleApi)
+        .getSignedUrlForBlob(
+            project,
+            new SignedUrlRequest()
+                .bucketName("bucket")
+                .blobName("path/to/file")
+                .duration(BigDecimal.valueOf(15)));
   }
 }

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -54,6 +54,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEn
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
+import org.broadinstitute.dsde.workbench.client.sam.model.SubsystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserInfo;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserResourcesResponse;
@@ -185,10 +186,20 @@ public class SamIamTest {
   public void testGetStatus() throws ApiException {
     when(samStatusApi.getSystemStatus())
         .thenReturn(
-            new SystemStatus().ok(true).systems(Map.of("GooglePubSub", Map.of("ok", true))));
+            new SystemStatus()
+                .ok(true)
+                .systems(Map.of("GooglePubSub", new SubsystemStatus().ok(true))));
     assertThat(
         samIam.samStatus(),
-        is(new RepositoryStatusModelSystems().ok(true).message("{GooglePubSub={ok=true}}")));
+        is(
+            new RepositoryStatusModelSystems()
+                .ok(true)
+                .message(
+                    """
+                        {GooglePubSub=class SubsystemStatus {
+                            ok: true
+                            messages: null
+                        }}""")));
   }
 
   @Test
@@ -294,7 +305,8 @@ public class SamIamTest {
       when(samGoogleApi.syncPolicy(
               IamResourceType.DATASET.getSamResourceName(),
               datasetId.toString(),
-              policy.toString()))
+              policy.toString(),
+              null))
           .thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", List.of()));
     }
 
@@ -411,7 +423,8 @@ public class SamIamTest {
       when(samGoogleApi.syncPolicy(
               IamResourceType.DATASNAPSHOT.getSamResourceName(),
               snapshotId.toString(),
-              policy.toString()))
+              policy.toString(),
+              null))
           .thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", List.of()));
     }
 
@@ -522,7 +535,8 @@ public class SamIamTest {
       when(samGoogleApi.syncPolicy(
               IamResourceType.DATASNAPSHOT.getSamResourceName(),
               profileId.toString(),
-              policy.toString()))
+              policy.toString(),
+              null))
           .thenReturn(Map.of("policygroup-" + policy + "@firecloud.org", List.of()));
     }
 
@@ -549,7 +563,8 @@ public class SamIamTest {
             IamResourceType.SPEND_PROFILE.getSamResourceName(),
             id.toString(),
             IamRole.OWNER.toString(),
-            userEmail);
+            userEmail,
+            null);
   }
 
   @Test
@@ -622,12 +637,12 @@ public class SamIamTest {
                 new UserInfo()
                     .userEmail("tdr-ingest-sa@my-project.iam.gserviceaccount.com")
                     .userSubjectId("subid"));
-    when(samUsersApi.createUserV2()).thenReturn(userStatus);
+    when(samUsersApi.createUserV2(null)).thenReturn(userStatus);
     when(samTosApi.acceptTermsOfService(anyString())).thenReturn(userStatus);
     UserStatus returnedUserStatus = samIam.registerUser(TEST_USER.getToken());
 
     // Verify that the correct Sam API calls were made
-    verify(samUsersApi).createUserV2();
+    verify(samUsersApi).createUserV2(null);
     verify(samTosApi).acceptTermsOfService(TOS_URL);
 
     assertThat("expected user is returned", returnedUserStatus, is(userStatus));
@@ -644,7 +659,7 @@ public class SamIamTest {
         "Firecloud group email is returned when creation succeeds and email returned by SAM",
         samIam.createGroup(accessToken, groupName),
         equalTo(groupEmail));
-    verify(samGroupApi).postGroup(groupName);
+    verify(samGroupApi).postGroup(groupName, null);
     verify(samGroupApi).getGroup(groupName);
   }
 
@@ -655,12 +670,12 @@ public class SamIamTest {
 
     ApiException samEx =
         new ApiException(HttpStatusCodes.STATUS_CODE_CONFLICT, "Group already exists");
-    doThrow(samEx).when(samGroupApi).postGroup(groupName);
+    doThrow(samEx).when(samGroupApi).postGroup(groupName, null);
     assertThrows(
         "IamConflictException is thrown when the group already exists",
         IamConflictException.class,
         () -> samIam.createGroup(accessToken, groupName));
-    verify(samGroupApi).postGroup(groupName);
+    verify(samGroupApi).postGroup(groupName, null);
     verify(samGroupApi, never()).getGroup(groupName);
   }
 
@@ -675,7 +690,7 @@ public class SamIamTest {
         "IamNotFoundException is thrown when the user cannot access their created group",
         IamNotFoundException.class,
         () -> samIam.createGroup(accessToken, groupName));
-    verify(samGroupApi).postGroup(groupName);
+    verify(samGroupApi).postGroup(groupName, null);
     verify(samGroupApi).getGroup(groupName);
   }
 

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.SyncReportEntry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -118,8 +119,9 @@ public class SamRetryIntegrationTest extends UsersBase {
   private String SyncPolicy(IamResourceType resourceType, UUID resourceId, IamRole role)
       throws ApiException {
 
-    Map<String, List<Object>> results =
-        samGoogleApi.syncPolicy(resourceType.toString(), resourceId.toString(), role.toString());
+    Map<String, List<SyncReportEntry>> results =
+        samGoogleApi.syncPolicy(
+            resourceType.toString(), resourceId.toString(), role.toString(), null);
     return results.keySet().iterator().next();
   }
 }


### PR DESCRIPTION
This PR adds a new optional header parameter to the DRS `GetAccessURL` endpoint named `x-user-project`.  When specified - and if the dataset is self hosted and in GCP - TDR will have Sam generate a signed URL to access the DRS-fronted file.  If it's not specified, then TDR will continue to use the snapshot's project to sign the URL.

Note: we'll still need the TDR or dataset service account to access the source bucket in order to detect the region that the bucket is in.

Also Note: the project needs to be a Terra workspace project.

![image](https://github.com/DataBiosphere/jade-data-repo/assets/5633787/2d665fc8-06b4-402d-9f46-eb48cb4c2eab)

A big part of this PR involves upgrading the Sam client, which also required upgrading the workbench libs version.  This in turn removed an old version of apache lang plugins so the PR upgrades the calls (just a matter of adding a 3 in the package name)

I tried to keep everything isolated into its own commit to make it easier to review
