### PR TITLE
DR-3410: Run staging tests nightly

### DIFF
--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -8,6 +8,8 @@ env:
   TDR_LOG_APPENDER: Console-Standard
 on:
   workflow_dispatch: {}
+  schedule:
+    - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
 jobs:
   test-runner-staging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3410
______

When we still had an alpha environment, we would deploy to alpha nightly and therefore run smoke tests against the alpha environment nightly.  We still promote to alpha and staging, but only alongside the monolith or independent release. This doesn't happen at a regular, nightly cadence. 

We think it will be helpful to get a nightly pulse of our non-development systems by running nightly tests against staging in the place of the nightly tests that used to run against alpha. 