### PR TITLE
DR-3093 - Enable B2C login for TDR on BEEs

### DIFF
--- a/src/main/java/bio/terra/app/configuration/OpenIDConnectConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/OpenIDConnectConfiguration.java
@@ -2,6 +2,8 @@ package bio.terra.app.configuration;
 
 import bio.terra.common.exception.ServiceInitializationException;
 import com.google.common.annotations.VisibleForTesting;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.PostConstruct;
@@ -85,7 +87,9 @@ public class OpenIDConnectConfiguration {
 
   String getOidcMetadataUrl() {
     String profileParameter =
-        StringUtils.isEmpty(getProfileParam()) ? "" : String.format("?p=%s", getProfileParam());
+        StringUtils.isEmpty(getProfileParam())
+            ? ""
+            : String.format("?p=%s", URLEncoder.encode(getProfileParam(), StandardCharsets.UTF_8));
     return getAuthorityEndpoint() + "/" + OIDC_METADATA_URL_SUFFIX + profileParameter;
   }
 

--- a/src/main/java/bio/terra/app/configuration/OpenIDConnectConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/OpenIDConnectConfiguration.java
@@ -83,9 +83,9 @@ public class OpenIDConnectConfiguration {
     }
   }
 
-  private String getOidcMetadataUrl() {
+  String getOidcMetadataUrl() {
     String profileParameter =
-        StringUtils.isEmpty(getProfileParam()) ? "" : String.format("?=%s", getProfileParam());
+        StringUtils.isEmpty(getProfileParam()) ? "" : String.format("?p=%s", getProfileParam());
     return getAuthorityEndpoint() + "/" + OIDC_METADATA_URL_SUFFIX + profileParameter;
   }
 

--- a/src/main/java/bio/terra/app/configuration/OpenIDConnectConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/OpenIDConnectConfiguration.java
@@ -32,6 +32,7 @@ public class OpenIDConnectConfiguration {
   private String clientSecret;
   private String extraAuthParams;
   private boolean addClientIdToScope;
+  private String profileParam;
 
   private String authorizationEndpoint;
   private String tokenEndpoint;
@@ -83,7 +84,9 @@ public class OpenIDConnectConfiguration {
   }
 
   private String getOidcMetadataUrl() {
-    return getAuthorityEndpoint() + "/" + OIDC_METADATA_URL_SUFFIX;
+    String profileParameter =
+        StringUtils.isEmpty(getProfileParam()) ? "" : String.format("?=%s", getProfileParam());
+    return getAuthorityEndpoint() + "/" + OIDC_METADATA_URL_SUFFIX + profileParameter;
   }
 
   public String getSchemeName() {
@@ -132,6 +135,14 @@ public class OpenIDConnectConfiguration {
 
   public void setAddClientIdToScope(Boolean addClientIdToScope) {
     this.addClientIdToScope = addClientIdToScope;
+  }
+
+  public void setProfileParam(String profileParam) {
+    this.profileParam = profileParam;
+  }
+
+  public String getProfileParam() {
+    return this.profileParam;
   }
 
   public String getAuthorizationEndpoint() {

--- a/src/main/java/bio/terra/app/controller/Oauth2ApiController.java
+++ b/src/main/java/bio/terra/app/controller/Oauth2ApiController.java
@@ -42,9 +42,11 @@ public class Oauth2ApiController {
 
   @RequestMapping(value = AUTHORIZE_ENDPOINT)
   public String oauthAuthorize(HttpServletRequest request) {
+    String concatCharacter =
+        openIDConnectConfiguration.getAuthorizationEndpoint().contains("?") ? "&" : "?";
     return "redirect:"
         + openIDConnectConfiguration.getAuthorizationEndpoint()
-        + "?"
+        + concatCharacter
         + decorateAuthRedirectQueryParameters(request.getQueryString());
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,7 @@ oidc.clientSecret=
 oidc.authorityEndpoint=
 oidc.addClientIdToScope=
 oidc.extraAuthParams=
+oidc.profileParam=
 
 datarepo.resourceId=broad-jade-dev
 datarepo.userEmail=${JADE_USER_EMAIL}

--- a/src/test/java/bio/terra/app/configuration/OpenIDConnectConfigurationTest.java
+++ b/src/test/java/bio/terra/app/configuration/OpenIDConnectConfigurationTest.java
@@ -4,16 +4,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.common.category.Unit;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 
-@Category(Unit.class)
-public class OpenIDConnectConfigurationTest {
+@ActiveProfiles({"google", "unittest"})
+@Tag(Unit.TAG)
+class OpenIDConnectConfigurationTest {
 
   @Test
-  public void testInitializeWithGoogleOidc() {
+  void testInitializeWithGoogleOidc() {
     OpenIDConnectConfiguration openIDConnectConfiguration = new OpenIDConnectConfiguration();
-
     // Test will read the Oauth config from Google's Oauth endpoint
     openIDConnectConfiguration.setAuthorityEndpoint("https://accounts.google.com");
 
@@ -28,5 +29,28 @@ public class OpenIDConnectConfigurationTest {
         "there is a authorization endpoint",
         openIDConnectConfiguration.getTokenEndpoint(),
         equalTo("https://oauth2.googleapis.com/token"));
+  }
+
+  @Test
+  void testGetOIDCMetadata() {
+    String authorityEndpoint = "https://oauth-proxy.dsp-eng-tools.broadinstitute.org/b2c";
+    String profileName = "b2c_1a_signup_signin_tdr_dev";
+    String expectedOidcMetadata =
+        "https://oauth-proxy.dsp-eng-tools.broadinstitute.org/b2c/.well-known/openid-configuration?p=b2c_1a_signup_signin_tdr_dev";
+
+    OpenIDConnectConfiguration openIDConnectConfiguration = new OpenIDConnectConfiguration();
+    openIDConnectConfiguration.setProfileParam(profileName);
+    openIDConnectConfiguration.setAuthorityEndpoint(authorityEndpoint);
+    openIDConnectConfiguration.init();
+
+    assertThat(
+        "Profile Param is correctly returned",
+        openIDConnectConfiguration.getProfileParam(),
+        equalTo(profileName));
+
+    assertThat(
+        "Expected oidcMetadataUrl is returned",
+        openIDConnectConfiguration.getOidcMetadataUrl(),
+        equalTo(expectedOidcMetadata));
   }
 }

--- a/src/test/java/bio/terra/app/configuration/OpenIDConnectConfigurationTest.java
+++ b/src/test/java/bio/terra/app/configuration/OpenIDConnectConfigurationTest.java
@@ -2,6 +2,8 @@ package bio.terra.app.configuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import bio.terra.common.category.Unit;
 import org.junit.jupiter.api.Tag;
@@ -47,6 +49,27 @@ class OpenIDConnectConfigurationTest {
         "Profile Param is correctly returned",
         openIDConnectConfiguration.getProfileParam(),
         equalTo(profileName));
+
+    assertThat(
+        "Expected oidcMetadataUrl is returned",
+        openIDConnectConfiguration.getOidcMetadataUrl(),
+        equalTo(expectedOidcMetadata));
+  }
+
+  @Test
+  void testGetOIDCMetadataNoProfile() {
+    String authorityEndpoint = "https://oauth-proxy.dsp-eng-tools.broadinstitute.org/b2c";
+    String expectedOidcMetadata =
+        "https://oauth-proxy.dsp-eng-tools.broadinstitute.org/b2c/.well-known/openid-configuration";
+
+    OpenIDConnectConfiguration openIDConnectConfiguration = new OpenIDConnectConfiguration();
+    openIDConnectConfiguration.setAuthorityEndpoint(authorityEndpoint);
+    openIDConnectConfiguration.init();
+
+    assertThat(
+        "Profile Param is correctly returned",
+        openIDConnectConfiguration.getProfileParam(),
+        is(nullValue()));
 
     assertThat(
         "Expected oidcMetadataUrl is returned",

--- a/src/test/java/bio/terra/app/controller/Oauth2ApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/Oauth2ApiControllerTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.app.configuration.OpenIDConnectConfiguration;
+import bio.terra.common.category.Unit;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +38,7 @@ import org.springframework.web.client.RestTemplate;
 
 @ActiveProfiles({"google", "unittest"})
 @ContextConfiguration(classes = Oauth2ApiController.class)
-@Tag("bio.terra.common.category.Unit")
+@Tag(Unit.TAG)
 @WebMvcTest
 public class Oauth2ApiControllerTest {
   @Autowired private MockMvc mvc;
@@ -72,6 +73,15 @@ public class Oauth2ApiControllerTest {
     mvc.perform(get(AUTHORIZE_ENDPOINT + "?id=client_id&scope=foo bar"))
         .andExpect(status().is3xxRedirection())
         .andExpect(redirectedUrl(OIDC_AUTH_ENDPOINT + "?id=client_id&scope=foo+bar+my_id"));
+  }
+
+  @Test
+  void testConcatLogicForRedirect() throws Exception {
+    when(openIDConnectConfiguration.getAuthorizationEndpoint())
+        .thenReturn("http://foo.com/auth?p=profile1");
+    mvc.perform(get(AUTHORIZE_ENDPOINT + "?id=client_id&scope=foo bar"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("http://foo.com/auth?p=profile1&id=client_id&scope=foo+bar"));
   }
 
   @Test


### PR DESCRIPTION
# The Changes
For BEEs, we need to use the latest OIDC urls listed [here](https://github.com/broadinstitute/terra-helmfile/blob/50ea05d3db8aebfdbf815330e6b521f1ef3cffb8/values/app/bpm/bee.yaml.gotmpl#L49). In particular, we need to use the one with "tdr" in the name because it includes the google scopes used in the UI.  These new URLS include a profile parameter. Our handling of the OIDC urls were not set up to handle extra parameters.

Additionally, we need to update the BEE helm definitions to reflect the B2C OIDC information. PR up for review here: https://github.com/broadinstitute/terra-helmfile/pull/4655 (Merge order: Terra-helmfile PR will be merged after TDR PR)

Updated TDR on BEEs Doc: https://docs.google.com/document/d/1kyjrOKzUthwKu-m38Da2niNEh-IkbUzxtfT29EWw8ag/edit

# Testing
Changes deployed to this BEE: https://data.shelbee.bee.envs-terra.bio/ (If you want to test this out, you first need to register your account with https://terra.shelbee.bee.envs-terra.bio/)

Additionally, these changes have been deployed to my personal dev environment to prove that the exisiting OIDC urls should still work with these code changes: https://jade-sh.datarepo-dev.broadinstitute.org/ 



