### PR TITLE
QA-2170: Lift and shift to use semver versioning for contract tests

### DIFF
--- a/.github/actions/bump-skip/action.yml
+++ b/.github/actions/bump-skip/action.yml
@@ -1,0 +1,28 @@
+# This action must be done after the checkout action
+name: 'bump-skip'
+description: 'Set skip-out when we are doing a version bump'
+author: 'dd'
+inputs:
+  event-name:
+    description: 'github.event_name from the calling workflow'
+    required: true
+outputs:
+  is-bump:
+    description: 'yes if this is a push made by bumper; no if it is a regular push'
+    value: ${{ steps.bumptest.outputs.is-bump }}
+runs:
+  using: "composite"
+  steps:
+    - name: Bump test
+      id: bumptest
+      run: |
+        log=$(git log --pretty='%B')
+        echo "log=$log"
+        pattern="^bump .*"
+        IS_BUMP=no
+        if [[ "${{ inputs.event-name }}" == "push" && "$log" =~ $pattern ]]; then
+          IS_BUMP=yes
+        fi
+        echo "IS_BUMP=$IS_BUMP"
+        echo ::set-output name=is-bump::$IS_BUMP
+      shell: bash

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -47,7 +47,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,67 @@
+name: Tag
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout"
+        default: ''
+        required: false
+        type: string
+      dry-run:
+        description: "Determine the next version without tagging the branch. The workflow can use the outputs new_tag and tag in subsequent steps. Possible values are true and false (default)"
+        default: false
+        required: false
+        type: string
+      print-tag:
+        description: "Echo tag to console"
+        default: true
+        required: false
+        type: string
+    outputs:
+      tag:
+        description: "The value of the latest tag after running this action"
+        value: ${{ jobs.tag-job.outputs.tag }}
+      new-tag:
+        description: "The value of the newly created tag"
+        value: ${{ jobs.tag-job.outputs.new-tag }}
+    secrets:
+      BROADBOT_TOKEN:
+        required: true
+
+jobs:
+  # On tag vs. new-tag.
+  # The new-tag is always the tag resulting from a bump to the original tag.
+  # However, the tag is by definition the value of the latest tag after running the action,
+  # which might not change if dry run is used, and remains same as the original tag.
+  tag-job:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      new-tag: ${{ steps.tag.outputs.new_tag }}
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
+      - name: Bump the tag to a new version
+        # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
+        id: tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          HOTFIX_BRANCHES: hotfix.*
+          DEFAULT_BUMP: minor
+          DRY_RUN: ${{ inputs.dry-run }}
+          RELEASE_BRANCHES: develop
+          VERSION_FILE_PATH: build.gradle
+          VERSION_LINE_MATCH: "^\\s*version\\s+'.*'"
+          VERSION_SUFFIX: SNAPSHOT
+      - name: Echo tag to console
+        if: ${{ inputs.print-tag == 'true' }}
+        run: |
+          echo "Newly created version tag: '${{ steps.tag.outputs.new_tag }}'"
+          echo "settings.gradle"
+          echo "==============="
+          cat settings.gradle

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -52,7 +52,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -67,6 +67,6 @@ jobs:
         if: ${{ inputs.print-tag == 'true' }}
         run: |
           echo "Newly created version tag: '${{ steps.tag.outputs.new_tag }}'"
-          echo "settings.gradle"
+          echo "build.gradle"
           echo "==============="
-          cat settings.gradle
+          cat build.gradle

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,6 +18,11 @@ on:
         default: true
         required: false
         type: string
+      release-branches:
+        description: "Default branch (main, develop, etc)"
+        default: 'main'
+        required: false
+        type: string
     outputs:
       tag:
         description: "The value of the latest tag after running this action"
@@ -54,7 +59,7 @@ jobs:
           HOTFIX_BRANCHES: hotfix.*
           DEFAULT_BUMP: minor
           DRY_RUN: ${{ inputs.dry-run }}
-          RELEASE_BRANCHES: develop
+          RELEASE_BRANCHES: ${{ inputs.release-branches }}
           VERSION_FILE_PATH: build.gradle
           VERSION_LINE_MATCH: "^\\s*version\\s+'.*'"
           VERSION_SUFFIX: SNAPSHOT

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -100,7 +100,7 @@ jobs:
       ref: ${{ github.head_ref || '' }}
       # The 'dry-run' parameter prevents the new tag from being dispatched.
       # We only need to dispatch a tag once if this is a PR merge.
-      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/${{ env.RELEASE_BRANCHES }}' }}
+      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       release-branches: ${{ env.RELEASE_BRANCHES }}
     secrets: inherit
 

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -99,11 +99,11 @@ jobs:
   test-needs-context:
     runs-on: ubuntu-latest
     needs: [ needs-context ]
-    if: ${{ github.event_name == 'pull_request' && github.head_ref == needs.needs-context.outputs.feature-branch }}
     steps:
       - run: |
           echo "${{ github.event_name }}"
           echo "${{ github.head_ref }}"
+          echo "${{ needs.needs-context.outputs.release-branch }}"
           echo "${{ needs.needs-context.outputs.release-ref }}"
 
   bump-check:

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -83,16 +83,11 @@ jobs:
     outputs:
       release-branch: ${{ steps.set-release-branch.outputs.release-branch }}
       # You can include more outputs for additional envvar you want to expose to job.
-      release-ref: ${{ steps.set-release-ref.outputs.release-ref }}
     steps:
       - id: set-release-branch
         run: |
           echo "release-branch=${{ env.RELEASE_BRANCH }}" >> $GITHUB_OUTPUT
       # You can add more steps for each additional envvar you want to expose to job.
-      - id: set-release-ref
-        run: |
-          ref=$(echo "refs/heads/${{ env.RELEASE_BRANCH }}" | sed 's#//*#/#g')
-          echo "release-ref=$ref" >> $GITHUB_OUTPUT
 
   bump-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -98,9 +98,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ needs-context ]
     if: ${{ github.event_name == 'pull_request' && github.head_ref == needs.needs-context.outputs.feature-branch }}
-    run: |
-      echo "${{ github.event_name }}"
-      echo "${{ github.head_ref }}"
+    steps:
+      - run: |
+          echo "${{ github.event_name }}"
+          echo "${{ github.head_ref }}"
 
   bump-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -72,6 +72,34 @@ on:
         type: string
 
 jobs:
+  bump-check:
+    runs-on: ubuntu-latest
+    outputs:
+      is-bump: ${{ steps.skiptest.outputs.is-bump }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Skip version bump merges
+        id: skiptest
+        uses: ./.github/actions/bump-skip
+        with:
+          event-name: ${{ github.event_name }}
+  # We only need a new version tag when this workflow is triggered by opening, updating a PR or PR merge.
+  # When triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
+  # is already included in the payload, then a new version tag wouldn't be needed.
+  #
+  regulated-tag-job:
+    needs: [ bump-check ]
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
+    uses: ./.github/workflows/tag.yml
+    with:
+      # The 'ref' parameter ensures that the provider version is postfixed with the HEAD commit of the PR branch,
+      # facilitating cross-referencing of a pact between Pact Broker and GitHub.
+      ref: ${{ github.head_ref || '' }}
+      # The 'dry-run' parameter prevents the new tag from being dispatched.
+      # We only need to dispatch a tag once if this is a PR merge.
+      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    secrets: inherit
+
   verify-consumer-pact:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -16,6 +16,7 @@ name: Verify consumer pacts
 # They are managed by Atlantis and were added to Terraform here:
 # https://github.com/broadinstitute/terraform-ap-deployments/pull/1255
 env:
+  PACTICIPANT: 'datarepo'
   RELEASE_BRANCHES: 'develop'
   TDR_LOG_APPENDER: 'Console-Standard'
   CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
@@ -239,6 +240,6 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{
             "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
-            "pacticipant": "datarepo",
+            "pacticipant": "${{ env.PACTICIPANT }}",
             "version": "${{ needs.verify-consumer-pact.outputs.provider-version }}"
           }'

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -208,7 +208,6 @@ jobs:
       - name: Verify consumer pacts and publish verification status to Pact Broker
         id: verification-test
         env:
-          PACT_BROKER_URL: 'https://pact-broker.dsp-eng-tools.broadinstitute.org'
           PACT_PROVIDER_VERSION: ${{ env.PROVIDER_VERSION }}
           PACT_PROVIDER_BRANCH:  ${{ env.PROVIDER_BRANCH }}
           PACT_BROKER_USERNAME:  ${{ secrets.PACT_BROKER_USERNAME }}

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -17,7 +17,6 @@ name: Verify consumer pacts
 # https://github.com/broadinstitute/terraform-ap-deployments/pull/1255
 env:
   PACTICIPANT: 'datarepo'
-  RELEASE_BRANCH: 'develop'
   TDR_LOG_APPENDER: 'Console-Standard'
   CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 on:
@@ -75,20 +74,6 @@ on:
         type: string
 
 jobs:
-  # The workflow key 'jobs.<job_id>.with.<with_id>' lacks 'env' in its context.
-  # However, we can use the 'needs' context to include the necessary envvar.
-  # Reference: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-  needs-context:
-    runs-on: ubuntu-latest
-    outputs:
-      release-branch: ${{ steps.set-release-branch.outputs.release-branch }}
-      # You can include more outputs for additional envvar you want to expose to job.
-    steps:
-      - id: set-release-branch
-        run: |
-          echo "release-branch=${{ env.RELEASE_BRANCH }}" >> $GITHUB_OUTPUT
-      # You can add more steps for each additional envvar you want to expose to job.
-
   bump-check:
     runs-on: ubuntu-latest
     outputs:
@@ -104,7 +89,7 @@ jobs:
   # When triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
   # is already included in the payload, then a new version tag wouldn't be needed.
   regulated-tag-job:
-    needs: [ needs-context, bump-check ]
+    needs: [ bump-check ]
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
     with:
@@ -114,7 +99,7 @@ jobs:
       # The 'dry-run' parameter prevents the new tag from being dispatched.
       # We only need to dispatch a tag once if this is a PR merge.
       dry-run: true
-      release-branches: ${{ needs.needs-context.outputs.release-branch }}
+      release-branches: develop
     secrets: inherit
 
   verify-consumer-pact:

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -93,18 +93,7 @@ jobs:
       - id: set-release-ref
         run: |
           ref=$(echo "refs/heads/${{ env.RELEASE_BRANCH }}" | sed 's#//*#/#g')
-          echo "$ref"
           echo "release-ref=$ref" >> $GITHUB_OUTPUT
-
-  test-needs-context:
-    runs-on: ubuntu-latest
-    needs: [ needs-context ]
-    steps:
-      - run: |
-          echo "${{ github.event_name }}"
-          echo "${{ github.head_ref }}"
-          echo "${{ needs.needs-context.outputs.release-branch }}"
-          echo "${{ needs.needs-context.outputs.release-ref }}"
 
   bump-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -17,7 +17,8 @@ name: Verify consumer pacts
 # https://github.com/broadinstitute/terraform-ap-deployments/pull/1255
 env:
   PACTICIPANT: 'datarepo'
-  MY_BRANCH: 'develop'
+  RELEASE_BRANCHES: 'develop'
+  FEATURE_BRANCH: 'QA-2170-1'
   TDR_LOG_APPENDER: 'Console-Standard'
   CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 on:
@@ -75,6 +76,32 @@ on:
         type: string
 
 jobs:
+  # The workflow key 'jobs.<job_id>.with.<with_id>' lacks 'env' in its context.
+  # However, we can use the 'needs' context to include the necessary envvar.
+  # Reference: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+  needs-context:
+    runs-on: ubuntu-latest
+    outputs:
+      release-branches: ${{ steps.set-release-branches.outputs.release-branches }}
+      # You can include more outputs for additional envvar you want to expose to job.
+      feature-branch: ${{ steps.set-feature-branch.outputs.feature-branch }}
+    steps:
+      - id: set-release-branches
+        run: |
+          echo "release-branches=${{ env.RELEASE_BRANCHES }}" >> $GITHUB_OUTPUT
+      # You can add more steps for each additional envvar you want to expose to job.
+      - id: set-feature-branch
+        run: |
+          echo "feature-branch=${{ env.FEATURE_BRANCH }}" >> $GITHUB_OUTPUT
+
+  test-needs-context:
+    runs-on: ubuntu-latest
+    needs: [ needs-context ]
+    if: ${{ github.event_name == 'pull_request' && github.head_ref == needs.needs-context.outputs.feature-branch }}
+    run: |
+      echo "${{ github.event_name }}"
+      echo "${{ github.head_ref }}"
+
   bump-check:
     runs-on: ubuntu-latest
     outputs:
@@ -89,9 +116,8 @@ jobs:
   # We only need a new version tag when this workflow is triggered by opening, updating a PR or PR merge.
   # When triggered by a Pact Broker webhook, the provider version (GIT hash or release tag)
   # is already included in the payload, then a new version tag wouldn't be needed.
-  #
   regulated-tag-job:
-    needs: [ bump-check ]
+    needs: [ needs-context, bump-check ]
     if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     uses: ./.github/workflows/tag.yml
     with:
@@ -101,7 +127,7 @@ jobs:
       # The 'dry-run' parameter prevents the new tag from being dispatched.
       # We only need to dispatch a tag once if this is a PR merge.
       dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-      release-branches: ${{ env.MY_BRANCH }}
+      release-branches: ${{ needs.needs-context.outputs.release-branches }}
     secrets: inherit
 
   verify-consumer-pact:

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -18,7 +18,6 @@ name: Verify consumer pacts
 env:
   PACTICIPANT: 'datarepo'
   RELEASE_BRANCH: 'develop'
-  FEATURE_BRANCH: 'QA-2170-1'
   TDR_LOG_APPENDER: 'Console-Standard'
   CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 on:

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -17,6 +17,7 @@ name: Verify consumer pacts
 # https://github.com/broadinstitute/terraform-ap-deployments/pull/1255
 env:
   TDR_LOG_APPENDER: 'Console-Standard'
+  CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 on:
   pull_request:
     branches:
@@ -102,11 +103,13 @@ jobs:
 
   verify-consumer-pact:
     runs-on: ubuntu-latest
+    needs: [ bump-check, regulated-tag-job ]
+    if: ${{ needs.bump-check.outputs.is-bump == 'no' }}
     permissions:
       contents: 'read'
       id-token: 'write'
     outputs:
-      provider-sha: ${{ steps.verification-test.outputs.provider-sha }}
+      provider-version: ${{ steps.verification-test.outputs.provider-version }}
 
     steps:
       - name: Checkout current code
@@ -120,65 +123,70 @@ jobs:
           GITHUB_EVENT_NAME=${{ github.event_name }}
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             GITHUB_REF=${{ github.ref }}
-            GITHUB_SHA=${{ github.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             GITHUB_REF=refs/heads/${{ github.head_ref }}
-            GITHUB_SHA=${{ github.event.pull_request.head.sha }}
           elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             GITHUB_REF=${{ github.ref }} # The Git Ref that this workflow runs on
-            GITHUB_SHA=${{ github.sha }} # The Git Sha that this workflow runs on
           else
             echo "Failed to extract branch information"
             exit 1
           fi
           echo "CURRENT_BRANCH=${GITHUB_REF/refs\/heads\//""}" >> $GITHUB_ENV
-          echo "CURRENT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
 
-      - name: "This step will only run when this workflow is triggered by a Pact Broker webhook event"
+      - name: Capture webhook event payload as envvars
         if: ${{ inputs.pb-event-type != '' }}
         run: |
           echo "pb-event-type=${{ inputs.pb-event-type }}"
           echo "consumer-name=${{ inputs.consumer-name }}"
+
+          # The consumer-version-branch and consumer-version-number identify the most recent
+          # consumer branch and version associated with the pact content.
           echo "consumer-version-branch/consumer-version-number=${{ inputs.consumer-version-branch }}/${{ inputs.consumer-version-number }}"
+
+          # The provider-version-number represents the provider version number in the webhook event payload.
+          # This corresponds to the GitHub release tag recorded by Sherlock for the corresponding
+          # deployment environment (dev, staging, and prod).
           echo "provider-version-branch/provider-version-number=${{ inputs.provider-version-branch }}/${{ inputs.provider-version-number }}"
-          # The consumer-version-branch/consumer-version-number is practically sufficient.
+
           # The pact-url is included here in case future pact4s client supports it.
           echo "pact-url=${{ inputs.pact-url }}"
-          if [[ ! -z "${{ inputs.provider-version-branch }}" ]]; then
-            echo "PROVIDER_BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
-            echo "CHECKOUT_BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
-          fi
-          if [[ ! -z "${{ inputs.provider-version-number }}" ]]; then
-            echo "PROVIDER_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
-            echo "CHECKOUT_SHA=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
-          fi
-          echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
-          echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
-          echo "CONSUMER_SHA=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
 
-      - name: Switch to appropriate branch
+          # Save webhook event parameters as envvars
+          echo "PROVIDER_BRANCH=${{ inputs.provider-version-branch }}" >> $GITHUB_ENV
+          echo "PROVIDER_TAG=${{ inputs.provider-version-number }}" >> $GITHUB_ENV
+          echo "CONSUMER_BRANCH=${{ inputs.consumer-version-branch }}" >> $GITHUB_ENV
+          echo "CONSUMER_NAME=${{ inputs.consumer-name }}" >> $GITHUB_ENV
+          echo "CONSUMER_VERSION=${{ inputs.consumer-version-number }}" >> $GITHUB_ENV
+
+      - name: Set PROVIDER_VERSION envvar
         run: |
-          if [[ -z "${{ env.PROVIDER_BRANCH }}" ]]; then
+          # The PROVIDER_VERSION envvar is used to identify the provider version
+          # for publishing the results of provider verification.
+          if [[ -z "${{ inputs.pb-event-type }}" ]]; then
             echo "PROVIDER_BRANCH=${{ env.CURRENT_BRANCH }}" >> $GITHUB_ENV
-          fi
-          if [[ -z "${{ env.PROVIDER_SHA }}" ]]; then
-            echo "PROVIDER_SHA=${{ env.CURRENT_SHA }}" >> $GITHUB_ENV
-          fi
-          git fetch
-          if [[ ! -z "${{ env.CHECKOUT_BRANCH }}" ]] && [[ ! -z "${{ env.CHECKOUT_SHA }}" ]]; then
-            echo "git checkout -b ${{ env.CHECKOUT_BRANCH }} ${{ env.CHECKOUT_SHA }}"
-            git checkout -b ${{ env.CHECKOUT_BRANCH }} ${{ env.CHECKOUT_SHA }} || echo "already in ${{ env.CHECKOUT_BRANCH }}"
-            echo "git branch"
-            git branch
+            echo "PROVIDER_VERSION=${{ needs.regulated-tag-job.outputs.new-tag }}" >> $GITHUB_ENV
           else
-            if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-              echo "git checkout ${{ env.CURRENT_BRANCH }}"
-              git checkout ${{ env.CURRENT_BRANCH }}
-            else
-              echo "git checkout -b ${{ env.CURRENT_BRANCH }} ${{ env.CURRENT_SHA }}"
-              git checkout -b ${{ env.CURRENT_BRANCH }} ${{ env.CURRENT_SHA }}
-            fi
+            echo "PROVIDER_VERSION=${{ env.PROVIDER_TAG }}" >> $GITHUB_ENV
           fi
+
+      - name: Switch to appropriate provider branch
+        run: |
+          echo "This workflow has been triggered by '${{ github.event_name }}' event."
+
+          # If the PROVIDER_TAG envvar exists, switch to the corresponding tag.
+          # This condition is true when the workflow is triggered by a Pact Broker webhook event.
+          if [[ -n "${{ env.PROVIDER_TAG }}" ]]; then
+            echo "git checkout tags/${{ env.PROVIDER_TAG }}"
+            git checkout tags/${{ env.PROVIDER_TAG }}
+
+          # Otherwise, switch to CURRENT_BRANCH if the workflow has been triggered by a
+          # PR commit or merge onto the main branch.
+          elif [[ "${{ github.event_name }}" == "pull_request" ]] || [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "git checkout ${{ env.CURRENT_BRANCH }}"
+            git checkout ${{ env.CURRENT_BRANCH }}
+          fi
+
+          # Echo the HEAD commit of the provider branch that has been switched to.
           echo "git rev-parse HEAD"
           git rev-parse HEAD
 
@@ -200,34 +208,36 @@ jobs:
       - name: Verify consumer pacts and publish verification status to Pact Broker
         id: verification-test
         env:
-          PACT_PROVIDER_COMMIT: ${{ env.PROVIDER_SHA }}
-          PACT_PROVIDER_BRANCH: ${{ env.PROVIDER_BRANCH }}
-          PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
-          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+          PACT_BROKER_URL: 'https://pact-broker.dsp-eng-tools.broadinstitute.org'
+          PACT_PROVIDER_VERSION: ${{ env.PROVIDER_VERSION }}
+          PACT_PROVIDER_BRANCH:  ${{ env.PROVIDER_BRANCH }}
+          PACT_BROKER_USERNAME:  ${{ secrets.PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD:  ${{ secrets.PACT_BROKER_PASSWORD }}
         run: |
-          echo "provider-sha=${{ env.PROVIDER_SHA }}" >> $GITHUB_OUTPUT
-          echo "env.CHECKOUT_BRANCH=${{ env.CHECKOUT_BRANCH }} # If not empty, this reflects the branch being checked out (generated by Pact Broker)"
-          echo "env.CHECKOUT_SHA=${{ env.CHECKOUT_SHA }}       # If not empty, this reflects the git commit hash of the branch being checked out (generated by Pact Broker)"
-          echo "env.CURRENT_BRANCH=${{ env.CURRENT_BRANCH }}   # This reflects the branch being checked out if CHECKOUT_BRANCH is empty"
-          echo "env.CURRENT_SHA=${{ env.CURRENT_SHA }}         # This reflects the git commit hash of the branch being checked out if CHECKOUT_BRANCH is empty"
-          echo "env.PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }} # This reflects the provider branch for pact verification"
-          echo "env.PROVIDER_SHA=${{ env.PROVIDER_SHA }}       # This reflects the provider version for pact verification"
-          echo "env.CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }} # This reflects the consumer branch for pact verification (generated by Pact Broker)"
-          echo "env.CONSUMER_SHA=${{ env.CONSUMER_SHA }}       # This reflects the consumer version for pact verification (generated by Pact Broker)"
+          echo "provider-version=${{ env.PACT_PROVIDER_VERSION }}" >> $GITHUB_OUTPUT
+          echo "env.CONSUMER_BRANCH=${{ env.CONSUMER_BRANCH }}   # This reflects the consumer branch for pact verification (generated by Pact Broker)"
+          echo "env.PROVIDER_BRANCH=${{ env.PROVIDER_BRANCH }}   # This reflects the provider branch to switch to for pact verification"
+          echo "env.CONSUMER_VERSION=${{ env.CONSUMER_VERSION }} # This reflects the consumer version for pact verification (generated by Pact Broker)"
+          echo "env.PROVIDER_VERSION=${{ env.PROVIDER_VERSION }} # Deprecate env.PACT_PROVIDER_COMMIT. This new envvar is used for migrating GIT hash to app versioning"
           ./gradlew --build-cache verifyPacts --scan
 
   can-i-deploy:
     # The can-i-deploy job will run as a result of a jade-data-repo PR.
     # It reports the pact verification statuses on all deployed environments.
     runs-on: ubuntu-latest
-    if: ${{ inputs.pb-event-type == '' }}
-    needs: [ verify-consumer-pact ]
+    if: ${{ inputs.pb-event-type == '' && needs.bump-check.outputs.is-bump == 'no' }}
+    needs: [ verify-consumer-pact, bump-check ]
     steps:
       - name: Dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v3
+        uses: broadinstitute/workflow-dispatch@v4.0.0
         with:
+          run-name: "${{ env.CAN_I_DEPLOY_RUN_NAME }}"
           workflow: .github/workflows/can-i-deploy.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "datarepo", "version": "${{ needs.verify-consumer-pact.outputs.provider-sha }}" }'
+          inputs: '{
+            "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
+            "pacticipant": "datarepo",
+            "version": "${{ needs.verify-consumer-pact.outputs.provider-version }}"
+          }'

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -16,6 +16,7 @@ name: Verify consumer pacts
 # They are managed by Atlantis and were added to Terraform here:
 # https://github.com/broadinstitute/terraform-ap-deployments/pull/1255
 env:
+  RELEASE_BRANCHES: 'develop'
   TDR_LOG_APPENDER: 'Console-Standard'
   CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 on:
@@ -98,7 +99,8 @@ jobs:
       ref: ${{ github.head_ref || '' }}
       # The 'dry-run' parameter prevents the new tag from being dispatched.
       # We only need to dispatch a tag once if this is a PR merge.
-      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/${{ env.RELEASE_BRANCHES }}' }}
+      release-branches: ${{ env.RELEASE_BRANCHES }}
     secrets: inherit
 
   verify-consumer-pact:

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -17,7 +17,7 @@ name: Verify consumer pacts
 # https://github.com/broadinstitute/terraform-ap-deployments/pull/1255
 env:
   PACTICIPANT: 'datarepo'
-  RELEASE_BRANCHES: 'develop'
+  MY_BRANCH: 'develop'
   TDR_LOG_APPENDER: 'Console-Standard'
   CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 on:
@@ -101,7 +101,7 @@ jobs:
       # The 'dry-run' parameter prevents the new tag from being dispatched.
       # We only need to dispatch a tag once if this is a PR merge.
       dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-      release-branches: develop
+      release-branches: ${{ env.MY_BRANCH }}
     secrets: inherit
 
   verify-consumer-pact:

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -17,7 +17,7 @@ name: Verify consumer pacts
 # https://github.com/broadinstitute/terraform-ap-deployments/pull/1255
 env:
   PACTICIPANT: 'datarepo'
-  RELEASE_BRANCHES: 'develop'
+  RELEASE_BRANCH: 'develop'
   FEATURE_BRANCH: 'QA-2170-1'
   TDR_LOG_APPENDER: 'Console-Standard'
   CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
@@ -82,17 +82,19 @@ jobs:
   needs-context:
     runs-on: ubuntu-latest
     outputs:
-      release-branches: ${{ steps.set-release-branches.outputs.release-branches }}
+      release-branch: ${{ steps.set-release-branch.outputs.release-branch }}
       # You can include more outputs for additional envvar you want to expose to job.
-      feature-branch: ${{ steps.set-feature-branch.outputs.feature-branch }}
+      release-ref: ${{ steps.set-release-ref.outputs.release-ref }}
     steps:
-      - id: set-release-branches
+      - id: set-release-branch
         run: |
-          echo "release-branches=${{ env.RELEASE_BRANCHES }}" >> $GITHUB_OUTPUT
+          echo "release-branch=${{ env.RELEASE_BRANCH }}" >> $GITHUB_OUTPUT
       # You can add more steps for each additional envvar you want to expose to job.
-      - id: set-feature-branch
+      - id: set-release-ref
         run: |
-          echo "feature-branch=${{ env.FEATURE_BRANCH }}" >> $GITHUB_OUTPUT
+          ref=$(echo "refs/heads/${{ env.RELEASE_BRANCH }}" | sed 's#//*#/#g')
+          echo "$ref"
+          echo "release-ref=$ref" >> $GITHUB_OUTPUT
 
   test-needs-context:
     runs-on: ubuntu-latest
@@ -102,6 +104,7 @@ jobs:
       - run: |
           echo "${{ github.event_name }}"
           echo "${{ github.head_ref }}"
+          echo "${{ needs.needs-context.outputs.release-ref }}"
 
   bump-check:
     runs-on: ubuntu-latest
@@ -127,8 +130,8 @@ jobs:
       ref: ${{ github.head_ref || '' }}
       # The 'dry-run' parameter prevents the new tag from being dispatched.
       # We only need to dispatch a tag once if this is a PR merge.
-      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-      release-branches: ${{ needs.needs-context.outputs.release-branches }}
+      dry-run: ${{ github.event_name == 'push' && github.ref == needs.needs-context.outputs.release-ref }}
+      release-branches: ${{ needs.needs-context.outputs.release-branch }}
     secrets: inherit
 
   verify-consumer-pact:

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -97,7 +97,6 @@ jobs:
       # facilitating cross-referencing of a pact between Pact Broker and GitHub.
       ref: ${{ github.head_ref || '' }}
       # The 'dry-run' parameter prevents the new tag from being dispatched.
-      # We only need to dispatch a tag once if this is a PR merge.
       dry-run: true
       release-branches: develop
     secrets: inherit

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -118,7 +118,7 @@ jobs:
       ref: ${{ github.head_ref || '' }}
       # The 'dry-run' parameter prevents the new tag from being dispatched.
       # We only need to dispatch a tag once if this is a PR merge.
-      dry-run: ${{ github.event_name == 'push' && github.ref == needs.needs-context.outputs.release-ref }}
+      dry-run: true
       release-branches: ${{ needs.needs-context.outputs.release-branch }}
     secrets: inherit
 

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -98,7 +98,7 @@ jobs:
       ref: ${{ github.head_ref || '' }}
       # The 'dry-run' parameter prevents the new tag from being dispatched.
       # We only need to dispatch a tag once if this is a PR merge.
-      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     secrets: inherit
 
   verify-consumer-pact:

--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -101,7 +101,7 @@ jobs:
       # The 'dry-run' parameter prevents the new tag from being dispatched.
       # We only need to dispatch a tag once if this is a PR merge.
       dry-run: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-      release-branches: ${{ env.RELEASE_BRANCHES }}
+      release-branches: develop
     secrets: inherit
 
   verify-consumer-pact:

--- a/build.gradle
+++ b/build.gradle
@@ -586,9 +586,14 @@ task verifyPacts(type: Test) {
     if (isCiServer) {
         systemProperty 'pact.verifier.publishResults', true
     }
+    // to run a local pactbroker, see:
+    // https://broadworkbench.atlassian.net/wiki/spaces/IRT/pages/2829680649/Contract+Test+Local+Development
+    if (System.getenv().containsKey('PACT_BROKER_URL')) {
+        systemProperty 'pactbroker.url', System.getenv('PACT_BROKER_URL')
+    }
     systemProperty 'pactbroker.auth.username', System.getenv('PACT_BROKER_USERNAME')
     systemProperty 'pactbroker.auth.password', System.getenv('PACT_BROKER_PASSWORD')
-    systemProperty 'pact.provider.version', System.getenv('PACT_PROVIDER_COMMIT')
+    systemProperty 'pact.provider.version', System.getenv('PACT_PROVIDER_VERSION')
     systemProperty 'pact.provider.branch', System.getenv('PACT_PROVIDER_BRANCH')
 }
 

--- a/src/test/java/bio/terra/pact/provider/SnapshotsApiControllerTest.java
+++ b/src/test/java/bio/terra/pact/provider/SnapshotsApiControllerTest.java
@@ -70,17 +70,13 @@ class SnapshotsApiControllerTest {
 
   @PactBrokerConsumerVersionSelectors
   public static SelectorBuilder consumerVersionSelectors() {
-    // Select consumer pacts published from default branch or pacts marked as deployed or released.
-    // If you wish to pick up Pacts from a consumer's feature branch for development purposes or PR
-    // runs, and your consumer is publishing such Pacts under their feature branch name, you can add
-    // the following to the SelectorBuilder:
-    //   .branch("consumer-feature-branch-name")
-    // New comments.
-    // The following match condition basically says
-    // If verification is triggered by Pact Broker webhook due to consumer pact change, verify only
-    // the changed pact.
-    // Otherwise, this is a PR, verify all consumer pacts in Pact Broker marked with a deployment
-    // tag (e.g. dev, alpha).
+    // If CONSUMER_BRANCH envvar is unset, choose consumer pacts from the default branch or those
+    // marked as deployed/released (e.g., dev, staging, production). This scenario covers PRs, merge
+    // commits, or local verification tests.
+
+    // If CONSUMER_BRANCH envvar is set (either locally or in the webhook payload), download the
+    // latest version of the pact from Pact Broker on the specified CONSUMER_BRANCH for
+    // verification.
     if (StringUtils.isBlank(CONSUMER_BRANCH)) {
       return new SelectorBuilder().mainBranch().deployedOrReleased();
     } else {


### PR DESCRIPTION
Jira ticket: [QA-2170](https://broadworkbench.atlassian.net/browse/QA-2170)

[QA-2170]: https://broadworkbench.atlassian.net/browse/QA-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

More details on why we're doing this shifting. Considering the creation of a ledger to trace contracts through PR and merge commits. It is also crucial for Sherlock to be able to interact with Pact Broker to record deployment environment for the appropriate release tag.

1.     Multiple Developers and Commits in a PR:
- Multiple developers can collaborate on the same pull request (PR).
- The PR can have multiple commits.

2.     Sherlock and Helm Charts for `datarepo`:
- Sherlock doesn't synchronize Helm charts for the `datarepo` on PR commits
- The synchronization is only called upon during merge commit to `develop` branch

3.     Continuous Publishing and Verification of Contracts:
- You still want contracts from the PR to be continually published or verified.
- The tagging mechanism is introduced to create a ledger of published and verified contracts in Pact Broker. For PRs, the tag is appended with the commit hash. When the live tag is pushed to GitHub during merge commit, the contracts will be published or verified using the live tag without hash.
- This ledger allows developers to trace issues on both the consumer or provider side.