### PR TITLE
DR-3026 Enable Secure Logging on Azure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,11 +258,14 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
 
     // Azure related dependencies
-    implementation 'com.azure:azure-identity:1.2.5'
-    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.4.0'
-    implementation 'com.azure:azure-storage-common:12.11.1'
-    implementation 'com.azure:azure-storage-file-datalake:12.5.1'
-    implementation 'com.azure:azure-data-tables:12.1.0'
+    implementation 'com.azure:azure-identity:1.9.1'
+    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.28.0'
+    implementation 'com.azure.resourcemanager:azure-resourcemanager-loganalytics:1.0.0-beta.3'
+    implementation 'com.azure.resourcemanager:azure-resourcemanager-securityinsights:1.0.0-beta.4'
+    implementation 'com.azure:azure-storage-common:12.21.1'
+    implementation 'com.azure:azure-storage-file-datalake:12.15.2'
+    implementation 'com.azure:azure-data-tables:12.3.11'
+
 
     implementation 'io.sentry:sentry-logback:6.5.0'
 

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -65,11 +65,11 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jackson}"
 
     // Azure related dependencies
-    implementation 'com.azure:azure-identity:1.2.5'
-    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.4.0'
-    implementation 'com.azure:azure-storage-common:12.11.1'
-    implementation 'com.azure:azure-storage-file-datalake:12.5.1'
-    implementation 'com.azure:azure-data-tables:12.1.0'
+    implementation 'com.azure:azure-identity:1.9.1'
+    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.28.0'
+    implementation 'com.azure:azure-storage-common:12.21.1'
+    implementation 'com.azure:azure-storage-file-datalake:12.15.2'
+    implementation 'com.azure:azure-data-tables:12.3.11'
 
     // Gradle project property "datarepoclientjar" overrides the fetch from Maven
     if (project.hasProperty("datarepoclientjar")) {

--- a/src/main/java/bio/terra/app/utils/startup/StartupInitializer.java
+++ b/src/main/java/bio/terra/app/utils/startup/StartupInitializer.java
@@ -1,5 +1,8 @@
 package bio.terra.app.utils.startup;
 
+import bio.terra.service.filedata.azure.AzureSynapsePdao;
+import bio.terra.service.job.JobService;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -11,6 +14,16 @@ public final class StartupInitializer {
 
   public static void initialize(ApplicationContext applicationContext) {
     // Initialize jobService, stairway, migrate databases, perform recovery
-    applicationContext.getBean("jobService");
+    applicationContext.getBean(JobService.class);
+
+    AzureResourceConfiguration config =
+        applicationContext.getBean(AzureResourceConfiguration.class);
+    // Initialize the Synapse DB if needed
+    applicationContext
+        .getBean(AzureSynapsePdao.class)
+        .initializeDb(
+            config.getSynapse().getDatabaseName(),
+            config.getSynapse().getEncryptionKey(),
+            config.getSynapse().getParquetFileFormatName());
   }
 }

--- a/src/main/java/bio/terra/app/utils/startup/StartupInitializer.java
+++ b/src/main/java/bio/terra/app/utils/startup/StartupInitializer.java
@@ -1,9 +1,6 @@
 package bio.terra.app.utils.startup;
 
-import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.job.JobService;
-import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
-import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration.Synapse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -16,19 +13,5 @@ public final class StartupInitializer {
   public static void initialize(ApplicationContext applicationContext) {
     // Initialize jobService, stairway, migrate databases, perform recovery
     applicationContext.getBean(JobService.class);
-
-    // Initialize the Synapse DB if needed
-    Synapse config = applicationContext.getBean(AzureResourceConfiguration.class).getSynapse();
-    if (config != null && config.isInitialize()) {
-      logger.info("Initializing Synapse DB");
-      applicationContext
-          .getBean(AzureSynapsePdao.class)
-          .initializeDb(
-              config.getDatabaseName(),
-              config.getEncryptionKey(),
-              config.getParquetFileFormatName());
-    } else {
-      logger.info("Skipping Synapse DB initialization");
-    }
   }
 }

--- a/src/main/java/bio/terra/service/common/CommonMapKeys.java
+++ b/src/main/java/bio/terra/service/common/CommonMapKeys.java
@@ -7,6 +7,7 @@ public final class CommonMapKeys {
 
   public static final String DATASET_STORAGE_AUTH_INFO = PREFIX + "datasetStorageAuthInfo";
   public static final String SNAPSHOT_STORAGE_AUTH_INFO = PREFIX + "snapshotStorageAuthInfo";
+  public static final String SHOULD_PERFORM_CONTAINER_ROLLBACK = PREFIX + "rollbackContainer";
   public static final String DATASET_STORAGE_ACCOUNT_RESOURCE =
       PREFIX + "datasetStorageAccountResource";
   public static final String SNAPSHOT_STORAGE_ACCOUNT_RESOURCE =

--- a/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
@@ -59,7 +59,9 @@ public abstract class CreateAzureContainerStep implements Step {
         workingMap.get(getStorageAccountContextKey(), AzureStorageAccountResource.class);
 
     // If the container was created, delete it
-    if (workingMap.get(SHOULD_PERFORM_CONTAINER_ROLLBACK, Boolean.class)) {
+    Boolean shouldPerformRollback =
+        workingMap.get(SHOULD_PERFORM_CONTAINER_ROLLBACK, Boolean.class);
+    if (shouldPerformRollback != null && shouldPerformRollback) {
       resourceService.deleteStorageContainer(
           datasetAzureStorageAccountResource.getResourceId(),
           profileModel.getId(),

--- a/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
@@ -69,7 +69,7 @@ public abstract class CreateAzureContainerStep implements Step {
     return StepResult.getStepResultSuccess();
   }
 
-  /** Implement this method to return the billing profile model from the flight's context */
+  /** Return the billing profile model from the flight's context */
   protected BillingProfileModel getProfileModel(FlightContext context) {
     return context.getWorkingMap().get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
   }

--- a/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
@@ -25,7 +25,9 @@ public abstract class CreateAzureContainerStep implements Step {
   protected final String storageAccountContextKey;
 
   protected CreateAzureContainerStep(
-      ResourceService resourceService, AzureContainerPdao azureContainerPdao, String storageAccountContextKey) {
+      ResourceService resourceService,
+      AzureContainerPdao azureContainerPdao,
+      String storageAccountContextKey) {
     this.resourceService = resourceService;
     this.azureContainerPdao = azureContainerPdao;
     this.storageAccountContextKey = storageAccountContextKey;

--- a/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
@@ -21,10 +21,14 @@ public abstract class CreateAzureContainerStep implements Step {
   protected final ResourceService resourceService;
   protected final AzureContainerPdao azureContainerPdao;
 
+  /* the key that will store the storage account metadata in the flight's context */
+  protected final String storageAccountContextKey;
+
   protected CreateAzureContainerStep(
-      ResourceService resourceService, AzureContainerPdao azureContainerPdao) {
+      ResourceService resourceService, AzureContainerPdao azureContainerPdao, String storageAccountContextKey) {
     this.resourceService = resourceService;
     this.azureContainerPdao = azureContainerPdao;
+    this.storageAccountContextKey = storageAccountContextKey;
   }
 
   @Override
@@ -46,7 +50,7 @@ public abstract class CreateAzureContainerStep implements Step {
     }
 
     // Store the storage account in the working map.  This will be used in case of needing to undo
-    context.getWorkingMap().put(getStorageAccountContextKey(), storageAccount);
+    context.getWorkingMap().put(storageAccountContextKey, storageAccount);
 
     return StepResult.getStepResultSuccess();
   }
@@ -56,7 +60,7 @@ public abstract class CreateAzureContainerStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     BillingProfileModel profileModel = getProfileModel(context);
     AzureStorageAccountResource datasetAzureStorageAccountResource =
-        workingMap.get(getStorageAccountContextKey(), AzureStorageAccountResource.class);
+        workingMap.get(storageAccountContextKey, AzureStorageAccountResource.class);
 
     // If the container was created, delete it
     Boolean shouldPerformRollback =
@@ -75,12 +79,6 @@ public abstract class CreateAzureContainerStep implements Step {
   protected BillingProfileModel getProfileModel(FlightContext context) {
     return context.getWorkingMap().get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
   }
-
-  /**
-   * Implement this method to return the key that will store the storage account metadata in the
-   * flight's context
-   */
-  protected abstract String getStorageAccountContextKey();
 
   /** Implement this method to return the AzureStorageAccountResource from the flight's context */
   protected abstract AzureStorageAccountResource getAzureStorageAccountResource(

--- a/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
@@ -21,7 +21,7 @@ public abstract class CreateAzureContainerStep implements Step {
   protected final ResourceService resourceService;
   protected final AzureContainerPdao azureContainerPdao;
 
-  public CreateAzureContainerStep(
+  protected CreateAzureContainerStep(
       ResourceService resourceService, AzureContainerPdao azureContainerPdao) {
     this.resourceService = resourceService;
     this.azureContainerPdao = azureContainerPdao;

--- a/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/common/CreateAzureContainerStep.java
@@ -1,0 +1,74 @@
+package bio.terra.service.common;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+/**
+ * Extend this class to ensure that a created storage container gets created in a way that can be
+ * cleaned up if the flight fails
+ */
+public abstract class CreateAzureContainerStep implements Step {
+  protected final ResourceService resourceService;
+  protected final AzureContainerPdao azureContainerPdao;
+
+  public CreateAzureContainerStep(
+      ResourceService resourceService, AzureContainerPdao azureContainerPdao) {
+    this.resourceService = resourceService;
+    this.azureContainerPdao = azureContainerPdao;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    BillingProfileModel profileModel = getProfileModel(context);
+
+    // Retrieve the internal object that represents the storage account
+    AzureStorageAccountResource storageAccount =
+        getAzureStorageAccountResource(context, profileModel);
+
+    // Create the storage container if needed.  Note creating directly with the pdao since there
+    // is no new metadata being recorded with this operation.
+    azureContainerPdao.getOrCreateContainer(profileModel, storageAccount);
+
+    // Store the storage account in the working map.  This will be used in case of needing to undo
+    context.getWorkingMap().put(getStorageAccountContextKey(), storageAccount);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel = getProfileModel(context);
+    AzureStorageAccountResource datasetAzureStorageAccountResource =
+        workingMap.get(getStorageAccountContextKey(), AzureStorageAccountResource.class);
+
+    resourceService.deleteStorageContainer(
+        datasetAzureStorageAccountResource.getResourceId(),
+        profileModel.getId(),
+        context.getFlightId());
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  /** Implement this method to return the billing profile model from the flight's context */
+  protected BillingProfileModel getProfileModel(FlightContext context) {
+    return context.getWorkingMap().get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+  }
+
+  /**
+   * Implement this method to return the key that will store the storage account metadata in the
+   * flight's context
+   */
+  protected abstract String getStorageAccountContextKey();
+
+  /** Implement this method to return the AzureStorageAccountResource from the flight's context */
+  protected abstract AzureStorageAccountResource getAzureStorageAccountResource(
+      FlightContext context, BillingProfileModel profileModel) throws InterruptedException;
+}

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
@@ -2,58 +2,40 @@ package bio.terra.service.dataset.flight.create;
 
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetRequestModel;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.common.CreateAzureContainerStep;
 import bio.terra.service.dataset.DatasetJsonConversion;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
-import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
-import bio.terra.stairway.StepResult;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class CreateDatasetGetOrCreateContainerStep implements Step {
-  private static final Logger logger =
-      LoggerFactory.getLogger(CreateDatasetGetOrCreateContainerStep.class);
-  private final ResourceService resourceService;
+public class CreateDatasetGetOrCreateContainerStep extends CreateAzureContainerStep {
   private final DatasetRequestModel datasetRequestModel;
-  private final AzureContainerPdao azureContainerPdao;
 
   public CreateDatasetGetOrCreateContainerStep(
       ResourceService resourceService,
       DatasetRequestModel datasetRequestModel,
       AzureContainerPdao azureContainerPdao) {
-    this.resourceService = resourceService;
+    super(resourceService, azureContainerPdao);
     this.datasetRequestModel = datasetRequestModel;
-    this.azureContainerPdao = azureContainerPdao;
   }
 
   @Override
-  public StepResult doStep(FlightContext context) throws InterruptedException {
-    logger.info("Creating a container for an Azure backed dataset");
-    FlightMap workingMap = context.getWorkingMap();
-    BillingProfileModel profileModel =
-        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
-    UUID datasetId = workingMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
-
-    AzureStorageAccountResource storageAccount =
-        resourceService.getOrCreateDatasetStorageAccount(
-            DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel, datasetId),
-            profileModel,
-            context.getFlightId());
-
-    azureContainerPdao.getOrCreateContainer(profileModel, storageAccount);
-
-    return StepResult.getStepResultSuccess();
+  protected String getStorageAccountContextKey() {
+    return CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE;
   }
 
   @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
-    // Leaving artifacts on undo
-    return StepResult.getStepResultSuccess();
+  protected AzureStorageAccountResource getAzureStorageAccountResource(
+      FlightContext context, BillingProfileModel profileModel) throws InterruptedException {
+    UUID datasetId = context.getWorkingMap().get(DatasetWorkingMapKeys.DATASET_ID, UUID.class);
+
+    return resourceService.getOrCreateDatasetStorageAccount(
+        DatasetJsonConversion.datasetRequestToDataset(datasetRequestModel, datasetId),
+        profileModel,
+        context.getFlightId());
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateContainerStep.java
@@ -19,13 +19,8 @@ public class CreateDatasetGetOrCreateContainerStep extends CreateAzureContainerS
       ResourceService resourceService,
       DatasetRequestModel datasetRequestModel,
       AzureContainerPdao azureContainerPdao) {
-    super(resourceService, azureContainerPdao);
+    super(resourceService, azureContainerPdao, CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE);
     this.datasetRequestModel = datasetRequestModel;
-  }
-
-  @Override
-  protected String getStorageAccountContextKey() {
-    return CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -27,7 +27,7 @@ import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
-import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringProvider;
+import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringStepProvider;
 import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.Flight;
@@ -66,8 +66,8 @@ public class DatasetCreateFlight extends Flight {
     DatasetRequestModel datasetRequest =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), DatasetRequestModel.class);
 
-    AzureStorageMonitoringProvider azureStorageMonitoringProvider =
-        new AzureStorageMonitoringProvider(monitoringService);
+    AzureStorageMonitoringStepProvider azureStorageMonitoringStepProvider =
+        new AzureStorageMonitoringStepProvider(monitoringService);
 
     var platform = CloudPlatformWrapper.of(datasetRequest.getCloudPlatform());
 
@@ -116,7 +116,7 @@ public class DatasetCreateFlight extends Flight {
               resourceService, datasetRequest, azureContainerPdao));
 
       // Turn on logging and monitoring for the storage account associated with the dataset
-      azureStorageMonitoringProvider
+      azureStorageMonitoringStepProvider
           .configureSteps(datasetRequest.isEnableSecureMonitoring())
           .forEach(s -> this.addStep(s.step(), s.retryRule()));
     }

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -26,6 +26,8 @@ import bio.terra.service.profile.google.GoogleBillingService;
 import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringProvider;
 import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.Flight;
@@ -59,9 +61,13 @@ public class DatasetCreateFlight extends Flight {
     GoogleResourceManagerService googleResourceManagerService =
         appContext.getBean(GoogleResourceManagerService.class);
     JournalService journalService = appContext.getBean(JournalService.class);
+    AzureMonitoringService monitoringService = appContext.getBean(AzureMonitoringService.class);
 
     DatasetRequestModel datasetRequest =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), DatasetRequestModel.class);
+
+    AzureStorageMonitoringProvider azureStorageMonitoringProvider =
+        new AzureStorageMonitoringProvider(monitoringService);
 
     var platform = CloudPlatformWrapper.of(datasetRequest.getCloudPlatform());
 
@@ -108,6 +114,11 @@ public class DatasetCreateFlight extends Flight {
       addStep(
           new CreateDatasetGetOrCreateContainerStep(
               resourceService, datasetRequest, azureContainerPdao));
+
+      // Turn on logging and monitoring for the storage account associated with the dataset
+      azureStorageMonitoringProvider
+          .configureSteps(datasetRequest.isEnableSecureMonitoring())
+          .forEach(s -> this.addStep(s.step(), s.retryRule()));
     }
 
     // Create dataset metadata objects in postgres and lock the dataset

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -59,7 +59,7 @@ import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
-import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringProvider;
+import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringStepProvider;
 import bio.terra.service.resourcemanagement.google.GoogleProjectService;
 import bio.terra.service.tabulardata.azure.StorageTableService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
@@ -110,8 +110,8 @@ public class DatasetIngestFlight extends Flight {
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
-    AzureStorageMonitoringProvider azureStorageMonitoringProvider =
-        new AzureStorageMonitoringProvider(monitoringService);
+    AzureStorageMonitoringStepProvider azureStorageMonitoringStepProvider =
+        new AzureStorageMonitoringStepProvider(monitoringService);
 
     RetryRule lockDatasetRetry =
         getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads());
@@ -137,7 +137,7 @@ public class DatasetIngestFlight extends Flight {
       addStep(new IngestCreateAzureContainerStep(resourceService, azureContainerPdao, dataset));
       // Turn on logging and monitoring for the storage account associated with the dataset and
       // billing profile
-      azureStorageMonitoringProvider
+      azureStorageMonitoringStepProvider
           .configureSteps(dataset.isSecureMonitoringEnabled())
           .forEach(s -> this.addStep(s.step(), s.retryRule()));
     }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -35,6 +35,7 @@ import bio.terra.service.filedata.flight.ingest.IngestBuildAndWriteScratchLoadFi
 import bio.terra.service.filedata.flight.ingest.IngestCleanFileStateStep;
 import bio.terra.service.filedata.flight.ingest.IngestCopyLoadHistoryToBQStep;
 import bio.terra.service.filedata.flight.ingest.IngestCopyLoadHistoryToStorageTableStep;
+import bio.terra.service.filedata.flight.ingest.IngestCreateAzureContainerStep;
 import bio.terra.service.filedata.flight.ingest.IngestCreateAzureStorageAccountStep;
 import bio.terra.service.filedata.flight.ingest.IngestDriverStep;
 import bio.terra.service.filedata.flight.ingest.IngestFileAzureMakeStorageAccountLinkStep;
@@ -127,6 +128,7 @@ public class DatasetIngestFlight extends Flight {
               profileService, ingestRequestModel.getProfileId(), userReq));
 
       addStep(new IngestCreateAzureStorageAccountStep(resourceService, dataset));
+      addStep(new IngestCreateAzureContainerStep(resourceService, azureContainerPdao, dataset));
     }
 
     addStep(new LockDatasetStep(datasetService, datasetId, true), lockDatasetRetry);

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
@@ -41,5 +41,4 @@ public class CreateScratchFileForAzureStep extends DefaultUndoStep {
     context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), path);
     return StepResult.getStepResultSuccess();
   }
-
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/CreateScratchFileForAzureStep.java
@@ -42,8 +42,4 @@ public class CreateScratchFileForAzureStep extends DefaultUndoStep {
     return StepResult.getStepResultSuccess();
   }
 
-  @Override
-  public StepResult undoStep(FlightContext context) {
-    return StepResult.getStepResultSuccess();
-  }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/DatasetScratchFilePrepareFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/DatasetScratchFilePrepareFlight.java
@@ -16,7 +16,7 @@ import bio.terra.service.profile.flight.AuthorizeBillingProfileUseStep;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
-import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringProvider;
+import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringStepProvider;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import java.util.UUID;
@@ -38,8 +38,8 @@ public class DatasetScratchFilePrepareFlight extends Flight {
     AzureContainerPdao azureContainerPdao = appContext.getBean(AzureContainerPdao.class);
     AzureMonitoringService monitoringService = appContext.getBean(AzureMonitoringService.class);
 
-    AzureStorageMonitoringProvider azureStorageMonitoringProvider =
-        new AzureStorageMonitoringProvider(monitoringService);
+    AzureStorageMonitoringStepProvider azureStorageMonitoringStepProvider =
+        new AzureStorageMonitoringStepProvider(monitoringService);
 
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
@@ -65,7 +65,7 @@ public class DatasetScratchFilePrepareFlight extends Flight {
       addStep(new IngestCreateAzureContainerStep(resourceService, azureContainerPdao, dataset));
       // Turn on logging and monitoring for the storage account associated with the dataset and
       // billing profile
-      azureStorageMonitoringProvider
+      azureStorageMonitoringStepProvider
           .configureSteps(dataset.isSecureMonitoringEnabled())
           .forEach(s -> this.addStep(s.step(), s.retryRule()));
       addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/DatasetScratchFilePrepareFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/DatasetScratchFilePrepareFlight.java
@@ -8,6 +8,7 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.filedata.flight.ingest.CreateBucketForBigQueryScratchStep;
+import bio.terra.service.filedata.flight.ingest.IngestCreateAzureContainerStep;
 import bio.terra.service.filedata.flight.ingest.IngestCreateAzureStorageAccountStep;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.profile.ProfileService;
@@ -55,6 +56,7 @@ public class DatasetScratchFilePrepareFlight extends Flight {
     } else if (cloudPlatform.isAzure()) {
       addStep(new AuthorizeBillingProfileUseStep(profileService, profileId, userReq));
       addStep(new IngestCreateAzureStorageAccountStep(resourceService, dataset));
+      addStep(new IngestCreateAzureContainerStep(resourceService, azureContainerPdao, dataset));
       addStep(
           new CreateScratchFileForAzureStep(azureContainerPdao),
           getDefaultRandomBackoffRetryRule(appConfig.getMaxStairwayThreads()));

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -62,6 +62,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
@@ -376,38 +377,50 @@ public class AzureSynapsePdao {
   /**
    * Initialize a Synapse database with the given name and encryption key. Note: we need to connect
    * to the default `master` database to create the new database.
-   *
-   * @param dbName Name of the database of initialize
-   * @param encryptionKey The key to use for encrypting secrets
-   * @param parquetFormatName The name to give the parquet format
    */
-  public void initializeDb(String dbName, String encryptionKey, String parquetFormatName) {
-    logger.info("Initializing Synapse database {}", dbName);
-    SQLServerDataSource dsInit = getDatasource(DEFAULT_DB_NAME);
-    try (Connection connection = dsInit.getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute(new ST(DB_CREATION_TEMPLATE).add("dbname", dbName).render());
-    } catch (SQLException e) {
-      throw new PdaoException("Error creating database", e);
+  @PostConstruct
+  private void initializeDb() {
+    // If this configuration wasn't set, skip initialization
+    if (azureResourceConfiguration.getSynapse() == null) {
+      return;
     }
+    boolean initialize = azureResourceConfiguration.getSynapse().isInitialize();
+    String dbName = azureResourceConfiguration.getSynapse().getDatabaseName();
+    String encryptionKey = azureResourceConfiguration.getSynapse().getEncryptionKey();
+    String parquetFormatName = azureResourceConfiguration.getSynapse().getParquetFileFormatName();
 
-    // Connect to the newly created db to set up encryption
-    SQLServerDataSource ds = getDatasource();
-    try (Connection connection = ds.getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute(
-          new ST(DB_ENCRYPTION_TEMPLATE).add("encryptionKey", encryptionKey).render());
-    } catch (SQLException e) {
-      throw new PdaoException("Error setting up database encryption", e);
-    }
+    if (initialize) {
+      logger.info("Initializing Synapse database {}", dbName);
+      SQLServerDataSource dsInit = getDatasource(DEFAULT_DB_NAME);
+      try (Connection connection = dsInit.getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute(new ST(DB_CREATION_TEMPLATE).add("dbname", dbName).render());
+      } catch (SQLException e) {
+        throw new PdaoException("Error creating database", e);
+      }
 
-    // Connect to the newly created db to set up the parquet file format used to transform data
-    try (Connection connection = ds.getConnection();
-        Statement statement = connection.createStatement()) {
-      statement.execute(
-          new ST(DB_PARQUET_FORMAT_TEMPLATE).add("parquetFormatName", parquetFormatName).render());
-    } catch (SQLException e) {
-      throw new PdaoException("Error setting up parquet file format", e);
+      // Connect to the newly created db to set up encryption
+      SQLServerDataSource ds = getDatasource();
+      try (Connection connection = ds.getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute(
+            new ST(DB_ENCRYPTION_TEMPLATE).add("encryptionKey", encryptionKey).render());
+      } catch (SQLException e) {
+        throw new PdaoException("Error setting up database encryption", e);
+      }
+
+      // Connect to the newly created db to set up the parquet file format used to transform data
+      try (Connection connection = ds.getConnection();
+          Statement statement = connection.createStatement()) {
+        statement.execute(
+            new ST(DB_PARQUET_FORMAT_TEMPLATE)
+                .add("parquetFormatName", parquetFormatName)
+                .render());
+      } catch (SQLException e) {
+        throw new PdaoException("Error setting up parquet file format", e);
+      }
+    } else {
+      logger.info("Skipping Synapse database initialization");
     }
   }
 

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -110,7 +110,7 @@ public class AzureSynapsePdao {
            )
     """;
 
-  private static final String scopedCredentialCreateTemplate =
+  private static final String SCOPED_CREDENTIAL_CREATE_TEMPLATE =
       """
           IF EXISTS (SELECT * FROM sys.database_scoped_credentials WHERE name = '<scopedCredentialName>')
               ALTER DATABASE SCOPED CREDENTIAL [<scopedCredentialName>]
@@ -121,7 +121,7 @@ public class AzureSynapsePdao {
               WITH IDENTITY = 'SHARED ACCESS SIGNATURE',
                    SECRET = '<secret>' ;""";
 
-  private static final String dataSourceCreateTemplate =
+  private static final String DATA_SOURCE_CREATE_TEMPLATE =
       """
       IF NOT EXISTS (SELECT * FROM sys.external_data_sources WHERE name = '<dataSourceName>')
       CREATE EXTERNAL DATA SOURCE [<dataSourceName>]
@@ -130,7 +130,7 @@ public class AzureSynapsePdao {
               CREDENTIAL = [<credential>]
           );""";
 
-  private static final String createSnapshotTableTemplate =
+  private static final String CREATE_SNAPSHOT_TABLE_TEMPLATE =
       """
       CREATE EXTERNAL TABLE [<tableName>]
           WITH (
@@ -163,32 +163,32 @@ public class AzureSynapsePdao {
                  FORMAT = 'parquet') AS rows
               """;
 
-  private static final String createSnapshotTableByRowIdTemplate =
-      createSnapshotTableTemplate + " WHERE rows.datarepo_row_id IN (:datarepoRowIds);";
+  private static final String CREATE_SNAPSHOT_TABLE_BY_ROW_ID_TEMPLATE =
+      CREATE_SNAPSHOT_TABLE_TEMPLATE + " WHERE rows.datarepo_row_id IN (:datarepoRowIds);";
 
-  private static final String createSnapshotTableByQueryTemplate =
-      createSnapshotTableTemplate + " WHERE rows.datarepo_row_id IN (<query>);";
+  private static final String CREATE_SNAPSHOT_TABLE_BY_QUERY_TEMPLATE =
+      CREATE_SNAPSHOT_TABLE_TEMPLATE + " WHERE rows.datarepo_row_id IN (<query>);";
 
-  private static final String createSnapshotTableArrayRootColumnClause =
+  private static final String CREATE_SNAPSHOT_TABLE_ARRAY_ROOT_COLUMN_CLAUSE =
       """
           <if(isRootColumnArray)>
            CROSS APPLY OPENJSON(<rootColumn>) WITH (value <arrayRootColumnType> '$')
           <endif>
           """;
-  private static final String createSnapshotTableArrayFromColumnClause =
+  private static final String CREATE_SNAPSHOT_TABLE_ARRAY_FROM_COLUMN_CLAUSE =
       """
           <if(isFromColumnArray)>
            CROSS APPLY OPENJSON(<fromTableColumn>) WITH (value <arrayFromColumnType> '$')
           <endif>
           """;
-  private static final String createSnapshotTableByAssetTemplate =
-      createSnapshotTableTemplate
-          + createSnapshotTableArrayRootColumnClause
+  private static final String CREATE_SNAPSHOT_TABLE_BY_ASSET_TEMPLATE =
+      CREATE_SNAPSHOT_TABLE_TEMPLATE
+          + CREATE_SNAPSHOT_TABLE_ARRAY_ROOT_COLUMN_CLAUSE
           + " WHERE <if(isRootColumnArray)>value<else>rows.<rootColumn><endif> in (:rootValues);";
 
-  private static final String createSnapshotTableWalkRelationshipTemplate =
-      createSnapshotTableTemplate
-          + createSnapshotTableArrayRootColumnClause
+  private static final String CREATE_SNAPSHOT_TABLE_WALK_RELATIONSHIP_TEMPLATE =
+      CREATE_SNAPSHOT_TABLE_TEMPLATE
+          + CREATE_SNAPSHOT_TABLE_ARRAY_ROOT_COLUMN_CLAUSE
           + """
             WHERE
             (<if(isRootColumnArray)>value<else>rows.<toTableColumn><endif> IN
@@ -200,11 +200,11 @@ public class AzureSynapsePdao {
                   FORMAT = 'parquet'
                 ) as from_rows
           """
-          + createSnapshotTableArrayFromColumnClause
+          + CREATE_SNAPSHOT_TABLE_ARRAY_FROM_COLUMN_CLAUSE
           + "   ))";
 
-  private static final String createSnapshotTableWithExistingRowsTemplate =
-      createSnapshotTableWalkRelationshipTemplate
+  private static final String CREATE_SNAPSHOT_TABLE_WITH_EXISTING_ROWS_TEMPLATE =
+      CREATE_SNAPSHOT_TABLE_WALK_RELATIONSHIP_TEMPLATE
           + """
          AND (rows.datarepo_row_id NOT IN
              (
@@ -217,7 +217,7 @@ public class AzureSynapsePdao {
             ));
           """;
 
-  private static final String createSnapshotRowIdTableTemplate =
+  private static final String CREATE_SNAPSHOT_ROW_ID_TABLE_TEMPLATE =
       """
       CREATE EXTERNAL TABLE [<tableName>]
           WITH (
@@ -225,7 +225,7 @@ public class AzureSynapsePdao {
               DATA_SOURCE = [<destinationDataSourceName>],
               FILE_FORMAT = [<fileFormat>]) AS  <selectStatements>""";
 
-  private static final String getLiveViewTableTemplate =
+  private static final String GET_LIVE_VIEW_TABLE_TEMPLATE =
       """
       SELECT '<tableId>' as <tableIdColumn>, <dataRepoRowIdColumn>
         FROM OPENROWSET(
@@ -233,10 +233,10 @@ public class AzureSynapsePdao {
                  DATA_SOURCE = '<snapshotDataSourceName>',
                  FORMAT = 'parquet') AS rows""";
 
-  private static final String mergeLiveViewTablesTemplate =
+  private static final String MERGE_LIVE_VIEW_TABLES_TEMPLATE =
       "<selectStatements; separator=\" UNION ALL \">;";
 
-  private static final String createTableTemplate =
+  private static final String CREATE_TABLE_TEMPLATE =
       """
       CREATE EXTERNAL TABLE [<tableName>]
           WITH (
@@ -278,10 +278,10 @@ public class AzureSynapsePdao {
           <endif>
           ) AS rows;""";
 
-  private static final String countNullsInTableTemplate =
+  private static final String COUNT_NULLS_IN_TABLE_TEMPLATE =
       "SELECT COUNT(DISTINCT(datarepo_row_id)) AS rows_with_nulls FROM [<tableName>] WHERE <nullChecks>;";
 
-  private static final String createFinalParquetFilesTemplate =
+  private static final String CREATE_FINAL_PARQUET_FILES_TEMPLATE =
       """
       CREATE EXTERNAL TABLE [<finalTableName>]
           WITH (
@@ -290,10 +290,10 @@ public class AzureSynapsePdao {
               FILE_FORMAT = [<fileFormat>]
           ) AS SELECT datarepo_row_id, <columns> FROM [<scratchTableName>] <where> <nullChecks>;""";
 
-  private static final String queryColumnsFromExternalTableTemplate =
+  private static final String QUERY_COLUMNS_FROM_EXTERNAL_TABLE_TEMPLATE =
       "SELECT DISTINCT [<refCol>] FROM [<tableName>] WHERE [<refCol>] IS NOT NULL;";
 
-  private static final String queryArrayColumnsFromExternalTableTemplate =
+  private static final String QUERY_ARRAY_COLUMNS_FROM_EXTERNAL_TABLE_TEMPLATE =
       """
       SELECT DISTINCT [Element] AS [<refCol>]
           FROM [<tableName>]
@@ -302,7 +302,7 @@ public class AzureSynapsePdao {
           WHERE [<refCol>] IS NOT NULL
           AND [Element] IS NOT NULL;""";
 
-  private static final String queryTableTotalRowCountTemplate =
+  private static final String QUERY_TABLE_TOTAL_ROW_COUNT_TEMPLATE =
       """
           SELECT count(*) <totalRowCountColumnName>
             FROM OPENROWSET(
@@ -311,7 +311,7 @@ public class AzureSynapsePdao {
               FORMAT='PARQUET'
             ) AS rows;
           """;
-  private static final String queryFromDatasourceTemplate =
+  private static final String QUERY_FROM_DATASOURCE_TEMPLATE =
       """
       SELECT <columns:{c|final_rows.[<c>]}; separator=",">,final_rows.[<filteredRowCountColumnName>]<if(includeTotalRowCount)>,final_rows.[<totalRowCountColumnName>]<endif>
       FROM (
@@ -330,7 +330,7 @@ public class AzureSynapsePdao {
       WHERE final_rows.[datarepo_row_number] >= :offset
         AND final_rows.[datarepo_row_number] \\<= :offset + :limit;""";
 
-  private static final String queryTextColumnStatsTemplate =
+  private static final String QUERY_TEXT_COLUMN_STATS_TEMPLATE =
       """
       SELECT <column>,count(*) AS <countColumn>
         FROM OPENROWSET(BULK '<parquetFileLocation>',
@@ -340,19 +340,19 @@ public class AzureSynapsePdao {
           GROUP BY <column>
           ORDER BY <column> <direction>;""";
 
-  private static final String queryNumericColumnStatsTemplate =
+  private static final String QUERY_NUMERIC_COLUMN_STATS_TEMPLATE =
       """
         SELECT MIN(<column>) AS min, MAX(<column>) AS max
           FROM OPENROWSET(BULK '<parquetFileLocation>',
                           DATA_SOURCE = '<datasource>',
                           FORMAT='PARQUET') AS rows
           <userFilter>;""";
-  private static final String dropTableTemplate = "DROP EXTERNAL TABLE [<resourceName>];";
+  private static final String DROP_TABLE_TEMPLATE = "DROP EXTERNAL TABLE [<resourceName>];";
 
-  private static final String dropDataSourceTemplate =
+  private static final String DROP_DATA_SOURCE_TEMPLATE =
       "DROP EXTERNAL DATA SOURCE [<resourceName>];";
 
-  private static final String dropScopedCredentialTemplate =
+  private static final String DROP_SCOPED_CREDENTIAL_TEMPLATE =
       "DROP DATABASE SCOPED CREDENTIAL [<resourceName>];";
 
   private final ApplicationConfiguration applicationConfiguration;
@@ -416,8 +416,8 @@ public class AzureSynapsePdao {
 
     var template =
         refColumn.isArrayOf()
-            ? new ST(queryArrayColumnsFromExternalTableTemplate)
-            : new ST(queryColumnsFromExternalTableTemplate);
+            ? new ST(QUERY_ARRAY_COLUMNS_FROM_EXTERNAL_TABLE_TEMPLATE)
+            : new ST(QUERY_COLUMNS_FROM_EXTERNAL_TABLE_TEMPLATE);
 
     template.add("refCol", refColumn.getName());
     template.add("tableName", tableName);
@@ -488,12 +488,12 @@ public class AzureSynapsePdao {
 
     String credentialName = sanitizeStringForSql(scopedCredentialName);
     String dsName = sanitizeStringForSql(dataSourceName);
-    ST sqlScopedCredentialCreateTemplate = new ST(scopedCredentialCreateTemplate);
+    ST sqlScopedCredentialCreateTemplate = new ST(SCOPED_CREDENTIAL_CREATE_TEMPLATE);
     sqlScopedCredentialCreateTemplate.add("scopedCredentialName", credentialName);
     sqlScopedCredentialCreateTemplate.add("secret", blobContainerSasTokenCreds.getSignature());
     executeSynapseQuery(sqlScopedCredentialCreateTemplate.render());
 
-    ST sqlDataSourceCreateTemplate = new ST(dataSourceCreateTemplate);
+    ST sqlDataSourceCreateTemplate = new ST(DATA_SOURCE_CREATE_TEMPLATE);
     sqlDataSourceCreateTemplate.add("dataSourceName", dsName);
     sqlDataSourceCreateTemplate.add("scheme", signedBlobUrl.getScheme());
     sqlDataSourceCreateTemplate.add("host", signedBlobUrl.getHost());
@@ -517,7 +517,7 @@ public class AzureSynapsePdao {
 
     boolean isCSV = ingestType == FormatEnum.CSV;
 
-    ST sqlCreateTableTemplate = new ST(createTableTemplate);
+    ST sqlCreateTableTemplate = new ST(CREATE_TABLE_TEMPLATE);
     sqlCreateTableTemplate.add("isCSV", isCSV);
     if (isCSV) {
       sqlCreateTableTemplate.add("parserVersion", PARSER_VERSION);
@@ -552,7 +552,7 @@ public class AzureSynapsePdao {
       return 0;
     }
 
-    ST sqlCountNullsTemplate = new ST(countNullsInTableTemplate);
+    ST sqlCountNullsTemplate = new ST(COUNT_NULLS_IN_TABLE_TEMPLATE);
     sqlCountNullsTemplate.add("tableName", scratchTableName);
     sqlCountNullsTemplate.add("nullChecks", nullChecks);
 
@@ -567,7 +567,7 @@ public class AzureSynapsePdao {
       DatasetTable datasetTable)
       throws SQLException {
 
-    ST sqlCreateFinalParquetFilesTemplate = new ST(createFinalParquetFilesTemplate);
+    ST sqlCreateFinalParquetFilesTemplate = new ST(CREATE_FINAL_PARQUET_FILES_TEMPLATE);
     sqlCreateFinalParquetFilesTemplate.add("finalTableName", finalTableName);
     sqlCreateFinalParquetFilesTemplate.add("destinationParquetFile", destinationParquetFile);
     sqlCreateFinalParquetFilesTemplate.add("destinationDataSourceName", destinationDataSourceName);
@@ -618,7 +618,7 @@ public class AzureSynapsePdao {
             IngestUtils.getSnapshotParquetFilePathForQuery(table.getName());
 
         ST sqlTableTemplate =
-            new ST(getLiveViewTableTemplate)
+            new ST(GET_LIVE_VIEW_TABLE_TEMPLATE)
                 .add("tableId", table.getId().toString())
                 .add("tableIdColumn", PDAO_TABLE_ID_COLUMN)
                 .add("dataRepoRowIdColumn", PDAO_ROW_ID_COLUMN)
@@ -631,14 +631,14 @@ public class AzureSynapsePdao {
       throw new InvalidSnapshotException("Snapshot cannot be empty.");
     }
     ST sqlMergeTablesTemplate =
-        new ST(mergeLiveViewTablesTemplate).add("selectStatements", selectStatements);
+        new ST(MERGE_LIVE_VIEW_TABLES_TEMPLATE).add("selectStatements", selectStatements);
 
     // Create row id table
     String rowIdTableName = IngestUtils.formatSnapshotTableName(snapshotId, PDAO_ROW_ID_TABLE);
     String rowIdParquetFile =
         IngestUtils.getSnapshotSliceParquetFilePath(PDAO_ROW_ID_TABLE, PDAO_ROW_ID_PARQUET_NAME);
     ST sqlCreateRowIdTable =
-        new ST(createSnapshotRowIdTableTemplate)
+        new ST(CREATE_SNAPSHOT_ROW_ID_TABLE_TEMPLATE)
             .add("tableName", rowIdTableName)
             .add("destinationParquetFile", rowIdParquetFile)
             .add("destinationDataSourceName", snapshotDataSourceName)
@@ -662,7 +662,7 @@ public class AzureSynapsePdao {
     AssetTable rootTable = assetSpec.getRootTable();
     String rootTableName = rootTable.getTable().getName();
 
-    ST sqlCreateSnapshotTableTemplate = new ST(createSnapshotTableByQueryTemplate);
+    ST sqlCreateSnapshotTableTemplate = new ST(CREATE_SNAPSHOT_TABLE_BY_QUERY_TEMPLATE);
     ST queryTemplate =
         generateSnapshotParquetCreateQuery(
             sqlCreateSnapshotTableTemplate,
@@ -740,7 +740,7 @@ public class AzureSynapsePdao {
     AssetTable rootTable = assetSpec.getRootTable();
     String rootTableName = rootTable.getTable().getName();
 
-    ST sqlCreateSnapshotTableTemplate = new ST(createSnapshotTableByAssetTemplate);
+    ST sqlCreateSnapshotTableTemplate = new ST(CREATE_SNAPSHOT_TABLE_BY_ASSET_TEMPLATE);
     ST queryTemplate =
         generateSnapshotParquetCreateQuery(
             sqlCreateSnapshotTableTemplate,
@@ -955,8 +955,8 @@ public class AzureSynapsePdao {
 
     return new ST(
         toTableAlreadyHasRows
-            ? createSnapshotTableWithExistingRowsTemplate
-            : createSnapshotTableWalkRelationshipTemplate + ";");
+            ? CREATE_SNAPSHOT_TABLE_WITH_EXISTING_ROWS_TEMPLATE
+            : CREATE_SNAPSHOT_TABLE_WALK_RELATIONSHIP_TEMPLATE + ";");
   }
 
   public Map<String, Long> createSnapshotParquetFilesByRowId(
@@ -988,7 +988,7 @@ public class AzureSynapsePdao {
                 .filter(c -> columnsToInclude.contains(c.getName()))
                 .map(Column::toSynapseColumn)
                 .collect(Collectors.toList());
-        sqlCreateSnapshotTableTemplate = new ST(createSnapshotTableByRowIdTemplate);
+        sqlCreateSnapshotTableTemplate = new ST(CREATE_SNAPSHOT_TABLE_BY_ROW_ID_TEMPLATE);
         query =
             generateSnapshotParquetCreateQuery(
                     sqlCreateSnapshotTableTemplate,
@@ -1034,7 +1034,7 @@ public class AzureSynapsePdao {
     Map<String, Long> tableRowCounts = new HashMap<>();
 
     for (SnapshotTable table : tables) {
-      ST sqlCreateSnapshotTableTemplate = new ST(createSnapshotTableTemplate);
+      ST sqlCreateSnapshotTableTemplate = new ST(CREATE_SNAPSHOT_TABLE_TEMPLATE);
 
       String query =
           generateSnapshotParquetCreateQuery(
@@ -1099,22 +1099,22 @@ public class AzureSynapsePdao {
   }
 
   public void dropTables(List<String> tableNames) {
-    cleanup(tableNames, dropTableTemplate);
+    cleanup(tableNames, DROP_TABLE_TEMPLATE);
   }
 
   public void dropDataSources(List<String> dataSourceNames) {
-    cleanup(dataSourceNames, dropDataSourceTemplate);
+    cleanup(dataSourceNames, DROP_DATA_SOURCE_TEMPLATE);
   }
 
   public void dropScopedCredentials(List<String> credentialNames) {
-    cleanup(credentialNames, dropScopedCredentialTemplate);
+    cleanup(credentialNames, DROP_SCOPED_CREDENTIAL_TEMPLATE);
   }
 
   public int getTableTotalRowCount(
       String tableName, String dataSourceName, String parquetFileLocation) {
     try {
       final String sql =
-          new ST(queryTableTotalRowCountTemplate)
+          new ST(QUERY_TABLE_TOTAL_ROW_COUNT_TEMPLATE)
               .add("datasource", dataSourceName)
               .add("parquetFileLocation", parquetFileLocation)
               .add("tableName", tableName)
@@ -1131,7 +1131,11 @@ public class AzureSynapsePdao {
       Column column, String dataSourceName, String parquetFileLocation, String filter) {
     final String sql =
         queryColumnStats(
-            column, dataSourceName, parquetFileLocation, filter, queryNumericColumnStatsTemplate);
+            column,
+            dataSourceName,
+            parquetFileLocation,
+            filter,
+            QUERY_NUMERIC_COLUMN_STATS_TEMPLATE);
     ColumnStatisticsDoubleModel doubleModel =
         (ColumnStatisticsDoubleModel)
             new ColumnStatisticsDoubleModel().dataType(column.getType().toString());
@@ -1169,7 +1173,11 @@ public class AzureSynapsePdao {
       Column column, String dataSourceName, String parquetFileLocation, String filter) {
     final String sql =
         queryColumnStats(
-            column, dataSourceName, parquetFileLocation, filter, queryNumericColumnStatsTemplate);
+            column,
+            dataSourceName,
+            parquetFileLocation,
+            filter,
+            QUERY_NUMERIC_COLUMN_STATS_TEMPLATE);
     ColumnStatisticsIntModel intModel =
         (ColumnStatisticsIntModel)
             new ColumnStatisticsIntModel().dataType(column.getType().toString());
@@ -1190,7 +1198,7 @@ public class AzureSynapsePdao {
       Column column, String dataSourceName, String parquetFileLocation, String userFilter) {
     String columnName = column.getName();
     final String sql =
-        new ST(queryTextColumnStatsTemplate)
+        new ST(QUERY_TEXT_COLUMN_STATS_TEMPLATE)
             .add("column", columnName)
             .add("countColumn", PDAO_COUNT_COLUMN_NAME)
             .add("datasource", dataSourceName)
@@ -1246,7 +1254,7 @@ public class AzureSynapsePdao {
             table.getColumns());
     boolean includeTotalRowCount = collectionType.equals(CollectionType.DATASET);
     final String sql =
-        new ST(queryFromDatasourceTemplate)
+        new ST(QUERY_FROM_DATASOURCE_TEMPLATE)
             .add("columns", columns.stream().map(Column::getName).toList())
             .add("datasource", dataSourceName)
             .add("parquetFileLocation", parquetFileLocation)

--- a/src/main/java/bio/terra/service/filedata/azure/util/AzureConstants.java
+++ b/src/main/java/bio/terra/service/filedata/azure/util/AzureConstants.java
@@ -1,0 +1,18 @@
+package bio.terra.service.filedata.azure.util;
+
+public class AzureConstants {
+
+  private AzureConstants() {}
+
+  /** The code that the Azure resource management APIs found when a resource is not found */
+  public static final String RESOURCE_NOT_FOUND_CODE = "ResourceNotFound";
+  /**
+   * The code that the Azure security insights management APIs found when a resource is not found
+   */
+  public static final String NOT_FOUND_CODE = "NotFound";
+  /**
+   * The code that the Azure resource management APIs found when an invalid request is sent. This
+   * can sometimes be equivalent to a 404
+   */
+  public static final String BAD_REQUEST_CODE = "BadRequest";
+}

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCreateAzureContainerStep.java
@@ -15,13 +15,8 @@ public class IngestCreateAzureContainerStep extends CreateAzureContainerStep {
 
   public IngestCreateAzureContainerStep(
       ResourceService resourceService, AzureContainerPdao azureContainerPdao, Dataset dataset) {
-    super(resourceService, azureContainerPdao);
+    super(resourceService, azureContainerPdao, CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE);
     this.dataset = dataset;
-  }
-
-  @Override
-  protected String getStorageAccountContextKey() {
-    return CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestCreateAzureContainerStep.java
@@ -1,0 +1,33 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.common.CreateAzureContainerStep;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+
+public class IngestCreateAzureContainerStep extends CreateAzureContainerStep {
+
+  private final Dataset dataset;
+
+  public IngestCreateAzureContainerStep(
+      ResourceService resourceService, AzureContainerPdao azureContainerPdao, Dataset dataset) {
+    super(resourceService, azureContainerPdao);
+    this.dataset = dataset;
+  }
+
+  @Override
+  protected String getStorageAccountContextKey() {
+    return CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE;
+  }
+
+  @Override
+  protected AzureStorageAccountResource getAzureStorageAccountResource(
+      FlightContext context, BillingProfileModel profileModel) throws InterruptedException {
+    return resourceService.getOrCreateDatasetStorageAccount(
+        dataset, profileModel, context.getFlightId());
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/AzureDataLocationSelector.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/AzureDataLocationSelector.java
@@ -14,10 +14,17 @@ import org.springframework.stereotype.Component;
 public class AzureDataLocationSelector {
 
   public String createStorageAccountName(
-      String prefix, AzureRegion region, BillingProfileModel billingProfile) {
+      String prefix,
+      AzureRegion region,
+      BillingProfileModel billingProfile,
+      boolean isSecureMonitoringEnabled) {
     int maxStorageAccountNameLength = 24;
     int randomLength = maxStorageAccountNameLength - prefix.length();
-    return prefix + armUniqueString(region.getValue() + billingProfile.toString(), randomLength);
+    String seed = region.getValue() + billingProfile;
+    if (isSecureMonitoringEnabled) {
+      seed += " secure";
+    }
+    return prefix + armUniqueString(seed, randomLength);
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -29,7 +29,6 @@ import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotStorageAccountDao;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
-import com.azure.storage.blob.BlobContainerClient;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
@@ -374,16 +373,11 @@ public class ResourceService {
 
     sasToDelete.forEach(
         s -> {
-          logger.info("Deleting dataset storage account id {}", s);
-          // get container
+          logger.info("Deleting dataset storage account and container id {}", s);
           AzureStorageAccountResource storageAccountResource =
               storageAccountService.retrieveStorageAccountById(s);
-          BlobContainerClient container =
-              azureContainerPdao.getOrCreateContainer(
-                  dataset.getDatasetSummary().getDefaultBillingProfile(), storageAccountResource);
-          if (container != null && container.exists()) {
-            container.delete();
-          }
+          azureContainerPdao.deleteContainer(
+              dataset.getDatasetSummary().getDefaultBillingProfile(), storageAccountResource);
           storageAccountService.deleteCloudStorageAccountMetadata(
               storageAccountResource.getName(),
               storageAccountResource.getTopLevelContainer(),
@@ -406,11 +400,7 @@ public class ResourceService {
     // get container
     AzureStorageAccountResource storageAccountResource =
         storageAccountService.retrieveStorageAccountById(storageResourceId);
-    BlobContainerClient container =
-        azureContainerPdao.getOrCreateContainer(snapshotBillingProfile, storageAccountResource);
-    if (container != null && container.exists()) {
-      container.delete();
-    }
+    azureContainerPdao.deleteContainer(snapshotBillingProfile, storageAccountResource);
 
     storageAccountService.deleteCloudStorageAccountMetadata(
         storageAccountResource.getName(), storageAccountResource.getTopLevelContainer(), flightId);

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -273,7 +273,8 @@ public class ResourceService {
                 azureDataLocationSelector.createStorageAccountName(
                     applicationResource.getStorageAccountPrefix(),
                     dataset.getStorageAccountRegion(),
-                    billingProfile));
+                    billingProfile,
+                    dataset.isSecureMonitoringEnabled()));
 
     return storageAccountService.getOrCreateStorageAccount(
         storageAccountName, dataset.getId().toString(), applicationResource, region, flightId);
@@ -283,14 +284,18 @@ public class ResourceService {
       UUID snapshotId,
       AzureRegion datasetAzureRegion,
       BillingProfileModel billingProfile,
-      String flightId)
+      String flightId,
+      boolean isSecureMonitoringEnabled)
       throws InterruptedException {
 
     final AzureApplicationDeploymentResource applicationResource =
         applicationDeploymentService.getOrRegisterApplicationDeployment(billingProfile);
     String computedStorageAccountName =
         azureDataLocationSelector.createStorageAccountName(
-            applicationResource.getStorageAccountPrefix(), datasetAzureRegion, billingProfile);
+            applicationResource.getStorageAccountPrefix(),
+            datasetAzureRegion,
+            billingProfile,
+            isSecureMonitoringEnabled);
 
     AzureStorageAccountResource storageAccountResource =
         storageAccountService.getOrCreateStorageAccount(

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentResource.java
@@ -2,6 +2,7 @@ package bio.terra.service.resourcemanagement.azure;
 
 import bio.terra.app.model.AzureRegion;
 import bio.terra.app.model.AzureStorageAccountSkuType;
+import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -104,6 +105,10 @@ public class AzureApplicationDeploymentResource {
       AzureStorageAccountSkuType storageAccountSkuType) {
     this.storageAccountSkuType = storageAccountSkuType;
     return this;
+  }
+
+  public UUID getSubscriptionId() {
+    return UUID.fromString(ResourceId.fromString(azureApplicationDeploymentId).subscriptionId());
   }
 
   @Override

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureAuthService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureAuthService.java
@@ -43,7 +43,7 @@ public class AzureAuthService {
         new RequestRetryOptions(
             RetryPolicyType.EXPONENTIAL, maxRetries, retryTimeoutSeconds, null, null, null);
     // wrap the cache map with a synchronized map to safely share the cache across threads
-    authorizedMap = Collections.synchronizedMap(new PassiveExpiringMap<>(24, TimeUnit.HOURS));
+    authorizedMap = Collections.synchronizedMap(new PassiveExpiringMap<>(15, TimeUnit.MINUTES));
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
@@ -40,6 +40,21 @@ public class AzureContainerPdao {
     return blobContainerClient;
   }
 
+  /**
+   * Delete a container in an Azure storage account
+   *
+   * @param profileModel The profile that describes information needed to access the storage account
+   * @param storageAccountResource Metadata describing the storage account that contains the
+   *     container
+   */
+  public void deleteContainer(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
+    BlobContainerClient blobContainerClient =
+        authService.getBlobContainerClient(
+            profileModel, storageAccountResource, storageAccountResource.getTopLevelContainer());
+    blobContainerClient.deleteIfExists();
+  }
+
   public String getDestinationContainerSignedUrl(
       BillingProfileModel profileModel,
       AzureStorageAccountResource storageAccountResource,

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
@@ -59,7 +59,8 @@ public class AzureContainerPdao {
   }
 
   /**
-   * Delete a container in an Azure storage account
+   * Delete a container in an Azure storage account if it happens to exist. If it does not exist,
+   * nothing will happen.
    *
    * @param profileModel The profile that describes information needed to access the storage account
    * @param storageAccountResource Metadata describing the storage account that contains the

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdao.java
@@ -41,6 +41,24 @@ public class AzureContainerPdao {
   }
 
   /**
+   * Get a container in an Azure storage account. Note: this will return a client even if the
+   * container does not exist. Existence can be checked with the exists() method on the client.
+   *
+   * @param profileModel The profile that describes information needed to access the storage account
+   * @param storageAccountResource Metadata describing the storage account that contains the
+   *     container
+   * @return A client connection object that can be used to create folders and files
+   */
+  public BlobContainerClient getContainer(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
+    BlobContainerClient blobContainerClient =
+        authService.getBlobContainerClient(
+            profileModel, storageAccountResource, storageAccountResource.getTopLevelContainer());
+
+    return blobContainerClient;
+  }
+
+  /**
    * Delete a container in an Azure storage account
    *
    * @param profileModel The profile that describes information needed to access the storage account

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -348,8 +348,7 @@ public class AzureMonitoringService {
       return sentinelOnboardingState;
     } catch (ManagementException e) {
       logger.debug("No Sentinel instance found", e);
-      if (Objects.equals(e.getValue().getCode(), RESOURCE_NOT_FOUND_CODE)
-          || Objects.equals(e.getValue().getCode(), NOT_FOUND_CODE)) {
+      if (List.of(RESOURCE_NOT_FOUND_CODE, NOT_FOUND_CODE).contains(e.getValue().getCode())) {
         return null;
       } else {
         throw e;
@@ -433,8 +432,7 @@ public class AzureMonitoringService {
       return alertRule;
     } catch (ManagementException e) {
       logger.debug("No Sentinel UnauthorizedAccess alert rule found", e);
-      if (Objects.equals(e.getValue().getCode(), RESOURCE_NOT_FOUND_CODE)
-          || Objects.equals(e.getValue().getCode(), NOT_FOUND_CODE)
+      if (List.of(RESOURCE_NOT_FOUND_CODE, NOT_FOUND_CODE).contains(e.getValue().getCode())
           || (Objects.equals(e.getValue().getCode(), BAD_REQUEST_CODE)
               && e.getMessage().contains("is not onboarded to Microsoft Sentinel"))) {
         return null;
@@ -545,8 +543,7 @@ public class AzureMonitoringService {
       return automationRule;
     } catch (ManagementException e) {
       logger.debug("No Sentinel alert rule", e);
-      if (Objects.equals(e.getValue().getCode(), RESOURCE_NOT_FOUND_CODE)
-          || Objects.equals(e.getValue().getCode(), NOT_FOUND_CODE)) {
+      if (List.of(RESOURCE_NOT_FOUND_CODE, NOT_FOUND_CODE).contains(e.getValue().getCode())) {
         return null;
       } else {
         throw e;

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -121,6 +121,7 @@ public class AzureMonitoringService {
         .withRegion(Region.fromName(storageAccount.getRegion().getValue()))
         .withExistingResourceGroup(
             storageAccount.getApplicationResource().getAzureResourceGroupName())
+        // Bill the user per GB of ingested log/event data
         .withSku(new WorkspaceSku().withName(WorkspaceSkuNameEnum.PER_GB2018))
         .withRetentionInDays(LOG_DATA_RETENTION_DAYS)
         .create()

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -468,7 +468,7 @@ public class AzureMonitoringService {
         .createOrUpdate(
             storageAccount.getApplicationResource().getAzureResourceGroupName(),
             storageAccount.getName(),
-            "UnauthorizedAccess",
+            UNAUTHORIZED_ACCESS_ALERT_NAME,
             new ScheduledAlertRule()
                 .withDisplayName("File access attempts by unauthorized user accounts")
                 .withQuery(

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -1,0 +1,626 @@
+package bio.terra.service.resourcemanagement.azure;
+
+import static bio.terra.service.filedata.azure.util.AzureConstants.BAD_REQUEST_CODE;
+import static bio.terra.service.filedata.azure.util.AzureConstants.NOT_FOUND_CODE;
+import static bio.terra.service.filedata.azure.util.AzureConstants.RESOURCE_NOT_FOUND_CODE;
+
+import bio.terra.model.BillingProfileModel;
+import com.azure.core.management.Region;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
+import com.azure.resourcemanager.loganalytics.models.DataExport;
+import com.azure.resourcemanager.loganalytics.models.Workspace;
+import com.azure.resourcemanager.loganalytics.models.WorkspaceSku;
+import com.azure.resourcemanager.loganalytics.models.WorkspaceSkuNameEnum;
+import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
+import com.azure.resourcemanager.monitor.models.DiagnosticSettingsCategory;
+import com.azure.resourcemanager.securityinsights.SecurityInsightsManager;
+import com.azure.resourcemanager.securityinsights.models.AlertRule;
+import com.azure.resourcemanager.securityinsights.models.AlertSeverity;
+import com.azure.resourcemanager.securityinsights.models.AutomationRule;
+import com.azure.resourcemanager.securityinsights.models.AutomationRuleRunPlaybookAction;
+import com.azure.resourcemanager.securityinsights.models.AutomationRuleTriggeringLogic;
+import com.azure.resourcemanager.securityinsights.models.PlaybookActionProperties;
+import com.azure.resourcemanager.securityinsights.models.ScheduledAlertRule;
+import com.azure.resourcemanager.securityinsights.models.SentinelOnboardingState;
+import com.azure.resourcemanager.securityinsights.models.TriggerOperator;
+import com.azure.resourcemanager.securityinsights.models.TriggersOn;
+import com.azure.resourcemanager.securityinsights.models.TriggersWhen;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AzureMonitoringService {
+
+  private static final Logger logger = LoggerFactory.getLogger(AzureMonitoringService.class);
+
+  private static final int LOG_DATA_RETENTION_DAYS = 90;
+  private static final Duration METRIC_GRANULARITY = Duration.ofMinutes(5);
+  private static final String UNAUTHORIZED_ACCESS_ALERT_NAME = "UnauthorizedAccess";
+  private static final String SENTINEL_ONBOARD_STATE_NAME = "default";
+  private static final String SLACK_ALERT_RULE_NAME = "runSendSlackNotificationPlaybook";
+  // Leaving this as static as opposed to config since these do not change from one environment to
+  // the next
+  private static final List<String> TABLES_TO_EXPORT =
+      List.of(
+          "Alert",
+          "AppCenterError",
+          "AzureMetrics",
+          "ComputerGroup",
+          "InsightsMetrics",
+          "Operation",
+          "StorageBlobLogs",
+          "Usage");
+
+  private final AzureResourceConfiguration resourceConfiguration;
+
+  @Autowired
+  public AzureMonitoringService(AzureResourceConfiguration resourceConfiguration) {
+    this.resourceConfiguration = resourceConfiguration;
+  }
+
+  /**
+   * Retrieve an existing Log Analytics workspace
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being logged
+   * @return A {@link Workspace} object representing the Log Analytics workspace, or null if it does
+   *     not exist
+   */
+  public Workspace getLogAnalyticsWorkspace(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    LogAnalyticsManager client =
+        resourceConfiguration.getLogAnalyticsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+    try {
+      Workspace byResourceGroup =
+          client
+              .workspaces()
+              .getByResourceGroup(
+                  storageAccount.getApplicationResource().getAzureResourceGroupName(),
+                  storageAccount.getName());
+      logger.info("Found Log Analytics Workspace");
+      return byResourceGroup;
+    } catch (ManagementException e) {
+      logger.warn("No Log Analytics Workspace found", e);
+      if (Objects.equals(e.getValue().getCode(), RESOURCE_NOT_FOUND_CODE)) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Create a new Log Analytics workspace
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being logged
+   * @return A string representing the id of the Log Analytics workspace that was created
+   */
+  public String createLogAnalyticsWorkspace(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    LogAnalyticsManager client =
+        resourceConfiguration.getLogAnalyticsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info(
+        "Creating new Log Analytics Workspace for Storage Account {}",
+        storageAccount.getStorageAccountId());
+    return client
+        .workspaces()
+        .define(storageAccount.getName())
+        .withRegion(Region.fromName(storageAccount.getRegion().getValue()))
+        .withExistingResourceGroup(
+            storageAccount.getApplicationResource().getAzureResourceGroupName())
+        .withSku(new WorkspaceSku().withName(WorkspaceSkuNameEnum.PER_GB2018))
+        .withRetentionInDays(LOG_DATA_RETENTION_DAYS)
+        .create()
+        .id();
+  }
+
+  /**
+   * Delete an existing Log Analytics workspace
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param id The Azure id of the Log Analytics workspace to delete
+   */
+  public void deleteLogAnalyticsWorkspace(BillingProfileModel profileModel, String id) {
+    LogAnalyticsManager client =
+        resourceConfiguration.getLogAnalyticsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info("Deleting Log Analytics Workspace {}", id);
+
+    client.workspaces().deleteById(id);
+  }
+
+  /**
+   * Retrieve an existing Log Analytics diagnostic setting
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being logged
+   * @return A {@link DiagnosticSetting} object representing the storage account diagnostic setting
+   *     or null if it does not exist
+   */
+  public DiagnosticSetting getDiagnosticSetting(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    AzureResourceManager client = resourceConfiguration.getClient(profileModel.getSubscriptionId());
+
+    try {
+      DiagnosticSetting diagnosticSetting =
+          client
+              .diagnosticSettings()
+              .get(getStorageAccountLoggingResourceId(storageAccount), storageAccount.getName());
+      logger.debug("Found Log Analytics Workspace Diagnostic settings");
+      return diagnosticSetting;
+    } catch (ManagementException e) {
+      logger.debug("No Log Analytics Workspace Diagnostic settings found", e);
+      if (Objects.equals(e.getValue().getCode(), RESOURCE_NOT_FOUND_CODE)) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Create a new Log Analytics diagnostic setting
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being logged
+   * @param workspaceId ID of the Log Analytics workspace that the diagnostic setting is associated
+   *     with
+   * @return A string representing the id of the storage account diagnostic setting that was created
+   */
+  public String createDiagnosticSetting(
+      BillingProfileModel profileModel,
+      AzureStorageAccountResource storageAccount,
+      String workspaceId) {
+    AzureResourceManager client = resourceConfiguration.getClient(profileModel.getSubscriptionId());
+
+    logger.info(
+        "Creating new Log Analytics Workspace Diagnostic settings for Storage Account {}",
+        storageAccount.getStorageAccountId());
+
+    // Obtain all categories that can be tracked
+    List<DiagnosticSettingsCategory> logCategories =
+        client
+            .diagnosticSettings()
+            .listCategoriesByResource(getStorageAccountLoggingResourceId(storageAccount))
+            .stream()
+            .toList();
+
+    return client
+        .diagnosticSettings()
+        .define(storageAccount.getName())
+        .withResource(getStorageAccountLoggingResourceId(storageAccount))
+        .withLogAnalytics(workspaceId)
+        .withLogsAndMetrics(logCategories, METRIC_GRANULARITY, LOG_DATA_RETENTION_DAYS)
+        .create()
+        .id();
+  }
+
+  /**
+   * Delete an existing Log Analytics diagnostic setting
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param id The Azure id of the Log Analytics diagnostic setting to delete
+   */
+  public void deleteDiagnosticSetting(BillingProfileModel profileModel, String id) {
+    AzureResourceManager client = resourceConfiguration.getClient(profileModel.getSubscriptionId());
+
+    logger.info("Deleting Log Analytics Workspace Diagnostic settings {}", id);
+
+    client.diagnosticSettings().deleteById(id);
+  }
+
+  /**
+   * Retrieve an existing data export rule for the given Log Analytics workspace
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being logged
+   * @return A {@link DataExport} object representing the data export rule or null if it does not
+   *     exist
+   */
+  public DataExport getDataExportRule(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+
+    LogAnalyticsManager client =
+        resourceConfiguration.getLogAnalyticsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    try {
+      DataExport dataExport =
+          client
+              .dataExports()
+              .get(
+                  storageAccount.getApplicationResource().getAzureResourceGroupName(),
+                  storageAccount.getName(),
+                  storageAccount.getName());
+      logger.debug("Found Log Analytics Workspace data export rule");
+      return dataExport;
+    } catch (ManagementException e) {
+      logger.debug("No Log Analytics Workspace data export rule found", e);
+      // This Azure SDK returns 404 differently than the others
+      if (e.getResponse().getStatusCode() == 404) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Create a data export rule for the given Log Analytics workspace for long term log storage
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being logged
+   * @return A string representing the id of the object representing the data export rule that was
+   *     created
+   * @throws IllegalArgumentException if no log collection config is found for the storage account's
+   *     region
+   */
+  public String createDataExportRule(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+
+    String resourceId =
+        resourceConfiguration
+            .getMonitoring()
+            .getLogCollectionConfigsAsMap()
+            .get(storageAccount.getRegion());
+    if (resourceId == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "No log collection config found for region %s", storageAccount.getRegion()));
+    }
+    LogAnalyticsManager client =
+        resourceConfiguration.getLogAnalyticsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info(
+        "Creating new export rule for Log Analytics Workspace linked to Storage Account {}",
+        storageAccount.getStorageAccountId());
+
+    return client
+        .dataExports()
+        .define(storageAccount.getName())
+        .withExistingWorkspace(
+            storageAccount.getApplicationResource().getAzureResourceGroupName(),
+            storageAccount.getName())
+        .withTableNames(TABLES_TO_EXPORT)
+        .withResourceId(resourceId)
+        .create()
+        .id();
+  }
+
+  /**
+   * Delete a data export rule for the given Log Analytics workspace
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param id The Azure id of the data export rule to delete
+   */
+  public void deleteDataExportRule(BillingProfileModel profileModel, String id) {
+    LogAnalyticsManager client =
+        resourceConfiguration.getLogAnalyticsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info("Deleting Log Analytics Workspace data export rule {}", id);
+
+    client.dataExports().deleteById(id);
+  }
+
+  /**
+   * Retrieve a Sentinel instance
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being monitored
+   * @param storageAccount The Storage Account being monitored
+   * @return A {@link SentinelOnboardingState} object representing the Sentinel instance or null if
+   *     it does not exist
+   */
+  public SentinelOnboardingState getSentinel(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    try {
+      SentinelOnboardingState sentinelOnboardingState =
+          client
+              .sentinelOnboardingStates()
+              .get(
+                  storageAccount.getApplicationResource().getAzureResourceGroupName(),
+                  storageAccount.getName(),
+                  SENTINEL_ONBOARD_STATE_NAME);
+      logger.debug("Found Sentinel instance");
+      return sentinelOnboardingState;
+    } catch (ManagementException e) {
+      logger.debug("No Sentinel instance found", e);
+      if (Objects.equals(e.getValue().getCode(), RESOURCE_NOT_FOUND_CODE)
+          || Objects.equals(e.getValue().getCode(), NOT_FOUND_CODE)) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Create a new Sentinel instance
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being monitored
+   * @param storageAccount The Storage Account being monitored
+   * @return A string representing the Sentinel instance that was created
+   */
+  public String createSentinel(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info(
+        "Creating new Sentinel deployment for Log Analytics Workspace that monitors Storage Account {}",
+        storageAccount.getStorageAccountId());
+    // Need to register `Microsoft.SecurityInsights`, `Microsoft.OperationsManagement` resource
+    // providers on the customer subscription before we can create a Sentinel instance
+    // TODO: this shows up as throwing a 401 or a 400.  Throw a more specific exception in that case
+    // to help the users debug
+    // Just create (if it already exists, the request has no effect)
+    return client
+        .sentinelOnboardingStates()
+        .define(SENTINEL_ONBOARD_STATE_NAME)
+        .withExistingWorkspace(
+            storageAccount.getApplicationResource().getAzureResourceGroupName(),
+            storageAccount.getName())
+        .create()
+        .id();
+  }
+
+  /**
+   * Delete a Sentinel instance
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being monitored
+   * @param id The azure id of the Sentinel instance to delete
+   */
+  public void deleteSentinel(BillingProfileModel profileModel, String id) {
+
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info("Deleting Sentinel instance {}", id);
+
+    client.sentinelOnboardingStates().deleteById(id);
+  }
+
+  /**
+   * Get the Sentinel alert rule for the Sentinel instance monitoring the given Storage Account that
+   * will alert if too many unauthorized access attempts are made on said Storage Account
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being monitored
+   * @return A {@link ScheduledAlertRule} object representing the Sentinel rule that was created
+   */
+  public AlertRule getSentinelRuleUnauthorizedAccess(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+    try {
+      AlertRule alertRule =
+          client
+              .alertRules()
+              .get(
+                  storageAccount.getApplicationResource().getAzureResourceGroupName(),
+                  storageAccount.getName(),
+                  UNAUTHORIZED_ACCESS_ALERT_NAME);
+      logger.debug("Found Sentinel UnauthorizedAccess alert rule");
+      return alertRule;
+    } catch (ManagementException e) {
+      logger.debug("No Sentinel UnauthorizedAccess alert rule found", e);
+      if (Objects.equals(e.getValue().getCode(), RESOURCE_NOT_FOUND_CODE)
+          || Objects.equals(e.getValue().getCode(), NOT_FOUND_CODE)
+          || (Objects.equals(e.getValue().getCode(), BAD_REQUEST_CODE)
+              && e.getMessage().contains("is not onboarded to Microsoft Sentinel"))) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Create the Sentinel alert rule for the Sentinel instance monitoring the given Storage Account
+   * that will alert if too many unauthorized access attempts are made on said Storage Account
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being monitored
+   * @return A string representing the id of the Sentinel rule that was created
+   */
+  public String createSentinelRuleUnauthorizedAccess(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    // Note: this is copied from the rule defined in the Terra landing zone service
+    logger.info(
+        "Creating new Sentinel rule for Sentinel instance monitoring Storage Account {} - UnauthorizedAccess",
+        storageAccount.getStorageAccountId());
+    return client
+        .alertRules()
+        .createOrUpdate(
+            storageAccount.getApplicationResource().getAzureResourceGroupName(),
+            storageAccount.getName(),
+            "UnauthorizedAccess",
+            new ScheduledAlertRule()
+                .withDisplayName("File access attempts by unauthorized user accounts")
+                .withQuery(
+                    """
+            StorageBlobLogs\s
+            | where StatusCode in (401,403)
+            | extend CallerIpAddress = tostring(split(CallerIpAddress, ":")[0]),
+                     Identity = coalesce(parse_urlquery(Uri)["Query Parameters"]["rscd"], AuthenticationHash, AuthenticationType)
+            | summarize
+                Attempts = count(), TimeStart = min(TimeGenerated), TimeEnd = max(TimeGenerated)
+                by AccountName, CallerIpAddress, Identity, bin(TimeGenerated, 10m)
+            | where Attempts > 10
+            | project TimeStart, TimeEnd, Attempts, CallerIpAddress, AccountName, Identity
+                                        """)
+                .withSuppressionEnabled(false)
+                .withSuppressionDuration(Duration.parse("PT1H"))
+                .withQueryPeriod(Duration.ofDays(1))
+                .withQueryFrequency(Duration.ofDays(1))
+                .withEnabled(true)
+                .withSeverity(AlertSeverity.INFORMATIONAL)
+                .withTriggerOperator(TriggerOperator.GREATER_THAN)
+                .withTriggerThreshold(0))
+        .id();
+  }
+
+  /**
+   * Delete the Sentinel alert rule for the Sentinel instance monitoring the given Storage Account.
+   * Note: this is for the rule that track unauthorized access to the storage account's files
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being monitored
+   */
+  public void deleteSentinelRuleUnauthorizedAccess(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info(
+        "Deleting Sentinel UnauthorizedAccess alert rule for Storage Account {}",
+        storageAccount.getStorageAccountId());
+    client
+        .alertRules()
+        .delete(
+            storageAccount.getApplicationResource().getAzureResourceGroupName(),
+            storageAccount.getName(),
+            UNAUTHORIZED_ACCESS_ALERT_NAME);
+  }
+
+  /**
+   * Retrieve the rule for sending Slack notifications
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being monitored
+   * @param storageAccount The Storage Account being monitored
+   * @return A {@link AutomationRule} object representing the Sentinel notification rule or null if
+   *     it doesn't exist
+   */
+  public AutomationRule getNotificationRule(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+    try {
+      AutomationRule automationRule =
+          client
+              .automationRules()
+              .get(
+                  storageAccount.getApplicationResource().getAzureResourceGroupName(),
+                  storageAccount.getName(),
+                  SLACK_ALERT_RULE_NAME);
+      logger.debug("Found Sentinel alert rule");
+      return automationRule;
+    } catch (ManagementException e) {
+      logger.debug("No Sentinel alert rule", e);
+      if (Objects.equals(e.getValue().getCode(), RESOURCE_NOT_FOUND_CODE)
+          || Objects.equals(e.getValue().getCode(), NOT_FOUND_CODE)) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Create the rule for sending Slack notifications. The Logic App that sends the notifications has
+   * an ID configured in the application configuration: azure.monitoring.notificationApplicationId.
+   *
+   * <p>The app is defined as part of the Azure Terraform <a
+   * href="https://github.com/broadinstitute/terraform-ap-deployments/blob/master/azure/terra-tenant/sentinel.tf#L26">here</a>
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccount The Storage Account being monitored
+   * @return A string representing the Sentinel rule that was created
+   */
+  public String createNotificationRule(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+    logger.info(
+        "Creating new Sentinel alert rule for Sentinel instance monitoring Storage Account {}",
+        storageAccount.getStorageAccountId());
+    AutomationRuleTriggeringLogic trigger =
+        new AutomationRuleTriggeringLogic()
+            .withTriggersWhen(TriggersWhen.CREATED)
+            .withTriggersOn(TriggersOn.INCIDENTS)
+            .withIsEnabled(true);
+    AutomationRuleRunPlaybookAction runPlaybookAction =
+        new AutomationRuleRunPlaybookAction()
+            // There should ever only be one of these
+            .withOrder(1)
+            .withActionConfiguration(
+                new PlaybookActionProperties()
+                    .withLogicAppResourceId(
+                        resourceConfiguration.getMonitoring().getNotificationApplicationId())
+                    .withTenantId(resourceConfiguration.getCredentials().getHomeTenantId()));
+    return client
+        .automationRules()
+        .define(SLACK_ALERT_RULE_NAME)
+        .withExistingWorkspace(
+            storageAccount.getApplicationResource().getAzureResourceGroupName(),
+            storageAccount.getName())
+        .withDisplayName("Run Slack Notification Playbook")
+        .withOrder(1)
+        .withTriggeringLogic(trigger)
+        .withActions(List.of(runPlaybookAction))
+        .create()
+        .id();
+  }
+
+  /**
+   * Delete the rule for sending Slack notifications
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param id The Azure id of the notification rule to delete
+   */
+  public void deleteNotificationRule(BillingProfileModel profileModel, String id) {
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.getCredentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info("Deleting Sentinel alert rule {}", id);
+
+    client.automationRules().deleteById(id);
+  }
+
+  private String getStorageAccountLoggingResourceId(AzureStorageAccountResource storageAccount) {
+    return storageAccount.getStorageAccountId() + "/blobServices/default";
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -84,10 +84,10 @@ public class AzureMonitoringService {
               .getByResourceGroup(
                   storageAccount.getApplicationResource().getAzureResourceGroupName(),
                   storageAccount.getName());
-      logger.info("Found Log Analytics Workspace");
+      logger.debug("Found Log Analytics Workspace");
       return byResourceGroup;
     } catch (ManagementException e) {
-      logger.warn("No Log Analytics Workspace found", e);
+      logger.debug("No Log Analytics Workspace found", e);
       if (Objects.equals(e.getValue().getCode(), RESOURCE_NOT_FOUND_CODE)) {
         return null;
       } else {

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -60,7 +59,6 @@ public class AzureMonitoringService {
 
   private final AzureResourceConfiguration resourceConfiguration;
 
-  @Autowired
   public AzureMonitoringService(AzureResourceConfiguration resourceConfiguration) {
     this.resourceConfiguration = resourceConfiguration;
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -142,7 +142,7 @@ public class AzureResourceConfiguration {
    * @param tenantId The ID of the user's tenant
    * @param subscriptionId The ID of the subscription that will be charged for the resources created
    *     with this client
-   * @return An authenticated {@link LogAnalyticsManager} client
+   * @return An authenticated {@link SecurityInsightsManager} client
    */
   public SecurityInsightsManager getSecurityInsightsManagerClient(
       final UUID tenantId, final UUID subscriptionId) {

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -203,6 +203,7 @@ public class AzureResourceConfiguration {
     private String sqlAdminPassword;
     private String databaseName;
     private String parquetFileFormatName;
+    private String encryptionKey;
 
     public String getWorkspaceName() {
       return workspaceName;
@@ -242,6 +243,14 @@ public class AzureResourceConfiguration {
 
     public void setParquetFileFormatName(String parquetFileFormatName) {
       this.parquetFileFormatName = parquetFileFormatName;
+    }
+
+    public String getEncryptionKey() {
+      return encryptionKey;
+    }
+
+    public void setEncryptionKey(String encryptionKey) {
+      this.encryptionKey = encryptionKey;
     }
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -5,6 +5,8 @@ import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
+import com.azure.resourcemanager.securityinsights.SecurityInsightsManager;
 import java.util.UUID;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -99,6 +101,41 @@ public class AzureResourceConfiguration {
         new AzureProfile(tenantId.toString(), subscriptionId.toString(), AzureEnvironment.AZURE);
     return AzureResourceManager.authenticate(getAppToken(tenantId), profile)
         .withSubscription(subscriptionId.toString());
+  }
+
+  /**
+   * Get a log analytics resource manager client to a user's tenant. This object can then be used to
+   * create/destroy resources Note: this is a separate method from the one above because the log
+   * analytics client is not GA yet so does not return a generic AzureResourceManager object
+   *
+   * @param tenantId The ID of the user's tenant
+   * @param subscriptionId The ID of the subscription that will be charged for the resources created
+   *     with this client
+   * @return An authenticated {@link LogAnalyticsManager} client
+   */
+  public LogAnalyticsManager getLogAnalyticsManagerClient(
+      final UUID tenantId, final UUID subscriptionId) {
+    final AzureProfile profile =
+        new AzureProfile(tenantId.toString(), subscriptionId.toString(), AzureEnvironment.AZURE);
+    return LogAnalyticsManager.authenticate(getAppToken(), profile);
+  }
+
+  /**
+   * Get a security insights (e.g. Sentinel) resource manager client to a user's tenant. This object
+   * can then be used to create/destroy resources Note: this is a separate method from the one above
+   * because the security insights client is not GA yet so does not return a generic
+   * AzureResourceManager object
+   *
+   * @param tenantId The ID of the user's tenant
+   * @param subscriptionId The ID of the subscription that will be charged for the resources created
+   *     with this client
+   * @return An authenticated {@link LogAnalyticsManager} client
+   */
+  public SecurityInsightsManager getSecurityInsightsManagerClient(
+      final UUID tenantId, final UUID subscriptionId) {
+    final AzureProfile profile =
+        new AzureProfile(tenantId.toString(), subscriptionId.toString(), AzureEnvironment.AZURE);
+    return SecurityInsightsManager.authenticate(getAppToken(), profile);
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -204,6 +204,7 @@ public class AzureResourceConfiguration {
     private String databaseName;
     private String parquetFileFormatName;
     private String encryptionKey;
+    private boolean initialize;
 
     public String getWorkspaceName() {
       return workspaceName;
@@ -251,6 +252,14 @@ public class AzureResourceConfiguration {
 
     public void setEncryptionKey(String encryptionKey) {
       this.encryptionKey = encryptionKey;
+    }
+
+    public boolean isInitialize() {
+      return initialize;
+    }
+
+    public void setInitialize(boolean initialize) {
+      this.initialize = initialize;
     }
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResource.java
@@ -119,6 +119,16 @@ public class AzureStorageAccountResource {
     return storageAccountURL.render();
   }
 
+  public String getStorageAccountId() {
+    String storageAccountIdTemplate =
+        "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroup>/providers/Microsoft.Storage/storageAccounts/<storageAccount>";
+    return new ST(storageAccountIdTemplate)
+        .add("subscriptionId", applicationResource.getSubscriptionId())
+        .add("resourceGroup", applicationResource.getAzureResourceGroupName())
+        .add("storageAccount", name)
+        .render();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -1,5 +1,7 @@
 package bio.terra.service.resourcemanagement.azure;
 
+import static bio.terra.service.filedata.azure.util.AzureConstants.RESOURCE_NOT_FOUND_CODE;
+
 import bio.terra.app.model.AzureRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.profile.ProfileDao;
@@ -317,7 +319,7 @@ public class AzureStorageAccountService {
               storageAccountResource.getApplicationResource().getAzureResourceGroupName(),
               storageAccountResource.getName());
     } catch (ManagementException e) {
-      if (e.getValue().getCode().equals("ResourceNotFound")) {
+      if (e.getValue().getCode().equals(RESOURCE_NOT_FOUND_CODE)) {
         return null;
       }
       throw new AzureResourceException("Could not check storage account existence", e);

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AbstractCreateMonitoringResourceStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AbstractCreateMonitoringResourceStep.java
@@ -1,0 +1,38 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.common.exception.NotFoundException;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+
+public abstract class AbstractCreateMonitoringResourceStep implements Step {
+
+  /**
+   * Return the storage account resource object regardless of whether it is a dataset or snapshot
+   *
+   * @param context The current flight's context
+   * @return A {@link AzureStorageAccountResource} object or null if not found
+   * @throws NotFoundException If a storage account resource is not found
+   */
+  protected AzureStorageAccountResource getStorageAccount(FlightContext context)
+      throws NotFoundException {
+    AzureStorageAccountResource storageAccountResource =
+        context
+            .getWorkingMap()
+            .get(CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
+    if (storageAccountResource != null) {
+      return storageAccountResource;
+    }
+    storageAccountResource =
+        context
+            .getWorkingMap()
+            .get(
+                CommonMapKeys.SNAPSHOT_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
+    if (storageAccountResource != null) {
+      return storageAccountResource;
+    }
+    throw new NotFoundException(
+        "Storage account resource not found in the current flight's working map");
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AzureMonitoringMapKeys.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AzureMonitoringMapKeys.java
@@ -1,0 +1,13 @@
+package bio.terra.service.resourcemanagement.flight;
+
+public final class AzureMonitoringMapKeys {
+  private AzureMonitoringMapKeys() {}
+
+  public static final String PREFIX = "azmonitoring-";
+  public static final String LOG_ANALYTICS_WORKSPACE_ID = PREFIX + "law-id";
+  public static final String DIAGNOSTIC_SETTING_ID = PREFIX + "ds-id";
+  public static final String EXPORT_RULE_ID = PREFIX + "er-id";
+  public static final String SENTINEL_ID = PREFIX + "sentinel-id";
+  public static final String ALERT_RULE_UNAUTHED_ACCESS_ID = PREFIX + "ar-unauthed-id";
+  public static final String NOTIFICATION_RULE_ID = PREFIX + "nr-id";
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringProvider.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringProvider.java
@@ -1,0 +1,54 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.stairway.RetryRule;
+import bio.terra.stairway.RetryRuleNone;
+import bio.terra.stairway.Step;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AzureStorageMonitoringProvider {
+
+  private final AzureMonitoringService monitoringService;
+
+  public AzureStorageMonitoringProvider(AzureMonitoringService monitoringService) {
+    this.monitoringService = monitoringService;
+  }
+
+  /**
+   * Configure the steps needed to configure storage account logging and monitoring. If the dataset
+   * or snapshot has secure monitoring enabled, this will configure extra log retention and
+   * monitoring resources
+   *
+   * @param isSecureMonitoringEnabled Is this a dataset or snapshot with secure monitoring enabled?
+   */
+  public List<StepDef> configureSteps(boolean isSecureMonitoringEnabled) {
+    List<StepDef> steps = new ArrayList<>();
+    RetryRuleNone noRetry = RetryRuleNone.getRetryRuleNone();
+
+    // Deploy a Log Analytics Workspace if it doesn't exist already
+    steps.add(new StepDef(new CreateLogAnalyticsWorkspaceStep(monitoringService), noRetry));
+    // Create a diagnostic setting for the storage account if it doesn't exist already
+    // This is what tells the storage account to send logs to the Log Analytics Workspace
+    steps.add(new StepDef(new CreateDiagnosticSettingStep(monitoringService), noRetry));
+
+    // The following steps are only required for FedRAMP compliance
+    // They are not turned on in all cases due to cost
+    if (isSecureMonitoringEnabled) {
+      // Create a rule to send the Log Analytics logs to a central storage account where the logs
+      // will be retained for longer than the default 90 day minimum that the Log Analytics
+      // Workspace stores
+      steps.add(new StepDef(new CreateExportRuleStep(monitoringService), noRetry));
+      // Deploy a Sentinel Workspace if it doesn't exist already
+      steps.add(new StepDef(new CreateSentinelStep(monitoringService), noRetry));
+      // Add any rules to Sentinel that will detect events of interest
+      steps.add(new StepDef(new CreateSentinelAlertRulesStep(monitoringService), noRetry));
+      // Add a notification playbook rule to the Sentinel instance.  This ensures that a Slack
+      // notification is sent when an alert is triggered.
+      steps.add(new StepDef(new CreateSentinelNotificationRuleStep(monitoringService), noRetry));
+    }
+    return steps;
+  }
+
+  public record StepDef(Step step, RetryRule retryRule) {}
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
@@ -11,11 +11,15 @@ import bio.terra.stairway.Step;
 import java.util.ArrayList;
 import java.util.List;
 
-public class AzureStorageMonitoringProvider {
+/**
+ * This class provides methods to generate the steps needed to configure storage account logging and
+ * monitoring.
+ */
+public class AzureStorageMonitoringStepProvider {
 
   private final AzureMonitoringService monitoringService;
 
-  public AzureStorageMonitoringProvider(AzureMonitoringService monitoringService) {
+  public AzureStorageMonitoringStepProvider(AzureMonitoringService monitoringService) {
     this.monitoringService = monitoringService;
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateDiagnosticSettingStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateDiagnosticSettingStep.java
@@ -1,0 +1,52 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+
+public class CreateDiagnosticSettingStep extends AbstractCreateMonitoringResourceStep {
+
+  private final AzureMonitoringService monitoringService;
+
+  public CreateDiagnosticSettingStep(AzureMonitoringService monitoringService) {
+    this.monitoringService = monitoringService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    AzureStorageAccountResource storageAccount = getStorageAccount(context);
+    if (monitoringService.getDiagnosticSetting(profileModel, storageAccount) != null) {
+      return StepResult.getStepResultSuccess();
+    }
+    String logAnalyticsWorkspaceId =
+        workingMap.get(AzureMonitoringMapKeys.LOG_ANALYTICS_WORKSPACE_ID, String.class);
+    String diagnosticSettingId =
+        monitoringService.createDiagnosticSetting(
+            profileModel, storageAccount, logAnalyticsWorkspaceId);
+    // Only record if we created the Diagnostic Setting as an indicator that we need to remove
+    // it on failure
+    workingMap.put(AzureMonitoringMapKeys.DIAGNOSTIC_SETTING_ID, diagnosticSettingId);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    String diagnosticSettingId =
+        workingMap.get(AzureMonitoringMapKeys.DIAGNOSTIC_SETTING_ID, String.class);
+    if (diagnosticSettingId != null) {
+      monitoringService.deleteDiagnosticSetting(profileModel, diagnosticSettingId);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateExportRuleStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateExportRuleStep.java
@@ -1,0 +1,47 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+
+public class CreateExportRuleStep extends AbstractCreateMonitoringResourceStep {
+
+  private final AzureMonitoringService monitoringService;
+
+  public CreateExportRuleStep(AzureMonitoringService monitoringService) {
+    this.monitoringService = monitoringService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    AzureStorageAccountResource storageAccount = getStorageAccount(context);
+    if (monitoringService.getDataExportRule(profileModel, storageAccount) != null) {
+      return StepResult.getStepResultSuccess();
+    }
+    String exportRuleId = monitoringService.createDataExportRule(profileModel, storageAccount);
+    // Only record if we created the data export rule as an indicator that we need to remove
+    // it on failure
+    workingMap.put(AzureMonitoringMapKeys.EXPORT_RULE_ID, exportRuleId);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    String exportRuleId = workingMap.get(AzureMonitoringMapKeys.EXPORT_RULE_ID, String.class);
+    if (exportRuleId != null) {
+      monitoringService.deleteDataExportRule(profileModel, exportRuleId);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateLogAnalyticsWorkspaceStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateLogAnalyticsWorkspaceStep.java
@@ -1,0 +1,49 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+
+public class CreateLogAnalyticsWorkspaceStep extends AbstractCreateMonitoringResourceStep {
+
+  private final AzureMonitoringService monitoringService;
+
+  public CreateLogAnalyticsWorkspaceStep(AzureMonitoringService monitoringService) {
+    this.monitoringService = monitoringService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    AzureStorageAccountResource storageAccount = getStorageAccount(context);
+    if (monitoringService.getLogAnalyticsWorkspace(profileModel, storageAccount) != null) {
+      return StepResult.getStepResultSuccess();
+    }
+    String logAnalyticsWorkspaceId =
+        monitoringService.createLogAnalyticsWorkspace(profileModel, storageAccount);
+    // Only record if we created the Log Analytics Workspace as an indicator that we need to remove
+    // it on failure
+    workingMap.put(AzureMonitoringMapKeys.LOG_ANALYTICS_WORKSPACE_ID, logAnalyticsWorkspaceId);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    String logAnalyticsWorkspaceId =
+        workingMap.get(AzureMonitoringMapKeys.LOG_ANALYTICS_WORKSPACE_ID, String.class);
+    if (logAnalyticsWorkspaceId != null) {
+      monitoringService.deleteLogAnalyticsWorkspace(profileModel, logAnalyticsWorkspaceId);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelAlertRulesStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelAlertRulesStep.java
@@ -1,0 +1,50 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+
+public class CreateSentinelAlertRulesStep extends AbstractCreateMonitoringResourceStep {
+
+  private final AzureMonitoringService monitoringService;
+
+  public CreateSentinelAlertRulesStep(AzureMonitoringService monitoringService) {
+    this.monitoringService = monitoringService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    AzureStorageAccountResource storageAccount = getStorageAccount(context);
+    if (monitoringService.getSentinelRuleUnauthorizedAccess(profileModel, storageAccount) != null) {
+      return StepResult.getStepResultSuccess();
+    }
+    String alertRuleUnauthedAccessId =
+        monitoringService.createSentinelRuleUnauthorizedAccess(profileModel, storageAccount);
+    // Only record if we created the alert rule as an indicator that we need to remove
+    // it on failure
+    workingMap.put(AzureMonitoringMapKeys.ALERT_RULE_UNAUTHED_ACCESS_ID, alertRuleUnauthedAccessId);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    String sentinelId =
+        workingMap.get(AzureMonitoringMapKeys.ALERT_RULE_UNAUTHED_ACCESS_ID, String.class);
+    if (sentinelId != null) {
+      AzureStorageAccountResource storageAccount = getStorageAccount(context);
+      monitoringService.deleteSentinelRuleUnauthorizedAccess(profileModel, storageAccount);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelNotificationRuleStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelNotificationRuleStep.java
@@ -1,0 +1,49 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+
+public class CreateSentinelNotificationRuleStep extends AbstractCreateMonitoringResourceStep {
+
+  private final AzureMonitoringService monitoringService;
+
+  public CreateSentinelNotificationRuleStep(AzureMonitoringService monitoringService) {
+    this.monitoringService = monitoringService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    AzureStorageAccountResource storageAccount = getStorageAccount(context);
+    if (monitoringService.getNotificationRule(profileModel, storageAccount) != null) {
+      return StepResult.getStepResultSuccess();
+    }
+    String notificationRuleID =
+        monitoringService.createNotificationRule(profileModel, storageAccount);
+    // Only record if we created the Sentinel deployment as an indicator that we need to remove
+    // it on failure
+    workingMap.put(AzureMonitoringMapKeys.NOTIFICATION_RULE_ID, notificationRuleID);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    String notificationRuleID =
+        workingMap.get(AzureMonitoringMapKeys.NOTIFICATION_RULE_ID, String.class);
+    if (notificationRuleID != null) {
+      monitoringService.deleteNotificationRule(profileModel, notificationRuleID);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelStep.java
@@ -1,0 +1,47 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+
+public class CreateSentinelStep extends AbstractCreateMonitoringResourceStep {
+
+  private final AzureMonitoringService monitoringService;
+
+  public CreateSentinelStep(AzureMonitoringService monitoringService) {
+    this.monitoringService = monitoringService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    AzureStorageAccountResource storageAccount = getStorageAccount(context);
+    if (monitoringService.getSentinel(profileModel, storageAccount) != null) {
+      return StepResult.getStepResultSuccess();
+    }
+    String sentinelId = monitoringService.createSentinel(profileModel, storageAccount);
+    // Only record if we created the Sentinel deployment as an indicator that we need to remove
+    // it on failure
+    workingMap.put(AzureMonitoringMapKeys.SENTINEL_ID, sentinelId);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    String sentinelId = workingMap.get(AzureMonitoringMapKeys.SENTINEL_ID, String.class);
+    if (sentinelId != null) {
+      monitoringService.deleteSentinel(profileModel, sentinelId);
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureContainerStep.java
@@ -17,8 +17,6 @@ public class CreateSnapshotCreateAzureContainerStep extends CreateAzureContainer
   @Override
   protected AzureStorageAccountResource getAzureStorageAccountResource(
       FlightContext context, BillingProfileModel profileModel) throws InterruptedException {
-    return context
-        .getWorkingMap()
-        .get(storageAccountContextKey, AzureStorageAccountResource.class);
+    return context.getWorkingMap().get(storageAccountContextKey, AzureStorageAccountResource.class);
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureContainerStep.java
@@ -1,0 +1,29 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.common.CreateAzureContainerStep;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+
+public class CreateSnapshotCreateAzureContainerStep extends CreateAzureContainerStep {
+  public CreateSnapshotCreateAzureContainerStep(
+      ResourceService resourceService, AzureContainerPdao azureContainerPdao) {
+    super(resourceService, azureContainerPdao);
+  }
+
+  @Override
+  protected String getStorageAccountContextKey() {
+    return CommonMapKeys.SNAPSHOT_STORAGE_ACCOUNT_RESOURCE;
+  }
+
+  @Override
+  protected AzureStorageAccountResource getAzureStorageAccountResource(
+      FlightContext context, BillingProfileModel profileModel) throws InterruptedException {
+    return context
+        .getWorkingMap()
+        .get(getStorageAccountContextKey(), AzureStorageAccountResource.class);
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureContainerStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureContainerStep.java
@@ -11,12 +11,7 @@ import bio.terra.stairway.FlightContext;
 public class CreateSnapshotCreateAzureContainerStep extends CreateAzureContainerStep {
   public CreateSnapshotCreateAzureContainerStep(
       ResourceService resourceService, AzureContainerPdao azureContainerPdao) {
-    super(resourceService, azureContainerPdao);
-  }
-
-  @Override
-  protected String getStorageAccountContextKey() {
-    return CommonMapKeys.SNAPSHOT_STORAGE_ACCOUNT_RESOURCE;
+    super(resourceService, azureContainerPdao, CommonMapKeys.SNAPSHOT_STORAGE_ACCOUNT_RESOURCE);
   }
 
   @Override
@@ -24,6 +19,6 @@ public class CreateSnapshotCreateAzureContainerStep extends CreateAzureContainer
       FlightContext context, BillingProfileModel profileModel) throws InterruptedException {
     return context
         .getWorkingMap()
-        .get(getStorageAccountContextKey(), AzureStorageAccountResource.class);
+        .get(storageAccountContextKey, AzureStorageAccountResource.class);
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCreateAzureStorageAccountStep.java
@@ -42,7 +42,11 @@ public class CreateSnapshotCreateAzureStorageAccountStep extends CreateAzureStor
 
     AzureStorageAccountResource storageAccountResource =
         resourceService.createSnapshotStorageAccount(
-            snapshotId, dataset.getStorageAccountRegion(), billingProfile, flightId);
+            snapshotId,
+            dataset.getStorageAccountRegion(),
+            billingProfile,
+            flightId,
+            dataset.isSecureMonitoringEnabled());
     workingMap.put(CommonMapKeys.SNAPSHOT_STORAGE_ACCOUNT_RESOURCE, storageAccountResource);
 
     AzureStorageAuthInfo storageAuthInfo =

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -38,6 +38,7 @@ import bio.terra.service.profile.google.GoogleBillingService;
 import bio.terra.service.resourcemanagement.BufferService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
 import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
@@ -94,6 +95,7 @@ public class SnapshotCreateFlight extends Flight {
     DuosService duosService = appContext.getBean(DuosService.class);
     PolicyService policyService = appContext.getBean(PolicyService.class);
     ApplicationConfiguration appConfig = appContext.getBean(ApplicationConfiguration.class);
+    AzureContainerPdao azureContainerPdao = appContext.getBean(AzureContainerPdao.class);
 
     SnapshotRequestModel snapshotReq =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), SnapshotRequestModel.class);
@@ -161,6 +163,8 @@ public class SnapshotCreateFlight extends Flight {
 
     if (platform.isAzure()) {
       addStep(new CreateSnapshotCreateAzureStorageAccountStep(resourceService, sourceDataset));
+      addStep(new CreateSnapshotCreateAzureContainerStep(resourceService, azureContainerPdao));
+
       addStep(
           new CreateSnapshotSourceDatasetDataSourceAzureStep(
               azureSynapsePdao, azureBlobStorePdao, userReq));

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -40,7 +40,7 @@ import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
-import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringProvider;
+import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringStepProvider;
 import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
@@ -99,8 +99,8 @@ public class SnapshotCreateFlight extends Flight {
     ApplicationConfiguration appConfig = appContext.getBean(ApplicationConfiguration.class);
     AzureContainerPdao azureContainerPdao = appContext.getBean(AzureContainerPdao.class);
     AzureMonitoringService monitoringService = appContext.getBean(AzureMonitoringService.class);
-    AzureStorageMonitoringProvider azureStorageMonitoringProvider =
-        new AzureStorageMonitoringProvider(monitoringService);
+    AzureStorageMonitoringStepProvider azureStorageMonitoringStepProvider =
+        new AzureStorageMonitoringStepProvider(monitoringService);
 
     SnapshotRequestModel snapshotReq =
         inputParameters.get(JobMapKeys.REQUEST.getKeyName(), SnapshotRequestModel.class);
@@ -171,7 +171,7 @@ public class SnapshotCreateFlight extends Flight {
       addStep(new CreateSnapshotCreateAzureContainerStep(resourceService, azureContainerPdao));
 
       // Turn on logging and monitoring for the storage account associated with the snapshot
-      azureStorageMonitoringProvider
+      azureStorageMonitoringStepProvider
           .configureSteps(sourceDataset.isSecureMonitoringEnabled())
           .forEach(s -> this.addStep(s.step(), s.retryRule()));
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -110,6 +110,11 @@ azure.synapse.parquetFileFormatName=ParquetFileFormat
 azure.apiVersion=2021-07-01
 azure.maxRetries=3
 azure.retryTimeoutSeconds=3600
+#azure.monitoring.notificationApplicationId=resource id for Logic app that sends slack messages
+#azure.monitoring.logCollectionConfigs[0].region=region, e.g. eastus
+#azure.monitoring.logCollectionConfigs[0].targetStorageAccountResourceId=resource id for storage account to store logs
+# ...
+
 features.search.api=disabled
 elasticsearch.hostname=localhost
 elasticsearch.port=9200

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -107,6 +107,7 @@ azure.synapse.sqlAdminUser=
 azure.synapse.sqlAdminPassword=
 azure.synapse.databaseName=datarepo
 azure.synapse.parquetFileFormatName=ParquetFileFormat
+azure.synapse.encryptionKey=
 azure.apiVersion=2021-07-01
 azure.maxRetries=3
 azure.retryTimeoutSeconds=3600

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -108,6 +108,7 @@ azure.synapse.sqlAdminPassword=
 azure.synapse.databaseName=datarepo
 azure.synapse.parquetFileFormatName=ParquetFileFormat
 azure.synapse.encryptionKey=
+azure.synapse.initialize=false
 azure.apiVersion=2021-07-01
 azure.maxRetries=3
 azure.retryTimeoutSeconds=3600

--- a/src/test/java/bio/terra/common/AzureUtils.java
+++ b/src/test/java/bio/terra/common/AzureUtils.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.configuration.TestConfiguration;
+import bio.terra.model.BillingProfileModel;
 import bio.terra.service.filedata.google.firestore.FireStoreDependency;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import com.azure.data.tables.models.TableEntity;
@@ -12,6 +13,7 @@ import com.azure.resourcemanager.AzureResourceManager;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.stringtemplate.v4.ST;
 
 @Component
 public class AzureUtils {
@@ -51,5 +53,37 @@ public class AzureUtils {
         equalTo(entity.getProperty(FireStoreDependency.SNAPSHOT_ID_FIELD_NAME)));
     assertThat(fileId, equalTo(entity.getProperty(FireStoreDependency.FILE_ID_FIELD_NAME)));
     assertThat(refCount, equalTo(entity.getProperty(FireStoreDependency.REF_COUNT_FIELD_NAME)));
+  }
+
+  /**
+   * Generate the resource id for an application deployment Azure resource
+   *
+   * @param billingProfile The {@link BillingProfileModel} object that contains the relevant
+   *     identifying information
+   * @return A string representing the resource id of the application deployment
+   */
+  public static String getApplicationDeploymentResourceId(BillingProfileModel billingProfile) {
+    return getApplicationDeploymentResourceId(
+        billingProfile.getSubscriptionId(),
+        billingProfile.getResourceGroupName(),
+        billingProfile.getApplicationDeploymentName());
+  }
+
+  /**
+   * Generate the resource id for an application deployment Azure resource
+   *
+   * @param subscriptionId The Id of the subscription where the application is deployed
+   * @param resourceGroupName The name of the resource group where the application is deployed
+   * @param appName The name of the application deployment
+   * @return A string representing the resource id of the application deployment
+   */
+  public static String getApplicationDeploymentResourceId(
+      UUID subscriptionId, String resourceGroupName, String appName) {
+    return new ST(
+            "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/microsoft.solutions/applications/<appName>")
+        .add("subscriptionId", subscriptionId)
+        .add("resourceGroup", resourceGroupName)
+        .add("appName", appName)
+        .render();
   }
 }

--- a/src/test/java/bio/terra/common/AzureUtils.java
+++ b/src/test/java/bio/terra/common/AzureUtils.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.configuration.TestConfiguration;
-import bio.terra.model.BillingProfileModel;
 import bio.terra.service.filedata.google.firestore.FireStoreDependency;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import com.azure.data.tables.models.TableEntity;
@@ -13,7 +12,6 @@ import com.azure.resourcemanager.AzureResourceManager;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.stringtemplate.v4.ST;
 
 @Component
 public class AzureUtils {
@@ -53,37 +51,5 @@ public class AzureUtils {
         equalTo(entity.getProperty(FireStoreDependency.SNAPSHOT_ID_FIELD_NAME)));
     assertThat(fileId, equalTo(entity.getProperty(FireStoreDependency.FILE_ID_FIELD_NAME)));
     assertThat(refCount, equalTo(entity.getProperty(FireStoreDependency.REF_COUNT_FIELD_NAME)));
-  }
-
-  /**
-   * Generate the resource id for an application deployment Azure resource
-   *
-   * @param billingProfile The {@link BillingProfileModel} object that contains the relevant
-   *     identifying information
-   * @return A string representing the resource id of the application deployment
-   */
-  public static String getApplicationDeploymentResourceId(BillingProfileModel billingProfile) {
-    return getApplicationDeploymentResourceId(
-        billingProfile.getSubscriptionId(),
-        billingProfile.getResourceGroupName(),
-        billingProfile.getApplicationDeploymentName());
-  }
-
-  /**
-   * Generate the resource id for an application deployment Azure resource
-   *
-   * @param subscriptionId The Id of the subscription where the application is deployed
-   * @param resourceGroupName The name of the resource group where the application is deployed
-   * @param appName The name of the application deployment
-   * @return A string representing the resource id of the application deployment
-   */
-  public static String getApplicationDeploymentResourceId(
-      UUID subscriptionId, String resourceGroupName, String appName) {
-    return new ST(
-            "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/microsoft.solutions/applications/<appName>")
-        .add("subscriptionId", subscriptionId)
-        .add("resourceGroup", resourceGroupName)
-        .add("appName", appName)
-        .render();
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -43,10 +43,13 @@ import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
 import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
+import com.azure.resourcemanager.loganalytics.models.Workspace;
+import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import java.io.IOException;
@@ -111,6 +114,7 @@ public class DatasetServiceTest {
   @MockBean private GcsPdao gcsPdao;
   @MockBean private AzureContainerPdao azureContainerPdao;
   @MockBean private AzureBlobStorePdao azureBlobStorePdao;
+  @MockBean private AzureMonitoringService azureMonitoringService;
 
   @Captor private ArgumentCaptor<List<String>> listCaptor;
   @Captor private ArgumentCaptor<IngestRequestModel> requestCaptor;
@@ -591,6 +595,12 @@ public class DatasetServiceTest {
     when(storageAccountResource.getApplicationResource()).thenReturn(applicationResource);
     when(resourceService.getOrCreateDatasetStorageAccount(any(), any(), any()))
         .thenReturn(storageAccountResource);
+    // Mock that the monitoring stack already exists so creation steps are skipped
+    when(azureMonitoringService.getLogAnalyticsWorkspace(any(), any()))
+        .thenReturn(mock(Workspace.class));
+    when(azureMonitoringService.getDiagnosticSetting(any(), any()))
+        .thenReturn(mock(DiagnosticSetting.class));
+    when(azureContainerPdao.getContainer(any(), any())).thenReturn(containerClient);
     when(azureContainerPdao.getOrCreateContainer(any(), any())).thenReturn(containerClient);
     when(azureBlobStorePdao.signFile(any(), eq(storageAccountResource), eq(filePath), any()))
         .thenReturn(signedPath);

--- a/src/test/java/bio/terra/service/resourcemanagement/AzureDataLocationSelectorTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/AzureDataLocationSelectorTest.java
@@ -1,0 +1,95 @@
+package bio.terra.service.resourcemanagement;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import bio.terra.app.model.AzureRegion;
+import bio.terra.model.BillingProfileModel;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"google", "unittest"})
+@Tag("bio.terra.common.category.Unit")
+public class AzureDataLocationSelectorTest {
+
+  private static final BillingProfileModel PROFILE_1 =
+      new BillingProfileModel().id(UUID.randomUUID()).profileName("foo");
+  private static final BillingProfileModel PROFILE_2 =
+      new BillingProfileModel().id(UUID.randomUUID()).profileName("bar");
+
+  private static final AzureRegion REGION_1 = AzureRegion.ASIA;
+  private static final AzureRegion REGION_2 = AzureRegion.EAST_US;
+
+  private final AzureDataLocationSelector dataLocationSelector = new AzureDataLocationSelector();
+
+  @Test
+  void testGenerateNamePrefixIsCorrect() {
+    assertThat(
+        "prefix is correct",
+        dataLocationSelector.createStorageAccountName("test", REGION_1, PROFILE_1, false),
+        startsWith("test"));
+  }
+
+  @Test
+  void testGenerateNameValuesAreRepeatable() {
+    assertThat(
+        "values are repeatable",
+        dataLocationSelector.createStorageAccountName("test", REGION_1, PROFILE_1, false),
+        is(dataLocationSelector.createStorageAccountName("test", REGION_1, PROFILE_1, false)));
+  }
+
+  private record Parameters(
+      String prefix,
+      AzureRegion region,
+      BillingProfileModel profile,
+      boolean secureMonitoringEnabled) {}
+
+  private static Stream<Arguments> testGeneratedNamesAreDifferent() {
+    return Stream.of(
+        arguments(
+            "prefix is different",
+            new Parameters("foo", REGION_1, PROFILE_1, false),
+            new Parameters("bar", REGION_1, PROFILE_1, false)),
+        arguments(
+            "region is different",
+            new Parameters("foo", REGION_1, PROFILE_1, false),
+            new Parameters("foo", REGION_2, PROFILE_1, false)),
+        arguments(
+            "profile is different",
+            new Parameters("foo", REGION_1, PROFILE_1, false),
+            new Parameters("foo", REGION_1, PROFILE_2, false)),
+        arguments(
+            "secure monitoring is different",
+            new Parameters("foo", REGION_1, PROFILE_1, false),
+            new Parameters("foo", REGION_1, PROFILE_1, true)));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testGeneratedNamesAreDifferent(
+      String message, Parameters parameters1, Parameters parameters2) {
+    assertThat(
+        "names don't match when the " + message,
+        dataLocationSelector.createStorageAccountName(
+            parameters1.prefix,
+            parameters1.region,
+            parameters1.profile,
+            parameters1.secureMonitoringEnabled),
+        is(
+            not(
+                dataLocationSelector.createStorageAccountName(
+                    parameters2.prefix,
+                    parameters2.region,
+                    parameters2.profile,
+                    parameters2.secureMonitoringEnabled))));
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentResourceTest.java
@@ -3,11 +3,11 @@ package bio.terra.service.resourcemanagement.azure;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import bio.terra.common.AzureUtils;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
-import org.stringtemplate.v4.ST;
 
 @ActiveProfiles({"google", "unittest"})
 @Tag("bio.terra.common.category.Unit")
@@ -18,12 +18,7 @@ class AzureApplicationDeploymentResourceTest {
     UUID subscriptionId = UUID.randomUUID();
 
     String resourceId =
-        new ST(
-                "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroup>/providers/microsoft.solutions/applications/<appName>")
-            .add("subscriptionId", subscriptionId)
-            .add("resourceGroup", "TDR")
-            .add("appName", "myapp")
-            .render();
+        AzureUtils.getApplicationDeploymentResourceId(subscriptionId, "TDR", "myapp");
 
     AzureApplicationDeploymentResource resource =
         new AzureApplicationDeploymentResource().azureApplicationDeploymentId(resourceId);

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentResourceTest.java
@@ -1,0 +1,32 @@
+package bio.terra.service.resourcemanagement.azure;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.stringtemplate.v4.ST;
+
+@ActiveProfiles({"google", "unittest"})
+@Tag("bio.terra.common.category.Unit")
+class AzureApplicationDeploymentResourceTest {
+
+  @Test
+  void testExtractSubscriptionFromResourceId() {
+    UUID subscriptionId = UUID.randomUUID();
+
+    String resourceId =
+        new ST(
+                "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroup>/providers/microsoft.solutions/applications/<appName>")
+            .add("subscriptionId", subscriptionId)
+            .add("resourceGroup", "TDR")
+            .add("appName", "myapp")
+            .render();
+
+    AzureApplicationDeploymentResource resource =
+        new AzureApplicationDeploymentResource().azureApplicationDeploymentId(resourceId);
+    assertThat("subscription can be extracted", resource.getSubscriptionId(), is(subscriptionId));
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentResourceTest.java
@@ -3,7 +3,7 @@ package bio.terra.service.resourcemanagement.azure;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import bio.terra.common.AzureUtils;
+import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -18,7 +18,7 @@ class AzureApplicationDeploymentResourceTest {
     UUID subscriptionId = UUID.randomUUID();
 
     String resourceId =
-        AzureUtils.getApplicationDeploymentResourceId(subscriptionId, "TDR", "myapp");
+        MetadataDataAccessUtils.getApplicationDeploymentId(subscriptionId, "TDR", "myapp");
 
     AzureApplicationDeploymentResource resource =
         new AzureApplicationDeploymentResource().azureApplicationDeploymentId(resourceId);

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.app.model.AzureRegion;
 import bio.terra.app.model.AzureStorageAccountSkuType;
+import bio.terra.common.AzureUtils;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.model.BillingProfileModel;
@@ -66,15 +67,8 @@ public class AzureApplicationDeploymentServiceTest {
                     DEFAULT_REGION_KEY, Map.of(PARAMETER_VALUE_KEY, "AUSTRALIA"),
                     STORAGE_PREFIX_KEY, Map.of(PARAMETER_VALUE_KEY, "tdr"),
                     STORAGE_TYPE_KEY, Map.of(PARAMETER_VALUE_KEY, "Standard_LRS"))));
-    when(genericResources.getById(
-            "/subscriptions/"
-                + billingProfileModel.getSubscriptionId()
-                + "/resourceGroups"
-                + "/"
-                + billingProfileModel.getResourceGroupName()
-                + "/providers/Microsoft.Solutions/applications/"
-                + billingProfileModel.getApplicationDeploymentName(),
-            resourceConfiguration.getApiVersion()))
+    String appResourceId = AzureUtils.getApplicationDeploymentResourceId(billingProfileModel);
+    when(genericResources.getById(appResourceId, resourceConfiguration.getApiVersion()))
         .thenReturn(genericResource);
     when(client.genericResources()).thenReturn(genericResources);
     when(resourceDao.retrieveApplicationDeploymentByName(

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentServiceTest.java
@@ -13,10 +13,10 @@ import static org.mockito.Mockito.when;
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.app.model.AzureRegion;
 import bio.terra.app.model.AzureStorageAccountSkuType;
-import bio.terra.common.AzureUtils;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.model.BillingProfileModel;
+import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import bio.terra.service.resourcemanagement.exception.AzureResourceNotFoundException;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.resources.models.GenericResource;
@@ -67,7 +67,7 @@ public class AzureApplicationDeploymentServiceTest {
                     DEFAULT_REGION_KEY, Map.of(PARAMETER_VALUE_KEY, "AUSTRALIA"),
                     STORAGE_PREFIX_KEY, Map.of(PARAMETER_VALUE_KEY, "tdr"),
                     STORAGE_TYPE_KEY, Map.of(PARAMETER_VALUE_KEY, "Standard_LRS"))));
-    String appResourceId = AzureUtils.getApplicationDeploymentResourceId(billingProfileModel);
+    String appResourceId = MetadataDataAccessUtils.getApplicationDeploymentId(billingProfileModel);
     when(genericResources.getById(appResourceId, resourceConfiguration.getApiVersion()))
         .thenReturn(genericResource);
     when(client.genericResources()).thenReturn(genericResources);

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
@@ -76,4 +76,10 @@ public class AzureContainerPdaoTest {
 
     verify(blobContainerClient, times(1)).create();
   }
+
+  @Test
+  public void testDeleteContainer() {
+    dao.deleteContainer(billingProfile, storageAccountResource);
+    verify(blobContainerClient).deleteIfExists();
+  }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
@@ -1,0 +1,281 @@
+package bio.terra.service.resourcemanagement.azure;
+
+import static bio.terra.service.filedata.azure.util.AzureConstants.NOT_FOUND_CODE;
+import static bio.terra.service.filedata.azure.util.AzureConstants.RESOURCE_NOT_FOUND_CODE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration.Credentials;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.management.exception.ManagementError;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.loganalytics.LogAnalyticsManager;
+import com.azure.resourcemanager.loganalytics.models.DataExport;
+import com.azure.resourcemanager.loganalytics.models.DataExports;
+import com.azure.resourcemanager.loganalytics.models.Workspace;
+import com.azure.resourcemanager.loganalytics.models.Workspaces;
+import com.azure.resourcemanager.monitor.models.DiagnosticSetting;
+import com.azure.resourcemanager.monitor.models.DiagnosticSettings;
+import com.azure.resourcemanager.securityinsights.SecurityInsightsManager;
+import com.azure.resourcemanager.securityinsights.models.AlertRule;
+import com.azure.resourcemanager.securityinsights.models.AlertRules;
+import com.azure.resourcemanager.securityinsights.models.AutomationRule;
+import com.azure.resourcemanager.securityinsights.models.AutomationRules;
+import com.azure.resourcemanager.securityinsights.models.SentinelOnboardingState;
+import com.azure.resourcemanager.securityinsights.models.SentinelOnboardingStates;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.stringtemplate.v4.ST;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
+class AzureMonitoringServiceTest {
+
+  @Mock private AzureResourceConfiguration resourceConfiguration;
+
+  // Azure clients
+  @Mock private LogAnalyticsManager logAnalyticsManager;
+  @Mock private AzureResourceManager azureResourceManager;
+  @Mock private SecurityInsightsManager securityInsightsManager;
+
+  private AzureMonitoringService service;
+
+  private static final UUID HOME_TENANT_ID = UUID.randomUUID();
+  private static final UUID SUBSCRIPTION_ID = UUID.randomUUID();
+  private static final BillingProfileModel PROFILE_MODEL =
+      new BillingProfileModel().subscriptionId(SUBSCRIPTION_ID);
+
+  private static final String STORAGE_ACCOUNT_NAME = "foo";
+  private static final String TOP_LEVEL_CONTAINER = "tlc";
+  private static final String RESOURCE_GROUP = "rg";
+  private static final String APPLICATION_NAME = "myapp";
+  private static final AzureApplicationDeploymentResource APPLICATION =
+      new AzureApplicationDeploymentResource()
+          .azureResourceGroupName(RESOURCE_GROUP)
+          .azureApplicationDeploymentId(
+              new ST(
+                      "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroup>/providers/microsoft.solutions/applications/<appName>")
+                  .add("subscriptionId", SUBSCRIPTION_ID)
+                  .add("resourceGroup", RESOURCE_GROUP)
+                  .add("appName", APPLICATION_NAME)
+                  .render());
+
+  private static final AzureStorageAccountResource STORAGE_ACCOUNT =
+      new AzureStorageAccountResource()
+          .name(STORAGE_ACCOUNT_NAME)
+          .topLevelContainer(TOP_LEVEL_CONTAINER)
+          .applicationResource(APPLICATION);
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    service = new AzureMonitoringService(resourceConfiguration);
+  }
+
+  @Test
+  void testGetLogAnalytics() {
+    mockLogAnalyticsClient();
+    Workspaces workspaceClient = mock(Workspaces.class);
+    when(logAnalyticsManager.workspaces()).thenReturn(workspaceClient);
+    Workspace workspace = mock(Workspace.class);
+    when(workspaceClient.getByResourceGroup(RESOURCE_GROUP, STORAGE_ACCOUNT_NAME))
+        .thenReturn(workspace);
+    assertThat(
+        "value returned when found",
+        service.getLogAnalyticsWorkspace(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(workspace));
+  }
+
+  @Test
+  void testGetLogAnalyticsNotFound() {
+    mockLogAnalyticsClient();
+    Workspaces workspaceClient = mock(Workspaces.class);
+    when(logAnalyticsManager.workspaces()).thenReturn(workspaceClient);
+    when(workspaceClient.getByResourceGroup(RESOURCE_GROUP, STORAGE_ACCOUNT_NAME))
+        .thenThrow(
+            new ManagementException(
+                "Not found", null, new ManagementError(RESOURCE_NOT_FOUND_CODE, null)));
+    assertThat(
+        "null returned when not found",
+        service.getLogAnalyticsWorkspace(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(nullValue()));
+  }
+
+  @Test
+  void testGetDiagnosticSetting() {
+    mockArmClient();
+    DiagnosticSettings diagnosticSettingsClient = mock(DiagnosticSettings.class);
+    when(azureResourceManager.diagnosticSettings()).thenReturn(diagnosticSettingsClient);
+    DiagnosticSetting diagnosticSetting = mock(DiagnosticSetting.class);
+    when(diagnosticSettingsClient.get(
+            STORAGE_ACCOUNT.getStorageAccountId() + "/blobServices/default", STORAGE_ACCOUNT_NAME))
+        .thenReturn(diagnosticSetting);
+    assertThat(
+        "value returned when found",
+        service.getDiagnosticSetting(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(diagnosticSetting));
+  }
+
+  @Test
+  void testGetDiagnosticSettingNotFound() {
+    mockArmClient();
+    DiagnosticSettings diagnosticSettingsClient = mock(DiagnosticSettings.class);
+    when(azureResourceManager.diagnosticSettings()).thenReturn(diagnosticSettingsClient);
+    when(diagnosticSettingsClient.get(
+            STORAGE_ACCOUNT.getStorageAccountId() + "/blobServices/default", STORAGE_ACCOUNT_NAME))
+        .thenThrow(
+            new ManagementException(
+                "Not found", null, new ManagementError(RESOURCE_NOT_FOUND_CODE, null)));
+    assertThat(
+        "null returned when not found",
+        service.getDiagnosticSetting(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(nullValue()));
+  }
+
+  @Test
+  void testGetLogAnalyticsExportRule() {
+    mockLogAnalyticsClient();
+    DataExports dataExportClient = mock(DataExports.class);
+    when(logAnalyticsManager.dataExports()).thenReturn(dataExportClient);
+    DataExport dataExportRule = mock(DataExport.class);
+    when(dataExportClient.get(RESOURCE_GROUP, STORAGE_ACCOUNT_NAME, STORAGE_ACCOUNT_NAME))
+        .thenReturn(dataExportRule);
+    assertThat(
+        "value returned when found",
+        service.getDataExportRule(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(dataExportRule));
+  }
+
+  @Test
+  void testGetLogAnalyticsExportRuleNotFound() {
+    mockLogAnalyticsClient();
+    DataExports dataExportClient = mock(DataExports.class);
+    when(logAnalyticsManager.dataExports()).thenReturn(dataExportClient);
+
+    HttpResponse response = mock(HttpResponse.class);
+    when(response.getStatusCode()).thenReturn(404);
+
+    when(dataExportClient.get(RESOURCE_GROUP, STORAGE_ACCOUNT_NAME, STORAGE_ACCOUNT_NAME))
+        .thenThrow(new ManagementException("Not found", response, null));
+    assertThat(
+        "null returned when not found",
+        service.getDataExportRule(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(nullValue()));
+  }
+
+  @Test
+  void testGetSentinel() {
+    mockSecurityInsightsClient();
+    SentinelOnboardingStates sentinelClient = mock(SentinelOnboardingStates.class);
+    when(securityInsightsManager.sentinelOnboardingStates()).thenReturn(sentinelClient);
+    SentinelOnboardingState sentinel = mock(SentinelOnboardingState.class);
+    when(sentinelClient.get(RESOURCE_GROUP, STORAGE_ACCOUNT_NAME, "default")).thenReturn(sentinel);
+    assertThat(
+        "value returned when found",
+        service.getSentinel(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(sentinel));
+  }
+
+  @Test
+  void testGetSentinelNotFound() {
+    mockSecurityInsightsClient();
+    SentinelOnboardingStates sentinelClient = mock(SentinelOnboardingStates.class);
+    when(securityInsightsManager.sentinelOnboardingStates()).thenReturn(sentinelClient);
+    when(sentinelClient.get(RESOURCE_GROUP, STORAGE_ACCOUNT_NAME, "default"))
+        .thenThrow(
+            new ManagementException("Not found", null, new ManagementError(NOT_FOUND_CODE, null)));
+    assertThat(
+        "null returned when not found",
+        service.getSentinel(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(nullValue()));
+  }
+
+  @Test
+  void testGetSentinelAlertRule() {
+    mockSecurityInsightsClient();
+    AlertRules alertRulesClient = mock(AlertRules.class);
+    when(securityInsightsManager.alertRules()).thenReturn(alertRulesClient);
+    AlertRule alertRule = mock(AlertRule.class);
+    when(alertRulesClient.get(RESOURCE_GROUP, STORAGE_ACCOUNT_NAME, "UnauthorizedAccess"))
+        .thenReturn(alertRule);
+    assertThat(
+        "value returned when found",
+        service.getSentinelRuleUnauthorizedAccess(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(alertRule));
+  }
+
+  @Test
+  void testGetSentinelAlertRuleNotFound() {
+    mockSecurityInsightsClient();
+    AlertRules alertRulesClient = mock(AlertRules.class);
+    when(securityInsightsManager.alertRules()).thenReturn(alertRulesClient);
+    when(alertRulesClient.get(RESOURCE_GROUP, STORAGE_ACCOUNT_NAME, "UnauthorizedAccess"))
+        .thenThrow(
+            new ManagementException("Not found", null, new ManagementError(NOT_FOUND_CODE, null)));
+    assertThat(
+        "null returned when not found",
+        service.getSentinelRuleUnauthorizedAccess(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(nullValue()));
+  }
+
+  @Test
+  void testNotificationRule() {
+    mockSecurityInsightsClient();
+    AutomationRules automationRulesClient = mock(AutomationRules.class);
+    when(securityInsightsManager.automationRules()).thenReturn(automationRulesClient);
+    AutomationRule automationRule = mock(AutomationRule.class);
+    when(automationRulesClient.get(
+            RESOURCE_GROUP, STORAGE_ACCOUNT_NAME, "runSendSlackNotificationPlaybook"))
+        .thenReturn(automationRule);
+    assertThat(
+        "value returned when found",
+        service.getNotificationRule(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(automationRule));
+  }
+
+  @Test
+  void testNotificationRuleNotFound() {
+    mockSecurityInsightsClient();
+    AutomationRules automationRulesClient = mock(AutomationRules.class);
+    when(securityInsightsManager.automationRules()).thenReturn(automationRulesClient);
+    when(automationRulesClient.get(
+            RESOURCE_GROUP, STORAGE_ACCOUNT_NAME, "runSendSlackNotificationPlaybook"))
+        .thenThrow(
+            new ManagementException("Not found", null, new ManagementError(NOT_FOUND_CODE, null)));
+    assertThat(
+        "null returned when not found",
+        service.getNotificationRule(PROFILE_MODEL, STORAGE_ACCOUNT),
+        is(nullValue()));
+  }
+
+  private void mockLogAnalyticsClient() {
+    Credentials credentials = new Credentials();
+    credentials.setHomeTenantId(HOME_TENANT_ID);
+    when(resourceConfiguration.getCredentials()).thenReturn(credentials);
+
+    when(resourceConfiguration.getLogAnalyticsManagerClient(HOME_TENANT_ID, SUBSCRIPTION_ID))
+        .thenReturn(logAnalyticsManager);
+  }
+
+  private void mockSecurityInsightsClient() {
+    Credentials credentials = new Credentials();
+    credentials.setHomeTenantId(HOME_TENANT_ID);
+    when(resourceConfiguration.getCredentials()).thenReturn(credentials);
+
+    when(resourceConfiguration.getSecurityInsightsManagerClient(HOME_TENANT_ID, SUBSCRIPTION_ID))
+        .thenReturn(securityInsightsManager);
+  }
+
+  private void mockArmClient() {
+    when(resourceConfiguration.getClient(SUBSCRIPTION_ID)).thenReturn(azureResourceManager);
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.AzureUtils;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration.Credentials;
 import com.azure.core.http.HttpResponse;
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.stringtemplate.v4.ST;
 
 @ExtendWith(MockitoExtension.class)
 @Tag("bio.terra.common.category.Unit")
@@ -63,12 +63,8 @@ class AzureMonitoringServiceTest {
       new AzureApplicationDeploymentResource()
           .azureResourceGroupName(RESOURCE_GROUP)
           .azureApplicationDeploymentId(
-              new ST(
-                      "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroup>/providers/microsoft.solutions/applications/<appName>")
-                  .add("subscriptionId", SUBSCRIPTION_ID)
-                  .add("resourceGroup", RESOURCE_GROUP)
-                  .add("appName", APPLICATION_NAME)
-                  .render());
+              AzureUtils.getApplicationDeploymentResourceId(
+                  SUBSCRIPTION_ID, RESOURCE_GROUP, APPLICATION_NAME));
 
   private static final AzureStorageAccountResource STORAGE_ACCOUNT =
       new AzureStorageAccountResource()

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
@@ -8,8 +8,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import bio.terra.common.AzureUtils;
 import bio.terra.model.BillingProfileModel;
+import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration.Credentials;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.management.exception.ManagementError;
@@ -63,7 +63,7 @@ class AzureMonitoringServiceTest {
       new AzureApplicationDeploymentResource()
           .azureResourceGroupName(RESOURCE_GROUP)
           .azureApplicationDeploymentId(
-              AzureUtils.getApplicationDeploymentResourceId(
+              MetadataDataAccessUtils.getApplicationDeploymentId(
                   SUBSCRIPTION_ID, RESOURCE_GROUP, APPLICATION_NAME));
 
   private static final AzureStorageAccountResource STORAGE_ACCOUNT =

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResourceTest.java
@@ -2,13 +2,12 @@ package bio.terra.service.resourcemanagement.azure;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
 
+import bio.terra.common.AzureUtils;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
-import org.stringtemplate.v4.ST;
 
 @ActiveProfiles({"google", "unittest"})
 @Tag("bio.terra.common.category.Unit")
@@ -17,12 +16,7 @@ class AzureStorageAccountResourceTest {
   void testGetStorageAccountResourceId() {
     UUID subscriptionId = UUID.fromString("deadbeef-face-cafe-bead-0ddba11deed5");
     String resourceId =
-        new ST(
-                "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroup>/providers/microsoft.solutions/applications/<appName>")
-            .add("subscriptionId", subscriptionId)
-            .add("resourceGroup", "TDR")
-            .add("appName", "myapp")
-            .render();
+        AzureUtils.getApplicationDeploymentResourceId(subscriptionId, "TDR", "myapp");
     AzureApplicationDeploymentResource appResource =
         new AzureApplicationDeploymentResource()
             .azureApplicationDeploymentId(resourceId)

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResourceTest.java
@@ -1,0 +1,40 @@
+package bio.terra.service.resourcemanagement.azure;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.stringtemplate.v4.ST;
+
+@ActiveProfiles({"google", "unittest"})
+@Tag("bio.terra.common.category.Unit")
+class AzureStorageAccountResourceTest {
+  @Test
+  void testGetStorageAccountResourceId() {
+    UUID subscriptionId = UUID.fromString("deadbeef-face-cafe-bead-0ddba11deed5");
+    String resourceId =
+        new ST(
+                "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroup>/providers/microsoft.solutions/applications/<appName>")
+            .add("subscriptionId", subscriptionId)
+            .add("resourceGroup", "TDR")
+            .add("appName", "myapp")
+            .render();
+    AzureApplicationDeploymentResource appResource =
+        new AzureApplicationDeploymentResource()
+            .azureApplicationDeploymentId(resourceId)
+            .azureResourceGroupName("mrg");
+
+    AzureStorageAccountResource resource =
+        new AzureStorageAccountResource().applicationResource(appResource).name("storagename");
+
+    assertThat(
+        "storage account resource id can be generated",
+        resource.getStorageAccountId(),
+        is(
+            "/subscriptions/deadbeef-face-cafe-bead-0ddba11deed5/resourceGroups/mrg/providers/Microsoft.Storage/storageAccounts/storagename"));
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResourceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountResourceTest.java
@@ -3,7 +3,7 @@ package bio.terra.service.resourcemanagement.azure;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import bio.terra.common.AzureUtils;
+import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,7 @@ class AzureStorageAccountResourceTest {
   void testGetStorageAccountResourceId() {
     UUID subscriptionId = UUID.fromString("deadbeef-face-cafe-bead-0ddba11deed5");
     String resourceId =
-        AzureUtils.getApplicationDeploymentResourceId(subscriptionId, "TDR", "myapp");
+        MetadataDataAccessUtils.getApplicationDeploymentId(subscriptionId, "TDR", "myapp");
     AzureApplicationDeploymentResource appResource =
         new AzureApplicationDeploymentResource()
             .azureApplicationDeploymentId(resourceId)

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountServiceTest.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.azure;
 
+import static bio.terra.service.filedata.azure.util.AzureConstants.RESOURCE_NOT_FOUND_CODE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -304,7 +305,7 @@ public class AzureStorageAccountServiceTest {
             new ManagementException(
                 "Could not find storage account",
                 null,
-                new ManagementError("ResourceNotFound", "Couldn't find resource")));
+                new ManagementError(RESOURCE_NOT_FOUND_CODE, "Couldn't find resource")));
   }
 
   /** Mocks the fluent interface needed to create a storage account with the Azure client */

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProviderTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProviderTest.java
@@ -1,0 +1,56 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.stairway.Step;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
+class AzureStorageMonitoringStepProviderTest {
+
+  private static final List<Class<? extends Step>> EXPECTED_STANDARD_STEPS =
+      List.of(CreateLogAnalyticsWorkspaceStep.class, CreateDiagnosticSettingStep.class);
+
+  private static final List<Class<? extends Step>> EXPECTED_PROTECTED_DATA_STEPS =
+      List.of(
+          CreateLogAnalyticsWorkspaceStep.class,
+          CreateDiagnosticSettingStep.class,
+          CreateExportRuleStep.class,
+          CreateSentinelStep.class,
+          CreateSentinelAlertRulesStep.class,
+          CreateSentinelNotificationRuleStep.class);
+
+  @Mock AzureMonitoringService monitoringService;
+
+  AzureStorageMonitoringStepProvider stepProvider;
+
+  @BeforeEach
+  void setUp() {
+    stepProvider = new AzureStorageMonitoringStepProvider(monitoringService);
+  }
+
+  @Test
+  void testConfigureStandardSteps() {
+    assertThat(
+        "only standard steps returned",
+        stepProvider.configureSteps(false).stream().map(s -> s.step().getClass()).toList(),
+        is(EXPECTED_STANDARD_STEPS));
+  }
+
+  @Test
+  void testConfigureProtectedDataSteps() {
+    assertThat(
+        "protected data steps also returned",
+        stepProvider.configureSteps(true).stream().map(s -> s.step().getClass()).toList(),
+        is(EXPECTED_PROTECTED_DATA_STEPS));
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/SnapshotStorageAccountDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotStorageAccountDaoTest.java
@@ -90,7 +90,11 @@ public class SnapshotStorageAccountDaoTest {
 
     AzureStorageAccountResource azureStorageAccountResource =
         resourceService.createSnapshotStorageAccount(
-            snapshotId, dataset.getStorageAccountRegion(), billingProfile, flightId);
+            snapshotId,
+            dataset.getStorageAccountRegion(),
+            billingProfile,
+            flightId,
+            dataset.isSecureMonitoringEnabled());
 
     assertThat(
         "Returns the new storage account resource", azureStorageAccountResource, notNullValue());


### PR DESCRIPTION
This PR ended needing to do quite a bit but at a high level.  This:

- Allows the set up of advanced logging and monitoring for datasets and snapshots that contain federally protected data. A doc describing this can be found [here](https://docs.google.com/document/d/1AYPaowjBzOxlLD2MvaO77Upl7PpBbr_InaWSXSaRus8/edit)
- Does a cleanup to ensure that storage accounts get properly deleted when the flight that created them fails
- Optionally initializes the central Synapse instance associated with the TDR deployment (ultimately, the code will serve to initialize instances deployed in the user's MRG)
- Shortens a cache length from 24 hours to 15 minutes for storage account keys. This was causing an issue when dropping and recreating storage accounts with the same name

At a glance, this diagram might be helpful to view the end state of the resource setup
![image](https://github.com/DataBiosphere/jade-data-repo/assets/5633787/b020b1a6-86a9-4e09-99ff-3b963939cb73)

A note on testing: the biggest class in here is the new one that controls CRUD on all logging/monitoring related resources.  It's basically a passthrough to Azure APIs.  I ended up adding unit testing for the getters since those had the most complexity