### PR TITLE
[DR-2849] Return the DUOS base URI in the config endpoint

### DIFF
--- a/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
+++ b/src/main/java/bio/terra/app/controller/UnauthenticatedApiController.java
@@ -1,5 +1,6 @@
 package bio.terra.app.controller;
 
+import bio.terra.app.configuration.DuosConfiguration;
 import bio.terra.app.configuration.OauthConfiguration;
 import bio.terra.app.configuration.OpenIDConnectConfiguration;
 import bio.terra.app.configuration.SamConfiguration;
@@ -36,6 +37,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
   private final StatusService statusService;
   private final SamConfiguration samConfiguration;
   private final TerraConfiguration terraConfiguration;
+  private final DuosConfiguration duosConfiguration;
 
   private static final String DEFAULT_SEMVER = "1.0.0-UNKNOWN";
   private static final String DEFAULT_GITHASH = "00000000";
@@ -50,7 +52,8 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
       Environment env,
       StatusService statusService,
       TerraConfiguration terraConfiguration,
-      SamConfiguration samConfiguration) {
+      SamConfiguration samConfiguration,
+      DuosConfiguration duosConfiguration) {
     this.oauthConfig = oauthConfig;
     this.openIDConnectConfiguration = openIDConnectConfiguration;
     this.jobService = jobService;
@@ -58,6 +61,7 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
     this.statusService = statusService;
     this.terraConfiguration = terraConfiguration;
     this.samConfiguration = samConfiguration;
+    this.duosConfiguration = duosConfiguration;
 
     Properties properties = new Properties();
     try (InputStream versionFile =
@@ -88,7 +92,8 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
             .gitHash(gitHash)
             .terraUrl(terraConfiguration.basePath())
             .samUrl(samConfiguration.basePath())
-            .authorityEndpoint(openIDConnectConfiguration.getAuthorityEndpoint());
+            .authorityEndpoint(openIDConnectConfiguration.getAuthorityEndpoint())
+            .duosUrl(duosConfiguration.basePath());
 
     return new ResponseEntity<>(configurationModel, HttpStatus.OK);
   }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -6095,11 +6095,15 @@ components:
         samUrl:
           type: string
           format: uri
-          description: the URI of SAM this instance uses
+          description: the URI of Sam this instance uses
         authorityEndpoint:
           type: string
           format: uri
           description: the URI of oauth authority for the UI to use (e.g. .well-known/openid-configuration gets appended to it)
+        duosUrl:
+          type: string
+          format: uri
+          description: the URI of DUOS this instance uses
     DrsAliasModel:
       type: object
       properties:

--- a/src/test/java/bio/terra/app/controller/UnauthenticatedApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/UnauthenticatedApiControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.app.configuration.DuosConfiguration;
 import bio.terra.app.configuration.OauthConfiguration;
 import bio.terra.app.configuration.OpenIDConnectConfiguration;
 import bio.terra.app.configuration.SamConfiguration;
@@ -34,6 +35,7 @@ public class UnauthenticatedApiControllerTest {
   @MockBean private StatusService statusService;
   @MockBean private TerraConfiguration terraConfiguration;
   @MockBean private SamConfiguration samConfiguration;
+  @MockBean private DuosConfiguration duosConfiguration;
 
   private void mockGetStatus(boolean ok) {
     when(statusService.getStatus()).thenReturn(new RepositoryStatusModel().ok(ok));
@@ -58,12 +60,14 @@ public class UnauthenticatedApiControllerTest {
     String terraUrl = "terra.base.url";
     String samUrl = "sam.base.url";
     String oidcAuthorityEndpoint = "/oidc/authority/endpoint";
+    String duosUrl = "duos.base.url";
 
     when(oauthConfig.clientId()).thenReturn(oauthClientId);
     when(openIDConnectConfiguration.getClientId()).thenReturn(oidcClientId);
     when(terraConfiguration.basePath()).thenReturn(terraUrl);
     when(samConfiguration.basePath()).thenReturn(samUrl);
     when(openIDConnectConfiguration.getAuthorityEndpoint()).thenReturn(oidcAuthorityEndpoint);
+    when(duosConfiguration.basePath()).thenReturn(duosUrl);
 
     mvc.perform(get("/configuration"))
         .andExpect(status().isOk())
@@ -71,6 +75,7 @@ public class UnauthenticatedApiControllerTest {
         .andExpect(jsonPath("$.oidcClientId").value(oidcClientId))
         .andExpect(jsonPath("$.terraUrl").value(terraUrl))
         .andExpect(jsonPath("$.samUrl").value(samUrl))
-        .andExpect(jsonPath("$.authorityEndpoint").value(oidcAuthorityEndpoint));
+        .andExpect(jsonPath("$.authorityEndpoint").value(oidcAuthorityEndpoint))
+        .andExpect(jsonPath("$.duosUrl").value(duosUrl));
   }
 }


### PR DESCRIPTION
We're going to need this for the UI to know where to send DUOS requests.  This just returns the value that is set in the appropriate environment when calling the `GET /configuration` endpoint.

The response will look something like:
```
{
  "clientId": "oauthid",
  "oidcClientId": "oauthid",
  "activeProfiles": [
    "google",
    "azure",
    "local",
    "human-readable-logging"
  ],
  "semVer": "1.522.0-SNAPSHOT",
  "gitHash": "1eba6215",
  "terraUrl": "https://bvdp-saturn-dev.appspot.com",
  "samUrl": "https://sam.dsde-dev.broadinstitute.org",
  "authorityEndpoint": "https://accounts.google.com/",
  "duosUrl": "https://consent.dsde-dev.broadinstitute.org"
}
```
