### PR TITLE
[DR-3200] Upgrade Sam client and make sure to pass in request pays option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
     implementation 'org.springframework:spring-jdbc:5.1.9.RELEASE'
     implementation 'org.springframework.cloud:spring-cloud-gcp-starter-logging:1.2.8.RELEASE'
     implementation "org.springframework.cloud:spring-cloud-starter-sleuth:3.0.2"
-    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-7bfd91d'
+    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-c1e35e6'
     implementation 'org.antlr:ST4:4.3'                          // String templating
     implementation group: 'io.kubernetes', name: 'client-java', version: '18.0.0'
 

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -33,7 +33,6 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -663,12 +662,12 @@ public class SamIam implements IamProviderInterface {
   }
 
   AccessPolicyMembershipRequest createAccessPolicyOne(IamRole role, String email) {
-    return createAccessPolicy(role, Collections.singletonList(email));
+    return createAccessPolicy(role, List.of(email));
   }
 
   AccessPolicyMembershipRequest createAccessPolicy(IamRole role, List<String> emails) {
     AccessPolicyMembershipRequest membership =
-        new AccessPolicyMembershipRequest().roles(Collections.singletonList(role.toString()));
+        new AccessPolicyMembershipRequest().roles(List.of(role.toString()));
     if (emails != null) {
       membership.memberEmails(emails);
     }

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -47,6 +47,7 @@ import org.broadinstitute.dsde.workbench.client.sam.api.GroupApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembershipV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntryV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
@@ -195,19 +196,19 @@ public class SamIamTest {
         containsInAnyOrder(
             IamRole.ADMIN, IamRole.STEWARD, IamRole.CUSTODIAN, IamRole.SNAPSHOT_CREATOR));
 
-    AccessPolicyMembershipV2 admin = req.getPolicies().get(IamRole.ADMIN.toString());
+    AccessPolicyMembershipRequest admin = req.getPolicies().get(IamRole.ADMIN.toString());
     assertThat(admin.getRoles(), contains(IamRole.ADMIN.toString()));
     assertThat(admin.getMemberEmails(), contains(ADMIN_EMAIL));
 
-    AccessPolicyMembershipV2 steward = req.getPolicies().get(IamRole.STEWARD.toString());
+    AccessPolicyMembershipRequest steward = req.getPolicies().get(IamRole.STEWARD.toString());
     assertThat(steward.getRoles(), contains(IamRole.STEWARD.toString()));
     assertThat(steward.getMemberEmails(), contains(userEmail, stewardEmail1, stewardEmail2));
 
-    AccessPolicyMembershipV2 custodian = req.getPolicies().get(IamRole.CUSTODIAN.toString());
+    AccessPolicyMembershipRequest custodian = req.getPolicies().get(IamRole.CUSTODIAN.toString());
     assertThat(custodian.getRoles(), contains(IamRole.CUSTODIAN.toString()));
     assertThat(custodian.getMemberEmails(), contains(custodianEmail));
 
-    AccessPolicyMembershipV2 snapshotCreator =
+    AccessPolicyMembershipRequest snapshotCreator =
         req.getPolicies().get(IamRole.SNAPSHOT_CREATOR.toString());
     assertThat(snapshotCreator.getRoles(), contains(IamRole.SNAPSHOT_CREATOR.toString()));
     assertThat(snapshotCreator.getMemberEmails(), contains(snapshotCreatorEmail));
@@ -236,19 +237,20 @@ public class SamIamTest {
           policyKeys,
           containsInAnyOrder(IamRole.ADMIN, IamRole.STEWARD, IamRole.READER, IamRole.DISCOVERER));
 
-      AccessPolicyMembershipV2 admin = req.getPolicies().get(IamRole.ADMIN.toString());
+      AccessPolicyMembershipRequest admin = req.getPolicies().get(IamRole.ADMIN.toString());
       assertThat(admin.getRoles(), contains(IamRole.ADMIN.toString()));
       assertThat(admin.getMemberEmails(), contains(ADMIN_EMAIL));
 
-      AccessPolicyMembershipV2 steward = req.getPolicies().get(IamRole.STEWARD.toString());
+      AccessPolicyMembershipRequest steward = req.getPolicies().get(IamRole.STEWARD.toString());
       assertThat(steward.getRoles(), contains(IamRole.STEWARD.toString()));
       assertThat(steward.getMemberEmails(), contains(userEmail));
 
-      AccessPolicyMembershipV2 reader = req.getPolicies().get(IamRole.READER.toString());
+      AccessPolicyMembershipRequest reader = req.getPolicies().get(IamRole.READER.toString());
       assertThat(reader.getRoles(), contains(IamRole.READER.toString()));
       assertThat(reader.getMemberEmails(), empty());
 
-      AccessPolicyMembershipV2 discoverer = req.getPolicies().get(IamRole.DISCOVERER.toString());
+      AccessPolicyMembershipRequest discoverer =
+          req.getPolicies().get(IamRole.DISCOVERER.toString());
       assertThat(discoverer.getRoles(), contains(IamRole.DISCOVERER.toString()));
       assertThat(discoverer.getMemberEmails(), empty());
     }
@@ -282,19 +284,19 @@ public class SamIamTest {
         policyKeys,
         containsInAnyOrder(IamRole.ADMIN, IamRole.STEWARD, IamRole.READER, IamRole.DISCOVERER));
 
-    AccessPolicyMembershipV2 admin = req.getPolicies().get(IamRole.ADMIN.toString());
+    AccessPolicyMembershipRequest admin = req.getPolicies().get(IamRole.ADMIN.toString());
     assertThat(admin.getRoles(), contains(IamRole.ADMIN.toString()));
     assertThat(admin.getMemberEmails(), contains(ADMIN_EMAIL));
 
-    AccessPolicyMembershipV2 steward = req.getPolicies().get(IamRole.STEWARD.toString());
+    AccessPolicyMembershipRequest steward = req.getPolicies().get(IamRole.STEWARD.toString());
     assertThat(steward.getRoles(), contains(IamRole.STEWARD.toString()));
     assertThat(steward.getMemberEmails(), contains(userEmail, stewardEmail1, stewardEmail2));
 
-    AccessPolicyMembershipV2 reader = req.getPolicies().get(IamRole.READER.toString());
+    AccessPolicyMembershipRequest reader = req.getPolicies().get(IamRole.READER.toString());
     assertThat(reader.getRoles(), contains(IamRole.READER.toString()));
     assertThat(reader.getMemberEmails(), contains(readerEmail));
 
-    AccessPolicyMembershipV2 discoverer = req.getPolicies().get(IamRole.DISCOVERER.toString());
+    AccessPolicyMembershipRequest discoverer = req.getPolicies().get(IamRole.DISCOVERER.toString());
     assertThat(discoverer.getRoles(), contains(IamRole.DISCOVERER.toString()));
     assertThat(discoverer.getMemberEmails(), contains(discovererEmail));
   }
@@ -323,19 +325,19 @@ public class SamIamTest {
           containsInAnyOrder(
               IamRole.ADMIN, IamRole.STEWARD, IamRole.CUSTODIAN, IamRole.SNAPSHOT_CREATOR));
 
-      AccessPolicyMembershipV2 admin = req.getPolicies().get(IamRole.ADMIN.toString());
+      AccessPolicyMembershipRequest admin = req.getPolicies().get(IamRole.ADMIN.toString());
       assertThat(admin.getRoles(), contains(IamRole.ADMIN.toString()));
       assertThat(admin.getMemberEmails(), contains(ADMIN_EMAIL));
 
-      AccessPolicyMembershipV2 steward = req.getPolicies().get(IamRole.STEWARD.toString());
+      AccessPolicyMembershipRequest steward = req.getPolicies().get(IamRole.STEWARD.toString());
       assertThat(steward.getRoles(), contains(IamRole.STEWARD.toString()));
       assertThat(steward.getMemberEmails(), contains(userEmail));
 
-      AccessPolicyMembershipV2 custodian = req.getPolicies().get(IamRole.CUSTODIAN.toString());
+      AccessPolicyMembershipRequest custodian = req.getPolicies().get(IamRole.CUSTODIAN.toString());
       assertThat(custodian.getRoles(), contains(IamRole.CUSTODIAN.toString()));
       assertThat(custodian.getMemberEmails(), empty());
 
-      AccessPolicyMembershipV2 snapshotCreator =
+      AccessPolicyMembershipRequest snapshotCreator =
           req.getPolicies().get(IamRole.SNAPSHOT_CREATOR.toString());
       assertThat(snapshotCreator.getRoles(), contains(IamRole.SNAPSHOT_CREATOR.toString()));
       assertThat(snapshotCreator.getMemberEmails(), empty());
@@ -370,6 +372,7 @@ public class SamIamTest {
             new SignedUrlRequest()
                 .bucketName("bucket")
                 .blobName("path/to/file")
+                .requesterPays(true)
                 .duration(BigDecimal.valueOf(15)));
   }
 
@@ -546,17 +549,17 @@ public class SamIamTest {
       req.setResourceId(profileId.toString());
       req.putPoliciesItem(
           IamRole.ADMIN.toString(),
-          new AccessPolicyMembershipV2()
+          new AccessPolicyMembershipRequest()
               .memberEmails(List.of(samConfig.adminsGroupEmail()))
               .roles(List.of(IamRole.ADMIN.toString())));
       req.putPoliciesItem(
           IamRole.OWNER.toString(),
-          new AccessPolicyMembershipV2()
+          new AccessPolicyMembershipRequest()
               .memberEmails(List.of(userEmail))
               .roles(List.of(IamRole.OWNER.toString())));
       req.putPoliciesItem(
           IamRole.USER.toString(),
-          new AccessPolicyMembershipV2().roles(List.of(IamRole.USER.toString())));
+          new AccessPolicyMembershipRequest().roles(List.of(IamRole.USER.toString())));
       req.authDomain(List.of());
       samIam.createProfileResource(TEST_USER, profileId.toString());
       verify(samResourceApi).createResourceV2(IamResourceType.SPEND_PROFILE.toString(), req);


### PR DESCRIPTION
Note: we only use the Sam url signing API in the case where we are getting a signed URL from a requester pays bucket-backed Terra workspace

This fixes a bug where we were calling the Sam `Google/getSignedUrlForBlob` API and getting back a signed URL that didn't include the userProject Url parameter

Note: upgrading the client removed a class so a lot of the changes class name changes