### PR TITLE
[DR-3392] Make sure that parquet download paths aren't overly url encoded

### DIFF
--- a/src/main/java/bio/terra/service/common/azure/AzureUriUtils.java
+++ b/src/main/java/bio/terra/service/common/azure/AzureUriUtils.java
@@ -1,0 +1,29 @@
+package bio.terra.service.common.azure;
+
+import com.azure.storage.blob.BlobUrlParts;
+import com.azure.storage.common.sas.CommonSasQueryParameters;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+public final class AzureUriUtils {
+
+  /**
+   * The Azure {@link BlobUrlParts} class improperly handles blob names by URL encoding the blob
+   * name. This leads to invalid URLs. This method will return the blob name without over encoding.
+   *
+   * @return A string representing a usable Blob URL
+   */
+  public static String getUriFromBlobUrlParts(BlobUrlParts blobUrlParts) {
+    String sasToken =
+        Optional.ofNullable(blobUrlParts.getCommonSasQueryParameters())
+            .map(CommonSasQueryParameters::encode)
+            .orElse("");
+    return String.format(
+        "https://%s.blob.core.windows.net/%s/%s%s",
+        blobUrlParts.getAccountName(),
+        blobUrlParts.getBlobContainerName(),
+        URLDecoder.decode(blobUrlParts.getBlobName(), StandardCharsets.UTF_8),
+        sasToken.isEmpty() ? "" : "?" + sasToken);
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportWriteManifestAzureStep.java
@@ -9,6 +9,7 @@ import bio.terra.model.SnapshotExportResponseModelFormatParquet;
 import bio.terra.model.SnapshotExportResponseModelFormatParquetLocation;
 import bio.terra.model.SnapshotExportResponseModelFormatParquetLocationTables;
 import bio.terra.model.SnapshotModel;
+import bio.terra.service.common.azure.AzureUriUtils;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
 import bio.terra.service.job.DefaultUndoStep;
 import bio.terra.service.job.JobMapKeys;
@@ -102,7 +103,7 @@ public class SnapshotExportWriteManifestAzureStep extends DefaultUndoStep {
                 new SnapshotExportResponseModelFormat()
                     .parquet(
                         new SnapshotExportResponseModelFormatParquet()
-                            .manifest(snapshotSignedUrlBlob.toUrl().toString())
+                            .manifest(AzureUriUtils.getUriFromBlobUrlParts(snapshotSignedUrlBlob))
                             .location(
                                 new SnapshotExportResponseModelFormatParquetLocation()
                                     .tables(tables))));

--- a/src/test/java/bio/terra/service/common/azure/AzureUriUtilsTest.java
+++ b/src/test/java/bio/terra/service/common/azure/AzureUriUtilsTest.java
@@ -1,0 +1,40 @@
+package bio.terra.service.common.azure;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.azure.storage.blob.BlobUrlParts;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"google", "unittest"})
+@Tag("bio.terra.common.category.Unit")
+class AzureUriUtilsTest {
+
+  private static Stream<Arguments> testEncodedUrls() {
+    return Stream.of(
+        arguments(
+            BlobUrlParts.parse("https://foo.blob.core.windows.net/container/blobname.txt"),
+            "https://foo.blob.core.windows.net/container/blobname.txt"),
+        arguments(
+            BlobUrlParts.parse("https://foo.blob.core.windows.net/container/blob/name.txt"),
+            "https://foo.blob.core.windows.net/container/blob/name.txt"),
+        arguments(
+            BlobUrlParts.parse("https://foo.blob.core.windows.net/container/blobname.txt?sp=r"),
+            "https://foo.blob.core.windows.net/container/blobname.txt?sp=r"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testEncodedUrls(BlobUrlParts urlParts, String expectedUrl) {
+    assertThat(
+        "url looks as expected",
+        AzureUriUtils.getUriFromBlobUrlParts(urlParts),
+        equalTo(expectedUrl));
+  }
+}


### PR DESCRIPTION
Paths currently look like:
`https://myacoount.blob.core.windows.net/datasetId/metadata%2Fmanifests%2FflightId%2Fmanifest.json?<sas_oken>`
 which is not valid.
This PR would make the same URL look like:
`https://myacoount.blob.core.windows.net/datasetId/metadata/manifests/flightId/Fmanifest.json?<sas_token>`

This is due to what I would categorize as bad behavior with the Azure client sdk's `BlobUrlParts` class where blob paths are url encoded which leads to urls that are generated and not recognized by Azure.  I created a utility method to take in a `BlobUrlParts` object and return a properly encoded url.

I manually tested that the export works as expected but leaned on unit testing for validation