### PR TITLE
[DC-787]Add endpoint to return list of all snapshot requests for a dataset

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -26,6 +26,7 @@ import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateDatasetModel;
+import bio.terra.model.EnumerateSnapshotAccessRequest;
 import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.FileModel;
@@ -543,6 +544,17 @@ public class DatasetsApiController implements DatasetsApi {
     return ResponseEntity.ok(
         snapshotBuilderService.createSnapshotRequest(
             id, snapshotAccessRequest, userRequest.getEmail()));
+  }
+
+  @Override
+  public ResponseEntity<EnumerateSnapshotAccessRequest> enumerateSnapshotRequests(UUID id) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    iamService.verifyAuthorization(
+        userRequest,
+        IamResourceType.DATASET,
+        id.toString(),
+        IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS);
+    return ResponseEntity.ok(snapshotBuilderService.enumerateByDatasetId(id));
   }
 
   private void validateIngestParams(IngestRequestModel ingestRequestModel, UUID datasetId) {

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -59,7 +59,7 @@ public class SnapshotBuilderService {
       List<SnapshotAccessRequestResponse> responses) {
     EnumerateSnapshotAccessRequest enumerateModel = new EnumerateSnapshotAccessRequest();
     for (SnapshotAccessRequestResponse response : responses) {
-      enumerateModel.add(
+      enumerateModel.addItemsItem(
           new EnumerateSnapshotAccessRequestItem()
               .id(response.getId())
               .status(response.getStatus())

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -55,7 +55,7 @@ public class SnapshotBuilderService {
     return convertToEnumerateModel(snapshotRequestDao.enumerateByDatasetId(id));
   }
 
-  public EnumerateSnapshotAccessRequest convertToEnumerateModel(
+  private EnumerateSnapshotAccessRequest convertToEnumerateModel(
       List<SnapshotAccessRequestResponse> responses) {
     EnumerateSnapshotAccessRequest enumerateModel = new EnumerateSnapshotAccessRequest();
     for (SnapshotAccessRequestResponse response : responses) {

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -1,5 +1,7 @@
 package bio.terra.service.snapshotbuilder;
 
+import bio.terra.model.EnumerateSnapshotAccessRequest;
+import bio.terra.model.EnumerateSnapshotAccessRequestItem;
 import bio.terra.model.SnapshotAccessRequest;
 import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotBuilderCohort;
@@ -47,5 +49,24 @@ public class SnapshotBuilderService {
     return new SnapshotBuilderCountResponse()
         .sql("")
         .result(new SnapshotBuilderCountResponseResult().total(getRollupCount(id, cohorts)));
+  }
+
+  public EnumerateSnapshotAccessRequest enumerateByDatasetId(UUID id) {
+    return convertToEnumerateModel(snapshotRequestDao.enumerateByDatasetId(id));
+  }
+
+  public EnumerateSnapshotAccessRequest convertToEnumerateModel(
+      List<SnapshotAccessRequestResponse> responses) {
+    EnumerateSnapshotAccessRequest enumerateModel = new EnumerateSnapshotAccessRequest();
+    for (SnapshotAccessRequestResponse response : responses) {
+      enumerateModel.add(
+          new EnumerateSnapshotAccessRequestItem()
+              .id(response.getId())
+              .status(response.getStatus())
+              .createdDate(response.getCreatedDate())
+              .name(response.getSnapshotName())
+              .researchPurpose(response.getSnapshotResearchPurpose()));
+    }
+    return enumerateModel;
   }
 }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -7,6 +7,7 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.model.SnapshotAccessRequest;
 import bio.terra.model.SnapshotAccessRequestResponse;
+import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.model.SnapshotBuilderRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,7 +51,7 @@ public class SnapshotRequestDao {
               .createdDate(getInstantString(rs, CREATED_DATE))
               .updatedDate(getInstantString(rs, UPDATED_DATE))
               .createdBy(rs.getString(CREATED_BY))
-              .status(SnapshotAccessRequestResponse.StatusEnum.valueOf(rs.getString(STATUS)));
+              .status(SnapshotAccessRequestStatus.valueOf(rs.getString(STATUS)));
 
   public SnapshotRequestDao(
       NamedParameterJdbcTemplate jdbcTemplate,
@@ -135,8 +136,7 @@ public class SnapshotRequestDao {
   }
 
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
-  public SnapshotAccessRequestResponse update(
-      UUID requestId, SnapshotAccessRequestResponse.StatusEnum status) {
+  public SnapshotAccessRequestResponse update(UUID requestId, SnapshotAccessRequestStatus status) {
     String sql =
         """
         UPDATE snapshot_request SET

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2828,6 +2828,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+  /api/repository/v1/datasets/{id}/enumerateSnapshotRequests:
+    post:
+      tags:
+        - datasets
+      description: As an admin for this dataset, view all snapshot requests for this dataset.
+      operationId: enumerateSnapshotRequests
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: The snapshot requests have been retrieved.
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/EnumerateSnapshotAccessRequest'
+        400:
+          description: Bad request - invalid id, or badly formed IamResourceType.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        401:
+          description: Unauthorized - dataset does not exist or missing permissions to view.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: Unauthorized - missing permissions to view snapshot requests.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: No dataset found that meets the request parameter.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
   /api/repository/v1/register/user:
     get:
       tags:
@@ -6931,6 +6976,32 @@ components:
           items:
             type: string
 
+    EnumerateSnapshotAccessRequest:
+      type: array
+      items:
+        $ref: '#/components/schemas/EnumerateSnapshotAccessRequestItem'
+
+    EnumerateSnapshotAccessRequestItem:
+      type: object
+      description: The model for SnapshotAccessRequests when enumerated in a response.
+      required:
+        - id
+        - status
+        - createdDate
+        - name
+        - researchPurpose
+      properties:
+        id:
+          $ref: '#/components/schemas/UniqueIdProperty'
+        status:
+          $ref: '#/components/schemas/SnapshotAccessRequestStatus'
+        createdDate:
+          type: string
+        name:
+          type: string
+        researchPurpose:
+          type: string
+
     SnapshotAccessRequestResponse:
       type: object
       description: The response object for a submitted SnapshotAccessRequest.
@@ -6957,12 +7028,15 @@ components:
         createdBy:
           type: string
         status:
-          type: string
-          enum: [ SUBMITTED, APPROVED, REJECTED ]
+          $ref: '#/components/schemas/SnapshotAccessRequestStatus'
         createdDate:
           type: string
         updatedDate:
           type: string
+
+    SnapshotAccessRequestStatus:
+      type: string
+      enum: [ SUBMITTED, APPROVED, REJECTED ]
 
     SnapshotBuilderCountRequest:
       type: object

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3003,7 +3003,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
-  /api/repository/v1/datasets/{id}/createSnapshotRequest:
+  /api/repository/v1/datasets/{id}/snapshotRequests:
+    get:
+      tags:
+        - datasets
+      description: As an admin for this dataset, view all snapshot requests for this dataset.
+      operationId: enumerateSnapshotRequests
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: The snapshot requests have been retrieved.
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/EnumerateSnapshotAccessRequest'
+        400:
+          description: Bad request - invalid id, or badly formed IamResourceType.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        401:
+          description: Unauthorized - dataset does not exist or missing permissions to view.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: Unauthorized - missing permissions to view snapshot requests.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: No dataset found that meets the request parameter.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
     post:
       tags:
         - datasets
@@ -3045,51 +3089,6 @@ paths:
                 $ref: '#/components/schemas/ErrorModel'
         404:
           description: No dataset found that meets the request parameters.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        500:
-          description: An unexpected error occurred.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-  /api/repository/v1/datasets/{id}/enumerateSnapshotRequests:
-    post:
-      tags:
-        - datasets
-      description: As an admin for this dataset, view all snapshot requests for this dataset.
-      operationId: enumerateSnapshotRequests
-      parameters:
-        - $ref: '#/components/parameters/Id'
-      responses:
-        200:
-          description: The snapshot requests have been retrieved.
-          content:
-            application/json:
-              schema:
-                  $ref: '#/components/schemas/EnumerateSnapshotAccessRequest'
-        400:
-          description: Bad request - invalid id, or badly formed IamResourceType.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        401:
-          description: Unauthorized - dataset does not exist or missing permissions to view.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        403:
-          description: Unauthorized - missing permissions to view snapshot requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        404:
-          description: No dataset found that meets the request parameter.
           content:
             application/json:
               schema:
@@ -7224,6 +7223,7 @@ components:
 
     EnumerateSnapshotAccessRequest:
       type: object
+      description: The model for enumerated SnapshotAccessRequests.
       properties:
         items:
           type: array

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -6977,9 +6977,12 @@ components:
             type: string
 
     EnumerateSnapshotAccessRequest:
-      type: array
-      items:
-        $ref: '#/components/schemas/EnumerateSnapshotAccessRequestItem'
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnumerateSnapshotAccessRequestItem'
 
     EnumerateSnapshotAccessRequestItem:
       type: object

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -388,7 +388,7 @@ class DatasetsApiControllerTest {
     EnumerateSnapshotAccessRequestItem responseItem =
         SnapshotBuilderTestData.createEnumerateSnapshotAccessRequestModelItem();
     EnumerateSnapshotAccessRequest response = new EnumerateSnapshotAccessRequest();
-    response.addAll(List.of(responseItem, responseItem));
+    response.items(List.of(responseItem, responseItem));
     when(snapshotBuilderService.enumerateByDatasetId(DATASET_ID)).thenReturn(response);
     String actualJson =
         mvc.perform(post(ENUMERATE_SNAPSHOT_REQUESTS_ENDPOINT, DATASET_ID))

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -28,7 +28,6 @@ import bio.terra.model.DatasetDataModel;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestAccessIncludeModel;
 import bio.terra.model.EnumerateSnapshotAccessRequest;
-import bio.terra.model.EnumerateSnapshotAccessRequestItem;
 import bio.terra.model.QueryColumnStatisticsRequestModel;
 import bio.terra.model.QueryDataRequestModel;
 import bio.terra.model.ResourceLocks;
@@ -367,10 +366,10 @@ class DatasetsApiControllerTest {
   void testCreateSnapshotRequest() throws Exception {
     mockValidators();
     SnapshotAccessRequest request = SnapshotBuilderTestData.createSnapshotAccessRequest();
-    SnapshotAccessRequestResponse response =
+    SnapshotAccessRequestResponse expectedResponse =
         SnapshotBuilderTestData.createSnapshotAccessRequestResponse();
     when(snapshotBuilderService.createSnapshotRequest(eq(DATASET_ID), eq(request), anyString()))
-        .thenReturn(response);
+        .thenReturn(expectedResponse);
     String actualJson =
         mvc.perform(
                 post(REQUEST_SNAPSHOT_ENDPOINT, DATASET_ID)
@@ -382,18 +381,17 @@ class DatasetsApiControllerTest {
             .getContentAsString();
     SnapshotAccessRequestResponse actual =
         TestUtils.mapFromJson(actualJson, SnapshotAccessRequestResponse.class);
-    assertThat("The method returned the expected response", actual, equalTo(response));
+    assertThat("The method returned the expected response", actual, equalTo(expectedResponse));
     verifyAuthorizationCall(IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS);
   }
 
   @Test
   void testEnumerateSnapshotRequests() throws Exception {
     mockValidators();
-    EnumerateSnapshotAccessRequestItem responseItem =
-        SnapshotBuilderTestData.createEnumerateSnapshotAccessRequestModelItem();
-    EnumerateSnapshotAccessRequest response = new EnumerateSnapshotAccessRequest();
-    response.items(List.of(responseItem, responseItem));
-    when(snapshotBuilderService.enumerateByDatasetId(DATASET_ID)).thenReturn(response);
+    var expectedResponseItem = SnapshotBuilderTestData.createEnumerateSnapshotAccessRequestModelItem();
+    var expectedResponse = new EnumerateSnapshotAccessRequest();
+    expectedResponse.items(List.of(expectedResponseItem, expectedResponseItem));
+    when(snapshotBuilderService.enumerateByDatasetId(DATASET_ID)).thenReturn(expectedResponse);
     String actualJson =
         mvc.perform(post(ENUMERATE_SNAPSHOT_REQUESTS_ENDPOINT, DATASET_ID))
             .andExpect(status().isOk())
@@ -402,7 +400,7 @@ class DatasetsApiControllerTest {
             .getContentAsString();
     EnumerateSnapshotAccessRequest actual =
         TestUtils.mapFromJson(actualJson, EnumerateSnapshotAccessRequest.class);
-    assertThat("The method returned the expected response", actual, equalTo(response));
+    assertThat("The method returned the expected response", actual, equalTo(expectedResponse));
     verifyAuthorizationCall(IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS);
   }
 

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -100,10 +100,8 @@ class DatasetsApiControllerTest {
   private static final String RETRIEVE_DATASET_ENDPOINT = "/api/repository/v1/datasets/{id}";
   private static final String LOCK_DATASET_ENDPOINT = "/api/repository/v1/datasets/{id}/lock";
   private static final String UNLOCK_DATASET_ENDPOINT = "/api/repository/v1/datasets/{id}/unlock";
-  private static final String REQUEST_SNAPSHOT_ENDPOINT =
-      RETRIEVE_DATASET_ENDPOINT + "/createSnapshotRequest";
-  private static final String ENUMERATE_SNAPSHOT_REQUESTS_ENDPOINT =
-      RETRIEVE_DATASET_ENDPOINT + "/enumerateSnapshotRequests";
+  private static final String SNAPSHOT_REQUESTS_ENDPOINT =
+      RETRIEVE_DATASET_ENDPOINT + "/snapshotRequests";
   private static final DatasetRequestAccessIncludeModel INCLUDE =
       DatasetRequestAccessIncludeModel.NONE;
   private static final String QUERY_DATA_ENDPOINT = RETRIEVE_DATASET_ENDPOINT + "/data/{table}";
@@ -372,7 +370,7 @@ class DatasetsApiControllerTest {
         .thenReturn(expectedResponse);
     String actualJson =
         mvc.perform(
-                post(REQUEST_SNAPSHOT_ENDPOINT, DATASET_ID)
+                post(SNAPSHOT_REQUESTS_ENDPOINT, DATASET_ID)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(TestUtils.mapToJson(request)))
             .andExpect(status().isOk())
@@ -388,12 +386,13 @@ class DatasetsApiControllerTest {
   @Test
   void testEnumerateSnapshotRequests() throws Exception {
     mockValidators();
-    var expectedResponseItem = SnapshotBuilderTestData.createEnumerateSnapshotAccessRequestModelItem();
+    var expectedResponseItem =
+        SnapshotBuilderTestData.createEnumerateSnapshotAccessRequestModelItem();
     var expectedResponse = new EnumerateSnapshotAccessRequest();
     expectedResponse.items(List.of(expectedResponseItem, expectedResponseItem));
     when(snapshotBuilderService.enumerateByDatasetId(DATASET_ID)).thenReturn(expectedResponse);
     String actualJson =
-        mvc.perform(post(ENUMERATE_SNAPSHOT_REQUESTS_ENDPOINT, DATASET_ID))
+        mvc.perform(get(SNAPSHOT_REQUESTS_ENDPOINT, DATASET_ID))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -3,7 +3,10 @@ package bio.terra.service.snapshotbuilder;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
+import bio.terra.model.EnumerateSnapshotAccessRequest;
+import bio.terra.model.EnumerateSnapshotAccessRequestItem;
 import bio.terra.model.SnapshotAccessRequestResponse;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,5 +39,38 @@ class SnapshotBuilderServiceTest {
         snapshotBuilderService.createSnapshotRequest(
             datasetId, SnapshotBuilderTestData.createSnapshotAccessRequest(), email),
         response);
+  }
+
+  @Test
+  void enumerateSnapshotRequestsByDatasetId() {
+    UUID datasetId = UUID.randomUUID();
+    SnapshotAccessRequestResponse responseItem = new SnapshotAccessRequestResponse();
+    List<SnapshotAccessRequestResponse> response = List.of(responseItem, responseItem);
+    when(snapshotRequestDao.enumerateByDatasetId(datasetId)).thenReturn(response);
+    Assertions.assertEquals(
+        snapshotBuilderService.enumerateByDatasetId(datasetId),
+        snapshotBuilderService.convertToEnumerateModel(response));
+  }
+
+  @Test
+  void convertToEnumerateModel() {
+    SnapshotAccessRequestResponse inputItem =
+        SnapshotBuilderTestData.createSnapshotAccessRequestResponse();
+    List<SnapshotAccessRequestResponse> response = List.of(inputItem);
+
+    EnumerateSnapshotAccessRequestItem expectedItem = new EnumerateSnapshotAccessRequestItem();
+    expectedItem.id(inputItem.getId());
+    expectedItem.status(inputItem.getStatus());
+    expectedItem.createdDate(inputItem.getCreatedDate());
+    expectedItem.name(inputItem.getSnapshotName());
+    expectedItem.researchPurpose(inputItem.getSnapshotResearchPurpose());
+    EnumerateSnapshotAccessRequest expected = new EnumerateSnapshotAccessRequest();
+    expected.add(expectedItem);
+
+    EnumerateSnapshotAccessRequest converted = snapshotBuilderService.convertToEnumerateModel(response);
+    EnumerateSnapshotAccessRequestItem convertedItem = converted.get(0);
+
+    Assertions.assertEquals(converted.size(), expected.size());
+    Assertions.assertEquals(convertedItem, expectedItem);
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -65,13 +65,13 @@ class SnapshotBuilderServiceTest {
     expectedItem.name(inputItem.getSnapshotName());
     expectedItem.researchPurpose(inputItem.getSnapshotResearchPurpose());
     EnumerateSnapshotAccessRequest expected = new EnumerateSnapshotAccessRequest();
-    expected.add(expectedItem);
+    expected.addItemsItem(expectedItem);
 
     EnumerateSnapshotAccessRequest converted =
         snapshotBuilderService.convertToEnumerateModel(response);
-    EnumerateSnapshotAccessRequestItem convertedItem = converted.get(0);
+    EnumerateSnapshotAccessRequestItem convertedItem = converted.getItems().get(0);
 
-    Assertions.assertEquals(converted.size(), expected.size());
+    Assertions.assertEquals(converted.getItems().size(), expected.getItems().size());
     Assertions.assertEquals(convertedItem, expectedItem);
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -1,5 +1,7 @@
 package bio.terra.service.snapshotbuilder;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
@@ -8,7 +10,6 @@ import bio.terra.model.EnumerateSnapshotAccessRequestItem;
 import bio.terra.model.SnapshotAccessRequestResponse;
 import java.util.List;
 import java.util.UUID;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -35,43 +36,34 @@ class SnapshotBuilderServiceTest {
     when(snapshotRequestDao.create(
             datasetId, SnapshotBuilderTestData.createSnapshotAccessRequest(), email))
         .thenReturn(response);
-    Assertions.assertEquals(
+    assertThat(
+        "createSnapshotRequest returns the expected response",
         snapshotBuilderService.createSnapshotRequest(
             datasetId, SnapshotBuilderTestData.createSnapshotAccessRequest(), email),
-        response);
+        equalTo(response));
   }
 
   @Test
   void enumerateSnapshotRequestsByDatasetId() {
     UUID datasetId = UUID.randomUUID();
-    SnapshotAccessRequestResponse responseItem = new SnapshotAccessRequestResponse();
-    List<SnapshotAccessRequestResponse> response = List.of(responseItem, responseItem);
-    when(snapshotRequestDao.enumerateByDatasetId(datasetId)).thenReturn(response);
-    Assertions.assertEquals(
-        snapshotBuilderService.enumerateByDatasetId(datasetId),
-        snapshotBuilderService.convertToEnumerateModel(response));
-  }
-
-  @Test
-  void convertToEnumerateModel() {
-    SnapshotAccessRequestResponse inputItem =
+    SnapshotAccessRequestResponse responseItem =
         SnapshotBuilderTestData.createSnapshotAccessRequestResponse();
-    List<SnapshotAccessRequestResponse> response = List.of(inputItem);
+    List<SnapshotAccessRequestResponse> response = List.of(responseItem);
+    when(snapshotRequestDao.enumerateByDatasetId(datasetId)).thenReturn(response);
 
-    EnumerateSnapshotAccessRequestItem expectedItem = new EnumerateSnapshotAccessRequestItem();
-    expectedItem.id(inputItem.getId());
-    expectedItem.status(inputItem.getStatus());
-    expectedItem.createdDate(inputItem.getCreatedDate());
-    expectedItem.name(inputItem.getSnapshotName());
-    expectedItem.researchPurpose(inputItem.getSnapshotResearchPurpose());
-    EnumerateSnapshotAccessRequest expected = new EnumerateSnapshotAccessRequest();
-    expected.addItemsItem(expectedItem);
+    EnumerateSnapshotAccessRequestItem expectedItem =
+        new EnumerateSnapshotAccessRequestItem()
+            .id(responseItem.getId())
+            .status(responseItem.getStatus())
+            .createdDate(responseItem.getCreatedDate())
+            .name(responseItem.getSnapshotName())
+            .researchPurpose(responseItem.getSnapshotResearchPurpose());
+    EnumerateSnapshotAccessRequest expected =
+        new EnumerateSnapshotAccessRequest().addItemsItem(expectedItem);
 
-    EnumerateSnapshotAccessRequest converted =
-        snapshotBuilderService.convertToEnumerateModel(response);
-    EnumerateSnapshotAccessRequestItem convertedItem = converted.getItems().get(0);
-
-    Assertions.assertEquals(converted.getItems().size(), expected.getItems().size());
-    Assertions.assertEquals(convertedItem, expectedItem);
+    assertThat(
+        "EnumerateByDatasetId returns the expected response",
+        snapshotBuilderService.enumerateByDatasetId(datasetId),
+        equalTo(expected));
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -67,7 +67,8 @@ class SnapshotBuilderServiceTest {
     EnumerateSnapshotAccessRequest expected = new EnumerateSnapshotAccessRequest();
     expected.add(expectedItem);
 
-    EnumerateSnapshotAccessRequest converted = snapshotBuilderService.convertToEnumerateModel(response);
+    EnumerateSnapshotAccessRequest converted =
+        snapshotBuilderService.convertToEnumerateModel(response);
     EnumerateSnapshotAccessRequestItem convertedItem = converted.get(0);
 
     Assertions.assertEquals(converted.size(), expected.size());

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -2,8 +2,10 @@ package bio.terra.service.snapshotbuilder;
 
 import bio.terra.common.Column;
 import bio.terra.model.CloudPlatform;
+import bio.terra.model.EnumerateSnapshotAccessRequestItem;
 import bio.terra.model.SnapshotAccessRequest;
 import bio.terra.model.SnapshotAccessRequestResponse;
+import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.model.SnapshotBuilderCohort;
 import bio.terra.model.SnapshotBuilderConcept;
 import bio.terra.model.SnapshotBuilderCriteria;
@@ -161,6 +163,17 @@ public class SnapshotBuilderTestData {
         .snapshotResearchPurpose(createSnapshotAccessRequest().getResearchPurposeStatement())
         .snapshotSpecification(createSnapshotAccessRequest().getDatasetRequest())
         .createdDate("date")
-        .createdBy("user@gmail.com");
+        .createdBy("user@gmail.com")
+        .status(SnapshotAccessRequestStatus.SUBMITTED);
+  }
+
+  public static EnumerateSnapshotAccessRequestItem
+      createEnumerateSnapshotAccessRequestModelItem() {
+    return new EnumerateSnapshotAccessRequestItem()
+        .id(UUID.randomUUID())
+        .name(createSnapshotAccessRequest().getName())
+        .researchPurpose(createSnapshotAccessRequest().getResearchPurposeStatement())
+        .createdDate(createSnapshotAccessRequestResponse().getCreatedDate())
+        .status(SnapshotAccessRequestStatus.SUBMITTED);
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -167,8 +167,7 @@ public class SnapshotBuilderTestData {
         .status(SnapshotAccessRequestStatus.SUBMITTED);
   }
 
-  public static EnumerateSnapshotAccessRequestItem
-      createEnumerateSnapshotAccessRequestModelItem() {
+  public static EnumerateSnapshotAccessRequestItem createEnumerateSnapshotAccessRequestModelItem() {
     return new EnumerateSnapshotAccessRequestItem()
         .id(UUID.randomUUID())
         .name(createSnapshotAccessRequest().getName())

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
@@ -16,6 +16,7 @@ import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.fixtures.DaoOperations;
 import bio.terra.model.SnapshotAccessRequest;
 import bio.terra.model.SnapshotAccessRequestResponse;
+import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.service.dataset.Dataset;
 import java.io.IOException;
 import java.util.UUID;
@@ -62,7 +63,7 @@ class SnapshotRequestDaoTest {
         SnapshotBuilderTestData.createSnapshotAccessRequestResponse().getSnapshotResearchPurpose());
     expected.snapshotSpecification(SnapshotBuilderTestData.createSnapshotBuilderRequest());
     expected.createdBy(EMAIL);
-    expected.status(SnapshotAccessRequestResponse.StatusEnum.SUBMITTED);
+    expected.status(SnapshotAccessRequestStatus.SUBMITTED);
     assertThat(
         "Given response is the same as expected.",
         response,
@@ -135,13 +136,12 @@ class SnapshotRequestDaoTest {
     verifyResponseContents(response);
 
     SnapshotAccessRequestResponse updatedResponse =
-        snapshotRequestDao.update(
-            response.getId(), SnapshotAccessRequestResponse.StatusEnum.APPROVED);
+        snapshotRequestDao.update(response.getId(), SnapshotAccessRequestStatus.APPROVED);
 
     assertThat(
         "Updated Snapshot Access Request Response should have approved status",
         updatedResponse.getStatus(),
-        equalTo(SnapshotAccessRequestResponse.StatusEnum.APPROVED));
+        equalTo(SnapshotAccessRequestStatus.APPROVED));
     assertNotNull(
         updatedResponse.getUpdatedDate(),
         "Updated Snapshot Access Request Response should have an update date");
@@ -152,9 +152,7 @@ class SnapshotRequestDaoTest {
     System.out.println(TestUtils.mapToJson(SnapshotBuilderTestData.SETTINGS));
     assertThrows(
         NotFoundException.class,
-        () ->
-            snapshotRequestDao.update(
-                UUID.randomUUID(), SnapshotAccessRequestResponse.StatusEnum.APPROVED));
+        () -> snapshotRequestDao.update(UUID.randomUUID(), SnapshotAccessRequestStatus.APPROVED));
   }
 
   @Test


### PR DESCRIPTION
### Endpoint
This is a per dataset api that returns a list of all snapshot requests for a single dataset. This requires ‘custodian’ permissions (or the UPDATE_SNAPSHOT_SETTINGS action as a placeholder) in TDR. 

### Data Model
This returns the status and the id as requested by the ticket description. It also returns create date because I thought we would want that for display order. It also returns the name and research purpose of the request because I thought we would want to display that information to an admin making a decision on this request. So, I added a new EnumerateSnapshotAccessRequestItem to encapsulate this information. 