### PR TITLE
[DR-3293] Upgrade google cloud library to address CVE-2023-5072

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,7 @@ dependencies {
     implementation 'com.google.apis:google-api-services-appengine:v1-rev20230206-2.0.0'
     implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-2.0.0'
     implementation 'com.google.apis:google-api-services-iam:v1-rev20230209-2.0.0'
-    implementation platform('com.google.cloud:libraries-bom:26.22.0')
+    implementation platform('com.google.cloud:libraries-bom:26.26.0')
     implementation 'com.google.cloud:google-cloud-billing'
     implementation 'com.google.cloud:google-cloud-resourcemanager'
     implementation 'com.google.cloud:google-cloud-bigquery'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3293
https://nvd.nist.gov/vuln/detail/CVE-2023-5072

Our previous version of `com.google.cloud:google-cloud-bigquery` -- 2.31.1 -- had a vulnerable version of `JSON-java`.
Upgrading our google cloud library brought `google-cloud-bigquery` up to 2.34.0, past the vulnerability:
```
./gradlew -q dependencyInsight --dependency google-cloud-bigquery  
…
com.google.cloud:google-cloud-bigquery:2.34.0 (by constraint)
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes)
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 17
   ]

com.google.cloud:google-cloud-bigquery:2.34.0
\--- com.google.cloud:libraries-bom:26.26.0
     \--- compileClasspath

com.google.cloud:google-cloud-bigquery -> 2.34.0
\--- compileClasspath
```