### PR TITLE
[DR-2992] Pin json-smart to 2.4.10 to address CVE-2023-1370

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,9 +173,10 @@ configurations {
     runtimeClasspath
 }
 
-// Fix for CVE-2021-45046
-// See https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot
-ext['log4j2.version'] = '2.17.0'
+// Fix for CVE-2023-1370 which identifies a vulnerability in json-smart 2.4.8
+// 2.4.9 fixes the vulnerability and 2.4.10 fixes an additional bug
+// This override can be removed when we upgrade to spring-boot v2.6.15+, v2.7.10+, or v3.0.5+
+ext['json-smart.version'] = '2.4.10'
 
 dependencies {
     // TODO: Unpack the "starter" and include just what we use


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2992
https://github.com/advisories/GHSA-493p-pfq6-5258

The affected version is 2.4.8 and the maintainers recommend upgrading to 2.4.10 for an adjacent bug fix.

`json-smart` is a transitive dependency from `azure-identity` and Spring Boot. We r[ecently upgraded `azure-identity`](https://github.com/DataBiosphere/jade-data-repo/pull/1477) which gave us the necessary `json-smart` bump, but a larger Spring Boot upgrade that would have given us the `json-smart` bump for free was not working out of the box.

For now, we'll pin `json-smart` to 2.4.10 and note that it can be removed when we next upgrade Spring Boot.

As a drive-by, we don't need to pin Log4J to mitigate the Log4Shell vulnerability anymore.  We are naturally getting Log4J v2.17.2 with our current Spring Boot version.

I used Gradle's [dependencyInsight](https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html) task to verify versioning for these two dependencies.