### PR TITLE
[DR-3161] Fix Azure Resource Regions

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -4,6 +4,7 @@ import static bio.terra.common.FlightUtils.getDefaultExponentialBackoffRetryRule
 import static bio.terra.common.FlightUtils.getDefaultRandomBackoffRetryRule;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.app.model.AzureRegion;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.GetResourceBufferProjectStep;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -117,7 +118,9 @@ public class DatasetCreateFlight extends Flight {
 
       // Turn on logging and monitoring for the storage account associated with the dataset
       azureStorageMonitoringStepProvider
-          .configureSteps(datasetRequest.isEnableSecureMonitoring())
+          .configureSteps(
+              datasetRequest.isEnableSecureMonitoring(),
+              AzureRegion.fromValue(datasetRequest.getRegion()))
           .forEach(s -> this.addStep(s.step(), s.retryRule()));
     }
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -138,7 +138,7 @@ public class DatasetIngestFlight extends Flight {
       // Turn on logging and monitoring for the storage account associated with the dataset and
       // billing profile
       azureStorageMonitoringStepProvider
-          .configureSteps(dataset.isSecureMonitoringEnabled())
+          .configureSteps(dataset.isSecureMonitoringEnabled(), dataset.getStorageAccountRegion())
           .forEach(s -> this.addStep(s.step(), s.retryRule()));
     }
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/DatasetScratchFilePrepareFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/scratch/DatasetScratchFilePrepareFlight.java
@@ -66,7 +66,7 @@ public class DatasetScratchFilePrepareFlight extends Flight {
       // Turn on logging and monitoring for the storage account associated with the dataset and
       // billing profile
       azureStorageMonitoringStepProvider
-          .configureSteps(dataset.isSecureMonitoringEnabled())
+          .configureSteps(dataset.isSecureMonitoringEnabled(), dataset.getStorageAccountRegion())
           .forEach(s -> this.addStep(s.step(), s.retryRule()));
       addStep(
           new CreateScratchFileForAzureStep(azureContainerPdao),

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AbstractCreateMonitoringResourceStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AbstractCreateMonitoringResourceStep.java
@@ -1,15 +1,29 @@
 package bio.terra.service.resourcemanagement.flight;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 
 public abstract class AbstractCreateMonitoringResourceStep implements Step {
 
+  protected final AzureMonitoringService monitoringService;
+  protected final AzureRegion region;
+
+  public AbstractCreateMonitoringResourceStep(
+      AzureMonitoringService monitoringService, AzureRegion region) {
+    this.monitoringService = monitoringService;
+    this.region = region;
+  }
+
   /**
    * Return the storage account resource object regardless of whether it is a dataset or snapshot
+   *
+   * <p>Note: always force the region to the one specified in the constructor since it's not always
+   * possible to get the region from the storage account resource while the flight is running
    *
    * @param context The current flight's context
    * @return A {@link AzureStorageAccountResource} object or null if not found
@@ -22,6 +36,9 @@ public abstract class AbstractCreateMonitoringResourceStep implements Step {
             .getWorkingMap()
             .get(CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
     if (storageAccountResource != null) {
+      if (region != null) {
+        storageAccountResource.region(region);
+      }
       return storageAccountResource;
     }
     storageAccountResource =
@@ -30,6 +47,9 @@ public abstract class AbstractCreateMonitoringResourceStep implements Step {
             .get(
                 CommonMapKeys.SNAPSHOT_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
     if (storageAccountResource != null) {
+      if (region != null) {
+        storageAccountResource.region(region);
+      }
       return storageAccountResource;
     }
     throw new NotFoundException(

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
@@ -3,6 +3,7 @@ package bio.terra.service.resourcemanagement.flight;
 import static bio.terra.common.FlightUtils.getDefaultExponentialBackoffRetryRule;
 import static bio.terra.stairway.RetryRuleNone.getRetryRuleNone;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
 import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.RetryRuleExponentialBackoff;
@@ -29,17 +30,18 @@ public class AzureStorageMonitoringStepProvider {
    * monitoring resources
    *
    * @param isSecureMonitoringEnabled Is this a dataset or snapshot with secure monitoring enabled?
+   * @param region The Azure region where all monitoring resources should be deployed
    */
-  public List<StepDef> configureSteps(boolean isSecureMonitoringEnabled) {
+  public List<StepDef> configureSteps(boolean isSecureMonitoringEnabled, AzureRegion region) {
     List<StepDef> steps = new ArrayList<>();
     RetryRuleNone noRetry = getRetryRuleNone();
     RetryRuleExponentialBackoff expBackoffRetry = getDefaultExponentialBackoffRetryRule();
 
     // Deploy a Log Analytics Workspace if it doesn't exist already
-    steps.add(new StepDef(new CreateLogAnalyticsWorkspaceStep(monitoringService), noRetry));
+    steps.add(new StepDef(new CreateLogAnalyticsWorkspaceStep(monitoringService, region), noRetry));
     // Create a diagnostic setting for the storage account if it doesn't exist already
     // This is what tells the storage account to send logs to the Log Analytics Workspace
-    steps.add(new StepDef(new CreateDiagnosticSettingStep(monitoringService), noRetry));
+    steps.add(new StepDef(new CreateDiagnosticSettingStep(monitoringService, region), noRetry));
 
     // The following steps are only required for FedRAMP compliance
     // They are not turned on in all cases due to cost
@@ -47,15 +49,18 @@ public class AzureStorageMonitoringStepProvider {
       // Create a rule to send the Log Analytics logs to a central storage account where the logs
       // will be retained for longer than the default 90 day minimum that the Log Analytics
       // Workspace stores
-      steps.add(new StepDef(new CreateExportRuleStep(monitoringService), noRetry));
+      steps.add(new StepDef(new CreateExportRuleStep(monitoringService, region), noRetry));
       // Deploy a Sentinel Workspace if it doesn't exist already
-      steps.add(new StepDef(new CreateSentinelStep(monitoringService), noRetry));
+      steps.add(new StepDef(new CreateSentinelStep(monitoringService, region), noRetry));
       // Add any rules to Sentinel that will detect events of interest.  It takes a little bit for
       // Sentinel to be available so adding a retry rule here.
-      steps.add(new StepDef(new CreateSentinelAlertRulesStep(monitoringService), expBackoffRetry));
+      steps.add(
+          new StepDef(
+              new CreateSentinelAlertRulesStep(monitoringService, region), expBackoffRetry));
       // Add a notification playbook rule to the Sentinel instance.  This ensures that a Slack
       // notification is sent when an alert is triggered.
-      steps.add(new StepDef(new CreateSentinelNotificationRuleStep(monitoringService), noRetry));
+      steps.add(
+          new StepDef(new CreateSentinelNotificationRuleStep(monitoringService, region), noRetry));
     }
     return steps;
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateDiagnosticSettingStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateDiagnosticSettingStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.flight;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
@@ -11,10 +12,8 @@ import bio.terra.stairway.exception.RetryException;
 
 public class CreateDiagnosticSettingStep extends AbstractCreateMonitoringResourceStep {
 
-  private final AzureMonitoringService monitoringService;
-
-  public CreateDiagnosticSettingStep(AzureMonitoringService monitoringService) {
-    this.monitoringService = monitoringService;
+  public CreateDiagnosticSettingStep(AzureMonitoringService monitoringService, AzureRegion region) {
+    super(monitoringService, region);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateExportRuleStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateExportRuleStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.flight;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
@@ -11,10 +12,8 @@ import bio.terra.stairway.exception.RetryException;
 
 public class CreateExportRuleStep extends AbstractCreateMonitoringResourceStep {
 
-  private final AzureMonitoringService monitoringService;
-
-  public CreateExportRuleStep(AzureMonitoringService monitoringService) {
-    this.monitoringService = monitoringService;
+  public CreateExportRuleStep(AzureMonitoringService monitoringService, AzureRegion region) {
+    super(monitoringService, region);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateLogAnalyticsWorkspaceStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateLogAnalyticsWorkspaceStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.flight;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
@@ -11,10 +12,9 @@ import bio.terra.stairway.exception.RetryException;
 
 public class CreateLogAnalyticsWorkspaceStep extends AbstractCreateMonitoringResourceStep {
 
-  private final AzureMonitoringService monitoringService;
-
-  public CreateLogAnalyticsWorkspaceStep(AzureMonitoringService monitoringService) {
-    this.monitoringService = monitoringService;
+  public CreateLogAnalyticsWorkspaceStep(
+      AzureMonitoringService monitoringService, AzureRegion region) {
+    super(monitoringService, region);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelAlertRulesStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelAlertRulesStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.flight;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
@@ -11,10 +12,9 @@ import bio.terra.stairway.exception.RetryException;
 
 public class CreateSentinelAlertRulesStep extends AbstractCreateMonitoringResourceStep {
 
-  private final AzureMonitoringService monitoringService;
-
-  public CreateSentinelAlertRulesStep(AzureMonitoringService monitoringService) {
-    this.monitoringService = monitoringService;
+  public CreateSentinelAlertRulesStep(
+      AzureMonitoringService monitoringService, AzureRegion region) {
+    super(monitoringService, region);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelNotificationRuleStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelNotificationRuleStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.flight;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
@@ -11,10 +12,9 @@ import bio.terra.stairway.exception.RetryException;
 
 public class CreateSentinelNotificationRuleStep extends AbstractCreateMonitoringResourceStep {
 
-  private final AzureMonitoringService monitoringService;
-
-  public CreateSentinelNotificationRuleStep(AzureMonitoringService monitoringService) {
-    this.monitoringService = monitoringService;
+  public CreateSentinelNotificationRuleStep(
+      AzureMonitoringService monitoringService, AzureRegion region) {
+    super(monitoringService, region);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.resourcemanagement.flight;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
@@ -11,10 +12,8 @@ import bio.terra.stairway.exception.RetryException;
 
 public class CreateSentinelStep extends AbstractCreateMonitoringResourceStep {
 
-  private final AzureMonitoringService monitoringService;
-
-  public CreateSentinelStep(AzureMonitoringService monitoringService) {
-    this.monitoringService = monitoringService;
+  public CreateSentinelStep(AzureMonitoringService monitoringService, AzureRegion region) {
+    super(monitoringService, region);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -172,7 +172,8 @@ public class SnapshotCreateFlight extends Flight {
 
       // Turn on logging and monitoring for the storage account associated with the snapshot
       azureStorageMonitoringStepProvider
-          .configureSteps(sourceDataset.isSecureMonitoringEnabled())
+          .configureSteps(
+              sourceDataset.isSecureMonitoringEnabled(), sourceDataset.getStorageAccountRegion())
           .forEach(s -> this.addStep(s.step(), s.retryRule()));
 
       addStep(

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.oneOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import bio.terra.app.model.CloudRegion;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.TestUtils;
 import bio.terra.common.configuration.TestConfiguration;
@@ -205,13 +206,17 @@ public class DataRepoFixtures {
       boolean selfHosted,
       boolean dedicatedServiceAccount,
       boolean predictableIds,
-      DatasetRequestModelPolicies policies)
+      DatasetRequestModelPolicies policies,
+      CloudRegion region)
       throws Exception {
     DatasetRequestModel requestModel = jsonLoader.loadObject(filename, DatasetRequestModel.class);
     requestModel.setDefaultProfileId(profileId);
     requestModel.setName(Names.randomizeName(requestModel.getName()));
     if (cloudPlatform != null && requestModel.getCloudPlatform() == null) {
       requestModel.setCloudPlatform(cloudPlatform);
+    }
+    if (region != null && requestModel.getRegion() == null) {
+      requestModel.setRegion(region.getValue());
     }
     requestModel.experimentalSelfHosted(selfHosted);
     requestModel.experimentalPredictableFileIds(predictableIds);
@@ -231,7 +236,7 @@ public class DataRepoFixtures {
   public DatasetSummaryModel createDataset(
       TestConfiguration.User user, UUID profileId, String filename, CloudPlatform cloudPlatform)
       throws Exception {
-    return createDataset(user, profileId, filename, cloudPlatform, false);
+    return createDataset(user, profileId, filename, cloudPlatform, false, null);
   }
 
   public DatasetSummaryModel createDataset(
@@ -257,6 +262,7 @@ public class DataRepoFixtures {
             true,
             dedicatedServiceAccount,
             false,
+            null,
             null);
     return waitForDatasetCreate(user, jobResponse);
   }
@@ -265,7 +271,7 @@ public class DataRepoFixtures {
       TestConfiguration.User user, UUID profileId, String fileName) throws Exception {
     DataRepoResponse<JobModel> jobResponse =
         createDatasetRaw(
-            user, profileId, fileName, CloudPlatform.GCP, false, false, true, false, null);
+            user, profileId, fileName, CloudPlatform.GCP, false, false, true, false, null, null);
     return waitForDatasetCreate(user, jobResponse);
   }
 
@@ -274,11 +280,21 @@ public class DataRepoFixtures {
       UUID profileId,
       String filename,
       CloudPlatform cloudPlatform,
-      boolean usePetAccount)
+      boolean usePetAccount,
+      CloudRegion region)
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
         createDatasetRaw(
-            user, profileId, filename, cloudPlatform, usePetAccount, false, false, false, null);
+            user,
+            profileId,
+            filename,
+            cloudPlatform,
+            usePetAccount,
+            false,
+            false,
+            false,
+            null,
+            region);
     return waitForDatasetCreate(user, jobResponse);
   }
 
@@ -290,7 +306,16 @@ public class DataRepoFixtures {
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
         createDatasetRaw(
-            user, profileId, filename, CloudPlatform.GCP, false, false, false, false, policies);
+            user,
+            profileId,
+            filename,
+            CloudPlatform.GCP,
+            false,
+            false,
+            false,
+            false,
+            policies,
+            null);
     return waitForDatasetCreate(user, jobResponse);
   }
 
@@ -323,7 +348,7 @@ public class DataRepoFixtures {
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
         createDatasetRaw(
-            user, profileId, filename, cloudPlatform, false, false, false, false, null);
+            user, profileId, filename, cloudPlatform, false, false, false, false, null, null);
     assertTrue("dataset create launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
     assertTrue(
         "dataset create launch response is present", jobResponse.getResponseObject().isPresent());

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -673,7 +673,8 @@ public class FileTest extends UsersBase {
             selfHosted,
             false,
             predictableFileIds,
-            new DatasetRequestModelPolicies());
+            new DatasetRequestModelPolicies(),
+            null);
 
     datasetSummaryModel = dataRepoFixtures.waitForDatasetCreate(steward(), datasetCreateJob);
     datasetId = datasetSummaryModel.getId();

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -262,7 +262,7 @@ public class DatasetIntegrationTest extends UsersBase {
   public void datasetHappyPathWithPet() throws Exception {
     DatasetSummaryModel summaryModel =
         dataRepoFixtures.createDataset(
-            steward(), profileId, "it-dataset-omop.json", CloudPlatform.GCP, true);
+            steward(), profileId, "it-dataset-omop.json", CloudPlatform.GCP, true, null);
     datasetId = summaryModel.getId();
 
     logger.info("dataset id is " + summaryModel.getId());

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -87,7 +87,8 @@ public class JobPermissionTest extends UsersBase {
             false,
             false,
             false,
-            new DatasetRequestModelPolicies().addCustodiansItem(custodian().getEmail()));
+            new DatasetRequestModelPolicies().addCustodiansItem(custodian().getEmail()),
+            null);
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.waitForDatasetCreate(steward(), jobResponse);
 

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProviderTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProviderTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.resourcemanagement.flight;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import bio.terra.app.model.AzureRegion;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
 import bio.terra.stairway.Step;
 import java.util.List;
@@ -42,7 +43,9 @@ class AzureStorageMonitoringStepProviderTest {
   void testConfigureStandardSteps() {
     assertThat(
         "only standard steps returned",
-        stepProvider.configureSteps(false).stream().map(s -> s.step().getClass()).toList(),
+        stepProvider.configureSteps(false, AzureRegion.DEFAULT_AZURE_REGION).stream()
+            .map(s -> s.step().getClass())
+            .toList(),
         is(EXPECTED_STANDARD_STEPS));
   }
 
@@ -50,7 +53,9 @@ class AzureStorageMonitoringStepProviderTest {
   void testConfigureProtectedDataSteps() {
     assertThat(
         "protected data steps also returned",
-        stepProvider.configureSteps(true).stream().map(s -> s.step().getClass()).toList(),
+        stepProvider.configureSteps(true, AzureRegion.DEFAULT_AZURE_REGION).stream()
+            .map(s -> s.step().getClass())
+            .toList(),
         is(EXPECTED_PROTECTED_DATA_STEPS));
   }
 }


### PR DESCRIPTION
This PR fixes a bug where we were potentially creating azure resources like log analytics workspaces in the wrong regions because the query that we use to get the region depends on the dataset being fully finished creating and while the dataset create flight is running, that's just not the case.

The approach was to hard code setting the region to the dataset creation request, so fairly straightforward.

The testing was handled by doing an extra check on the Azure Integration test suite.