### PR TITLE
[DR-3038] Fix Azure Synapse Querying

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -56,6 +56,7 @@ public final class IngestUtils {
   private static final String TARGET_DATA_SOURCE_PREFIX = "target_data_source_";
   private static final String INGEST_TABLE_NAME_PREFIX = "ingest_";
   private static final String SCRATCH_TABLE_NAME_PREFIX = "scratch_";
+  private static final String FLIGHT_ID_PREFIX = "flight_";
 
   private static final Logger logger = LoggerFactory.getLogger(IngestUtils.class);
 
@@ -386,7 +387,7 @@ public final class IngestUtils {
 
   // Note: this is the unqualified path (e.g. it gets used in metadata and scratch directories)
   public static String getParquetFilePath(String targetTableName, String flightId) {
-    return "parquet/" + targetTableName + "/" + flightId + ".parquet";
+    return "parquet/" + targetTableName + "/" + FLIGHT_ID_PREFIX + flightId + ".parquet";
   }
 
   /**

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -57,6 +57,7 @@ public final class IngestUtils {
   private static final String INGEST_TABLE_NAME_PREFIX = "ingest_";
   private static final String SCRATCH_TABLE_NAME_PREFIX = "scratch_";
   private static final String FLIGHT_ID_PREFIX = "flight_";
+  private static final String PARQUET_PATH_PREFIX = "parquet";
 
   private static final Logger logger = LoggerFactory.getLogger(IngestUtils.class);
 
@@ -387,7 +388,13 @@ public final class IngestUtils {
 
   // Note: this is the unqualified path (e.g. it gets used in metadata and scratch directories)
   public static String getParquetFilePath(String targetTableName, String flightId) {
-    return "parquet/" + targetTableName + "/" + FLIGHT_ID_PREFIX + flightId + ".parquet";
+    return PARQUET_PATH_PREFIX
+        + "/"
+        + targetTableName
+        + "/"
+        + FLIGHT_ID_PREFIX
+        + flightId
+        + ".parquet";
   }
 
   /**
@@ -398,7 +405,8 @@ public final class IngestUtils {
    * @return
    */
   public static String getSnapshotParquetFilePathForQuery(String targetTableName) {
-    return FolderType.METADATA.getPath("parquet/" + targetTableName + "/*.parquet/*");
+    return FolderType.METADATA.getPath(
+        PARQUET_PATH_PREFIX + "/" + targetTableName + "/*.parquet/*");
   }
 
   /**
@@ -413,11 +421,11 @@ public final class IngestUtils {
   public static String getSnapshotSliceParquetFilePath(
       String targetTableName, String snapshotSliceName) {
     return FolderType.METADATA.getPath(
-        "parquet/" + targetTableName + "/" + snapshotSliceName + ".parquet");
+        PARQUET_PATH_PREFIX + "/" + targetTableName + "/" + snapshotSliceName + ".parquet");
   }
 
   public static String getSourceDatasetParquetFilePath(String tableName) {
-    return FolderType.METADATA.getPath("parquet/" + tableName + "/*/*.parquet");
+    return FolderType.METADATA.getPath(PARQUET_PATH_PREFIX + "/" + tableName + "/*/*.parquet");
   }
 
   public static String formatSnapshotTableName(UUID snapshotId, String tableName) {

--- a/src/test/java/bio/terra/common/SynapseUtils.java
+++ b/src/test/java/bio/terra/common/SynapseUtils.java
@@ -232,23 +232,23 @@ public class SynapseUtils {
     try {
       azureSynapsePdao.dropTables(tableNames);
     } catch (Exception ex) {
-      logger.warn("[Cleanup exception] Unable to drop tables.", ex.getMessage());
+      logger.warn("[Cleanup exception] Unable to drop tables. {}", ex.getMessage());
     }
     try {
       azureSynapsePdao.dropDataSources(dataSources);
     } catch (Exception ex) {
-      logger.warn("[Cleanup exception] Unable to drop data sources", ex.getMessage());
+      logger.warn("[Cleanup exception] Unable to drop data sources. {}", ex.getMessage());
     }
     try {
       azureSynapsePdao.dropScopedCredentials(scopedCredentials);
     } catch (Exception ex) {
-      logger.warn("[Cleanup exception] Unable to drop scoped credentials", ex.getMessage());
+      logger.warn("[Cleanup exception] Unable to drop scoped credentials. {}", ex.getMessage());
     }
     for (String storageAccountId : storageAccountIds) {
       try {
         client.storageAccounts().deleteById(storageAccountId);
       } catch (Exception ex) {
-        logger.warn("[Cleanup exception] Unable to delete storage account", ex.getMessage());
+        logger.warn("[Cleanup exception] Unable to delete storage account. {}", ex.getMessage());
       }
     }
     // Parquet File delete is not currently operational
@@ -492,11 +492,8 @@ public class SynapseUtils {
 
     String scratchParquetFile =
         FolderType.SCRATCH.getPath(
-            "parquet/scratch_"
-                + destinationTable.getName()
-                + "/flight"
-                + randomFlightId
-                + ".parquet");
+            IngestUtils.getParquetFilePath(
+                SCRATCH_TABLE_NAME_PREFIX + destinationTable.getName(), randomFlightId));
     addParquetFileName(scratchParquetFile, datasetStorageAccountResource);
     addParquetFileName(
         IngestUtils.getParquetFilePath(destinationTable.getName(), randomFlightId),

--- a/src/test/java/bio/terra/common/SynapseUtils.java
+++ b/src/test/java/bio/terra/common/SynapseUtils.java
@@ -407,11 +407,11 @@ public class SynapseUtils {
     // 3 - Retrieve info about database schema so that we can populate the parquet create query
     String tableName = destinationTable.getName();
     String destinationParquetFile =
-        FolderType.METADATA.getPath("parquet/" + tableName + "/" + ingestFlightId + ".parquet");
+        FolderType.METADATA.getPath(IngestUtils.getParquetFilePath(tableName, ingestFlightId));
 
     String scratchParquetFile =
         FolderType.SCRATCH.getPath(
-            "parquet/" + SCRATCH_TABLE_NAME_PREFIX + tableName + "/" + ingestFlightId + ".parquet");
+            IngestUtils.getParquetFilePath(SCRATCH_TABLE_NAME_PREFIX + tableName, ingestFlightId));
 
     // 4 - Create parquet files via external table
     // All inputs should be sanitized before passed into this method
@@ -492,7 +492,11 @@ public class SynapseUtils {
 
     String scratchParquetFile =
         FolderType.SCRATCH.getPath(
-            "parquet/scratch_" + destinationTable.getName() + "/" + randomFlightId + ".parquet");
+            "parquet/scratch_"
+                + destinationTable.getName()
+                + "/flight"
+                + randomFlightId
+                + ".parquet");
     addParquetFileName(scratchParquetFile, datasetStorageAccountResource);
     addParquetFileName(
         IngestUtils.getParquetFilePath(destinationTable.getName(), randomFlightId),

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import bio.terra.model.IngestRequestModel;
@@ -12,6 +13,7 @@ import bio.terra.model.IngestRequestModel.FormatEnum;
 import bio.terra.service.dataset.exception.InvalidBlobURLException;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.ShortUUID;
 import com.azure.storage.blob.BlobUrlParts;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
@@ -121,6 +123,14 @@ public class IngestUtilsTest {
     assertTrue(
         "Ingests in merge mode will have any specified row IDs unset",
         IngestUtils.shouldIgnoreUserSpecifiedRowIds(flightMapMerge));
+  }
+
+  @Test
+  void testGetParquetFilePath() {
+    String targetTableName = "sample";
+    String flightId = "_" + ShortUUID.get();
+    String expectedPath = "parquet/" + targetTableName + "/flight_" + flightId + ".parquet";
+    assertEquals(IngestUtils.getParquetFilePath(targetTableName, flightId), expectedPath);
   }
 
   /**

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
@@ -319,7 +319,7 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
     assertThat(
         "Table row count should equal 4 for destination table",
         tableRowCounts,
-        hasEntry(participantTable.getName(), 4));
+        hasEntry(participantTable.getName(), 4L));
   }
 
   private void setupFourTableDataset() throws SQLException, IOException {

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
@@ -4,6 +4,7 @@ import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_COLUMN;
 import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_TABLE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.Relationship;
@@ -296,7 +297,7 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
 
   @Test
   public void testQuerySnapshotWithUnderscoreInFlightId() throws SQLException, IOException {
-    String ingestFlightId = "_" + UUID.randomUUID().toString();
+    String ingestFlightId = "_" + UUID.randomUUID();
     SnapshotTable participantSnapshotTable = setupParticipantTable(ingestFlightId);
     List<SnapshotTable> tables = List.of(participantSnapshotTable);
     snapshot.snapshotTables(tables);
@@ -317,8 +318,8 @@ public class AzureSynapsePdaoSnapshotConnectedTest {
         equalTo(List.of("Sally", "Bobby", "Freddy", "Charles")));
     assertThat(
         "Table row count should equal 4 for destination table",
-        tableRowCounts.get(participantTable.getName()),
-        equalTo(4L));
+        tableRowCounts,
+        hasEntry(participantTable.getName(), 4));
   }
 
   private void setupFourTableDataset() throws SQLException, IOException {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3038

Some parquet file directories use the flight id, and if it begins with an underscore synapse will ignore the path when performing a wildcard query (which occurs when using the preview data endpoint). This PR adds a prefix to the flight id parquet directories. 