### PR TITLE
[DR-3243] Call the new URL signing endpoint in Sam

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
     implementation 'org.springframework:spring-jdbc:5.1.9.RELEASE'
     implementation 'org.springframework.cloud:spring-cloud-gcp-starter-logging:1.2.8.RELEASE'
     implementation "org.springframework.cloud:spring-cloud-starter-sleuth:3.0.2"
-    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-c1e35e6'
+    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-ae94a59'
     implementation 'org.antlr:ST4:4.3'                          // String templating
     implementation group: 'io.kubernetes', name: 'client-java', version: '18.0.0'
 

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -416,7 +416,8 @@ public class IamService {
   /**
    * Gets a signed URL for the given blob, signed by the Pet Service account of the calling user.
    * The signed URL is scoped to the permissions of the signing Pet Service Account. Will provide a
-   * signed URL for any object path, even if that object does not exist.
+   * signed URL for any object path, even if that object does not exist. The signed URL will work
+   * for data stored in requester pays hosted buckets.
    *
    * @param userReq authenticated user
    * @param project Google project to use to sign blob

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -22,12 +22,10 @@ import bio.terra.service.auth.iam.exception.IamForbiddenException;
 import bio.terra.service.auth.iam.exception.IamInternalServerErrorException;
 import bio.terra.service.auth.iam.exception.IamNotFoundException;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
-import bio.terra.service.common.gcs.GcsUriUtils;
 import bio.terra.service.configuration.ConfigurationService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.cloud.storage.BlobId;
 import com.google.common.annotations.VisibleForTesting;
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -53,8 +51,8 @@ import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembership
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntryV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
+import org.broadinstitute.dsde.workbench.client.sam.model.RequesterPaysSignedUrlRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
-import org.broadinstitute.dsde.workbench.client.sam.model.SignedUrlRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.SyncReportEntry;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.slf4j.Logger;
@@ -642,14 +640,12 @@ public class SamIam implements IamProviderInterface {
   private String signUrlForBlobInner(
       AuthenticatedUserRequest userReq, String project, String path, Duration duration)
       throws ApiException {
-    BlobId blobId = GcsUriUtils.parseBlobUri(path);
-    SignedUrlRequest request =
-        new SignedUrlRequest()
-            .bucketName(blobId.getBucket())
-            .blobName(blobId.getName())
+    RequesterPaysSignedUrlRequest request =
+        new RequesterPaysSignedUrlRequest()
+            .gsPath(path)
             .duration(BigDecimal.valueOf(duration.toMinutes()))
-            .requesterPays(true);
-    return samApiService.googleApi(userReq.getToken()).getSignedUrlForBlob(project, request);
+            .requesterPaysProject(project);
+    return samApiService.googleApi(userReq.getToken()).getRequesterPaysSignedUrlForBlob(request);
   }
 
   private UserStatusInfo getUserInfoAndVerify(AuthenticatedUserRequest userReq) {

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -52,8 +52,8 @@ import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyMembership
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntryV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.CreateResourceRequestV2;
 import org.broadinstitute.dsde.workbench.client.sam.model.ErrorReport;
+import org.broadinstitute.dsde.workbench.client.sam.model.RequesterPaysSignedUrlRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.RolesAndActions;
-import org.broadinstitute.dsde.workbench.client.sam.model.SignedUrlRequest;
 import org.broadinstitute.dsde.workbench.client.sam.model.SubsystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserInfo;
@@ -367,13 +367,11 @@ public class SamIamTest {
 
     // Verify the arguments are properly parsed and passed through
     verify(samGoogleApi)
-        .getSignedUrlForBlob(
-            project,
-            new SignedUrlRequest()
-                .bucketName("bucket")
-                .blobName("path/to/file")
-                .requesterPays(true)
-                .duration(BigDecimal.valueOf(15)));
+        .getRequesterPaysSignedUrlForBlob(
+            new RequesterPaysSignedUrlRequest()
+                .gsPath(path)
+                .duration(BigDecimal.valueOf(15))
+                .requesterPaysProject(project));
   }
 
   @Nested


### PR DESCRIPTION
The existing one has bugs in certain cases.  This will fix an issue where users trying to access file data in requester pays buckets would get an invalid signature