### PR TITLE
[DR-3187] Disable integration, connected test retries when running locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -523,8 +523,6 @@ task testConnected(type: Test) {
         if (isCiServer) {
             maxRetries = 3
             maxFailures = 15
-        } else {
-            maxRetries = 2
         }
     }
     maxParallelForks = 4
@@ -544,8 +542,6 @@ task testIntegration(type: Test) {
         if (isCiServer) {
             maxRetries = 3
             maxFailures = 15
-        } else {
-            maxRetries = 2
         }
     }
     maxParallelForks = 8


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3187

Proposal: most often when we run these tests locally it's because we're debugging failures exposed in a CI run.  In these cases, local retries slow developer velocity.  CI run retries offer resilience against transient issues failing a test run, but don't provide the same value locally.

Note that unit tests already have no retries configured, for either local or CI runs.