### PR TITLE
[DR-3027] Disable pushing Bard events to MixPanel

### DIFF
--- a/src/main/java/bio/terra/app/usermetrics/BardEvent.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardEvent.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class BardEvent {
   private static final String APP_ID_FIELD = "appId";
   private static final String HOSTNAME_FIELD = "hostname";
+  private static final String USE_BIGQUERY_FIELD = "useBigQuery";
   private final String event;
   private final Map<String, Object> properties;
 
@@ -18,6 +19,7 @@ public class BardEvent {
     this.properties.putAll(properties);
     this.properties.put(APP_ID_FIELD, appId);
     this.properties.put(HOSTNAME_FIELD, hostName);
+    this.properties.put(USE_BIGQUERY_FIELD, true);
   }
 
   public String getEvent() {

--- a/src/main/java/bio/terra/app/usermetrics/BardEvent.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardEvent.java
@@ -9,7 +9,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class BardEvent {
   private static final String APP_ID_FIELD = "appId";
   private static final String HOSTNAME_FIELD = "hostname";
-  private static final String USE_BIGQUERY_FIELD = "useBigQuery";
+  private static final String PUSH_TO_MIXPANEL_FIELD = "pushToMixpanel";
   private final String event;
   private final Map<String, Object> properties;
 
@@ -19,7 +19,7 @@ public class BardEvent {
     this.properties.putAll(properties);
     this.properties.put(APP_ID_FIELD, appId);
     this.properties.put(HOSTNAME_FIELD, hostName);
-    this.properties.put(USE_BIGQUERY_FIELD, true);
+    this.properties.put(PUSH_TO_MIXPANEL_FIELD, false);
   }
 
   public String getEvent() {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3027

This PR sets the new `pushToMixPanel` Bard event property to `false`, which will prevent Bard from sending events to MixPanel (follow-on to https://github.com/DataBiosphere/bard/pull/63). The event logs in GCP now get sent to a bigQuery data warehouse so it is still possible to query the event data.