### PR TITLE
[DR-3399] Fix NPE when DRS PostObject endpoint called without expand

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -277,7 +277,7 @@ public class DrsService {
    * @throws TooManyRequestsException if there are too many concurrent DRS lookup requests
    */
   public DRSObject lookupObjectByDrsId(
-      AuthenticatedUserRequest authUser, String drsObjectId, Boolean expand) {
+      AuthenticatedUserRequest authUser, String drsObjectId, boolean expand) {
     try (DrsRequestResource r = new DrsRequestResource()) {
       DrsId resolvedDrsObjectId = resolveDrsObjectId(drsObjectId);
       String samTimer = performanceLogger.timerStart();
@@ -321,7 +321,7 @@ public class DrsService {
   private DRSObject resolveDRSObject(
       AuthenticatedUserRequest authUser,
       DrsId drsId,
-      Boolean expand,
+      boolean expand,
       List<SnapshotCacheResult> cachedSnapshots,
       boolean passportAuth) {
 
@@ -426,14 +426,14 @@ public class DrsService {
   }
 
   private DRSObject lookupDRSObjectAfterAuth(
-      Boolean expand,
+      boolean expand,
       SnapshotCacheResult snapshot,
       DrsId drsId,
       AuthenticatedUserRequest authUser,
       boolean passportAuth,
       String billingSnapshot) {
     SnapshotProject snapshotProject = getSnapshotProject(snapshot.id);
-    int depth = (Optional.ofNullable(expand).orElse(false) ? -1 : 1);
+    int depth = (expand ? -1 : 1);
 
     FSItem fsObject;
     try {

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -314,7 +314,7 @@ public class DrsService {
   }
 
   /**
-   * Given the precalculated list of associated snaphots, look up the DRS object in the various
+   * Given the precalculated list of associated snapshots, look up the DRS object in the various
    * firstore/azure table dbs and merged into a single DRSObject. Note: this will fail if object
    * overlap in invalid ways, such as mismatched checksums, multiple names, etc.
    */
@@ -426,14 +426,14 @@ public class DrsService {
   }
 
   private DRSObject lookupDRSObjectAfterAuth(
-      boolean expand,
+      Boolean expand,
       SnapshotCacheResult snapshot,
       DrsId drsId,
       AuthenticatedUserRequest authUser,
       boolean passportAuth,
       String billingSnapshot) {
     SnapshotProject snapshotProject = getSnapshotProject(snapshot.id);
-    int depth = (expand ? -1 : 1);
+    int depth = (Optional.ofNullable(expand).orElse(false) ? -1 : 1);
 
     FSItem fsObject;
     try {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7395,6 +7395,7 @@ components:
         expand:
           type: boolean
           example: false
+          default: false
           description: >-
             If false and the object_id refers to a bundle, then the ContentsObject array
             contains only those objects directly contained in the bundle. That is, if the

--- a/src/test/java/bio/terra/model/DRSPassportRequestModelTest.java
+++ b/src/test/java/bio/terra/model/DRSPassportRequestModelTest.java
@@ -1,0 +1,22 @@
+package bio.terra.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.common.category.Unit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"google", "unittest"})
+@Tag(Unit.TAG)
+class DRSPassportRequestModelTest {
+
+  @Test
+  void testDRSPassportRequestModelDefault() {
+    var modelExpandDefault = new DRSPassportRequestModel();
+    var modelExpandFalse = new DRSPassportRequestModel().expand(false);
+
+    assertThat(modelExpandDefault, equalTo(modelExpandFalse));
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -234,8 +234,7 @@ public class DrsServiceTest {
     when(resourceService.lookupStorageAccountMetadata(storageAccountResourceId))
         .thenReturn(new AzureStorageAccountResource().region(AzureRegion.DEFAULT_AZURE_REGION));
 
-    drsPassportRequestModel =
-        new DRSPassportRequestModel().addPassportsItem("longPassportToken").expand(false);
+    drsPassportRequestModel = new DRSPassportRequestModel().addPassportsItem("longPassportToken");
 
     when(ecmConfiguration.rasIssuer()).thenReturn(RAS_ISSUER);
   }

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -234,7 +234,8 @@ public class DrsServiceTest {
     when(resourceService.lookupStorageAccountMetadata(storageAccountResourceId))
         .thenReturn(new AzureStorageAccountResource().region(AzureRegion.DEFAULT_AZURE_REGION));
 
-    drsPassportRequestModel = new DRSPassportRequestModel().addPassportsItem("longPassportToken");
+    drsPassportRequestModel =
+        new DRSPassportRequestModel().addPassportsItem("longPassportToken").expand(false);
 
     when(ecmConfiguration.rasIssuer()).thenReturn(RAS_ISSUER);
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3399

OpenAPI generates a `DRSPassportRequestModel` for us with a **B**oolean (capital b :-) field called 'expand'.

If our DRS [PostObject](https://jade.datarepo-dev.broadinstitute.org/swagger-ui.html#/DataRepositoryService/PostObject) endpoint is called without 'expand' set in this response body (as is the case with calls from DrsHub), we'd get an NPE when trying to convert the Boolean to a boolean.

This PR adjusts the OpenAPI spec for `DRSPassportRequestModel` to default `expand` to false, and added a unit test to reflect this. (Before the fix, the unit test rightfully failed.)

I wasn't sure initially if we wanted our spec to match the [GA4GH spec exactly](https://github.com/ga4gh/data-repository-service-schemas/blob/master/openapi/components/requestBodies/PostObjectBody.yaml), but after discussing with the team @snf2ye reminded me that we do something similar with our DRS [GetObject](https://jade.datarepo-dev.broadinstitute.org/swagger-ui.html#/DataRepositoryService/GetObject) endpoint (supply a sensible default of false for `expand` when unspecified).