### PR TITLE
[DR-3424] Use Micrometer gauges to monitor concurrent DRS requests

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsMetricsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsMetricsService.java
@@ -8,18 +8,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class DrsMetricsService {
   private static final String NAME_PREFIX = "datarepo.drs";
-  private static final String REQUEST_COUNT_NAME_PREFIX = NAME_PREFIX + ".requestCount";
-  static final String REQUEST_COUNT_GAUGE_NAME = REQUEST_COUNT_NAME_PREFIX + ".gauge";
-  static final String REQUEST_COUNT_MAX_GAUGE_NAME = REQUEST_COUNT_NAME_PREFIX + ".max";
+  private static final String OPEN_REQUEST_NAME_PREFIX = NAME_PREFIX + ".openRequests";
+  static final String OPEN_REQUEST_GAUGE_NAME = OPEN_REQUEST_NAME_PREFIX + ".gauge";
+  static final String OPEN_REQUEST_MAX_GAUGE_NAME = OPEN_REQUEST_NAME_PREFIX + ".max";
 
   private final AtomicInteger currentDrsRequestCount;
   private final AtomicInteger drsRequestCountMax;
 
   public DrsMetricsService(MeterRegistry meterRegistry) {
     this.currentDrsRequestCount =
-        meterRegistry.gauge(REQUEST_COUNT_GAUGE_NAME, new AtomicInteger(0));
+        meterRegistry.gauge(OPEN_REQUEST_GAUGE_NAME, new AtomicInteger(0));
     this.drsRequestCountMax =
-        meterRegistry.gauge(REQUEST_COUNT_MAX_GAUGE_NAME, new AtomicInteger(0));
+        meterRegistry.gauge(OPEN_REQUEST_MAX_GAUGE_NAME, new AtomicInteger(0));
   }
 
   /**
@@ -45,6 +45,9 @@ public class DrsMetricsService {
     currentDrsRequestCount.decrementAndGet();
   }
 
+  /**
+   * @param newMax value to set as the maximum number of concurrent DRS requests allowed per pod.
+   */
   public void setDrsRequestMax(int newMax) {
     drsRequestCountMax.set(newMax);
   }

--- a/src/main/java/bio/terra/service/filedata/DrsMetricsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsMetricsService.java
@@ -1,0 +1,51 @@
+package bio.terra.service.filedata;
+
+import bio.terra.app.controller.exception.TooManyRequestsException;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DrsMetricsService {
+  private static final String NAME_PREFIX = "datarepo.drs";
+  private static final String REQUEST_COUNT_NAME_PREFIX = NAME_PREFIX + ".requestCount";
+  static final String REQUEST_COUNT_GAUGE_NAME = REQUEST_COUNT_NAME_PREFIX + ".gauge";
+  static final String REQUEST_COUNT_MAX_GAUGE_NAME = REQUEST_COUNT_NAME_PREFIX + ".max";
+
+  private final AtomicInteger currentDrsRequestCount;
+  private final AtomicInteger drsRequestCountMax;
+
+  public DrsMetricsService(MeterRegistry meterRegistry) {
+    this.currentDrsRequestCount =
+        meterRegistry.gauge(REQUEST_COUNT_GAUGE_NAME, new AtomicInteger(0));
+    this.drsRequestCountMax =
+        meterRegistry.gauge(REQUEST_COUNT_MAX_GAUGE_NAME, new AtomicInteger(0));
+  }
+
+  /**
+   * Increment request count gauge representing the DRS requests currently being serviced, meant to
+   * be called on request arrival.
+   *
+   * @throws TooManyRequestsException if incrementing the request count would exceed the maximum
+   *     allowed
+   */
+  public void tryIncrementCurrentDrsRequestCount() throws TooManyRequestsException {
+    if (currentDrsRequestCount.get() >= drsRequestCountMax.get()) {
+      throw new TooManyRequestsException(
+          "Too many DataRepositoryService requests are being made at once. Please try again later.");
+    }
+    currentDrsRequestCount.incrementAndGet();
+  }
+
+  /**
+   * Decrement request count gauge representing the DRS requests currently being serviced, meant to
+   * be called on request response.
+   */
+  public void decrementCurrentDrsRequestCount() {
+    currentDrsRequestCount.decrementAndGet();
+  }
+
+  public void setDrsRequestMax(int newMax) {
+    drsRequestCountMax.set(newMax);
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/DrsMetricsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsMetricsServiceTest.java
@@ -33,9 +33,9 @@ class DrsMetricsServiceTest {
     this.currentDrsRequestCount = new AtomicInteger(0);
     this.drsRequestCountMax = new AtomicInteger(1);
 
-    when(meterRegistry.gauge(eq(DrsMetricsService.REQUEST_COUNT_GAUGE_NAME), any()))
+    when(meterRegistry.gauge(eq(DrsMetricsService.OPEN_REQUEST_GAUGE_NAME), any()))
         .thenReturn(currentDrsRequestCount);
-    when(meterRegistry.gauge(eq(DrsMetricsService.REQUEST_COUNT_MAX_GAUGE_NAME), any()))
+    when(meterRegistry.gauge(eq(DrsMetricsService.OPEN_REQUEST_MAX_GAUGE_NAME), any()))
         .thenReturn(drsRequestCountMax);
 
     drsMetricsService = new DrsMetricsService(meterRegistry);

--- a/src/test/java/bio/terra/service/filedata/DrsMetricsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsMetricsServiceTest.java
@@ -1,0 +1,73 @@
+package bio.terra.service.filedata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import bio.terra.app.controller.exception.TooManyRequestsException;
+import bio.terra.common.category.Unit;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"google", "unittest"})
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class DrsMetricsServiceTest {
+  @Mock private MeterRegistry meterRegistry;
+  private AtomicInteger currentDrsRequestCount;
+  private AtomicInteger drsRequestCountMax;
+
+  private DrsMetricsService drsMetricsService;
+
+  @BeforeEach
+  void beforeEach() {
+    this.currentDrsRequestCount = new AtomicInteger(0);
+    this.drsRequestCountMax = new AtomicInteger(1);
+
+    when(meterRegistry.gauge(eq(DrsMetricsService.REQUEST_COUNT_GAUGE_NAME), any()))
+        .thenReturn(currentDrsRequestCount);
+    when(meterRegistry.gauge(eq(DrsMetricsService.REQUEST_COUNT_MAX_GAUGE_NAME), any()))
+        .thenReturn(drsRequestCountMax);
+
+    drsMetricsService = new DrsMetricsService(meterRegistry);
+  }
+
+  @Test
+  void tryIncrementCurrentDrsRequestCount() {
+    drsMetricsService.tryIncrementCurrentDrsRequestCount();
+    assertEquals(
+        1,
+        currentDrsRequestCount.get(),
+        "current request count is incremented when we are below the max");
+
+    assertThrows(
+        TooManyRequestsException.class,
+        () -> drsMetricsService.tryIncrementCurrentDrsRequestCount());
+    assertEquals(
+        1,
+        currentDrsRequestCount.get(),
+        "current request count is untouched if too many open requests");
+  }
+
+  @Test
+  void decrementCurrentDrsRequestCount() {
+    drsMetricsService.decrementCurrentDrsRequestCount();
+    assertEquals(-1, currentDrsRequestCount.get(), "current request count is decremented");
+  }
+
+  @Test
+  void setDrsRequestMax() {
+    var newMax = 20;
+    drsMetricsService.setDrsRequestMax(newMax);
+    assertEquals(newMax, drsRequestCountMax.get(), "maximum request count is set");
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3424

`DrsService` restricts the number of concurrent DRS requests to 500 across our deployment (more accurately, splitting our limit of 500 across the deployment's pods).

When a new request is opened, it would log the current number of concurrent requests along with the maximum allowed for the pod.  We didn't have an easy way to monitor concurrent request load over time, which would be especially helpful for DRS resolution scale tests (Terra workflow running with up to 20k DRS URIs to resolve). 

This PR introduces new `DrsMetricsService`, which manages the following [Micrometer gauges](https://docs.micrometer.io/micrometer/reference/concepts/gauges.html):
- `datarepo.drs.openRequests.gauge` - the number of DRS requests currently active
- `datarepo.drs.openRequests.max` - the maximum number of concurrent DRS requests allowed for the pod

Micrometer says:
> A gauge is a handle to get the current value. Typical examples for gauges would be the size of a collection or map or number of threads in a running state.

We will be able to visualize these gauges in our TDR Grafana instances, specifically our DRS dashboards in dev and prod.

**Testing**

I added new unit tests for the new `DrsMetricsService` and supplemented existing `DrsService` unit tests to verify that we are making the expected metrics collection calls.  Previously we had no unit tests verifying the old behavior.

For manual verification, I locally added a 10 second sleep to DRS resolution code and observed that our active request gauge is incremented during open requests and decremented once the request finishes.  (The metrics names differ slightly from the final version committed.)

During open request:
```
(base) okotsopo@wm111-e35 jade-data-repo % curl http://localhost:8080/actuator/prometheus | grep drs_requestCount_
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 85934  100 85934    0     0  1701k      0 --:--:-- --:--:-- --:--:-- 1712k
# HELP datarepo_drs_requestCount_gauge  
# TYPE datarepo_drs_requestCount_gauge gauge
datarepo_drs_requestCount_gauge 1.0
# HELP datarepo_drs_requestCount_max  
# TYPE datarepo_drs_requestCount_max gauge
datarepo_drs_requestCount_max 500.0
```

After request completes:
```
(base) okotsopo@wm111-e35 jade-data-repo % curl http://localhost:8080/actuator/prometheus | grep drs_requestCount_
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 99909  100 99909    0     0  9276k      0 --:--:-- --:--:-- --:--:-- 9756k
# HELP datarepo_drs_requestCount_gauge  
# TYPE datarepo_drs_requestCount_gauge gauge
datarepo_drs_requestCount_gauge 0.0
# HELP datarepo_drs_requestCount_max  
# TYPE datarepo_drs_requestCount_max gauge
datarepo_drs_requestCount_max 500.0
```