### PR TITLE
DR-3152: Adapt ANTLR to accept casting in where clause

### DIFF
--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -64,8 +64,12 @@ expr : number
     | '(' expr ')'
     | column_expr
     | keyword
+    | cast_clause
     ;
 
+cast_clause
+    : CAST '(' expr AS datatype_name ')'
+    ;
 over_clause
     : OVER '(' (PARTITION BY expr)? order_by_clause? ')'
     ;

--- a/src/test/java/bio/terra/grammar/GrammarTest.java
+++ b/src/test/java/bio/terra/grammar/GrammarTest.java
@@ -120,6 +120,12 @@ public class GrammarTest {
   }
 
   @Test
+  public void testJSONDataInStringField() {
+    Query.parse(
+        "SELECT * FROM foo.bar WHERE CAST(JSON_EXTRACT_SCALAR(Description, '$.favoriteNumber') AS INT64) > 5");
+  }
+
+  @Test
   public void test1000Genomes() {
     // test for DR-2143 Fix validating dataset names that start with a number
     Query.parse("SELECT * FROM 1000GenomesDataset.sample_info");

--- a/src/test/resources/ingest-test-dataset.json
+++ b/src/test/resources/ingest-test-dataset.json
@@ -10,7 +10,8 @@
           {"name": "id", "datatype": "string"},
           {"name": "age", "datatype": "integer"},
           {"name": "children", "datatype": "string", "array_of": true},
-          {"name": "donated", "datatype": "string", "array_of": true}
+          {"name": "donated", "datatype": "string", "array_of": true},
+          {"name":  "jsonData", "datatype": "string"}
         ],
         "primaryKey": ["id"]
       },

--- a/src/test/resources/ingest-test-participant-with-json-data.json
+++ b/src/test/resources/ingest-test-participant-with-json-data.json
@@ -1,0 +1,5 @@
+{"id":"participant_1","age":65,"children":["participant_3","participant_4"],"donated":["sample1"],"jsonData": "{\"testField\": \"value42\", \"numericField\": 42}"}
+{"id":"participant_2","age":42,"children":["participant_3","participant_5"],"donated":["sample2","sample5"],"jsonData": "{\"testField\": \"value1\", \"numericField\": 1}"}
+{"id":"participant_3","age":15,"children":[],"donated":["sample3","sample4"],"jsonData": "{\"testField\": \"value5\", \"numericField\": 5}"}
+{"id":"participant_4","age":27,"children":["participant_5"],"donated":[],"jsonData": "{\"testField\": \"value4.0\", \"numericField\": 4}"}
+{"id":"participant_5","age":3,"children":[],"donated":["sample5"],"jsonData": "{\"testField\": \"value100\", \"numericField\": 100}"}


### PR DESCRIPTION
Users can ingest json data into string field by escaping the json data. Example ingest request:
```
{"id": "1", "jsonData": "{\"testField\": \"value1\", \"numericField\": 1}"}
{"id": "2", "jsonData": "{\"testField\": \"value2\", \"numericField\": 2}"}
```

There is desire to use numeric comparisons to filter rows when retrieving row data. This would mean using the lookupDatasetDatabyId with a filter parameter like the following would only return the second row: `CAST(JSON_EXTRACT_SCALAR(jsonData, '$.numericField') AS INT64) > 1`  

We already enable JSON_EXTRACT_SCALAR, but we don't yet enable "CAST" in the where clause. 