### PR TITLE
[DR-3390] Snapshot auth domain language -> data access controls

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -40,7 +40,6 @@ import bio.terra.service.job.JobService;
 import bio.terra.service.snapshot.SnapshotRequestValidator;
 import bio.terra.service.snapshot.SnapshotService;
 import io.swagger.annotations.Api;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -304,7 +303,7 @@ public class SnapshotsApiController implements SnapshotsApi {
             .filter(filter));
   }
 
-  // --snapshot auth domains --
+  // --snapshot data access controls (auth domains, group access constraints) --
 
   @Override
   public ResponseEntity<AddAuthDomainResponseModel> addSnapshotAuthDomain(
@@ -312,7 +311,7 @@ public class SnapshotsApiController implements SnapshotsApi {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     verifySnapshotAuthorization(userReq, id.toString(), IamAction.UPDATE_AUTH_DOMAIN);
     AddAuthDomainResponseModel result =
-        snapshotService.addSnapshotAuthDomain(userReq, id, new ArrayList<>(userGroups));
+        snapshotService.addSnapshotDataAccessControls(userReq, id, userGroups);
     return ResponseEntity.ok(result);
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -74,7 +74,7 @@ import bio.terra.service.rawls.RawlsService;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
 import bio.terra.service.snapshot.exception.AssetNotFoundException;
 import bio.terra.service.snapshot.exception.SnapshotPreviewException;
-import bio.terra.service.snapshot.flight.authDomain.SnapshotAddAuthDomainFlight;
+import bio.terra.service.snapshot.flight.authDomain.SnapshotAddDataAccessControlsFlight;
 import bio.terra.service.snapshot.flight.create.SnapshotCreateFlight;
 import bio.terra.service.snapshot.flight.delete.SnapshotDeleteFlight;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
@@ -591,11 +591,13 @@ public class SnapshotService {
         .collect(Collectors.toList());
   }
 
-  public AddAuthDomainResponseModel addSnapshotAuthDomain(
+  public AddAuthDomainResponseModel addSnapshotDataAccessControls(
       AuthenticatedUserRequest userReq, UUID snapshotId, List<String> userGroups) {
-    String description = "Patch auth domain for snapshot " + snapshotId;
+    String userGroupsString = StringUtils.join(userGroups, ", ");
+    String description =
+        "Add data access control groups " + userGroupsString + " to snapshot " + snapshotId;
     return jobService
-        .newJob(description, SnapshotAddAuthDomainFlight.class, userGroups, userReq)
+        .newJob(description, SnapshotAddDataAccessControlsFlight.class, userGroups, userReq)
         .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), snapshotId.toString())
         .submitAndWait(AddAuthDomainResponseModel.class);
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/authDomain/SnapshotAddDataAccessControlsFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/authDomain/SnapshotAddDataAccessControlsFlight.java
@@ -17,9 +17,15 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.context.ApplicationContext;
 
-public class SnapshotAddAuthDomainFlight extends Flight {
+/**
+ * This flight adds data access control groups to a snapshot. The provided user groups will be
+ * registered as a group constraint policy in Terra Policy Service, and as an auth domain in Sam. If
+ * a snapshot has data access controls, a user must have access to the resource directly (via a
+ * policy) and belong to all of its data access control groups in order to view and access the data.
+ */
+public class SnapshotAddDataAccessControlsFlight extends Flight {
 
-  public SnapshotAddAuthDomainFlight(FlightMap inputParameters, Object applicationContext) {
+  public SnapshotAddDataAccessControlsFlight(FlightMap inputParameters, Object applicationContext) {
     super(inputParameters, applicationContext);
 
     ApplicationContext appContext = (ApplicationContext) applicationContext;
@@ -50,7 +56,7 @@ public class SnapshotAddAuthDomainFlight extends Flight {
             userReq,
             snapshotId,
             IamResourceType.DATASNAPSHOT,
-            "The auth domain group for this snapshot was updated."));
+            "Data access control groups were added to this snapshot."));
 
     addStep(new AddSnapshotAuthDomainSetResponseStep(iamService, userReq, snapshotId));
   }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1131,11 +1131,18 @@ paths:
       tags:
         - snapshots
         - repository
-      description: Add an auth domain to the snapshot. *** WARNING - Once this is set it cannot be modified ***
-                  A Sam auth domain consists of a collection of user groups. If a snapshot has an auth domain,
-                  users must have access to the resource directly (via a policy) and belong to all user groups
-                  in the auth domain in order to view and export the data. For example, if a user is a snapshot
-                  steward but is not included in the auth domain, Sam will prevent that user from accessing the resource.
+      description: >
+        Add data access control groups to the snapshot.  The provided user groups will be registered
+        as a group constraint policy in Terra Policy Service, and as an auth domain in Sam.
+
+
+        *** WARNING - Once this is set it cannot be modified ***
+
+
+        If a snapshot has data access controls, a user must have access to the resource directly
+        (via a policy) and belong to all of its data access control groups in order to view and
+        export the data. For example, if a user is a steward of a snapshot with but is not a member
+        of its data access control groups, Sam will prevent that user from accessing the resource.
       operationId: addSnapshotAuthDomain
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -1149,7 +1156,7 @@ paths:
                 type: string
       responses:
         200:
-          description: Auth domain of this snapshot
+          description: The snapshot's data access control groups
           content:
             application/json:
               schema:
@@ -1161,7 +1168,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
         403:
-          description: No permission to add an auth domain to this snapshot
+          description: No permission to add data access control groups to this snapshot
           content:
             application/json:
               schema:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1141,7 +1141,7 @@ paths:
 
         If a snapshot has data access controls, a user must have access to the resource directly
         (via a policy) and belong to all of its data access control groups in order to view and
-        export the data. For example, if a user is a steward of a snapshot with but is not a member
+        export the data. For example, if a user is a steward of a snapshot but is not a member
         of its data access control groups, Sam will prevent that user from accessing the resource.
       operationId: addSnapshotAuthDomain
       parameters:

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -89,7 +89,7 @@ import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.SnapshotService.SnapshotAccessibleResult;
 import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
-import bio.terra.service.snapshot.flight.authDomain.SnapshotAddAuthDomainFlight;
+import bio.terra.service.snapshot.flight.authDomain.SnapshotAddDataAccessControlsFlight;
 import bio.terra.service.snapshot.flight.create.SnapshotCreateFlight;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
 import bio.terra.service.snapshot.flight.duos.SnapshotUpdateDuosDatasetFlight;
@@ -1170,11 +1170,14 @@ public class SnapshotServiceTest {
     when(jobBuilder.addParameter(any(), any())).thenReturn(jobBuilder);
     when(jobBuilder.submitAndWait(AddAuthDomainResponseModel.class)).thenReturn(jobResponse);
     when(jobService.newJob(
-            anyString(), eq(SnapshotAddAuthDomainFlight.class), eq(userGroups), eq(TEST_USER)))
+            anyString(),
+            eq(SnapshotAddDataAccessControlsFlight.class),
+            eq(userGroups),
+            eq(TEST_USER)))
         .thenReturn(jobBuilder);
 
     AddAuthDomainResponseModel result =
-        service.addSnapshotAuthDomain(TEST_USER, snapshotId, userGroups);
+        service.addSnapshotDataAccessControls(TEST_USER, snapshotId, userGroups);
     assertThat("Job is submitted and response returned", result, equalTo(jobResponse));
     verify(jobBuilder).addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), snapshotId.toString());
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3390

Updated public-facing documentation of `addSnapshotAuthDomain` endpoint to match prevailing terminology (data access controls) and highlight that a group constraint policy is also added in TPS when called, rather than only modifying the snapshot's auth domain in Sam.

Down the call chain, I updated method names, class names, and docstrings accordingly, but stopped short of making any breaking changes (such as changes to the endpoint path, name, or generated response body model).

Here is how the endpoint documentation change is rendered in Swagger:

<img width="1467" alt="Screenshot 2024-01-02 at 6 16 16 PM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/12522221-1b07-4a48-9f0f-6ccd9e852a74">
