### PR TITLE
[DR-3106] Improve batch firestore operation error message

### DIFF
--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -271,7 +271,8 @@ public class FireStoreUtils {
             } else {
               throw new FileSystemExecutionException(
                   "[batchOperation] Parent exception caught but neither parent nor nested "
-                      + "exceptions were designated for retry.",
+                      + "exceptions were designated for retry: "
+                      + formatNestedExceptions(ex, ""),
                   ex);
             }
           }
@@ -321,6 +322,14 @@ public class FireStoreUtils {
       return true;
     }
     return shouldRetry(throwable.getCause(), isBatch);
+  }
+
+  public static String formatNestedExceptions(Throwable throwable, String message) {
+    if (throwable == null) {
+      return message;
+    }
+    message += "Caused by: " + throwable.getMessage() + " ";
+    return formatNestedExceptions(throwable.getCause(), message);
   }
 
   public <T> T runTransactionWithRetry(

--- a/src/test/java/bio/terra/service/filedata/google/firestore/ArrayMultiFileLoadTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/ArrayMultiFileLoadTest.java
@@ -4,11 +4,13 @@ import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_TABLE;
 import static org.assertj.core.api.Fail.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
@@ -26,6 +28,7 @@ import bio.terra.model.ConfigGroupModel;
 import bio.terra.model.ConfigModel;
 import bio.terra.model.ConfigParameterModel;
 import bio.terra.model.DatasetSummaryModel;
+import bio.terra.model.ErrorModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
@@ -239,6 +242,40 @@ public class ArrayMultiFileLoadTest {
         "fileIds should contain fileIds from datarepo_load_history",
         fileIds,
         containsInAnyOrder(bq_fileIds.toArray()));
+  }
+
+  @Test
+  public void arrayDoubleFileLoadBulkModeFailTest() throws Exception {
+    int fileCount = 1;
+    BulkLoadArrayRequestModel arrayLoad =
+        makeSuccessArrayLoad("arrayMultiFileLoadSuccessTest", 0, fileCount);
+
+    BulkLoadArrayResultModel result =
+        connectedOperations.ingestArraySuccess(datasetSummary.getId(), arrayLoad.bulkMode(true));
+
+    FileOperationTest.checkLoadSummary(
+        result.getLoadSummary(), arrayLoad.getLoadTag(), fileCount, fileCount, 0, 0);
+
+    var loadHistoryList =
+        connectedOperations.getLoadHistory(
+            datasetSummary.getId(), result.getLoadSummary().getLoadTag(), 0, 20);
+
+    assertThat(
+        "The correct number of load history entries are returned",
+        loadHistoryList.getTotal(),
+        equalTo(fileCount));
+
+    assertThat(
+        "getting load history has the same items as response from bulk file load",
+        loadHistoryList.getItems().stream().map(TestUtils::toBulkLoadFileResultModel).toList(),
+        containsInAnyOrder(result.getLoadFileResults().toArray()));
+
+    BulkLoadArrayRequestModel failedArrayLoad = arrayLoad.loadTag("duplicate");
+
+    ErrorModel failedResult =
+        connectedOperations.ingestArrayFailure(datasetSummary.getId(), failedArrayLoad);
+    assertThat(failedResult.getMessage(), contains(equalTo("FileAlreadyExistsException")),
+        equalTo("Path already exists: / with load tag " + arrayLoad.getLoadTag()));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/google/firestore/ArrayMultiFileLoadTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/ArrayMultiFileLoadTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
@@ -274,7 +273,9 @@ public class ArrayMultiFileLoadTest {
 
     ErrorModel failedResult =
         connectedOperations.ingestArrayFailure(datasetSummary.getId(), failedArrayLoad);
-    assertThat(failedResult.getMessage(), contains(equalTo("FileAlreadyExistsException")),
+    assertThat(
+        failedResult.getMessage(),
+        contains(equalTo("FileAlreadyExistsException")),
         equalTo("Path already exists: / with load tag " + arrayLoad.getLoadTag()));
   }
 

--- a/src/test/java/bio/terra/service/filedata/google/firestore/ArrayMultiFileLoadTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/ArrayMultiFileLoadTest.java
@@ -2,9 +2,9 @@ package bio.terra.service.filedata.google.firestore;
 
 import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_TABLE;
 import static org.assertj.core.api.Fail.fail;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
@@ -248,6 +248,7 @@ public class ArrayMultiFileLoadTest {
     int fileCount = 1;
     BulkLoadArrayRequestModel arrayLoad =
         makeSuccessArrayLoad("arrayMultiFileLoadSuccessTest", 0, fileCount);
+    String originalLoadTag = arrayLoad.getLoadTag();
 
     BulkLoadArrayResultModel result =
         connectedOperations.ingestArraySuccess(datasetSummary.getId(), arrayLoad.bulkMode(true));
@@ -273,10 +274,10 @@ public class ArrayMultiFileLoadTest {
 
     ErrorModel failedResult =
         connectedOperations.ingestArrayFailure(datasetSummary.getId(), failedArrayLoad);
+    assertThat(failedResult.getMessage(), containsString("FileAlreadyExistsException"));
     assertThat(
         failedResult.getMessage(),
-        contains(equalTo("FileAlreadyExistsException")),
-        equalTo("Path already exists: / with load tag " + arrayLoad.getLoadTag()));
+        containsString("Path already exists: / with load tag " + originalLoadTag));
   }
 
   @Test


### PR DESCRIPTION
If a user attempts to re-ingest a file with the same target path and load tag, they will get this ambiguous error from Firestore: `[batchOperation] Parent exception caught but neither parent nor nested exceptions were designated for retry`

This PR includes the underlying exceptions in the error message so that the user can better understand what went wrong.