### PR TITLE
[DR-3315] Snapshot auth domain can't be set when snapshot already has a policy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ dependencies {
         }
     }
 
-    implementation group: "bio.terra", name: "terra-policy-client", version: "0.2.50-SNAPSHOT"
+    implementation group: "bio.terra", name: "terra-policy-client", version: "1.0.4-SNAPSHOT"
     implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.4.3-SNAPSHOT"
     implementation group: "bio.terra", name: "externalcreds-client-resttemplate", version: "0.72.0-SNAPSHOT"
     implementation group: "org.glassfish.jersey.inject", name: "jersey-hk2", version: "2.30.1"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3315

**Desired Behavior**

When creating a Policy Access Object (PAO), if Terra Policy Service (TPS) throws an exception then fall back to updating the existing PAO.

**Background**

When attempting to set the auth domain on a [protected Azure snapshot in TDR Dev](https://jade.datarepo-dev.broadinstitute.org/snapshots/5d476eb1-7a90-4e34-817c-bbbb23a41d7f), [the job failed dismally](https://cloudlogging.app.goo.gl/qpoFeyRTXeUkLYWP9).

On doing `CreateSnapshotGroupConstraintPolicyStep`:
```
Step Result exception
bio.terra.service.policy.exception.PolicyServiceDuplicateException: Request contains duplicate policy attribute
	at bio.terra.service.policy.PolicyService.convertApiException(PolicyService.java:121)
	at bio.terra.service.policy.PolicyService.createPao(PolicyService.java:73)
	at bio.terra.service.policy.PolicyService.createOrUpdatePao(PolicyService.java:89)
	at bio.terra.service.snapshot.flight.authDomain.CreateSnapshotGroupConstraintPolicyStep.doStep(CreateSnapshotGroupConstraintPolicyStep.java:34)
…
Caused by: bio.terra.policy.client.ApiException: {"message":"Duplicate policy attributes object with objectId 5d476eb1-7a90-4e34-817c-bbbb23a41d7f","statusCode":400,"causes":[]}
```
On undoing that step:
```
Step Result exception
bio.terra.service.policy.exception.PolicyServiceApiException: Error from Policy Service: 
	at bio.terra.service.policy.PolicyService.convertApiException(PolicyService.java:124)
	at bio.terra.service.policy.PolicyService.updatePao(PolicyService.java:82)
	at bio.terra.service.snapshot.flight.authDomain.CreateSnapshotGroupConstraintPolicyStep.undoStep(CreateSnapshotGroupConstraintPolicyStep.java:44)
…
Caused by: bio.terra.policy.client.ApiException: {"message":"Request could not be parsed or was invalid: MethodArgumentNotValidException. Ensure that all types are correct and that enums have valid values.","statusCode":400,"causes":[]}
```
**Fixes**

1. We were not handling the actual exception thrown by TPS when trying to create a PAO when one already exists: its [DuplicateObjectException](https://github.com/DataBiosphere/terra-policy-service/blob/main/service/src/main/java/bio/terra/policy/db/exception/DuplicateObjectException.java#L5) extends a BadRequestException (400) rather than a ConflictException (409).

2. We had not specified all required arguments when calling TPS' [updatePao](https://tps.dsde-dev.broadinstitute.org/#/Tps/updatePao) and also needed to specify updateMode.

**Manual Verification**

My [developer environment](https://jade-ok.datarepo-dev.broadinstitute.org/) is up to date with these changes.

I first created a [snapshot](https://jade-ok.datarepo-dev.broadinstitute.org/snapshots/0a4da971-3b28-4a40-af60-1704216e6989) off of a [protected dataset](https://jade-ok.datarepo-dev.broadinstitute.org/datasets/786725ff-5822-4e51-9e71-50793c561d32), meaning that the snapshot itself would have a protected data policy added to it on creation.

I then successfully [added an auth domain](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/snapshots/addSnapshotAuthDomain) `20231024_policy_test ` to the snapshot.  Since the snapshot already has a PAO, this falls back to updating the existing PAO.

I then [retrieved the PAO](https://tps.dsde-dev.broadinstitute.org/#/Tps/getPao) and verified that its policy object reflected both its protected status and auth domain, along with the differing creation and last updated timestamps:

```
{
  "objectId": "0a4da971-3b28-4a40-af60-1704216e6989",
  "component": "TDR",
  "objectType": "snapshot",
  "attributes": {
    "inputs": [
      {
        "namespace": "terra",
        "name": "protected-data",
        "additionalData": []
      },
      {
        "namespace": "terra",
        "name": "group-constraint",
        "additionalData": [
          {
            "key": "group",
            "value": "20231024_policy_test"
          }
        ]
      }
    ]
  },
  "effectiveAttributes": {
    "inputs": [
      {
        "namespace": "terra",
        "name": "protected-data",
        "additionalData": []
      },
      {
        "namespace": "terra",
        "name": "group-constraint",
        "additionalData": [
          {
            "key": "group",
            "value": "20231024_policy_test"
          }
        ]
      }
    ]
  },
  "deleted": false,
  "sourcesObjectIds": [],
  "createdDate": "2023-10-30T20:04:56.665542Z",
  "lastUpdatedDate": "2023-10-30T20:07:28.745389Z"
}
```

**Follow-On Work**
Related to https://broadworkbench.atlassian.net/browse/ID-899 --
- Clean up special error handling when TPS properly classifies its conflict errors as 409s
- Add contract tests with TDR as consumer and TPS as provider to explicitly define our expectations for `createPao` when a PAO already exists
  - As TPS does not yet have any support for contract testing, this is a bigger lift: higher priority is to finish up setting up TDR as a Pact provider, the learnings from which will enable us to help with that same set-up in TPS.