### PR TITLE
[DR-3405] Micrometer: publish percentile histograms for per-endpoint latencies

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -99,8 +99,16 @@ google.allowReuseExistingBuckets=false
 google.firestoreRetries=10
 google.secureFolderResourceId=753276429356
 google.defaultFolderResourceId=270278425081
+
+## Prometheus, Micrometer metrics gathering
 management.health.probes.enabled=true
 management.endpoints.web.exposure.include=*
+management.metrics.distribution.maximum-expected-value[http.server.requests]=60s
+# Used to publish a histogram suitable for computing aggregable (across dimensions) percentile
+# latency approximations in Prometheus (by using histogram_quantile)
+# For more information: https://micrometer.io/docs/concepts#_histograms_and_percentiles
+management.metrics.distribution.percentiles-histogram[http.server.requests]=true
+
 # Use to authenticate the TDR service to user tenants
 azure.credentials.applicationId=
 azure.credentials.secret=


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3405

Similar to https://github.com/DataBiosphere/terra-drs-hub/pull/90, we’d like to expose per-endpoint percentile latency metrics for TDR, and display them in Grafana.  While these metrics won’t be much help for asynchronous jobs (resource creation, data ingest, etc). they will be useful in evaluating DRS resolution performance at scale.

Driver: investigating sluggish performance of prod-tier TDR AnVIL DRS resolution scale tests (controlled access data, v2 compact identifiers).  Our most recent scale tests pointed towards TDR DRS resolution via bearer token as regularly taking more than 10 seconds to complete, and the likely driver of ~20s successful DRS resolution response times (95th percentile) rather than an ECM-side bottleneck.

To see new metrics:
- Spin up a local TDR
- Interact with the endpoints of your choosing
- Navigate to `localhost:8080/actuator/prometheus`
- Look for `http_server_requests_seconds_bucket` metrics reflecting your interactions, e.g.
```
…
http_server_requests_seconds_bucket{exception="InvalidDrsIdException",method="GET",outcome="CLIENT_ERROR",status="400",uri="/ga4gh/drs/v1/objects/{object_id}",le="0.805306366",} 0.0
http_server_requests_seconds_bucket{exception="InvalidDrsIdException",method="GET",outcome="CLIENT_ERROR",status="400",uri="/ga4gh/drs/v1/objects/{object_id}",le="0.894784851",} 1.0
…
```