### PR TITLE
[DC-754] Add snapshot_builder_settings table and logic

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -35,6 +35,7 @@ import bio.terra.model.PolicyMemberRequest;
 import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
 import bio.terra.model.SamPolicyModel;
+import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.model.SqlSortDirection;
 import bio.terra.model.TagCountResultModel;
 import bio.terra.model.TagUpdateRequestModel;
@@ -54,6 +55,7 @@ import bio.terra.service.dataset.IngestRequestValidator;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.job.JobService;
 import bio.terra.service.job.exception.InvalidJobParameterException;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import io.swagger.annotations.Api;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -84,11 +86,11 @@ public class DatasetsApiController implements DatasetsApi {
   private final DatasetService datasetService;
   private final IamService iamService;
   private final FileService fileService;
+  private final SnapshotBuilderService snapshotBuilderService;
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final AssetModelValidator assetModelValidator;
   private final IngestRequestValidator ingestRequestValidator;
   private final DataDeletionRequestValidator dataDeletionRequestValidator;
-
   private final DatasetSchemaUpdateValidator datasetSchemaUpdateValidator;
 
   @Autowired
@@ -99,6 +101,7 @@ public class DatasetsApiController implements DatasetsApi {
       DatasetService datasetService,
       IamService iamService,
       FileService fileService,
+      SnapshotBuilderService snapshotBuilderService,
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
       AssetModelValidator assetModelValidator,
       IngestRequestValidator ingestRequestValidator,
@@ -110,6 +113,7 @@ public class DatasetsApiController implements DatasetsApi {
     this.datasetService = datasetService;
     this.iamService = iamService;
     this.fileService = fileService;
+    this.snapshotBuilderService = snapshotBuilderService;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
     this.assetModelValidator = assetModelValidator;
     this.ingestRequestValidator = ingestRequestValidator;
@@ -162,6 +166,21 @@ public class DatasetsApiController implements DatasetsApi {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     iamService.verifyAuthorization(userRequest, IamResourceType.DATASET, id.toString());
     return ResponseEntity.ok(datasetService.retrieveDatasetSummary(id));
+  }
+
+  @Override
+  public ResponseEntity<DatasetModel> updateDatasetSnapshotBuilderSettings(
+      UUID id, SnapshotBuilderSettings settings) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    iamService.verifyAuthorization(
+        userRequest,
+        IamResourceType.DATASET,
+        id.toString(),
+        IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS);
+    snapshotBuilderService.updateSnapshotBuilderSettings(id, settings);
+    return ResponseEntity.ok(
+        datasetService.retrieveDatasetModel(
+            id, userRequest, List.of(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_SETTINGS)));
   }
 
   @Override

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -170,7 +170,7 @@ public class DatasetsApiController implements DatasetsApi {
 
   @Override
   public ResponseEntity<DatasetModel> updateDatasetSnapshotBuilderSettings(
-      UUID id, SnapshotBuilderSettings settings) {
+      @PathVariable("id") UUID id, @Valid @RequestBody SnapshotBuilderSettings settings) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     iamService.verifyAuthorization(
         userRequest,

--- a/src/main/java/bio/terra/service/auth/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamAction.java
@@ -39,7 +39,8 @@ public enum IamAction {
   LINK,
   // journal
   VIEW_JOURNAL,
-  VIEW_SNAPSHOT_BUILDER_SETTINGS;
+  VIEW_SNAPSHOT_BUILDER_SETTINGS,
+  UPDATE_SNAPSHOT_BUILDER_SETTINGS;
 
   private final String samActionName;
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -1,136 +1,23 @@
 package bio.terra.service.snapshotbuilder;
 
-import bio.terra.model.SnapshotBuilderConcept;
-import bio.terra.model.SnapshotBuilderDatasetConceptSets;
-import bio.terra.model.SnapshotBuilderDomainOption;
-import bio.terra.model.SnapshotBuilderFeatureValueGroup;
-import bio.terra.model.SnapshotBuilderListOption;
-import bio.terra.model.SnapshotBuilderProgramDataOption;
 import bio.terra.model.SnapshotBuilderSettings;
-import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SnapshotBuilderService {
+  private final SnapshotBuilderSettingsDao snapshotBuilderSettingsDao;
 
-  public SnapshotBuilderService() {}
-  /**
-   * Fetch the snapshot builder settings for a given dataset Currently just returns dummy data for
-   * the sake of parallelizing UI and API development Will eventually be adapted to read from the DB
-   *
-   * @param datasetId in UUID format
-   * @return a SnapshotBuilderSettings = API output-friendly representation of the Dataset's
-   *     snapshot builder settings
-   */
+  public SnapshotBuilderService(SnapshotBuilderSettingsDao snapshotBuilderSettingsDao) {
+    this.snapshotBuilderSettingsDao = snapshotBuilderSettingsDao;
+  }
+
   public SnapshotBuilderSettings getSnapshotBuilderSettings(UUID datasetId) {
-    return new SnapshotBuilderSettings()
-        .domainOptions(
-            List.of(
-                new SnapshotBuilderDomainOption()
-                    .id(10)
-                    .category("Condition")
-                    .conceptCount(18000)
-                    .participantCount(12500)
-                    .root(
-                        new SnapshotBuilderConcept()
-                            .id(100)
-                            .name("Condition")
-                            .count(100)
-                            .hasChildren(true)),
-                new SnapshotBuilderDomainOption()
-                    .id(11)
-                    .category("Procedure")
-                    .conceptCount(22500)
-                    .participantCount(11328)
-                    .root(
-                        new SnapshotBuilderConcept()
-                            .id(200)
-                            .name("Procedure")
-                            .count(100)
-                            .hasChildren(true)),
-                new SnapshotBuilderDomainOption()
-                    .id(12)
-                    .category("Observation")
-                    .conceptCount(12300)
-                    .participantCount(23223)
-                    .root(
-                        new SnapshotBuilderConcept()
-                            .id(300)
-                            .name("Observation")
-                            .count(100)
-                            .hasChildren(true))))
-        .programDataOptions(
-            List.of(
-                new SnapshotBuilderProgramDataOption()
-                    .id(1)
-                    .name("Year of birth")
-                    .kind(SnapshotBuilderProgramDataOption.KindEnum.RANGE)
-                    .min(1900)
-                    .max(2023),
-                new SnapshotBuilderProgramDataOption()
-                    .id(2)
-                    .name("Ethnicity")
-                    .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
-                    .values(
-                        List.of(
-                            new SnapshotBuilderListOption().name("Hispanic or Latino").id(20),
-                            new SnapshotBuilderListOption().name("Not Hispanic or Latino").id(21),
-                            new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
-                new SnapshotBuilderProgramDataOption()
-                    .id(3)
-                    .name("Gender identity")
-                    .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
-                    .values(
-                        List.of(
-                            new SnapshotBuilderListOption().name("FEMALE").id(22),
-                            new SnapshotBuilderListOption().name("MALE").id(23),
-                            new SnapshotBuilderListOption().name("NON BINARY").id(24),
-                            new SnapshotBuilderListOption().name("GENDERQUEER").id(25),
-                            new SnapshotBuilderListOption().name("TWO SPIRIT").id(26),
-                            new SnapshotBuilderListOption().name("AGENDER").id(27),
-                            new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
-                new SnapshotBuilderProgramDataOption()
-                    .id(4)
-                    .name("Race")
-                    .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
-                    .values(
-                        List.of(
-                            new SnapshotBuilderListOption()
-                                .name("American Indian or Alaska Native")
-                                .id(28),
-                            new SnapshotBuilderListOption().name("Asian").id(29),
-                            new SnapshotBuilderListOption().name("Black").id(30),
-                            new SnapshotBuilderListOption().name("White").id(31)))))
-        .featureValueGroups(
-            List.of(
-                new SnapshotBuilderFeatureValueGroup()
-                    .id(0)
-                    .name("Condition")
-                    .values(List.of("Condition Column 1", "Condition Column 2")),
-                new SnapshotBuilderFeatureValueGroup()
-                    .id(1)
-                    .name("Observation")
-                    .values(List.of("Observation Column 1", "Observation Column 2")),
-                new SnapshotBuilderFeatureValueGroup()
-                    .id(2)
-                    .name("Procedure")
-                    .values(List.of("Procedure Column 1", "Procedure Column 2")),
-                new SnapshotBuilderFeatureValueGroup()
-                    .id(3)
-                    .name("Surveys")
-                    .values(List.of("Surveys Column 1", "Surveys Column 2")),
-                new SnapshotBuilderFeatureValueGroup()
-                    .id(4)
-                    .name("Person")
-                    .values(List.of("Demographics Column 1", "Demographics Column 2"))))
-        .datasetConceptSets(
-            List.of(
-                new SnapshotBuilderDatasetConceptSets()
-                    .name("Demographics")
-                    .featureValueGroupName("Person"),
-                new SnapshotBuilderDatasetConceptSets()
-                    .name("All surveys")
-                    .featureValueGroupName("Surveys")));
+    return snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(datasetId);
+  }
+
+  public SnapshotBuilderSettings updateSnapshotBuilderSettings(
+      UUID id, SnapshotBuilderSettings settings) {
+    return snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(id, settings);
   }
 }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SnapshotBuilderSettingsDao {
   private final NamedParameterJdbcTemplate jdbcTemplate;
   private static final ObjectMapper objectMapper = new ObjectMapper();
-  private final String datasetIdField = "dataset_id";
+  private static final String datasetIdField = "dataset_id";
 
   private static final RowMapper<SnapshotBuilderSettings> MAPPER =
       (rs, rowNum) -> {

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
@@ -1,0 +1,75 @@
+package bio.terra.service.snapshotbuilder;
+
+import bio.terra.model.SnapshotBuilderSettings;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ServerErrorException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class SnapshotBuilderSettingsDao {
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private static ObjectMapper objectMapper = new ObjectMapper();
+
+  private static class SnapshotBuilderSettingsMapper implements RowMapper<SnapshotBuilderSettings> {
+
+    public SnapshotBuilderSettings mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+      try {
+        return objectMapper.readValue(rs.getString("settings"), SnapshotBuilderSettings.class);
+      } catch (JsonProcessingException e) {
+        throw new ServerErrorException("Settings not stored as properly formatted json", 500, e);
+      }
+    }
+  }
+
+  @Autowired
+  public SnapshotBuilderSettingsDao(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
+  public SnapshotBuilderSettings getSnapshotBuilderSettingsByDatasetId(UUID id) {
+    try {
+
+      return jdbcTemplate.queryForObject(
+          "SELECT settings FROM snapshot_builder_settings WHERE dataset_id = :id",
+          new MapSqlParameterSource().addValue("id", id),
+          new SnapshotBuilderSettingsMapper());
+    } catch (EmptyResultDataAccessException ex) {
+      throw new NotFoundException("No snapshot builder settings found for dataset", ex);
+    }
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public SnapshotBuilderSettings upsertSnapshotBuilderSettingsByDataset(
+      UUID id, SnapshotBuilderSettings settings) {
+    Gson gson = new Gson();
+    MapSqlParameterSource mapSqlParameterSource =
+        new MapSqlParameterSource().addValue("id", id).addValue("settings", gson.toJson(settings));
+    try {
+      getSnapshotBuilderSettingsByDatasetId(id);
+      jdbcTemplate.update(
+          "UPDATE snapshot_builder_settings SET settings = :settings WHERE dataset_id = :id",
+          mapSqlParameterSource);
+    } catch (NotFoundException ex) {
+      jdbcTemplate.update(
+          "INSERT INTO snapshot_builder_settings (dataset_id, settings) VALUES (:id, :settings)",
+          mapSqlParameterSource);
+    }
+    return getSnapshotBuilderSettingsByDatasetId(id);
+  }
+}

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
@@ -65,9 +65,7 @@ public class SnapshotBuilderSettingsDao {
             + " VALUES (:dataset_id, cast(:settings as jsonb))"
             + " ON CONFLICT ON CONSTRAINT snapshot_builder_settings_dataset_id_key"
             + " DO UPDATE SET settings = cast(:settings as jsonb)",
-        Map.of(
-            datasetIdField, datasetId,
-            "settings", jsonValue));
+        Map.of(datasetIdField, datasetId, "settings", jsonValue));
     return getSnapshotBuilderSettingsByDatasetId(datasetId);
   }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SnapshotBuilderSettingsDao {
   private final NamedParameterJdbcTemplate jdbcTemplate;
   private static final ObjectMapper objectMapper = new ObjectMapper();
+  private final String datasetIdField = "dataset_id";
 
   private static final RowMapper<SnapshotBuilderSettings> MAPPER =
       (rs, rowNum) -> {
@@ -43,7 +44,7 @@ public class SnapshotBuilderSettingsDao {
 
       return jdbcTemplate.queryForObject(
           "SELECT settings FROM snapshot_builder_settings WHERE dataset_id = :dataset_id",
-          Map.of("dataset_id", datasetId),
+          Map.of(datasetIdField, datasetId),
           MAPPER);
     } catch (EmptyResultDataAccessException ex) {
       throw new NotFoundException("No snapshot builder settings found for dataset", ex);
@@ -65,7 +66,7 @@ public class SnapshotBuilderSettingsDao {
             + " ON CONFLICT ON CONSTRAINT snapshot_builder_settings_dataset_id_key"
             + " DO UPDATE SET settings = cast(:settings as jsonb)",
         Map.of(
-            "dataset_id", datasetId,
+            datasetIdField, datasetId,
             "settings", jsonValue));
     return getSnapshotBuilderSettingsByDatasetId(datasetId);
   }
@@ -75,7 +76,7 @@ public class SnapshotBuilderSettingsDao {
     try {
       jdbcTemplate.update(
           "DELETE FROM snapshot_builder_settings WHERE dataset_id = :dataset_id",
-          Map.of("dataset_id", datasetId));
+          Map.of(datasetIdField, datasetId));
     } catch (EmptyResultDataAccessException ex) {
       throw new NotFoundException("No snapshot builder settings found for dataset", ex);
     }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDao.java
@@ -67,16 +67,9 @@ public class SnapshotBuilderSettingsDao {
         new MapSqlParameterSource()
             .addValue("dataset_id", datasetId)
             .addValue("settings", jsonValue);
-    try {
-      getSnapshotBuilderSettingsByDatasetId(datasetId);
-      jdbcTemplate.update(
-          "UPDATE snapshot_builder_settings SET settings = cast(:settings as jsonb) WHERE dataset_id = :dataset_id",
-          mapSqlParameterSource);
-    } catch (NotFoundException ex) {
-      jdbcTemplate.update(
-          "INSERT INTO snapshot_builder_settings (dataset_id, settings) VALUES (:dataset_id, cast(:settings as jsonb))",
-          mapSqlParameterSource);
-    }
+    jdbcTemplate.update(
+        "INSERT INTO snapshot_builder_settings (dataset_id, settings) VALUES (:dataset_id, cast(:settings as jsonb)) ON CONFLICT ON CONSTRAINT snapshot_builder_settings_dataset_id_key DO UPDATE SET settings = cast(:settings as jsonb)",
+        mapSqlParameterSource);
     return getSnapshotBuilderSettingsByDatasetId(datasetId);
   }
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4066,6 +4066,70 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+  ##############################################################################
+  ## SNAPSHOT BUILDER API ENDPOINTS
+  ## ⚠️ NOTE: ALL SNAPSHOT APIS ARE SUBJECT TO CHANGE
+  ##############################################################################
+  /api/repository/v1/datasets/{id}/snapshot-builder/settings:
+    post:
+      tags:
+        - datasets
+        - repository
+      description: >
+        Updates the settings for using the dataset in the snapshot builder.
+      operationId: updateDatasetSnapshotBuilderSettings
+      parameters:
+        - in: path
+          description: The UUID of the dataset.
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: New settings for the dataset to use for snapshot building
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SnapshotBuilderSettings'
+        required: true
+      responses:
+        200:
+          description: The updated Dataset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetModel'
+        400:
+          description: Bad request - invalid id, badly formed IamResourceType.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        401:
+          description: Unauthorized - dataset does not exist or missing permissions to view.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: Unauthorized - missing permissions to update snapshot builder settings.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: No dataset found that meets the request parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
 components:
   schemas:
     TableDataType:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4070,7 +4070,7 @@ paths:
   ## SNAPSHOT BUILDER API ENDPOINTS
   ## ⚠️ NOTE: ALL SNAPSHOT APIS ARE SUBJECT TO CHANGE
   ##############################################################################
-  /api/repository/v1/datasets/{id}/snapshot-builder/settings:
+  /api/repository/v1/datasets/{id}/snapshotBuilder/settings:
     post:
       tags:
         - datasets

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -75,4 +75,5 @@
     <include file="changesets/20230314_datasettags.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20230314_snapshottags.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20230519_drsalias.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20230906_snapshotbuildersettings.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20230906_snapshotbuildersettings.yaml
+++ b/src/main/resources/db/changesets/20230906_snapshotbuildersettings.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: snapshot_builder_settings
+      author: srubenstein
+      changes:
+        - createTable:
+            tableName: snapshot_builder_settings
+            columns:
+              - column:
+                  name: id
+                  type: ${uuid_type}
+                  defaultValueComputed: ${uuid_function}
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: dataset_id
+                  type: ${uuid_type}
+                  constraints:
+                    nullable: false
+                    unique: true
+                    foreignKeyName: fk_dataset_snapshot_builder_settings
+                    references: dataset(id)
+                    deleteCascade: true
+              - column:
+                  name: settings
+                  type: jsonb
+                  constraints:
+                    nullable: false

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -33,6 +33,7 @@ import bio.terra.service.dataset.IngestRequestValidator;
 import bio.terra.service.dataset.exception.DatasetDataException;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.job.JobService;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,6 +64,7 @@ public class DatasetsApiControllerTest {
   @MockBean private IngestRequestValidator ingestRequestValidator;
   @MockBean private DataDeletionRequestValidator dataDeletionRequestValidator;
   @MockBean private DatasetSchemaUpdateValidator datasetSchemaUpdateValidator;
+  @MockBean private SnapshotBuilderService snapshotBuilderService;
 
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -37,7 +37,6 @@ import bio.terra.service.filedata.FileService;
 import bio.terra.service.job.JobService;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -77,7 +76,7 @@ public class DatasetsApiControllerTest {
       DatasetRequestAccessIncludeModel.NONE;
   private static final String GET_PREVIEW_ENDPOINT = RETRIEVE_DATASET_ENDPOINT + "/data/{table}";
   private static final String GET_SNAPSHOT_BUILDER_SETTINGS_ENDPOINT =
-      RETRIEVE_DATASET_ENDPOINT + "/snapshot-builder/settings";
+      RETRIEVE_DATASET_ENDPOINT + "/snapshotBuilder/settings";
   private static final SqlSortDirection DIRECTION = SqlSortDirection.ASC;
   private static final UUID DATASET_ID = UUID.randomUUID();
   private static final int LIMIT = 10;
@@ -198,6 +197,11 @@ public class DatasetsApiControllerTest {
     when(snapshotBuilderService.updateSnapshotBuilderSettings(
             DATASET_ID, SAMPLE_SNAPSHOT_BUILDER_SETTINGS))
         .thenReturn(SAMPLE_SNAPSHOT_BUILDER_SETTINGS);
+    when(ingestRequestValidator.supports(any())).thenReturn(true);
+    when(datasetRequestValidator.supports(any())).thenReturn(true);
+    when(assetModelValidator.supports(any())).thenReturn(true);
+    when(dataDeletionRequestValidator.supports(any())).thenReturn(true);
+    when(datasetSchemaUpdateValidator.supports(any())).thenReturn(true);
 
     mvc.perform(
             post(GET_SNAPSHOT_BUILDER_SETTINGS_ENDPOINT, DATASET_ID)

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -1,6 +1,6 @@
 package bio.terra.app.controller;
 
-import static bio.terra.service.snapshotbuilder.SnapshotBuilderTestData.SAMPLE_SNAPSHOT_BUILDER_SETTINGS;
+import static bio.terra.service.snapshotbuilder.SnapshotBuilderTestData.SETTINGS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -194,9 +194,8 @@ public class DatasetsApiControllerTest {
             TEST_USER,
             List.of(DatasetRequestAccessIncludeModel.SNAPSHOT_BUILDER_SETTINGS)))
         .thenReturn(new DatasetModel());
-    when(snapshotBuilderService.updateSnapshotBuilderSettings(
-            DATASET_ID, SAMPLE_SNAPSHOT_BUILDER_SETTINGS))
-        .thenReturn(SAMPLE_SNAPSHOT_BUILDER_SETTINGS);
+    when(snapshotBuilderService.updateSnapshotBuilderSettings(DATASET_ID, SETTINGS))
+        .thenReturn(SETTINGS);
     when(ingestRequestValidator.supports(any())).thenReturn(true);
     when(datasetRequestValidator.supports(any())).thenReturn(true);
     when(assetModelValidator.supports(any())).thenReturn(true);
@@ -206,13 +205,12 @@ public class DatasetsApiControllerTest {
     mvc.perform(
             post(GET_SNAPSHOT_BUILDER_SETTINGS_ENDPOINT, DATASET_ID)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(TestUtils.mapToJson(SAMPLE_SNAPSHOT_BUILDER_SETTINGS)))
+                .content(TestUtils.mapToJson(SETTINGS)))
         .andExpect(status().is2xxSuccessful())
         .andReturn();
 
     verifyAuthorizationCall(IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS);
-    verify(snapshotBuilderService)
-        .updateSnapshotBuilderSettings(DATASET_ID, SAMPLE_SNAPSHOT_BUILDER_SETTINGS);
+    verify(snapshotBuilderService).updateSnapshotBuilderSettings(DATASET_ID, SETTINGS);
   }
 
   /** Mock so that the user does not hold `iamAction` on the dataset. */

--- a/src/test/java/bio/terra/service/filedata/DrsDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsDaoTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.Assert.assertNull;
 
 import bio.terra.common.EmbeddedDatabaseTest;
+import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.service.filedata.DrsDao.DrsAlias;
@@ -23,7 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "unittest"})
-@Tag("bio.terra.common.category.Unit")
+@Tag(Unit.TAG)
 @EmbeddedDatabaseTest
 class DrsDaoTest {
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
@@ -119,22 +119,20 @@ public class SnapshotBuilderSettingsDaoTest {
 
   @Test
   public void upsertSnapshotBuilderSettingsUpdatesWhenExisting() {
-    snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
-        dataset.getId(), new SnapshotBuilderSettings());
     assertThat(
         "Snapshot builder settings should be the new upserted value",
-        snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(dataset.getId()),
+        snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
+            dataset.getId(), new SnapshotBuilderSettings()),
         equalTo(new SnapshotBuilderSettings()));
   }
 
   @Test
   public void upsertSnapshotBuilderSettingsCreatesWhenNotExisting() {
     snapshotBuilderSettingsDao.delete(dataset.getId());
-    snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
-        dataset.getId(), SAMPLE_SNAPSHOT_BUILDER_SETTINGS);
     assertThat(
         "Snapshot builder settings should be the same as the example",
-        snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(dataset.getId()),
+        snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
+            dataset.getId(), SAMPLE_SNAPSHOT_BUILDER_SETTINGS),
         equalTo(SAMPLE_SNAPSHOT_BUILDER_SETTINGS));
   }
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
@@ -1,0 +1,250 @@
+package bio.terra.service.snapshotbuilder;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import bio.terra.common.EmbeddedDatabaseTest;
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.DaoOperations;
+import bio.terra.common.fixtures.ProfileFixtures;
+import bio.terra.common.fixtures.ResourceFixtures;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.BillingProfileRequestModel;
+import bio.terra.model.SnapshotBuilderConcept;
+import bio.terra.model.SnapshotBuilderDatasetConceptSets;
+import bio.terra.model.SnapshotBuilderDomainOption;
+import bio.terra.model.SnapshotBuilderFeatureValueGroup;
+import bio.terra.model.SnapshotBuilderListOption;
+import bio.terra.model.SnapshotBuilderProgramDataOption;
+import bio.terra.model.SnapshotBuilderSettings;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetBucketDaoTest;
+import bio.terra.service.dataset.DatasetDao;
+import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import javax.ws.rs.NotFoundException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+@EmbeddedDatabaseTest
+public class SnapshotBuilderSettingsDaoTest {
+  private static final Logger logger = LoggerFactory.getLogger(DatasetBucketDaoTest.class);
+
+  @Autowired private DaoOperations daoOperations;
+  @Autowired private ProfileDao profileDao;
+  @Autowired private GoogleResourceDao resourceDao;
+  @Autowired private DatasetDao datasetDao;
+  @Autowired private SnapshotBuilderSettingsDao snapshotBuilderSettingsDao;
+
+  private BillingProfileModel billingProfile;
+  private GoogleProjectResource projectResource;
+  private Dataset dataset;
+  private SnapshotBuilderSettings snapshotBuilderSettings;
+
+  @Before
+  public void setup() throws IOException {
+    BillingProfileRequestModel profileRequest = ProfileFixtures.randomBillingProfileRequest();
+    billingProfile = profileDao.createBillingProfile(profileRequest, "testUser");
+
+    projectResource = ResourceFixtures.randomProjectResource(billingProfile);
+    UUID projectId = resourceDao.createProject(projectResource);
+    projectResource.id(projectId);
+
+    dataset = daoOperations.createMinimalDataset(billingProfile.getId(), projectId);
+    snapshotBuilderSettings =
+        snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
+            dataset.getId(), SAMPLE_SNAPSHOT_BUILDER_SETTINGS);
+  }
+
+  @After
+  public void teardown() {
+    try {
+      snapshotBuilderSettingsDao.delete(dataset.getId());
+    } catch (Exception ex) {
+      logger.error(
+          "[CLEANUP] Unable to delete snapshot builder settings for dataset {}", dataset.getId());
+    }
+    try {
+      datasetDao.delete(dataset.getId());
+    } catch (Exception ex) {
+      logger.error("[CLEANUP] Unable to delete dataset {}", dataset.getId());
+    }
+    try {
+      resourceDao.deleteProject(projectResource.getId());
+    } catch (Exception ex) {
+      logger.error(
+          "[CLEANUP] Unable to delete entry in database for projects {}", projectResource.getId());
+    }
+    try {
+      profileDao.deleteBillingProfileById(billingProfile.getId());
+    } catch (Exception ex) {
+      logger.error("[CLEANUP] Unable to billing profile {}", billingProfile.getId());
+    }
+  }
+
+  @Test
+  public void getSnapshotBuilderSettingsReturnsSettings() {
+    assertThat(
+        "Snapshot builder settings should be the same as the example",
+        snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(dataset.getId()),
+        equalTo(SAMPLE_SNAPSHOT_BUILDER_SETTINGS));
+  }
+
+  @Test
+  public void getSnapshotBuilderSettingsForDatasetThatDoesNotExistErrors() {
+    assertThrows(
+        NotFoundException.class,
+        () -> snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(UUID.randomUUID()));
+  }
+
+  @Test
+  public void upsertSnapshotBuilderSettingsUpdatesWhenExisting() {
+    snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
+        dataset.getId(), new SnapshotBuilderSettings());
+    assertThat(
+        "Snapshot builder settings should be the new upserted value",
+        snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(dataset.getId()),
+        equalTo(new SnapshotBuilderSettings()));
+  }
+
+  @Test
+  public void upsertSnapshotBuilderSettingsCreatesWhenNotExisting() {
+    snapshotBuilderSettingsDao.delete(dataset.getId());
+    snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
+        dataset.getId(), SAMPLE_SNAPSHOT_BUILDER_SETTINGS);
+    assertThat(
+        "Snapshot builder settings should be the same as the example",
+        snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(dataset.getId()),
+        equalTo(SAMPLE_SNAPSHOT_BUILDER_SETTINGS));
+  }
+
+  private static final SnapshotBuilderSettings SAMPLE_SNAPSHOT_BUILDER_SETTINGS =
+      new SnapshotBuilderSettings()
+          .domainOptions(
+              List.of(
+                  new SnapshotBuilderDomainOption()
+                      .id(10)
+                      .category("Condition")
+                      .conceptCount(18000)
+                      .participantCount(12500)
+                      .root(
+                          new SnapshotBuilderConcept()
+                              .id(100)
+                              .name("Condition")
+                              .count(100)
+                              .hasChildren(true)),
+                  new SnapshotBuilderDomainOption()
+                      .id(11)
+                      .category("Procedure")
+                      .conceptCount(22500)
+                      .participantCount(11328)
+                      .root(
+                          new SnapshotBuilderConcept()
+                              .id(200)
+                              .name("Procedure")
+                              .count(100)
+                              .hasChildren(true)),
+                  new SnapshotBuilderDomainOption()
+                      .id(12)
+                      .category("Observation")
+                      .conceptCount(12300)
+                      .participantCount(23223)
+                      .root(
+                          new SnapshotBuilderConcept()
+                              .id(300)
+                              .name("Observation")
+                              .count(100)
+                              .hasChildren(true))))
+          .programDataOptions(
+              List.of(
+                  new SnapshotBuilderProgramDataOption()
+                      .id(1)
+                      .name("Year of birth")
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.RANGE)
+                      .min(1900)
+                      .max(2023),
+                  new SnapshotBuilderProgramDataOption()
+                      .id(2)
+                      .name("Ethnicity")
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                      .values(
+                          List.of(
+                              new SnapshotBuilderListOption().name("Hispanic or Latino").id(20),
+                              new SnapshotBuilderListOption().name("Not Hispanic or Latino").id(21),
+                              new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
+                  new SnapshotBuilderProgramDataOption()
+                      .id(3)
+                      .name("Gender identity")
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                      .values(
+                          List.of(
+                              new SnapshotBuilderListOption().name("FEMALE").id(22),
+                              new SnapshotBuilderListOption().name("MALE").id(23),
+                              new SnapshotBuilderListOption().name("NON BINARY").id(24),
+                              new SnapshotBuilderListOption().name("GENDERQUEER").id(25),
+                              new SnapshotBuilderListOption().name("TWO SPIRIT").id(26),
+                              new SnapshotBuilderListOption().name("AGENDER").id(27),
+                              new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
+                  new SnapshotBuilderProgramDataOption()
+                      .id(4)
+                      .name("Race")
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                      .values(
+                          List.of(
+                              new SnapshotBuilderListOption()
+                                  .name("American Indian or Alaska Native")
+                                  .id(28),
+                              new SnapshotBuilderListOption().name("Asian").id(29),
+                              new SnapshotBuilderListOption().name("Black").id(30),
+                              new SnapshotBuilderListOption().name("White").id(31)))))
+          .featureValueGroups(
+              List.of(
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(0)
+                      .name("Condition")
+                      .values(List.of("Condition Column 1", "Condition Column 2")),
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(1)
+                      .name("Observation")
+                      .values(List.of("Observation Column 1", "Observation Column 2")),
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(2)
+                      .name("Procedure")
+                      .values(List.of("Procedure Column 1", "Procedure Column 2")),
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(3)
+                      .name("Surveys")
+                      .values(List.of("Surveys Column 1", "Surveys Column 2")),
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(4)
+                      .name("Person")
+                      .values(List.of("Demographics Column 1", "Demographics Column 2"))))
+          .datasetConceptSets(
+              List.of(
+                  new SnapshotBuilderDatasetConceptSets()
+                      .name("Demographics")
+                      .featureValueGroupName("Person"),
+                  new SnapshotBuilderDatasetConceptSets()
+                      .name("All surveys")
+                      .featureValueGroupName("Surveys")));
+}

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
@@ -1,6 +1,5 @@
 package bio.terra.service.snapshotbuilder;
 
-import static bio.terra.service.snapshotbuilder.SnapshotBuilderTestData.SAMPLE_SNAPSHOT_BUILDER_SETTINGS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -13,7 +12,6 @@ import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.common.fixtures.ResourceFixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
-import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
@@ -55,7 +53,7 @@ class SnapshotBuilderSettingsDaoTest {
 
     dataset = daoOperations.createMinimalDataset(billingProfile.getId(), projectId);
     snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
-        dataset.getId(), SAMPLE_SNAPSHOT_BUILDER_SETTINGS);
+        dataset.getId(), SnapshotBuilderTestData.SETTINGS);
   }
 
   @Test
@@ -63,7 +61,7 @@ class SnapshotBuilderSettingsDaoTest {
     assertThat(
         "Snapshot builder settings should be the same as the example",
         snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(dataset.getId()),
-        equalTo(SAMPLE_SNAPSHOT_BUILDER_SETTINGS));
+        equalTo(SnapshotBuilderTestData.SETTINGS));
   }
 
   @Test
@@ -79,8 +77,8 @@ class SnapshotBuilderSettingsDaoTest {
     assertThat(
         "Snapshot builder settings should be the new upserted value",
         snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
-            dataset.getId(), new SnapshotBuilderSettings()),
-        equalTo(new SnapshotBuilderSettings()));
+            dataset.getId(), SnapshotBuilderTestData.SETTINGS),
+        equalTo(SnapshotBuilderTestData.SETTINGS));
   }
 
   @Test
@@ -89,7 +87,7 @@ class SnapshotBuilderSettingsDaoTest {
     assertThat(
         "Snapshot builder settings should be the same as the example",
         snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
-            dataset.getId(), SAMPLE_SNAPSHOT_BUILDER_SETTINGS),
-        equalTo(SAMPLE_SNAPSHOT_BUILDER_SETTINGS));
+            dataset.getId(), SnapshotBuilderTestData.SETTINGS),
+        equalTo(SnapshotBuilderTestData.SETTINGS));
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
@@ -1,5 +1,6 @@
 package bio.terra.service.snapshotbuilder;
 
+import static bio.terra.service.snapshotbuilder.SnapshotBuilderTestData.SAMPLE_SNAPSHOT_BUILDER_SETTINGS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -11,12 +12,6 @@ import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.common.fixtures.ResourceFixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
-import bio.terra.model.SnapshotBuilderConcept;
-import bio.terra.model.SnapshotBuilderDatasetConceptSets;
-import bio.terra.model.SnapshotBuilderDomainOption;
-import bio.terra.model.SnapshotBuilderFeatureValueGroup;
-import bio.terra.model.SnapshotBuilderListOption;
-import bio.terra.model.SnapshotBuilderProgramDataOption;
 import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetBucketDaoTest;
@@ -25,7 +20,6 @@ import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.ws.rs.NotFoundException;
 import org.junit.After;
@@ -135,114 +129,4 @@ public class SnapshotBuilderSettingsDaoTest {
             dataset.getId(), SAMPLE_SNAPSHOT_BUILDER_SETTINGS),
         equalTo(SAMPLE_SNAPSHOT_BUILDER_SETTINGS));
   }
-
-  private static final SnapshotBuilderSettings SAMPLE_SNAPSHOT_BUILDER_SETTINGS =
-      new SnapshotBuilderSettings()
-          .domainOptions(
-              List.of(
-                  new SnapshotBuilderDomainOption()
-                      .id(10)
-                      .category("Condition")
-                      .conceptCount(18000)
-                      .participantCount(12500)
-                      .root(
-                          new SnapshotBuilderConcept()
-                              .id(100)
-                              .name("Condition")
-                              .count(100)
-                              .hasChildren(true)),
-                  new SnapshotBuilderDomainOption()
-                      .id(11)
-                      .category("Procedure")
-                      .conceptCount(22500)
-                      .participantCount(11328)
-                      .root(
-                          new SnapshotBuilderConcept()
-                              .id(200)
-                              .name("Procedure")
-                              .count(100)
-                              .hasChildren(true)),
-                  new SnapshotBuilderDomainOption()
-                      .id(12)
-                      .category("Observation")
-                      .conceptCount(12300)
-                      .participantCount(23223)
-                      .root(
-                          new SnapshotBuilderConcept()
-                              .id(300)
-                              .name("Observation")
-                              .count(100)
-                              .hasChildren(true))))
-          .programDataOptions(
-              List.of(
-                  new SnapshotBuilderProgramDataOption()
-                      .id(1)
-                      .name("Year of birth")
-                      .kind(SnapshotBuilderProgramDataOption.KindEnum.RANGE)
-                      .min(1900)
-                      .max(2023),
-                  new SnapshotBuilderProgramDataOption()
-                      .id(2)
-                      .name("Ethnicity")
-                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
-                      .values(
-                          List.of(
-                              new SnapshotBuilderListOption().name("Hispanic or Latino").id(20),
-                              new SnapshotBuilderListOption().name("Not Hispanic or Latino").id(21),
-                              new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
-                  new SnapshotBuilderProgramDataOption()
-                      .id(3)
-                      .name("Gender identity")
-                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
-                      .values(
-                          List.of(
-                              new SnapshotBuilderListOption().name("FEMALE").id(22),
-                              new SnapshotBuilderListOption().name("MALE").id(23),
-                              new SnapshotBuilderListOption().name("NON BINARY").id(24),
-                              new SnapshotBuilderListOption().name("GENDERQUEER").id(25),
-                              new SnapshotBuilderListOption().name("TWO SPIRIT").id(26),
-                              new SnapshotBuilderListOption().name("AGENDER").id(27),
-                              new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
-                  new SnapshotBuilderProgramDataOption()
-                      .id(4)
-                      .name("Race")
-                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
-                      .values(
-                          List.of(
-                              new SnapshotBuilderListOption()
-                                  .name("American Indian or Alaska Native")
-                                  .id(28),
-                              new SnapshotBuilderListOption().name("Asian").id(29),
-                              new SnapshotBuilderListOption().name("Black").id(30),
-                              new SnapshotBuilderListOption().name("White").id(31)))))
-          .featureValueGroups(
-              List.of(
-                  new SnapshotBuilderFeatureValueGroup()
-                      .id(0)
-                      .name("Condition")
-                      .values(List.of("Condition Column 1", "Condition Column 2")),
-                  new SnapshotBuilderFeatureValueGroup()
-                      .id(1)
-                      .name("Observation")
-                      .values(List.of("Observation Column 1", "Observation Column 2")),
-                  new SnapshotBuilderFeatureValueGroup()
-                      .id(2)
-                      .name("Procedure")
-                      .values(List.of("Procedure Column 1", "Procedure Column 2")),
-                  new SnapshotBuilderFeatureValueGroup()
-                      .id(3)
-                      .name("Surveys")
-                      .values(List.of("Surveys Column 1", "Surveys Column 2")),
-                  new SnapshotBuilderFeatureValueGroup()
-                      .id(4)
-                      .name("Person")
-                      .values(List.of("Demographics Column 1", "Demographics Column 2"))))
-          .datasetConceptSets(
-              List.of(
-                  new SnapshotBuilderDatasetConceptSets()
-                      .name("Demographics")
-                      .featureValueGroupName("Person"),
-                  new SnapshotBuilderDatasetConceptSets()
-                      .name("All surveys")
-                      .featureValueGroupName("Surveys")));
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThrows;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
+import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.fixtures.DaoOperations;
 import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.common.fixtures.ResourceFixtures;
@@ -14,49 +15,37 @@ import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
 import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.service.dataset.Dataset;
-import bio.terra.service.dataset.DatasetBucketDaoTest;
-import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.profile.ProfileDao;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.resourcemanagement.google.GoogleResourceDao;
 import java.io.IOException;
 import java.util.UUID;
-import javax.ws.rs.NotFoundException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
+@Tag(Unit.TAG)
 @EmbeddedDatabaseTest
 public class SnapshotBuilderSettingsDaoTest {
-  private static final Logger logger = LoggerFactory.getLogger(DatasetBucketDaoTest.class);
 
   @Autowired private DaoOperations daoOperations;
   @Autowired private ProfileDao profileDao;
   @Autowired private GoogleResourceDao resourceDao;
-  @Autowired private DatasetDao datasetDao;
   @Autowired private SnapshotBuilderSettingsDao snapshotBuilderSettingsDao;
 
   private BillingProfileModel billingProfile;
   private GoogleProjectResource projectResource;
   private Dataset dataset;
-  private SnapshotBuilderSettings snapshotBuilderSettings;
 
-  @Before
-  public void setup() throws IOException {
+  @BeforeEach
+  void setup() throws IOException {
     BillingProfileRequestModel profileRequest = ProfileFixtures.randomBillingProfileRequest();
     billingProfile = profileDao.createBillingProfile(profileRequest, "testUser");
 
@@ -65,39 +54,12 @@ public class SnapshotBuilderSettingsDaoTest {
     projectResource.id(projectId);
 
     dataset = daoOperations.createMinimalDataset(billingProfile.getId(), projectId);
-    snapshotBuilderSettings =
-        snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
-            dataset.getId(), SAMPLE_SNAPSHOT_BUILDER_SETTINGS);
-  }
-
-  @After
-  public void teardown() {
-    try {
-      snapshotBuilderSettingsDao.delete(dataset.getId());
-    } catch (Exception ex) {
-      logger.error(
-          "[CLEANUP] Unable to delete snapshot builder settings for dataset {}", dataset.getId());
-    }
-    try {
-      datasetDao.delete(dataset.getId());
-    } catch (Exception ex) {
-      logger.error("[CLEANUP] Unable to delete dataset {}", dataset.getId());
-    }
-    try {
-      resourceDao.deleteProject(projectResource.getId());
-    } catch (Exception ex) {
-      logger.error(
-          "[CLEANUP] Unable to delete entry in database for projects {}", projectResource.getId());
-    }
-    try {
-      profileDao.deleteBillingProfileById(billingProfile.getId());
-    } catch (Exception ex) {
-      logger.error("[CLEANUP] Unable to billing profile {}", billingProfile.getId());
-    }
+    snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
+        dataset.getId(), SAMPLE_SNAPSHOT_BUILDER_SETTINGS);
   }
 
   @Test
-  public void getSnapshotBuilderSettingsReturnsSettings() {
+  void getSnapshotBuilderSettingsReturnsSettings() {
     assertThat(
         "Snapshot builder settings should be the same as the example",
         snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(dataset.getId()),
@@ -105,14 +67,14 @@ public class SnapshotBuilderSettingsDaoTest {
   }
 
   @Test
-  public void getSnapshotBuilderSettingsForDatasetThatDoesNotExistErrors() {
+  void getSnapshotBuilderSettingsForDatasetThatDoesNotExistErrors() {
     assertThrows(
         NotFoundException.class,
         () -> snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(UUID.randomUUID()));
   }
 
   @Test
-  public void upsertSnapshotBuilderSettingsUpdatesWhenExisting() {
+  void upsertSnapshotBuilderSettingsUpdatesWhenExisting() {
     assertThat(
         "Snapshot builder settings should be the new upserted value",
         snapshotBuilderSettingsDao.upsertSnapshotBuilderSettingsByDataset(
@@ -121,7 +83,7 @@ public class SnapshotBuilderSettingsDaoTest {
   }
 
   @Test
-  public void upsertSnapshotBuilderSettingsCreatesWhenNotExisting() {
+  void upsertSnapshotBuilderSettingsCreatesWhenNotExisting() {
     snapshotBuilderSettingsDao.delete(dataset.getId());
     assertThat(
         "Snapshot builder settings should be the same as the example",

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
@@ -1,9 +1,9 @@
 package bio.terra.service.snapshotbuilder;
 
 import static bio.terra.service.snapshotbuilder.SnapshotBuilderTestData.SAMPLE_SNAPSHOT_BUILDER_SETTINGS;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
@@ -33,7 +33,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles({"google", "unittest"})
 @Tag(Unit.TAG)
 @EmbeddedDatabaseTest
-public class SnapshotBuilderSettingsDaoTest {
+class SnapshotBuilderSettingsDaoTest {
 
   @Autowired private DaoOperations daoOperations;
   @Autowired private ProfileDao profileDao;
@@ -68,9 +68,10 @@ public class SnapshotBuilderSettingsDaoTest {
 
   @Test
   void getSnapshotBuilderSettingsForDatasetThatDoesNotExistErrors() {
+    UUID unusedUUID = UUID.randomUUID();
     assertThrows(
         NotFoundException.class,
-        () -> snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(UUID.randomUUID()));
+        () -> snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(unusedUUID));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsServiceTest.java
@@ -1,0 +1,53 @@
+package bio.terra.service.snapshotbuilder;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.SnapshotBuilderDatasetConceptSets;
+import bio.terra.model.SnapshotBuilderSettings;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@RunWith(MockitoJUnitRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "unittest"})
+@Category(Unit.class)
+public class SnapshotBuilderSettingsServiceTest {
+  @Mock private SnapshotBuilderSettingsDao snapshotBuilderSettingsDao;
+
+  private SnapshotBuilderService snapshotBuilderService;
+
+  @Before
+  public void setUp() {
+    snapshotBuilderService = new SnapshotBuilderService(snapshotBuilderSettingsDao);
+  }
+
+  @Test
+  public void testGetSnapshotBuilderSettings() {
+    UUID datasetId = UUID.randomUUID();
+    snapshotBuilderService.getSnapshotBuilderSettings(datasetId);
+    verify(snapshotBuilderSettingsDao, times(1)).getSnapshotBuilderSettingsByDatasetId(datasetId);
+  }
+
+  @Test
+  public void testUpdateSnapshotBuilderSettings() {
+    UUID datasetId = UUID.randomUUID();
+    SnapshotBuilderSettings settings =
+        new SnapshotBuilderSettings()
+            .datasetConceptSets(List.of(new SnapshotBuilderDatasetConceptSets()));
+    snapshotBuilderService.updateSnapshotBuilderSettings(datasetId, settings);
+    verify(snapshotBuilderSettingsDao, times(1))
+        .upsertSnapshotBuilderSettingsByDataset(datasetId, settings);
+  }
+}

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsServiceTest.java
@@ -3,32 +3,31 @@ package bio.terra.service.snapshotbuilder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
 import bio.terra.model.SnapshotBuilderDatasetConceptSets;
 import bio.terra.model.SnapshotBuilderSettings;
 import java.util.List;
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@RunWith(MockitoJUnitRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
+@Tag(Unit.TAG)
+@EmbeddedDatabaseTest
 public class SnapshotBuilderSettingsServiceTest {
   @Mock private SnapshotBuilderSettingsDao snapshotBuilderSettingsDao;
 
   private SnapshotBuilderService snapshotBuilderService;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     snapshotBuilderService = new SnapshotBuilderService(snapshotBuilderSettingsDao);
   }
@@ -47,7 +46,6 @@ public class SnapshotBuilderSettingsServiceTest {
         new SnapshotBuilderSettings()
             .datasetConceptSets(List.of(new SnapshotBuilderDatasetConceptSets()));
     snapshotBuilderService.updateSnapshotBuilderSettings(datasetId, settings);
-    verify(snapshotBuilderSettingsDao, times(1))
-        .upsertSnapshotBuilderSettingsByDataset(datasetId, settings);
+    verify(snapshotBuilderSettingsDao).upsertSnapshotBuilderSettingsByDataset(datasetId, settings);
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsServiceTest.java
@@ -1,13 +1,9 @@
 package bio.terra.service.snapshotbuilder;
 
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
-import bio.terra.model.SnapshotBuilderDatasetConceptSets;
-import bio.terra.model.SnapshotBuilderSettings;
-import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -36,16 +32,15 @@ public class SnapshotBuilderSettingsServiceTest {
   public void testGetSnapshotBuilderSettings() {
     UUID datasetId = UUID.randomUUID();
     snapshotBuilderService.getSnapshotBuilderSettings(datasetId);
-    verify(snapshotBuilderSettingsDao, times(1)).getSnapshotBuilderSettingsByDatasetId(datasetId);
+    verify(snapshotBuilderSettingsDao).getSnapshotBuilderSettingsByDatasetId(datasetId);
   }
 
   @Test
   public void testUpdateSnapshotBuilderSettings() {
     UUID datasetId = UUID.randomUUID();
-    SnapshotBuilderSettings settings =
-        new SnapshotBuilderSettings()
-            .datasetConceptSets(List.of(new SnapshotBuilderDatasetConceptSets()));
-    snapshotBuilderService.updateSnapshotBuilderSettings(datasetId, settings);
-    verify(snapshotBuilderSettingsDao).upsertSnapshotBuilderSettingsByDataset(datasetId, settings);
+    snapshotBuilderService.updateSnapshotBuilderSettings(
+        datasetId, SnapshotBuilderTestData.SETTINGS);
+    verify(snapshotBuilderSettingsDao)
+        .upsertSnapshotBuilderSettingsByDataset(datasetId, SnapshotBuilderTestData.SETTINGS);
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -10,7 +10,7 @@ import bio.terra.model.SnapshotBuilderSettings;
 import java.util.List;
 
 public class SnapshotBuilderTestData {
-  public static final SnapshotBuilderSettings SAMPLE_SNAPSHOT_BUILDER_SETTINGS =
+  public static final SnapshotBuilderSettings SETTINGS =
       new SnapshotBuilderSettings()
           .domainOptions(
               List.of(

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -1,0 +1,122 @@
+package bio.terra.service.snapshotbuilder;
+
+import bio.terra.model.SnapshotBuilderConcept;
+import bio.terra.model.SnapshotBuilderDatasetConceptSets;
+import bio.terra.model.SnapshotBuilderDomainOption;
+import bio.terra.model.SnapshotBuilderFeatureValueGroup;
+import bio.terra.model.SnapshotBuilderListOption;
+import bio.terra.model.SnapshotBuilderProgramDataOption;
+import bio.terra.model.SnapshotBuilderSettings;
+import java.util.List;
+
+public class SnapshotBuilderTestData {
+  public static final SnapshotBuilderSettings SAMPLE_SNAPSHOT_BUILDER_SETTINGS =
+      new SnapshotBuilderSettings()
+          .domainOptions(
+              List.of(
+                  new SnapshotBuilderDomainOption()
+                      .id(10)
+                      .category("Condition")
+                      .conceptCount(18000)
+                      .participantCount(12500)
+                      .root(
+                          new SnapshotBuilderConcept()
+                              .id(100)
+                              .name("Condition")
+                              .count(100)
+                              .hasChildren(true)),
+                  new SnapshotBuilderDomainOption()
+                      .id(11)
+                      .category("Procedure")
+                      .conceptCount(22500)
+                      .participantCount(11328)
+                      .root(
+                          new SnapshotBuilderConcept()
+                              .id(200)
+                              .name("Procedure")
+                              .count(100)
+                              .hasChildren(true)),
+                  new SnapshotBuilderDomainOption()
+                      .id(12)
+                      .category("Observation")
+                      .conceptCount(12300)
+                      .participantCount(23223)
+                      .root(
+                          new SnapshotBuilderConcept()
+                              .id(300)
+                              .name("Observation")
+                              .count(100)
+                              .hasChildren(true))))
+          .programDataOptions(
+              List.of(
+                  new SnapshotBuilderProgramDataOption()
+                      .id(1)
+                      .name("Year of birth")
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.RANGE)
+                      .min(1900)
+                      .max(2023),
+                  new SnapshotBuilderProgramDataOption()
+                      .id(2)
+                      .name("Ethnicity")
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                      .values(
+                          List.of(
+                              new SnapshotBuilderListOption().name("Hispanic or Latino").id(20),
+                              new SnapshotBuilderListOption().name("Not Hispanic or Latino").id(21),
+                              new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
+                  new SnapshotBuilderProgramDataOption()
+                      .id(3)
+                      .name("Gender identity")
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                      .values(
+                          List.of(
+                              new SnapshotBuilderListOption().name("FEMALE").id(22),
+                              new SnapshotBuilderListOption().name("MALE").id(23),
+                              new SnapshotBuilderListOption().name("NON BINARY").id(24),
+                              new SnapshotBuilderListOption().name("GENDERQUEER").id(25),
+                              new SnapshotBuilderListOption().name("TWO SPIRIT").id(26),
+                              new SnapshotBuilderListOption().name("AGENDER").id(27),
+                              new SnapshotBuilderListOption().name("No Matching Concept").id(0))),
+                  new SnapshotBuilderProgramDataOption()
+                      .id(4)
+                      .name("Race")
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                      .values(
+                          List.of(
+                              new SnapshotBuilderListOption()
+                                  .name("American Indian or Alaska Native")
+                                  .id(28),
+                              new SnapshotBuilderListOption().name("Asian").id(29),
+                              new SnapshotBuilderListOption().name("Black").id(30),
+                              new SnapshotBuilderListOption().name("White").id(31)))))
+          .featureValueGroups(
+              List.of(
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(0)
+                      .name("Condition")
+                      .values(List.of("Condition Column 1", "Condition Column 2")),
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(1)
+                      .name("Observation")
+                      .values(List.of("Observation Column 1", "Observation Column 2")),
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(2)
+                      .name("Procedure")
+                      .values(List.of("Procedure Column 1", "Procedure Column 2")),
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(3)
+                      .name("Surveys")
+                      .values(List.of("Surveys Column 1", "Surveys Column 2")),
+                  new SnapshotBuilderFeatureValueGroup()
+                      .id(4)
+                      .name("Person")
+                      .values(List.of("Demographics Column 1", "Demographics Column 2"))))
+          .datasetConceptSets(
+              List.of(
+                  new SnapshotBuilderDatasetConceptSets()
+                      .name("Demographics")
+                      .featureValueGroupName("Person"),
+                  new SnapshotBuilderDatasetConceptSets()
+                      .name("All surveys")
+                      .featureValueGroupName("Surveys")));
+}


### PR DESCRIPTION
This adds the database table for snapshot builder settings. To avoid needing to drop and rebuild the database constantly, we currently have it as jsonb and are using the api generated model to validate. 