### PR TITLE
[DR-3127] Update google cloud library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,7 @@ dependencies {
     implementation 'com.google.apis:google-api-services-appengine:v1-rev20230206-2.0.0'
     implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-2.0.0'
     implementation 'com.google.apis:google-api-services-iam:v1-rev20230209-2.0.0'
-    implementation platform('com.google.cloud:libraries-bom:26.6.0')
+    implementation platform('com.google.cloud:libraries-bom:26.22.0')
     implementation 'com.google.cloud:google-cloud-billing'
     implementation 'com.google.cloud:google-cloud-resourcemanager'
     implementation 'com.google.cloud:google-cloud-bigquery'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3127

This updates `com.google.cloud:libraries-bom` to the latest version so that it's dependency `io.grpc:grpc-xds` is on a non-vulnerable version.