### PR TITLE
[DR-3067] Include array ingest in Azure integration test

### DIFF
--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -474,6 +474,41 @@ public class AzureIntegrationTest extends UsersBase {
     DatasetSpecificationModel datasetSchema = datasetModel.getSchema();
 
     // dataset ingest
+    // Ingest Metadata - 1 row in ARRAY mode
+    String arrayIngestTableName = "person";
+    String personIdField = "person_id";
+    String personYearOfBirthField = "year_of_birth";
+    Map<String, Integer> records = Map.of(personIdField, 1, personYearOfBirthField, 1980);
+    IngestRequestModel arrayIngestRequest =
+        new IngestRequestModel()
+            .ignoreUnknownValues(false)
+            .maxBadRecords(0)
+            .table(arrayIngestTableName)
+            .profileId(profileId)
+            .addRecordsItem(records)
+            .format(IngestRequestModel.FormatEnum.ARRAY)
+            .loadTag(Names.randomizeName("azureArrayIngest"));
+
+    IngestResponseModel arrayIngestResponse =
+        dataRepoFixtures.ingestJsonData(steward, datasetId, arrayIngestRequest);
+    assertThat("1 row was ingested", arrayIngestResponse.getRowCount(), equalTo(1L));
+    tableRowCount.put(arrayIngestTableName, 1);
+
+    Object firstPersonRow =
+        dataRepoFixtures
+            .retrieveDatasetData(steward, datasetId, arrayIngestTableName, 0, 1, null)
+            .getResult()
+            .get(0);
+    assertThat(
+        "record looks as expected - person_id",
+        ((LinkedHashMap) firstPersonRow).get(personIdField),
+        equalTo(records.get(personIdField)));
+
+    assertThat(
+        "record looks as expected - person_id",
+        ((LinkedHashMap) firstPersonRow).get(personYearOfBirthField),
+        equalTo(records.get(personYearOfBirthField)));
+
     // Ingest Metadata - 1 row from JSON file
     String datasetIngestFlightId = UUID.randomUUID().toString();
     String datasetIngestControlFileBlob =

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -4,6 +4,7 @@ import static bio.terra.service.filedata.azure.util.AzureBlobIOTestUtility.MIB;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
@@ -479,35 +480,8 @@ public class AzureIntegrationTest extends UsersBase {
     String personIdField = "person_id";
     String personYearOfBirthField = "year_of_birth";
     Map<String, Integer> records = Map.of(personIdField, 1, personYearOfBirthField, 1980);
-    IngestRequestModel arrayIngestRequest =
-        new IngestRequestModel()
-            .ignoreUnknownValues(false)
-            .maxBadRecords(0)
-            .table(arrayIngestTableName)
-            .profileId(profileId)
-            .addRecordsItem(records)
-            .format(IngestRequestModel.FormatEnum.ARRAY)
-            .loadTag(Names.randomizeName("azureArrayIngest"));
-
-    IngestResponseModel arrayIngestResponse =
-        dataRepoFixtures.ingestJsonData(steward, datasetId, arrayIngestRequest);
-    assertThat("1 row was ingested", arrayIngestResponse.getRowCount(), equalTo(1L));
+    testMetadataArrayIngest(arrayIngestTableName, records);
     tableRowCount.put(arrayIngestTableName, 1);
-
-    Object firstPersonRow =
-        dataRepoFixtures
-            .retrieveDatasetData(steward, datasetId, arrayIngestTableName, 0, 1, null)
-            .getResult()
-            .get(0);
-    assertThat(
-        "record looks as expected - person_id",
-        ((LinkedHashMap) firstPersonRow).get(personIdField),
-        equalTo(records.get(personIdField)));
-
-    assertThat(
-        "record looks as expected - person_id",
-        ((LinkedHashMap) firstPersonRow).get(personYearOfBirthField),
-        equalTo(records.get(personYearOfBirthField)));
 
     // Ingest Metadata - 1 row from JSON file
     String datasetIngestFlightId = UUID.randomUUID().toString();
@@ -1476,6 +1450,32 @@ public class AzureIntegrationTest extends UsersBase {
         dataRepoFixtures.ingestJsonData(steward, datasetId, ingestRequest);
 
     dataRepoFixtures.assertCombinedIngestCorrect(ingestResponse, steward);
+  }
+
+  public void testMetadataArrayIngest(String arrayIngestTableName, Map<String, Integer> records)
+      throws Exception {
+    IngestRequestModel arrayIngestRequest =
+        new IngestRequestModel()
+            .ignoreUnknownValues(false)
+            .maxBadRecords(0)
+            .table(arrayIngestTableName)
+            .profileId(profileId)
+            .addRecordsItem(records)
+            .format(IngestRequestModel.FormatEnum.ARRAY)
+            .loadTag(Names.randomizeName("azureArrayIngest"));
+
+    IngestResponseModel arrayIngestResponse =
+        dataRepoFixtures.ingestJsonData(steward, datasetId, arrayIngestRequest);
+    assertThat("1 row was ingested", arrayIngestResponse.getRowCount(), equalTo(1L));
+
+    @SuppressWarnings("unchecked")
+    Map<Object, Object> firstPersonRow =
+        (Map<Object, Object>)
+            dataRepoFixtures
+                .retrieveDatasetData(steward, datasetId, arrayIngestTableName, 0, 1, null)
+                .getResult()
+                .get(0);
+    records.forEach((key, value) -> assertThat(firstPersonRow, hasEntry(key, value)));
   }
 
   private String getSourceStorageAccountPrimarySharedKey() {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3067

This ticket was originally to add support for Azure array ingest, but it turns out it already exists! 🎉 This PR updates the Azure file ingest test to include ingesting metadata in `ARRAY` mode (the test already includes the `JSON` and `CSV` modes).