### PR TITLE
DR-3376 Add a filter to the job enumeration function to only return recent jobs

### DIFF
--- a/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
@@ -145,6 +145,9 @@ public class ApplicationConfiguration {
    */
   private List<String> compactIdPrefixAllowList = new ArrayList<>();
 
+  /** Maximum number of days to show jobs in the job history when non-admin users enumerate jobs */
+  private int maxNumberOfDaysToShowJobs;
+
   public String getUserEmail() {
     return userEmail;
   }
@@ -355,6 +358,14 @@ public class ApplicationConfiguration {
 
   public void setCompactIdPrefixAllowList(List<String> compactIdPrefixAllowList) {
     this.compactIdPrefixAllowList = compactIdPrefixAllowList;
+  }
+
+  public int getMaxNumberOfDaysToShowJobs() {
+    return maxNumberOfDaysToShowJobs;
+  }
+
+  public void setMaxNumberOfDaysToShowJobs(int maxNumberOfDaysToShowJobs) {
+    this.maxNumberOfDaysToShowJobs = maxNumberOfDaysToShowJobs;
   }
 
   @Primary

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -40,9 +40,8 @@ import bio.terra.stairway.exception.FlightNotFoundException;
 import bio.terra.stairway.exception.StairwayException;
 import bio.terra.stairway.exception.StairwayExecutionException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -66,7 +65,6 @@ public class JobService {
   private static final Logger logger = LoggerFactory.getLogger(JobService.class);
   private static final int MIN_SHUTDOWN_TIMEOUT = 14;
   private static final int POD_LISTENER_SHUTDOWN_TIMEOUT = 2;
-  @VisibleForTesting static final int DAYS_BACK_TO_QUERY = 30;
 
   private final IamService samService;
   private final ApplicationConfiguration appConfig;
@@ -351,10 +349,11 @@ public class JobService {
 
     // Only return recent flights. This is a performance enhancement since it causes the query to
     // NOT do a full table scan.
-    // TODO: make this an option in the API.  Not tackled yet since I'm not sure of the value
+    // TODO<DR-3379>: make an option in the API. Not tackled yet since I'm not sure of the value
     topLevelBooleans.add(
         makePredicateSubmitTime(
-            FlightFilterOp.GREATER_THAN, Instant.now().minus(DAYS_BACK_TO_QUERY, ChronoUnit.DAYS)));
+            FlightFilterOp.GREATER_THAN,
+            Instant.now().minus(Duration.ofDays(appConfig.getMaxNumberOfDaysToShowJobs()))));
 
     // Make sure that only flights a user has access to are returned if the user is not an admin
     if (!checkUserCanListAnyJob(userReq)) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3385,7 +3385,7 @@ paths:
         - jobs
         - repository
       description: >
-        Returns a list of all of the jobs the caller has access to
+        Returns a list of all recently jobs submitted that the caller has access to
       operationId: enumerateJobs
       parameters:
         - name: offset

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3385,7 +3385,7 @@ paths:
         - jobs
         - repository
       description: >
-        Returns a list of all recently jobs submitted that the caller has access to
+        Returns a list of all recently submitted jobs that the caller has access to
       operationId: enumerateJobs
       parameters:
         - name: offset

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -85,6 +85,7 @@ datarepo.bq.rateLimitRetryWaitMs=500
 datarepo.numPerformanceThreads=50
 datarepo.maxPerformanceThreadQueueSize=1000
 #datarepo.compactIdPrefixAllowList[0]=<compact id allowed to point back to TDR>
+datarepo.maxNumberOfDaysToShowJobs=30
 sam.basePath=https://sam.dsde-dev.broadinstitute.org
 sam.stewardsGroupEmail=JadeStewards-dev@dev.test.firecloud.org
 sam.adminsGroupEmail=DataRepoAdmins@dev.test.firecloud.org


### PR DESCRIPTION
Specifically, jobs submitted in the last 30 days. This has a huge positive impact on perf.  Looking on prod, I'm seeing ~ 600X perf improvements.  This is because it eliminates doing a full table scan on the driving table of the enumeration query.

The testing a little gross based on what we aren't allowed (totally reasonable) to change in flight objects.  But all in all, this should make the jobs page a TON faster.  I was able to test the queries on prod directly and say the boost and could verify by looking at the explain plan.

Note: I hard coded to 30 days and didn't expose in the API. We may eventually want to add explicit date filtering in the API so I didn't want to muddy the waters by adding "filter by N days back"