### PR TITLE
DR-3175 When ingesting, select TOP N rows in Synapse

### DIFF
--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -89,6 +89,7 @@ public class AzureSynapsePdao {
   private static final String DEFAULT_CSV_QUOTE = "\"";
   private static final String EMPTY_TABLE_ERROR_MESSAGE =
       "Unable to query the parquet file for this table. This is most likely because the table is empty.  See exception details if this does not appear to be the case.";
+  private static final String MAX_BIG_INT = "9223372036854770000";
 
   private static final String DB_CREATION_TEMPLATE =
       """
@@ -245,6 +246,8 @@ public class AzureSynapsePdao {
               DATA_SOURCE = [<destinationDataSourceName>],
               FILE_FORMAT = [<fileFormat>]
           ) AS SELECT
+          /* TOP forces synapse not to over-scatter writes by forcing a table scan  on the source */
+          TOP <maxBigInt>
           <if(isCSV)>newid() as datarepo_row_id,
           <columns:{c|[<c.name>]}; separator=",">
           <else>
@@ -541,6 +544,7 @@ public class AzureSynapsePdao {
       sqlCreateTableTemplate.add(
           "csvQuote", Objects.requireNonNullElse(csvStringDelimiter, DEFAULT_CSV_QUOTE));
     }
+    sqlCreateTableTemplate.add("maxBigInt", MAX_BIG_INT);
     sqlCreateTableTemplate.add("tableName", scratchTableName);
     sqlCreateTableTemplate.add("destinationParquetFile", scratchParquetFile);
     sqlCreateTableTemplate.add("destinationDataSourceName", scratchDataSourceName);


### PR DESCRIPTION
This PR should improve ingest performance into Azure tables that have larger tabular data.

This appears to force Synapse to not write literally 20 different parquet files into scratch and funnels the writes into a single file.

Tangibly, I saw this make a synthetic ingest of 1M rows go from taking infinity time (e.g. it timed out after 30 minutes) to roughly 30-40 seconds

This might not fix DR-3175 but it certainly makes it easier to test