### PR TITLE
[DR-3166] Fix a number of existing Sonar bugs

### DIFF
--- a/src/main/java/bio/terra/common/AclUtils.java
+++ b/src/main/java/bio/terra/common/AclUtils.java
@@ -18,9 +18,13 @@ public class AclUtils {
   private static final int RETRIES = 15;
   private static final int MAX_WAIT_SECONDS = 30;
   private static final int INITIAL_WAIT_SECONDS = 2;
+  private static final Random RANDOM = new Random();
+
+  private AclUtils() {
+    throw new IllegalStateException("Utility classes are not meant to be instantiated");
+  }
 
   public static <T> T aclUpdateRetry(Callable<T> aclUpdate) throws InterruptedException {
-    Random random = new Random();
     Throwable lastException = null;
     int retryWait = INITIAL_WAIT_SECONDS;
     for (int i = 0; i < RETRIES; i++) {
@@ -40,7 +44,7 @@ public class AclUtils {
       retryWait = retryWait + retryWait;
       if (retryWait > MAX_WAIT_SECONDS) {
         // Make it fuzzy to decrease chance of a bunch of stuff executing together
-        retryWait = MAX_WAIT_SECONDS + random.nextInt(10);
+        retryWait = MAX_WAIT_SECONDS + RANDOM.nextInt(10);
       }
     }
     throw new UpdatePermissionsFailedException("Cannot update ACL permissions", lastException);

--- a/src/main/java/bio/terra/common/AclUtils.java
+++ b/src/main/java/bio/terra/common/AclUtils.java
@@ -20,9 +20,7 @@ public class AclUtils {
   private static final int INITIAL_WAIT_SECONDS = 2;
   private static final Random RANDOM = new Random();
 
-  private AclUtils() {
-    throw new IllegalStateException("Utility classes are not meant to be instantiated");
-  }
+  private AclUtils() {}
 
   public static <T> T aclUpdateRetry(Callable<T> aclUpdate) throws InterruptedException {
     Throwable lastException = null;

--- a/src/main/java/bio/terra/service/dataset/AssetDao.java
+++ b/src/main/java/bio/terra/service/dataset/AssetDao.java
@@ -4,8 +4,6 @@ import bio.terra.common.Column;
 import bio.terra.common.DaoKeyHolder;
 import bio.terra.common.Relationship;
 import bio.terra.service.dataset.exception.InvalidAssetException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -125,13 +123,12 @@ public class AssetDao {
           UUID specId = rs.getObject("id", UUID.class);
           AssetSpecification spec = new AssetSpecification().id(specId).name(rs.getString("name"));
           spec.assetTables(
-              new ArrayList<>(
-                  retrieveAssetTablesAndColumns(
-                      spec,
-                      rs.getObject("root_table_id", UUID.class),
-                      rs.getObject("root_column_id", UUID.class),
-                      allTables,
-                      allColumns)));
+              retrieveAssetTablesAndColumns(
+                  spec,
+                  rs.getObject("root_table_id", UUID.class),
+                  rs.getObject("root_column_id", UUID.class),
+                  allTables,
+                  allColumns));
           spec.assetRelationships(retrieveAssetRelationships(spec.getId(), allRelationships));
 
           return spec;
@@ -139,7 +136,7 @@ public class AssetDao {
   }
 
   // also retrieves columns
-  private Collection<AssetTable> retrieveAssetTablesAndColumns(
+  private List<AssetTable> retrieveAssetTablesAndColumns(
       AssetSpecification spec,
       UUID rootTableId,
       UUID rootColumnId,
@@ -172,7 +169,7 @@ public class AssetDao {
           // add the new column to the asset table object
           assetTable.getColumns().add(newColumn);
         });
-    return tables.values();
+    return tables.values().stream().toList();
   }
 
   private List<AssetRelationship> retrieveAssetRelationships(

--- a/src/main/java/bio/terra/service/dataset/AssetDao.java
+++ b/src/main/java/bio/terra/service/dataset/AssetDao.java
@@ -169,7 +169,7 @@ public class AssetDao {
           // add the new column to the asset table object
           assetTable.getColumns().add(newColumn);
         });
-    return tables.values().stream().toList();
+    return List.copyOf(tables.values());
   }
 
   private List<AssetRelationship> retrieveAssetRelationships(

--- a/src/main/java/bio/terra/service/duos/DuosDao.java
+++ b/src/main/java/bio/terra/service/duos/DuosDao.java
@@ -43,12 +43,12 @@ public class DuosDao {
     this.tdrServiceAccountEmail = tdrServiceAccountEmail;
   }
 
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public DuosFirecloudGroupModel insertAndRetrieveFirecloudGroup(DuosFirecloudGroupModel created) {
     UUID id = insertFirecloudGroup(created);
     return retrieveFirecloudGroup(id);
   }
 
-  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   private UUID insertFirecloudGroup(DuosFirecloudGroupModel created) {
     String sql =
         """
@@ -123,6 +123,7 @@ public class DuosDao {
     }
   }
 
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public boolean updateFirecloudGroupLastSyncedDate(UUID id, Instant lastSyncedDate) {
     return updateFirecloudGroupsLastSyncedDate(List.of(id), lastSyncedDate) > 0;
   }

--- a/src/main/java/bio/terra/service/load/LoadDao.java
+++ b/src/main/java/bio/terra/service/load/LoadDao.java
@@ -303,14 +303,15 @@ public class LoadDao {
             if (state == null) {
               throw new CorruptMetadataException("Invalid file state");
             }
+            int statecount = rs.getInt("statecount");
             switch (state) {
               case RUNNING -> {
-                logger.info("Unexpected running loads: " + rs.getInt("statecount"));
+                logger.info("Unexpected running loads: {}", statecount);
                 throw new CorruptMetadataException("No loads should be running!");
               }
-              case FAILED -> result.setFailedFiles(rs.getInt("statecount"));
-              case NOT_TRIED -> result.setNotTriedFiles(rs.getInt("statecount"));
-              case SUCCEEDED -> result.setSucceededFiles(rs.getInt("statecount"));
+              case FAILED -> result.setFailedFiles(statecount);
+              case NOT_TRIED -> result.setNotTriedFiles(statecount);
+              case SUCCEEDED -> result.setSucceededFiles(statecount);
               default -> throw new CorruptMetadataException("Invalid load state");
             }
             result.setTotalFiles(

--- a/src/main/java/bio/terra/service/load/LoadDao.java
+++ b/src/main/java/bio/terra/service/load/LoadDao.java
@@ -6,7 +6,6 @@ import bio.terra.model.BulkLoadFileResultModel;
 import bio.terra.model.BulkLoadFileState;
 import bio.terra.model.BulkLoadHistoryModel;
 import bio.terra.model.BulkLoadResultModel;
-import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.FSFileInfo;
 import bio.terra.service.load.exception.LoadLockedException;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
@@ -18,12 +17,12 @@ import java.util.Spliterator;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.commons.codec.binary.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -35,13 +34,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class LoadDao {
   private final Logger logger = LoggerFactory.getLogger(LoadDao.class);
 
-  private NamedParameterJdbcTemplate jdbcTemplate;
-  private ConfigurationService configService;
+  private final NamedParameterJdbcTemplate jdbcTemplate;
 
   @Autowired
-  public LoadDao(NamedParameterJdbcTemplate jdbcTemplate, ConfigurationService configService) {
+  public LoadDao(NamedParameterJdbcTemplate jdbcTemplate) {
     this.jdbcTemplate = jdbcTemplate;
-    this.configService = configService;
   }
 
   // -- load tags public methods --
@@ -186,7 +183,7 @@ public class LoadDao {
     baseJdbcTemplate.batchUpdate(
         sql,
         new BatchPreparedStatementSetter() {
-          public void setValues(PreparedStatement ps, int i) throws SQLException {
+          public void setValues(@NotNull PreparedStatement ps, int i) throws SQLException {
             ps.setObject(1, loadId);
             ps.setString(2, loadFileModelList.get(i).getSourcePath());
             ps.setString(3, loadFileModelList.get(i).getTargetPath());
@@ -208,6 +205,7 @@ public class LoadDao {
    * @param loadId Load ID tying all these file ingests together
    * @param loadFileModelStream The stream to be chunked and processed over
    */
+  @Transactional
   public void populateFiles(
       UUID loadId, Stream<BulkLoadFileModel> loadFileModelStream, int batchSize) {
     Spliterator<BulkLoadFileModel> split = loadFileModelStream.spliterator();
@@ -292,47 +290,34 @@ public class LoadDao {
     return jdbcTemplate.query(
         bulkLoadResultSql,
         params,
-        (ResultSetExtractor<BulkLoadResultModel>)
-            rs -> {
-              BulkLoadResultModel result =
-                  new BulkLoadResultModel()
-                      .succeededFiles(0)
-                      .failedFiles(0)
-                      .notTriedFiles(0)
-                      .totalFiles(0);
+        rs -> {
+          BulkLoadResultModel result =
+              new BulkLoadResultModel()
+                  .succeededFiles(0)
+                  .failedFiles(0)
+                  .notTriedFiles(0)
+                  .totalFiles(0);
 
-              while (rs.next()) {
-                BulkLoadFileState state = BulkLoadFileState.fromValue(rs.getString("state"));
-                if (state == null) {
-                  throw new CorruptMetadataException("Invalid file state");
-                }
-                switch (state) {
-                  case RUNNING:
-                    logger.info("Unexpected running loads: " + rs.getInt("statecount"));
-                    throw new CorruptMetadataException("No loads should be running!");
-
-                  case FAILED:
-                    result.setFailedFiles(rs.getInt("statecount"));
-                    break;
-
-                  case NOT_TRIED:
-                    result.setNotTriedFiles(rs.getInt("statecount"));
-                    break;
-
-                  case SUCCEEDED:
-                    result.setSucceededFiles(rs.getInt("statecount"));
-                    break;
-
-                  default:
-                    throw new CorruptMetadataException("Invalid load state");
-                }
-                result.setTotalFiles(
-                    result.getFailedFiles()
-                        + result.getNotTriedFiles()
-                        + result.getSucceededFiles());
+          while (rs.next()) {
+            BulkLoadFileState state = BulkLoadFileState.fromValue(rs.getString("state"));
+            if (state == null) {
+              throw new CorruptMetadataException("Invalid file state");
+            }
+            switch (state) {
+              case RUNNING -> {
+                logger.info("Unexpected running loads: " + rs.getInt("statecount"));
+                throw new CorruptMetadataException("No loads should be running!");
               }
-              return result;
-            });
+              case FAILED -> result.setFailedFiles(rs.getInt("statecount"));
+              case NOT_TRIED -> result.setNotTriedFiles(rs.getInt("statecount"));
+              case SUCCEEDED -> result.setSucceededFiles(rs.getInt("statecount"));
+              default -> throw new CorruptMetadataException("Invalid load state");
+            }
+            result.setTotalFiles(
+                result.getFailedFiles() + result.getNotTriedFiles() + result.getSucceededFiles());
+          }
+          return result;
+        });
   }
 
   public List<BulkLoadFileResultModel> makeBulkLoadFileArray(UUID loadId) {

--- a/src/test/java/bio/terra/service/filedata/google/firestore/ArrayMultiFileLoadTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/ArrayMultiFileLoadTest.java
@@ -3,9 +3,12 @@ package bio.terra.service.filedata.google.firestore;
 import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_TABLE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.oneOf;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
@@ -34,10 +37,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -143,10 +143,8 @@ public class ArrayMultiFileLoadTest {
 
     assertThat(
         "getting load history has the same items as response from bulk file load",
-        loadHistoryList.getItems().stream()
-            .map(TestUtils::toBulkLoadFileResultModel)
-            .collect(Collectors.toSet()),
-        Matchers.equalTo(Set.copyOf(result.getLoadFileResults())));
+        loadHistoryList.getItems().stream().map(TestUtils::toBulkLoadFileResultModel).toList(),
+        containsInAnyOrder(result.getLoadFileResults().toArray()));
 
     Map<String, String> fileIdMap = new HashMap<>();
     for (BulkLoadFileResultModel fileResult : result.getLoadFileResults()) {
@@ -163,14 +161,9 @@ public class ArrayMultiFileLoadTest {
         .forEach(r -> ids.add(r.get(columnToQuery).getStringValue()));
 
     assertThat(
-        "Number of files in datarepo_load_history table match load summary",
-        ids.size(),
-        equalTo(fileCount));
-    for (String bq_file_id : ids) {
-      assertNotNull(
-          "fileIdMap should contain File_id from datarepo_load_history",
-          fileIdMap.containsValue(bq_file_id));
-    }
+        "fileIdMap should contain fileIds from datarepo_load_history",
+        fileIdMap.values(),
+        containsInAnyOrder(ids.toArray()));
 
     // retry successful load to make sure it still succeeds and does nothing
     BulkLoadArrayResultModel result2 =
@@ -200,7 +193,6 @@ public class ArrayMultiFileLoadTest {
   @Test
   public void arrayMultiFileLoadDoubleSuccessTest() throws Exception {
     int fileCount = 8;
-    int totalfileCount = fileCount * 2;
     BulkLoadArrayRequestModel arrayLoad1 =
         makeSuccessArrayLoad("arrayMultiDoubleSuccess", 0, fileCount);
     BulkLoadArrayRequestModel arrayLoad2 =
@@ -243,16 +235,10 @@ public class ArrayMultiFileLoadTest {
     queryLoadHistoryTableResult
         .iterateAll()
         .forEach(r -> bq_fileIds.add(r.get(columnToQuery).getStringValue()));
-
     assertThat(
-        "Number of files in datarepo_load_history table match load summary",
-        totalfileCount,
-        equalTo(bq_fileIds.size()));
-    for (String bq_file_id : bq_fileIds) {
-      assertNotNull(
-          "fileIdMap should contain File_id from datarepo_load_history",
-          fileIds.contains(bq_file_id));
-    }
+        "fileIds should contain fileIds from datarepo_load_history",
+        fileIds,
+        containsInAnyOrder(bq_fileIds.toArray()));
   }
 
   @Test
@@ -282,20 +268,19 @@ public class ArrayMultiFileLoadTest {
     TableResult queryLoadHistoryTableResult = queryLoadHistoryTable(columnsToQuery);
     for (FieldValueList item : queryLoadHistoryTableResult.getValues()) {
       String state = item.get(0).getStringValue();
-      assertTrue(
-          "state should either be succeeded or failed.",
-          state.equals(BulkLoadFileState.SUCCEEDED.toString())
-              || state.equals(BulkLoadFileState.FAILED.toString()));
+      assertThat(
+          "state should either be succeeded or failed",
+          state,
+          oneOf(BulkLoadFileState.SUCCEEDED.toString(), BulkLoadFileState.FAILED.toString()));
       if (state.equals(BulkLoadFileState.SUCCEEDED.toString())) {
-        assertTrue("file_id should have value", item.get(1).getStringValue().length() > 0);
-        assertTrue("Error column should be empty", item.get(2).getStringValue().length() == 0);
+        assertThat("file_id should have value", item.get(1).getStringValue(), not(emptyString()));
+        assertThat("error column should be empty", item.get(2).getStringValue(), emptyString());
       } else if (state.equals(BulkLoadFileState.FAILED.toString())) {
-        assertTrue("file_id should NOT have value", item.get(1).getStringValue().length() == 0);
-        assertTrue("Error column should have value", item.get(2).getStringValue().length() > 0);
+        assertThat("file_id should not have value", item.get(1).getStringValue(), emptyString());
+        assertThat(
+            "error column should have value", item.get(2).getStringValue(), not(emptyString()));
       }
     }
-    FieldValueList curr_result;
-
     List<BulkLoadFileModel> loadArray = arrayLoad.getLoadArray();
     BulkLoadFileResultModel fileResult = resultMap.get(loadArray.get(0).getTargetPath());
     checkFileResultSuccess(fileResult);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3166

I focused on making a dent in blocker and critical Sonarcloud bugs that were present in our code before we enabled these scans:

https://sonarcloud.io/project/issues?assignees=okotsopoulos%40github&resolved=false&types=BUG&id=DataBiosphere_jade-data-repo

Notably:

- Methods should not call same-class methods with incompatible "@Transactional" values ([example](https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER&types=BUG&id=DataBiosphere_jade-data-repo&open=AYnf6eKdpPYKmNYiYIta))
- “Random” objects should be reused ([example](https://sonarcloud.io/project/issues?resolved=false&severities=CRITICAL&types=BUG&id=DataBiosphere_jade-data-repo&open=AYnWc8hjlT-BpJAqYHYi))
- Assertion methods should not be used within the try block of a try-catch catching an Error ([example](https://sonarcloud.io/project/issues?resolved=false&severities=CRITICAL&types=BUG&id=DataBiosphere_jade-data-repo&open=AYnWc74ElT-BpJAqYHK7))
- Assertions should not compare primitives with null ([example](https://sonarcloud.io/project/issues?resolved=false&severities=CRITICAL&types=BUG&id=DataBiosphere_jade-data-repo&open=AYnWc70QlT-BpJAqYHKo))

When I touched a file, I tried to also address lower-level bugs and smells as drive-bys.

