### PR TITLE
DR-3120:  Delete Azure Cloud Resources with Admin Option on Profile Delete 

### DIFF
--- a/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
@@ -119,7 +119,6 @@ public class SimpleDataset extends runner.TestScript {
   public void cleanup(List<TestUserSpecification> testUsers) throws Exception {
     // get the ApiClient for the dataset creator
     ApiClient datasetCreatorClient = DataRepoUtils.getClientForTestUser(datasetCreator, server);
-    ResourcesApi resourcesApi = new ResourcesApi(datasetCreatorClient);
     RepositoryApi repositoryApi = new RepositoryApi(datasetCreatorClient);
 
     // make the delete dataset request and wait for the job to finish
@@ -132,7 +131,10 @@ public class SimpleDataset extends runner.TestScript {
 
     // delete the profile
     if (deleteProfile) {
-      resourcesApi.deleteProfile(billingProfileModel.getId(), true);
+      TestUserSpecification admin = SAMUtils.findTestUserThatIsDataRepoAdmin(testUsers, server);
+      ApiClient adminClient = DataRepoUtils.getClientForTestUser(admin, server);
+      ResourcesApi adminResourcesApi = new ResourcesApi(adminClient);
+      adminResourcesApi.deleteProfile(billingProfileModel.getId(), true);
       logger.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
     } else {
       logger.info("Skipping profile delete because test is using a shared profile");

--- a/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
+++ b/datarepo-clienttests/src/main/java/scripts/testscripts/baseclasses/SimpleDataset.java
@@ -132,7 +132,7 @@ public class SimpleDataset extends runner.TestScript {
 
     // delete the profile
     if (deleteProfile) {
-      resourcesApi.deleteProfile(billingProfileModel.getId());
+      resourcesApi.deleteProfile(billingProfileModel.getId(), true);
       logger.info("Successfully deleted profile: {}", billingProfileModel.getProfileName());
     } else {
       logger.info("Skipping profile delete because test is using a shared profile");

--- a/datarepo-clienttests/src/main/java/scripts/utils/SAMUtils.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/SAMUtils.java
@@ -88,6 +88,17 @@ public class SAMUtils {
   }
 
   /**
+   * Call the SAM endpoint to check if the caller is a Data Repo Admin.
+   *
+   * @return true if the caller is a admin, false otherwise
+   */
+  public static boolean isDataRepoAdmin(ApiClient apiClient, String datarepoResourceId)
+      throws ApiException {
+    ResourcesApi resourcesApi = new ResourcesApi(apiClient);
+    return resourcesApi.resourcePermissionV2("datarepo", datarepoResourceId, "configure");
+  }
+
+  /**
    * Call the SAM endpoint to check if the provided test user is a steward
    *
    * @param testUser test user to check
@@ -118,6 +129,22 @@ public class SAMUtils {
     for (TestUserSpecification testUser : testUsersCopy) {
       ApiClient apiClient = getClientForTestUser(testUser, server);
       if (isDataRepoSteward(apiClient, server.samResourceIdForDatarepo)) {
+        return testUser;
+      }
+    }
+    return null;
+  }
+
+  public static TestUserSpecification findTestUserThatIsDataRepoAdmin(
+      List<TestUserSpecification> testUsers, ServerSpecification server) throws Exception {
+    // create a copy of the list and randomly reorder it
+    List<TestUserSpecification> testUsersCopy = new ArrayList<>(testUsers);
+    Collections.shuffle(testUsersCopy);
+
+    // iterate through the list copy, return the first test user that is a data repo admin
+    for (TestUserSpecification testUser : testUsersCopy) {
+      ApiClient apiClient = getClientForTestUser(testUser, server);
+      if (isDataRepoAdmin(apiClient, server.samResourceIdForDatarepo)) {
         return testUser;
       }
     }

--- a/datarepo-clienttests/src/main/java/scripts/utils/tdrwrapper/DataRepoWrap.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/tdrwrapper/DataRepoWrap.java
@@ -173,7 +173,7 @@ public class DataRepoWrap {
   }
 
   public WrapFuture<DeleteResponseModel> deleteProfileFuture(UUID profileId) {
-    JobModel jobResponse = apiCallThrow(() -> resourcesApi.deleteProfile(profileId, true));
+    JobModel jobResponse = apiCallThrow(() -> resourcesApi.deleteProfile(profileId, false));
     return new WrapFuture<>(jobResponse.getId(), repositoryApi, DeleteResponseModel.class);
   }
 

--- a/datarepo-clienttests/src/main/java/scripts/utils/tdrwrapper/DataRepoWrap.java
+++ b/datarepo-clienttests/src/main/java/scripts/utils/tdrwrapper/DataRepoWrap.java
@@ -173,7 +173,7 @@ public class DataRepoWrap {
   }
 
   public WrapFuture<DeleteResponseModel> deleteProfileFuture(UUID profileId) {
-    JobModel jobResponse = apiCallThrow(() -> resourcesApi.deleteProfile(profileId));
+    JobModel jobResponse = apiCallThrow(() -> resourcesApi.deleteProfile(profileId, true));
     return new WrapFuture<>(jobResponse.getId(), repositoryApi, DeleteResponseModel.class);
   }
 

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -21,7 +21,8 @@ public enum JobMapKeys {
   SNAPSHOT_ID("snapshotId"),
   FILE_ID("fileId"),
   ASSET_ID("assetId"),
-  TRANSACTION_ID("transactionId");
+  TRANSACTION_ID("transactionId"),
+  DELETE_CLOUD_RESOURCES("deleteCloudResources");
 
   private String keyName;
 

--- a/src/main/java/bio/terra/service/profile/ProfileApiController.java
+++ b/src/main/java/bio/terra/service/profile/ProfileApiController.java
@@ -118,8 +118,9 @@ public class ProfileApiController implements ProfilesApi {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
     if (deleteCloudResources) {
       verifyAdminAuthorization(user);
+    } else {
+      verifyProfileAuthorization(user, id.toString(), IamAction.DELETE);
     }
-    verifyProfileAuthorization(user, id.toString(), IamAction.DELETE);
     String jobId = profileService.deleteProfile(id, deleteCloudResources, user);
     return jobToResponse(jobService.retrieveJob(jobId, user));
   }

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -122,10 +122,13 @@ public class ProfileService {
    * </ul>
    *
    * @param id the unique id of the bill profile
+   * @param deleteCloudResources flag to also delete azure cloud resources such as storage account
+   *     and monitoring resources
    * @param user the user attempting the delete
    * @return jobId of the submitted stairway job
    */
-  public String deleteProfile(UUID id, AuthenticatedUserRequest user) {
+
+  public String deleteProfile(UUID id, Boolean deleteCloudResources, AuthenticatedUserRequest user) {
     CloudPlatform platform;
     try {
       BillingProfileModel billingProfile = profileDao.getBillingProfileById(id);
@@ -145,6 +148,7 @@ public class ProfileService {
         .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.SPEND_PROFILE)
         .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id)
         .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.DELETE)
+        .addParameter(JobMapKeys.DELETE_CLOUD_RESOURCES.getKeyName(), deleteCloudResources)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -127,8 +127,8 @@ public class ProfileService {
    * @param user the user attempting the delete
    * @return jobId of the submitted stairway job
    */
-
-  public String deleteProfile(UUID id, Boolean deleteCloudResources, AuthenticatedUserRequest user) {
+  public String deleteProfile(
+      UUID id, Boolean deleteCloudResources, AuthenticatedUserRequest user) {
     CloudPlatform platform;
     try {
       BillingProfileModel billingProfile = profileDao.getBillingProfileById(id);

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -128,7 +128,7 @@ public class ProfileService {
    * @return jobId of the submitted stairway job
    */
   public String deleteProfile(
-      UUID id, Boolean deleteCloudResources, AuthenticatedUserRequest user) {
+      UUID id, boolean deleteCloudResources, AuthenticatedUserRequest user) {
     CloudPlatform platform;
     try {
       BillingProfileModel billingProfile = profileDao.getBillingProfileById(id);

--- a/src/main/java/bio/terra/service/profile/flight/ProfileMapKeys.java
+++ b/src/main/java/bio/terra/service/profile/flight/ProfileMapKeys.java
@@ -6,6 +6,8 @@ public final class ProfileMapKeys {
   public static final String PROFILE_PROJECT_ID_LIST = "profileProjectIdList";
   public static final String PROFILE_APPLICATION_DEPLOYMENT_ID_LIST =
       "profileApplicationDeploymentIdList";
+  public static final String PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST =
+      "profileStorageAccountResourceList";
 
   private ProfileMapKeys() {}
 }

--- a/src/main/java/bio/terra/service/profile/flight/ProfileMapKeys.java
+++ b/src/main/java/bio/terra/service/profile/flight/ProfileMapKeys.java
@@ -6,8 +6,8 @@ public final class ProfileMapKeys {
   public static final String PROFILE_PROJECT_ID_LIST = "profileProjectIdList";
   public static final String PROFILE_APPLICATION_DEPLOYMENT_ID_LIST =
       "profileApplicationDeploymentIdList";
-  public static final String PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST =
-      "profileStorageAccountResourceList";
+  public static final String PROFILE_UNIQUE_STORAGE_ACCOUNT_RESOURCE_LIST =
+      "profileUniqueStorageAccountResourceList";
 
   private ProfileMapKeys() {}
 }

--- a/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
@@ -41,9 +41,6 @@ public class ProfileDeleteFlight extends Flight {
         CloudPlatformWrapper.of(
             inputParameters.get(JobMapKeys.CLOUD_PLATFORM.getKeyName(), String.class));
 
-    AzureStorageMonitoringStepProvider azureStorageMonitoringStepProvider =
-        new AzureStorageMonitoringStepProvider(monitoringService);
-
     // We do not delete unused Google projects at the point where they become unused; that is, the
     // last
     // file or dataset or snapshot is deleted from them. Instead, we use this profile delete
@@ -90,6 +87,8 @@ public class ProfileDeleteFlight extends Flight {
         // application deployment
         addStep(new RecordAzureStorageAccountsStep(azureStorageAccountService));
         // delete monitoring resources
+        AzureStorageMonitoringStepProvider azureStorageMonitoringStepProvider =
+            new AzureStorageMonitoringStepProvider(monitoringService);
         azureStorageMonitoringStepProvider
             .configureDeleteSteps()
             .forEach(s -> this.addStep(s.step(), s.retryRule()));

--- a/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
@@ -74,6 +74,12 @@ public class ProfileDeleteFlight extends Flight {
       addStep(
           new DeleteProfileMarkUnusedApplicationDeployments(
               profileService, resourceService, user, profileId));
+      if (inputParameters.get(JobMapKeys.DELETE_CLOUD_RESOURCES.getKeyName(), Boolean.class)) {
+        // TODO - add steps to delete azure cloud resources
+        // Delete sentinel instance
+        // Delete log workspace
+        // Delete storage account
+      }
       addStep(new DeleteProfileApplicationDeploymentMetadata(resourceService));
     }
 

--- a/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
@@ -13,6 +13,7 @@ import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
 import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringStepProvider;
 import bio.terra.service.resourcemanagement.flight.DeleteAzureStorageAccountStep;
+import bio.terra.service.resourcemanagement.flight.RecordAzureStorageAccountsStep;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import java.util.UUID;
@@ -85,6 +86,9 @@ public class ProfileDeleteFlight extends Flight {
           new DeleteProfileMarkUnusedApplicationDeployments(
               profileService, resourceService, user, profileId));
       if (inputParameters.get(JobMapKeys.DELETE_CLOUD_RESOURCES.getKeyName(), Boolean.class)) {
+        // Find all records of storage accounts marked for delete and associated with this
+        // application deployment
+        addStep(new RecordAzureStorageAccountsStep(azureStorageAccountService));
         // delete monitoring resources
         azureStorageMonitoringStepProvider
             .configureDeleteSteps(azureStorageAccountService)

--- a/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
@@ -12,6 +12,7 @@ import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
 import bio.terra.service.resourcemanagement.flight.AzureStorageMonitoringStepProvider;
+import bio.terra.service.resourcemanagement.flight.DeleteAzureStorageAccountStep;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import java.util.UUID;
@@ -89,6 +90,7 @@ public class ProfileDeleteFlight extends Flight {
             .configureDeleteSteps(azureStorageAccountService)
             .forEach(s -> this.addStep(s.step(), s.retryRule()));
         // Delete storage account
+        addStep(new DeleteAzureStorageAccountStep(azureStorageAccountService));
       }
       addStep(new DeleteProfileApplicationDeploymentMetadata(resourceService));
     }

--- a/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
+++ b/src/main/java/bio/terra/service/profile/flight/delete/ProfileDeleteFlight.java
@@ -91,7 +91,7 @@ public class ProfileDeleteFlight extends Flight {
         addStep(new RecordAzureStorageAccountsStep(azureStorageAccountService));
         // delete monitoring resources
         azureStorageMonitoringStepProvider
-            .configureDeleteSteps(azureStorageAccountService)
+            .configureDeleteSteps()
             .forEach(s -> this.addStep(s.step(), s.retryRule()));
         // Delete storage account
         addStep(new DeleteAzureStorageAccountStep(azureStorageAccountService));

--- a/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/ResourceService.java
@@ -402,7 +402,7 @@ public class ResourceService {
               storageAccountService.retrieveStorageAccountById(s);
           azureContainerPdao.deleteContainer(
               dataset.getDatasetSummary().getDefaultBillingProfile(), storageAccountResource);
-          storageAccountService.deleteCloudStorageAccountMetadata(
+          storageAccountService.markForDeleteCloudStorageAccountMetadata(
               storageAccountResource.getName(),
               storageAccountResource.getTopLevelContainer(),
               flightId);
@@ -426,7 +426,7 @@ public class ResourceService {
         storageAccountService.retrieveStorageAccountById(storageResourceId);
     azureContainerPdao.deleteContainer(snapshotBillingProfile, storageAccountResource);
 
-    storageAccountService.deleteCloudStorageAccountMetadata(
+    storageAccountService.markForDeleteCloudStorageAccountMetadata(
         storageAccountResource.getName(), storageAccountResource.getTopLevelContainer(), flightId);
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -144,6 +144,31 @@ public class AzureMonitoringService {
   }
 
   /**
+   * Delete an existing Log Analytics workspace
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being logged
+   * @param storageAccountResource The AzureStorageAccountResource associated with the Log Analytics
+   *     workspace to delete
+   */
+  public void deleteLogAnalyticsWorkspace(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
+    LogAnalyticsManager client =
+        resourceConfiguration.getLogAnalyticsManagerClient(
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info(
+        "Deleting Log Analytics Workspace for storage account {}",
+        storageAccountResource.getName());
+
+    client
+        .workspaces()
+        .delete(
+            storageAccountResource.getApplicationResource().getAzureResourceGroupName(),
+            storageAccountResource.getName());
+  }
+
+  /**
    * Retrieve an existing Log Analytics diagnostic setting
    *
    * @param profileModel The billing profile for the dataset or snapshot being logged
@@ -394,12 +419,12 @@ public class AzureMonitoringService {
   }
 
   /**
-   * Delete a Sentinel instance
+   * Delete a Sentinel instance by the Sentinel Id
    *
    * @param profileModel The billing profile for the dataset or snapshot being monitored
    * @param id The azure id of the Sentinel instance to delete
    */
-  public void deleteSentinel(BillingProfileModel profileModel, String id) {
+  public void deleteSentinelById(BillingProfileModel profileModel, String id) {
 
     SecurityInsightsManager client =
         resourceConfiguration.getSecurityInsightsManagerClient(
@@ -409,6 +434,31 @@ public class AzureMonitoringService {
     logger.info("Deleting Sentinel instance {}", id);
 
     client.sentinelOnboardingStates().deleteById(id);
+  }
+
+  /**
+   * Delete a Sentinel instance
+   *
+   * @param profileModel The billing profile for the dataset or snapshot being monitored
+   * @param storageAccountResource
+   */
+  public void deleteSentinelByStorageAccount(
+      BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
+
+    SecurityInsightsManager client =
+        resourceConfiguration.getSecurityInsightsManagerClient(
+            resourceConfiguration.credentials().getHomeTenantId(),
+            profileModel.getSubscriptionId());
+
+    logger.info(
+        "Deleting Sentinel instance on storage account {}", storageAccountResource.getName());
+
+    client
+        .sentinelOnboardingStates()
+        .delete(
+            storageAccountResource.getApplicationResource().getAzureResourceGroupName(),
+            storageAccountResource.getName(),
+            SENTINEL_ONBOARD_STATE_NAME);
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringService.java
@@ -74,9 +74,7 @@ public class AzureMonitoringService {
   public Workspace getLogAnalyticsWorkspace(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     LogAnalyticsManager client =
-        resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getLogAnalyticsManagerClient(profileModel.getSubscriptionId());
     try {
       Workspace byResourceGroup =
           client
@@ -106,9 +104,7 @@ public class AzureMonitoringService {
   public String createLogAnalyticsWorkspace(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     LogAnalyticsManager client =
-        resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getLogAnalyticsManagerClient(profileModel.getSubscriptionId());
 
     logger.info(
         "Creating new Log Analytics Workspace for Storage Account {}",
@@ -134,9 +130,7 @@ public class AzureMonitoringService {
    */
   public void deleteLogAnalyticsWorkspace(BillingProfileModel profileModel, String id) {
     LogAnalyticsManager client =
-        resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getLogAnalyticsManagerClient(profileModel.getSubscriptionId());
 
     logger.info("Deleting Log Analytics Workspace {}", id);
 
@@ -153,9 +147,7 @@ public class AzureMonitoringService {
   public void deleteLogAnalyticsWorkspace(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
     LogAnalyticsManager client =
-        resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getLogAnalyticsManagerClient(profileModel.getSubscriptionId());
 
     logger.info(
         "Deleting Log Analytics Workspace for storage account {}",
@@ -265,9 +257,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
 
     LogAnalyticsManager client =
-        resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getLogAnalyticsManagerClient(profileModel.getSubscriptionId());
 
     try {
       DataExport dataExport =
@@ -314,9 +304,7 @@ public class AzureMonitoringService {
               "No log collection config found for region %s", storageAccount.getRegion()));
     }
     LogAnalyticsManager client =
-        resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getLogAnalyticsManagerClient(profileModel.getSubscriptionId());
 
     logger.info(
         "Creating new export rule for Log Analytics Workspace linked to Storage Account {}",
@@ -342,9 +330,7 @@ public class AzureMonitoringService {
    */
   public void deleteDataExportRule(BillingProfileModel profileModel, String id) {
     LogAnalyticsManager client =
-        resourceConfiguration.getLogAnalyticsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getLogAnalyticsManagerClient(profileModel.getSubscriptionId());
 
     logger.info("Deleting Log Analytics Workspace data export rule {}", id);
 
@@ -362,9 +348,7 @@ public class AzureMonitoringService {
   public SentinelOnboardingState getSentinel(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
 
     try {
       SentinelOnboardingState sentinelOnboardingState =
@@ -396,9 +380,7 @@ public class AzureMonitoringService {
   public String createSentinel(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
 
     logger.info(
         "Creating new Sentinel deployment for Log Analytics Workspace that monitors Storage Account {}",
@@ -427,9 +409,7 @@ public class AzureMonitoringService {
   public void deleteSentinelById(BillingProfileModel profileModel, String id) {
 
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
 
     logger.info("Deleting Sentinel instance {}", id);
 
@@ -446,9 +426,7 @@ public class AzureMonitoringService {
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
 
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
 
     logger.info(
         "Deleting Sentinel instance on storage account {}", storageAccountResource.getName());
@@ -472,9 +450,7 @@ public class AzureMonitoringService {
   public AlertRule getSentinelRuleUnauthorizedAccess(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
     try {
       AlertRule alertRule =
           client
@@ -508,9 +484,7 @@ public class AzureMonitoringService {
   public String createSentinelRuleUnauthorizedAccess(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
 
     // Note: this is copied from the rule defined in the Terra landing zone service
     logger.info(
@@ -557,9 +531,7 @@ public class AzureMonitoringService {
   public void deleteSentinelRuleUnauthorizedAccess(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
 
     logger.info(
         "Deleting Sentinel UnauthorizedAccess alert rule for Storage Account {}",
@@ -583,9 +555,7 @@ public class AzureMonitoringService {
   public AutomationRule getNotificationRule(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
     try {
       AutomationRule automationRule =
           client
@@ -620,9 +590,7 @@ public class AzureMonitoringService {
   public String createNotificationRule(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccount) {
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
     logger.info(
         "Creating new Sentinel alert rule for Sentinel instance monitoring Storage Account {}",
         storageAccount.getStorageAccountId());
@@ -662,9 +630,7 @@ public class AzureMonitoringService {
    */
   public void deleteNotificationRule(BillingProfileModel profileModel, String id) {
     SecurityInsightsManager client =
-        resourceConfiguration.getSecurityInsightsManagerClient(
-            resourceConfiguration.credentials().getHomeTenantId(),
-            profileModel.getSubscriptionId());
+        resourceConfiguration.getSecurityInsightsManagerClient(profileModel.getSubscriptionId());
 
     logger.info("Deleting Sentinel alert rule {}", id);
 

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -73,15 +73,16 @@ public record AzureResourceConfiguration(
    * create/destroy resources Note: this is a separate method from the one above because the log
    * analytics client is not GA yet so does not return a generic AzureResourceManager object
    *
-   * @param tenantId The ID of the user's tenant
    * @param subscriptionId The ID of the subscription that will be charged for the resources created
    *     with this client
    * @return An authenticated {@link LogAnalyticsManager} client
    */
-  public LogAnalyticsManager getLogAnalyticsManagerClient(
-      final UUID tenantId, final UUID subscriptionId) {
+  public LogAnalyticsManager getLogAnalyticsManagerClient(final UUID subscriptionId) {
     final AzureProfile profile =
-        new AzureProfile(tenantId.toString(), subscriptionId.toString(), AzureEnvironment.AZURE);
+        new AzureProfile(
+            credentials().getHomeTenantId().toString(),
+            subscriptionId.toString(),
+            AzureEnvironment.AZURE);
     return LogAnalyticsManager.authenticate(getAppToken(), profile);
   }
 
@@ -91,15 +92,16 @@ public record AzureResourceConfiguration(
    * because the security insights client is not GA yet so does not return a generic
    * AzureResourceManager object
    *
-   * @param tenantId The ID of the user's tenant
    * @param subscriptionId The ID of the subscription that will be charged for the resources created
    *     with this client
    * @return An authenticated {@link SecurityInsightsManager} client
    */
-  public SecurityInsightsManager getSecurityInsightsManagerClient(
-      final UUID tenantId, final UUID subscriptionId) {
+  public SecurityInsightsManager getSecurityInsightsManagerClient(final UUID subscriptionId) {
     final AzureProfile profile =
-        new AzureProfile(tenantId.toString(), subscriptionId.toString(), AzureEnvironment.AZURE);
+        new AzureProfile(
+            credentials().getHomeTenantId().toString(),
+            subscriptionId.toString(),
+            AzureEnvironment.AZURE);
     return SecurityInsightsManager.authenticate(getAppToken(), profile);
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
@@ -496,48 +496,43 @@ public class AzureResourceDao {
 
   private List<AzureStorageAccountResource> retrieveStorageAccountsBy(
       String sql, MapSqlParameterSource params) {
-    List<AzureStorageAccountResource> storageAccountResources =
-        jdbcTemplate.query(
-            sql,
-            params,
-            (rs, rowNum) -> {
-              // Make deployed application resource and a storage account resource from the query
-              // result
-              AzureApplicationDeploymentResource applicationResource =
-                  new AzureApplicationDeploymentResource()
-                      .id(rs.getObject("application_resource_id", UUID.class))
-                      .profileId(rs.getObject("profile_id", UUID.class))
-                      .azureApplicationDeploymentId(rs.getString("azure_application_deployment_id"))
-                      .azureApplicationDeploymentName(
-                          rs.getString("azure_application_deployment_name"))
-                      .azureResourceGroupName(rs.getString("azure_resource_group_name"))
-                      .azureSynapseWorkspaceName(rs.getString("azure_synapse_workspace"))
-                      .defaultRegion(AzureRegion.fromName(rs.getString("default_region")))
-                      .storageAccountPrefix(rs.getString("storage_account_prefix"))
-                      .storageAccountSkuType(
-                          AzureStorageAccountSkuType.valueOf(
-                              rs.getString("storage_account_sku_type")));
-
-              AzureRegion region =
-                  Optional.ofNullable(rs.getString("region"))
-                      .map(AzureRegion::valueOf)
-                      .orElse(applicationResource.getDefaultRegion());
-
-              // Since storing the region was not in the original data, we supply the
-              // default if a value is not present.
-              return new AzureStorageAccountResource()
-                  .applicationResource(applicationResource)
+    return jdbcTemplate.query(
+        sql,
+        params,
+        (rs, rowNum) -> {
+          // Make deployed application resource and a storage account resource from the query
+          // result
+          AzureApplicationDeploymentResource applicationResource =
+              new AzureApplicationDeploymentResource()
+                  .id(rs.getObject("application_resource_id", UUID.class))
                   .profileId(rs.getObject("profile_id", UUID.class))
-                  .resourceId(rs.getObject("storage_account_resource_id", UUID.class))
-                  .name(rs.getString("name"))
-                  .topLevelContainer(rs.getString("toplevelcontainer"))
-                  .dataContainer(rs.getString("datacontainer"))
-                  .metadataContainer(rs.getString("metadatacontainer"))
-                  .dbName(rs.getString("dbname"))
-                  .flightId(rs.getString("flightid"))
-                  .region(region);
-            });
+                  .azureApplicationDeploymentId(rs.getString("azure_application_deployment_id"))
+                  .azureApplicationDeploymentName(rs.getString("azure_application_deployment_name"))
+                  .azureResourceGroupName(rs.getString("azure_resource_group_name"))
+                  .azureSynapseWorkspaceName(rs.getString("azure_synapse_workspace"))
+                  .defaultRegion(AzureRegion.fromName(rs.getString("default_region")))
+                  .storageAccountPrefix(rs.getString("storage_account_prefix"))
+                  .storageAccountSkuType(
+                      AzureStorageAccountSkuType.valueOf(rs.getString("storage_account_sku_type")));
 
-    return storageAccountResources;
+          AzureRegion region =
+              Optional.ofNullable(rs.getString("region"))
+                  .map(AzureRegion::valueOf)
+                  .orElse(applicationResource.getDefaultRegion());
+
+          // Since storing the region was not in the original data, we supply the
+          // default if a value is not present.
+          return new AzureStorageAccountResource()
+              .applicationResource(applicationResource)
+              .profileId(rs.getObject("profile_id", UUID.class))
+              .resourceId(rs.getObject("storage_account_resource_id", UUID.class))
+              .name(rs.getString("name"))
+              .topLevelContainer(rs.getString("toplevelcontainer"))
+              .dataContainer(rs.getString("datacontainer"))
+              .metadataContainer(rs.getString("metadatacontainer"))
+              .dbName(rs.getString("dbname"))
+              .flightId(rs.getString("flightid"))
+              .region(region);
+        });
   }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
@@ -56,7 +56,8 @@ public class AzureResourceDao {
           + "LEFT JOIN storage_resource sr on dsa.dataset_id = sr.dataset_id AND sr.cloud_resource='STORAGE_ACCOUNT' ";
 
   private static final String sqlStorageAccountRetrievedByApplicationResource =
-      sqlStorageAccountRetrieve + "WHERE sa.marked_for_delete = :marked_for_delete AND application_resource_id = :application_resource_id";
+      sqlStorageAccountRetrieve
+          + "WHERE sa.marked_for_delete = :marked_for_delete AND application_resource_id = :application_resource_id";
   private static final String sqlStorageAccountRetrievedById =
       sqlStorageAccountRetrieve + "WHERE sa.marked_for_delete = false AND sa.id = :id";
   private static final String sqlStorageAccountRetrievedByName =
@@ -162,10 +163,10 @@ public class AzureResourceDao {
       isolation = Isolation.SERIALIZABLE,
       readOnly = true)
   public List<AzureStorageAccountResource> retrieveStorageAccountsByApplicationResource(
-      UUID applicationResourceId,
-      boolean markedForDelete) {
+      UUID applicationResourceId, boolean markedForDelete) {
     MapSqlParameterSource params =
-        new MapSqlParameterSource().addValue("application_resource_id", applicationResourceId)
+        new MapSqlParameterSource()
+            .addValue("application_resource_id", applicationResourceId)
             .addValue("marked_for_delete", markedForDelete);
     return retrieveStorageAccountsBy(sqlStorageAccountRetrievedByApplicationResource, params);
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
@@ -56,7 +56,7 @@ public class AzureResourceDao {
           + "LEFT JOIN storage_resource sr on dsa.dataset_id = sr.dataset_id AND sr.cloud_resource='STORAGE_ACCOUNT' ";
 
   private static final String sqlStorageAccountRetrievedByApplicationResource =
-      sqlStorageAccountRetrieve + "WHERE application_resource_id = :application_resource_id";
+      sqlStorageAccountRetrieve + "WHERE sa.marked_for_delete = :marked_for_delete AND application_resource_id = :application_resource_id";
   private static final String sqlStorageAccountRetrievedById =
       sqlStorageAccountRetrieve + "WHERE sa.marked_for_delete = false AND sa.id = :id";
   private static final String sqlStorageAccountRetrievedByName =
@@ -162,9 +162,11 @@ public class AzureResourceDao {
       isolation = Isolation.SERIALIZABLE,
       readOnly = true)
   public List<AzureStorageAccountResource> retrieveStorageAccountsByApplicationResource(
-      UUID applicationResourceId) {
+      UUID applicationResourceId,
+      boolean markedForDelete) {
     MapSqlParameterSource params =
-        new MapSqlParameterSource().addValue("application_resource_id", applicationResourceId);
+        new MapSqlParameterSource().addValue("application_resource_id", applicationResourceId)
+            .addValue("marked_for_delete", markedForDelete);
     return retrieveStorageAccountsBy(sqlStorageAccountRetrievedByApplicationResource, params);
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
@@ -451,40 +451,22 @@ public class AzureResourceDao {
     return storageAccountResource;
   }
 
+  /**
+   * Mark the storage_account_resource metadata row associated with the storage account for delete,
+   * provided the row is either unlocked or locked by the provided flight.
+   *
+   * <p>Actual delete is performed when the associated application deployment is deleted
+   *
+   * @param storageAccountName name of storage account to delete
+   * @param flightId flight trying to delete storage account
+   * @return true if a row is deleted, false otherwise
+   */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public boolean markForDeleteStorageAccountMetadata(
       String storageAccountName, String topLevelContainer, String flightId) {
     String sql =
         """
       UPDATE storage_account_resource SET marked_for_delete = true
-      WHERE name = :name
-      AND toplevelcontainer = :topLevelContainer
-      AND (flightid = :flightid OR flightid IS NULL)
-      """;
-
-    MapSqlParameterSource params =
-        new MapSqlParameterSource()
-            .addValue("name", storageAccountName)
-            .addValue("topLevelContainer", topLevelContainer)
-            .addValue("flightid", flightId);
-    int numRowsUpdated = jdbcTemplate.update(sql, params);
-    return (numRowsUpdated == 1);
-  }
-
-  /**
-   * Delete the storage_account_resource metadata row associated with the storage account, provided
-   * the row is either unlocked or locked by the provided flight.
-   *
-   * @param storageAccountName name of storage account to delete
-   * @param flightId flight trying to do the delete
-   * @return true if a row is deleted, false otherwise
-   */
-  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public boolean deleteStorageAccountMetadata(
-      String storageAccountName, String topLevelContainer, String flightId) {
-    String sql =
-        """
-      DELETE FROM storage_account_resource
       WHERE name = :name
       AND toplevelcontainer = :topLevelContainer
       AND (flightid = :flightid OR flightid IS NULL)

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceDao.java
@@ -451,6 +451,26 @@ public class AzureResourceDao {
     return storageAccountResource;
   }
 
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public boolean markForDeleteStorageAccountMetadata(
+      String storageAccountName, String topLevelContainer, String flightId) {
+    String sql =
+        """
+      UPDATE storage_account_resource SET marked_for_delete = true
+      WHERE name = :name
+      AND toplevelcontainer = :topLevelContainer
+      AND (flightid = :flightid OR flightid IS NULL)
+      """;
+
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("name", storageAccountName)
+            .addValue("topLevelContainer", topLevelContainer)
+            .addValue("flightid", flightId);
+    int numRowsUpdated = jdbcTemplate.update(sql, params);
+    return (numRowsUpdated == 1);
+  }
+
   /**
    * Delete the storage_account_resource metadata row associated with the storage account, provided
    * the row is either unlocked or locked by the provided flight.

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -222,14 +222,20 @@ public class AzureStorageAccountService {
 
   /**
    * Delete the Azure cloud storage account resource.
+   *
    * @param profileModel the TDR billing profile associated with this storage account
    * @param storageAccountResource
    */
   public void deleteCloudStorageAccount(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
     logger.info("Deleting storage account {}", storageAccountResource.getName());
-    AzureResourceManager clientSa = resourceConfiguration.getClient(profileModel.getSubscriptionId());
-    clientSa.storageAccounts().deleteByResourceGroup(storageAccountResource.getApplicationResource().getAzureResourceGroupName(), storageAccountResource.getName());
+    AzureResourceManager clientSa =
+        resourceConfiguration.getClient(profileModel.getSubscriptionId());
+    clientSa
+        .storageAccounts()
+        .deleteByResourceGroup(
+            storageAccountResource.getApplicationResource().getAzureResourceGroupName(),
+            storageAccountResource.getName());
   }
 
   public List<AzureStorageAccountResource> listStorageAccountIdsPerAppDeployment(
@@ -239,7 +245,8 @@ public class AzureStorageAccountService {
         .forEach(
             applicationResourceId -> {
               resources.addAll(
-                  resourceDao.retrieveStorageAccountsByApplicationResource(applicationResourceId, markedForDelete));
+                  resourceDao.retrieveStorageAccountsByApplicationResource(
+                      applicationResourceId, markedForDelete));
             });
     return resources;
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -208,18 +208,6 @@ public class AzureStorageAccountService {
     return resourceDao.retrieveStorageAccountById(storageAccountId);
   }
 
-  public void deleteCloudStorageAccountMetadata(
-      String storageAccountResourceName, String topLevelContainer, String flightId) {
-    logger.info(
-        "Deleting Azure storage account metadata named {} with top level container {}",
-        storageAccountResourceName,
-        topLevelContainer);
-    boolean deleted =
-        resourceDao.deleteStorageAccountMetadata(
-            storageAccountResourceName, topLevelContainer, flightId);
-    logger.info("Metadata removed: {}", deleted);
-  }
-
   public void markForDeleteCloudStorageAccountMetadata(
       String storageAccountResourceName, String topLevelContainer, String flightId) {
     logger.info(

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -12,6 +12,7 @@ import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.storage.models.StorageAccount;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -239,14 +240,15 @@ public class AzureStorageAccountService {
 
   public List<AzureStorageAccountResource> listStorageAccountPerAppDeployment(
       List<UUID> applicationResourceIds, boolean markedForDelete) {
-    return applicationResourceIds.stream()
-        .flatMap(
-            applicationResourceId ->
-                resourceDao
-                    .retrieveStorageAccountsByApplicationResource(
-                        applicationResourceId, markedForDelete)
-                    .stream())
-        .toList();
+    List<AzureStorageAccountResource> resources = new ArrayList<>();
+    applicationResourceIds.stream()
+        .forEach(
+            applicationResourceId -> {
+              resources.addAll(
+                  resourceDao.retrieveStorageAccountsByApplicationResource(
+                      applicationResourceId, markedForDelete));
+            });
+    return resources;
   }
 
   private StorageAccountLockException storageAccountLockException(String flightId) {

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -12,7 +12,6 @@ import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.storage.models.StorageAccount;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -240,15 +239,14 @@ public class AzureStorageAccountService {
 
   public List<AzureStorageAccountResource> listStorageAccountPerAppDeployment(
       List<UUID> applicationResourceIds, boolean markedForDelete) {
-    List<AzureStorageAccountResource> resources = new ArrayList<>();
-    applicationResourceIds.stream()
-        .forEach(
-            applicationResourceId -> {
-              resources.addAll(
-                  resourceDao.retrieveStorageAccountsByApplicationResource(
-                      applicationResourceId, markedForDelete));
-            });
-    return resources;
+    return applicationResourceIds.stream()
+        .flatMap(
+            applicationResourceId ->
+                resourceDao
+                    .retrieveStorageAccountsByApplicationResource(
+                        applicationResourceId, markedForDelete)
+                    .stream())
+        .toList();
   }
 
   private StorageAccountLockException storageAccountLockException(String flightId) {

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -220,6 +220,18 @@ public class AzureStorageAccountService {
     logger.info("Metadata removed: {}", deleted);
   }
 
+  public void markForDeleteCloudStorageAccountMetadata(
+      String storageAccountResourceName, String topLevelContainer, String flightId) {
+    logger.info(
+        "Marking for delete Azure storage account metadata named {} with top level container {}",
+        storageAccountResourceName,
+        topLevelContainer);
+    boolean deleted =
+        resourceDao.markForDeleteStorageAccountMetadata(
+            storageAccountResourceName, topLevelContainer, flightId);
+    logger.info("Metadata marked for delete: {}", deleted);
+  }
+
   /**
    * Delete the Azure cloud storage account resource.
    *
@@ -238,7 +250,7 @@ public class AzureStorageAccountService {
             storageAccountResource.getName());
   }
 
-  public List<AzureStorageAccountResource> listStorageAccountIdsPerAppDeployment(
+  public List<AzureStorageAccountResource> listStorageAccountPerAppDeployment(
       List<UUID> applicationResourceIds, boolean markedForDelete) {
     List<AzureStorageAccountResource> resources = new ArrayList<>();
     applicationResourceIds.stream()
@@ -340,7 +352,7 @@ public class AzureStorageAccountService {
    * @return a reference to the storage account as an Azure storage account object, null if not
    *     found
    */
-  StorageAccount getCloudStorageAccount(
+  public StorageAccount getCloudStorageAccount(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
     if (storageAccountResource == null) {
       return null;

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountService.java
@@ -11,6 +11,8 @@ import bio.terra.service.resourcemanagement.exception.StorageAccountLockExceptio
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.storage.models.StorageAccount;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
@@ -215,6 +217,18 @@ public class AzureStorageAccountService {
         resourceDao.deleteStorageAccountMetadata(
             storageAccountResourceName, topLevelContainer, flightId);
     logger.info("Metadata removed: {}", deleted);
+  }
+
+  public List<AzureStorageAccountResource> listStorageAccountIdsPerAppDeployment(
+      List<UUID> applicationResourceIds) {
+    List<AzureStorageAccountResource> resources = new ArrayList<>();
+    applicationResourceIds.stream()
+        .forEach(
+            applicationResourceId -> {
+              resources.addAll(
+                  resourceDao.retrieveStorageAccountsByApplicationResource(applicationResourceId));
+            });
+    return resources;
   }
 
   private StorageAccountLockException storageAccountLockException(String flightId) {

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
@@ -67,13 +67,11 @@ public class AzureStorageMonitoringStepProvider {
   }
 
   public List<StepDef> configureDeleteSteps(AzureStorageAccountService azureStorageAccountService) {
-    List<StepDef> steps = new ArrayList<>();
     RetryRuleNone noRetry = getRetryRuleNone();
-    steps.add(
+    return List.of(
         new StepDef(
-            new DeleteSentinelStep(monitoringService, azureStorageAccountService), noRetry));
-    steps.add(new StepDef(new DeleteLogAnalyticsWorkspaceStep(monitoringService), noRetry));
-    return steps;
+            new DeleteSentinelStep(monitoringService, azureStorageAccountService), noRetry),
+    new StepDef(new DeleteLogAnalyticsWorkspaceStep(monitoringService), noRetry));
   }
 
   public record StepDef(Step step, RetryRule retryRule) {}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
@@ -5,6 +5,7 @@ import static bio.terra.stairway.RetryRuleNone.getRetryRuleNone;
 
 import bio.terra.app.model.AzureRegion;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
 import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.RetryRuleExponentialBackoff;
 import bio.terra.stairway.RetryRuleNone;
@@ -62,6 +63,16 @@ public class AzureStorageMonitoringStepProvider {
       steps.add(
           new StepDef(new CreateSentinelNotificationRuleStep(monitoringService, region), noRetry));
     }
+    return steps;
+  }
+
+  public List<StepDef> configureDeleteSteps(AzureStorageAccountService azureStorageAccountService) {
+    List<StepDef> steps = new ArrayList<>();
+    RetryRuleNone noRetry = getRetryRuleNone();
+    steps.add(
+        new StepDef(
+            new DeleteSentinelStep(monitoringService, azureStorageAccountService), noRetry));
+    steps.add(new StepDef(new DeleteLogAnalyticsWorkspaceStep(monitoringService), noRetry));
     return steps;
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
@@ -5,7 +5,6 @@ import static bio.terra.stairway.RetryRuleNone.getRetryRuleNone;
 
 import bio.terra.app.model.AzureRegion;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
 import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.RetryRuleExponentialBackoff;
 import bio.terra.stairway.Step;
@@ -63,9 +62,9 @@ public class AzureStorageMonitoringStepProvider {
     return steps;
   }
 
-  public List<StepDef> configureDeleteSteps(AzureStorageAccountService azureStorageAccountService) {
+  public List<StepDef> configureDeleteSteps() {
     return List.of(
-        new StepDef(new DeleteSentinelStep(monitoringService, azureStorageAccountService)),
+        new StepDef(new DeleteSentinelStep(monitoringService)),
         new StepDef(new DeleteLogAnalyticsWorkspaceStep(monitoringService)));
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/AzureStorageMonitoringStepProvider.java
@@ -8,7 +8,6 @@ import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
 import bio.terra.stairway.RetryRule;
 import bio.terra.stairway.RetryRuleExponentialBackoff;
-import bio.terra.stairway.RetryRuleNone;
 import bio.terra.stairway.Step;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,14 +34,13 @@ public class AzureStorageMonitoringStepProvider {
    */
   public List<StepDef> configureSteps(boolean isSecureMonitoringEnabled, AzureRegion region) {
     List<StepDef> steps = new ArrayList<>();
-    RetryRuleNone noRetry = getRetryRuleNone();
     RetryRuleExponentialBackoff expBackoffRetry = getDefaultExponentialBackoffRetryRule();
 
     // Deploy a Log Analytics Workspace if it doesn't exist already
-    steps.add(new StepDef(new CreateLogAnalyticsWorkspaceStep(monitoringService, region), noRetry));
+    steps.add(new StepDef(new CreateLogAnalyticsWorkspaceStep(monitoringService, region)));
     // Create a diagnostic setting for the storage account if it doesn't exist already
     // This is what tells the storage account to send logs to the Log Analytics Workspace
-    steps.add(new StepDef(new CreateDiagnosticSettingStep(monitoringService, region), noRetry));
+    steps.add(new StepDef(new CreateDiagnosticSettingStep(monitoringService, region)));
 
     // The following steps are only required for FedRAMP compliance
     // They are not turned on in all cases due to cost
@@ -50,9 +48,9 @@ public class AzureStorageMonitoringStepProvider {
       // Create a rule to send the Log Analytics logs to a central storage account where the logs
       // will be retained for longer than the default 90 day minimum that the Log Analytics
       // Workspace stores
-      steps.add(new StepDef(new CreateExportRuleStep(monitoringService, region), noRetry));
+      steps.add(new StepDef(new CreateExportRuleStep(monitoringService, region)));
       // Deploy a Sentinel Workspace if it doesn't exist already
-      steps.add(new StepDef(new CreateSentinelStep(monitoringService, region), noRetry));
+      steps.add(new StepDef(new CreateSentinelStep(monitoringService, region)));
       // Add any rules to Sentinel that will detect events of interest.  It takes a little bit for
       // Sentinel to be available so adding a retry rule here.
       steps.add(
@@ -60,19 +58,20 @@ public class AzureStorageMonitoringStepProvider {
               new CreateSentinelAlertRulesStep(monitoringService, region), expBackoffRetry));
       // Add a notification playbook rule to the Sentinel instance.  This ensures that a Slack
       // notification is sent when an alert is triggered.
-      steps.add(
-          new StepDef(new CreateSentinelNotificationRuleStep(monitoringService, region), noRetry));
+      steps.add(new StepDef(new CreateSentinelNotificationRuleStep(monitoringService, region)));
     }
     return steps;
   }
 
   public List<StepDef> configureDeleteSteps(AzureStorageAccountService azureStorageAccountService) {
-    RetryRuleNone noRetry = getRetryRuleNone();
     return List.of(
-        new StepDef(
-            new DeleteSentinelStep(monitoringService, azureStorageAccountService), noRetry),
-    new StepDef(new DeleteLogAnalyticsWorkspaceStep(monitoringService), noRetry));
+        new StepDef(new DeleteSentinelStep(monitoringService, azureStorageAccountService)),
+        new StepDef(new DeleteLogAnalyticsWorkspaceStep(monitoringService)));
   }
 
-  public record StepDef(Step step, RetryRule retryRule) {}
+  public record StepDef(Step step, RetryRule retryRule) {
+    public StepDef(Step step) {
+      this(step, getRetryRuleNone());
+    }
+  }
 }

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/CreateSentinelStep.java
@@ -39,7 +39,7 @@ public class CreateSentinelStep extends AbstractCreateMonitoringResourceStep {
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     String sentinelId = workingMap.get(AzureMonitoringMapKeys.SENTINEL_ID, String.class);
     if (sentinelId != null) {
-      monitoringService.deleteSentinel(profileModel, sentinelId);
+      monitoringService.deleteSentinelById(profileModel, sentinelId);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteAzureStorageAccountStep.java
@@ -3,7 +3,6 @@ package bio.terra.service.resourcemanagement.flight;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.profile.flight.ProfileMapKeys;
-import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
 import bio.terra.stairway.FlightContext;
@@ -16,8 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DeleteAzureStorageAccountStep extends DefaultUndoStep {
-  private static final Logger logger =
-      LoggerFactory.getLogger(DeleteAzureStorageAccountStep.class);
+  private static final Logger logger = LoggerFactory.getLogger(DeleteAzureStorageAccountStep.class);
   private AzureStorageAccountService azureStorageAccountService;
 
   public DeleteAzureStorageAccountStep(AzureStorageAccountService azureStorageAccountService) {}
@@ -32,11 +30,11 @@ public class DeleteAzureStorageAccountStep extends DefaultUndoStep {
             ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
 
     for (AzureStorageAccountResource storageAccountResource : storageAccounts) {
-      if (azureStorageAccountService.retrieveStorageAccountById(storageAccountResource.getResourceId())
+      if (azureStorageAccountService.retrieveStorageAccountById(
+              storageAccountResource.getResourceId())
           != null) {
         logger.info(
-            "Azure storage account {} found; Attempting delete.",
-            storageAccountResource.getName());
+            "Azure storage account {} found; Attempting delete.", storageAccountResource.getName());
         // TODO - how should we do error handling?
         azureStorageAccountService.deleteCloudStorageAccount(profileModel, storageAccountResource);
       } else {

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteAzureStorageAccountStep.java
@@ -18,7 +18,9 @@ public class DeleteAzureStorageAccountStep extends DefaultUndoStep {
   private static final Logger logger = LoggerFactory.getLogger(DeleteAzureStorageAccountStep.class);
   private AzureStorageAccountService azureStorageAccountService;
 
-  public DeleteAzureStorageAccountStep(AzureStorageAccountService azureStorageAccountService) {}
+  public DeleteAzureStorageAccountStep(AzureStorageAccountService azureStorageAccountService) {
+    this.azureStorageAccountService = azureStorageAccountService;
+  }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
@@ -30,12 +32,10 @@ public class DeleteAzureStorageAccountStep extends DefaultUndoStep {
             ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
 
     for (AzureStorageAccountResource storageAccountResource : storageAccounts) {
-      if (azureStorageAccountService.retrieveStorageAccountById(
-              storageAccountResource.getResourceId())
+      if (azureStorageAccountService.getCloudStorageAccount(profileModel, storageAccountResource)
           != null) {
         logger.info(
             "Azure storage account {} found; Attempting delete.", storageAccountResource.getName());
-        // TODO - how should we do error handling?
         azureStorageAccountService.deleteCloudStorageAccount(profileModel, storageAccountResource);
       } else {
         logger.warn(

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteAzureStorageAccountStep.java
@@ -1,0 +1,50 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteAzureStorageAccountStep extends DefaultUndoStep {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DeleteAzureStorageAccountStep.class);
+  private AzureStorageAccountService azureStorageAccountService;
+
+  public DeleteAzureStorageAccountStep(AzureStorageAccountService azureStorageAccountService) {}
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    List<AzureStorageAccountResource> storageAccounts =
+        workingMap.get(
+            ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
+
+    for (AzureStorageAccountResource storageAccountResource : storageAccounts) {
+      if (azureStorageAccountService.retrieveStorageAccountById(storageAccountResource.getResourceId())
+          != null) {
+        logger.info(
+            "Azure storage account {} found; Attempting delete.",
+            storageAccountResource.getName());
+        // TODO - how should we do error handling?
+        azureStorageAccountService.deleteCloudStorageAccount(profileModel, storageAccountResource);
+      } else {
+        logger.warn(
+            "Azure Storage Account NOT FOUND for storage account {}; Skipping delete.",
+            storageAccountResource.getName());
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteAzureStorageAccountStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteAzureStorageAccountStep.java
@@ -29,7 +29,7 @@ public class DeleteAzureStorageAccountStep extends DefaultUndoStep {
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     List<AzureStorageAccountResource> storageAccounts =
         workingMap.get(
-            ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
+            ProfileMapKeys.PROFILE_UNIQUE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
 
     for (AzureStorageAccountResource storageAccountResource : storageAccounts) {
       if (azureStorageAccountService.getCloudStorageAccount(profileModel, storageAccountResource)

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
@@ -38,7 +38,6 @@ public class DeleteLogAnalyticsWorkspaceStep extends DefaultUndoStep {
         logger.info(
             "Log Analytics Workspace found for storage account {}; Attempting delete.",
             storageAccountResource.getName());
-        // TODO - how should we do error handling?
         monitoringService.deleteLogAnalyticsWorkspace(profileModel, storageAccountResource);
       } else {
         logger.warn(

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
@@ -30,7 +30,7 @@ public class DeleteLogAnalyticsWorkspaceStep extends DefaultUndoStep {
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     List<AzureStorageAccountResource> storageAccounts =
         workingMap.get(
-            ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
+            ProfileMapKeys.PROFILE_UNIQUE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
 
     for (AzureStorageAccountResource storageAccountResource : storageAccounts) {
       if (monitoringService.getLogAnalyticsWorkspace(profileModel, storageAccountResource)

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
@@ -19,7 +19,9 @@ public class DeleteLogAnalyticsWorkspaceStep extends DefaultUndoStep {
       LoggerFactory.getLogger(DeleteLogAnalyticsWorkspaceStep.class);
   private AzureMonitoringService monitoringService;
 
-  public DeleteLogAnalyticsWorkspaceStep(AzureMonitoringService monitoringService) {}
+  public DeleteLogAnalyticsWorkspaceStep(AzureMonitoringService monitoringService) {
+    this.monitoringService = monitoringService;
+  }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 public class DeleteLogAnalyticsWorkspaceStep extends DefaultUndoStep {
   private static final Logger logger =
       LoggerFactory.getLogger(DeleteLogAnalyticsWorkspaceStep.class);
-  private AzureMonitoringService monitoringService;
+  private final AzureMonitoringService monitoringService;
 
   public DeleteLogAnalyticsWorkspaceStep(AzureMonitoringService monitoringService) {
     this.monitoringService = monitoringService;

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteLogAnalyticsWorkspaceStep.java
@@ -1,0 +1,49 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteLogAnalyticsWorkspaceStep extends DefaultUndoStep {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DeleteLogAnalyticsWorkspaceStep.class);
+  private AzureMonitoringService monitoringService;
+
+  public DeleteLogAnalyticsWorkspaceStep(AzureMonitoringService monitoringService) {}
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+    List<AzureStorageAccountResource> storageAccounts =
+        workingMap.get(
+            ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
+
+    for (AzureStorageAccountResource storageAccountResource : storageAccounts) {
+      if (monitoringService.getLogAnalyticsWorkspace(profileModel, storageAccountResource)
+          != null) {
+        logger.info(
+            "Log Analytics Workspace found for storage account {}; Attempting delete.",
+            storageAccountResource.getName());
+        // TODO - how should we do error handling?
+        monitoringService.deleteLogAnalyticsWorkspace(profileModel, storageAccountResource);
+      } else {
+        logger.warn(
+            "Log Analytics Workspace NOT FOUND for storage account {}; Skipping delete.",
+            storageAccountResource.getName());
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteSentinelStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteSentinelStep.java
@@ -33,7 +33,7 @@ public class DeleteSentinelStep extends DefaultUndoStep {
     List<UUID> appIdList =
         workingMap.get(ProfileMapKeys.PROFILE_APPLICATION_DEPLOYMENT_ID_LIST, List.class);
     List<AzureStorageAccountResource> storageAccounts =
-        azureStorageAccountService.listStorageAccountIdsPerAppDeployment(appIdList);
+        azureStorageAccountService.listStorageAccountIdsPerAppDeployment(appIdList, true);
     workingMap.put(ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, storageAccounts);
 
     BillingProfileModel profileModel =

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteSentinelStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteSentinelStep.java
@@ -29,7 +29,7 @@ public class DeleteSentinelStep extends DefaultUndoStep {
         workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
     List<AzureStorageAccountResource> storageAccounts =
         workingMap.get(
-            ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
+            ProfileMapKeys.PROFILE_UNIQUE_STORAGE_ACCOUNT_RESOURCE_LIST, new TypeReference<>() {});
 
     for (AzureStorageAccountResource storageAccountResource : storageAccounts) {
       var sentinel = monitoringService.getSentinel(profileModel, storageAccountResource);

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteSentinelStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteSentinelStep.java
@@ -5,7 +5,6 @@ import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.profile.flight.ProfileMapKeys;
 import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
-import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
@@ -17,14 +16,10 @@ import org.slf4j.LoggerFactory;
 
 public class DeleteSentinelStep extends DefaultUndoStep {
   private static final Logger logger = LoggerFactory.getLogger(DeleteSentinelStep.class);
-  private AzureStorageAccountService azureStorageAccountService;
   private AzureMonitoringService monitoringService;
 
-  public DeleteSentinelStep(
-      AzureMonitoringService monitoringService,
-      AzureStorageAccountService azureStorageAccountService) {
+  public DeleteSentinelStep(AzureMonitoringService monitoringService) {
     this.monitoringService = monitoringService;
-    this.azureStorageAccountService = azureStorageAccountService;
   }
 
   @Override

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteSentinelStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/DeleteSentinelStep.java
@@ -1,0 +1,58 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureMonitoringService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteSentinelStep extends DefaultUndoStep {
+  private static final Logger logger = LoggerFactory.getLogger(DeleteSentinelStep.class);
+  private AzureStorageAccountService azureStorageAccountService;
+  private AzureMonitoringService monitoringService;
+
+  public DeleteSentinelStep(
+      AzureMonitoringService monitoringService,
+      AzureStorageAccountService azureStorageAccountService) {
+    this.monitoringService = monitoringService;
+    this.azureStorageAccountService = azureStorageAccountService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    List<UUID> appIdList =
+        workingMap.get(ProfileMapKeys.PROFILE_APPLICATION_DEPLOYMENT_ID_LIST, List.class);
+    List<AzureStorageAccountResource> storageAccounts =
+        azureStorageAccountService.listStorageAccountIdsPerAppDeployment(appIdList);
+    workingMap.put(ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, storageAccounts);
+
+    BillingProfileModel profileModel =
+        workingMap.get(ProfileMapKeys.PROFILE_MODEL, BillingProfileModel.class);
+
+    for (AzureStorageAccountResource storageAccountResource : storageAccounts) {
+      var sentinel = monitoringService.getSentinel(profileModel, storageAccountResource);
+      if (sentinel != null) {
+        logger.info(
+            "Sentinel instance found for storage account {}; Attempting delete.",
+            storageAccountResource.getName());
+        // TODO - how should we do error handling?
+        monitoringService.deleteSentinelByStorageAccount(profileModel, storageAccountResource);
+      } else {
+        logger.warn(
+            "Sentinel instance NOT FOUND for storage account {}; Skipping delete.",
+            storageAccountResource.getName());
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/RecordAzureStorageAccountsStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/RecordAzureStorageAccountsStep.java
@@ -8,6 +8,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -50,7 +51,11 @@ public class RecordAzureStorageAccountsStep extends DefaultUndoStep {
     List<AzureStorageAccountResource> storageAccounts =
         azureStorageAccountService.listStorageAccountPerAppDeployment(appIdList, true);
     // Filter down this list to only return one resource per unique cloud storage account resource
-    return storageAccounts.stream().filter(distinctByKey(sa -> sa.getName())).toList();
+    List<AzureStorageAccountResource> filteredStorageAccounts = new ArrayList<>();
+    storageAccounts.stream()
+        .filter(distinctByKey(sa -> sa.getName()))
+        .forEach(unique_sa -> filteredStorageAccounts.add(unique_sa));
+    return filteredStorageAccounts;
   }
 
   private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/RecordAzureStorageAccountsStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/RecordAzureStorageAccountsStep.java
@@ -1,0 +1,46 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.profile.flight.ProfileMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecordAzureStorageAccountsStep extends DefaultUndoStep {
+  private static final Logger logger =
+      LoggerFactory.getLogger(RecordAzureStorageAccountsStep.class);
+  AzureStorageAccountService azureStorageAccountService;
+
+  public RecordAzureStorageAccountsStep(AzureStorageAccountService azureStorageAccountService) {
+    this.azureStorageAccountService = azureStorageAccountService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    List<UUID> appIdList =
+        workingMap.get(ProfileMapKeys.PROFILE_APPLICATION_DEPLOYMENT_ID_LIST, List.class);
+
+    // Note: This will list a storage account for each top level container
+    // So, there may be duplicates of the cloud storage account resource
+    // Top level container and storage accounts have a many-to-one relationship
+    List<AzureStorageAccountResource> storageAccounts =
+        azureStorageAccountService.listStorageAccountPerAppDeployment(appIdList, true);
+    workingMap.put(ProfileMapKeys.PROFILE_STORAGE_ACCOUNT_RESOURCE_LIST, storageAccounts);
+    if (storageAccounts.isEmpty()) {
+      logger.warn("No storage accounts found to be deleted for this billing profile.");
+    } else {
+      logger.info(
+          "Found {} storage accounts to be deleted for this billing profile.",
+          storageAccounts.size());
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataAzureStep.java
@@ -24,7 +24,7 @@ public class DeleteSnapshotMetadataAzureStep implements Step {
     String storageAccountResourceTopLevelContainer =
         workingMap.get(SnapshotWorkingMapKeys.STORAGE_ACCOUNT_RESOURCE_TLC, String.class);
 
-    storageAccountService.deleteCloudStorageAccountMetadata(
+    storageAccountService.markForDeleteCloudStorageAccountMetadata(
         storageAccountResourceName, storageAccountResourceTopLevelContainer, context.getFlightId());
 
     return StepResult.getStepResultSuccess();

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -272,8 +272,8 @@ paths:
           description: ADMIN ONLY - Delete all Azure cloud resources along with billing profile.
           schema:
             type: boolean
-            default: false
-            required: false
+          default: false
+          required: false
       responses:
         200:
           description: Redirect for profile delete result

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -267,6 +267,12 @@ paths:
       operationId: deleteProfile
       parameters:
         - $ref: '#/components/parameters/Id'
+        - name: deleteCloudResources
+          in: query
+          description: ADMIN ONLY - Delete all Azure cloud resources along with billing profile.
+          schema:
+            type: boolean
+            default: false
       responses:
         200:
           description: Redirect for profile delete result

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -272,7 +272,7 @@ paths:
           description: ADMIN ONLY - Delete all Azure cloud resources along with billing profile.
           schema:
             type: boolean
-          default: false
+            default: false
           required: false
       responses:
         200:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -273,6 +273,7 @@ paths:
           schema:
             type: boolean
             default: false
+            required: false
       responses:
         200:
           description: Redirect for profile delete result

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -487,7 +487,7 @@ public class ConnectedOperations {
 
   public boolean deleteTestProfile(UUID id) throws Exception {
     MvcResult result =
-        mvc.perform(delete("/api/resources/v1/profiles/" + id + "?deleteCloudResources=true"))
+        mvc.perform(delete("/api/resources/v1/profiles/{id}?deleteCloudResources=true", id))
             .andReturn();
     MockHttpServletResponse response = validateJobModelAndWait(result);
     return checkDeleteResponse(response);

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -486,7 +486,9 @@ public class ConnectedOperations {
   }
 
   public boolean deleteTestProfile(UUID id) throws Exception {
-    MvcResult result = mvc.perform(delete("/api/resources/v1/profiles/" + id)).andReturn();
+    MvcResult result =
+        mvc.perform(delete("/api/resources/v1/profiles/" + id + "?deleteCloudResources=true"))
+            .andReturn();
     MockHttpServletResponse response = validateJobModelAndWait(result);
     return checkDeleteResponse(response);
   }

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -139,6 +139,7 @@ public class AzureIntegrationTest extends UsersBase {
 
   private String stewardToken;
   private User steward;
+  private User admin;
   private UUID datasetId;
   private List<UUID> snapshotIds;
   private UUID profileId;
@@ -153,6 +154,7 @@ public class AzureIntegrationTest extends UsersBase {
     // Voldemort is required by this test since the application is deployed with his user authz'ed
     steward = steward("voldemort");
     stewardToken = authService.getDirectAccessAuthToken(steward.getEmail());
+    admin = admin("hermione");
     dataRepoFixtures.resetConfig(steward);
     profileId = dataRepoFixtures.createAzureBillingProfile(steward).getId();
     retryOptions =
@@ -193,7 +195,7 @@ public class AzureIntegrationTest extends UsersBase {
       dataRepoFixtures.deleteDataset(steward, datasetId);
     }
     if (profileId != null) {
-      dataRepoFixtures.deleteProfileWithCloudResourceDelete(steward, profileId);
+      dataRepoFixtures.deleteProfileWithCloudResourceDelete(admin, profileId);
     }
     if (storageAccounts != null) {
       storageAccounts.forEach(this::deleteCloudResources);

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -193,7 +193,7 @@ public class AzureIntegrationTest extends UsersBase {
       dataRepoFixtures.deleteDataset(steward, datasetId);
     }
     if (profileId != null) {
-      dataRepoFixtures.deleteProfile(steward, profileId);
+      dataRepoFixtures.deleteProfileWithCloudResourceDelete(steward, profileId);
     }
     if (storageAccounts != null) {
       storageAccounts.forEach(this::deleteCloudResources);

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -1503,7 +1503,6 @@ public class AzureIntegrationTest extends UsersBase {
 
     LogAnalyticsManager clientLaw =
         azureResourceConfiguration.getLogAnalyticsManagerClient(
-            azureResourceConfiguration.credentials().getHomeTenantId(),
             testConfig.getTargetSubscriptionId());
     clientLaw
         .workspaces()
@@ -1530,9 +1529,7 @@ public class AzureIntegrationTest extends UsersBase {
 
     Workspace logAnalyticsWorkspace =
         azureResourceConfiguration
-            .getLogAnalyticsManagerClient(
-                azureResourceConfiguration.credentials().getHomeTenantId(),
-                testConfig.getTargetSubscriptionId())
+            .getLogAnalyticsManagerClient(testConfig.getTargetSubscriptionId())
             .workspaces()
             .getByResourceGroup(testConfig.getTargetManagedResourceGroupName(), storageAccountName);
     assertThat(

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -105,7 +105,18 @@ public class DataRepoClient {
 
   public <T> DataRepoResponse<T> delete(
       TestConfiguration.User user, String path, TypeReference<T> responseClass) throws Exception {
-    HttpEntity<String> entity = new HttpEntity<>(getHeaders(user));
+    return delete(user, path, null, responseClass);
+  }
+
+  public <T> DataRepoResponse<T> delete(
+      TestConfiguration.User user, String path, String json, TypeReference<T> responseClass)
+      throws Exception {
+    HttpEntity<String> entity;
+    if (json != null) {
+      entity = new HttpEntity<>(json, getHeaders(user));
+    } else {
+      entity = new HttpEntity<>(getHeaders(user));
+    }
     return makeDataRepoRequest(path, HttpMethod.DELETE, entity, user, responseClass);
   }
 

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -111,12 +111,7 @@ public class DataRepoClient {
   public <T> DataRepoResponse<T> delete(
       TestConfiguration.User user, String path, String json, TypeReference<T> responseClass)
       throws Exception {
-    HttpEntity<String> entity;
-    if (json != null) {
-      entity = new HttpEntity<>(json, getHeaders(user));
-    } else {
-      entity = new HttpEntity<>(getHeaders(user));
-    }
+    HttpEntity<String> entity = new HttpEntity<>(json, getHeaders(user));
     return makeDataRepoRequest(path, HttpMethod.DELETE, entity, user, responseClass);
   }
 

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -183,12 +183,31 @@ public class DataRepoFixtures {
     assertGoodDeleteResponse(deleteResponse);
   }
 
+  public void deleteProfileWithCloudResourceDelete(TestConfiguration.User user, UUID profileId)
+      throws Exception {
+    DataRepoResponse<DeleteResponseModel> deleteResponse = deleteProfileLog(user, profileId, true);
+    assertGoodDeleteResponse(deleteResponse);
+  }
+
   public DataRepoResponse<DeleteResponseModel> deleteProfileLog(
       TestConfiguration.User user, UUID profileId) throws Exception {
+    return deleteProfileLog(user, profileId, false);
+  }
 
+  public DataRepoResponse<DeleteResponseModel> deleteProfileLog(
+      TestConfiguration.User user, UUID profileId, boolean deleteCloudResources) throws Exception {
+
+    String deleteCloudResourcesQuery;
+    if (deleteCloudResources) {
+      deleteCloudResourcesQuery = "?deleteCloudResources=true";
+    } else {
+      deleteCloudResourcesQuery = "";
+    }
     DataRepoResponse<JobModel> jobResponse =
         dataRepoClient.delete(
-            user, "/api/resources/v1/profiles/" + profileId, new TypeReference<>() {});
+            user,
+            "/api/resources/v1/profiles/" + profileId + deleteCloudResourcesQuery,
+            new TypeReference<>() {});
     assertTrue("profile delete launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
     assertTrue(
         "profile delete launch response is present", jobResponse.getResponseObject().isPresent());

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -1,9 +1,9 @@
 package bio.terra.service.profile;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -34,19 +34,19 @@ import bio.terra.service.profile.exception.ProfileNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
 public class ProfileAPIControllerTest {
 
   @Mock private ObjectMapper objectMapper;
@@ -64,8 +64,8 @@ public class ProfileAPIControllerTest {
   private ProfileApiController apiController;
   private AuthenticatedUserRequest user;
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeEach
+  void setup() {
     apiController =
         new ProfileApiController(
             objectMapper,
@@ -87,7 +87,7 @@ public class ProfileAPIControllerTest {
   }
 
   @Test
-  public void testCreateProfile() {
+  void testCreateProfile() {
     when(authenticatedUserRequestFactory.from(eq(request))).thenReturn(user);
     var billingProfileRequestModel = new BillingProfileRequestModel();
     String jobId = "jobId";
@@ -104,7 +104,7 @@ public class ProfileAPIControllerTest {
   }
 
   @Test
-  public void testUpdateProfile() {
+  void testUpdateProfile() {
     when(authenticatedUserRequestFactory.from(eq(request))).thenReturn(user);
     var billingProfileUpdateModel = new BillingProfileUpdateModel().id(UUID.randomUUID());
     String jobId = "jobId";
@@ -120,7 +120,7 @@ public class ProfileAPIControllerTest {
   }
 
   @Test
-  public void testUpdateProfileNotFound() {
+  void testUpdateProfileNotFound() {
     UUID profileId = UUID.randomUUID();
     doThrow(ProfileNotFoundException.class).when(profileService).getProfileByIdNoCheck(profileId);
     var billingProfileUpdateModel = new BillingProfileUpdateModel().id(profileId);
@@ -132,7 +132,7 @@ public class ProfileAPIControllerTest {
   }
 
   @Test
-  public void testUpdateProfileForbidden() {
+  void testUpdateProfileForbidden() {
     when(authenticatedUserRequestFactory.from(eq(request))).thenReturn(user);
     UUID profileId = UUID.randomUUID();
     when(profileService.getProfileByIdNoCheck(profileId))
@@ -145,7 +145,7 @@ public class ProfileAPIControllerTest {
   }
 
   @Test
-  public void testDeleteProfile() {
+  void testDeleteProfile() {
     when(authenticatedUserRequestFactory.from(any())).thenReturn(user);
     UUID deleteId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     String jobId = "jobId";
@@ -161,7 +161,7 @@ public class ProfileAPIControllerTest {
   }
 
   @Test
-  public void testDeleteProfileNotFound() {
+  void testDeleteProfileNotFound() {
     UUID profileId = UUID.randomUUID();
     doThrow(ProfileNotFoundException.class).when(profileService).getProfileByIdNoCheck(profileId);
     assertThrows(
@@ -171,7 +171,7 @@ public class ProfileAPIControllerTest {
   }
 
   @Test
-  public void testDeleteProfileForbidden() {
+  void testDeleteProfileForbidden() {
     when(authenticatedUserRequestFactory.from(eq(request))).thenReturn(user);
     UUID profileId = UUID.randomUUID();
     when(profileService.getProfileByIdNoCheck(profileId))
@@ -182,7 +182,7 @@ public class ProfileAPIControllerTest {
   }
 
   @Test
-  public void testAddProfilePolicyMember() {
+  void testAddProfilePolicyMember() {
     when(authenticatedUserRequestFactory.from(any())).thenReturn(user);
 
     UUID id = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -161,8 +161,6 @@ public class ProfileAPIControllerTest {
     String jobId = "jobId";
     when(profileService.deleteProfile(eq(deleteId), eq(deleteCloudResources), eq(user)))
         .thenReturn(jobId);
-    //    when(profileService.getProfileByIdNoCheck(deleteId))
-    //        .thenReturn(new BillingProfileModel().id(deleteId));
     doNothing().when(iamService).verifyAuthorization(any(), any(), any(), any());
 
     var jobModel = new JobModel();

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -1,13 +1,13 @@
 package bio.terra.service.profile;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -105,7 +105,7 @@ public class ProfileAPIControllerTest {
     when(jobService.retrieveJob(jobId, user)).thenReturn(jobModel);
 
     ResponseEntity<JobModel> entity = apiController.createProfile(billingProfileRequestModel);
-    assertNotNull(entity);
+    assertThat("Correct job model is returned from request", entity.getBody(), is(jobModel));
   }
 
   @Test
@@ -120,7 +120,7 @@ public class ProfileAPIControllerTest {
     when(jobService.retrieveJob(jobId, user)).thenReturn(jobModel);
 
     ResponseEntity<JobModel> entity = apiController.updateProfile(billingProfileUpdateModel);
-    assertNotNull(entity);
+    assertThat("Correct job model is returned from request", entity.getBody(), is(jobModel));
   }
 
   @Test
@@ -158,7 +158,6 @@ public class ProfileAPIControllerTest {
     UUID deleteId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     String jobId = "jobId";
     when(profileService.deleteProfile(deleteId, deleteCloudResources, user)).thenReturn(jobId);
-    doNothing().when(iamService).verifyAuthorization(any(), any(), any(), any());
 
     var jobModel = new JobModel();
     jobModel.setJobStatus(JobStatusEnum.RUNNING);
@@ -176,7 +175,7 @@ public class ProfileAPIControllerTest {
             eq(IamResourceType.SPEND_PROFILE),
             eq(deleteId.toString()),
             eq(IamAction.DELETE));
-    assertNotNull(entity);
+    assertThat("Correct job model is returned from delete request", entity.getBody(), is(jobModel));
   }
 
   private static Stream<Arguments> testDeleteProfile() {

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -54,7 +54,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles({"google", "unittest"})
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
-public class ProfileAPIControllerTest {
+class ProfileAPIControllerTest {
 
   @Mock private ObjectMapper objectMapper;
   @Mock private HttpServletRequest request;

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -132,7 +132,7 @@ public class ProfileAPIControllerTest {
         ProfileNotFoundException.class,
         () -> apiController.updateProfile(billingProfileUpdateModel));
     verifyNoInteractions(iamService);
-    verify(profileService, never()).updateProfile(eq(billingProfileUpdateModel), eq(user));
+    verify(profileService, never()).updateProfile(billingProfileUpdateModel, user);
   }
 
   @Test
@@ -145,7 +145,7 @@ public class ProfileAPIControllerTest {
     var billingProfileUpdateModel = new BillingProfileUpdateModel().id(profileId);
     assertThrows(
         IamForbiddenException.class, () -> apiController.updateProfile(billingProfileUpdateModel));
-    verify(profileService, never()).updateProfile(eq(billingProfileUpdateModel), eq(user));
+    verify(profileService, never()).updateProfile(billingProfileUpdateModel, user);
   }
 
   @ParameterizedTest
@@ -171,10 +171,7 @@ public class ProfileAPIControllerTest {
     // Only check if user has access on the spend profile if we're not doing the admin check
     verify(iamService, times(expectedSpendProfileAuthNumberOfInvocations))
         .verifyAuthorization(
-            eq(user),
-            eq(IamResourceType.SPEND_PROFILE),
-            eq(deleteId.toString()),
-            eq(IamAction.DELETE));
+            user, IamResourceType.SPEND_PROFILE, deleteId.toString(), IamAction.DELETE);
     assertThat("Correct job model is returned from delete request", entity.getBody(), is(jobModel));
   }
 
@@ -189,7 +186,7 @@ public class ProfileAPIControllerTest {
     assertThrows(
         ProfileNotFoundException.class, () -> apiController.deleteProfile(profileId, false));
     verifyNoInteractions(iamService);
-    verify(profileService, never()).deleteProfile(eq(profileId), eq(false), eq(user));
+    verify(profileService, never()).deleteProfile(profileId, false, user);
   }
 
   @Test
@@ -200,7 +197,7 @@ public class ProfileAPIControllerTest {
         .thenReturn(new BillingProfileModel().id(profileId));
     mockProfileForbidden(profileId, IamAction.DELETE);
     assertThrows(IamForbiddenException.class, () -> apiController.deleteProfile(profileId, false));
-    verify(profileService, never()).deleteProfile(eq(profileId), eq(false), eq(user));
+    verify(profileService, never()).deleteProfile(profileId, false, user);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -104,7 +104,7 @@ public class ProfileAPIControllerTest {
     jobModel.setJobStatus(JobStatusEnum.RUNNING);
     when(jobService.retrieveJob(jobId, user)).thenReturn(jobModel);
 
-    ResponseEntity entity = apiController.createProfile(billingProfileRequestModel);
+    ResponseEntity<JobModel> entity = apiController.createProfile(billingProfileRequestModel);
     assertNotNull(entity);
   }
 
@@ -119,7 +119,7 @@ public class ProfileAPIControllerTest {
     jobModel.setJobStatus(JobStatusEnum.RUNNING);
     when(jobService.retrieveJob(jobId, user)).thenReturn(jobModel);
 
-    ResponseEntity entity = apiController.updateProfile(billingProfileUpdateModel);
+    ResponseEntity<JobModel> entity = apiController.updateProfile(billingProfileUpdateModel);
     assertNotNull(entity);
   }
 
@@ -164,7 +164,7 @@ public class ProfileAPIControllerTest {
     jobModel.setJobStatus(JobStatusEnum.RUNNING);
     when(jobService.retrieveJob(jobId, user)).thenReturn(jobModel);
 
-    ResponseEntity entity = apiController.deleteProfile(deleteId, deleteCloudResources);
+    ResponseEntity<JobModel> entity = apiController.deleteProfile(deleteId, deleteCloudResources);
     // Only check for admin auth if deleteCloudResources is true
     verify(iamService, times(expectedAdminAuthNumberOfInvocations))
         .verifyAuthorization(

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -134,7 +135,7 @@ public class ProfileAPIControllerTest {
         ProfileNotFoundException.class,
         () -> apiController.updateProfile(billingProfileUpdateModel));
     verifyNoInteractions(iamService);
-    verify(profileService, times(0)).updateProfile(eq(billingProfileUpdateModel), eq(user));
+    verify(profileService, never()).updateProfile(eq(billingProfileUpdateModel), eq(user));
   }
 
   @Test
@@ -147,7 +148,7 @@ public class ProfileAPIControllerTest {
     var billingProfileUpdateModel = new BillingProfileUpdateModel().id(profileId);
     assertThrows(
         IamForbiddenException.class, () -> apiController.updateProfile(billingProfileUpdateModel));
-    verify(profileService, times(0)).updateProfile(eq(billingProfileUpdateModel), eq(user));
+    verify(profileService, never()).updateProfile(eq(billingProfileUpdateModel), eq(user));
   }
 
   @ParameterizedTest
@@ -195,7 +196,7 @@ public class ProfileAPIControllerTest {
     assertThrows(
         ProfileNotFoundException.class, () -> apiController.deleteProfile(profileId, false));
     verifyNoInteractions(iamService);
-    verify(profileService, times(0)).deleteProfile(eq(profileId), eq(false), eq(user));
+    verify(profileService, never()).deleteProfile(eq(profileId), eq(false), eq(user));
   }
 
   @Test
@@ -206,7 +207,7 @@ public class ProfileAPIControllerTest {
         .thenReturn(new BillingProfileModel().id(profileId));
     mockProfileForbidden(profileId, IamAction.DELETE);
     assertThrows(IamForbiddenException.class, () -> apiController.deleteProfile(profileId, false));
-    verify(profileService, times(0)).deleteProfile(eq(profileId), eq(false), eq(user));
+    verify(profileService, never()).deleteProfile(eq(profileId), eq(false), eq(user));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -106,7 +106,6 @@ public class ProfileAPIControllerTest {
     when(jobService.retrieveJob(eq(jobId), eq(user))).thenReturn(jobModel);
 
     ResponseEntity entity = apiController.createProfile(billingProfileRequestModel);
-    verify(profileService, times(1)).createProfile(eq(billingProfileRequestModel), eq(user));
     assertNotNull(entity);
   }
 
@@ -122,7 +121,6 @@ public class ProfileAPIControllerTest {
     when(jobService.retrieveJob(eq(jobId), eq(user))).thenReturn(jobModel);
 
     ResponseEntity entity = apiController.updateProfile(billingProfileUpdateModel);
-    verify(profileService, times(1)).updateProfile(eq(billingProfileUpdateModel), eq(user));
     assertNotNull(entity);
   }
 
@@ -180,8 +178,6 @@ public class ProfileAPIControllerTest {
             eq(IamResourceType.SPEND_PROFILE),
             eq(deleteId.toString()),
             eq(IamAction.DELETE));
-    verify(profileService, times(1))
-        .deleteProfile(eq(deleteId), eq(deleteCloudResources), eq(user));
     assertNotNull(entity);
   }
 

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -95,15 +95,14 @@ public class ProfileAPIControllerTest {
 
   @Test
   void testCreateProfile() {
-    when(authenticatedUserRequestFactory.from(eq(request))).thenReturn(user);
+    when(authenticatedUserRequestFactory.from(request)).thenReturn(user);
     var billingProfileRequestModel = new BillingProfileRequestModel();
     String jobId = "jobId";
-    when(profileService.createProfile(eq(billingProfileRequestModel), eq(user)))
-        .thenReturn("jobId");
+    when(profileService.createProfile(billingProfileRequestModel, user)).thenReturn("jobId");
 
     var jobModel = new JobModel();
     jobModel.setJobStatus(JobStatusEnum.RUNNING);
-    when(jobService.retrieveJob(eq(jobId), eq(user))).thenReturn(jobModel);
+    when(jobService.retrieveJob(jobId, user)).thenReturn(jobModel);
 
     ResponseEntity entity = apiController.createProfile(billingProfileRequestModel);
     assertNotNull(entity);
@@ -111,14 +110,14 @@ public class ProfileAPIControllerTest {
 
   @Test
   void testUpdateProfile() {
-    when(authenticatedUserRequestFactory.from(eq(request))).thenReturn(user);
+    when(authenticatedUserRequestFactory.from(request)).thenReturn(user);
     var billingProfileUpdateModel = new BillingProfileUpdateModel().id(UUID.randomUUID());
     String jobId = "jobId";
-    when(profileService.updateProfile(eq(billingProfileUpdateModel), eq(user))).thenReturn(jobId);
+    when(profileService.updateProfile(billingProfileUpdateModel, user)).thenReturn(jobId);
 
     var jobModel = new JobModel();
     jobModel.setJobStatus(JobStatusEnum.RUNNING);
-    when(jobService.retrieveJob(eq(jobId), eq(user))).thenReturn(jobModel);
+    when(jobService.retrieveJob(jobId, user)).thenReturn(jobModel);
 
     ResponseEntity entity = apiController.updateProfile(billingProfileUpdateModel);
     assertNotNull(entity);
@@ -138,7 +137,7 @@ public class ProfileAPIControllerTest {
 
   @Test
   void testUpdateProfileForbidden() {
-    when(authenticatedUserRequestFactory.from(eq(request))).thenReturn(user);
+    when(authenticatedUserRequestFactory.from(request)).thenReturn(user);
     UUID profileId = UUID.randomUUID();
     when(profileService.getProfileByIdNoCheck(profileId))
         .thenReturn(new BillingProfileModel().id(profileId));
@@ -158,13 +157,12 @@ public class ProfileAPIControllerTest {
     when(authenticatedUserRequestFactory.from(any())).thenReturn(user);
     UUID deleteId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     String jobId = "jobId";
-    when(profileService.deleteProfile(eq(deleteId), eq(deleteCloudResources), eq(user)))
-        .thenReturn(jobId);
+    when(profileService.deleteProfile(deleteId, deleteCloudResources, user)).thenReturn(jobId);
     doNothing().when(iamService).verifyAuthorization(any(), any(), any(), any());
 
     var jobModel = new JobModel();
     jobModel.setJobStatus(JobStatusEnum.RUNNING);
-    when(jobService.retrieveJob(eq(jobId), eq(user))).thenReturn(jobModel);
+    when(jobService.retrieveJob(jobId, user)).thenReturn(jobModel);
 
     ResponseEntity entity = apiController.deleteProfile(deleteId, deleteCloudResources);
     // Only check for admin auth if deleteCloudResources is true
@@ -197,7 +195,7 @@ public class ProfileAPIControllerTest {
 
   @Test
   void testDeleteProfileForbidden() {
-    when(authenticatedUserRequestFactory.from(eq(request))).thenReturn(user);
+    when(authenticatedUserRequestFactory.from(request)).thenReturn(user);
     UUID profileId = UUID.randomUUID();
     when(profileService.getProfileByIdNoCheck(profileId))
         .thenReturn(new BillingProfileModel().id(profileId));
@@ -214,8 +212,7 @@ public class ProfileAPIControllerTest {
     String policyName = "policyName";
     var policyMemberRequest = new PolicyMemberRequest();
     var policyModel = new PolicyModel();
-    when(profileService.addProfilePolicyMember(
-            eq(id), eq(policyName), eq(policyMemberRequest), eq(user)))
+    when(profileService.addProfilePolicyMember(id, policyName, policyMemberRequest, user))
         .thenReturn(policyModel);
 
     ResponseEntity<PolicyResponse> response =

--- a/src/test/java/bio/terra/service/profile/ProfileServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileServiceUnitTest.java
@@ -44,7 +44,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles({"google", "unittest"})
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
-public class ProfileServiceUnitTest {
+class ProfileServiceUnitTest {
 
   @Mock private ProfileDao profileDao;
   @Mock private IamService iamService;
@@ -96,13 +96,12 @@ public class ProfileServiceUnitTest {
 
     var jobBuilder = mock(JobBuilder.class);
     when(jobBuilder.addParameter(
-            eq(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName()), eq(IamResourceType.SPEND_PROFILE)))
+            JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.SPEND_PROFILE))
+        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), updateId.toString()))
         .thenReturn(jobBuilder);
     when(jobBuilder.addParameter(
-            eq(JobMapKeys.IAM_RESOURCE_ID.getKeyName()), eq(updateId.toString())))
-        .thenReturn(jobBuilder);
-    when(jobBuilder.addParameter(
-            eq(JobMapKeys.IAM_ACTION.getKeyName()), eq(IamAction.UPDATE_BILLING_ACCOUNT)))
+            JobMapKeys.IAM_ACTION.getKeyName(), IamAction.UPDATE_BILLING_ACCOUNT))
         .thenReturn(jobBuilder);
 
     String jobId = "jobId";
@@ -126,17 +125,15 @@ public class ProfileServiceUnitTest {
     String jobId = "id";
     when(jobBuilder.submit()).thenReturn(jobId);
     UUID deleteId = PROFILE_ID;
-    when(jobBuilder.addParameter(eq(ProfileMapKeys.PROFILE_ID), eq(deleteId)))
+    when(jobBuilder.addParameter(ProfileMapKeys.PROFILE_ID, deleteId)).thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(JobMapKeys.CLOUD_PLATFORM.getKeyName(), CloudPlatform.GCP.name()))
         .thenReturn(jobBuilder);
     when(jobBuilder.addParameter(
-            eq(JobMapKeys.CLOUD_PLATFORM.getKeyName()), eq(CloudPlatform.GCP.name())))
+            JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.SPEND_PROFILE))
         .thenReturn(jobBuilder);
-    when(jobBuilder.addParameter(
-            eq(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName()), eq(IamResourceType.SPEND_PROFILE)))
+    when(jobBuilder.addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), deleteId))
         .thenReturn(jobBuilder);
-    when(jobBuilder.addParameter(eq(JobMapKeys.IAM_RESOURCE_ID.getKeyName()), eq(deleteId)))
-        .thenReturn(jobBuilder);
-    when(jobBuilder.addParameter(eq(JobMapKeys.IAM_ACTION.getKeyName()), eq(IamAction.DELETE)))
+    when(jobBuilder.addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.DELETE))
         .thenReturn(jobBuilder);
     when(jobBuilder.addParameter(
             JobMapKeys.DELETE_CLOUD_RESOURCES.getKeyName(), deleteCloudResources))

--- a/src/test/java/bio/terra/service/profile/ProfileServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileServiceUnitTest.java
@@ -139,7 +139,7 @@ public class ProfileServiceUnitTest {
     when(jobBuilder.addParameter(eq(JobMapKeys.IAM_ACTION.getKeyName()), eq(IamAction.DELETE)))
         .thenReturn(jobBuilder);
     when(jobBuilder.addParameter(
-            eq(JobMapKeys.DELETE_CLOUD_RESOURCES.getKeyName()), eq(deleteCloudResources)))
+            JobMapKeys.DELETE_CLOUD_RESOURCES.getKeyName(), deleteCloudResources))
         .thenReturn(jobBuilder);
 
     var billingProfileModel = new BillingProfileModel();

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureMonitoringServiceTest.java
@@ -8,9 +8,9 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.category.Unit;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
-import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration.Credentials;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.management.exception.ManagementError;
 import com.azure.core.management.exception.ManagementException;
@@ -38,7 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@Tag("bio.terra.common.category.Unit")
+@Tag(Unit.TAG)
 class AzureMonitoringServiceTest {
 
   @Mock private AzureResourceConfiguration resourceConfiguration;
@@ -254,20 +254,12 @@ class AzureMonitoringServiceTest {
   }
 
   private void mockLogAnalyticsClient() {
-    Credentials credentials = new Credentials();
-    credentials.setHomeTenantId(HOME_TENANT_ID);
-    when(resourceConfiguration.credentials()).thenReturn(credentials);
-
-    when(resourceConfiguration.getLogAnalyticsManagerClient(HOME_TENANT_ID, SUBSCRIPTION_ID))
+    when(resourceConfiguration.getLogAnalyticsManagerClient(SUBSCRIPTION_ID))
         .thenReturn(logAnalyticsManager);
   }
 
   private void mockSecurityInsightsClient() {
-    Credentials credentials = new Credentials();
-    credentials.setHomeTenantId(HOME_TENANT_ID);
-    when(resourceConfiguration.credentials()).thenReturn(credentials);
-
-    when(resourceConfiguration.getSecurityInsightsManagerClient(HOME_TENANT_ID, SUBSCRIPTION_ID))
+    when(resourceConfiguration.getSecurityInsightsManagerClient(SUBSCRIPTION_ID))
         .thenReturn(securityInsightsManager);
   }
 

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureResourceDaoTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.resourcemanagement.azure;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 import bio.terra.app.model.AzureRegion;
 import bio.terra.common.EmbeddedDatabaseTest;
@@ -105,8 +106,7 @@ public class AzureResourceDaoTest {
     var retrievedAppDeployments =
         azureResourceDao.retrieveApplicationDeploymentsByBillingProfileId(billingProfile.getId());
 
-    assertThat(
-        "Application Deployment count should be 1", retrievedAppDeployments.size(), equalTo(1));
+    assertThat("Application Deployment count should be 1", retrievedAppDeployments, hasSize(1));
 
     var retrievedAppDeployment = retrievedAppDeployments.get(0);
 
@@ -145,10 +145,8 @@ public class AzureResourceDaoTest {
     var appDeploymentId = applicationDeployments.get(0).getId();
     assertThat(
         "Before marking for delete, confirm that 2 storage accounts are returned when marked_for_delete = false",
-        azureResourceDao
-            .retrieveStorageAccountsByApplicationResource(appDeploymentId, false)
-            .size(),
-        equalTo(2));
+        azureResourceDao.retrieveStorageAccountsByApplicationResource(appDeploymentId, false),
+        hasSize(2));
 
     // Mark one storage account for delete
     var storageAccount1 = storageAccounts.get(0);
@@ -160,8 +158,7 @@ public class AzureResourceDaoTest {
 
     var storageAccountsMarkedForDelete =
         azureResourceDao.retrieveStorageAccountsByApplicationResource(appDeploymentId, true);
-    assertThat(
-        "Only 1 storage accounts is returned", storageAccountsMarkedForDelete.size(), equalTo(1));
+    assertThat("Only 1 storage accounts is returned", storageAccountsMarkedForDelete, hasSize(1));
     assertThat(
         "Storage account marked for delete is returned",
         storageAccountsMarkedForDelete.get(0).getStorageAccountId(),

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountServiceTest.java
@@ -1,6 +1,8 @@
 package bio.terra.service.resourcemanagement.azure;
 
 import static bio.terra.service.filedata.azure.util.AzureConstants.RESOURCE_NOT_FOUND_CODE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +27,7 @@ import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.resourcemanager.storage.models.StorageAccounts;
+import java.util.List;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -326,5 +329,19 @@ public class AzureStorageAccountServiceTest {
     doReturn(withSku).when(withGroup).withExistingResourceGroup(MANAGED_GROUP_NAME);
     doReturn(withGroup).when(withRegion).withRegion(REGION.getValue());
     doReturn(withRegion).when(storageAccounts).define(STORAGE_ACCOUNT_NAME);
+  }
+
+  @Test
+  public void listStorageAccountPerAppDeployment() {
+    UUID appId = UUID.randomUUID();
+    List<AzureStorageAccountResource> storageAccounts =
+        List.of(
+            new AzureStorageAccountResource().name("StorageAccount1"),
+            new AzureStorageAccountResource().name("StorageAccount2"));
+    when(resourceDao.retrieveStorageAccountsByApplicationResource(appId, true))
+        .thenReturn(storageAccounts);
+    var returnedStorageAccounts = service.listStorageAccountPerAppDeployment(List.of(appId), true);
+    assertThat(
+        "Correct storage accounts are returned", returnedStorageAccounts, equalTo(storageAccounts));
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/RecordAzureStorageAccountsStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/RecordAzureStorageAccountsStepTest.java
@@ -1,0 +1,46 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"google", "unittest"})
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class RecordAzureStorageAccountsStepTest {
+  @Mock private AzureStorageAccountService azureStorageAccountService;
+  private RecordAzureStorageAccountsStep recordAzureStorageAccountsStep;
+
+  @BeforeEach
+  void setUp() {
+    recordAzureStorageAccountsStep = new RecordAzureStorageAccountsStep(azureStorageAccountService);
+  }
+
+  @Test
+  void getUniqueStorageAccounts() {
+    List<UUID> appIdList = List.of(UUID.randomUUID());
+    AzureStorageAccountResource storageAccount1 =
+        new AzureStorageAccountResource().name("account1").topLevelContainer("container1");
+    AzureStorageAccountResource storageAccount2 =
+        new AzureStorageAccountResource().name("account1").topLevelContainer("container2");
+    when(azureStorageAccountService.listStorageAccountPerAppDeployment(appIdList, true))
+        .thenReturn(List.of(storageAccount1, storageAccount2));
+    List<AzureStorageAccountResource> resources =
+        recordAzureStorageAccountsStep.getUniqueStorageAccounts(appIdList);
+    assertThat("Only one unique storage account should be returned", resources, hasSize(1));
+  }
+}


### PR DESCRIPTION
The Changes:
- Added boolean option on the billing profile delete. When set to true, the associated azure storage account will be deleted. If there was a dataset/snapshot with secure monitoring enabled, then the log analytics and sentinel resources will be deleted as well. This option requires for a users to be an Admin in order to set it to true.
- Change for client (will be a breaking change when users upgrade their client): deleteProfile() will now require the the second boolean parameter to be included.
- Integration and test runner tests now clean up their azure storage account resources
- On dataset and snapshot delete, we now will set the marked_for_delete field on storage_account_resource entry in postgres to true instead of deleting the entry. They will now be deleted on billing profile delete.
- Updated a few unit tests to JUNIT5