### PR TITLE
DR-3100: Cherry-pick dev image to prod/public gcr on merge to dev

### DIFF
--- a/.github/workflows/alpha-tests-and-gcr-promotion.yaml
+++ b/.github/workflows/alpha-tests-and-gcr-promotion.yaml
@@ -1,4 +1,4 @@
-name: DataRepo Alpha Tests and Prod GCR Promotion
+name: DataRepo Alpha Tests
 env:
   K8_CLUSTER: jade-master-us-central1
   GOOGLE_APPLICATION_CREDENTIALS: /tmp/alpha-test-runner.json
@@ -6,15 +6,11 @@ env:
   GOOGLE_CLOUD_DATA_PROJECT: terra-datarepo-alpha-data
   JADE_USER_EMAIL: alpha-tdr-user@notarealemail.org
   TDR_LOG_APPENDER: Console-Standard
-  GCR_DEV_URL: gcr.io/broad-jade-dev
-  GCR_PUBLIC_URL: gcr.io/datarepo-public-gcr
-  API_REPO: jade-data-repo
-  UI_REPO: jade-data-repo-ui
 on:
   # Jenkins will kick this job off manually after Alpha is deployed
   workflow_dispatch: {}
 jobs:
-  alpha-tests-and-gcr-promotion:
+  alpha-tests:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout jade-data-repo and latest tags"
@@ -108,47 +104,6 @@ jobs:
         ./gradlew uploadResults --args="BroadJadeDev.json $outputDir"
         echo "[INFO] Uploading results SUCCEEDED"
         cd ${GITHUB_WORKSPACE}/${workingDir}
-    - name: "[Cherry-pick to public GCR] Import Vault Secrets for GCR Service Account"
-      uses: hashicorp/vault-action@v2.5.0
-      with:
-        url: ${{ secrets.VAULT_ADDR }}
-        method: approle
-        roleId: ${{ secrets.ROLE_ID }}
-        secretId: ${{ secrets.SECRET_ID }}
-        secrets: |
-          secret/dsde/datarepo/dev/gcr-sa-b64 key | B64_APPLICATION_CREDENTIALS ;
-    - name: "[Cherry-pick to public GCR] Authenticate with GCR SA Credentials"
-      env:
-        GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
-      run: |
-        # write vault tokens
-        base64 --decode <<< ${B64_APPLICATION_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
-
-        gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
-    - name: "[API][Cherry-pick to public GCR] Perform cherry-pick"
-      run: |
-        DEV_IMAGE="${GCR_DEV_URL}/${API_REPO}:${{ steps.configuration.outputs.alpha_version_api }}"
-        PUBLIC_IMAGE="${GCR_PUBLIC_URL}/${API_REPO}:${{ steps.configuration.outputs.alpha_version_api }}"
-        echo "Cherry picking ${{ steps.configuration.outputs.alpha_version_api }} from ${DEV_IMAGE} to ${PUBLIC_IMAGE}"
-        gcloud container images add-tag --quiet "${DEV_IMAGE}" "${PUBLIC_IMAGE}"
-    - name: "[UI][Cherry-pick to public GCR] Checkout datarepo-helm repo"
-      uses: actions/checkout@v3
-      with:
-        repository: 'broadinstitute/datarepo-helm'
-        token: ${{ secrets.BROADBOT_TOKEN }}
-        path: datarepo-helm
-    - name: "[UI][Cherry-pick to public GCR] Read UI version from datarepo-helm"
-      id: datarepohelm
-      run: |
-        alpha_version_ui=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq r datarepo-helm/charts/datarepo-ui/values.yaml image.tag)
-        echo "alpha_version_ui=${alpha_version_ui}" >> $GITHUB_OUTPUT
-        echo "Alpha UI Version: $alpha_version_ui"
-    - name: "[UI][Cherry-pick to public GCR] Perform cherry-pick"
-      run: |
-        DEV_IMAGE="${GCR_DEV_URL}/${UI_REPO}:${{ steps.datarepohelm.outputs.alpha_version_ui }}"
-        PUBLIC_IMAGE="${GCR_PUBLIC_URL}/${UI_REPO}:${{ steps.datarepohelm.outputs.alpha_version_ui }}"
-        echo "Cherry picking ${{ steps.datarepohelm.outputs.alpha_version_ui }} from ${DEV_IMAGE} to ${PUBLIC_IMAGE}"
-        gcloud container images add-tag --quiet "${DEV_IMAGE}" "${PUBLIC_IMAGE}"
     - name: "Notify Slack"
       if: always()
       uses: broadinstitute/action-slack@v3.15.0
@@ -160,7 +115,7 @@ jobs:
         fields: job,repo,message,author,took
         channel: "#jade-alerts"
         username: "Data Repo tests"
-        text: "Alpha Tests and GCR Promotion"
+        text: "Alpha Tests"
     - name: "Notify QA Slack"
       if: always()
       uses: broadinstitute/action-slack@v3.15.0
@@ -171,5 +126,5 @@ jobs:
         status: ${{ job.status }}
         channel: "#dsde-qa"
         username: "Data Repo tests"
-        text: "Alpha Tests and GCR Promotion"
+        text: "Alpha Tests"
         fields: job,repo,message,author,took

--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -1,6 +1,6 @@
 name: cherry-pick-image
 on:
-  - workflow_call:
+  workflow_call:
     inputs:
       gcr_tag:
         description: tag to cherry pick
@@ -12,16 +12,18 @@ on:
       target_gcr_url:
         type: string
         required: true
-  - workflow_dispatch:
+  workflow_dispatch:
       inputs:
         gcr_tag:
           description: tag to cherry pick
           type: string
           required: true
         source_gcr_url:
+          description: gcr url to cherry pick issue from
           type: string
           required: true
         target_gcr_url:
+          description: gcr url to cherry pick issue to
           type: string
           required: true
 jobs:

--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -19,11 +19,11 @@ on:
           type: string
           required: true
         source_gcr_url:
-          description: gcr url to cherry pick issue from
+          description: gcr url to cherry pick image from
           type: string
           required: true
         target_gcr_url:
-          description: gcr url to cherry pick issue to
+          description: gcr url to cherry pick image to
           type: string
           required: true
 jobs:

--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -1,0 +1,54 @@
+name: cherry-pick-image
+on:
+  - workflow_call:
+    inputs:
+      gcr_tag:
+        description: tag to cherry pick
+        type: string
+        required: true
+      source_gcr_url:
+        type: string
+        required: true
+      target_gcr_url:
+        type: string
+        required: true
+  - workflow_dispatch:
+      inputs:
+        gcr_tag:
+          description: tag to cherry pick
+          type: string
+          required: true
+        source_gcr_url:
+          type: string
+          required: true
+        target_gcr_url:
+          type: string
+          required: true
+jobs:
+  cherry-pick-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Import Vault Secrets for GCR Service Account"
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.ROLE_ID }}
+          secretId: ${{ secrets.SECRET_ID }}
+          secrets: |
+            secret/dsde/datarepo/dev/gcr-sa-b64 key | B64_APPLICATION_CREDENTIALS ;
+      - name: "Authenticate with GCR SA Credentials"
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
+        run: |
+          # write vault tokens
+          base64 --decode <<< ${B64_APPLICATION_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
+
+          gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
+      - name: "Perform cherry-pick"
+        run: |
+          SOURCE_IMAGE="${{ inputs.source_gcr_url }}:${{ inputs.gcr_tag }}"
+          TARGET_IMAGE="${{ inputs.target_gcr_url }}:${{ inputs.gcr_tag }}"
+          echo "Cherry picking ${{ inputs.gcr_tag }} from ${SOURCE_IMAGE} to ${TARGET_IMAGE}"
+          gcloud container images add-tag --quiet "${SOURCE_IMAGE}" "${TARGET_IMAGE}"
+

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -116,6 +116,14 @@ jobs:
       sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
     permissions:
       id-token: 'write'
+  cherry_pick_image_to_production_gcr:
+    needs: update_image
+    uses: ./.github/workflows/helmtagbumper.yaml
+    secrets: inherit
+    with:
+      gcr_tag: ${{ needs.update_image.outputs.api_image_tag }}
+      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
+      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
   helm_tag_bumper:
     needs: update_image
     uses: ./.github/workflows/helmtagbumper.yaml

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -118,7 +118,7 @@ jobs:
       id-token: 'write'
   cherry_pick_image_to_production_gcr:
     needs: update_image
-    uses: ./.github/workflows/helmtagbumper.yaml
+    uses: ./.github/workflows/cherry-pick-image.yaml
     secrets: inherit
     with:
       gcr_tag: ${{ needs.update_image.outputs.api_image_tag }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -133,6 +133,9 @@ jobs:
     if: always()
     needs:
       - update_image
+      - report-to-sherlock
+      - set-app-version-in-environment
+      - cherry_pick_image_to_production_gcr
       - helm_tag_bumper
     steps:
       - name: Slack job status


### PR DESCRIPTION
Cherry-pick TDR image from our dev GCR to production GCR on merge to develop. Previously, this happened after alpha tests ran. 
Note:
- There will be a similar change to jade-data-repo-ui
- Yes, the auth with the SA is ugly. This code will be removed when we move to artifact registry and we actually move to once registry. Also, we should move to workload-identity. 

### Testing
1. **Cherry-pick action:** 
Ran cherry-pick action with github CLI using same arguments as called in dev-image-update ([Job Run](https://github.com/DataBiosphere/jade-data-repo/actions/runs/6431924025/job/17465746212)):
```
gh workflow run cherry-pick-image  -r sh-dr-3100-one-gcr -F gcr_tag=947ccfe -F source_gcr_url=gcr.io/broad-jade-dev/jade-data-repo -F target_gcr_url=gcr.io/datarepo-public-gcr/jade-data-repo
✓ Created workflow_dispatch event for cherry-pick-image.yaml at sh-dr-3100-one-gcr
```

Test image successfully cherry-picked:
<img width="732" alt="image" src="https://github.com/DataBiosphere/jade-data-repo/assets/13254229/57a6043f-d318-42ee-b548-a63a5426ee64">

2. **Alpha Tests**: Test run - https://github.com/DataBiosphere/jade-data-repo/actions/runs/6432126276
3. **Dev image update**: Running this on my branch could get versions out of wack - I'd rather just wait for it run on merge. It's a relatively small change that I feel confident about. 