### PR TITLE
[DR-3210] Sign GCP urls for parquet exports

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -157,12 +157,16 @@ public class SnapshotsApiController implements SnapshotsApi {
 
   @Override
   public ResponseEntity<JobModel> exportSnapshot(
-      @PathVariable("id") UUID id, Boolean exportGsPaths, Boolean validatePrimaryKeyUniqueness) {
+      @PathVariable("id") UUID id,
+      Boolean exportGsPaths,
+      Boolean validatePrimaryKeyUniqueness,
+      Boolean signUrls) {
     logger.debug("Verifying user access");
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     verifySnapshotAuthorization(userReq, id.toString(), IamAction.EXPORT_SNAPSHOT);
     String jobId =
-        snapshotService.exportSnapshot(id, userReq, exportGsPaths, validatePrimaryKeyUniqueness);
+        snapshotService.exportSnapshot(
+            id, userReq, exportGsPaths, validatePrimaryKeyUniqueness, signUrls);
     // we can retrieve the job we just created
     return jobToResponse(jobService.retrieveJob(jobId, userReq));
   }

--- a/src/main/java/bio/terra/service/common/gcs/GcsUriUtils.java
+++ b/src/main/java/bio/terra/service/common/gcs/GcsUriUtils.java
@@ -1,12 +1,17 @@
 package bio.terra.service.common.gcs;
 
+import static bio.terra.service.filedata.google.gcs.GcsConstants.REQUESTED_BY_QUERY_PARAM;
 import static bio.terra.service.filedata.google.gcs.GcsConstants.USER_PROJECT_QUERY_PARAM;
 
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 public final class GcsUriUtils {
@@ -130,5 +135,30 @@ public final class GcsUriUtils {
    */
   public static boolean isGsUri(String uri) {
     return uri != null && uri.startsWith("gs://");
+  }
+
+  /**
+   * Sign a Google Cloud Storage URL for a given duration
+   *
+   * @param storage Storage object to use for signing
+   * @param gsPath The path of the object to sign
+   * @param duration The duration for which the URL should be valid
+   * @param requestorEmail The email of the user requesting the signed URL
+   * @return A valid type 4 GCS signed URL
+   */
+  public static String signGsUrl(
+      Storage storage, String gsPath, Duration duration, String requestorEmail) {
+    BlobId locator = GcsUriUtils.parseBlobUri(gsPath);
+    BlobInfo blobInfo = BlobInfo.newBuilder(locator).build();
+
+    Map<String, String> queryParams = Map.of(REQUESTED_BY_QUERY_PARAM, requestorEmail);
+    return storage
+        .signUrl(
+            blobInfo,
+            duration.toMinutes(),
+            TimeUnit.MINUTES,
+            Storage.SignUrlOption.withQueryParams(queryParams),
+            Storage.SignUrlOption.withV4Signature())
+        .toString();
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -258,7 +258,8 @@ public class SnapshotService {
       UUID id,
       AuthenticatedUserRequest userReq,
       boolean exportGsPaths,
-      boolean validatePrimaryKeyUniqueness) {
+      boolean validatePrimaryKeyUniqueness,
+      boolean signUrls) {
     Snapshot snapshot = snapshotDao.retrieveSnapshot(id);
     String description = "Export snapshot %s".formatted(snapshot.toLogString());
 
@@ -280,6 +281,7 @@ public class SnapshotService {
         .addParameter(JobMapKeys.CLOUD_PLATFORM.getKeyName(), snapshot.getCloudPlatform())
         .addParameter(ExportMapKeys.EXPORT_GSPATHS, exportGsPaths)
         .addParameter(ExportMapKeys.EXPORT_VALIDATE_PK_UNIQUENESS, validatePrimaryKeyUniqueness)
+        .addParameter(ExportMapKeys.EXPORT_SIGN_URLS, signUrls)
         .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASNAPSHOT)
         .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), id.toString())
         .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.EXPORT_SNAPSHOT)

--- a/src/main/java/bio/terra/service/snapshot/flight/export/ExportMapKeys.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/ExportMapKeys.java
@@ -4,4 +4,5 @@ public final class ExportMapKeys {
 
   public static final String EXPORT_VALIDATE_PK_UNIQUENESS = "exportValidatePkUniqueness";
   public static final String EXPORT_GSPATHS = "exportGsPaths";
+  public static final String EXPORT_SIGN_URLS = "signUrls";
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestStep.java
@@ -1,5 +1,7 @@
 package bio.terra.service.snapshot.flight.export;
 
+import static bio.terra.service.filedata.google.gcs.GcsConstants.REQUESTED_BY_QUERY_PARAM;
+
 import bio.terra.common.FlightUtils;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.SnapshotExportResponseModel;
@@ -10,6 +12,7 @@ import bio.terra.model.SnapshotExportResponseModelFormatParquetLocationTables;
 import bio.terra.model.SnapshotModel;
 import bio.terra.service.common.gcs.GcsUriUtils;
 import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.filedata.google.gcs.GcsProjectFactory;
 import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
@@ -22,34 +25,46 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
+import java.util.concurrent.TimeUnit;
 
 public class SnapshotExportWriteManifestStep extends DefaultUndoStep {
+
+  private static final Duration URL_TTL = Duration.ofMinutes(60);
 
   private final UUID snapshotId;
   private final SnapshotService snapshotService;
   private final GcsPdao gcsPdao;
+  private final GcsProjectFactory gcsProjectFactory;
   private final ObjectMapper objectMapper;
   private final AuthenticatedUserRequest userReq;
   private final boolean validatePrimaryKeyUniqueness;
+  private final boolean signUrls;
 
   public SnapshotExportWriteManifestStep(
       UUID snapshotId,
       SnapshotService snapshotService,
       GcsPdao gcsPdao,
+      GcsProjectFactory gcsProjectFactory,
       ObjectMapper objectMapper,
       AuthenticatedUserRequest userReq,
-      boolean validatePrimaryKeyUniqueness) {
+      boolean validatePrimaryKeyUniqueness,
+      boolean signUrls) {
     this.snapshotId = snapshotId;
     this.snapshotService = snapshotService;
     this.gcsPdao = gcsPdao;
+    this.gcsProjectFactory = gcsProjectFactory;
     this.objectMapper = objectMapper;
     this.userReq = userReq;
     this.validatePrimaryKeyUniqueness = validatePrimaryKeyUniqueness;
+    this.signUrls = signUrls;
   }
 
   @Override
@@ -65,17 +80,24 @@ public class SnapshotExportWriteManifestStep extends DefaultUndoStep {
         GcsUriUtils.getGsPathFromComponents(
             exportBucket.getName(), String.format("%s/manifest.json", context.getFlightId()));
 
+    SnapshotModel snapshot = snapshotService.retrieveSnapshotModel(snapshotId, userReq);
+    Storage storage = gcsProjectFactory.getStorage(snapshot.getDataProject(), true);
     List<SnapshotExportResponseModelFormatParquetLocationTables> tables =
         paths.entrySet().stream()
             .map(
                 entry ->
                     new SnapshotExportResponseModelFormatParquetLocationTables()
                         .name(entry.getKey())
-                        .paths(entry.getValue()))
-            .collect(Collectors.toList());
+                        .paths(
+                            signUrls
+                                ? entry.getValue().stream()
+                                    .map(path -> signGsUrl(storage, path))
+                                    .toList()
+                                : entry.getValue()))
+            .toList();
 
-    SnapshotModel snapshot = snapshotService.retrieveSnapshotModel(snapshotId, userReq);
-
+    String effectiveExportManifestFile =
+        signUrls ? signGsUrl(storage, exportManifestPath) : exportManifestPath;
     SnapshotExportResponseModel responseModel =
         new SnapshotExportResponseModel()
             .snapshot(snapshot)
@@ -83,7 +105,7 @@ public class SnapshotExportWriteManifestStep extends DefaultUndoStep {
                 new SnapshotExportResponseModelFormat()
                     .parquet(
                         new SnapshotExportResponseModelFormatParquet()
-                            .manifest(exportManifestPath)
+                            .manifest(effectiveExportManifestFile)
                             .location(
                                 new SnapshotExportResponseModelFormatParquetLocation()
                                     .tables(tables))));
@@ -106,5 +128,19 @@ public class SnapshotExportWriteManifestStep extends DefaultUndoStep {
     context.getWorkingMap().put(JobMapKeys.RESPONSE.getKeyName(), responseModel);
 
     return StepResult.getStepResultSuccess();
+  }
+
+  private String signGsUrl(Storage storage, String gsPath) {
+    BlobId locator = GcsUriUtils.parseBlobUri(gsPath);
+    BlobInfo blobInfo = BlobInfo.newBuilder(locator).build();
+    Map<String, String> queryParams = Map.of(REQUESTED_BY_QUERY_PARAM, userReq.getEmail());
+    return storage
+        .signUrl(
+            blobInfo,
+            URL_TTL.toMinutes(),
+            TimeUnit.MINUTES,
+            Storage.SignUrlOption.withQueryParams(queryParams),
+            Storage.SignUrlOption.withV4Signature())
+        .toString();
   }
 }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -892,6 +892,15 @@ paths:
             required: false
           description: Verify that primary keys are unique in all exported tables.
             Required for proper Terra workspace integration
+        - in: query
+          name: signUrls
+          schema:
+            type: boolean
+            default: true
+            required: false
+          description: If true, then the export will generate signed URLs for the
+            exported files and manifest. If false, then the export will return URLs native to
+            the cloud backing the snapshot.  Note that this has no effect on Azure backed snapshots
       responses:
         202:
           description: Job status of snapshot export job & url for polling in the

--- a/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
@@ -61,6 +61,7 @@ class SnapshotsApiControllerTest {
   private static final String JOB_ID = "a-job-id";
   private static final Boolean EXPORT_GCS_PATHS = false;
   private static final Boolean VALIDATE_PRIMARY_KEY_UNIQUENESS = true;
+  private static final Boolean SIGN_URLS = true;
 
   private static final String RETRIEVE_SNAPSHOT_ENDPOINT = "/api/repository/v1/snapshots/{id}";
   private static final String EXPORT_SNAPSHOT_ENDPOINT = RETRIEVE_SNAPSHOT_ENDPOINT + "/export";
@@ -75,7 +76,7 @@ class SnapshotsApiControllerTest {
     JobModel expected = new JobModel().id(JOB_ID).jobStatus(JobModel.JobStatusEnum.RUNNING);
 
     when(snapshotService.exportSnapshot(
-            SNAPSHOT_ID, TEST_USER, EXPORT_GCS_PATHS, VALIDATE_PRIMARY_KEY_UNIQUENESS))
+            SNAPSHOT_ID, TEST_USER, EXPORT_GCS_PATHS, VALIDATE_PRIMARY_KEY_UNIQUENESS, SIGN_URLS))
         .thenReturn(JOB_ID);
     when(jobService.retrieveJob(JOB_ID, TEST_USER)).thenReturn(expected);
 
@@ -95,7 +96,8 @@ class SnapshotsApiControllerTest {
 
     verifyAuthorizationCall(IamAction.EXPORT_SNAPSHOT);
     verify(snapshotService)
-        .exportSnapshot(SNAPSHOT_ID, TEST_USER, EXPORT_GCS_PATHS, VALIDATE_PRIMARY_KEY_UNIQUENESS);
+        .exportSnapshot(
+            SNAPSHOT_ID, TEST_USER, EXPORT_GCS_PATHS, VALIDATE_PRIMARY_KEY_UNIQUENESS, SIGN_URLS);
   }
 
   @Test

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -706,7 +706,7 @@ public class AzureIntegrationTest extends UsersBase {
 
     // Ensure that export works
     DataRepoResponse<SnapshotExportResponseModel> snapshotExport =
-        dataRepoFixtures.exportSnapshotLog(steward, snapshotByFullViewId, false, false);
+        dataRepoFixtures.exportSnapshotLog(steward, snapshotByFullViewId, false, false, true);
 
     assertThat(
         "snapshotExport is present", snapshotExport.getResponseObject().isPresent(), is(true));

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -1208,10 +1208,11 @@ public class DataRepoFixtures {
       TestConfiguration.User user,
       UUID snapshotId,
       boolean resolveGsPaths,
-      boolean validatePkUniqueness)
+      boolean validatePkUniqueness,
+      boolean signUrls)
       throws Exception {
     DataRepoResponse<JobModel> jobResponse =
-        exportSnapshot(user, snapshotId, resolveGsPaths, validatePkUniqueness);
+        exportSnapshot(user, snapshotId, resolveGsPaths, validatePkUniqueness, signUrls);
     assertTrue("snapshot export launch succeeded", jobResponse.getStatusCode().is2xxSuccessful());
     assertTrue(
         "snapshot export launch response is present", jobResponse.getResponseObject().isPresent());
@@ -1223,13 +1224,14 @@ public class DataRepoFixtures {
       TestConfiguration.User user,
       UUID snapshotId,
       boolean resolveGsPaths,
-      boolean validatePkUniqueness)
+      boolean validatePkUniqueness,
+      boolean signUrls)
       throws Exception {
     return dataRepoClient.get(
         user,
         String.format(
-            "/api/repository/v1/snapshots/%s/export?exportGsPaths=%s&validatePrimaryKeyUniqueness=%s",
-            snapshotId, resolveGsPaths, validatePkUniqueness),
+            "/api/repository/v1/snapshots/%s/export?exportGsPaths=%s&validatePrimaryKeyUniqueness=%s&signUrls=%s",
+            snapshotId, resolveGsPaths, validatePkUniqueness, signUrls),
         new TypeReference<>() {});
   }
 

--- a/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
@@ -313,14 +313,14 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
 
     // validate that snapshot export works correctly
     DataRepoResponse<SnapshotExportResponseModel> exportResponse =
-        dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, false, false);
+        dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, false, false, true);
     assertThat(
         "self-hosted snapshots can be exported with DRS URIs",
         exportResponse.getResponseObject().isPresent(),
         is(true));
 
     DataRepoResponse<JobModel> exportSnapshotExpectFailure =
-        dataRepoFixtures.exportSnapshot(steward(), snapshotId, true, false);
+        dataRepoFixtures.exportSnapshot(steward(), snapshotId, true, false, true);
     DataRepoResponse<ErrorModel> errorResponse =
         dataRepoClient.waitForResponseLog(
             steward(), exportSnapshotExpectFailure, new TypeReference<>() {});

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -311,7 +311,7 @@ public class SnapshotExportIntegrationTest extends UsersBase {
     UUID snapshotId = snapshotSummary.getId();
     createdSnapshotIds.add(snapshotId);
     DataRepoResponse<SnapshotExportResponseModel> exportResponse =
-        dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, true, false, true);
+        dataRepoFixtures.exportSnapshotLog(steward(), snapshotId, true, false, false);
 
     SnapshotExportResponseModel exportModel = exportResponse.getResponseObject().orElseThrow();
     SnapshotExportResponseModelFormatParquet parquet = exportModel.getFormat().getParquet();


### PR DESCRIPTION
We've run into a bunch of issues with permission propagation in Google when importing TDR exports.  This PR changes the default behavior of exports to provide signed URLs for the manifest and all parquet files instead of `gs://` paths.  These signed URLs are immediately accessible by the import-service and as of the next deployment, the import-service will be capable of ingesting these.

A couple of notes:
- The original behavior was left in but the default behavior is now to use signed URLs
- The length of the signed URL is 60 minutes, which seems like a reasonable amount of time to ingest