### PR TITLE
[DR-3203] Use at least jna v5.8.0 for compatibility with M1/M2 hardware

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,8 +217,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'javax.servlet:jstl:1.2'
 
-    implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.10.0'
-    implementation 'org.elasticsearch:elasticsearch:7.10.0'
+    implementation('org.elasticsearch.client:elasticsearch-rest-high-level-client:7.10.0')
 
     implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '9.2.1.jre11'
 

--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'javax.servlet:jstl:1.2'
 
-    implementation('org.elasticsearch.client:elasticsearch-rest-high-level-client:7.10.0')
+    implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.10.0'
 
     implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '9.2.1.jre11'
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3203

Remove pinned org.elasticsearch.elasticsearch:7.10.0, which was using an older version of jna (via org.elasticsearch.jna). Other libraries depend on jna as well, but gradle automatically resolves the different versions by using the latest (v5.13.0)