### PR TITLE
[DC-736] Add Snapshot Builder Config fake data and swagger code

### DIFF
--- a/docs/jade-getting-started.md
+++ b/docs/jade-getting-started.md
@@ -186,12 +186,12 @@ Download the team's projects:
 ```
 git clone git@github.com:DataBiosphere/jade-data-repo.git
 git clone git@github.com:DataBiosphere/jade-data-repo-ui.git
-git clone git@github.com:DataBiosphere/jade-data-repo-cli
-git clone git@github.com:broadinstitute/datarepo-helm
-git clone git@github.com:broadinstitute/datarepo-helm-definitions
-git clone git@github.com:broadinstitute/terra-helmfile
-git clone git@github.com:broadinstitute/terraform-ap-deployments
-git clone git@github.com:broadinstitute/terraform-jade
+git clone git@github.com:DataBiosphere/jade-data-repo-cli.git
+git clone git@github.com:broadinstitute/datarepo-helm.git
+git clone git@github.com:broadinstitute/datarepo-helm-definitions.git
+git clone git@github.com:broadinstitute/terra-helmfile.git
+git clone git@github.com:broadinstitute/terraform-ap-deployments.git
+git clone git@github.com:broadinstitute/terraform-jade.git
 ```
 
 ## 8. Set up your Development Environment
@@ -242,6 +242,8 @@ gcloud container clusters get-credentials dev-master --region us-central1 --proj
 
 4. Starting from your [project directory](#6-code-checkout) in `datarepo-helm-definitions`,
    bring up Helm services (note it will take up to 10-15 minutes for ingress and cert creation):
+
+Note: Make sure you are on the VPN, otherwise the helmfile apply will fail.
 
 ```
 cd datarepo-helm-definitions/dev/ZZ

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -150,6 +150,13 @@ public class DatasetsApiController implements DatasetsApi {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     iamService.verifyAuthorization(
         userRequest, IamResourceType.DATASET, id.toString(), IamAction.READ_DATASET);
+    if (include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG)) {
+      iamService.verifyAuthorization(
+          userRequest,
+          IamResourceType.DATASET,
+          id.toString(),
+          IamAction.VIEW_SNAPSHOT_BUILDER_CONFIG);
+    }
     return ResponseEntity.ok(datasetService.retrieveDatasetModel(id, userRequest, include));
   }
 

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -152,7 +152,7 @@ public class DatasetsApiController implements DatasetsApi {
         userRequest,
         IamResourceType.DATASET,
         id.toString(),
-        datasetService.getRetrieveDatasetRequiredActions(include));
+        DatasetService.getRetrieveDatasetRequiredActions(include));
 
     return ResponseEntity.ok(datasetService.retrieveDatasetModel(id, userRequest, include));
   }

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -148,15 +148,12 @@ public class DatasetsApiController implements DatasetsApi {
               defaultValue = RETRIEVE_INCLUDE_DEFAULT_VALUE)
           List<DatasetRequestAccessIncludeModel> include) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
-    iamService.verifyAuthorization(
-        userRequest, IamResourceType.DATASET, id.toString(), IamAction.READ_DATASET);
-    if (include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG)) {
-      iamService.verifyAuthorization(
-          userRequest,
-          IamResourceType.DATASET,
-          id.toString(),
-          IamAction.VIEW_SNAPSHOT_BUILDER_CONFIG);
-    }
+    iamService.verifyAuthorizations(
+        userRequest,
+        IamResourceType.DATASET,
+        id.toString(),
+        datasetService.getRetrieveDatasetRequiredActions(include));
+
     return ResponseEntity.ok(datasetService.retrieveDatasetModel(id, userRequest, include));
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamAction.java
@@ -39,7 +39,7 @@ public enum IamAction {
   LINK,
   // journal
   VIEW_JOURNAL,
-  VIEW_SNAPSHOT_BUILDER_CONFIG;
+  VIEW_SNAPSHOT_BUILDER_SETTINGS;
 
   private final String samActionName;
 

--- a/src/main/java/bio/terra/service/auth/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamAction.java
@@ -38,7 +38,8 @@ public enum IamAction {
   UPDATE_BILLING_ACCOUNT,
   LINK,
   // journal
-  VIEW_JOURNAL;
+  VIEW_JOURNAL,
+  VIEW_SNAPSHOT_BUILDER_CONFIG;
 
   private final String samActionName;
 

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -17,15 +17,9 @@ import bio.terra.model.DatePartitionOptionsModel;
 import bio.terra.model.IntPartitionOptionsModel;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
-import bio.terra.model.SnapshotBuilderConcept;
-import bio.terra.model.SnapshotBuilderConfig;
-import bio.terra.model.SnapshotBuilderDomainOption;
-import bio.terra.model.SnapshotBuilderFeatureValueGroup;
-import bio.terra.model.SnapshotBuilderListOption;
-import bio.terra.model.SnapshotBuilderPrepackagedConceptSets;
-import bio.terra.model.SnapshotBuilderProgramDataOption;
 import bio.terra.model.TableModel;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import bio.terra.service.tags.TagUtils;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,11 +30,17 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public final class DatasetJsonConversion {
+  private final SnapshotBuilderService snapshotBuilderService;
 
-  // only allow use of static methods
-  private DatasetJsonConversion() {}
+  @Autowired
+  private DatasetJsonConversion(SnapshotBuilderService snapshotBuilderService) {
+    this.snapshotBuilderService = snapshotBuilderService;
+  }
 
   public static Dataset datasetRequestToDataset(
       DatasetRequestModel datasetRequest, UUID datasetId) {
@@ -96,7 +96,7 @@ public final class DatasetJsonConversion {
         .assetSpecifications(assetSpecifications);
   }
 
-  public static DatasetModel populateDatasetModelFromDataset(
+  public DatasetModel populateDatasetModelFromDataset(
       Dataset dataset,
       List<DatasetRequestAccessIncludeModel> include,
       MetadataDataAccessUtils metadataDataAccessUtils,
@@ -146,121 +146,8 @@ public final class DatasetJsonConversion {
     }
 
     if (include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG)) {
-      datasetModel.snapshotBuilderConfig(
-          new SnapshotBuilderConfig()
-              .domainOptions(
-                  List.of(
-                      new SnapshotBuilderDomainOption()
-                          .id(10)
-                          .category("Condition")
-                          .conceptCount(18000)
-                          .participantCount(12500)
-                          .root(
-                              new SnapshotBuilderConcept()
-                                  .id(100)
-                                  .name("Condition")
-                                  .count(100)
-                                  .hasChildren(true)),
-                      new SnapshotBuilderDomainOption()
-                          .id(11)
-                          .category("Procedure")
-                          .conceptCount(22500)
-                          .participantCount(11328)
-                          .root(
-                              new SnapshotBuilderConcept()
-                                  .id(200)
-                                  .name("Procedure")
-                                  .count(100)
-                                  .hasChildren(true)),
-                      new SnapshotBuilderDomainOption()
-                          .id(12)
-                          .category("Observation")
-                          .conceptCount(12300)
-                          .participantCount(23223)
-                          .root(
-                              new SnapshotBuilderConcept()
-                                  .id(300)
-                                  .name("Observation")
-                                  .count(100)
-                                  .hasChildren(true))))
-              .programDataOptions(
-                  List.of(
-                      new SnapshotBuilderProgramDataOption()
-                          .id(1)
-                          .name("Year of birth")
-                          .kind(SnapshotBuilderProgramDataOption.KindEnum.RANGE)
-                          .min(1900)
-                          .max(2023),
-                      new SnapshotBuilderProgramDataOption()
-                          .id(2)
-                          .name("Ethnicity")
-                          .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
-                          .values(
-                              List.of(
-                                  new SnapshotBuilderListOption().name("Hispanic or Latino").id(20),
-                                  new SnapshotBuilderListOption()
-                                      .name("Not Hispanic or Latino")
-                                      .id(21),
-                                  new SnapshotBuilderListOption()
-                                      .name("No Matching Concept")
-                                      .id(0))),
-                      new SnapshotBuilderProgramDataOption()
-                          .id(3)
-                          .name("Gender identity")
-                          .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
-                          .values(
-                              List.of(
-                                  new SnapshotBuilderListOption().name("FEMALE").id(22),
-                                  new SnapshotBuilderListOption().name("MALE").id(23),
-                                  new SnapshotBuilderListOption().name("NON BINARY").id(24),
-                                  new SnapshotBuilderListOption().name("GENDERQUEER").id(25),
-                                  new SnapshotBuilderListOption().name("TWO SPIRIT").id(26),
-                                  new SnapshotBuilderListOption().name("AGENDER").id(27),
-                                  new SnapshotBuilderListOption()
-                                      .name("No Matching Concept")
-                                      .id(0))),
-                      new SnapshotBuilderProgramDataOption()
-                          .id(4)
-                          .name("Race")
-                          .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
-                          .values(
-                              List.of(
-                                  new SnapshotBuilderListOption()
-                                      .name("American Indian or Alaska Native")
-                                      .id(28),
-                                  new SnapshotBuilderListOption().name("Asian").id(29),
-                                  new SnapshotBuilderListOption().name("Black").id(30),
-                                  new SnapshotBuilderListOption().name("White").id(31)))))
-              .featureValueGroups(
-                  List.of(
-                      new SnapshotBuilderFeatureValueGroup()
-                          .id(0)
-                          .name("Condition")
-                          .values(List.of("Condition Column 1", "Condition Column 2")),
-                      new SnapshotBuilderFeatureValueGroup()
-                          .id(1)
-                          .name("Observation")
-                          .values(List.of("Observation Column 1", "Observation Column 2")),
-                      new SnapshotBuilderFeatureValueGroup()
-                          .id(2)
-                          .name("Procedure")
-                          .values(List.of("Procedure Column 1", "Procedure Column 2")),
-                      new SnapshotBuilderFeatureValueGroup()
-                          .id(3)
-                          .name("Surveys")
-                          .values(List.of("Surveys Column 1", "Surveys Column 2")),
-                      new SnapshotBuilderFeatureValueGroup()
-                          .id(4)
-                          .name("Person")
-                          .values(List.of("Demographics Column 1", "Demographics Column 2"))))
-              .prepackagedConceptSets(
-                  List.of(
-                      new SnapshotBuilderPrepackagedConceptSets()
-                          .name("Demographics")
-                          .featureValueGroupName("Person"),
-                      new SnapshotBuilderPrepackagedConceptSets()
-                          .name("All surveys")
-                          .featureValueGroupName("Surveys"))));
+      datasetModel.snapshotBuilderSettings(
+          snapshotBuilderService.getSnapshotBuilderSettings(dataset.getId()));
     }
 
     return datasetModel;

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -145,7 +145,7 @@ public final class DatasetJsonConversion {
           metadataDataAccessUtils.accessInfoFromDataset(dataset, userRequest));
     }
 
-    if (include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG)) {
+    if (include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_SETTINGS)) {
       datasetModel.snapshotBuilderSettings(
           snapshotBuilderService.getSnapshotBuilderSettings(dataset.getId()));
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -30,15 +30,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public final class DatasetJsonConversion {
   private final SnapshotBuilderService snapshotBuilderService;
 
-  @Autowired
-  private DatasetJsonConversion(SnapshotBuilderService snapshotBuilderService) {
+  public DatasetJsonConversion(SnapshotBuilderService snapshotBuilderService) {
     this.snapshotBuilderService = snapshotBuilderService;
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -17,6 +17,13 @@ import bio.terra.model.DatePartitionOptionsModel;
 import bio.terra.model.IntPartitionOptionsModel;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
+import bio.terra.model.SnapshotBuilderConcept;
+import bio.terra.model.SnapshotBuilderConfig;
+import bio.terra.model.SnapshotBuilderDomainOption;
+import bio.terra.model.SnapshotBuilderFeatureValueGroup;
+import bio.terra.model.SnapshotBuilderListOption;
+import bio.terra.model.SnapshotBuilderPrepackagedConceptSets;
+import bio.terra.model.SnapshotBuilderProgramDataOption;
 import bio.terra.model.TableModel;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import bio.terra.service.tags.TagUtils;
@@ -136,6 +143,124 @@ public final class DatasetJsonConversion {
     if (include.contains(DatasetRequestAccessIncludeModel.ACCESS_INFORMATION)) {
       datasetModel.accessInformation(
           metadataDataAccessUtils.accessInfoFromDataset(dataset, userRequest));
+    }
+
+    if (include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG)) {
+      datasetModel.snapshotBuilderConfig(
+          new SnapshotBuilderConfig()
+              .domainOptions(
+                  List.of(
+                      new SnapshotBuilderDomainOption()
+                          .id(10)
+                          .category("Condition")
+                          .conceptCount(18000)
+                          .participantCount(12500)
+                          .root(
+                              new SnapshotBuilderConcept()
+                                  .id(100)
+                                  .name("Condition")
+                                  .count(100)
+                                  .hasChildren(true)),
+                      new SnapshotBuilderDomainOption()
+                          .id(11)
+                          .category("Procedure")
+                          .conceptCount(22500)
+                          .participantCount(11328)
+                          .root(
+                              new SnapshotBuilderConcept()
+                                  .id(200)
+                                  .name("Procedure")
+                                  .count(100)
+                                  .hasChildren(true)),
+                      new SnapshotBuilderDomainOption()
+                          .id(12)
+                          .category("Observation")
+                          .conceptCount(12300)
+                          .participantCount(23223)
+                          .root(
+                              new SnapshotBuilderConcept()
+                                  .id(300)
+                                  .name("Observation")
+                                  .count(100)
+                                  .hasChildren(true))))
+              .programDataOptions(
+                  List.of(
+                      new SnapshotBuilderProgramDataOption()
+                          .id(1)
+                          .name("Year of birth")
+                          .kind(SnapshotBuilderProgramDataOption.KindEnum.RANGE)
+                          .min(1900)
+                          .max(2023),
+                      new SnapshotBuilderProgramDataOption()
+                          .id(2)
+                          .name("Ethnicity")
+                          .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                          .values(
+                              List.of(
+                                  new SnapshotBuilderListOption().name("Hispanic or Latino").id(20),
+                                  new SnapshotBuilderListOption()
+                                      .name("Not Hispanic or Latino")
+                                      .id(21),
+                                  new SnapshotBuilderListOption()
+                                      .name("No Matching Concept")
+                                      .id(0))),
+                      new SnapshotBuilderProgramDataOption()
+                          .id(3)
+                          .name("Gender identity")
+                          .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                          .values(
+                              List.of(
+                                  new SnapshotBuilderListOption().name("FEMALE").id(22),
+                                  new SnapshotBuilderListOption().name("MALE").id(23),
+                                  new SnapshotBuilderListOption().name("NON BINARY").id(24),
+                                  new SnapshotBuilderListOption().name("GENDERQUEER").id(25),
+                                  new SnapshotBuilderListOption().name("TWO SPIRIT").id(26),
+                                  new SnapshotBuilderListOption().name("AGENDER").id(27),
+                                  new SnapshotBuilderListOption()
+                                      .name("No Matching Concept")
+                                      .id(0))),
+                      new SnapshotBuilderProgramDataOption()
+                          .id(4)
+                          .name("Race")
+                          .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                          .values(
+                              List.of(
+                                  new SnapshotBuilderListOption()
+                                      .name("American Indian or Alaska Native")
+                                      .id(28),
+                                  new SnapshotBuilderListOption().name("Asian").id(29),
+                                  new SnapshotBuilderListOption().name("Black").id(30),
+                                  new SnapshotBuilderListOption().name("White").id(31)))))
+              .featureValueGroups(
+                  List.of(
+                      new SnapshotBuilderFeatureValueGroup()
+                          .id(0)
+                          .name("Condition")
+                          .values(List.of("Condition Column 1", "Condition Column 2")),
+                      new SnapshotBuilderFeatureValueGroup()
+                          .id(1)
+                          .name("Observation")
+                          .values(List.of("Observation Column 1", "Observation Column 2")),
+                      new SnapshotBuilderFeatureValueGroup()
+                          .id(2)
+                          .name("Procedure")
+                          .values(List.of("Procedure Column 1", "Procedure Column 2")),
+                      new SnapshotBuilderFeatureValueGroup()
+                          .id(3)
+                          .name("Surveys")
+                          .values(List.of("Surveys Column 1", "Surveys Column 2")),
+                      new SnapshotBuilderFeatureValueGroup()
+                          .id(4)
+                          .name("Person")
+                          .values(List.of("Demographics Column 1", "Demographics Column 2"))))
+              .prepackagedConceptSets(
+                  List.of(
+                      new SnapshotBuilderPrepackagedConceptSets()
+                          .name("Demographics")
+                          .featureValueGroupName("Person"),
+                      new SnapshotBuilderPrepackagedConceptSets()
+                          .name("All surveys")
+                          .featureValueGroupName("Surveys"))));
     }
 
     return datasetModel;

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -210,6 +210,13 @@ public class DatasetService {
     return retrieveDatasetModel(id, userRequest, getDefaultIncludes());
   }
 
+  public List<IamAction> getRetrieveDatasetRequiredActions(
+      List<DatasetRequestAccessIncludeModel> include) {
+    return include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG)
+        ? List.of(IamAction.READ_DATASET, IamAction.VIEW_SNAPSHOT_BUILDER_CONFIG)
+        : List.of(IamAction.READ_DATASET);
+  }
+
   /**
    * Convenience wrapper to grab the dataset model from the dataset object, avoids having to
    * retrieve the dataset a second time if you already have it

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -220,7 +220,7 @@ public class DatasetService {
    */
   public List<IamAction> getRetrieveDatasetRequiredActions(
       List<DatasetRequestAccessIncludeModel> include) {
-    return include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG)
+    return include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_SETTINGS)
         ? List.of(IamAction.READ_DATASET, IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS)
         : List.of(IamAction.READ_DATASET);
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -101,6 +101,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class DatasetService {
   private static final Logger logger = LoggerFactory.getLogger(DatasetService.class);
+  private final DatasetJsonConversion datasetJsonConversion;
   private final DatasetDao datasetDao;
   private final JobService jobService; // for handling flight response
   private final LoadService loadService;
@@ -121,6 +122,7 @@ public class DatasetService {
 
   @Autowired
   public DatasetService(
+      DatasetJsonConversion datasetJsonConversion,
       DatasetDao datasetDao,
       JobService jobService,
       LoadService loadService,
@@ -138,6 +140,7 @@ public class DatasetService {
       IamService iamService,
       DatasetTableDao datasetTableDao,
       AzureSynapsePdao azureSynapsePdao) {
+    this.datasetJsonConversion = datasetJsonConversion;
     this.datasetDao = datasetDao;
     this.jobService = jobService;
     this.loadService = loadService;
@@ -233,7 +236,7 @@ public class DatasetService {
       Dataset dataset,
       AuthenticatedUserRequest userRequest,
       List<DatasetRequestAccessIncludeModel> include) {
-    return DatasetJsonConversion.populateDatasetModelFromDataset(
+    return datasetJsonConversion.populateDatasetModelFromDataset(
         dataset, include, metadataDataAccessUtils, userRequest);
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -218,7 +218,7 @@ public class DatasetService {
    * @param include the list of dataset fields being requested
    * @return a List<IamAction> = The list of required actions to read these dataset fields
    */
-  public List<IamAction> getRetrieveDatasetRequiredActions(
+  public static List<IamAction> getRetrieveDatasetRequiredActions(
       List<DatasetRequestAccessIncludeModel> include) {
     return include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_SETTINGS)
         ? List.of(IamAction.READ_DATASET, IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS)

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -213,8 +213,7 @@ public class DatasetService {
     return retrieveDatasetModel(id, userRequest, getDefaultIncludes());
   }
   /**
-   * Helper method to retrieve the required actions to view the dataset retrieve the dataset a
-   * second time if you already have it
+   * Helper method to retrieve the required actions to view the dataset's requested fields
    *
    * @param include the list of dataset fields being requested
    * @return a List<IamAction> = The list of required actions to read these dataset fields

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -213,8 +213,8 @@ public class DatasetService {
     return retrieveDatasetModel(id, userRequest, getDefaultIncludes());
   }
   /**
-   * Helper method to retrieve the required actions to view the dataset
-   * retrieve the dataset a second time if you already have it
+   * Helper method to retrieve the required actions to view the dataset retrieve the dataset a
+   * second time if you already have it
    *
    * @param include the list of dataset fields being requested
    * @return a List<IamAction> = The list of required actions to read these dataset fields

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -212,11 +212,17 @@ public class DatasetService {
   public DatasetModel retrieveDatasetModel(UUID id, AuthenticatedUserRequest userRequest) {
     return retrieveDatasetModel(id, userRequest, getDefaultIncludes());
   }
-
+  /**
+   * Helper method to retrieve the required actions to view the dataset
+   * retrieve the dataset a second time if you already have it
+   *
+   * @param include the list of dataset fields being requested
+   * @return a List<IamAction> = The list of required actions to read these dataset fields
+   */
   public List<IamAction> getRetrieveDatasetRequiredActions(
       List<DatasetRequestAccessIncludeModel> include) {
     return include.contains(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG)
-        ? List.of(IamAction.READ_DATASET, IamAction.VIEW_SNAPSHOT_BUILDER_CONFIG)
+        ? List.of(IamAction.READ_DATASET, IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS)
         : List.of(IamAction.READ_DATASET);
   }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -9,15 +9,20 @@ import bio.terra.model.SnapshotBuilderProgramDataOption;
 import bio.terra.model.SnapshotBuilderSettings;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SnapshotBuilderService {
 
-  @Autowired
   public SnapshotBuilderService() {}
-
+  /**
+   * Fetch the snapshot builder settings for a given dataset
+   * Currently just returns dummy data for the sake of parallelizing UI and API development
+   * Will eventually be adapted to read from the DB
+   *
+   * @param datasetId in UUID format
+   * @return a SnapshotBuilderSettings = API output-friendly representation of the Dataset's snapshot builder settings
+   */
   public SnapshotBuilderSettings getSnapshotBuilderSettings(UUID datasetId) {
     return new SnapshotBuilderSettings()
         .domainOptions(

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -9,7 +9,6 @@ import bio.terra.model.SnapshotBuilderProgramDataOption;
 import bio.terra.model.SnapshotBuilderSettings;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class SnapshotBuilderService {
 
-  @Autowired
   public SnapshotBuilderService() {}
   /**
    * Fetch the snapshot builder settings for a given dataset Currently just returns dummy data for

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -18,12 +18,12 @@ public class SnapshotBuilderService {
   @Autowired
   public SnapshotBuilderService() {}
   /**
-   * Fetch the snapshot builder settings for a given dataset
-   * Currently just returns dummy data for the sake of parallelizing UI and API development
-   * Will eventually be adapted to read from the DB
+   * Fetch the snapshot builder settings for a given dataset Currently just returns dummy data for
+   * the sake of parallelizing UI and API development Will eventually be adapted to read from the DB
    *
    * @param datasetId in UUID format
-   * @return a SnapshotBuilderSettings = API output-friendly representation of the Dataset's snapshot builder settings
+   * @return a SnapshotBuilderSettings = API output-friendly representation of the Dataset's
+   *     snapshot builder settings
    */
   public SnapshotBuilderSettings getSnapshotBuilderSettings(UUID datasetId) {
     return new SnapshotBuilderSettings()

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -1,0 +1,131 @@
+package bio.terra.service.snapshotbuilder;
+
+import bio.terra.model.SnapshotBuilderConcept;
+import bio.terra.model.SnapshotBuilderDomainOption;
+import bio.terra.model.SnapshotBuilderFeatureValueGroup;
+import bio.terra.model.SnapshotBuilderListOption;
+import bio.terra.model.SnapshotBuilderPrepackagedConceptSets;
+import bio.terra.model.SnapshotBuilderProgramDataOption;
+import bio.terra.model.SnapshotBuilderSettings;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SnapshotBuilderService {
+
+  @Autowired
+  public SnapshotBuilderService() {}
+
+  public SnapshotBuilderSettings getSnapshotBuilderSettings(UUID datasetId) {
+    return new SnapshotBuilderSettings()
+        .domainOptions(
+            List.of(
+                new SnapshotBuilderDomainOption()
+                    .id(10)
+                    .category("Condition")
+                    .conceptCount(18000)
+                    .participantCount(12500)
+                    .root(
+                        new SnapshotBuilderConcept()
+                            .id(100)
+                            .name("Condition")
+                            .count(100)
+                            .hasChildren(true)),
+                new SnapshotBuilderDomainOption()
+                    .id(11)
+                    .category("Procedure")
+                    .conceptCount(22500)
+                    .participantCount(11328)
+                    .root(
+                        new SnapshotBuilderConcept()
+                            .id(200)
+                            .name("Procedure")
+                            .count(100)
+                            .hasChildren(true)),
+                new SnapshotBuilderDomainOption()
+                    .id(12)
+                    .category("Observation")
+                    .conceptCount(12300)
+                    .participantCount(23223)
+                    .root(
+                        new SnapshotBuilderConcept()
+                            .id(300)
+                            .name("Observation")
+                            .count(100)
+                            .hasChildren(true))))
+        .programDataOptions(
+            List.of(
+                new SnapshotBuilderProgramDataOption()
+                    .id(1)
+                    .name("Year of birth")
+                    .kind(SnapshotBuilderProgramDataOption.KindEnum.RANGE)
+                    .min(1900)
+                    .max(2023),
+                new SnapshotBuilderProgramDataOption()
+                    .id(2)
+                    .name("Ethnicity")
+                    .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                    .values(
+                        List.of(
+                            new SnapshotBuilderListOption().name("Hispanic or Latino").id(20),
+                            new SnapshotBuilderListOption().name("Not Hispanic or Latino").id(21),
+                            new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
+                new SnapshotBuilderProgramDataOption()
+                    .id(3)
+                    .name("Gender identity")
+                    .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                    .values(
+                        List.of(
+                            new SnapshotBuilderListOption().name("FEMALE").id(22),
+                            new SnapshotBuilderListOption().name("MALE").id(23),
+                            new SnapshotBuilderListOption().name("NON BINARY").id(24),
+                            new SnapshotBuilderListOption().name("GENDERQUEER").id(25),
+                            new SnapshotBuilderListOption().name("TWO SPIRIT").id(26),
+                            new SnapshotBuilderListOption().name("AGENDER").id(27),
+                            new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
+                new SnapshotBuilderProgramDataOption()
+                    .id(4)
+                    .name("Race")
+                    .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                    .values(
+                        List.of(
+                            new SnapshotBuilderListOption()
+                                .name("American Indian or Alaska Native")
+                                .id(28),
+                            new SnapshotBuilderListOption().name("Asian").id(29),
+                            new SnapshotBuilderListOption().name("Black").id(30),
+                            new SnapshotBuilderListOption().name("White").id(31)))))
+        .featureValueGroups(
+            List.of(
+                new SnapshotBuilderFeatureValueGroup()
+                    .id(0)
+                    .name("Condition")
+                    .values(List.of("Condition Column 1", "Condition Column 2")),
+                new SnapshotBuilderFeatureValueGroup()
+                    .id(1)
+                    .name("Observation")
+                    .values(List.of("Observation Column 1", "Observation Column 2")),
+                new SnapshotBuilderFeatureValueGroup()
+                    .id(2)
+                    .name("Procedure")
+                    .values(List.of("Procedure Column 1", "Procedure Column 2")),
+                new SnapshotBuilderFeatureValueGroup()
+                    .id(3)
+                    .name("Surveys")
+                    .values(List.of("Surveys Column 1", "Surveys Column 2")),
+                new SnapshotBuilderFeatureValueGroup()
+                    .id(4)
+                    .name("Person")
+                    .values(List.of("Demographics Column 1", "Demographics Column 2"))))
+        .prepackagedConceptSets(
+            List.of(
+                new SnapshotBuilderPrepackagedConceptSets()
+                    .name("Demographics")
+                    .featureValueGroupName("Person"),
+                new SnapshotBuilderPrepackagedConceptSets()
+                    .name("All surveys")
+                    .featureValueGroupName("Surveys")));
+  }
+}

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -1,10 +1,10 @@
 package bio.terra.service.snapshotbuilder;
 
 import bio.terra.model.SnapshotBuilderConcept;
+import bio.terra.model.SnapshotBuilderDatasetConceptSets;
 import bio.terra.model.SnapshotBuilderDomainOption;
 import bio.terra.model.SnapshotBuilderFeatureValueGroup;
 import bio.terra.model.SnapshotBuilderListOption;
-import bio.terra.model.SnapshotBuilderPrepackagedConceptSets;
 import bio.terra.model.SnapshotBuilderProgramDataOption;
 import bio.terra.model.SnapshotBuilderSettings;
 import java.util.List;
@@ -124,12 +124,12 @@ public class SnapshotBuilderService {
                     .id(4)
                     .name("Person")
                     .values(List.of("Demographics Column 1", "Demographics Column 2"))))
-        .prepackagedConceptSets(
+        .datasetConceptSets(
             List.of(
-                new SnapshotBuilderPrepackagedConceptSets()
+                new SnapshotBuilderDatasetConceptSets()
                     .name("Demographics")
                     .featureValueGroupName("Person"),
-                new SnapshotBuilderPrepackagedConceptSets()
+                new SnapshotBuilderDatasetConceptSets()
                     .name("All surveys")
                     .featureValueGroupName("Surveys")));
   }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -9,11 +9,13 @@ import bio.terra.model.SnapshotBuilderProgramDataOption;
 import bio.terra.model.SnapshotBuilderSettings;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SnapshotBuilderService {
 
+  @Autowired
   public SnapshotBuilderService() {}
   /**
    * Fetch the snapshot builder settings for a given dataset

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4282,8 +4282,8 @@ components:
             $ref: '#/components/schemas/Tag'
         resourceLocks:
           $ref: '#/components/schemas/ResourceLocks'
-        snapshotBuilderConfig:
-          $ref: '#/components/schemas/SnapshotBuilderConfig'
+        snapshotBuilderSettings:
+          $ref: '#/components/schemas/SnapshotBuilderSettings'
       description: >
         Complete definition of a dataset.
     DatasetSummaryModel:
@@ -6354,10 +6354,14 @@ components:
     ##############################################################################
     ## SNAPSHOT BUILDER API STANDARD MODELS
     ##############################################################################
-    SnapshotBuilderConfig:
+    SnapshotBuilderSettings:
       type: object
       description: >
         The configuration describing how to select criteria for issuing a snapshot builder request
+      required:
+        - domainOptions
+        - programDataOptions
+        - featureValueGroups
       properties:
         domainOptions:
           type: array
@@ -6381,6 +6385,9 @@ components:
       type: object
       description: >
         A concept set provided for the dataset, usually used to access tables that are not searchable as domains
+      required:
+        - name
+        - featureValueGroupName
       properties:
         name:
           type: string
@@ -6391,11 +6398,11 @@ components:
       type: object
       description: >
         An object describing high level information about a domain for use in the snapshot builder
+      required:
+        - id
+        - category
+        - root
       properties:
-        kind:
-          type: string
-          default: domain
-          enum: [ domain ]
         id:
           type: integer
         category:
@@ -6411,6 +6418,10 @@ components:
       type: object
       description: >
         An object describing a concept in the Snapshot Builder
+      required:
+        - id
+        - name
+        - hasChildren
       properties:
         id:
           type: integer
@@ -6425,6 +6436,10 @@ components:
       type: object
       description: >
         An object describing high level information about program data for use in the snapshot builder
+      required:
+        - id
+        - name
+        - kind
       properties:
         id:
           type: integer
@@ -6446,6 +6461,9 @@ components:
       type: object
       description: >
         An object describing a program data list option for the snapshot builder
+      required:
+        - id
+        - name
       properties:
         id:
           type: integer
@@ -6456,6 +6474,10 @@ components:
       type: object
       description: >
         Describes a set of columns for a table with given name
+      required:
+        - id
+        - name
+        - values
       properties:
         id:
           type: integer

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -6353,11 +6353,12 @@ components:
 
     ##############################################################################
     ## SNAPSHOT BUILDER API STANDARD MODELS
+    ## ⚠️ NOTE: ALL SNAPSHOT API MODELS ARE SUBJECT TO CHANGE
     ##############################################################################
     SnapshotBuilderSettings:
       type: object
       description: >
-        The configuration describing how to select criteria for issuing a snapshot builder request
+        ⚠️ The configuration describing how to select criteria for issuing a snapshot builder request
       required:
         - domainOptions
         - programDataOptions
@@ -6384,7 +6385,7 @@ components:
     SnapshotBuilderPrepackagedConceptSets:
       type: object
       description: >
-        A concept set provided for the dataset, usually used to access tables that are not searchable as domains
+        ⚠️ A concept set provided for the dataset, usually used to access tables that are not searchable as domains
       required:
         - name
         - featureValueGroupName
@@ -6397,7 +6398,7 @@ components:
     SnapshotBuilderDomainOption:
       type: object
       description: >
-        An object describing high level information about a domain for use in the snapshot builder
+        ⚠️ An object describing high level information about a domain for use in the snapshot builder
       required:
         - id
         - category
@@ -6417,7 +6418,7 @@ components:
     SnapshotBuilderConcept:
       type: object
       description: >
-        An object describing a concept in the Snapshot Builder
+        ⚠️ An object describing a concept in the Snapshot Builder
       required:
         - id
         - name
@@ -6435,7 +6436,7 @@ components:
     SnapshotBuilderProgramDataOption:
       type: object
       description: >
-        An object describing high level information about program data for use in the snapshot builder
+        ⚠️ An object describing high level information about program data for use in the snapshot builder
       required:
         - id
         - name
@@ -6460,7 +6461,7 @@ components:
     SnapshotBuilderListOption:
       type: object
       description: >
-        An object describing a program data list option for the snapshot builder
+        ⚠️ An object describing a program data list option for the snapshot builder
       required:
         - id
         - name
@@ -6473,7 +6474,7 @@ components:
     SnapshotBuilderFeatureValueGroup:
       type: object
       description: >
-        Describes a set of columns for a table with given name
+        ⚠️ Describes a set of columns for a table with given name
       required:
         - id
         - name

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4282,6 +4282,8 @@ components:
             $ref: '#/components/schemas/Tag'
         resourceLocks:
           $ref: '#/components/schemas/ResourceLocks'
+        snapshotBuilderConfig:
+          $ref: '#/components/schemas/SnapshotBuilderConfig'
       description: >
         Complete definition of a dataset.
     DatasetSummaryModel:
@@ -4445,7 +4447,7 @@ components:
       type: string
       description: >
         Type of information to include in the response
-      enum: [ NONE, SCHEMA, ACCESS_INFORMATION, PROFILE, PROPERTIES, DATA_PROJECT, STORAGE ]
+      enum: [ NONE, SCHEMA, ACCESS_INFORMATION, PROFILE, PROPERTIES, DATA_PROJECT, STORAGE, SNAPSHOT_BUILDER_CONFIG ]
     EnumerateDatasetModel:
       type: object
       properties:
@@ -6348,6 +6350,122 @@ components:
       properties:
         exclusive:
           $ref: '#/components/schemas/ShortIdProperty'
+
+    ##############################################################################
+    ## SNAPSHOT BUILDER API STANDARD MODELS
+    ##############################################################################
+    SnapshotBuilderConfig:
+      type: object
+      description: >
+        The configuration describing how to select criteria for issuing a snapshot builder request
+      properties:
+        domainOptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/SnapshotBuilderDomainOption'
+        programDataOptions:
+          type: array
+          items:
+            $ref: '#/components/schemas/SnapshotBuilderProgramDataOption'
+        featureValueGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/SnapshotBuilderFeatureValueGroup'
+        prepackagedConceptSets:
+          type: array
+          items:
+            $ref:
+              '#/components/schemas/SnapshotBuilderPrepackagedConceptSets'
+
+    SnapshotBuilderPrepackagedConceptSets:
+      type: object
+      description: >
+        A concept set provided for the dataset, usually used to access tables that are not searchable as domains
+      properties:
+        name:
+          type: string
+        featureValueGroupName:
+          type: string
+
+    SnapshotBuilderDomainOption:
+      type: object
+      description: >
+        An object describing high level information about a domain for use in the snapshot builder
+      properties:
+        kind:
+          type: string
+          default: domain
+          enum: [ domain ]
+        id:
+          type: integer
+        category:
+          type: string
+        conceptCount:
+          type: integer
+        participantCount:
+          type: integer
+        root:
+          $ref: '#/components/schemas/SnapshotBuilderConcept'
+
+    SnapshotBuilderConcept:
+      type: object
+      description: >
+        An object describing a concept in the Snapshot Builder
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        count:
+          type: integer
+        hasChildren:
+          type: boolean
+
+    SnapshotBuilderProgramDataOption:
+      type: object
+      description: >
+        An object describing high level information about program data for use in the snapshot builder
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        kind:
+          type: string
+          enum: [ range, list ]
+        min:
+          type: integer
+        max:
+          type: integer
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/SnapshotBuilderListOption'
+
+    SnapshotBuilderListOption:
+      type: object
+      description: >
+        An object describing a program data list option for the snapshot builder
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+
+    SnapshotBuilderFeatureValueGroup:
+      type: object
+      description: >
+        Describes a set of columns for a table with given name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        values:
+          type: array
+          items:
+            type: string
+
 
     ##############################################################################
     ## SEARCH API STANDARD MODELS

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4447,7 +4447,7 @@ components:
       type: string
       description: >
         Type of information to include in the response
-      enum: [ NONE, SCHEMA, ACCESS_INFORMATION, PROFILE, PROPERTIES, DATA_PROJECT, STORAGE, SNAPSHOT_BUILDER_CONFIG ]
+      enum: [ NONE, SCHEMA, ACCESS_INFORMATION, PROFILE, PROPERTIES, DATA_PROJECT, STORAGE, SNAPSHOT_BUILDER_SETTINGS ]
     EnumerateDatasetModel:
       type: object
       properties:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -6376,13 +6376,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SnapshotBuilderFeatureValueGroup'
-        prepackagedConceptSets:
+        datasetConceptSets:
           type: array
           items:
             $ref:
-              '#/components/schemas/SnapshotBuilderPrepackagedConceptSets'
+              '#/components/schemas/SnapshotBuilderDatasetConceptSets'
 
-    SnapshotBuilderPrepackagedConceptSets:
+    SnapshotBuilderDatasetConceptSets:
       type: object
       description: >
         ⚠️ A concept set provided for the dataset, usually used to access tables that are not searchable as domains

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -46,7 +46,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 
 @ActiveProfiles({"google", "unittest"})
 @ContextConfiguration(classes = {DatasetsApiController.class, GlobalExceptionHandler.class})
@@ -115,7 +114,7 @@ public class DatasetsApiControllerTest {
     when(datasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
         .thenReturn(List.of(iamAction));
 
-    ResultActions resultActions = mvc.perform(
+    mvc.perform(
             get(RETRIEVE_DATASET_ENDPOINT, DATASET_ID)
                 .queryParam("include", String.valueOf(INCLUDE)))
         .andExpect(status().isForbidden());

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -85,6 +85,8 @@ public class DatasetsApiControllerTest {
     DatasetModel expected = new DatasetModel().id(DATASET_ID);
     when(datasetService.retrieveDatasetModel(DATASET_ID, TEST_USER, List.of(INCLUDE)))
         .thenReturn(expected);
+    when(datasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
+        .thenCallRealMethod();
 
     String actualJson =
         mvc.perform(
@@ -105,6 +107,8 @@ public class DatasetsApiControllerTest {
   void testRetrieveDatasetForbidden() throws Exception {
     IamAction iamAction = IamAction.READ_DATASET;
     mockForbidden(iamAction);
+    when(datasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
+        .thenCallRealMethod();
 
     mvc.perform(
             get(RETRIEVE_DATASET_ENDPOINT, DATASET_ID)

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -86,7 +86,7 @@ public class DatasetsApiControllerTest {
     when(datasetService.retrieveDatasetModel(DATASET_ID, TEST_USER, List.of(INCLUDE)))
         .thenReturn(expected);
     when(datasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
-        .thenCallRealMethod();
+        .thenReturn(List.of(IamAction.READ_DATASET));
 
     String actualJson =
         mvc.perform(
@@ -108,7 +108,7 @@ public class DatasetsApiControllerTest {
     IamAction iamAction = IamAction.READ_DATASET;
     mockForbidden(iamAction);
     when(datasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
-        .thenCallRealMethod();
+        .thenReturn(List.of(IamAction.READ_DATASET));
 
     mvc.perform(
             get(RETRIEVE_DATASET_ENDPOINT, DATASET_ID)

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -86,7 +86,7 @@ public class DatasetsApiControllerTest {
     DatasetModel expected = new DatasetModel().id(DATASET_ID);
     when(datasetService.retrieveDatasetModel(DATASET_ID, TEST_USER, List.of(INCLUDE)))
         .thenReturn(expected);
-    when(datasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
+    when(DatasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
         .thenReturn(List.of(IamAction.READ_DATASET));
 
     String actualJson =
@@ -111,7 +111,7 @@ public class DatasetsApiControllerTest {
         .when(iamService)
         .verifyAuthorizations(
             TEST_USER, IamResourceType.DATASET, DATASET_ID.toString(), List.of(iamAction));
-    when(datasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
+    when(DatasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
         .thenReturn(List.of(iamAction));
 
     mvc.perform(
@@ -120,7 +120,6 @@ public class DatasetsApiControllerTest {
         .andExpect(status().isForbidden());
 
     verifyAuthorizationsCall(List.of(iamAction));
-    verify(datasetService).getRetrieveDatasetRequiredActions(List.of(INCLUDE));
     verifyNoMoreInteractions(datasetService);
   }
 

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -86,8 +86,6 @@ public class DatasetsApiControllerTest {
     DatasetModel expected = new DatasetModel().id(DATASET_ID);
     when(datasetService.retrieveDatasetModel(DATASET_ID, TEST_USER, List.of(INCLUDE)))
         .thenReturn(expected);
-    when(DatasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
-        .thenReturn(List.of(IamAction.READ_DATASET));
 
     String actualJson =
         mvc.perform(
@@ -111,8 +109,6 @@ public class DatasetsApiControllerTest {
         .when(iamService)
         .verifyAuthorizations(
             TEST_USER, IamResourceType.DATASET, DATASET_ID.toString(), List.of(iamAction));
-    when(DatasetService.getRetrieveDatasetRequiredActions(List.of(INCLUDE)))
-        .thenReturn(List.of(iamAction));
 
     mvc.perform(
             get(RETRIEVE_DATASET_ENDPOINT, DATASET_ID)

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -97,7 +97,7 @@ public class DatasetsApiControllerTest {
     DatasetModel actual = TestUtils.mapFromJson(actualJson, DatasetModel.class);
     assertThat("Dataset model is returned", actual, equalTo(expected));
 
-    verifyAuthorizationCall(IamAction.READ_DATASET);
+    verifyAuthorizationsCall(List.of(IamAction.READ_DATASET));
     verify(datasetService).retrieveDatasetModel(DATASET_ID, TEST_USER, List.of(INCLUDE));
   }
 
@@ -111,7 +111,7 @@ public class DatasetsApiControllerTest {
                 .queryParam("include", String.valueOf(INCLUDE)))
         .andExpect(status().isForbidden());
 
-    verifyAuthorizationCall(iamAction);
+    verifyAuthorizationsCall(List.of(iamAction));
     verifyNoInteractions(datasetService);
   }
 
@@ -187,5 +187,10 @@ public class DatasetsApiControllerTest {
   private void verifyAuthorizationCall(IamAction iamAction) {
     verify(iamService)
         .verifyAuthorization(TEST_USER, IamResourceType.DATASET, DATASET_ID.toString(), iamAction);
+  }
+
+  private void verifyAuthorizationsCall(List<IamAction> iamActions) {
+    verify(iamService)
+        .verifyAuthorizations(TEST_USER, IamResourceType.DATASET, DATASET_ID.toString(), iamActions);
   }
 }

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -191,6 +191,7 @@ public class DatasetsApiControllerTest {
 
   private void verifyAuthorizationsCall(List<IamAction> iamActions) {
     verify(iamService)
-        .verifyAuthorizations(TEST_USER, IamResourceType.DATASET, DATASET_ID.toString(), iamActions);
+        .verifyAuthorizations(
+            TEST_USER, IamResourceType.DATASET, DATASET_ID.toString(), iamActions);
   }
 }

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -49,6 +49,7 @@ import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotPreviewModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotSummaryModel;
+import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
@@ -143,6 +144,8 @@ public class ConnectedOperations {
     when(samService.createSnapshotResource(any(), any(), any())).thenReturn(snapshotPolicies);
     when(samService.isAuthorized(any(), any(), any(), any())).thenReturn(Boolean.TRUE);
     when(samService.createDatasetResource(any(), any(), any())).thenReturn(datasetPolicies);
+    when(samService.listActions(any(), eq(IamResourceType.DATASET), any()))
+        .thenReturn(List.of(IamAction.READ_DATASET.toString()));
 
     when(samService.retrievePolicyEmails(any(), eq(IamResourceType.DATASET), any()))
         .thenReturn(datasetPolicies);

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -31,8 +31,14 @@ import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
 
+@RunWith(SpringRunner.class)
+@SpringBootTest
 @ActiveProfiles({"google", "unittest"})
 @Category(Unit.class)
 public class DatasetJsonConversionTest {
@@ -51,6 +57,8 @@ public class DatasetJsonConversionTest {
   private static final UUID DATASET_COLUMN_ID = UUID.randomUUID();
   private static final String DATASET_ASSET_NAME = "asset1";
   private static final UUID DATASET_ASSET_ID = UUID.randomUUID();
+
+  @Autowired private DatasetJsonConversion datasetJsonConversion;
 
   private Dataset dataset;
   private DatasetModel datasetModel;
@@ -154,7 +162,7 @@ public class DatasetJsonConversionTest {
   @Test
   public void populateDatasetModelFromDataset() {
     assertThat(
-        DatasetJsonConversion.populateDatasetModelFromDataset(
+        datasetJsonConversion.populateDatasetModelFromDataset(
             dataset,
             List.of(
                 DatasetRequestAccessIncludeModel.SCHEMA,
@@ -168,7 +176,7 @@ public class DatasetJsonConversionTest {
   @Test
   public void populateDatasetModelFromDatasetNone() {
     assertThat(
-        DatasetJsonConversion.populateDatasetModelFromDataset(
+        datasetJsonConversion.populateDatasetModelFromDataset(
             dataset,
             List.of(
                 DatasetRequestAccessIncludeModel.NONE, DatasetRequestAccessIncludeModel.PROFILE),
@@ -181,7 +189,7 @@ public class DatasetJsonConversionTest {
   public void populateDatasetModelFromDatasetAccessInfo() {
     String expectedDatasetName = "datarepo_" + DATASET_NAME;
     assertThat(
-        DatasetJsonConversion.populateDatasetModelFromDataset(
+        datasetJsonConversion.populateDatasetModelFromDataset(
             dataset,
             List.of(DatasetRequestAccessIncludeModel.ACCESS_INFORMATION),
             metadataDataAccessUtils,

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.app.model.GoogleCloudResource;

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -177,7 +177,7 @@ public class DatasetJsonConversionTest {
             List.of(
                 DatasetRequestAccessIncludeModel.SCHEMA,
                 DatasetRequestAccessIncludeModel.PROFILE,
-                DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG,
+                DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_SETTINGS,
                 DatasetRequestAccessIncludeModel.DATA_PROJECT),
             metadataDataAccessUtils,
             testUser),

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -34,18 +34,15 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {DatasetJsonConversion.class})
+@ExtendWith(MockitoExtension.class)
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
+@Tag(Unit.TAG)
 public class DatasetJsonConversionTest {
   private AuthenticatedUserRequest testUser = AuthenticationFixtures.randomUserRequest();
 
@@ -63,9 +60,9 @@ public class DatasetJsonConversionTest {
   private static final String DATASET_ASSET_NAME = "asset1";
   private static final UUID DATASET_ASSET_ID = UUID.randomUUID();
 
-  @Autowired private DatasetJsonConversion datasetJsonConversion;
+  private DatasetJsonConversion datasetJsonConversion;
 
-  @MockBean private SnapshotBuilderService snapshotBuilderService;
+  @Mock private SnapshotBuilderService snapshotBuilderService;
 
   private Dataset dataset;
   private DatasetModel datasetModel;
@@ -73,6 +70,8 @@ public class DatasetJsonConversionTest {
 
   @Before
   public void setUp() throws Exception {
+    datasetJsonConversion = new DatasetJsonConversion(snapshotBuilderService);
+
     Column datasetColumn =
         new Column()
             .id(DATASET_COLUMN_ID)
@@ -182,7 +181,6 @@ public class DatasetJsonConversionTest {
             metadataDataAccessUtils,
             testUser),
         equalTo(datasetModel));
-    verify(snapshotBuilderService).getSnapshotBuilderSettings(DATASET_ID);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -175,6 +175,22 @@ public class DatasetJsonConversionTest {
             List.of(
                 DatasetRequestAccessIncludeModel.SCHEMA,
                 DatasetRequestAccessIncludeModel.PROFILE,
+                DatasetRequestAccessIncludeModel.DATA_PROJECT),
+            metadataDataAccessUtils,
+            testUser),
+        equalTo(datasetModel.snapshotBuilderSettings(null)));
+  }
+
+  @Test
+  public void populateDatasetModelFromDatasetIncludingSnapshotBuilderSettings() {
+    when(snapshotBuilderService.getSnapshotBuilderSettings(DATASET_ID))
+        .thenReturn(new SnapshotBuilderSettings());
+    assertThat(
+        datasetJsonConversion.populateDatasetModelFromDataset(
+            dataset,
+            List.of(
+                DatasetRequestAccessIncludeModel.SCHEMA,
+                DatasetRequestAccessIncludeModel.PROFILE,
                 DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_SETTINGS,
                 DatasetRequestAccessIncludeModel.DATA_PROJECT),
             metadataDataAccessUtils,

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -639,7 +639,7 @@ public class DatasetServiceTest {
   @Test
   public void getRetrieveDatasetRequiredActionsWithDefaults() {
     List<IamAction> actions =
-        datasetService.getRetrieveDatasetRequiredActions(
+        DatasetService.getRetrieveDatasetRequiredActions(
             List.of(
                 DatasetRequestAccessIncludeModel.SCHEMA,
                 DatasetRequestAccessIncludeModel.PROFILE,
@@ -651,7 +651,7 @@ public class DatasetServiceTest {
   @Test
   public void getRetrieveDatasetRequiredActionsWithSnapshotBuilderConfig() {
     List<IamAction> actions =
-        datasetService.getRetrieveDatasetRequiredActions(
+        DatasetService.getRetrieveDatasetRequiredActions(
             List.of(
                 DatasetRequestAccessIncludeModel.SCHEMA,
                 DatasetRequestAccessIncludeModel.PROFILE,

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -646,8 +646,7 @@ public class DatasetServiceTest {
                 DatasetRequestAccessIncludeModel.PROFILE,
                 DatasetRequestAccessIncludeModel.DATA_PROJECT,
                 DatasetRequestAccessIncludeModel.STORAGE));
-    assertThat(
-        "The only required action is reader", actions, contains(List.of(IamAction.READ_DATASET)));
+    assertThat("The only required action is reader", actions, contains(IamAction.READ_DATASET));
   }
 
   @Test
@@ -663,7 +662,6 @@ public class DatasetServiceTest {
     assertThat(
         "The only required action is reader",
         actions,
-        containsInAnyOrder(
-            List.of(IamAction.READ_DATASET, IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS)));
+        containsInAnyOrder(IamAction.READ_DATASET, IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -645,7 +645,10 @@ public class DatasetServiceTest {
                 DatasetRequestAccessIncludeModel.DATA_PROJECT,
                 DatasetRequestAccessIncludeModel.STORAGE));
     assertThat("There is only one action", actions.size(), equalTo(1));
-    assertThat("The only required action is reader", actions.contains(IamAction.READ_DATASET), is(IamAction.READ_DATASET));
+    assertThat(
+        "The only required action is reader",
+        actions.contains(IamAction.READ_DATASET),
+        is(IamAction.READ_DATASET));
   }
 
   @Test
@@ -658,7 +661,13 @@ public class DatasetServiceTest {
                 DatasetRequestAccessIncludeModel.DATA_PROJECT,
                 DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG));
     assertThat("There is only one action", actions.size(), is(2));
-    assertThat("The only required action is reader", actions.contains(IamAction.READ_DATASET), equalTo(true));
-    assertThat("The only required action is reader", actions.contains(IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS), equalTo(true));
+    assertThat(
+        "The only required action is reader",
+        actions.contains(IamAction.READ_DATASET),
+        equalTo(true));
+    assertThat(
+        "The only required action is reader",
+        actions.contains(IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS),
+        equalTo(true));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -657,10 +656,9 @@ public class DatasetServiceTest {
                 DatasetRequestAccessIncludeModel.SCHEMA,
                 DatasetRequestAccessIncludeModel.PROFILE,
                 DatasetRequestAccessIncludeModel.DATA_PROJECT,
-                DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_CONFIG));
-    assertThat("There is only one action", actions.size(), is(2));
+                DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_SETTINGS));
     assertThat(
-        "The only required action is reader",
+        "When requesting SnapshotBuilderSettings require VIEW_SNAPSHOT_BUILDER_SETTINGS permission",
         actions,
         containsInAnyOrder(IamAction.READ_DATASET, IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS));
   }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -646,9 +646,7 @@ public class DatasetServiceTest {
                 DatasetRequestAccessIncludeModel.STORAGE));
     assertThat("There is only one action", actions.size(), equalTo(1));
     assertThat(
-        "The only required action is reader",
-        actions.contains(IamAction.READ_DATASET),
-        is(IamAction.READ_DATASET));
+        "The only required action is reader", actions.contains(IamAction.READ_DATASET), is(true));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -1,6 +1,8 @@
 package bio.terra.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -644,9 +646,8 @@ public class DatasetServiceTest {
                 DatasetRequestAccessIncludeModel.PROFILE,
                 DatasetRequestAccessIncludeModel.DATA_PROJECT,
                 DatasetRequestAccessIncludeModel.STORAGE));
-    assertThat("There is only one action", actions.size(), equalTo(1));
     assertThat(
-        "The only required action is reader", actions.contains(IamAction.READ_DATASET), is(true));
+        "The only required action is reader", actions, contains(List.of(IamAction.READ_DATASET)));
   }
 
   @Test
@@ -661,11 +662,8 @@ public class DatasetServiceTest {
     assertThat("There is only one action", actions.size(), is(2));
     assertThat(
         "The only required action is reader",
-        actions.contains(IamAction.READ_DATASET),
-        equalTo(true));
-    assertThat(
-        "The only required action is reader",
-        actions.contains(IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS),
-        equalTo(true));
+        actions,
+        containsInAnyOrder(
+            List.of(IamAction.READ_DATASET, IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS)));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -81,6 +81,7 @@ public class DatasetServiceUnitTest {
   @Autowired private DatasetService datasetService;
 
   @MockBean private SnapshotBuilderService snapshotBuilderService;
+  @MockBean private DatasetJsonConversion datasetJsonConversion;
   @MockBean private JobService jobService;
   @MockBean private LoadService loadService;
   @MockBean private ProfileDao profileDao;

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -43,6 +43,7 @@ import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import bio.terra.service.tabulardata.azure.StorageTableService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDataResultModel;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
@@ -79,6 +80,7 @@ public class DatasetServiceUnitTest {
 
   @Autowired private DatasetService datasetService;
 
+  @MockBean private SnapshotBuilderService snapshotBuilderService;
   @MockBean private JobService jobService;
   @MockBean private LoadService loadService;
   @MockBean private ProfileDao profileDao;

--- a/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
@@ -48,6 +48,7 @@ public class ValidateAssetUnitTest {
   @Autowired private DatasetService datasetService;
 
   @MockBean private SnapshotBuilderService snapshotBuilderService;
+  @MockBean private DatasetJsonConversion datasetJsonConversion;
   @MockBean private JobService jobService;
   @MockBean private LoadService loadService;
   @MockBean private ProfileDao profileDao;

--- a/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
@@ -21,6 +21,7 @@ import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import bio.terra.service.tabulardata.azure.StorageTableService;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryTransactionPdao;
@@ -46,6 +47,7 @@ public class ValidateAssetUnitTest {
 
   @Autowired private DatasetService datasetService;
 
+  @MockBean private SnapshotBuilderService snapshotBuilderService;
   @MockBean private JobService jobService;
   @MockBean private LoadService loadService;
   @MockBean private ProfileDao profileDao;


### PR DESCRIPTION
This adds static snapshot builder config, building out the initial bits we need to power the UI. Over time, this static data will either turn into database driven configuration or calls to SQL. The idea eventually is that this is all user driven, and stewards can add dataset snapshot builder configuration and that will be used to populate dataset requests.