### PR TITLE
DR-2955: Enable Azure schema updates for additive changes

### DIFF
--- a/src/main/java/bio/terra/common/Column.java
+++ b/src/main/java/bio/terra/common/Column.java
@@ -43,6 +43,9 @@ public class Column {
             .requiresJSONCast(
                 SynapseColumn.checkForJSONCastRequirement(
                     datasetColumn.getType(), datasetColumn.isArrayOf()))
+            .requiresTypeCast(
+                SynapseColumn.checkForCastTypeArgRequirement(
+                    datasetColumn.getType(), datasetColumn.isArrayOf()))
             .name(datasetColumn.getName())
             .type(datasetColumn.getType())
             .arrayOf(datasetColumn.isArrayOf())

--- a/src/main/java/bio/terra/common/SynapseColumn.java
+++ b/src/main/java/bio/terra/common/SynapseColumn.java
@@ -60,12 +60,13 @@ public class SynapseColumn extends Column {
       case BYTES -> "varbinary";
       case DATE -> "date";
       case DATETIME, TIMESTAMP -> "datetime2";
-      case DIRREF, FILEREF -> "varchar(36)";
       case FLOAT, FLOAT64 -> "float";
       case INTEGER -> "numeric(10, 0)";
       case INT64 -> "numeric(19, 0)";
       case NUMERIC -> "real";
-      case TEXT, STRING -> "varchar(8000)";
+        // DIRREF and FILEREF store a UUID on ingest
+        // But, are translated to DRS URI on Snapshot Creation
+      case DIRREF, FILEREF, TEXT, STRING -> "varchar(8000)";
       case TIME -> "time";
         // Data of type RECORD contains table-like that can be nested or repeated
         // It's provided in JSON format, making it hard to parse from inside a CSV/JSON ingest

--- a/src/main/java/bio/terra/common/SynapseColumn.java
+++ b/src/main/java/bio/terra/common/SynapseColumn.java
@@ -93,13 +93,10 @@ public class SynapseColumn extends Column {
     if (isArrayOf) {
       return false;
     }
-    switch (dataType) {
-      case INTEGER:
-      case INT64:
-        return true;
-      default:
-        return false;
-    }
+    return switch (dataType) {
+      case INTEGER, INT64 -> true;
+      default -> false;
+    };
   }
 
   static boolean checkForCollateArgRequirement(TableDataType dataType, boolean isArrayOf) {

--- a/src/main/java/bio/terra/common/SynapseColumn.java
+++ b/src/main/java/bio/terra/common/SynapseColumn.java
@@ -12,12 +12,15 @@ public class SynapseColumn extends Column {
   private boolean requiresCollate;
   private boolean requiresJSONCast;
 
+  private boolean requiresTypeCast;
+
   public SynapseColumn() {}
 
   public SynapseColumn(SynapseColumn fromColumn) {
     this.synapseDataType = fromColumn.synapseDataType;
     this.requiresCollate = fromColumn.requiresCollate;
     this.requiresJSONCast = fromColumn.requiresJSONCast;
+    this.requiresTypeCast = fromColumn.requiresTypeCast;
   }
 
   public String getSynapseDataType() {
@@ -26,6 +29,15 @@ public class SynapseColumn extends Column {
 
   public SynapseColumn synapseDataType(String synapseDataType) {
     this.synapseDataType = synapseDataType;
+    return this;
+  }
+
+  public boolean getRequiresTypeCast() {
+    return requiresTypeCast;
+  }
+
+  public SynapseColumn requiresTypeCast(boolean requiresTypeCast) {
+    this.requiresTypeCast = requiresTypeCast;
     return this;
   }
 
@@ -73,6 +85,21 @@ public class SynapseColumn extends Column {
       case RECORD -> throw new NotSupportedException(
           "RECORD type is not yet supported for synapse");
     };
+  }
+
+  // Cast needed for backwards compatibility after Synapse type change
+  // Sept 2023 int moved to numeric(10,0) and int64 moved to numeric(19,0)
+  static boolean checkForCastTypeArgRequirement(TableDataType dataType, boolean isArrayOf) {
+    if (isArrayOf) {
+      return false;
+    }
+    switch (dataType) {
+      case INTEGER:
+      case INT64:
+        return true;
+      default:
+        return false;
+    }
   }
 
   static boolean checkForCollateArgRequirement(TableDataType dataType, boolean isArrayOf) {

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -1297,7 +1297,7 @@ public class AzureSynapsePdao {
     List<SynapseColumn> columns =
         ListUtils.union(
             List.of(
-                SynapseColumn.toSynapseColumn(
+                Column.toSynapseColumn(
                     new Column().name(PDAO_ROW_ID_COLUMN).type(TableDataType.STRING))),
             table.getSynapseColumns());
     boolean includeTotalRowCount = collectionType.equals(CollectionType.DATASET);

--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -87,6 +87,11 @@ public class AzureSynapsePdao {
   private static final String PARSER_VERSION = "2.0";
   private static final String DEFAULT_CSV_FIELD_TERMINATOR = ",";
   private static final String DEFAULT_CSV_QUOTE = "\"";
+
+  // Collation uses the Latin1 General dictionary sorting rules
+  // It is a version _100 collation, and is case-insensitive (CI) and accent-insensitive (AI).
+  // _SC = supports supplementary characters to be used for eligible data type (nvarchar)
+  // _UTF8 = Specifies UTF-8 encoding to be used for eligible data types (varchar)
   private static final String DEFAULT_COLLATION = "Latin1_General_100_CI_AI_SC_UTF8";
   private static final String EMPTY_TABLE_ERROR_MESSAGE =
       "Unable to query the parquet file for this table. This is most likely because the table is empty.  See exception details if this does not appear to be the case.";


### PR DESCRIPTION
### Remaining TODOs

- [x] Alter all synapse instances with alter collate statement (Update: all except perf done)
- [x] Add Code to alter collate on init (even though this isn't running right now) (Update: will be done with https://broadworkbench.atlassian.net/browse/DR-3297)
- [x] Make sure connected tests pass
- [x] Look into UI bug on filtering variant id (UI goes blank on trying to filter on id; How? point local UI to sh-dev to get better error message) ( Fixed with https://github.com/DataBiosphere/jade-data-repo-ui/pull/1523)
- [x] Finish putting together example on sh-dev (and finish documenting below)

_____

### Overview
Enable schema additive updates for Azure-backed TDR datasets. This enables the following three operations:
1) Add a new table to an existing dataset
2) Add a new column to an existing dataset/table
3) Add a relationship between new/existing columns/tables

All tabular data in Azure-backed TDR datasets is stored in parquet files. For each tabular data ingest job, we create a new parquet file to store just the data from that ingest job. Alongside the data, each parquet files has information about the schema for the data in that file, but parquet files are not mutable. We cannot go back and update existing parquet files. When we read data out of the parquet files, we effectively do a join across all parquet files for the dataset table. 

So, how can we make schema updates if we can't update the parquet file schema?
Well, we don't need to. For new ingests, we will include the additive changes.  Then, when we select the data out across all of the parquet files (containing new and old schemas), we will define the schema in the query that pulls data out of the parquet files. 

**Included Changes**
- Enable schema updates for azure datasets and disable gcp-specific steps
- [Specify the schema](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/query-parquet-files#explicitly-specify-schema) for any query that reads data out of parquet files. This allows the query to gracefully handle discrepancies between parquet file schemas.

### Complications
1) **Allowing for backwards compatibility due to change in int/int64 underlying SQL data type**

About a month ago, we made [a change](https://github.com/DataBiosphere/jade-data-repo/commit/928ac316d1522c8e27aabc5e66ff9a1f4cf4f544#diff-4b4d66994f401ea0167fb07c4dbc16d7940baba87260e1c427e849eb74e864e7R65) that updates the TDR `Integer` and `Integer64` types from using `int` type to `numeric(10,0)` and `numeric(19,0)` respectively.  These two types (`int` and `numeric`) are not inherently compatible. If we wanted to define the schema with the new numeric data type when retrieving the old data, we would run into an error like the following:
```
com.microsoft.sqlserver.jdbc.SQLServerException: Column 'position' of type 'DECIMAL' is not compatible with external data type 'Parquet physical type: INT32, logical type: INT_32', please try with 'INT'. File/External table name: 'metadata/parquet/variant/781_ApMbQoa-vOcOZROu-g.parquet/7CF96F70-EB5D-4BCD-9B7F-7361916F3FE4_22717_0-1.parquet'.
```
**Solution**: Allow for backwards compatibility by reading in Integer data as a varchar and then cast to the new numeric data type.

2) **Collation**
Default collation on the datarepo database in Synapse is `SQL_Latin1_General_CP1_CI_AS`. However, in our query and in existing queries, we've been setting the collation as `Latin1_General_100_CI_AI_SC_UTF8`.

**Solution**: I've changed the default collation in the dev, alpha, staging, and prod database to be `Latin1_General_100_CI_AI_SC_UTF8`. It appears that the perf synapse instance has never been initialized. So, we'll cover that work in a new ticket: https://broadworkbench.atlassian.net/browse/DR-3297
`ALTER DATABASE CURRENT COLLATE Latin1_General_100_CI_AI_SC_UTF8;`

### Testing

**Automated Testing**
Added a case to the large Azure Integration test so that all of the other operations are done on a dataset that has had schema updates. 

**Manual Testing**
Changes are deployed to [my dev instance](https://jade-sh.datarepo-dev.broadinstitute.org) and there is an Azure Dataset for testing (Azure_V2F_GWAS_Summary_Statistics).

Example usages of schema updates:
- New Table:
```
{
  "description": "Add new table",
  "changes": {
    "addTables": [
      {
        "name": "AddedTable",
        "columns": [
          {
            "name": "variant_id",
            "datatype": "string",
            "array_of": false,
            "required": false
          },
          {
            "name": "random_data",
            "datatype": "string",
            "array_of": false,
            "required": false
          }
        ]
      }
    ]
  }
}
```


- New Column in Table:
```
{
  "description": "Add column to variant table",
  "changes": {
    "addColumns": [
      {
        "tableName": "variant",
        "columns": [
          {
            "name": "NewColumn",
            "datatype": "string",
            "array_of": false,
            "required": false
          }
        ]
      }
    ]
  }
}
```
- New Relationship:
```
{
  "description": "New relationship between variant and new table",
  "changes": {
    "addRelationships": [
      {
        "name": "reversed_new_variant",
        "from": {
          "table": "AddedTable",
          "column": "variant_id"
        },
        "to": {
          "table": "variant",
          "column": "id"
        }
      }
    ]
  }
}
```

**Using these new elements**:
Note: You must create a new asset in order for new tables and columns to be included in the asset and subsequent snapshots.

1) Create new asset
```
{
  "name": "AddedTableVariantAsset",
  "tables": [
    {
      "name": "variant",
      "columns": []
    },
    {
      "name": "AddedTable",
      "columns": []
    }
  ],
  "rootTable": "variant",
  "rootColumn": "id",
  "follow": [
    "reversed_new_variant"
  ]
}
```
2) Ingest data into the new `AddedTable` and `variant` tables. Include variant_id's that match between the two tables and include data in the new column in the `variant` table. 

```
{
  "table": "AddedTable",
  "records": [
    {"variant_id":"1:50936208:A:G", "random_data":"1"},
    {"variant_id":"1:116762589:A:G", "random_data":"2"},
    {"variant_id":"1:215126241:A:C", "random_data":"3"},
    {"variant_id":"1:215126241:A:B", "random_data":"4"}
  ],
  "format": "array"
}
```

```
{
  "table": "variant",
  "records": [
    {"id":"1:215126241:A:B", "NewColumn":"Hello there!"}
  ],
  "format": "array"
}
```

3) Snapshot Create
```
{
  "name": "SnapshotWithAdditiveSchemaUpdates",
  "description": "snapshot with schema updates",
  "contents": [
    {
      "datasetName": "Azure_V2F_GWAS_Summary_Statistics",
      "mode": "byAsset",
      "assetSpec": {
        "assetName": "AddedTableVariantAsset",
        "rootValues": [
          "1:50936208:A:G", "1:116762589:A:G", "1:215126241:A:C", "1:215126241:A:B"
        ]
      }
    }
  ],
  "profileId": "356f4c1a-dd7c-468b-bf24-66ad91f2a2c4"
}
```
Resulting snapshot using added table, column and relationship: https://jade-sh.datarepo-dev.broadinstitute.org/snapshots/e26d9526-d2df-4a46-ae49-b2530398f5aa/data