### PR TITLE
[DR-3240] Add ability to filter datasets and snapshots by id

### DIFF
--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -49,7 +49,9 @@ public final class DaoUtils {
     if (!StringUtils.isEmpty(filter)) {
       params.addValue("filter", DaoUtils.escapeFilter(filter));
       clauses.add(
-          String.format(" (%s.name ILIKE :filter OR %s.description ILIKE :filter) ", table, table));
+          String.format(
+              " (%s.id::text ILIKE :filter OR %s.name ILIKE :filter OR %s.description ILIKE :filter) ",
+              table, table, table));
     }
   }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -234,6 +234,23 @@ public class DatasetDaoTest {
         filteredDatasets.get(0).getName(),
         equalTo(dataset1.getName()));
 
+    MetadataEnumeration<DatasetSummary> filterIdEnum =
+        datasetDao.enumerate(
+            0,
+            2,
+            EnumerateSortByParam.CREATED_DATE,
+            SqlSortDirection.ASC,
+            dataset1.getId().toString(),
+            null,
+            datasetIds,
+            null);
+    List<DatasetSummary> filteredDatasetsById = filterIdEnum.getItems();
+    assertThat("dataset filter by id returns correct total", filteredDatasets.size(), equalTo(1));
+    assertThat(
+        "dataset filter by name returns correct dataset",
+        filteredDatasetsById.get(0).getId(),
+        equalTo(dataset1.getId()));
+
     MetadataEnumeration<DatasetSummary> filterDefaultRegionEnum =
         datasetDao.enumerate(
             0,

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -369,6 +369,25 @@ public class SnapshotDaoTest {
     testSortingDescriptions(SqlSortDirection.DESC);
     testSortingDescriptions(SqlSortDirection.ASC);
 
+    SnapshotSummary snapshotSummary = allSnapshots.getItems().get(0);
+    MetadataEnumeration<SnapshotSummary> filterIdEnum =
+        snapshotDao.retrieveSnapshots(
+            0,
+            6,
+            null,
+            null,
+            snapshotSummary.getId().toString(),
+            null,
+            datasetIds,
+            snapshotIds,
+            null);
+    List<SnapshotSummary> filteredSnapshotsById = filterIdEnum.getItems();
+    assertThat("snapshot filter by id returns one snapshot", filteredSnapshotsById, hasSize(1));
+    assertThat(
+        "snapshot filter by id returns one snapshot",
+        filteredSnapshotsById.get(0).getId(),
+        equalTo(snapshotSummary.getId()));
+
     MetadataEnumeration<SnapshotSummary> filterDefaultRegionEnum =
         snapshotDao.retrieveSnapshots(
             0,


### PR DESCRIPTION
Update the `filter` query parameter in the enumerate datasets and enumerate snapshots endpoints to filter by a uuid.