### PR TITLE
[DR-3142] Make sure the empty batches of actions don't get sent to Azure storage tables

### DIFF
--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDependencyDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDependencyDao.java
@@ -58,7 +58,7 @@ public class TableDependencyDao {
               List<String> existing =
                   entities.stream()
                       .map(e -> e.getProperty(FireStoreDependency.FILE_ID_FIELD_NAME).toString())
-                      .collect(Collectors.toList());
+                      .toList();
               // Create any entities that do not already exist
               List<TableTransactionAction> batchEntities =
                   refIdChunk.stream()
@@ -77,8 +77,13 @@ public class TableDependencyDao {
                                 TableTransactionActionType.UPSERT_REPLACE,
                                 fireStoreDependencyEntity);
                           })
-                      .collect(Collectors.toList());
-              tableClient.submitTransaction(batchEntities);
+                      .toList();
+              if (!batchEntities.isEmpty()) {
+                // This can happen if retrying a failed transaction.  This would cause an
+                // IllegalArgumentException with message "A transaction must contain at least one
+                // operation"
+                tableClient.submitTransaction(batchEntities);
+              }
             });
   }
 

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyDaoTest.java
@@ -105,6 +105,7 @@ public class TableDependencyDaoTest {
 
     dao.storeSnapshotFileDependencies(tableServiceClient, datasetId, snapshotId, List.of(refId));
     verify(tableClient, times(0)).upsertEntity(any());
+    verify(tableClient, times(0)).submitTransaction(any());
   }
 
   @Test


### PR DESCRIPTION
Since this causes errors but it can really be ignored