### PR TITLE
[DR-3262] Retry intermittent SQL transaction errors

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
@@ -1,7 +1,6 @@
 package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.model.SnapshotRequestModel;
-import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
@@ -9,21 +8,25 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.transaction.TransactionSystemException;
 
 public class CreateSnapshotCountTableRowsAzureStep implements Step {
 
-  private final AzureSynapsePdao azureSynapsePdao;
   private final SnapshotDao snapshotDao;
   private final SnapshotRequestModel snapshotReq;
 
+  private static final Logger logger =
+      LoggerFactory.getLogger(CreateSnapshotCountTableRowsAzureStep.class);
+
   public CreateSnapshotCountTableRowsAzureStep(
-      AzureSynapsePdao azureSynapsePdao,
-      SnapshotDao snapshotDao,
-      SnapshotRequestModel snapshotReq) {
-    this.azureSynapsePdao = azureSynapsePdao;
+      SnapshotDao snapshotDao, SnapshotRequestModel snapshotReq) {
     this.snapshotDao = snapshotDao;
     this.snapshotReq = snapshotReq;
   }
@@ -35,7 +38,12 @@ public class CreateSnapshotCountTableRowsAzureStep implements Step {
     Snapshot snapshot = snapshotDao.retrieveSnapshotByName(snapshotReq.getName());
     Map<String, Long> tableRowCounts =
         workingMap.get(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, HashMap.class);
-    snapshotDao.updateSnapshotTableRowCounts(snapshot, tableRowCounts);
+    try {
+      snapshotDao.updateSnapshotTableRowCounts(snapshot, tableRowCounts);
+    } catch (CannotSerializeTransactionException | TransactionSystemException ex) {
+      logger.error("Could not serialize the transaction. Retrying.", ex);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+    }
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -253,12 +253,14 @@ public class SnapshotCreateFlight extends Flight {
     if (platform.isAzure()) {
       addStep(new CreateSnapshotCreateRowIdParquetFileStep(azureSynapsePdao, snapshotService));
       addStep(
-          new CreateSnapshotCountTableRowsAzureStep(azureSynapsePdao, snapshotDao, snapshotReq));
+          new CreateSnapshotCountTableRowsAzureStep(snapshotDao, snapshotReq), randomBackoffRetry);
     }
 
     if (platform.isGcp()) {
       // compute the row counts for each of the snapshot tables and store in metadata
-      addStep(new CountSnapshotTableRowsStep(bigQuerySnapshotPdao, snapshotDao, snapshotReq));
+      addStep(
+          new CountSnapshotTableRowsStep(bigQuerySnapshotPdao, snapshotDao, snapshotReq),
+          randomBackoffRetry);
     }
 
     // Create the IAM resource and readers for the snapshot

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStepTest.java
@@ -1,0 +1,67 @@
+package bio.terra.service.snapshot.flight.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotDao;
+import bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.CannotSerializeTransactionException;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
+public class CountSnapshotTableRowsStepTest {
+
+  @Mock private BigQuerySnapshotPdao bigQuerySnapshotPdao;
+  @Mock private SnapshotDao snapshotDao;
+  @Mock private FlightContext flightContext;
+  //  private FlightMap workingMap;
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final Snapshot SNAPSHOT =
+      new Snapshot().id(SNAPSHOT_ID).name("Snapshot-" + SNAPSHOT_ID);
+
+  private static final SnapshotRequestModel snapshotReq =
+      new SnapshotRequestModel().name(SNAPSHOT.getName());
+
+  private Map<String, Long> tableRowCounts;
+  private CountSnapshotTableRowsStep step;
+
+  @BeforeEach
+  void setup() throws InterruptedException {
+    when(snapshotDao.retrieveSnapshotByName(SNAPSHOT.getName())).thenReturn(SNAPSHOT);
+    tableRowCounts = Map.of("table", 5L);
+    when(bigQuerySnapshotPdao.getSnapshotTableRowCounts(SNAPSHOT)).thenReturn(tableRowCounts);
+  }
+
+  @Test
+  void testDoStep() throws InterruptedException {
+    step = new CountSnapshotTableRowsStep(bigQuerySnapshotPdao, snapshotDao, snapshotReq);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void testDoStepRetry() throws InterruptedException {
+    step = new CountSnapshotTableRowsStep(bigQuerySnapshotPdao, snapshotDao, snapshotReq);
+    doThrow(CannotSerializeTransactionException.class)
+        .when(snapshotDao)
+        .updateSnapshotTableRowCounts(SNAPSHOT, tableRowCounts);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStepTest.java
@@ -1,0 +1,71 @@
+package bio.terra.service.snapshot.flight.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import bio.terra.model.SnapshotRequestModel;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotDao;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.HashMap;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.CannotSerializeTransactionException;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("bio.terra.common.category.Unit")
+public class CreateSnapshotCountTableRowsAzureStepTest {
+
+  @Mock private SnapshotDao snapshotDao;
+  @Mock private FlightContext flightContext;
+
+  private FlightMap workingMap;
+
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final Snapshot SNAPSHOT =
+      new Snapshot().id(SNAPSHOT_ID).name("Snapshot-" + SNAPSHOT_ID);
+
+  private static final SnapshotRequestModel snapshotReq =
+      new SnapshotRequestModel().name(SNAPSHOT.getName());
+
+  private HashMap<String, Long> tableRowCounts = new HashMap<>();
+  private CreateSnapshotCountTableRowsAzureStep step;
+
+  @BeforeEach
+  void setup() {
+    when(snapshotDao.retrieveSnapshotByName(SNAPSHOT.getName())).thenReturn(SNAPSHOT);
+    tableRowCounts.put("table", (long) 5);
+    workingMap = new FlightMap();
+    workingMap.put(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, tableRowCounts);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void testDoStep() throws InterruptedException {
+    step = new CreateSnapshotCountTableRowsAzureStep(snapshotDao, snapshotReq);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void testDoStepRetry() throws InterruptedException {
+    step = new CreateSnapshotCountTableRowsAzureStep(snapshotDao, snapshotReq);
+    doThrow(CannotSerializeTransactionException.class)
+        .when(snapshotDao)
+        .updateSnapshotTableRowCounts(SNAPSHOT, tableRowCounts);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3262

This `CountSnapshotTableRowsStep` was failing occasionally due to a retryable SQL error, leaving the snapshot in a half-created state. I saw this was already handled in [CreateSnapshotMetadataStep](https://github.com/DataBiosphere/jade-data-repo/blob/947ccfe4991150b092b2ef1fe3ec2f451a580db4/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java#L66) so I did something similar here.