### PR TITLE
DR-3414: Upgrade Spring Boot to 2.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat
 
 buildscript {
     ext {
-        springBootVersion = '3.0.4'
+        springBootVersion = '2.6.15'
     }
     repositories {
         mavenCentral()
@@ -32,7 +32,7 @@ plugins {
     id 'antlr'
     id 'com.github.spotbugs' version '4.7.1'
     id "org.hidetake.swagger.generator" version "2.19.2"
-    id "org.springframework.boot" version "2.5.12"
+    id "org.springframework.boot" version "2.6.15"
     id "idea"
     id "java"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
@@ -255,7 +255,7 @@ dependencies {
     // Pin the version of the OkHttp client to avoid a conflict with the version used by the Sam client
     implementation group: "com.squareup.okhttp3", name: "okhttp", version: "4.10.0"
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-registry-prometheus:1.8.6'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'com.fasterxml.jackson.core:jackson-core:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat
 
 buildscript {
     ext {
-        springBootVersion = '2.6.15'
+        springBootVersion = '2.7.18'
     }
     repositories {
         mavenCentral()
@@ -32,7 +32,7 @@ plugins {
     id 'antlr'
     id 'com.github.spotbugs' version '4.7.1'
     id "org.hidetake.swagger.generator" version "2.19.2"
-    id "org.springframework.boot" version "2.6.15"
+    id "org.springframework.boot" version "2.7.18"
     id "idea"
     id "java"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"

--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ dependencies {
 
     implementation 'org.springframework:spring-jdbc:5.1.9.RELEASE'
     implementation 'org.springframework.cloud:spring-cloud-gcp-starter-logging:1.2.8.RELEASE'
-    implementation "org.springframework.cloud:spring-cloud-starter-sleuth:3.0.2"
+    implementation 'org.springframework.cloud:spring-cloud-starter-sleuth:3.1.7'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-ae94a59'
     implementation 'org.antlr:ST4:4.3'                          // String templating
     implementation group: 'io.kubernetes', name: 'client-java', version: '18.0.0'

--- a/src/main/java/bio/terra/app/configuration/DuosConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/DuosConfiguration.java
@@ -1,8 +1,6 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "duos")
-@ConstructorBinding
 public record DuosConfiguration(String basePath) {}

--- a/src/main/java/bio/terra/app/configuration/EcmConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/EcmConfiguration.java
@@ -1,8 +1,6 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "ecm")
-@ConstructorBinding
 public record EcmConfiguration(String basePath, String rasIssuer) {}

--- a/src/main/java/bio/terra/app/configuration/OauthConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/OauthConfiguration.java
@@ -1,9 +1,7 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "oauth")
-@ConstructorBinding
 public record OauthConfiguration(
     String schemeName, String loginEndpoint, String clientId, String clientSecret) {}

--- a/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/PolicyServiceConfiguration.java
@@ -5,11 +5,9 @@ import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 /** Configuration for managing connection to Terra Policy Service. * */
 @ConfigurationProperties(prefix = "tps")
-@ConstructorBinding
 public record PolicyServiceConfiguration(String basePath) {
 
   private static final List<String> POLICY_SCOPES = List.of("openid", "email", "profile");

--- a/src/main/java/bio/terra/app/configuration/RawlsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/RawlsConfiguration.java
@@ -1,8 +1,6 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "rawls")
-@ConstructorBinding
 public record RawlsConfiguration(String basePath) {}

--- a/src/main/java/bio/terra/app/configuration/ResourceBufferServiceConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ResourceBufferServiceConfiguration.java
@@ -7,11 +7,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 /** Configuration for managing connection to Buffer Service. * */
 @ConfigurationProperties(prefix = "rbs")
-@ConstructorBinding
 public record ResourceBufferServiceConfiguration(
     boolean enabled, String instanceUrl, String poolId, String clientCredentialFilePath) {
 

--- a/src/main/java/bio/terra/app/configuration/SamConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/SamConfiguration.java
@@ -1,7 +1,6 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 /*
  * SAM Retry notes:
@@ -16,7 +15,6 @@ import org.springframework.boot.context.properties.ConstructorBinding;
  * operationTimeoutSeconds before we reach retryMaximumSeconds.
  */
 @ConfigurationProperties(prefix = "sam")
-@ConstructorBinding
 public record SamConfiguration(
     String basePath,
     String stewardsGroupEmail,

--- a/src/main/java/bio/terra/app/configuration/SentryConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/SentryConfiguration.java
@@ -12,12 +12,10 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 @ConfigurationProperties(prefix = "sentry")
-@ConstructorBinding
 public record SentryConfiguration(String dsn, String environment) {
   private static final Logger logger = LoggerFactory.getLogger(SentryConfiguration.class);
   private static final String DEFAULT_UNDEFINED_ENVIRONMENT = "undefined";

--- a/src/main/java/bio/terra/app/configuration/TerraConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/TerraConfiguration.java
@@ -1,8 +1,6 @@
 package bio.terra.app.configuration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "terra")
-@ConstructorBinding
 public record TerraConfiguration(String basePath) {}

--- a/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/UserMetricsConfiguration.java
@@ -6,11 +6,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.context.annotation.Bean;
 
 @ConfigurationProperties(prefix = "usermetrics")
-@ConstructorBinding
 public record UserMetricsConfiguration(
     String appId,
     String bardBasePath,

--- a/src/main/java/bio/terra/service/filedata/google/bq/BigQueryConfiguration.java
+++ b/src/main/java/bio/terra/service/filedata/google/bq/BigQueryConfiguration.java
@@ -2,11 +2,9 @@ package bio.terra.service.filedata.google.bq;
 
 import java.util.Optional;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.context.annotation.Profile;
 
 /** Configuration for interacting with BigQuery. */
-@ConstructorBinding
 @Profile("google")
 @ConfigurationProperties(prefix = "datarepo.bq")
 public record BigQueryConfiguration(Integer rateLimitRetries, Integer rateLimitRetryWaitMs) {

--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsConfiguration.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsConfiguration.java
@@ -1,7 +1,6 @@
 package bio.terra.service.filedata.google.gcs;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.context.annotation.Profile;
 
 /**
@@ -9,7 +8,6 @@ import org.springframework.context.annotation.Profile;
  * That way, implementation specifics can be separated from the interface. We'll see if it works out
  * that way.
  */
-@ConstructorBinding
 @Profile("google")
 @ConfigurationProperties(prefix = "datarepo.gcs")
 public record GcsConfiguration(

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -13,11 +13,9 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 /** Configuration for working with Azure resources */
-@ConstructorBinding
 @EnableConfigurationProperties
 @ConfigurationProperties(prefix = "azure")
 public record AzureResourceConfiguration(

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceConfiguration.java
@@ -1,10 +1,8 @@
 package bio.terra.service.resourcemanagement.google;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-@ConstructorBinding
 @EnableConfigurationProperties
 @ConfigurationProperties(prefix = "google")
 public record GoogleResourceConfiguration(

--- a/src/main/java/bio/terra/service/upgrade/MigrateConfiguration.java
+++ b/src/main/java/bio/terra/service/upgrade/MigrateConfiguration.java
@@ -1,7 +1,6 @@
 package bio.terra.service.upgrade;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 /**
  * Provides methods for upgrading the data repository metadata and stairway databases. See <a
@@ -9,5 +8,4 @@ import org.springframework.boot.context.properties.ConstructorBinding;
  * Migration Notes</a></a>
  */
 @ConfigurationProperties(prefix = "db.migrate")
-@ConstructorBinding
 public record MigrateConfiguration(boolean dropAllOnStart, boolean updateAllOnStart) {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,9 +7,9 @@ spring.liquibase.enabled=false
 spring.profiles.active=google,human-readable-logging,local
 spring.main.allow-bean-definition-overriding=true
 spring.task.scheduling.pool.size=10
-spring.resources.cache.cachecontrol.max-age=0
-spring.resources.cache.cachecontrol.must-revalidate=true
-spring.resources.static-locations=classpath:/api/
+spring.web.resources.cache.cachecontrol.max-age=0
+spring.web.resources.cache.cachecontrol.must-revalidate=true
+spring.web.resources.static-locations=classpath:/api/
 db.migrate.dropAllOnStart=false
 db.migrate.updateAllOnStart=true
 db.datarepo.uri=jdbc:postgresql://127.0.0.1:5432/datarepo
@@ -101,7 +101,7 @@ google.secureFolderResourceId=753276429356
 google.defaultFolderResourceId=270278425081
 
 ## Prometheus, Micrometer metrics gathering
-management.health.probes.enabled=true
+management.endpoint.health.probes.enabled=true
 management.endpoints.web.exposure.include=*
 management.metrics.distribution.maximum-expected-value[http.server.requests]=60s
 # Used to publish a histogram suitable for computing aggregable (across dimensions) percentile


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3414
__________
### Upgrade from Spring Boot 2.5 to 2.7
Relevant Resources:
- [Spring Boot 2.6 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes)
- [Spring Boot 2.7 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes)

### Spring Cloud Sleuth Upgrade 
Thanks to @okotsopoulos for figuring this out!!
Without this upgrade, we could not start up the app with bootRun.  
The noted issue: https://github.com/spring-cloud/spring-cloud-sleuth/issues/1897

### Remove @ConstructorBinding tag
[With Spring Boot 2.6](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#records-and-configurationproperties), if you are using @ConfigurationProperties with a Java 16 record and the record has a single constructor, it no longer needs to be annotated with @ConstructorBinding.

### Unpin version of micrometer
Spring boot 2.7 upgraded to micrometer 1.9, so unpinning the version puts us on the same version. Using dependency insights, we can see it's on version 1.9.17. 

### Elasticsearch
Elasticsearch has ben removed from our repo with [DR-3348](https://github.com/DataBiosphere/jade-data-repo/pull/1561), so we no longer need to deal with upgrading.

### Application.Properties Updates
I made a few updates to settings our application.properties. These changed with previous upgrades to Spring boot. (2.3/2.4)
1) `spring.resources` was replaced with `spring.web.resources` with Spring boot 2.4 ([2.4.0-RC1 Configuration Changelog](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4.0-RC1-Configuration-Changelog))
2) management.health.probes.enabled migrated to management.endpoint.health.probes.enabled with Spring boot 2.3.2 ([source](https://www.baeldung.com/spring-liveness-readiness-probes#actuator-probes))


[DR-3348]: https://broadworkbench.atlassian.net/browse/DR-3348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ