### PR TITLE
[DR-3182] Use billing profile in Azure snapshot export without checking caller's access

### DIFF
--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -185,7 +185,8 @@ public class ProfileService {
    */
   public BillingProfileModel getProfileById(UUID id, AuthenticatedUserRequest user) {
     if (!iamService.hasAnyActions(user, IamResourceType.SPEND_PROFILE, id.toString())) {
-      throw new IamUnauthorizedException("unauthorized");
+      throw new IamUnauthorizedException(
+          "User '" + user.getEmail() + "' does not have access to billing profile '" + id + "'.");
     }
     return getProfileByIdNoCheck(id);
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
@@ -67,7 +67,10 @@ public class SnapshotExportWriteManifestAzureStep extends DefaultUndoStep {
         FlightUtils.getTyped(workingMap, SnapshotWorkingMapKeys.SNAPSHOT_EXPORT_PARQUET_PATHS);
 
     UUID billingProfileId = workingMap.get(JobMapKeys.BILLING_ID.getKeyName(), UUID.class);
-    BillingProfileModel billingProfile = profileService.getProfileById(billingProfileId, userReq);
+    // We do not check that the caller has direct access to the billing profile:
+    // It is sufficient that they hold the necessary action on the snapshot, which is checked
+    // before calling the flight.
+    BillingProfileModel billingProfile = profileService.getProfileByIdNoCheck(billingProfileId);
     AzureStorageAccountResource storageAccountResource =
         resourceService.getSnapshotStorageAccount(snapshotId);
     String exportManifestPath = "manifests/%s/manifest.json".formatted(context.getFlightId());

--- a/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.common.TestUtils;
+import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
@@ -38,7 +39,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @ActiveProfiles({"google", "unittest"})
 @ContextConfiguration(classes = {SnapshotsApiController.class, GlobalExceptionHandler.class})
-@Tag("bio.terra.common.category.Unit")
+@Tag(Unit.TAG)
 @WebMvcTest
 class SnapshotsApiControllerTest {
 
@@ -99,7 +100,10 @@ class SnapshotsApiControllerTest {
   @Test
   void testExportSnapshotForbidden() throws Exception {
     IamAction iamAction = IamAction.EXPORT_SNAPSHOT;
-    mockForbidden(iamAction);
+    doThrow(IamForbiddenException.class)
+        .when(iamService)
+        .verifyAuthorization(
+            TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID.toString(), iamAction);
 
     mvc.perform(
             get(EXPORT_SNAPSHOT_ENDPOINT, SNAPSHOT_ID)
@@ -111,14 +115,6 @@ class SnapshotsApiControllerTest {
 
     verifyAuthorizationCall(iamAction);
     verifyNoInteractions(snapshotService);
-  }
-
-  /** Mock so that the user does not hold `iamAction` on the dataset. */
-  private void mockForbidden(IamAction iamAction) {
-    doThrow(IamForbiddenException.class)
-        .when(iamService)
-        .verifyAuthorization(
-            TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID.toString(), iamAction);
   }
 
   /** Verify that snapshot authorization was checked. */

--- a/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
@@ -1,0 +1,130 @@
+package bio.terra.app.controller;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.common.TestUtils;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import bio.terra.model.JobModel;
+import bio.terra.service.auth.iam.IamAction;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.auth.iam.exception.IamForbiddenException;
+import bio.terra.service.dataset.AssetModelValidator;
+import bio.terra.service.dataset.IngestRequestValidator;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.job.JobService;
+import bio.terra.service.snapshot.SnapshotRequestValidator;
+import bio.terra.service.snapshot.SnapshotService;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles({"google", "unittest"})
+@ContextConfiguration(classes = {SnapshotsApiController.class, GlobalExceptionHandler.class})
+@Tag("bio.terra.common.category.Unit")
+@WebMvcTest
+public class SnapshotsApiControllerTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private JobService jobService;
+  @MockBean private SnapshotRequestValidator snapshotRequestValidator;
+  @MockBean private SnapshotService snapshotService;
+  @MockBean private IamService iamService;
+  @MockBean private IngestRequestValidator ingestRequestValidator;
+  @MockBean private FileService fileService;
+  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockBean private AssetModelValidator assetModelValidator;
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final String JOB_ID = "a-job-id";
+  private static final Boolean EXPORT_GCS_PATHS = false;
+  private static final Boolean VALIDATE_PRIMARY_KEY_UNIQUENESS = true;
+
+  private static final String RETRIEVE_SNAPSHOT_ENDPOINT = "/api/repository/v1/snapshots/{id}";
+  private static final String EXPORT_SNAPSHOT_ENDPOINT = RETRIEVE_SNAPSHOT_ENDPOINT + "/export";
+
+  @BeforeEach
+  void setUp() {
+    when(authenticatedUserRequestFactory.from(any())).thenReturn(TEST_USER);
+  }
+
+  @Test
+  void testExportSnapshot() throws Exception {
+    JobModel expected = new JobModel().id(JOB_ID).jobStatus(JobModel.JobStatusEnum.RUNNING);
+
+    when(snapshotService.exportSnapshot(
+            SNAPSHOT_ID, TEST_USER, EXPORT_GCS_PATHS, VALIDATE_PRIMARY_KEY_UNIQUENESS))
+        .thenReturn(JOB_ID);
+    when(jobService.retrieveJob(JOB_ID, TEST_USER)).thenReturn(expected);
+
+    String actualJson =
+        mvc.perform(
+                get(EXPORT_SNAPSHOT_ENDPOINT, SNAPSHOT_ID)
+                    .queryParam("exportGsPaths", String.valueOf(EXPORT_GCS_PATHS))
+                    .queryParam(
+                        "validatePrimaryKeyUniqueness",
+                        String.valueOf(VALIDATE_PRIMARY_KEY_UNIQUENESS)))
+            .andExpect(status().isAccepted())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    JobModel actual = TestUtils.mapFromJson(actualJson, JobModel.class);
+    assertThat("Job model is returned", actual, equalTo(expected));
+
+    verifyAuthorizationCall(IamAction.EXPORT_SNAPSHOT);
+    verify(snapshotService)
+        .exportSnapshot(SNAPSHOT_ID, TEST_USER, EXPORT_GCS_PATHS, VALIDATE_PRIMARY_KEY_UNIQUENESS);
+  }
+
+  @Test
+  void testExportSnapshotForbidden() throws Exception {
+    IamAction iamAction = IamAction.EXPORT_SNAPSHOT;
+    mockForbidden(iamAction);
+
+    mvc.perform(
+            get(EXPORT_SNAPSHOT_ENDPOINT, SNAPSHOT_ID)
+                .queryParam("exportGsPaths", String.valueOf(EXPORT_GCS_PATHS))
+                .queryParam(
+                    "validatePrimaryKeyUniqueness",
+                    String.valueOf(VALIDATE_PRIMARY_KEY_UNIQUENESS)))
+        .andExpect(status().isForbidden());
+
+    verifyAuthorizationCall(iamAction);
+    verifyNoInteractions(snapshotService);
+  }
+
+  /** Mock so that the user does not hold `iamAction` on the dataset. */
+  private void mockForbidden(IamAction iamAction) {
+    doThrow(IamForbiddenException.class)
+        .when(iamService)
+        .verifyAuthorization(
+            TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID.toString(), iamAction);
+  }
+
+  /** Verify that snapshot authorization was checked. */
+  private void verifyAuthorizationCall(IamAction iamAction) {
+    verify(iamService)
+        .verifyAuthorization(
+            TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID.toString(), iamAction);
+  }
+}

--- a/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
@@ -40,7 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @ContextConfiguration(classes = {SnapshotsApiController.class, GlobalExceptionHandler.class})
 @Tag("bio.terra.common.category.Unit")
 @WebMvcTest
-public class SnapshotsApiControllerTest {
+class SnapshotsApiControllerTest {
 
   @Autowired private MockMvc mvc;
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3182

Adam Mullen was getting an "unauthorized" error when trying to initiate the first step of an Azure snapshot export (TDR Dev job 0-Aks54WQR2eM7-uRPBI_Q)  The issue is that while he's a snapshot steward, he has no permissions on the billing profile directly.

I believe that this check is done in oversight and is not necessary.  I do not see a similar check performed for GCP snapshot export.  At this point we've already verified that the caller holds the needed action on the snapshot.

In addition to changing the billing profile fetch to an unchecked method, I expanded unit testing to verify our snapshot authorization check and improved the error thrown when trying to fetch an inaccessible billing profile.