### PR TITLE
[PROD-910] Loosen validation of Google appengine operation ID format

### DIFF
--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleProjectServiceTest.java
@@ -6,19 +6,24 @@ import static org.junit.Assert.assertEquals;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.resourcemanagement.exception.AppengineException;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-public class GoogleProjectServiceTest {
+@Tag(Unit.TAG)
+class GoogleProjectServiceTest {
+
+  private static final UUID RANDOM_UUID = UUID.randomUUID();
+  private static final String APP_ID = "my-project";
 
   @Test
-  public void testVerifyProjectId() {
+  void testVerifyProjectId() {
     // Should pass
     GoogleProjectService.ensureValidProjectId("abc1234-567");
     // All below should fail
@@ -62,35 +67,54 @@ public class GoogleProjectServiceTest {
         () -> GoogleProjectService.ensureValidProjectId("abc1234-567-"), "Can't end with a hyphen");
   }
 
-  @Test
-  public void testAppEngineOpIdExtraction() {
+  private static Stream<Arguments> extractOperationIdFromName_successful() {
+    return Stream.of(
+        Arguments.arguments(RANDOM_UUID.toString()),
+        Arguments.arguments("operation-" + RANDOM_UUID),
+        Arguments.arguments("operation-" + RANDOM_UUID.toString().substring(0, 24)));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void extractOperationIdFromName_successful(String opId) {
     assertThat(
             GoogleProjectService.extractOperationIdFromName(
-                "my-project", "apps/my-project/operations/aa9a20e4-69a9-488d-978f-0c55cc2beae8"))
+                APP_ID, String.format("apps/%s/operations/%s", APP_ID, opId)))
         .as("works as expected")
-        .isEqualTo("aa9a20e4-69a9-488d-978f-0c55cc2beae8");
+        .isEqualTo(opId);
+  }
 
-    assertThatThrownBy(
-            () ->
-                GoogleProjectService.extractOperationIdFromName(
-                    "my-project",
-                    "apps/my-project/somenewformat/aa9a20e4-69a9-488d-978f-0c55cc2beae8"))
-        .as("handles bad path")
-        .isInstanceOf(AppengineException.class)
-        .hasMessageStartingWith("Operation Name does not look as expected");
+  private static Stream<Arguments> extractOperationIdFromName_unexpectedPrefix() {
+    return Stream.of(
+        Arguments.arguments(String.format("apps-subpathmismatch/%s/operations/", APP_ID)),
+        Arguments.arguments(String.format("apps/%s-appidmismatch/operations/", APP_ID)),
+        Arguments.arguments(String.format("apps/%s/operations-subpathmismatch/", APP_ID)));
+  }
 
+  @ParameterizedTest
+  @MethodSource
+  void extractOperationIdFromName_unexpectedPrefix(String prefix) {
     assertThatThrownBy(
-            () ->
-                GoogleProjectService.extractOperationIdFromName(
-                    "my-project",
-                    "apps/my-project/operations/aa9a20g4-69a9-488d-978f-0c55cc2beae8"))
-        .as("handles bad uuid")
+            () -> GoogleProjectService.extractOperationIdFromName(APP_ID, prefix + RANDOM_UUID))
+        .as("handles unexpected prefix")
         .isInstanceOf(AppengineException.class)
-        .hasMessageStartingWith("Operation Name does not look as expected");
+        .hasMessageContaining("does not start with expected prefix");
   }
 
   @Test
-  public void testProjectLabelClean() {
+  void extractOperationIdFromName_unexpectedElementCount() {
+    assertThatThrownBy(
+            () ->
+                GoogleProjectService.extractOperationIdFromName(
+                    APP_ID,
+                    String.format("apps/%s/operations/extraelement/%s", APP_ID, RANDOM_UUID)))
+        .as("handles unexpected element count")
+        .isInstanceOf(AppengineException.class)
+        .hasMessageContaining("expected to have exactly 4 elements");
+  }
+
+  @Test
+  void testProjectLabelClean() {
     String tooLongName = "workflow_launcher_testing_dataset5243fe12db16406789e76e98dcf3aebd";
     assertEquals("Project label original length should be 65", tooLongName.length(), 65);
     String trimmedName = GoogleResourceManagerService.cleanForLabels(tooLongName);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-910
Debugging in Slack: https://broadinstitute.slack.com/archives/CADM7MZ35/p1702654403208449

Last night's smoke, connected, and integration test runs failed due to a chain of issues most likely related to new Google backend behavior.  We have also received user reports in production that resource creation has been failing inconsistently for them starting today.

**Problem 1: App Engine Admin API must be enabled for project**
Resource creation failing when trying to enable Firestore on projects with:

```
com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
POST https://appengine.googleapis.com/v1/apps
{
  "code" : 403,
  "details" : [ {
    "@type" : "type.googleapis.com/google.rpc.Help",
    "links" : [ {
      "description" : "Google developers console API activation",
      "url" : "https://console.developers.google.com/apis/api/appengine.googleapis.com/overview?project=545052482238"
    } ]
  }, {
    "@type" : "type.googleapis.com/google.rpc.ErrorInfo",
    "reason" : "SERVICE_DISABLED",
    "domain" : "googleapis.com",
    "metadata" : {
      "service" : "appengine.googleapis.com",
      "consumer" : "projects/545052482238"
    }
  } ],
  "errors" : [ {
    "domain" : "usageLimits",
    "message" : "App Engine Admin API has not been used in project 545052482238 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/appengine.googleapis.com/overview?project=545052482238 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
    "reason" : "accessNotConfigured",
    "extendedHelp" : "https://console.developers.google.com/"
  } ],
  "message" : "App Engine Admin API has not been used in project 545052482238 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/appengine.googleapis.com/overview?project=545052482238 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
  "status" : "PERMISSION_DENIED"
}
```

**Remediation:** manually enabled these APIs in the following TDR projects following the error message instructions:
- broad-jade-dev
- broad-jade-integration
- terra-datarepo-alpha
- terra-datarepo-staging
- terra-datarepo-production

**Resolution:** If this enablement is now required, it should be managed via Terraform, but we want a bit more time to validate that the Terraform plans are safe: https://github.com/broadinstitute/terraform-jade/pull/156

**Problem 2: App Engine operation ID format no longer matches our expectations**

Once the APIs were enabled, we [reran the tests and still saw failures](https://github.com/DataBiosphere/jade-data-repo/actions/runs/7217915078/job/19686368328), but different ones.  Example failure from smoke test 4,`BillingProfileAccess`:

```
Caused by: bio.terra.datarepo.client.ApiException: {"message":"Operation Name does not look as expected: apps/datarepo-tools-403fae37/operations/operation-1702658910061-60c8f2b820248-67c4276a-e6568941","errorDetail":[]}
```

While historically Google's operation ID has consistently been returned to us as a UUID, that was not guaranteed. We are now seeing IDs returned in different formats, e.g. `operation-1702658910061-60c8f2b820248-67c4276a-e6568941`:
- New prefix: `operation-`
- Suffix does not conform to UUID format

This was causing inconsistent issues in tests and users when creating certain resources.

**Resolution** This PR loosens our validation of Google appengine's operation ID format, using their library documentation to guide our expectations:
```
  /**
   * The server-assigned name, which is only unique within the same service that originally returns
   * it. If you use the default HTTP mapping, the name should be a resource name ending with
   * operations/{unique_id}.
   * The value may be {@code null}.
   */
  @com.google.api.client.util.Key
  private java.lang.String name;
```