### PR TITLE
[DR-2890] Update deprecated Github Actions set-output commands

### DIFF
--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -31,7 +31,7 @@ jobs:
       id: configuration
       run: |
         alpha_version_api=$(curl -s -X GET "https://data.alpha.envs-terra.bio/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
-        echo "::set-output name=alpha_version_api::$alpha_version_api"
+        echo "alpha_version_api=${alpha_version_api}" >> $GITHUB_OUTPUT
         echo "Alpha Version: $alpha_version_api"
     - name: "Checkout tag for DataBiosphere/jade-data-repo"
       if: github.ref == 'refs/heads/develop'
@@ -141,7 +141,7 @@ jobs:
       id: datarepohelm
       run: |
         alpha_version_ui=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq r datarepo-helm/charts/datarepo-ui/values.yaml image.tag)
-        echo "::set-output name=alpha_version_ui::$alpha_version_ui"
+        echo "alpha_version_ui=${alpha_version_ui}" >> $GITHUB_OUTPUT
         echo "Alpha UI Version: $alpha_version_ui"
     - name: "[UI][Cherry-pick to public GCR] Perform cherry-pick"
       run: |

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -107,7 +107,7 @@ jobs:
           ((a[2]++))
           printf "increase default api version: ${a[2]}\n\n"
           chartversion="${a[0]}.${a[1]}.${a[2]}"
-          echo "::set-output name=chartversion::$chartversion"
+          echo "chartversion=${chartversion}" >> $GITHUB_OUTPUT
       - name: "[datarepo-helm] [Chart.yaml] Update chart version"
         uses: docker://mikefarah/yq:3
         with:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -209,7 +209,7 @@ jobs:
         id: configuration
         run: |
           git_hash=$(git rev-parse --short HEAD)
-          echo "::set-output name=git_hash::$git_hash"
+          echo "git_hash=${git_hash}" >> $GITHUB_OUTPUT
           echo "Latest git hash for this branch: $git_hash"
       - name: "Wait for deployment to come back online"
         uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.69.0

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -26,7 +26,7 @@ jobs:
         id: configuration
         run: |
           staging_version=$(curl -s -X GET "https://data.staging.envs-terra.bio/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
-          echo "::set-output name=staging_version::$staging_version"
+          echo "staging_version=${staging_version}" >> $GITHUB_OUTPUT
           echo "Staging Version: $staging_version"
       - name: "Checkout tag for DataBiosphere/jade-data-repo"
         if: github.ref == 'refs/heads/develop'

--- a/.github/workflows/test-runner-on-perf.yml
+++ b/.github/workflows/test-runner-on-perf.yml
@@ -23,13 +23,13 @@ jobs:
         run: |
           CURRENT_VERSION=$(curl -s -X GET "https://jade-perf.datarepo-perf.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           echo "Current Version: $CURRENT_VERSION"
-          echo "::set-output name=CURRENT_SEMVER::$CURRENT_VERSION"
+          echo "CURRENT_SEMVER=${$CURRENT_VERSION}" >> $GITHUB_OUTPUT
           LATEST_VERSION=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.semVer|rtrimstr("-SNAPSHOT")')
           echo "Latest Version: $LATEST_VERSION"
-          echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"
+          echo "LATEST_VERSION=${LATEST_VERSION}" >> $GITHUB_OUTPUT
           LATEST_GITHASH=$(curl -s -X GET "https://jade.datarepo-dev.broadinstitute.org/configuration" -H "accept: application/json" | jq -r '.gitHash')
           echo "Latest git hash: $LATEST_GITHASH"
-          echo "::set-output name=LATEST_GITHASH::$LATEST_GITHASH"
+          echo "LATEST_GITHASH=${$LATEST_GITHASH}" >> $GITHUB_OUTPUT
       - name: "Checkout jade-data-repo ${{ steps.read_property.outputs.LATEST_VERSION }} branch"
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,7 +38,7 @@ jobs:
 
           # export image name from the log
           image=$(grep 'Built image' build.log | awk '{print $NF}')
-          echo "::set-output name=image::${image}"
+          echo "image=${image}" >> $GITHUB_OUTPUT
 
       # scan the image
       - uses: broadinstitute/dsp-appsec-trivy-action@v1


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2890

The `save-state` and `set-output` commands are going to be deprecated in Github Actions. This PR updates the syntax for `set-output` (`save-state` is not used anywhere). Here is more context about this change: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I checked the [Trivy](https://github.com/DataBiosphere/jade-data-repo/actions/runs/6227604695/job/16902584555?pr=1510) run on this PR and verified that the deprecation warning is no longer there compared to a [previous run](https://github.com/DataBiosphere/jade-data-repo/actions/runs/6226757065).