### PR TITLE
DR-3174 Set null retention policy for individual metrics and logs

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -204,7 +204,12 @@ public class AzureMonitoringService {
         .define(storageAccount.getName())
         .withResource(getStorageAccountLoggingResourceId(storageAccount))
         .withLogAnalytics(workspaceId)
-        .withLogsAndMetrics(logCategories, METRIC_GRANULARITY, LOG_DATA_RETENTION_DAYS)
+        // See
+        // https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy
+        // Setting a non-zero retention period is no longer supported
+        // Setting a retention period of 0 days means that the logs will be deleted after the
+        // workspace default of 90 days
+        .withLogsAndMetrics(logCategories, METRIC_GRANULARITY, 0)
         .create()
         .id();
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3174

This is the recommendation from Azure and is no longer support by Azure as of a few days ago.

The change is very straightforward:
- Remove the individual retention policies for metrics and logs and just use the one that is set at the top level (for the entire Log Analytics Workspace)
- Testing should basically just be that tests pass again (manually tested creating a dataset locally)