### PR TITLE
[DR-3128] Convert config classes to records

### DIFF
--- a/src/main/java/bio/terra/Main.java
+++ b/src/main/java/bio/terra/Main.java
@@ -5,7 +5,9 @@ import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan("bio.terra.app")
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class Main implements CommandLineRunner {
 

--- a/src/main/java/bio/terra/Main.java
+++ b/src/main/java/bio/terra/Main.java
@@ -7,8 +7,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
-@ConfigurationPropertiesScan("bio.terra.app")
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+@ConfigurationPropertiesScan("bio.terra")
+@SpringBootApplication(
+    exclude = {DataSourceAutoConfiguration.class},
+    scanBasePackages = {"bio.terra"})
 public class Main implements CommandLineRunner {
 
   @Override

--- a/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
@@ -369,10 +369,10 @@ public class ApplicationConfiguration {
       AzureResourceConfiguration azureResourceConfiguration) {
 
     SQLServerDataSource ds = new SQLServerDataSource();
-    ds.setServerName(azureResourceConfiguration.getSynapse().getWorkspaceName());
-    ds.setUser(azureResourceConfiguration.getSynapse().getSqlAdminUser());
-    ds.setPassword(azureResourceConfiguration.getSynapse().getSqlAdminPassword());
-    ds.setDatabaseName(azureResourceConfiguration.getSynapse().getDatabaseName());
+    ds.setServerName(azureResourceConfiguration.synapse().workspaceName());
+    ds.setUser(azureResourceConfiguration.synapse().sqlAdminUser());
+    ds.setPassword(azureResourceConfiguration.synapse().sqlAdminPassword());
+    ds.setDatabaseName(azureResourceConfiguration.synapse().databaseName());
 
     return new NamedParameterJdbcTemplate(ds);
   }

--- a/src/main/java/bio/terra/app/configuration/DuosConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/DuosConfiguration.java
@@ -1,6 +1,8 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "duos")
+@ConstructorBinding
 public record DuosConfiguration(String basePath) {}

--- a/src/main/java/bio/terra/app/configuration/DuosConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/DuosConfiguration.java
@@ -1,19 +1,6 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
 @ConfigurationProperties(prefix = "duos")
-public class DuosConfiguration {
-
-  private String basePath;
-
-  public String getBasePath() {
-    return basePath;
-  }
-
-  public void setBasePath(String basePath) {
-    this.basePath = basePath;
-  }
-}
+public record DuosConfiguration(String basePath) {}

--- a/src/main/java/bio/terra/app/configuration/EcmConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/EcmConfiguration.java
@@ -1,30 +1,6 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@EnableConfigurationProperties
 @ConfigurationProperties(prefix = "ecm")
-public class EcmConfiguration {
-
-  private String basePath;
-  private String rasIssuer;
-
-  public String getBasePath() {
-    return basePath;
-  }
-
-  public void setBasePath(String basePath) {
-    this.basePath = basePath;
-  }
-
-  public String getRasIssuer() {
-    return rasIssuer;
-  }
-
-  public void setRasIssuer(String rasIssuer) {
-    this.rasIssuer = rasIssuer;
-  }
-}
+public record EcmConfiguration(String basePath, String rasIssuer) {}

--- a/src/main/java/bio/terra/app/configuration/EcmConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/EcmConfiguration.java
@@ -1,6 +1,8 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "ecm")
+@ConstructorBinding
 public record EcmConfiguration(String basePath, String rasIssuer) {}

--- a/src/main/java/bio/terra/app/configuration/OauthConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/OauthConfiguration.java
@@ -3,5 +3,5 @@ package bio.terra.app.configuration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "oauth")
-public record OauthConfiguration(String schemeName, String loginEndpoint,
-                                 String clientId, String clientSecret) {}
+public record OauthConfiguration(
+    String schemeName, String loginEndpoint, String clientId, String clientSecret) {}

--- a/src/main/java/bio/terra/app/configuration/OauthConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/OauthConfiguration.java
@@ -1,48 +1,7 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@EnableConfigurationProperties
 @ConfigurationProperties(prefix = "oauth")
-public class OauthConfiguration {
-
-  private String schemeName;
-  private String loginEndpoint;
-  private String clientId;
-  private String clientSecret;
-
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public String getLoginEndpoint() {
-    return loginEndpoint;
-  }
-
-  public void setLoginEndpoint(String loginEndpoint) {
-    this.loginEndpoint = loginEndpoint;
-  }
-
-  public String getClientId() {
-    return clientId;
-  }
-
-  public void setClientId(String clientId) {
-    this.clientId = clientId;
-  }
-
-  public String getClientSecret() {
-    return clientSecret;
-  }
-
-  public void setClientSecret(String clientSecret) {
-    this.clientSecret = clientSecret;
-  }
-}
+public record OauthConfiguration(String schemeName, String loginEndpoint,
+                                 String clientId, String clientSecret) {}

--- a/src/main/java/bio/terra/app/configuration/OauthConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/OauthConfiguration.java
@@ -1,7 +1,9 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "oauth")
+@ConstructorBinding
 public record OauthConfiguration(
     String schemeName, String loginEndpoint, String clientId, String clientSecret) {}

--- a/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
@@ -6,35 +6,12 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
 /** Configuration for managing connection to Terra Policy Service. * */
-@Configuration
-@EnableConfigurationProperties
 @ConfigurationProperties(prefix = "tps")
-public class PolicyServiceConfiguration {
-
-  private boolean enabled;
-  private String basePath;
+public record PolicyServiceConfiguration(boolean enabled, String basePath) {
 
   private static final List<String> POLICY_SCOPES = List.of("openid", "email", "profile");
-
-  public boolean getEnabled() {
-    return enabled;
-  }
-
-  public void setEnabled(boolean enabled) {
-    this.enabled = enabled;
-  }
-
-  public String getBasePath() {
-    return basePath;
-  }
-
-  public void setBasePath(String basePath) {
-    this.basePath = basePath;
-  }
 
   public String getAccessToken() throws IOException {
     GoogleCredentials credentials =

--- a/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
@@ -6,9 +6,11 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 /** Configuration for managing connection to Terra Policy Service. * */
 @ConfigurationProperties(prefix = "tps")
+@ConstructorBinding
 public record PolicyServiceConfiguration(boolean enabled, String basePath) {
 
   private static final List<String> POLICY_SCOPES = List.of("openid", "email", "profile");

--- a/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
@@ -2,7 +2,6 @@ package bio.terra.app.configuration;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.auth.oauth2.ServiceAccountCredentials;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -17,7 +16,7 @@ public record PolicyServiceConfiguration(boolean enabled, String basePath) {
 
   public String getAccessToken() throws IOException {
     GoogleCredentials credentials =
-        ServiceAccountCredentials.getApplicationDefault().createScoped(POLICY_SCOPES);
+        GoogleCredentials.getApplicationDefault().createScoped(POLICY_SCOPES);
     AccessToken token = credentials.refreshAccessToken();
     return token.getTokenValue();
   }

--- a/src/main/java/bio/terra/app/configuration/RawlsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/RawlsConfiguration.java
@@ -1,21 +1,6 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@EnableConfigurationProperties
 @ConfigurationProperties(prefix = "rawls")
-public class RawlsConfiguration {
-
-  private String basePath;
-
-  public String getBasePath() {
-    return basePath;
-  }
-
-  public void setBasePath(String basePath) {
-    this.basePath = basePath;
-  }
-}
+public record RawlsConfiguration(String basePath) {}

--- a/src/main/java/bio/terra/app/configuration/RawlsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/RawlsConfiguration.java
@@ -1,6 +1,8 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "rawls")
+@ConstructorBinding
 public record RawlsConfiguration(String basePath) {}

--- a/src/main/java/bio/terra/app/configuration/ResourceBufferServiceConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ResourceBufferServiceConfiguration.java
@@ -7,9 +7,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 /** Configuration for managing connection to Buffer Service. * */
 @ConfigurationProperties(prefix = "rbs")
+@ConstructorBinding
 public record ResourceBufferServiceConfiguration(
     boolean enabled, String instanceUrl, String poolId, String clientCredentialFilePath) {
 

--- a/src/main/java/bio/terra/app/configuration/ResourceBufferServiceConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ResourceBufferServiceConfiguration.java
@@ -10,8 +10,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Configuration for managing connection to Buffer Service. * */
 @ConfigurationProperties(prefix = "rbs")
-public record ResourceBufferServiceConfiguration(boolean enabled, String instanceUrl, String poolId,
-                                                 String clientCredentialFilePath) {
+public record ResourceBufferServiceConfiguration(
+    boolean enabled, String instanceUrl, String poolId, String clientCredentialFilePath) {
 
   // I think we'd want to re-use our app scopes.
   private static final List<String> BUFFER_SCOPES = List.of("openid", "email", "profile");

--- a/src/main/java/bio/terra/app/configuration/ResourceBufferServiceConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ResourceBufferServiceConfiguration.java
@@ -7,54 +7,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
 /** Configuration for managing connection to Buffer Service. * */
-@Configuration
-@EnableConfigurationProperties
 @ConfigurationProperties(prefix = "rbs")
-public class ResourceBufferServiceConfiguration {
-
-  private boolean enabled;
-  private String instanceUrl;
-  private String poolId;
-  private String clientCredentialFilePath;
+public record ResourceBufferServiceConfiguration(boolean enabled, String instanceUrl, String poolId,
+                                                 String clientCredentialFilePath) {
 
   // I think we'd want to re-use our app scopes.
   private static final List<String> BUFFER_SCOPES = List.of("openid", "email", "profile");
-
-  public boolean getEnabled() {
-    return enabled;
-  }
-
-  public void setEnabled(boolean enabled) {
-    this.enabled = enabled;
-  }
-
-  public String getInstanceUrl() {
-    return instanceUrl;
-  }
-
-  public void setInstanceUrl(String instanceUrl) {
-    this.instanceUrl = instanceUrl;
-  }
-
-  public String getPoolId() {
-    return poolId;
-  }
-
-  public void setPoolId(String poolId) {
-    this.poolId = poolId;
-  }
-
-  public String getClientCredentialFilePath() {
-    return clientCredentialFilePath;
-  }
-
-  public void setClientCredentialFilePath(String clientCredentialFilePath) {
-    this.clientCredentialFilePath = clientCredentialFilePath;
-  }
 
   // TODO - not sure if this is actually how we want to do this, just copying wsm's implementation
   // for now

--- a/src/main/java/bio/terra/app/configuration/SamConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/SamConfiguration.java
@@ -1,6 +1,7 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 /* SAM Retry notes:
 We frequently experience socket timeouts with SAM, so we have implemented retry. The
@@ -14,6 +15,7 @@ reach the operationTimeoutSeconds limit. Well, depending on the numbers you choo
 operationTimeoutSeconds before we reach retryMaximumSeconds.*/
 
 @ConfigurationProperties(prefix = "sam")
+@ConstructorBinding
 public record SamConfiguration(
     String basePath,
     String stewardsGroupEmail,

--- a/src/main/java/bio/terra/app/configuration/SamConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/SamConfiguration.java
@@ -3,17 +3,18 @@ package bio.terra.app.configuration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
-/* SAM Retry notes:
-We frequently experience socket timeouts with SAM, so we have implemented retry. The
-configuration controls work like this. operationTimeoutSeconds is the maximum amount of time we
-allow for the SAM operation, including the SAM operations and our retry sleep time. This is the
-upper bound on how long the entire operation will take.
-
-The retry strategy is exponential backoff. The error wait starts at retryInitialWaitSeconds,
-and doubles up to retryMaximumWaitSeconds. The retry stays at retryMaximumWaitSeconds until we
-reach the operationTimeoutSeconds limit. Well, depending on the numbers you choose, we might hit
-operationTimeoutSeconds before we reach retryMaximumSeconds.*/
-
+/*
+ * SAM Retry notes:
+ * We frequently experience socket timeouts with SAM, so we have implemented retry. The
+ * configuration controls work like this. operationTimeoutSeconds is the maximum amount of time we
+ * allow for the SAM operation, including the SAM operations and our retry sleep time. This is the
+ * upper bound on how long the entire operation will take.
+ *
+ * The retry strategy is exponential backoff. The error wait starts at retryInitialWaitSeconds,
+ * and doubles up to retryMaximumWaitSeconds. The retry stays at retryMaximumWaitSeconds until we
+ * reach the operationTimeoutSeconds limit. Well, depending on the numbers you choose, we might hit
+ * operationTimeoutSeconds before we reach retryMaximumSeconds.
+ */
 @ConfigurationProperties(prefix = "sam")
 @ConstructorBinding
 public record SamConfiguration(

--- a/src/main/java/bio/terra/app/configuration/SamConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/SamConfiguration.java
@@ -1,81 +1,19 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@EnableConfigurationProperties
+/* SAM Retry notes:
+  We frequently experience socket timeouts with SAM, so we have implemented retry. The
+  configuration controls work like this. operationTimeoutSeconds is the maximum amount of time we
+  allow for the SAM operation, including the SAM operations and our retry sleep time. This is the
+  upper bound on how long the entire operation will take.
+
+  The retry strategy is exponential backoff. The error wait starts at retryInitialWaitSeconds,
+  and doubles up to retryMaximumWaitSeconds. The retry stays at retryMaximumWaitSeconds until we
+  reach the operationTimeoutSeconds limit. Well, depending on the numbers you choose, we might hit
+  operationTimeoutSeconds before we reach retryMaximumSeconds.*/
+
 @ConfigurationProperties(prefix = "sam")
-public class SamConfiguration {
-  private String basePath;
-  private String stewardsGroupEmail;
-  private String adminsGroupEmail;
-  private int retryInitialWaitSeconds;
-  private int retryMaximumWaitSeconds;
-  private int operationTimeoutSeconds;
-
-  public String getBasePath() {
-    return basePath;
-  }
-
-  public void setBasePath(String basePath) {
-    this.basePath = basePath;
-  }
-
-  public String getStewardsGroupEmail() {
-    return stewardsGroupEmail;
-  }
-
-  public void setStewardsGroupEmail(String stewardsGroupEmail) {
-    this.stewardsGroupEmail = stewardsGroupEmail;
-  }
-
-  public String getAdminsGroupEmail() {
-    return adminsGroupEmail;
-  }
-
-  public void setAdminsGroupEmail(String adminsGroupEmail) {
-    this.adminsGroupEmail = adminsGroupEmail;
-  }
-
-  // SAM Retry notes:
-  // We frequently experience socket timeouts with SAM, so we have implemented retry. The
-  // configuration controls
-  // work like this. operationTimeoutSeconds is the maximum amount of time we allow for the SAM
-  // operation,
-  // including the SAM operations and our retry sleep time. This is the upper bound on how long the
-  // entire
-  // operation will take.
-  //
-  // The retry strategy is exponential backoff. The error wait starts at retryInitialWaitSeconds,
-  // and doubles
-  // up to retryMaximumWaitSeconds. The retry stays at retryMaximumWaitSeconds until we reach the
-  // operationTimeoutSeconds limit. Well, depending on the numbers you choose, we might hit
-  // operationTimeoutSeconds
-  // before we reach retryMaximumSeconds.
-
-  public int getRetryInitialWaitSeconds() {
-    return retryInitialWaitSeconds;
-  }
-
-  public void setRetryInitialWaitSeconds(int retryInitialWaitSeconds) {
-    this.retryInitialWaitSeconds = retryInitialWaitSeconds;
-  }
-
-  public int getRetryMaximumWaitSeconds() {
-    return retryMaximumWaitSeconds;
-  }
-
-  public void setRetryMaximumWaitSeconds(int retryMaximumWaitSeconds) {
-    this.retryMaximumWaitSeconds = retryMaximumWaitSeconds;
-  }
-
-  public int getOperationTimeoutSeconds() {
-    return operationTimeoutSeconds;
-  }
-
-  public void setOperationTimeoutSeconds(int operationTimeoutSeconds) {
-    this.operationTimeoutSeconds = operationTimeoutSeconds;
-  }
-}
+public record SamConfiguration(String basePath, String stewardsGroupEmail, String adminsGroupEmail,
+                               int retryInitialWaitSeconds, int retryMaximumWaitSeconds,
+                               int operationTimeoutSeconds) {}

--- a/src/main/java/bio/terra/app/configuration/SamConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/SamConfiguration.java
@@ -3,17 +3,21 @@ package bio.terra.app.configuration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /* SAM Retry notes:
-  We frequently experience socket timeouts with SAM, so we have implemented retry. The
-  configuration controls work like this. operationTimeoutSeconds is the maximum amount of time we
-  allow for the SAM operation, including the SAM operations and our retry sleep time. This is the
-  upper bound on how long the entire operation will take.
+We frequently experience socket timeouts with SAM, so we have implemented retry. The
+configuration controls work like this. operationTimeoutSeconds is the maximum amount of time we
+allow for the SAM operation, including the SAM operations and our retry sleep time. This is the
+upper bound on how long the entire operation will take.
 
-  The retry strategy is exponential backoff. The error wait starts at retryInitialWaitSeconds,
-  and doubles up to retryMaximumWaitSeconds. The retry stays at retryMaximumWaitSeconds until we
-  reach the operationTimeoutSeconds limit. Well, depending on the numbers you choose, we might hit
-  operationTimeoutSeconds before we reach retryMaximumSeconds.*/
+The retry strategy is exponential backoff. The error wait starts at retryInitialWaitSeconds,
+and doubles up to retryMaximumWaitSeconds. The retry stays at retryMaximumWaitSeconds until we
+reach the operationTimeoutSeconds limit. Well, depending on the numbers you choose, we might hit
+operationTimeoutSeconds before we reach retryMaximumSeconds.*/
 
 @ConfigurationProperties(prefix = "sam")
-public record SamConfiguration(String basePath, String stewardsGroupEmail, String adminsGroupEmail,
-                               int retryInitialWaitSeconds, int retryMaximumWaitSeconds,
-                               int operationTimeoutSeconds) {}
+public record SamConfiguration(
+    String basePath,
+    String stewardsGroupEmail,
+    String adminsGroupEmail,
+    int retryInitialWaitSeconds,
+    int retryMaximumWaitSeconds,
+    int operationTimeoutSeconds) {}

--- a/src/main/java/bio/terra/app/configuration/SentryConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/SentryConfiguration.java
@@ -12,15 +12,11 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
-@Configuration
-@EnableConfigurationProperties
 @ConfigurationProperties(prefix = "sentry")
-public class SentryConfiguration {
+public record SentryConfiguration(String dsn, String environment) {
   private static final Logger logger = LoggerFactory.getLogger(SentryConfiguration.class);
   private static final String DEFAULT_UNDEFINED_ENVIRONMENT = "undefined";
   private static final List<Class<? extends Exception>> FILTERED =
@@ -33,25 +29,6 @@ public class SentryConfiguration {
           IllegalArgumentException.class,
           NoHandlerFoundException.class,
           ForbiddenException.class);
-
-  private String dsn;
-  private String environment;
-
-  public String getDsn() {
-    return dsn;
-  }
-
-  public void setDsn(String dsn) {
-    this.dsn = dsn;
-  }
-
-  public String getEnvironment() {
-    return environment;
-  }
-
-  public void setEnvironment(String environment) {
-    this.environment = environment;
-  }
 
   @PostConstruct
   private void postConstruct() {

--- a/src/main/java/bio/terra/app/configuration/SentryConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/SentryConfiguration.java
@@ -12,10 +12,12 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 @ConfigurationProperties(prefix = "sentry")
+@ConstructorBinding
 public record SentryConfiguration(String dsn, String environment) {
   private static final Logger logger = LoggerFactory.getLogger(SentryConfiguration.class);
   private static final String DEFAULT_UNDEFINED_ENVIRONMENT = "undefined";

--- a/src/main/java/bio/terra/app/configuration/TerraConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/TerraConfiguration.java
@@ -1,20 +1,6 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@EnableConfigurationProperties
 @ConfigurationProperties(prefix = "terra")
-public class TerraConfiguration {
-  private String basePath;
-
-  public String getBasePath() {
-    return basePath;
-  }
-
-  public void setBasePath(String basePath) {
-    this.basePath = basePath;
-  }
-}
+public record TerraConfiguration(String basePath) {}

--- a/src/main/java/bio/terra/app/configuration/TerraConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/TerraConfiguration.java
@@ -1,6 +1,8 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "terra")
+@ConstructorBinding
 public record TerraConfiguration(String basePath) {}

--- a/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
@@ -6,9 +6,11 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.context.annotation.Bean;
 
 @ConfigurationProperties(prefix = "usermetrics")
+@ConstructorBinding
 public record UserMetricsConfiguration(
     String appId,
     String bardBasePath,

--- a/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
@@ -6,61 +6,16 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
-@EnableConfigurationProperties
 @ConfigurationProperties(prefix = "usermetrics")
-public class UserMetricsConfiguration {
-
-  private String appId;
-  private String bardBasePath;
-  private Integer metricsReportingPoolSize;
-
-  private Integer syncRefreshIntervalSeconds;
-  private List<String> ignorePaths;
-
-  public String getAppId() {
-    return appId;
-  }
-
-  public void setAppId(String appId) {
-    this.appId = appId;
-  }
-
-  public String getBardBasePath() {
-    return bardBasePath;
-  }
-
-  public void setBardBasePath(String bardBasePath) {
-    this.bardBasePath = bardBasePath;
-  }
-
-  public Integer getMetricsReportingPoolSize() {
-    return metricsReportingPoolSize;
-  }
-
-  public Integer getSyncRefreshIntervalSeconds() {
-    return syncRefreshIntervalSeconds;
-  }
-
-  public void setMetricsReportingPoolSize(Integer metricsReportingPoolSize) {
-    this.metricsReportingPoolSize = metricsReportingPoolSize;
-  }
-
-  public void setSyncRefreshIntervalSeconds(Integer syncRefreshIntervalSeconds) {
-    this.syncRefreshIntervalSeconds = syncRefreshIntervalSeconds;
-  }
-
-  public List<String> getIgnorePaths() {
-    return ignorePaths;
-  }
-
-  public void setIgnorePaths(List<String> ignorePaths) {
-    this.ignorePaths = ignorePaths;
-  }
+public record UserMetricsConfiguration(
+    String appId,
+    String bardBasePath,
+    Integer metricsReportingPoolSize,
+    Integer syncRefreshIntervalSeconds,
+    List<String> ignorePaths
+) {
 
   @Bean("metricsReportingThreadpool")
   public ExecutorService metricsPerformanceThreadpool() {

--- a/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
@@ -14,8 +14,7 @@ public record UserMetricsConfiguration(
     String bardBasePath,
     Integer metricsReportingPoolSize,
     Integer syncRefreshIntervalSeconds,
-    List<String> ignorePaths
-) {
+    List<String> ignorePaths) {
 
   @Bean("metricsReportingThreadpool")
   public ExecutorService metricsPerformanceThreadpool() {

--- a/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
+++ b/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
@@ -86,7 +86,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
             .activeProfiles(Arrays.asList(env.getActiveProfiles()))
             .semVer(semVer)
             .gitHash(gitHash)
-            .terraUrl(terraConfiguration.getBasePath())
+            .terraUrl(terraConfiguration.basePath())
             .samUrl(samConfiguration.basePath())
             .authorityEndpoint(openIDConnectConfiguration.getAuthorityEndpoint());
 

--- a/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
+++ b/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
@@ -81,7 +81,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
   public ResponseEntity<RepositoryConfigurationModel> retrieveRepositoryConfig() {
     RepositoryConfigurationModel configurationModel =
         new RepositoryConfigurationModel()
-            .clientId(oauthConfig.getClientId())
+            .clientId(oauthConfig.clientId())
             .oidcClientId(openIDConnectConfiguration.getClientId())
             .activeProfiles(Arrays.asList(env.getActiveProfiles()))
             .semVer(semVer)
@@ -114,7 +114,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
 
   @RequestMapping(value = "/swagger-ui.html")
   public String getSwaggerUI(Model model) {
-    model.addAttribute("oauthClientId", oauthConfig.getClientId());
+    model.addAttribute("oauthClientId", oauthConfig.clientId());
     model.addAttribute("oidcClientId", openIDConnectConfiguration.getClientId());
     return "index";
   }

--- a/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
+++ b/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
@@ -87,7 +87,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
             .semVer(semVer)
             .gitHash(gitHash)
             .terraUrl(terraConfiguration.getBasePath())
-            .samUrl(samConfiguration.getBasePath())
+            .samUrl(samConfiguration.basePath())
             .authorityEndpoint(openIDConnectConfiguration.getAuthorityEndpoint());
 
     return new ResponseEntity<>(configurationModel, HttpStatus.OK);

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -49,8 +49,7 @@ public class BardClient {
 
     int ttl =
         Objects.requireNonNullElse(
-            metricsConfig.syncRefreshIntervalSeconds(),
-            DEFAULT_BEARER_TOKEN_CACHE_TIMEOUT_SECONDS);
+            metricsConfig.syncRefreshIntervalSeconds(), DEFAULT_BEARER_TOKEN_CACHE_TIMEOUT_SECONDS);
     this.bearerCache = Collections.synchronizedMap(new PassiveExpiringMap<>(ttl, TimeUnit.SECONDS));
 
     this.metricsConfig = metricsConfig;

--- a/src/main/java/bio/terra/app/usermetrics/BardClient.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardClient.java
@@ -49,7 +49,7 @@ public class BardClient {
 
     int ttl =
         Objects.requireNonNullElse(
-            metricsConfig.getSyncRefreshIntervalSeconds(),
+            metricsConfig.syncRefreshIntervalSeconds(),
             DEFAULT_BEARER_TOKEN_CACHE_TIMEOUT_SECONDS);
     this.bearerCache = Collections.synchronizedMap(new PassiveExpiringMap<>(ttl, TimeUnit.SECONDS));
 
@@ -116,11 +116,11 @@ public class BardClient {
 
   @VisibleForTesting
   String getApiUrl() {
-    return metricsConfig.getBardBasePath() + API_PATH;
+    return metricsConfig.bardBasePath() + API_PATH;
   }
 
   @VisibleForTesting
   String getSyncPathUrl() {
-    return metricsConfig.getBardBasePath() + SYNC_PATH;
+    return metricsConfig.bardBasePath() + SYNC_PATH;
   }
 }

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -58,7 +58,7 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
     }
 
     // Don't log metrics if bard isn't configured or the path is part of the ignore-list
-    if (StringUtils.isEmpty(metricsConfig.getBardBasePath()) || ignoreEventForPath(path)) {
+    if (StringUtils.isEmpty(metricsConfig.bardBasePath()) || ignoreEventForPath(path)) {
       return;
     }
 
@@ -78,13 +78,13 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
                 new BardEvent(
                     API_EVENT_NAME,
                     bardEventProperties,
-                    metricsConfig.getAppId(),
+                    metricsConfig.appId(),
                     applicationConfiguration.getDnsName())));
   }
 
   /** Should we actually ignore sending a tracking event for this path */
   private boolean ignoreEventForPath(String path) {
-    return metricsConfig.getIgnorePaths().stream()
+    return metricsConfig.ignorePaths().stream()
         .anyMatch(p -> FilenameUtils.wildcardMatch(path, p));
   }
 }

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -84,7 +84,6 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
 
   /** Should we actually ignore sending a tracking event for this path */
   private boolean ignoreEventForPath(String path) {
-    return metricsConfig.ignorePaths().stream()
-        .anyMatch(p -> FilenameUtils.wildcardMatch(path, p));
+    return metricsConfig.ignorePaths().stream().anyMatch(p -> FilenameUtils.wildcardMatch(path, p));
   }
 }

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamApiService.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamApiService.java
@@ -58,7 +58,7 @@ public class SamApiService {
     return new ApiClient()
         .setHttpClient(sharedHttpClient)
         .setUserAgent("OpenAPI-Generator/1.0.0 java") // only logs an error in sam
-        .setBasePath(samConfig.getBasePath());
+        .setBasePath(samConfig.basePath());
   }
 
   private ApiClient createApiClient(String accessToken) {

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -217,7 +217,7 @@ public class SamIam implements IamProviderInterface {
 
     req.putPoliciesItem(
         IamRole.ADMIN.toString(),
-        createAccessPolicyOneV2(IamRole.ADMIN, samConfig.getAdminsGroupEmail()));
+        createAccessPolicyOneV2(IamRole.ADMIN, samConfig.adminsGroupEmail()));
 
     List<String> stewards = new ArrayList<>();
     stewards.add(userStatusInfo.getUserEmail());
@@ -285,7 +285,7 @@ public class SamIam implements IamProviderInterface {
 
     req.putPoliciesItem(
         IamRole.ADMIN.toString(),
-        createAccessPolicyOneV2(IamRole.ADMIN, samConfig.getAdminsGroupEmail()));
+        createAccessPolicyOneV2(IamRole.ADMIN, samConfig.adminsGroupEmail()));
 
     List<String> stewards = new ArrayList<>();
     stewards.add(userStatusInfo.getUserEmail());
@@ -345,7 +345,7 @@ public class SamIam implements IamProviderInterface {
     req.setResourceId(profileId);
     req.putPoliciesItem(
         IamRole.ADMIN.toString(),
-        createAccessPolicyOneV2(IamRole.ADMIN, samConfig.getAdminsGroupEmail()));
+        createAccessPolicyOneV2(IamRole.ADMIN, samConfig.adminsGroupEmail()));
     req.putPoliciesItem(
         IamRole.OWNER.toString(),
         createAccessPolicyOneV2(IamRole.OWNER, userStatusInfo.getUserEmail()));

--- a/src/main/java/bio/terra/service/auth/ras/EcmService.java
+++ b/src/main/java/bio/terra/service/auth/ras/EcmService.java
@@ -56,13 +56,13 @@ public class EcmService {
 
   public PassportApi getPassportApi() {
     var client = new ApiClient(restTemplate);
-    client.setBasePath(ecmConfiguration.getBasePath());
+    client.setBasePath(ecmConfiguration.basePath());
 
     return new PassportApi(client);
   }
 
   public void addRasIssuerAndType(RASv1Dot1VisaCriterion criterion) {
-    criterion.issuer(ecmConfiguration.getRasIssuer()).type(RAS_CRITERIA_TYPE);
+    criterion.issuer(ecmConfiguration.rasIssuer()).type(RAS_CRITERIA_TYPE);
   }
 
   public ValidatePassportResult validatePassport(ValidatePassportRequest validatePassportRequest) {

--- a/src/main/java/bio/terra/service/auth/ras/OidcApiService.java
+++ b/src/main/java/bio/terra/service/auth/ras/OidcApiService.java
@@ -21,7 +21,7 @@ public class OidcApiService {
 
   public OidcApi getOidcApi(AuthenticatedUserRequest userReq) {
     var client = new ApiClient(restTemplate);
-    client.setBasePath(ecmConfiguration.getBasePath());
+    client.setBasePath(ecmConfiguration.basePath());
     client.setAccessToken(userReq.getToken());
 
     return new OidcApi(client);

--- a/src/main/java/bio/terra/service/configuration/ConfigurationService.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigurationService.java
@@ -202,9 +202,9 @@ public class ConfigurationService {
   // Setup the configuration. This is done once during construction.
   private void setConfiguration() {
     // -- Parameters --
-    addParameter(SAM_RETRY_INITIAL_WAIT_SECONDS, samConfiguration.getRetryInitialWaitSeconds());
-    addParameter(SAM_RETRY_MAXIMUM_WAIT_SECONDS, samConfiguration.getRetryMaximumWaitSeconds());
-    addParameter(SAM_OPERATION_TIMEOUT_SECONDS, samConfiguration.getOperationTimeoutSeconds());
+    addParameter(SAM_RETRY_INITIAL_WAIT_SECONDS, samConfiguration.retryInitialWaitSeconds());
+    addParameter(SAM_RETRY_MAXIMUM_WAIT_SECONDS, samConfiguration.retryMaximumWaitSeconds());
+    addParameter(SAM_OPERATION_TIMEOUT_SECONDS, samConfiguration.operationTimeoutSeconds());
     addParameter(LOAD_BULK_ARRAY_FILES_MAX, appConfiguration.getMaxBulkFileLoadArray());
     addParameter(LOAD_CONCURRENT_FILES, appConfiguration.getLoadConcurrentFiles());
     addParameter(LOAD_CONCURRENT_INGESTS, appConfiguration.getLoadConcurrentIngests());

--- a/src/main/java/bio/terra/service/configuration/ConfigurationService.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigurationService.java
@@ -219,8 +219,8 @@ public class ConfigurationService {
     addParameter(DRS_LOOKUP_MAX, appConfiguration.getMaxDrsLookups());
     addParameter(AUTH_CACHE_TIMEOUT_SECONDS, appConfiguration.getAuthCacheTimeoutSeconds());
     addParameter(
-        ALLOW_REUSE_EXISTING_BUCKETS, googleResourceConfiguration.getAllowReuseExistingBuckets());
-    addParameter(FIRESTORE_RETRIES, googleResourceConfiguration.getFirestoreRetries());
+        ALLOW_REUSE_EXISTING_BUCKETS, googleResourceConfiguration.allowReuseExistingBuckets());
+    addParameter(FIRESTORE_RETRIES, googleResourceConfiguration.firestoreRetries());
 
     // -- Faults --
     addFaultSimple(CREATE_ASSET_FAULT);

--- a/src/main/java/bio/terra/service/duos/DuosClient.java
+++ b/src/main/java/bio/terra/service/duos/DuosClient.java
@@ -51,7 +51,7 @@ public class DuosClient {
 
   @VisibleForTesting
   String getStatusUrl() {
-    return String.format("%s/status", duosConfiguration.getBasePath());
+    return String.format("%s/status", duosConfiguration.basePath());
   }
 
   /**
@@ -67,7 +67,7 @@ public class DuosClient {
 
   @VisibleForTesting
   String getDatasetUrl(String duosId) {
-    return String.format("%s/api/tdr/%s", duosConfiguration.getBasePath(), duosId);
+    return String.format("%s/api/tdr/%s", duosConfiguration.basePath(), duosId);
   }
 
   /**

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -203,7 +203,7 @@ public class DrsService {
     DRSAuthorizations auths = new DRSAuthorizations();
     if (passportAuthorizationAvailable) {
       auths.addSupportedTypesItem(DRSAuthorizations.SupportedTypesEnum.PASSPORTAUTH);
-      auths.addPassportAuthIssuersItem(ecmConfiguration.getRasIssuer());
+      auths.addPassportAuthIssuersItem(ecmConfiguration.rasIssuer());
     }
     auths.addSupportedTypesItem(DRSAuthorizations.SupportedTypesEnum.BEARERAUTH);
     return auths;

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -381,13 +381,13 @@ public class AzureSynapsePdao {
   @PostConstruct
   private void initializeDb() {
     // If this configuration wasn't set, skip initialization
-    if (azureResourceConfiguration.getSynapse() == null) {
+    if (azureResourceConfiguration.synapse() == null) {
       return;
     }
-    boolean initialize = azureResourceConfiguration.getSynapse().isInitialize();
-    String dbName = azureResourceConfiguration.getSynapse().getDatabaseName();
-    String encryptionKey = azureResourceConfiguration.getSynapse().getEncryptionKey();
-    String parquetFormatName = azureResourceConfiguration.getSynapse().getParquetFileFormatName();
+    boolean initialize = azureResourceConfiguration.synapse().initialize();
+    String dbName = azureResourceConfiguration.synapse().databaseName();
+    String encryptionKey = azureResourceConfiguration.synapse().encryptionKey();
+    String parquetFormatName = azureResourceConfiguration.synapse().parquetFileFormatName();
 
     if (initialize) {
       logger.info("Initializing Synapse database {}", dbName);
@@ -545,7 +545,7 @@ public class AzureSynapsePdao {
     sqlCreateTableTemplate.add("destinationParquetFile", scratchParquetFile);
     sqlCreateTableTemplate.add("destinationDataSourceName", scratchDataSourceName);
     sqlCreateTableTemplate.add(
-        "fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName());
+        "fileFormat", azureResourceConfiguration.synapse().parquetFileFormatName());
     sqlCreateTableTemplate.add("ingestFileName", ingestFileName);
     sqlCreateTableTemplate.add("controlFileDataSourceName", controlFileDataSourceName);
     sqlCreateTableTemplate.add("columns", datasetTable.getSynapseColumns());
@@ -585,7 +585,7 @@ public class AzureSynapsePdao {
     sqlCreateFinalParquetFilesTemplate.add("destinationParquetFile", destinationParquetFile);
     sqlCreateFinalParquetFilesTemplate.add("destinationDataSourceName", destinationDataSourceName);
     sqlCreateFinalParquetFilesTemplate.add(
-        "fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName());
+        "fileFormat", azureResourceConfiguration.synapse().parquetFileFormatName());
     sqlCreateFinalParquetFilesTemplate.add("scratchTableName", scratchTableName);
 
     String columns =
@@ -655,7 +655,7 @@ public class AzureSynapsePdao {
             .add("tableName", rowIdTableName)
             .add("destinationParquetFile", rowIdParquetFile)
             .add("destinationDataSourceName", snapshotDataSourceName)
-            .add("fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName())
+            .add("fileFormat", azureResourceConfiguration.synapse().parquetFileFormatName())
             .add("selectStatements", sqlMergeTablesTemplate.render());
     executeSynapseQuery(sqlCreateRowIdTable.render());
   }
@@ -1101,7 +1101,7 @@ public class AzureSynapsePdao {
         .add("tableName", snapshotTableName)
         .add("destinationParquetFile", snapshotParquetFileName)
         .add("destinationDataSourceName", snapshotDataSourceName)
-        .add("fileFormat", azureResourceConfiguration.getSynapse().getParquetFileFormatName())
+        .add("fileFormat", azureResourceConfiguration.synapse().parquetFileFormatName())
         .add("ingestFileName", datasetParquetFileName)
         .add("ingestFileDataSourceName", datasetDataSourceName)
         .add("drsLocator", drsLocator)
@@ -1330,14 +1330,14 @@ public class AzureSynapsePdao {
 
   @VisibleForTesting
   public SQLServerDataSource getDatasource() {
-    return getDatasource(azureResourceConfiguration.getSynapse().getDatabaseName());
+    return getDatasource(azureResourceConfiguration.synapse().databaseName());
   }
 
   private SQLServerDataSource getDatasource(String databaseName) {
     SQLServerDataSource ds = new SQLServerDataSource();
-    ds.setServerName(azureResourceConfiguration.getSynapse().getWorkspaceName());
-    ds.setUser(azureResourceConfiguration.getSynapse().getSqlAdminUser());
-    ds.setPassword(azureResourceConfiguration.getSynapse().getSqlAdminPassword());
+    ds.setServerName(azureResourceConfiguration.synapse().workspaceName());
+    ds.setUser(azureResourceConfiguration.synapse().sqlAdminUser());
+    ds.setPassword(azureResourceConfiguration.synapse().sqlAdminPassword());
     ds.setDatabaseName(databaseName);
     return ds;
   }

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -112,8 +112,8 @@ public class AzureBlobStorePdao implements CloudFileReader {
   private RequestRetryOptions getRetryOptions() {
     return new RequestRetryOptions(
         RetryPolicyType.EXPONENTIAL,
-        this.resourceConfiguration.getMaxRetries(),
-        this.resourceConfiguration.getRetryTimeoutSeconds(),
+        this.resourceConfiguration.maxRetries(),
+        this.resourceConfiguration.retryTimeoutSeconds(),
         null,
         null,
         null);

--- a/src/main/java/bio/terra/service/filedata/google/bq/BigQueryConfiguration.java
+++ b/src/main/java/bio/terra/service/filedata/google/bq/BigQueryConfiguration.java
@@ -2,35 +2,24 @@ package bio.terra.service.filedata.google.bq;
 
 import java.util.Optional;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.context.annotation.Profile;
 
 /** Configuration for interacting with BigQuery. */
-@Configuration
+@ConstructorBinding
 @Profile("google")
 @ConfigurationProperties(prefix = "datarepo.bq")
-public class BigQueryConfiguration {
+public record BigQueryConfiguration(Integer rateLimitRetries, Integer rateLimitRetryWaitMs) {
 
   private static final int DEFAULT_MAX_NUM_UPDATE_LIMIT_INDUCED_RETRIES = 3;
   private static final int DEFAULT_RETRY_WAIT_MS = 500;
-
-  private Integer rateLimitRetries;
-  private Integer rateLimitRetryWaitMs;
 
   public int getRateLimitRetries() {
     return Optional.ofNullable(rateLimitRetries)
         .orElse(DEFAULT_MAX_NUM_UPDATE_LIMIT_INDUCED_RETRIES);
   }
 
-  public void setRateLimitRetries(Integer rateLimitRetries) {
-    this.rateLimitRetries = rateLimitRetries;
-  }
-
   public int getRateLimitRetryWaitMs() {
     return Optional.ofNullable(rateLimitRetryWaitMs).orElse(DEFAULT_RETRY_WAIT_MS);
-  }
-
-  public void setRateLimitRetryWaitMs(Integer rateLimitRetryWaitMs) {
-    this.rateLimitRetryWaitMs = rateLimitRetryWaitMs;
   }
 }

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsConfiguration.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsConfiguration.java
@@ -1,7 +1,7 @@
 package bio.terra.service.filedata.google.gcs;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.context.annotation.Profile;
 
 /**
@@ -9,44 +9,8 @@ import org.springframework.context.annotation.Profile;
  * That way, implementation specifics can be separated from the interface. We'll see if it works out
  * that way.
  */
-@Configuration
+@ConstructorBinding
 @Profile("google")
 @ConfigurationProperties(prefix = "datarepo.gcs")
-public class GcsConfiguration {
-  private String bucket;
-  private String region;
-  private int connectTimeoutSeconds;
-  private int readTimeoutSeconds;
-
-  public String getBucket() {
-    return bucket;
-  }
-
-  public void setBucket(String bucket) {
-    this.bucket = bucket;
-  }
-
-  public String getRegion() {
-    return region;
-  }
-
-  public void setRegion(String region) {
-    this.region = region;
-  }
-
-  public int getConnectTimeoutSeconds() {
-    return connectTimeoutSeconds;
-  }
-
-  public void setConnectTimeoutSeconds(int connectTimeoutSeconds) {
-    this.connectTimeoutSeconds = connectTimeoutSeconds;
-  }
-
-  public int getReadTimeoutSeconds() {
-    return readTimeoutSeconds;
-  }
-
-  public void setReadTimeoutSeconds(int readTimeoutSeconds) {
-    this.readTimeoutSeconds = readTimeoutSeconds;
-  }
-}
+public record GcsConfiguration(
+    String bucket, String region, int connectTimeoutSeconds, int readTimeoutSeconds) {}

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsProjectFactory.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsProjectFactory.java
@@ -69,8 +69,8 @@ public class GcsProjectFactory {
         p ->
             new GcsProject(
                 p,
-                gcsConfiguration.getConnectTimeoutSeconds(),
-                gcsConfiguration.getReadTimeoutSeconds()));
+                gcsConfiguration.connectTimeoutSeconds(),
+                gcsConfiguration.readTimeoutSeconds()));
   }
 
   private GoogleProjectResource retrieveProjectResource(String projectId) {

--- a/src/main/java/bio/terra/service/policy/PolicyApiService.java
+++ b/src/main/java/bio/terra/service/policy/PolicyApiService.java
@@ -25,7 +25,7 @@ public class PolicyApiService {
   private ApiClient getApiClient() {
     return new ApiClient()
         .setHttpClient(sharedHttpClient)
-        .setBasePath(policyServiceConfiguration.getBasePath());
+        .setBasePath(policyServiceConfiguration.basePath());
   }
 
   private ApiClient getApiClient(String accessToken) {

--- a/src/main/java/bio/terra/service/policy/PolicyService.java
+++ b/src/main/java/bio/terra/service/policy/PolicyService.java
@@ -50,7 +50,7 @@ public class PolicyService {
 
   public void createPao(
       UUID resourceId, TpsObjectType resourceType, @Nullable TpsPolicyInputs policyInputs) {
-    if (!policyServiceConfiguration.getEnabled()) {
+    if (!policyServiceConfiguration.enabled()) {
       logger.info("Terra Policy Service is not enabled.");
       return;
     }
@@ -74,7 +74,7 @@ public class PolicyService {
    * the PolicyServiceNotFoundException exception.
    */
   public void deletePaoIfExists(UUID resourceId) {
-    if (!policyServiceConfiguration.getEnabled()) {
+    if (!policyServiceConfiguration.enabled()) {
       logger.info("Terra Policy Service is not enabled.");
       return;
     }
@@ -119,14 +119,14 @@ public class PolicyService {
       publicApi.getStatus();
       return new RepositoryStatusModelSystems()
           .ok(true)
-          .critical(policyServiceConfiguration.getEnabled())
+          .critical(policyServiceConfiguration.enabled())
           .message("Terra Policy Service status ok");
     } catch (Exception ex) {
       String errorMsg = "Terra Policy Service status check failed";
       logger.error(errorMsg, ex);
       return new RepositoryStatusModelSystems()
           .ok(false)
-          .critical(policyServiceConfiguration.getEnabled())
+          .critical(policyServiceConfiguration.enabled())
           .message(errorMsg + ": " + ExceptionUtils.formatException(ex));
     }
   }

--- a/src/main/java/bio/terra/service/profile/azure/AzureAuthzService.java
+++ b/src/main/java/bio/terra/service/profile/azure/AzureAuthzService.java
@@ -38,7 +38,7 @@ public class AzureAuthzService {
       GenericResource applicationDeployment =
           client
               .genericResources()
-              .getById(applicationResourceId, resourceConfiguration.getApiVersion());
+              .getById(applicationResourceId, resourceConfiguration.apiVersion());
 
       return ((Map<String, Map<String, Map<String, String>>>) applicationDeployment.properties())
           .get("parameters")

--- a/src/main/java/bio/terra/service/rawls/RawlsClient.java
+++ b/src/main/java/bio/terra/service/rawls/RawlsClient.java
@@ -40,8 +40,7 @@ public class RawlsClient {
     try {
       ResponseEntity<WorkspaceResponse> workspaceCall =
           restTemplate.exchange(
-              String.format(
-                  "%s/api/workspaces/id/%s", rawlsConfiguration.basePath(), workspaceId),
+              String.format("%s/api/workspaces/id/%s", rawlsConfiguration.basePath(), workspaceId),
               HttpMethod.GET,
               new HttpEntity<>(headers),
               WorkspaceResponse.class);

--- a/src/main/java/bio/terra/service/rawls/RawlsClient.java
+++ b/src/main/java/bio/terra/service/rawls/RawlsClient.java
@@ -41,7 +41,7 @@ public class RawlsClient {
       ResponseEntity<WorkspaceResponse> workspaceCall =
           restTemplate.exchange(
               String.format(
-                  "%s/api/workspaces/id/%s", rawlsConfiguration.getBasePath(), workspaceId),
+                  "%s/api/workspaces/id/%s", rawlsConfiguration.basePath(), workspaceId),
               HttpMethod.GET,
               new HttpEntity<>(headers),
               WorkspaceResponse.class);

--- a/src/main/java/bio/terra/service/rawls/RawlsService.java
+++ b/src/main/java/bio/terra/service/rawls/RawlsService.java
@@ -85,6 +85,6 @@ public class RawlsService {
       return null;
     }
     return "%s/#workspaces/%s/%s"
-        .formatted(terraConfiguration.getBasePath(), workspace.getNamespace(), workspace.getName());
+        .formatted(terraConfiguration.basePath(), workspace.getNamespace(), workspace.getName());
   }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
@@ -55,7 +55,7 @@ public class BufferService {
   private ApiClient createUnauthApiClient() {
     return new ApiClient()
         .setHttpClient(sharedHttpClient)
-        .setBasePath(bufferServiceConfiguration.getInstanceUrl());
+        .setBasePath(bufferServiceConfiguration.instanceUrl());
   }
 
   private ApiClient createApiClient(String accessToken) {
@@ -81,11 +81,11 @@ public class BufferService {
     try {
       BufferApi bufferApi = bufferApi();
       ResourceInfo info =
-          bufferApi.handoutResource(requestBody, bufferServiceConfiguration.getPoolId());
+          bufferApi.handoutResource(requestBody, bufferServiceConfiguration.poolId());
       logger.info(
           "Retrieved resource from pool {} on Buffer Service instance {}",
-          bufferServiceConfiguration.getPoolId(),
-          bufferServiceConfiguration.getInstanceUrl());
+          bufferServiceConfiguration.poolId(),
+          bufferServiceConfiguration.instanceUrl());
 
       if (enableSecureMonitoring) {
         var projectId = info.getCloudResourceUid().getGoogleProjectUid().getProjectId();
@@ -136,12 +136,12 @@ public class BufferService {
       Map<String, SystemStatusSystems> subsystemStatusMap = status.getSystems();
       return new RepositoryStatusModelSystems()
           .ok(status.isOk())
-          .critical(bufferServiceConfiguration.getEnabled())
+          .critical(bufferServiceConfiguration.enabled())
           .message(subsystemStatusMap.toString());
     } catch (ApiException e) {
       return new RepositoryStatusModelSystems()
           .ok(false)
-          .critical(bufferServiceConfiguration.getEnabled())
+          .critical(bufferServiceConfiguration.enabled())
           .message(e.getResponseBody());
     }
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
@@ -117,7 +117,7 @@ public class BufferService {
     var project = cloudResourceManager.projects().get(projectId).execute();
 
     ResourceId resourceId =
-        new ResourceId().setType(GCS_FOLDER_TYPE).setId(googleConfig.getSecureFolderResourceId());
+        new ResourceId().setType(GCS_FOLDER_TYPE).setId(googleConfig.secureFolderResourceId());
 
     project.setParent(resourceId);
 

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -648,7 +648,7 @@ public class ResourceService {
 
   private Map<String, List<String>> getStewardPolicy() {
     // get steward emails and add to policy
-    String stewardsGroupEmail = formatEmailForPolicy(samConfiguration.getStewardsGroupEmail());
+    String stewardsGroupEmail = formatEmailForPolicy(samConfiguration.stewardsGroupEmail());
     Map<String, List<String>> policyMap = new HashMap<>();
     policyMap.put(BQ_JOB_USER_ROLE, Collections.singletonList(stewardsGroupEmail));
     return Collections.unmodifiableMap(policyMap);

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentService.java
@@ -117,7 +117,7 @@ public class AzureApplicationDeploymentService {
         MetadataDataAccessUtils.getApplicationDeploymentId(billingProfile);
     return client
         .genericResources()
-        .getById(applicationResourceId, resourceConfiguration.getApiVersion());
+        .getById(applicationResourceId, resourceConfiguration.apiVersion());
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureAuthService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureAuthService.java
@@ -37,8 +37,8 @@ public class AzureAuthService {
   @Autowired
   public AzureAuthService(AzureResourceConfiguration configuration) {
     this.configuration = configuration;
-    var maxRetries = configuration.getMaxRetries();
-    var retryTimeoutSeconds = configuration.getRetryTimeoutSeconds();
+    var maxRetries = configuration.maxRetries();
+    var retryTimeoutSeconds = configuration.retryTimeoutSeconds();
     retryOptions =
         new RequestRetryOptions(
             RetryPolicyType.EXPONENTIAL, maxRetries, retryTimeoutSeconds, null, null, null);

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -75,7 +75,8 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
     try {
       Workspace byResourceGroup =
           client
@@ -106,7 +107,8 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     logger.info(
         "Creating new Log Analytics Workspace for Storage Account {}",
@@ -133,7 +135,8 @@ public class AzureMonitoringService {
   public void deleteLogAnalyticsWorkspace(BillingProfileModel profileModel, String id) {
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     logger.info("Deleting Log Analytics Workspace {}", id);
 
@@ -233,7 +236,8 @@ public class AzureMonitoringService {
 
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     try {
       DataExport dataExport =
@@ -281,7 +285,8 @@ public class AzureMonitoringService {
     }
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     logger.info(
         "Creating new export rule for Log Analytics Workspace linked to Storage Account {}",
@@ -308,7 +313,8 @@ public class AzureMonitoringService {
   public void deleteDataExportRule(BillingProfileModel profileModel, String id) {
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     logger.info("Deleting Log Analytics Workspace data export rule {}", id);
 
@@ -327,7 +333,8 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     try {
       SentinelOnboardingState sentinelOnboardingState =
@@ -360,7 +367,8 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     logger.info(
         "Creating new Sentinel deployment for Log Analytics Workspace that monitors Storage Account {}",
@@ -390,7 +398,8 @@ public class AzureMonitoringService {
 
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     logger.info("Deleting Sentinel instance {}", id);
 
@@ -409,7 +418,8 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
     try {
       AlertRule alertRule =
           client
@@ -444,7 +454,8 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     // Note: this is copied from the rule defined in the Terra landing zone service
     logger.info(
@@ -492,7 +503,8 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     logger.info(
         "Deleting Sentinel UnauthorizedAccess alert rule for Storage Account {}",
@@ -517,7 +529,8 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
     try {
       AutomationRule automationRule =
           client
@@ -553,7 +566,8 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
     logger.info(
         "Creating new Sentinel alert rule for Sentinel instance monitoring Storage Account {}",
         storageAccount.getStorageAccountId());
@@ -570,7 +584,7 @@ public class AzureMonitoringService {
                 new PlaybookActionProperties()
                     .withLogicAppResourceId(
                         resourceConfiguration.monitoring().notificationApplicationId())
-                    .withTenantId(resourceConfiguration.credentials().homeTenantId()));
+                    .withTenantId(resourceConfiguration.credentials().getHomeTenantId()));
     return client
         .automationRules()
         .define(SLACK_ALERT_RULE_NAME)
@@ -594,7 +608,8 @@ public class AzureMonitoringService {
   public void deleteNotificationRule(BillingProfileModel profileModel, String id) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
 
     logger.info("Deleting Sentinel alert rule {}", id);
 

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -75,8 +75,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
     try {
       Workspace byResourceGroup =
           client
@@ -107,8 +106,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     logger.info(
         "Creating new Log Analytics Workspace for Storage Account {}",
@@ -135,8 +133,7 @@ public class AzureMonitoringService {
   public void deleteLogAnalyticsWorkspace(BillingProfileModel profileModel, String id) {
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     logger.info("Deleting Log Analytics Workspace {}", id);
 
@@ -236,8 +233,7 @@ public class AzureMonitoringService {
 
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     try {
       DataExport dataExport =
@@ -275,7 +271,7 @@ public class AzureMonitoringService {
 
     String resourceId =
         resourceConfiguration
-            .getMonitoring()
+            .monitoring()
             .getLogCollectionConfigsAsMap()
             .get(storageAccount.getRegion());
     if (resourceId == null) {
@@ -285,8 +281,7 @@ public class AzureMonitoringService {
     }
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     logger.info(
         "Creating new export rule for Log Analytics Workspace linked to Storage Account {}",
@@ -313,8 +308,7 @@ public class AzureMonitoringService {
   public void deleteDataExportRule(BillingProfileModel profileModel, String id) {
     LogAnalyticsManager client =
         resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     logger.info("Deleting Log Analytics Workspace data export rule {}", id);
 
@@ -333,8 +327,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     try {
       SentinelOnboardingState sentinelOnboardingState =
@@ -367,8 +360,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     logger.info(
         "Creating new Sentinel deployment for Log Analytics Workspace that monitors Storage Account {}",
@@ -398,8 +390,7 @@ public class AzureMonitoringService {
 
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     logger.info("Deleting Sentinel instance {}", id);
 
@@ -418,8 +409,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
     try {
       AlertRule alertRule =
           client
@@ -454,8 +444,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     // Note: this is copied from the rule defined in the Terra landing zone service
     logger.info(
@@ -503,8 +492,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     logger.info(
         "Deleting Sentinel UnauthorizedAccess alert rule for Storage Account {}",
@@ -529,8 +517,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
     try {
       AutomationRule automationRule =
           client
@@ -566,8 +553,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
     logger.info(
         "Creating new Sentinel alert rule for Sentinel instance monitoring Storage Account {}",
         storageAccount.getStorageAccountId());
@@ -583,8 +569,8 @@ public class AzureMonitoringService {
             .withActionConfiguration(
                 new PlaybookActionProperties()
                     .withLogicAppResourceId(
-                        resourceConfiguration.getMonitoring().getNotificationApplicationId())
-                    .withTenantId(resourceConfiguration.getCredentials().getHomeTenantId()));
+                        resourceConfiguration.monitoring().notificationApplicationId())
+                    .withTenantId(resourceConfiguration.credentials().homeTenantId()));
     return client
         .automationRules()
         .define(SLACK_ALERT_RULE_NAME)
@@ -608,8 +594,7 @@ public class AzureMonitoringService {
   public void deleteNotificationRule(BillingProfileModel profileModel, String id) {
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.getCredentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+            resourceConfiguration.credentials().homeTenantId(), profileModel.getSubscriptionId());
 
     logger.info("Deleting Sentinel alert rule {}", id);
 

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -13,68 +13,20 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
 /** Configuration for working with Azure resources */
-@Configuration
+@ConstructorBinding
 @EnableConfigurationProperties
 @ConfigurationProperties(prefix = "azure")
-public class AzureResourceConfiguration {
-  private Credentials credentials;
-  private Synapse synapse;
-  private int maxRetries;
-  private int retryTimeoutSeconds;
-  private String apiVersion;
-  private Monitoring monitoring;
-
-  public Credentials getCredentials() {
-    return credentials;
-  }
-
-  public void setCredentials(Credentials credentials) {
-    this.credentials = credentials;
-  }
-
-  public Synapse getSynapse() {
-    return synapse;
-  }
-
-  public void setSynapse(Synapse synapse) {
-    this.synapse = synapse;
-  }
-
-  public int getMaxRetries() {
-    return maxRetries;
-  }
-
-  public void setMaxRetries(int maxRetries) {
-    this.maxRetries = maxRetries;
-  }
-
-  public int getRetryTimeoutSeconds() {
-    return retryTimeoutSeconds;
-  }
-
-  public void setRetryTimeoutSeconds(int retryTimeoutSeconds) {
-    this.retryTimeoutSeconds = retryTimeoutSeconds;
-  }
-
-  public String getApiVersion() {
-    return apiVersion;
-  }
-
-  public void setApiVersion(String apiVersion) {
-    this.apiVersion = apiVersion;
-  }
-
-  public Monitoring getMonitoring() {
-    return monitoring;
-  }
-
-  public void setMonitoring(Monitoring monitoring) {
-    this.monitoring = monitoring;
-  }
+public record AzureResourceConfiguration(
+    Credentials credentials,
+    Synapse synapse,
+    int maxRetries,
+    int retryTimeoutSeconds,
+    String apiVersion,
+    Monitoring monitoring) {
 
   /**
    * Given a user tenant Id, return Azure credentials
@@ -97,7 +49,7 @@ public class AzureResourceConfiguration {
    * @return A credential object that can be used to interact with Azure apis
    */
   public TokenCredential getAppToken() {
-    return getAppToken(credentials.getHomeTenantId());
+    return getAppToken(credentials.homeTenantId());
   }
 
   /**
@@ -159,139 +111,40 @@ public class AzureResourceConfiguration {
    * @return An authenticated {@link AzureResourceManager} client
    */
   public AzureResourceManager getClient(final UUID subscriptionId) {
-    return getClient(credentials.getHomeTenantId(), subscriptionId);
+    return getClient(credentials.homeTenantId(), subscriptionId);
   }
 
   /** Information for authenticating the TDR service against user Azure tenants */
-  public static class Credentials {
-    // The unique UUID of the TDR application
-    private UUID applicationId;
-    // A valid and current secret (e.g. application password) for the TDR application
-    private String secret;
-    // The UUID of the tenant to which the application belongs
-    private UUID homeTenantId;
+  public record Credentials(
+      // The unique UUID of the TDR application
+      UUID applicationId,
+      // A valid and current secret (e.g. application password) for the TDR application
+      String secret,
+      // The UUID of the tenant to which the application belongs
+      UUID homeTenantId) {}
 
-    public UUID getApplicationId() {
-      return applicationId;
-    }
-
-    public void setApplicationId(UUID applicationId) {
-      this.applicationId = applicationId;
-    }
-
-    public String getSecret() {
-      return secret;
-    }
-
-    public void setSecret(String secret) {
-      this.secret = secret;
-    }
-
-    public UUID getHomeTenantId() {
-      return homeTenantId;
-    }
-
-    public void setHomeTenantId(UUID homeTenantId) {
-      this.homeTenantId = homeTenantId;
-    }
-  }
-
-  public static class Synapse {
-
-    private String workspaceName;
-    private String sqlAdminUser;
-    private String sqlAdminPassword;
-    private String databaseName;
-    private String parquetFileFormatName;
-    private String encryptionKey;
-    private boolean initialize;
-
-    public String getWorkspaceName() {
-      return workspaceName;
-    }
-
-    public void setWorkspaceName(String workspaceName) {
-      this.workspaceName = workspaceName;
-    }
-
-    public String getSqlAdminUser() {
-      return sqlAdminUser;
-    }
-
-    public void setSqlAdminUser(String sqlAdminUser) {
-      this.sqlAdminUser = sqlAdminUser;
-    }
-
-    public String getSqlAdminPassword() {
-      return sqlAdminPassword;
-    }
-
-    public void setSqlAdminPassword(String sqlAdminPassword) {
-      this.sqlAdminPassword = sqlAdminPassword;
-    }
-
-    public String getDatabaseName() {
-      return databaseName;
-    }
-
-    public void setDatabaseName(String databaseName) {
-      this.databaseName = databaseName;
-    }
-
-    public String getParquetFileFormatName() {
-      return parquetFileFormatName;
-    }
-
-    public void setParquetFileFormatName(String parquetFileFormatName) {
-      this.parquetFileFormatName = parquetFileFormatName;
-    }
-
-    public String getEncryptionKey() {
-      return encryptionKey;
-    }
-
-    public void setEncryptionKey(String encryptionKey) {
-      this.encryptionKey = encryptionKey;
-    }
-
-    public boolean isInitialize() {
-      return initialize;
-    }
-
-    public void setInitialize(boolean initialize) {
-      this.initialize = initialize;
-    }
-  }
+  public record Synapse(
+      String workspaceName,
+      String sqlAdminUser,
+      String sqlAdminPassword,
+      String databaseName,
+      String parquetFileFormatName,
+      String encryptionKey,
+      boolean initialize) {}
 
   /** Track the monitoring-related configuration */
-  public static class Monitoring {
-    // The resource ID of the Azure Logic app that handles sending Slack notifications
-    private String notificationApplicationId;
-    // The list of regional storage accounts to send long term logs to
-    private List<LogCollectionConfig> logCollectionConfigs;
-
-    public String getNotificationApplicationId() {
-      return notificationApplicationId;
-    }
-
-    public void setNotificationApplicationId(String notificationApplicationId) {
-      this.notificationApplicationId = notificationApplicationId;
-    }
-
-    public List<LogCollectionConfig> getLogCollectionConfigs() {
-      return logCollectionConfigs;
-    }
-
-    public void setLogCollectionConfigs(List<LogCollectionConfig> logCollectionConfigs) {
-      this.logCollectionConfigs = logCollectionConfigs;
-    }
+  public record Monitoring(
+      // The resource ID of the Azure Logic app that handles sending Slack notifications
+      String notificationApplicationId,
+      // The list of regional storage accounts to send long term logs to
+      List<LogCollectionConfig> logCollectionConfigs) {
 
     public Map<AzureRegion, String> getLogCollectionConfigsAsMap() {
       return logCollectionConfigs.stream()
           .collect(
               Collectors.toMap(
-                  LogCollectionConfig::getRegion,
-                  LogCollectionConfig::getTargetStorageAccountResourceId));
+                  LogCollectionConfig::region,
+                  LogCollectionConfig::targetStorageAccountResourceId));
     }
   }
 
@@ -300,31 +153,5 @@ public class AzureResourceConfiguration {
    * in the same region as the Log Analytics workspace which is why there may be several of these
    * objects in the service configuration
    */
-  public static class LogCollectionConfig {
-
-    private AzureRegion region;
-    private String targetStorageAccountResourceId;
-
-    public AzureRegion getRegion() {
-      return region;
-    }
-
-    public void setRegion(String region) {
-      AzureRegion azureRegion = AzureRegion.fromValue(region);
-      if (azureRegion == null) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Invalid region '%s' specified in azure.monitoring.logCollectionConfigs", region));
-      }
-      this.region = azureRegion;
-    }
-
-    public String getTargetStorageAccountResourceId() {
-      return targetStorageAccountResourceId;
-    }
-
-    public void setTargetStorageAccountResourceId(String targetStorageAccountResourceId) {
-      this.targetStorageAccountResourceId = targetStorageAccountResourceId;
-    }
-  }
+  public record LogCollectionConfig(AzureRegion region, String targetStorageAccountResourceId) {}
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -36,8 +36,8 @@ public record AzureResourceConfiguration(
    */
   public TokenCredential getAppToken(final UUID tenantId) {
     return new ClientSecretCredentialBuilder()
-        .clientId(credentials.applicationId.toString())
-        .clientSecret(credentials.secret)
+        .clientId(credentials.getApplicationId().toString())
+        .clientSecret(credentials.getSecret())
         .tenantId(tenantId.toString())
         .build();
   }
@@ -49,7 +49,7 @@ public record AzureResourceConfiguration(
    * @return A credential object that can be used to interact with Azure apis
    */
   public TokenCredential getAppToken() {
-    return getAppToken(credentials.homeTenantId());
+    return getAppToken(credentials.getHomeTenantId());
   }
 
   /**
@@ -111,17 +111,42 @@ public record AzureResourceConfiguration(
    * @return An authenticated {@link AzureResourceManager} client
    */
   public AzureResourceManager getClient(final UUID subscriptionId) {
-    return getClient(credentials.homeTenantId(), subscriptionId);
+    return getClient(credentials.getHomeTenantId(), subscriptionId);
   }
 
   /** Information for authenticating the TDR service against user Azure tenants */
-  public record Credentials(
-      // The unique UUID of the TDR application
-      UUID applicationId,
-      // A valid and current secret (e.g. application password) for the TDR application
-      String secret,
-      // The UUID of the tenant to which the application belongs
-      UUID homeTenantId) {}
+  public static class Credentials {
+    // The unique UUID of the TDR application
+    private UUID applicationId;
+    // A valid and current secret (e.g. application password) for the TDR application
+    private String secret;
+    // The UUID of the tenant to which the application belongs
+    private UUID homeTenantId;
+
+    public UUID getApplicationId() {
+      return applicationId;
+    }
+
+    public void setApplicationId(UUID applicationId) {
+      this.applicationId = applicationId;
+    }
+
+    public String getSecret() {
+      return secret;
+    }
+
+    public void setSecret(String secret) {
+      this.secret = secret;
+    }
+
+    public UUID getHomeTenantId() {
+      return homeTenantId;
+    }
+
+    public void setHomeTenantId(UUID homeTenantId) {
+      this.homeTenantId = homeTenantId;
+    }
+  }
 
   public record Synapse(
       String workspaceName,

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleProjectService.java
@@ -301,7 +301,7 @@ public class GoogleProjectService {
                 .map(GoogleApiServiceusageV1Service::getName)
                 .collect(Collectors.toList());
       }
-      long timeout = resourceConfiguration.getProjectCreateTimeoutSeconds();
+      long timeout = resourceConfiguration.projectCreateTimeoutSeconds();
 
       if (actualServiceNames.containsAll(requiredServices)) {
         logger.info("project already has the right resources enabled, skipping");
@@ -389,7 +389,7 @@ public class GoogleProjectService {
     }
 
     return new Appengine.Builder(httpTransport, jsonFactory, credential)
-        .setApplicationName(resourceConfiguration.getApplicationName())
+        .setApplicationName(resourceConfiguration.applicationName())
         .build();
   }
 
@@ -536,7 +536,7 @@ public class GoogleProjectService {
     }
 
     return new ServiceUsage.Builder(httpTransport, jsonFactory, credential)
-        .setApplicationName(resourceConfiguration.getApplicationName())
+        .setApplicationName(resourceConfiguration.applicationName())
         .build();
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
@@ -1,56 +1,15 @@
 package bio.terra.service.resourcemanagement.google;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@ConstructorBinding
 @EnableConfigurationProperties
 @ConfigurationProperties(prefix = "google")
-public class GoogleResourceConfiguration {
-  private String applicationName;
-  private long projectCreateTimeoutSeconds;
-  private int firestoreRetries;
-  private boolean allowReuseExistingBuckets;
-  private String secureFolderResourceId;
-
-  public String getApplicationName() {
-    return applicationName;
-  }
-
-  public void setApplicationName(String applicationName) {
-    this.applicationName = applicationName;
-  }
-
-  public long getProjectCreateTimeoutSeconds() {
-    return projectCreateTimeoutSeconds;
-  }
-
-  public void setProjectCreateTimeoutSeconds(long projectCreateTimeoutSeconds) {
-    this.projectCreateTimeoutSeconds = projectCreateTimeoutSeconds;
-  }
-
-  public boolean getAllowReuseExistingBuckets() {
-    return allowReuseExistingBuckets;
-  }
-
-  public void setAllowReuseExistingBuckets(boolean allowReuseExistingBuckets) {
-    this.allowReuseExistingBuckets = allowReuseExistingBuckets;
-  }
-
-  public int getFirestoreRetries() {
-    return firestoreRetries;
-  }
-
-  public void setFirestoreRetries(int firestoreRetries) {
-    this.firestoreRetries = firestoreRetries;
-  }
-
-  public String getSecureFolderResourceId() {
-    return secureFolderResourceId;
-  }
-
-  public void setSecureFolderResourceId(String secureFolderResourceId) {
-    this.secureFolderResourceId = secureFolderResourceId;
-  }
-}
+public record GoogleResourceConfiguration(
+    String applicationName,
+    long projectCreateTimeoutSeconds,
+    int firestoreRetries,
+    boolean allowReuseExistingBuckets,
+    String secureFolderResourceId) {}

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
@@ -500,7 +500,7 @@ public class GoogleResourceDao {
     if (bucketResources.size() > 1) {
       // TODO This is only here because of the dev case. It should be removed when we start using
       // RBS in dev.
-      if (googleResourceConfiguration.getAllowReuseExistingBuckets()) {
+      if (googleResourceConfiguration.allowReuseExistingBuckets()) {
         return bucketResources.get(0).region(defaultRegion);
       }
       throw new CorruptMetadataException(

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
@@ -111,7 +111,7 @@ public class GoogleResourceDao {
       @Qualifier("tdrServiceAccountEmail") String tdrServiceAccountEmail)
       throws SQLException {
     this.jdbcTemplate = jdbcTemplate;
-    this.defaultRegion = GoogleRegion.fromValue(gcsConfiguration.getRegion());
+    this.defaultRegion = GoogleRegion.fromValue(gcsConfiguration.region());
     this.googleResourceConfiguration = googleResourceConfiguration;
     this.tdrServiceAccountEmail = tdrServiceAccountEmail;
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceManagerService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceManagerService.java
@@ -63,7 +63,7 @@ public class GoogleResourceManagerService {
     }
 
     return new CloudResourceManager.Builder(httpTransport, jsonFactory, credential)
-        .setApplicationName(resourceConfiguration.getApplicationName())
+        .setApplicationName(resourceConfiguration.applicationName())
         .build();
   }
 

--- a/src/main/java/bio/terra/service/upgrade/Migrate.java
+++ b/src/main/java/bio/terra/service/upgrade/Migrate.java
@@ -55,21 +55,20 @@ public class Migrate {
               changesetFile, new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
 
       logger.info(
-          String.format("dropAllOnStart is set to %s", migrateConfiguration.getDropAllOnStart()));
+          String.format("dropAllOnStart is set to %s", migrateConfiguration.dropAllOnStart()));
       boolean allowDropAllOnStart =
           Arrays.stream(env.getActiveProfiles())
               .anyMatch(env -> env.contains("dev") || env.contains("test") || env.contains("int"));
       logger.info(String.format("Allow dropAllOnStart is set to %s", allowDropAllOnStart));
 
-      if (allowDropAllOnStart && migrateConfiguration.getDropAllOnStart()) {
+      if (allowDropAllOnStart && migrateConfiguration.dropAllOnStart()) {
         logger.info("Dropping all db objects in the default schema");
         liquibase
             .dropAll(); // drops everything in the default schema. The migrate schema should be OK
       }
       logger.info(
-          String.format(
-              "updateAllOnStart is set to %s", migrateConfiguration.getUpdateAllOnStart()));
-      if (migrateConfiguration.getUpdateAllOnStart()) {
+          String.format("updateAllOnStart is set to %s", migrateConfiguration.updateAllOnStart()));
+      if (migrateConfiguration.updateAllOnStart()) {
         liquibase.update(new Contexts()); // Run all migrations - no context filtering
       }
     } catch (LiquibaseException | SQLException ex) {

--- a/src/main/java/bio/terra/service/upgrade/MigrateConfiguration.java
+++ b/src/main/java/bio/terra/service/upgrade/MigrateConfiguration.java
@@ -1,34 +1,13 @@
 package bio.terra.service.upgrade;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.stereotype.Component;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
 /**
  * Provides methods for upgrading the data repository metadata and stairway databases. See <a
  * href="https://docs.google.com/document/d/1CY9bOSwaw0HjdZ9uuxwm1rh4LkcOqV65tjI77IhKcxE/edit#">Liquibase
  * Migration Notes</a></a>
  */
-@Component
-@EnableConfigurationProperties
 @ConfigurationProperties(prefix = "db.migrate")
-public class MigrateConfiguration {
-  private boolean dropAllOnStart;
-  private boolean updateAllOnStart;
-
-  public boolean getDropAllOnStart() {
-    return dropAllOnStart;
-  }
-
-  public void setDropAllOnStart(boolean dropAllOnStart) {
-    this.dropAllOnStart = dropAllOnStart;
-  }
-
-  public boolean getUpdateAllOnStart() {
-    return updateAllOnStart;
-  }
-
-  public void setUpdateAllOnStart(boolean updateAllOnStart) {
-    this.updateAllOnStart = updateAllOnStart;
-  }
-}
+@ConstructorBinding
+public record MigrateConfiguration(boolean dropAllOnStart, boolean updateAllOnStart) {}

--- a/src/test/java/bio/terra/app/controller/UnauthenticatedApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/UnauthenticatedApiControllerTest.java
@@ -62,7 +62,7 @@ public class UnauthenticatedApiControllerTest {
     when(oauthConfig.clientId()).thenReturn(oauthClientId);
     when(openIDConnectConfiguration.getClientId()).thenReturn(oidcClientId);
     when(terraConfiguration.getBasePath()).thenReturn(terraUrl);
-    when(samConfiguration.getBasePath()).thenReturn(samUrl);
+    when(samConfiguration.basePath()).thenReturn(samUrl);
     when(openIDConnectConfiguration.getAuthorityEndpoint()).thenReturn(oidcAuthorityEndpoint);
 
     mvc.perform(get("/configuration"))

--- a/src/test/java/bio/terra/app/controller/UnauthenticatedApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/UnauthenticatedApiControllerTest.java
@@ -61,7 +61,7 @@ public class UnauthenticatedApiControllerTest {
 
     when(oauthConfig.clientId()).thenReturn(oauthClientId);
     when(openIDConnectConfiguration.getClientId()).thenReturn(oidcClientId);
-    when(terraConfiguration.getBasePath()).thenReturn(terraUrl);
+    when(terraConfiguration.basePath()).thenReturn(terraUrl);
     when(samConfiguration.basePath()).thenReturn(samUrl);
     when(openIDConnectConfiguration.getAuthorityEndpoint()).thenReturn(oidcAuthorityEndpoint);
 

--- a/src/test/java/bio/terra/app/controller/UnauthenticatedApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/UnauthenticatedApiControllerTest.java
@@ -59,7 +59,7 @@ public class UnauthenticatedApiControllerTest {
     String samUrl = "sam.base.url";
     String oidcAuthorityEndpoint = "/oidc/authority/endpoint";
 
-    when(oauthConfig.getClientId()).thenReturn(oauthClientId);
+    when(oauthConfig.clientId()).thenReturn(oauthClientId);
     when(openIDConnectConfiguration.getClientId()).thenReturn(oidcClientId);
     when(terraConfiguration.getBasePath()).thenReturn(terraUrl);
     when(samConfiguration.getBasePath()).thenReturn(samUrl);

--- a/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/BardClientTest.java
@@ -38,7 +38,7 @@ public class BardClientTest {
 
   @BeforeEach
   void setup() {
-    when(userMetricsConfiguration.getSyncRefreshIntervalSeconds()).thenReturn(1000);
+    when(userMetricsConfiguration.syncRefreshIntervalSeconds()).thenReturn(1000);
 
     bardClient = new BardClient(userMetricsConfiguration, restTemplate);
 

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -68,9 +68,9 @@ public class UserMetricsInterceptorTest {
 
   @BeforeEach
   void setUp() {
-    when(metricsConfig.getIgnorePaths()).thenReturn(List.of());
-    when(metricsConfig.getAppId()).thenReturn(APP_ID);
-    when(metricsConfig.getBardBasePath()).thenReturn(BARD_BASE_PATH);
+    when(metricsConfig.ignorePaths()).thenReturn(List.of());
+    when(metricsConfig.appId()).thenReturn(APP_ID);
+    when(metricsConfig.bardBasePath()).thenReturn(BARD_BASE_PATH);
 
     when(applicationConfiguration.getDnsName()).thenReturn(DNS_NAME);
 
@@ -150,7 +150,7 @@ public class UserMetricsInterceptorTest {
 
   @Test
   void testSendEventNotFiredWithNoBardBasePath() throws Exception {
-    when(metricsConfig.getBardBasePath()).thenReturn(null);
+    when(metricsConfig.bardBasePath()).thenReturn(null);
 
     runAndWait();
 
@@ -170,7 +170,7 @@ public class UserMetricsInterceptorTest {
   @ParameterizedTest
   @ValueSource(strings = {REQUEST_URI, "/foo/*"})
   void testSendEventNotFiredWithIgnoredUrl(String ignorePath) throws Exception {
-    when(metricsConfig.getIgnorePaths()).thenReturn(List.of(ignorePath));
+    when(metricsConfig.ignorePaths()).thenReturn(List.of(ignorePath));
     mockRequestAuth(request);
 
     runAndWait();

--- a/src/test/java/bio/terra/common/SynapseUtils.java
+++ b/src/test/java/bio/terra/common/SynapseUtils.java
@@ -129,7 +129,7 @@ public class SynapseUtils {
 
     client =
         azureResourceConfiguration.getClient(
-            azureResourceConfiguration.getCredentials().getHomeTenantId(),
+            azureResourceConfiguration.credentials().getHomeTenantId(),
             billingProfile.getSubscriptionId());
 
     applicationResource =

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -159,8 +159,8 @@ public class AzureIntegrationTest extends UsersBase {
     retryOptions =
         new RequestRetryOptions(
             RetryPolicyType.EXPONENTIAL,
-            azureResourceConfiguration.getMaxRetries(),
-            azureResourceConfiguration.getRetryTimeoutSeconds(),
+            azureResourceConfiguration.maxRetries(),
+            azureResourceConfiguration.retryTimeoutSeconds(),
             null,
             null,
             null);

--- a/src/test/java/bio/terra/integration/SamFixtures.java
+++ b/src/test/java/bio/terra/integration/SamFixtures.java
@@ -40,7 +40,7 @@ public class SamFixtures {
   }
 
   public void deleteServiceAccountFromTerra(TestConfiguration.User user, String serviceAccount) {
-    logger.info("Deleting user {} from Sam {}", serviceAccount, samConfig.getBasePath());
+    logger.info("Deleting user {} from Sam {}", serviceAccount, samConfig.basePath());
     try {
       // Get the user ID to delete
       HttpHeaders authedHeader = getHeaders(user);
@@ -63,7 +63,7 @@ public class SamFixtures {
       // Delete the user
       String userDeletionUrl =
           "%s/api/admin/v1/user/%s"
-              .formatted(samConfig.getBasePath(), userStatus.getUserInfo().getUserSubjectId());
+              .formatted(samConfig.basePath(), userStatus.getUserInfo().getUserSubjectId());
       try {
         restTemplate.exchange(
             userDeletionUrl, HttpMethod.DELETE, new HttpEntity<>(null, authedHeader), Void.class);
@@ -86,7 +86,7 @@ public class SamFixtures {
     ApiClient apiClient = new ApiClient();
     apiClient.setAccessToken(accessToken);
     apiClient.setUserAgent("OpenAPI-Generator/1.0.0 java"); // only logs an error in sam
-    return apiClient.setBasePath(samConfig.getBasePath());
+    return apiClient.setBasePath(samConfig.basePath());
   }
 
   private HttpHeaders getHeaders(TestConfiguration.User user) {

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -76,13 +76,14 @@ public class SamIamTest {
 
   private SamIam samIam;
   private static final String ADMIN_EMAIL = "samAdminGroupEmail@a.com";
-  private final SamConfiguration samConfig = new SamConfiguration(
-      "https://sam.dsde-dev.broadinstitute.org",
-      "samStewardsGroupEmail@a.com",
-      ADMIN_EMAIL,
-      10,
-      30,
-      60);
+  private final SamConfiguration samConfig =
+      new SamConfiguration(
+          "https://sam.dsde-dev.broadinstitute.org",
+          "samStewardsGroupEmail@a.com",
+          ADMIN_EMAIL,
+          10,
+          30,
+          60);
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
 

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -89,11 +89,13 @@ public class SamIamTest {
 
   @BeforeEach
   void setUp() throws Exception {
+    GoogleResourceConfiguration resourceConfiguration =
+        new GoogleResourceConfiguration("jade-data-repo", 600, 4, false, "123456");
     samIam =
         new SamIam(
             samConfig,
             new ConfigurationService(
-                samConfig, null, new GoogleResourceConfiguration(), new ApplicationConfiguration()),
+                samConfig, null, resourceConfiguration, new ApplicationConfiguration()),
             samApiService);
   }
 

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -75,14 +75,19 @@ public class SamIamTest {
   @Mock private UsersApi samUsersApi;
 
   private SamIam samIam;
-  private final SamConfiguration samConfig = new SamConfiguration();
   private static final String ADMIN_EMAIL = "samAdminGroupEmail@a.com";
+  private final SamConfiguration samConfig = new SamConfiguration(
+      "https://sam.dsde-dev.broadinstitute.org",
+      "samStewardsGroupEmail@a.com",
+      ADMIN_EMAIL,
+      10,
+      30,
+      60);
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
 
   @BeforeEach
   void setUp() throws Exception {
-    samConfig.setAdminsGroupEmail(ADMIN_EMAIL);
     samIam =
         new SamIam(
             samConfig,
@@ -539,7 +544,7 @@ public class SamIamTest {
       req.putPoliciesItem(
           IamRole.ADMIN.toString(),
           new AccessPolicyMembershipV2()
-              .memberEmails(List.of(samConfig.getAdminsGroupEmail()))
+              .memberEmails(List.of(samConfig.adminsGroupEmail()))
               .roles(List.of(IamRole.ADMIN.toString())));
       req.putPoliciesItem(
           IamRole.OWNER.toString(),

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
@@ -57,7 +57,7 @@ public class SamRetryIntegrationTest extends UsersBase {
     ApiClient apiClient = new ApiClient();
     apiClient.setAccessToken(accessToken);
     apiClient.setUserAgent("OpenAPI-Generator/1.0.0 java"); // only logs an error in sam
-    return apiClient.setBasePath(samConfig.getBasePath());
+    return apiClient.setBasePath(samConfig.basePath());
   }
 
   @Before

--- a/src/test/java/bio/terra/service/configuration/ConfigServiceTest.java
+++ b/src/test/java/bio/terra/service/configuration/ConfigServiceTest.java
@@ -53,9 +53,9 @@ public class ConfigServiceTest {
     configService.reset();
 
     final int delta = 10;
-    int retryInitialWaitSeconds = samConfiguration.getRetryInitialWaitSeconds();
-    int retryMaximumWaitSeconds = samConfiguration.getRetryMaximumWaitSeconds();
-    int operationTimeoutSeconds = samConfiguration.getOperationTimeoutSeconds();
+    int retryInitialWaitSeconds = samConfiguration.retryInitialWaitSeconds();
+    int retryMaximumWaitSeconds = samConfiguration.retryMaximumWaitSeconds();
+    int operationTimeoutSeconds = samConfiguration.operationTimeoutSeconds();
 
     // Retrieve all config and make sure initialization worked
     List<ConfigModel> configModelList = configService.getConfigList().getItems();

--- a/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
@@ -108,7 +108,7 @@ public class SecureMonitoringIntegrationTest extends UsersBase {
     assertThat(
         "The parent of the dataset project is in the 'secure' folder",
         datasetParent.getId(),
-        equalTo(googleResourceConfiguration.getSecureFolderResourceId()));
+        equalTo(googleResourceConfiguration.secureFolderResourceId()));
 
     String datasetName = dataset.getName();
     SnapshotRequestModel requestModel =
@@ -161,7 +161,7 @@ public class SecureMonitoringIntegrationTest extends UsersBase {
     assertThat(
         "The parent of the snapshot project is in the 'secure' folder",
         snapshotParent.getId(),
-        equalTo(googleResourceConfiguration.getSecureFolderResourceId()));
+        equalTo(googleResourceConfiguration.secureFolderResourceId()));
   }
 
   private DatasetSummaryModel datasetWithSecureMonitoring(boolean secureMonitoringEnabled)

--- a/src/test/java/bio/terra/service/duos/DuosClientTest.java
+++ b/src/test/java/bio/terra/service/duos/DuosClientTest.java
@@ -60,7 +60,7 @@ public class DuosClientTest {
     when(googleCredentialsService.getApplicationDefaultAccessToken(DuosClient.SCOPES))
         .thenReturn(TDR_SA_TOKEN);
 
-    when(duosConfiguration.getBasePath()).thenReturn(BASE_PATH);
+    when(duosConfiguration.basePath()).thenReturn(BASE_PATH);
 
     duosClient = new DuosClient(duosConfiguration, restTemplate, googleCredentialsService);
   }

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -237,7 +237,7 @@ public class DrsServiceTest {
     drsPassportRequestModel =
         new DRSPassportRequestModel().addPassportsItem("longPassportToken").expand(false);
 
-    when(ecmConfiguration.getRasIssuer()).thenReturn(RAS_ISSUER);
+    when(ecmConfiguration.rasIssuer()).thenReturn(RAS_ISSUER);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -55,6 +55,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -86,7 +87,7 @@ public class AzureIngestFileConnectedTest {
   private FileLoadModel fileLoadModel;
   private TableServiceClient tableServiceClient;
 
-  @Autowired private AzureResourceConfiguration azureResourceConfiguration;
+  @SpyBean private AzureResourceConfiguration azureResourceConfiguration;
   @Autowired AzureSynapsePdao azureSynapsePdao;
   @Autowired ConnectedOperations connectedOperations;
   @Autowired private ConnectedTestConfiguration testConfig;
@@ -107,8 +108,8 @@ public class AzureIngestFileConnectedTest {
     UUID storageAccountId = UUID.randomUUID();
     datasetId = UUID.randomUUID();
 
-    homeTenantId = azureResourceConfiguration.getCredentials().getHomeTenantId();
-    azureResourceConfiguration.getCredentials().setHomeTenantId(testConfig.getTargetTenantId());
+    AzureResourceConfiguration.Credentials credentials = azureResourceConfiguration.credentials();
+    credentials.setHomeTenantId(testConfig.getTargetTenantId());
 
     billingProfile =
         new BillingProfileModel()
@@ -177,7 +178,6 @@ public class AzureIngestFileConnectedTest {
     } catch (Exception ex) {
       logger.error("Unable to clean up metadata for fileId {}", fileId, ex);
     }
-    azureResourceConfiguration.getCredentials().setHomeTenantId(homeTenantId);
     connectedOperations.teardown();
   }
 

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -142,8 +142,8 @@ public class AzureBlobStorePdaoTest {
     dataset = new Dataset().id(DATASET_ID);
     when(profileDao.getBillingProfileById(PROFILE_ID)).thenReturn(BILLING_PROFILE);
     when(resourceConfiguration.getAppToken(TENANT_ID)).thenReturn(targetCredential);
-    when(resourceConfiguration.getMaxRetries()).thenReturn(3);
-    when(resourceConfiguration.getRetryTimeoutSeconds()).thenReturn(60);
+    when(resourceConfiguration.maxRetries()).thenReturn(3);
+    when(resourceConfiguration.retryTimeoutSeconds()).thenReturn(60);
     when(azureResourceDao.retrieveStorageAccountById(RESOURCE_ID))
         .thenReturn(AZURE_STORAGE_ACCOUNT_RESOURCE);
     targetBlobContainerFactory = mock(BlobContainerClientFactory.class);

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -58,8 +58,8 @@ public class BlobContainerClientFactoryTest {
     retryOptions =
         new RequestRetryOptions(
             RetryPolicyType.EXPONENTIAL,
-            azureResourceConfiguration.getMaxRetries(),
-            azureResourceConfiguration.getRetryTimeoutSeconds(),
+            azureResourceConfiguration.maxRetries(),
+            azureResourceConfiguration.retryTimeoutSeconds(),
             null,
             null,
             null);

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -64,8 +64,8 @@ public class BlobContainerCopierTest {
     retryOptions =
         new RequestRetryOptions(
             RetryPolicyType.EXPONENTIAL,
-            azureResourceConfiguration.getMaxRetries(),
-            azureResourceConfiguration.getRetryTimeoutSeconds(),
+            azureResourceConfiguration.maxRetries(),
+            azureResourceConfiguration.retryTimeoutSeconds(),
             null,
             null,
             null);

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
@@ -58,8 +58,8 @@ public class BlobCrlTest {
     RequestRetryOptions retryOptions =
         new RequestRetryOptions(
             RetryPolicyType.EXPONENTIAL,
-            azureResourceConfiguration.getMaxRetries(),
-            azureResourceConfiguration.getRetryTimeoutSeconds(),
+            azureResourceConfiguration.maxRetries(),
+            azureResourceConfiguration.retryTimeoutSeconds(),
             null,
             null,
             null);

--- a/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
@@ -56,8 +56,8 @@ public class SasUrlFactoriesTest {
     RequestRetryOptions retryOptions =
         new RequestRetryOptions(
             RetryPolicyType.EXPONENTIAL,
-            azureResourceConfiguration.getMaxRetries(),
-            azureResourceConfiguration.getRetryTimeoutSeconds(),
+            azureResourceConfiguration.maxRetries(),
+            azureResourceConfiguration.retryTimeoutSeconds(),
             null,
             null,
             null);

--- a/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
@@ -37,8 +37,9 @@ public class BatchOperationTest {
 
   @Before
   public void setup() {
-    GoogleResourceConfiguration resourceConfiguration = new GoogleResourceConfiguration();
-    resourceConfiguration.setFirestoreRetries(4);
+    // Use fewer firestoreRetries for testing
+    GoogleResourceConfiguration resourceConfiguration =
+        new GoogleResourceConfiguration("jade-data-repo", 600, 4, false, "123456");
     ConfigurationService configurationService =
         new ConfigurationService(
             samConfiguration, gcsConfiguration, resourceConfiguration, appConfiguration);

--- a/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
+++ b/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
@@ -58,7 +58,7 @@ public class PolicyServiceTest {
   }
 
   private void mockPolicyServiceConfiguration() {
-    when(policyServiceConfiguration.getEnabled()).thenReturn(true);
+    when(policyServiceConfiguration.enabled()).thenReturn(true);
   }
 
   private void mockPolicyApi() {
@@ -163,7 +163,7 @@ public class PolicyServiceTest {
     mockUnauthPolicyApi();
     RepositoryStatusModelSystems status = policyService.status();
     assertTrue(status.isOk());
-    assertThat(status.isCritical(), equalTo(policyServiceConfiguration.getEnabled()));
+    assertThat(status.isCritical(), equalTo(policyServiceConfiguration.enabled()));
     assertThat(status.getMessage(), containsString("Terra Policy Service status ok"));
   }
 
@@ -175,7 +175,7 @@ public class PolicyServiceTest {
     doThrow(exception).when(tpsUnauthApi).getStatus();
     RepositoryStatusModelSystems status = policyService.status();
     assertFalse(status.isOk());
-    assertThat(status.isCritical(), equalTo(policyServiceConfiguration.getEnabled()));
+    assertThat(status.isCritical(), equalTo(policyServiceConfiguration.enabled()));
     assertThat(status.getMessage(), containsString(exception.getMessage()));
   }
 }

--- a/src/test/java/bio/terra/service/profile/azure/AzureAuthzServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/azure/AzureAuthzServiceTest.java
@@ -49,7 +49,7 @@ public class AzureAuthzServiceTest {
         .thenReturn(Map.of("parameters", Map.of(AUTH_PARAM_KEY, Map.of("value", USER_EMAIL))));
     when(resourceManager.genericResources()).thenReturn(genericResources);
     when(resourceConfiguration.getClient(SUBSCRIPTION_ID)).thenReturn(resourceManager);
-    when(genericResources.getById(RESOURCE_ID, resourceConfiguration.getApiVersion()))
+    when(genericResources.getById(RESOURCE_ID, resourceConfiguration.apiVersion()))
         .thenReturn(genericResource);
     azureAuthzService = new AzureAuthzService(resourceConfiguration);
   }
@@ -86,7 +86,7 @@ public class AzureAuthzServiceTest {
 
   @Test
   public void testValidateResourceNotFound() {
-    when(genericResources.getById(RESOURCE_ID, resourceConfiguration.getApiVersion()))
+    when(genericResources.getById(RESOURCE_ID, resourceConfiguration.apiVersion()))
         .thenThrow(ResourceManagerException.class);
 
     assertThat(

--- a/src/test/java/bio/terra/service/rawls/RawlsServiceTest.java
+++ b/src/test/java/bio/terra/service/rawls/RawlsServiceTest.java
@@ -64,7 +64,7 @@ public class RawlsServiceTest {
   public void setUp() throws Exception {
     rawlsService = new RawlsService(terraConfiguration, rawlsClient);
 
-    when(terraConfiguration.getBasePath()).thenReturn(BASE_PATH);
+    when(terraConfiguration.basePath()).thenReturn(BASE_PATH);
 
     when(rawlsClient.getWorkspace(accessibleWorkspaceId, TEST_USER))
         .thenReturn(accessibleWorkspaceResponse);

--- a/src/test/java/bio/terra/service/resourcemanagement/BufferServiceConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/BufferServiceConnectedTest.java
@@ -162,7 +162,7 @@ public class BufferServiceConnectedTest {
     assertThat(
         "Sensitive project was moved to the correct folder",
         sensitiveParent.getId(),
-        equalTo(googleResourceConfiguration.getSecureFolderResourceId()));
+        equalTo(googleResourceConfiguration.secureFolderResourceId()));
   }
 
   private SnapshotModel getTestSnapshot(UUID id) throws Exception {

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentServiceTest.java
@@ -68,7 +68,7 @@ public class AzureApplicationDeploymentServiceTest {
                     STORAGE_PREFIX_KEY, Map.of(PARAMETER_VALUE_KEY, "tdr"),
                     STORAGE_TYPE_KEY, Map.of(PARAMETER_VALUE_KEY, "Standard_LRS"))));
     String appResourceId = MetadataDataAccessUtils.getApplicationDeploymentId(billingProfileModel);
-    when(genericResources.getById(appResourceId, resourceConfiguration.getApiVersion()))
+    when(genericResources.getById(appResourceId, resourceConfiguration.apiVersion()))
         .thenReturn(genericResource);
     when(client.genericResources()).thenReturn(genericResources);
     when(resourceDao.retrieveApplicationDeploymentByName(

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
@@ -256,7 +256,7 @@ class AzureMonitoringServiceTest {
   private void mockLogAnalyticsClient() {
     Credentials credentials = new Credentials();
     credentials.setHomeTenantId(HOME_TENANT_ID);
-    when(resourceConfiguration.getCredentials()).thenReturn(credentials);
+    when(resourceConfiguration.credentials()).thenReturn(credentials);
 
     when(resourceConfiguration.getLogAnalyticsManagerClient(HOME_TENANT_ID, SUBSCRIPTION_ID))
         .thenReturn(logAnalyticsManager);
@@ -265,7 +265,7 @@ class AzureMonitoringServiceTest {
   private void mockSecurityInsightsClient() {
     Credentials credentials = new Credentials();
     credentials.setHomeTenantId(HOME_TENANT_ID);
-    when(resourceConfiguration.getCredentials()).thenReturn(credentials);
+    when(resourceConfiguration.credentials()).thenReturn(credentials);
 
     when(resourceConfiguration.getSecurityInsightsManagerClient(HOME_TENANT_ID, SUBSCRIPTION_ID))
         .thenReturn(securityInsightsManager);

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfigurationTest.java
@@ -171,7 +171,7 @@ public class AzureResourceConfigurationTest {
         () -> {
           AzureResourceManager clientFromHome =
               azureResourceConfiguration.getClient(
-                  azureResourceConfiguration.getCredentials().getHomeTenantId(),
+                  azureResourceConfiguration.credentials().getHomeTenantId(),
                   profileModel.getSubscriptionId());
 
           clientFromHome
@@ -235,7 +235,7 @@ public class AzureResourceConfigurationTest {
                         // user's subscription
                         AzureResourceManager clientFromHome =
                             azureResourceConfiguration.getClient(
-                                azureResourceConfiguration.getCredentials().getHomeTenantId(),
+                                azureResourceConfiguration.credentials().getHomeTenantId(),
                                 profileModel.getSubscriptionId());
 
                         try {
@@ -372,7 +372,7 @@ public class AzureResourceConfigurationTest {
           ((Map<String, Map<String, Map<String, String>>>)
                   client
                       .genericResources()
-                      .getById(resourceReference.id(), azureResourceConfiguration.getApiVersion())
+                      .getById(resourceReference.id(), azureResourceConfiguration.apiVersion())
                       .properties())
               .get("outputs");
 


### PR DESCRIPTION
The following config classes were not converted to records because they extend or are extended by another config class:
- ApplicationConfiguration
- DataRepoJdbcConfiguration
- JdbcConfiguration
- StairwayJdbcConfiguration

In addition:
- `OpenIDConnectConfiguration` was left as-is because the constructor initializes the `oidcRestTemplate` (and in a record the overloaded constructor [must call another constructor on the first line](https://www.baeldung.com/java-records-custom-constructor#2-limitations))