### PR TITLE
[DR-3188] Push filtering down to the Stairway DB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
         implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
         implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.2'
     } else {
-        implementation 'bio.terra:stairway:0.0.75-SNAPSHOT'
+        implementation 'bio.terra:stairway:0.0.78-SNAPSHOT'
     }
 
     // Similar development mode for pointing to terra common library

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -1,5 +1,10 @@
 package bio.terra.service.job;
 
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeAnd;
+import static bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression.makeOr;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateFlightClass;
+import static bio.terra.stairway.FlightFilter.FlightFilterPredicate.makePredicateInput;
+
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.app.configuration.StairwayJdbcConfiguration;
 import bio.terra.app.logging.PerformanceLogger;
@@ -21,8 +26,9 @@ import bio.terra.service.job.exception.JobUnauthorizedException;
 import bio.terra.service.upgrade.Migrate;
 import bio.terra.stairway.ExceptionSerializer;
 import bio.terra.stairway.Flight;
-import bio.terra.stairway.FlightEnumeration;
 import bio.terra.stairway.FlightFilter;
+import bio.terra.stairway.FlightFilter.FlightBooleanOperationExpression;
+import bio.terra.stairway.FlightFilter.FlightFilterPredicateInterface;
 import bio.terra.stairway.FlightFilterOp;
 import bio.terra.stairway.FlightFilterSortDirection;
 import bio.terra.stairway.FlightMap;
@@ -34,12 +40,14 @@ import bio.terra.stairway.exception.StairwayException;
 import bio.terra.stairway.exception.StairwayExecutionException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -305,7 +313,7 @@ public class JobService {
 
     // if the user has access to all jobs, then fetch everything
     // otherwise, filter the jobs on the user
-    FlightFilter filter = new FlightFilter();
+    FlightFilter filter = new FlightFilter(createFlightFilter(userReq, className));
     // Set the order to use to return values
     switch (direction) {
       case ASC:
@@ -318,89 +326,70 @@ public class JobService {
         throw new IllegalArgumentException(String.format("Unrecognized direction %s", direction));
     }
 
-    // Filter on FQ class name if specified
-    if (!StringUtils.isEmpty(className)) {
-      filter.addFilterFlightClass(FlightFilterOp.EQUAL, className);
-    }
-
-    List<FlightState> flightStateList;
-    boolean canListAnyJob = checkUserCanListAnyJob(userReq);
+    List<FlightState> flightStateList = null;
     try {
-      if (canListAnyJob) {
-        flightStateList = stairway.getFlights(offset, limit, filter);
-      } else {
-        // Filter out sub-flights
-        filter.addFilterFlightClass(FlightFilterOp.NOT_EQUAL, FileIngestWorkerFlight.class);
-
-        flightStateList = getAccessibleFlights(offset, limit, filter, userReq);
-      }
-    } catch (InterruptedException ex) {
-      throw new JobServiceShutdownException("Job service interrupted", ex);
+      flightStateList = stairway.getFlights(offset, limit, filter);
+    } catch (InterruptedException e) {
+      throw new JobServiceShutdownException("Job service interrupted", e);
     }
     return flightStateList.stream()
         .map(this::mapFlightStateToJobModel)
         .collect(Collectors.toList());
   }
 
-  private List<FlightState> getAccessibleFlights(
-      int offset, int limit, FlightFilter filter, AuthenticatedUserRequest userReq)
-      throws InterruptedException {
-
-    String nextPageToken = null;
-    HashMap<String, List<String>> roleMap = new HashMap<>();
-    ArrayList<FlightState> flightStateList = new ArrayList<>();
-    int numTimesQueried = 0;
-    while (flightStateList.size() < offset + limit && numTimesQueried < MAX_FLIGHT_SEARCH_QUERIES) {
-      logger.info("Getting flight batch {} with nextPageToken {}", numTimesQueried, nextPageToken);
-      FlightEnumeration filterResults =
-          stairway.getFlights(nextPageToken, FLIGHT_SEARCH_BATCH_SIZE, filter);
-      if (filterResults.getFlightStateList().size() == 0) {
-        break;
-      }
-
-      for (var flightState : filterResults.getFlightStateList()) {
-        if (userLaunchedFlight(flightState, userReq)) {
-          flightStateList.add(flightState);
-        } else {
-          FlightMap inputParameters = flightState.getInputParameters();
-          IamResourceType resourceType =
-              inputParameters.get(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.class);
-          String resourceId =
-              inputParameters.get(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), String.class);
-          IamAction action =
-              inputParameters.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class);
-          if (resourceType != null & resourceId != null && action != null) {
-            String key = String.format("%s-%s", resourceType, resourceId);
-            List<String> userRoles = roleMap.get(key);
-            if (userRoles == null) {
-              userRoles = samService.listActions(userReq, resourceType, resourceId);
-              roleMap.put(key, userRoles);
-            }
-            if (userRoles.contains(action.toString())) {
-              flightStateList.add(flightState);
-            }
-          }
-        }
-        // Stop processing as soon as we've got enough to return
-        if (flightStateList.size() == offset + limit) {
-          break;
-        }
-      }
-      numTimesQueried++;
-      nextPageToken = filterResults.getNextPageToken();
+  private FlightBooleanOperationExpression createFlightFilter(
+      AuthenticatedUserRequest userReq, String className) {
+    List<FlightFilterPredicateInterface> topLevelBooleans = new ArrayList<>();
+    // Exclude FileIngestWorkerFlight subflights since they pollute the jobs page.  We may
+    // eventually add a boolean to re-add or display the subflights as children.
+    // Note: do not add this filter if the user is explicitly requesting FileIngestWorkerFlight's
+    if (!StringUtils.isEmpty(className)) {
+      topLevelBooleans.add(makePredicateFlightClass(FlightFilterOp.EQUAL, className));
     }
-    if (flightStateList.size() <= offset) {
-      return new ArrayList<>();
-    } else if (flightStateList.size() < offset + limit) {
-      return flightStateList.subList(offset, flightStateList.size());
+    if (!StringUtils.isEmpty(className) && !className.equals(FileIngestWorkerFlight.class.getName())
+        || StringUtils.isEmpty(className)) {
+      topLevelBooleans.add(
+          makePredicateFlightClass(FlightFilterOp.NOT_EQUAL, FileIngestWorkerFlight.class));
     }
-    return flightStateList.subList(offset, offset + limit);
+
+    // Make sure that only flights a user has access to are returned if the user is not an admin
+    if (!checkUserCanListAnyJob(userReq)) {
+      topLevelBooleans.add(
+          makeOr(
+              Stream.of(
+                      // Always allow the user to see their own flights
+                      makePredicateInput(
+                          JobMapKeys.SUBJECT_ID.getKeyName(),
+                          FlightFilterOp.EQUAL,
+                          userReq.getSubjectId()),
+                      // The user can view flights associated with profiles they have access to
+                      makeResourceTypeFilter(IamResourceType.SPEND_PROFILE, userReq),
+                      // The user can view flights associated with datasets they have access to
+                      makeResourceTypeFilter(IamResourceType.DATASET, userReq),
+                      // The user can view flights associated with snapshots they have access to
+                      makeResourceTypeFilter(IamResourceType.DATASNAPSHOT, userReq))
+                  // Remove nulls (e.g. if the user doesn't have access to any profiles or datasets)
+                  .filter(Objects::nonNull)
+                  .toArray(FlightFilterPredicateInterface[]::new)));
+    }
+
+    return makeAnd(topLevelBooleans.toArray(new FlightFilterPredicateInterface[0]));
   }
 
-  private boolean userLaunchedFlight(FlightState flightState, AuthenticatedUserRequest userReq) {
-    FlightMap inputParameters = flightState.getInputParameters();
-    String flightSubjectId = inputParameters.get(JobMapKeys.SUBJECT_ID.getKeyName(), String.class);
-    return StringUtils.equals(flightSubjectId, userReq.getSubjectId());
+  private FlightBooleanOperationExpression makeResourceTypeFilter(
+      IamResourceType resourceType, AuthenticatedUserRequest userReq) {
+    List<String> authorizedResources =
+        samService.listAuthorizedResources(userReq, resourceType).keySet().stream()
+            .map(UUID::toString)
+            .toList();
+    if (authorizedResources.isEmpty()) {
+      return null;
+    }
+    return makeAnd(
+        makePredicateInput(
+            JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), FlightFilterOp.EQUAL, resourceType),
+        makePredicateInput(
+            JobMapKeys.IAM_RESOURCE_ID.getKeyName(), FlightFilterOp.IN, authorizedResources));
   }
 
   public JobModel retrieveJob(String jobId, AuthenticatedUserRequest userReq) {


### PR DESCRIPTION
Stairway introduced more complex query capabilities which give us the chance to push queries down to the DB.

Note on a behavior change: if a user has any access to any action on a resource, the user can see the jobs status related to that resource.  That seems like a reasonable approach from a security standpoint and should perform well at scale

I have this deployed on my instance:
https://jade-nm.datarepo-dev.broadinstitute.org/activity

Feel free to mess around with non-admin users if you'd like