### PR TITLE
[DR-3144] Allow passing in encoded slashes to Spring

### DIFF
--- a/src/main/java/bio/terra/Main.java
+++ b/src/main/java/bio/terra/Main.java
@@ -22,10 +22,6 @@ public class Main implements CommandLineRunner {
     // ITFOT, we can parameterize the profile to include the appropriate pdao implementations.
     theApp.setAdditionalProfiles("google");
 
-    // Enable sending %2F (e.g. url encoded forward slashes) in the path of a URL which is helpful
-    // if there is a path parameter that contains a value with a slash in it.
-    System.setProperty("org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH", "true");
-
     theApp.run(args);
   }
 

--- a/src/main/java/bio/terra/Main.java
+++ b/src/main/java/bio/terra/Main.java
@@ -21,6 +21,11 @@ public class Main implements CommandLineRunner {
     // Initially, Jade runs only with Google cloud parts right now, so we set the profile here.
     // ITFOT, we can parameterize the profile to include the appropriate pdao implementations.
     theApp.setAdditionalProfiles("google");
+
+    // Enable sending %2F (e.g. url encoded forward slashes) in the path of a URL which is helpful
+    // if there is a path parameter that contains a value with a slash in it.
+    System.setProperty("org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH", "true");
+
     theApp.run(args);
   }
 

--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -5,8 +5,10 @@ import bio.terra.app.usermetrics.UserMetricsInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.util.UrlPathHelper;
 
 @Component
 public class WebConfig implements WebMvcConfigurer {
@@ -17,6 +19,17 @@ public class WebConfig implements WebMvcConfigurer {
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(loggerInterceptor);
     registry.addInterceptor(metricsInterceptor);
+  }
+
+  @Override
+  public void configurePathMatch(PathMatchConfigurer configurer) {
+    // This override is needed in order to allow encoded slashes in the path of a URL.
+    UrlPathHelper urlPathHelper = new UrlPathHelper();
+    // By setting this to false, Spring does not decode the path before matching it to a
+    // method.  Rather, it does it after matching so that by the time the value reaches the
+    // controller function, the value is decoded.
+    urlPathHelper.setUrlDecode(false);
+    configurer.setUrlPathHelper(urlPathHelper);
   }
 
   @Override

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -1,0 +1,146 @@
+package bio.terra.app.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.common.TestUtils;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import bio.terra.model.DRSAccessURL;
+import bio.terra.model.DRSAuthorizations;
+import bio.terra.model.DRSObject;
+import bio.terra.model.DRSPassportRequestModel;
+import bio.terra.service.filedata.DrsService;
+import bio.terra.service.filedata.exception.DrsObjectNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles({"google", "unittest"})
+@ContextConfiguration(classes = {DataRepositoryServiceApiController.class})
+@Tag("bio.terra.common.category.Unit")
+@WebMvcTest
+public class DataRepositoryServiceApiControllerTest {
+
+  private static final String GET_DRS_OBJECT_ENDPOINT = "/ga4gh/drs/v1/objects/{object_id}";
+  private static final String GET_DRS_OBJECT_ACCESS_ENDPOINT =
+      "/ga4gh/drs/v1/objects/{object_id}/access/{access_id}";
+
+  // Test fixtures
+  private static final String DRS_ID = "foo";
+  private static final String DRS_ACCESS_ID = "bar";
+  private static final DRSObject DRS_OBJECT = new DRSObject().id(DRS_ID);
+  private static final String DRS_ACCESS_URL = "http://foo.bar/baz";
+  private static final DRSAccessURL DRS_ACCESS_URL_OBJECT = new DRSAccessURL().url(DRS_ACCESS_URL);
+  private static final DRSPassportRequestModel PASSPORT = new DRSPassportRequestModel();
+  private static final String PASSPORT_ISSUER = "baz";
+  private static final DRSAuthorizations PASSPORT_AUTHORIZATIONS =
+      new DRSAuthorizations().addPassportAuthIssuersItem(PASSPORT_ISSUER);
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private ApplicationConfiguration applicationConfiguration;
+  @MockBean private DrsService drsService;
+  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+
+  @BeforeEach
+  void setUp() {
+    when(authenticatedUserRequestFactory.from(any())).thenReturn(TEST_USER);
+  }
+
+  @Test
+  void testUnknownDrsIdWithGetFlow() throws Exception {
+    when(drsService.lookupObjectByDrsId(TEST_USER, DRS_ID, false))
+        .thenThrow(DrsObjectNotFoundException.class);
+    mvc.perform(get(GET_DRS_OBJECT_ENDPOINT, DRS_ID)).andExpect(status().isNotFound());
+
+    when(drsService.getAccessUrlForObjectId(TEST_USER, DRS_ID, DRS_ACCESS_ID, null))
+        .thenThrow(DrsObjectNotFoundException.class);
+    mvc.perform(get(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void testKnownDrsIdWithGetFlow() throws Exception {
+    when(drsService.lookupObjectByDrsId(TEST_USER, DRS_ID, false)).thenReturn(DRS_OBJECT);
+    mvc.perform(get(GET_DRS_OBJECT_ENDPOINT, DRS_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(DRS_ID));
+
+    when(drsService.getAccessUrlForObjectId(TEST_USER, DRS_ID, DRS_ACCESS_ID, null))
+        .thenReturn(DRS_ACCESS_URL_OBJECT);
+    mvc.perform(get(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.url").value(DRS_ACCESS_URL));
+  }
+
+  @Test
+  void testUnknownDrsIdWithPostFlow() throws Exception {
+    when(drsService.lookupObjectByDrsIdPassport(DRS_ID, PASSPORT))
+        .thenThrow(DrsObjectNotFoundException.class);
+    mvc.perform(
+        post(GET_DRS_OBJECT_ENDPOINT, DRS_ID)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtils.mapToJson(PASSPORT)));
+
+    when(drsService.postAccessUrlForObjectId(DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+        .thenThrow(DrsObjectNotFoundException.class);
+    mvc.perform(
+            post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(PASSPORT)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void testKnownDrsIdWithPostFlow() throws Exception {
+    when(drsService.lookupObjectByDrsIdPassport(DRS_ID, PASSPORT)).thenReturn(DRS_OBJECT);
+    mvc.perform(
+            post(GET_DRS_OBJECT_ENDPOINT, DRS_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(PASSPORT)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(DRS_ID));
+
+    when(drsService.postAccessUrlForObjectId(DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+        .thenReturn(DRS_ACCESS_URL_OBJECT);
+    mvc.perform(
+            post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(PASSPORT)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.url").value(DRS_ACCESS_URL));
+  }
+
+  @Test
+  void testUnknownDrsIdWithOptionsFlow() throws Exception {
+    when(drsService.lookupAuthorizationsByDrsId(DRS_ID))
+        .thenThrow(DrsObjectNotFoundException.class);
+    mvc.perform(options(GET_DRS_OBJECT_ENDPOINT, DRS_ID)).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void testKnownDrsIdWithOptionsFlow() throws Exception {
+    when(drsService.lookupAuthorizationsByDrsId(DRS_ID)).thenReturn(PASSPORT_AUTHORIZATIONS);
+    mvc.perform(options(GET_DRS_OBJECT_ENDPOINT, DRS_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.passport_auth_issuers[0]").value(PASSPORT_ISSUER));
+  }
+}


### PR DESCRIPTION
This PR allows Spring to recognize path parameters with encoded slashes (`%2f`).  There is a matching PR here:
https://github.com/broadinstitute/datarepo-helm/pull/242
It enables the Apache proxy to passthrough encoded slashes to Spring

I couldn't find a way to unit test the setup but did take the opportunity to add some general unit tests to The DataRepositoryServiceApiController class. I've also manually tested that this does what it's supposed to.

This can be tested on my personal deployment:
https://jade-nm.datarepo-dev.broadinstitute.org/swagger-ui.html#/DataRepositoryService/GetObject

try to get with drs id = `foo/bar`

I have a followon ticket (https://broadworkbench.atlassian.net/browse/DR-3147) to add an admin method to delete aliases which will allow us to safely integration test this but I wanted to keep the scope of this change narrow