### PR TITLE
[DR-3381] Add DUOS-ID filter option when enumerating snapshots

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -184,7 +184,8 @@ public class SnapshotsApiController implements SnapshotsApi {
       String filter,
       String region,
       List<String> datasetIds,
-      List<String> tags) {
+      List<String> tags,
+      List<String> duosIds) {
     ControllerUtils.validateEnumerateParams(offset, limit);
     List<UUID> datasetUUIDs =
         ListUtils.emptyIfNull(datasetIds).stream()
@@ -200,7 +201,8 @@ public class SnapshotsApiController implements SnapshotsApi {
             filter,
             region,
             datasetUUIDs,
-            tags);
+            tags,
+            duosIds);
     return ResponseEntity.ok(esm);
   }
 

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/enableSecureMonitoring/SecureMonitoringRefolderGcpProjectsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/enableSecureMonitoring/SecureMonitoringRefolderGcpProjectsStep.java
@@ -72,6 +72,7 @@ public class SecureMonitoringRefolderGcpProjectsStep extends DefaultUndoStep {
             "",
             "",
             List.of(dataset.getId()),
+            List.of(),
             List.of())
         .getItems()
         .stream()

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsVerifyDatasetStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsVerifyDatasetStep.java
@@ -37,7 +37,8 @@ public class ConvertToPredictableFileIdsVerifyDatasetStep extends DefaultUndoSte
                 null,
                 null,
                 List.of(datasetId),
-                null)
+                null,
+                List.of())
             .getFilteredTotal();
     if (numSnapshotsFromDataset > 0) {
       throw new IllegalArgumentException(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -43,10 +43,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import javax.sql.DataSource;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -560,23 +560,18 @@ public class SnapshotDao implements TaggableResourceDao {
       Collection<UUID> accessibleSnapshotIds,
       List<String> tags,
       List<String> duosIds) {
-    logger.debug(
-        "retrieve snapshots offset: "
-            + offset
-            + " limit: "
-            + limit
-            + " sort: "
-            + sort
-            + " direction: "
-            + direction
-            + " filter: "
-            + filter
-            + " datasetIds: "
-            + StringUtils.join(datasetIds, ",")
-            + " tags: "
-            + StringUtils.join(tags, ",")
-            + " duosIds: "
-            + StringUtils.join(duosIds, ","));
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+          "retrieve snapshots offset: {} limit: {} sort: {} direction: {} filter: {} datasetIds: {} tags: {} duosIds: {}",
+          offset,
+          limit,
+          sort,
+          direction,
+          filter,
+          String.join(",", datasetIds.stream().map(UUID::toString).toList()),
+          String.join(",", tags),
+          String.join(",", duosIds));
+    }
     MapSqlParameterSource params = new MapSqlParameterSource();
     List<String> whereClauses = new ArrayList<>();
     DaoUtils.addAuthzIdsClause(accessibleSnapshotIds, params, whereClauses, TABLE_NAME);
@@ -613,7 +608,7 @@ public class SnapshotDao implements TaggableResourceDao {
       throw new IllegalArgumentException(
           "Failed to convert snapshot request tags list to SQL array", e);
     }
-    if (!ListUtils.emptyIfNull(duosIds).isEmpty()) {
+    if (!Objects.requireNonNullElse(duosIds, List.of()).isEmpty()) {
       String duosIdMatchSql = "dfg.duos_id IN (:duosIds)";
       whereClauses.add(duosIdMatchSql);
       params.addValue("duosIds", duosIds);

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -380,7 +380,8 @@ public class SnapshotService {
       String filter,
       String region,
       List<UUID> datasetIds,
-      List<String> tags) {
+      List<String> tags,
+      List<String> duosIds) {
     List<ErrorModel> errors = new ArrayList<>();
     Map<UUID, Set<IamRole>> idsAndRoles = listAuthorizedSnapshots(userReq, errors);
     if (idsAndRoles.isEmpty()) {
@@ -388,7 +389,16 @@ public class SnapshotService {
     }
     var enumeration =
         snapshotDao.retrieveSnapshots(
-            offset, limit, sort, direction, filter, region, datasetIds, idsAndRoles.keySet(), tags);
+            offset,
+            limit,
+            sort,
+            direction,
+            filter,
+            region,
+            datasetIds,
+            idsAndRoles.keySet(),
+            tags,
+            duosIds);
     List<SnapshotSummaryModel> models =
         enumeration.getItems().stream().map(SnapshotSummary::toModel).collect(Collectors.toList());
 
@@ -1199,6 +1209,7 @@ public class SnapshotService {
             "",
             "",
             List.of(datasetId),
+            List.of(),
             List.of())
         .getItems()
         .stream()

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -28,6 +28,7 @@ public class SnapshotSummary {
   private boolean globalFileIds;
   private List<String> tags;
   private ResourceLocks resourceLocks;
+  private String duosId;
 
   public UUID getId() {
     return id;
@@ -173,6 +174,15 @@ public class SnapshotSummary {
     return this;
   }
 
+  public String getDuosId() {
+    return duosId;
+  }
+
+  public SnapshotSummary duosId(String duosId) {
+    this.duosId = duosId;
+    return this;
+  }
+
   public SnapshotSummaryModel toModel() {
     return new SnapshotSummaryModel()
         .id(getId())
@@ -190,7 +200,8 @@ public class SnapshotSummary {
         .selfHosted(isSelfHosted())
         .globalFileIds(isGlobalFileIds())
         .tags(getTags())
-        .resourceLocks(getResourceLocks());
+        .resourceLocks(getResourceLocks())
+        .duosId(getDuosId());
   }
 
   private List<StorageResourceModel> toStorageResourceModel() {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -524,6 +524,17 @@ paths:
             type: array
             items:
               $ref: '#/components/schemas/Tag'
+        - name: duosDatasetIds
+          in: query
+          description: >
+            Filter the results where snapshots have been linked to one of these DUOS datasetIds
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/DuosId'
       responses:
         200:
           description: List of snapshots
@@ -6227,6 +6238,8 @@ components:
             $ref: '#/components/schemas/Tag'
         resourceLocks:
           $ref: '#/components/schemas/ResourceLocks'
+        duosId:
+          $ref: '#/components/schemas/DuosId'
       description: >
         summary of snapshot
     EnumerateSnapshotModel:

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -413,10 +413,11 @@ public class SnapshotServiceTest {
             any(),
             any(),
             eq(resourcesAndRoles.keySet()),
+            any(),
             any()))
         .thenReturn(metadataEnumeration);
     var snapshots =
-        service.enumerateSnapshots(TEST_USER, 0, 10, null, null, null, null, List.of(), null);
+        service.enumerateSnapshots(TEST_USER, 0, 10, null, null, null, null, List.of(), null, null);
     assertThat(snapshots.getItems().get(0).getId(), equalTo(snapshotId));
     assertThat(snapshots.getRoleMap(), hasEntry(snapshotId.toString(), List.of(role.toString())));
   }


### PR DESCRIPTION
Add the ability to filter on a list of DUOS IDs.  Also return the duos id of a snapshot as part of the snapshot summary.

This is to enable functionality in the DUOS UI that will allow seeing which snapshots are linked to to which DUOS datasets and will allow exporting to Terra from DUOS.

A new `duosIds` query parameter will now be available for the enumerateSnapshots endpoint.
Note: it's not wired into the TDR UI so there won't be any visible change. This is again just to power the DUOS UI