### PR TITLE
[DR-3168] BucketResourceTest should use globally-unique bucket names

### DIFF
--- a/src/test/java/bio/terra/common/fixtures/Names.java
+++ b/src/test/java/bio/terra/common/fixtures/Names.java
@@ -1,14 +1,13 @@
 package bio.terra.common.fixtures;
 
 import java.util.UUID;
-import org.apache.commons.lang3.StringUtils;
 
 public final class Names {
   private Names() {}
 
   public static String randomizeName(String baseName) {
     String name = baseName + UUID.randomUUID();
-    return StringUtils.replaceChars(name, '-', '_');
+    return name.replace('-', '_');
   }
 
   public static String randomizeNameInfix(String baseName, String infix) {

--- a/src/test/java/bio/terra/common/fixtures/Names.java
+++ b/src/test/java/bio/terra/common/fixtures/Names.java
@@ -7,7 +7,7 @@ public final class Names {
   private Names() {}
 
   public static String randomizeName(String baseName) {
-    String name = baseName + UUID.randomUUID().toString();
+    String name = baseName + UUID.randomUUID();
     return StringUtils.replaceChars(name, '-', '_');
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3168

[Google Cloud Storage (GCS) documentation](https://cloud.google.com/storage/docs/buckets#naming) presents the following bucket name requirements and considerations:

> Bucket names reside in a single namespace that is shared by all Cloud Storage users. This means that **every bucket name must be globally unique.**
>…
>Once you delete a bucket, anyone can reuse its name for a new bucket.
>The time it takes a deleted bucket's name to become available again is typically on the order of seconds; however, keep in mind the following:
>If you delete the project that contains the bucket, which effectively deletes the bucket as well, **the bucket name may not be released for weeks or longer.**

Previously, the `BucketResourceTest` connected test suite reused fixed bucket names. There were no issues with this when buckets were properly removed on test tear-down and the same test was not run concurrently. But in a recent connected test run, we think that a bucket was not properly torn down but its parent project was marked for deletion and has not yet been released by GCS.

To guard against this issue, any bucket names created in this test suite are now guaranteed to be globally unique.  We also try to ensure their adherence to other GCS bucket naming requirements (length, allowed characters, etc.) via an assertion, so that future debugging is hopefully made easier.

There may be further opportunities to refactor some of these connected tests into unit tests, but for now we are prioritizing getting our tests passing.