### PR TITLE
DR-3420: Upgrade Postgres, Liquibase, Google BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,22 +26,22 @@ buildscript {
 }
 
 plugins {
-    id "com.google.cloud.tools.jib" version "3.2.0"
+    id 'com.google.cloud.tools.jib' version '3.2.0'
     id 'org.liquibase.gradle' version '2.1.1'
-    id "org.gradle.test-retry" version "1.4.0"
+    id 'org.gradle.test-retry' version '1.4.0'
     id 'antlr'
     id 'com.github.spotbugs' version '4.7.1'
-    id "org.hidetake.swagger.generator" version "2.19.2"
-    id "org.springframework.boot" version "2.7.18"
-    id "idea"
-    id "java"
-    id "io.spring.dependency-management" version "1.0.11.RELEASE"
-    id "jacoco"
-    id "com.diffplug.spotless" version "6.7.1"
-    id "com.dorongold.task-tree" version "2.1.0"
+    id 'org.hidetake.swagger.generator' version '2.19.2'
+    id 'org.springframework.boot' version '2.7.18'
+    id 'idea'
+    id 'java'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'jacoco'
+    id 'com.diffplug.spotless' version '6.7.1'
+    id 'com.dorongold.task-tree' version '2.1.0'
     // enables release info in sentry events
-    id "com.gorylenko.gradle-git-properties" version "2.4.1"
-    id "org.sonarqube" version "4.2.1.3168"
+    id 'com.gorylenko.gradle-git-properties' version '2.4.1'
+    id 'org.sonarqube' version '4.2.1.3168'
 }
 
 allprojects {
@@ -59,8 +59,8 @@ allprojects {
             mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
         }
         dependencies {
-            dependency group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.1.12"
-            dependency group: "io.swagger.codegen.v3", name: "swagger-codegen-cli", version: "3.0.47"
+            dependency 'io.swagger.core.v3:swagger-annotations:2.1.12'
+            dependency 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.47'
         }
     }
 }
@@ -194,19 +194,19 @@ dependencies {
     implementation 'com.google.http-client:google-http-client'
     implementation 'org.apache.commons:commons-dbcp2:2.7.0'     // For database connection support
     implementation 'org.apache.commons:commons-lang3:3.11'
-    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+    implementation 'org.apache.commons:commons-collections4:4.4'
     implementation 'org.apache.directory.studio:org.apache.commons.io:2.4'
     implementation 'org.liquibase:liquibase-core:3.8.0'         // For upgrade
     implementation 'org.postgresql:postgresql:42.2.18'          // Postgres jdbc driver
     implementation 'ch.qos.logback:logback-core:1.2.13'      // Unpin logback versions with DR-3404 Spring 3 Upgrade
     implementation 'ch.qos.logback:logback-classic:1.2.13'  // logback-classic natively implements slf4j api
-
+    
     implementation 'org.codehaus.janino:janino:3.1.11'           // Provides if/else xml parsing for logback config
-    implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation group: "javax.validation", name: "validation-api"
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'javax.validation:validation-api'
 
-    implementation group: "io.swagger.core.v3", name: "swagger-annotations"
-    swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"
+    implementation 'io.swagger.core.v3:swagger-annotations'
+    swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli'
 
     implementation 'org.springframework:spring-jdbc:5.1.9.RELEASE'
     implementation 'org.springframework.cloud:spring-cloud-gcp-starter-logging:1.2.8.RELEASE'
@@ -226,7 +226,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'javax.servlet:jstl:1.2'
 
-    implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '11.2.3.jre17'
+    implementation 'com.microsoft.sqlserver:mssql-jdbc:11.2.3.jre17'
 
     // For distributed locking of Spring @Scheduled tasks across multiple instances
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.2.0'
@@ -237,8 +237,8 @@ dependencies {
     // Or define the environment variable ORG_GRADLE_PROJECT_stairwayjar
     if (project.hasProperty("stairwayjar")) {
         implementation files(project.ext.get("stairwayjar"))
-        implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
-        implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.2'
+        implementation 'org.apache.commons:commons-collections4:4.4'
+        implementation 'org.openapitools:jackson-databind-nullable:0.2.2'
     } else {
         implementation 'bio.terra:stairway:0.0.78-SNAPSHOT'
     }
@@ -246,27 +246,26 @@ dependencies {
     // Similar development mode for pointing to terra common library
     if (project.hasProperty("commonlibjar")) {
         implementation files(project.ext.get("commonlibjar"))
-        implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
-        implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.2'
+        implementation 'org.apache.commons:commons-collections4:4.4'
+        implementation 'org.openapitools:jackson-databind-nullable:0.2.2'
     } else {
         implementation ('bio.terra:terra-common-lib:0.0.89-SNAPSHOT') {
             exclude group: 'org.broadinstitute.dsde.workbench', module: 'sam-client_2.12'
         }
     }
 
-    implementation group: "bio.terra", name: "terra-policy-client", version: "1.0.4-SNAPSHOT"
-    implementation group: "bio.terra", name: "terra-resource-buffer-client", version: "0.4.3-SNAPSHOT"
-    implementation group: "bio.terra", name: "externalcreds-client-resttemplate", version: "0.72.0-SNAPSHOT"
-    implementation group: "org.glassfish.jersey.inject", name: "jersey-hk2", version: "2.30.1"
+    implementation 'bio.terra:terra-policy-client:1.0.4-SNAPSHOT'
+    implementation 'bio.terra:terra-resource-buffer-client:0.4.3-SNAPSHOT'
+    implementation 'bio.terra:externalcreds-client-resttemplate:0.72.0-SNAPSHOT'
+    implementation 'org.glassfish.jersey.inject:jersey-hk2:2.30.1'
 
     // Pin the version of the OkHttp client to avoid a conflict with the version used by the Sam client
-    implementation group: "com.squareup.okhttp3", name: "okhttp", version: "4.10.0"
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.16.1'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
 
     // Azure related dependencies
     implementation 'com.azure:azure-identity:1.9.1'
@@ -281,11 +280,11 @@ dependencies {
     implementation('io.sentry:sentry-spring-boot-starter')
     implementation('io.sentry:sentry-logback')
 
-    testImplementation "org.apache.parquet:parquet-common:1.12.0"
-    testImplementation "org.apache.parquet:parquet-hadoop:1.12.0"
-    testImplementation "org.apache.parquet:parquet-hadoop-bundle:1.12.0"
-    testImplementation "org.apache.parquet:parquet-encoding:1.12.0"
-    testImplementation "org.apache.parquet:parquet-column:1.12.0"
+    testImplementation 'org.apache.parquet:parquet-common:1.12.0'
+    testImplementation 'org.apache.parquet:parquet-hadoop:1.12.0'
+    testImplementation 'org.apache.parquet:parquet-hadoop-bundle:1.12.0'
+    testImplementation 'org.apache.parquet:parquet-encoding:1.12.0'
+    testImplementation 'org.apache.parquet:parquet-column:1.12.0'
     testImplementation ('org.apache.hadoop:hadoop-common:3.3.1')  {
         exclude group: 'com.sun.jersey', module: 'jersey-core'
         exclude group: 'com.sun.jersey', module: 'jersey-servlet'
@@ -308,12 +307,12 @@ dependencies {
     testImplementation 'au.com.dius.pact.provider:junit5:4.3.19'
     testImplementation 'au.com.dius.pact.provider:junit5spring:4.3.19'
 
-    antlr "org.antlr:antlr4:4.8"
+    antlr 'org.antlr:antlr4:4.8'
     spotbugs 'com.github.spotbugs:spotbugs:4.2.3'
 
     // Need groovy on the class path for the logback config. Could use XML and skip this dependency,
     // but the groovy config is... well... groovy.
-    runtimeOnly group: 'org.codehaus.groovy', name: 'groovy', version: '3.0.7'
+    runtimeOnly 'org.codehaus.groovy:groovy:3.0.7'
 
     // Findbugs annotations, so we can selectively suppress findbugs findings
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
@@ -321,8 +320,8 @@ dependencies {
     liquibaseRuntime 'org.liquibase:liquibase-core:3.8.0'
     liquibaseRuntime 'org.postgresql:postgresql:42.2.7'
 
-    testImplementation group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.3.0-M1'
-    testImplementation "org.springframework.boot:spring-boot-starter-test"
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.0-M1'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.postgresql:postgresql:42.2.8'
     testImplementation 'com.google.code.findbugs:annotations:3.0.1'
     testImplementation 'io.zonky.test:embedded-database-spring-test:2.1.1'
@@ -335,11 +334,11 @@ dependencies {
     // boot-starter-validation required for javax.validation.Valid references, @Valid tags
     generatedCompile 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation group: "org.webjars", name: "webjars-locator-core", version: "0.46"
-    runtimeOnly group: "org.webjars.npm", name: "swagger-ui-dist", version: "4.3.0"
-    generatedCompile group: "io.swagger.core.v3", name: "swagger-annotations"
+    implementation 'org.webjars:webjars-locator-core:0.46'
+    runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.3.0'
+    generatedCompile 'io.swagger.core.v3:swagger-annotations'
 
-    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }
 
 def getGitHash = { ->

--- a/build.gradle
+++ b/build.gradle
@@ -196,8 +196,8 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'org.apache.commons:commons-collections4:4.4'
     implementation 'org.apache.directory.studio:org.apache.commons.io:2.4'
-    implementation 'org.liquibase:liquibase-core:3.8.0'         // For upgrade
-    implementation 'org.postgresql:postgresql:42.2.18'          // Postgres jdbc driver
+    implementation 'org.liquibase:liquibase-core'
+    implementation 'org.postgresql:postgresql'          // Postgres jdbc driver
     implementation 'ch.qos.logback:logback-core:1.2.13'      // Unpin logback versions with DR-3404 Spring 3 Upgrade
     implementation 'ch.qos.logback:logback-classic:1.2.13'  // logback-classic natively implements slf4j api
     
@@ -317,12 +317,8 @@ dependencies {
     // Findbugs annotations, so we can selectively suppress findbugs findings
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
 
-    liquibaseRuntime 'org.liquibase:liquibase-core:3.8.0'
-    liquibaseRuntime 'org.postgresql:postgresql:42.2.7'
-
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.0-M1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.postgresql:postgresql:42.2.8'
     testImplementation 'com.google.code.findbugs:annotations:3.0.1'
     testImplementation 'io.zonky.test:embedded-database-spring-test:2.1.1'
     testImplementation 'io.zonky.test:embedded-postgres:1.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     implementation 'com.google.apis:google-api-services-appengine:v1-rev20230206-2.0.0'
     implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-2.0.0'
     implementation 'com.google.apis:google-api-services-iam:v1-rev20230209-2.0.0'
-    implementation platform('com.google.cloud:libraries-bom:26.26.0')
+    implementation platform('com.google.cloud:libraries-bom:26.29.0')
     implementation 'com.google.cloud:google-cloud-billing'
     implementation 'com.google.cloud:google-cloud-resourcemanager'
     implementation 'com.google.cloud:google-cloud-bigquery'

--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ dependencies {
     implementation 'org.postgresql:postgresql'          // Postgres jdbc driver
     implementation 'ch.qos.logback:logback-core:1.2.13'      // Unpin logback versions with DR-3404 Spring 3 Upgrade
     implementation 'ch.qos.logback:logback-classic:1.2.13'  // logback-classic natively implements slf4j api
-    
+
     implementation 'org.codehaus.janino:janino:3.1.11'           // Provides if/else xml parsing for logback config
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'javax.validation:validation-api'
@@ -316,6 +316,9 @@ dependencies {
 
     // Findbugs annotations, so we can selectively suppress findbugs findings
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
+
+    liquibaseRuntime 'org.liquibase:liquibase-core:4.9.1'
+    liquibaseRuntime 'org.postgresql:postgresql:42.3.8'
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.0-M1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     implementation 'com.google.apis:google-api-services-appengine:v1-rev20230206-2.0.0'
     implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-2.0.0'
     implementation 'com.google.apis:google-api-services-iam:v1-rev20230209-2.0.0'
-    implementation platform('com.google.cloud:libraries-bom:26.29.0')
+    implementation platform('com.google.cloud:libraries-bom:26.30.0')
     implementation 'com.google.cloud:google-cloud-billing'
     implementation 'com.google.cloud:google-cloud-resourcemanager'
     implementation 'com.google.cloud:google-cloud-bigquery'

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import liquibase.util.StringUtils;
+import liquibase.util.StringUtil;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -58,7 +58,7 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
     }
 
     // Don't log metrics if bard isn't configured or the path is part of the ignore-list
-    if (StringUtils.isEmpty(metricsConfig.bardBasePath()) || ignoreEventForPath(path)) {
+    if (StringUtil.isEmpty(metricsConfig.bardBasePath()) || ignoreEventForPath(path)) {
       return;
     }
 

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -10,8 +10,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import liquibase.util.StringUtil;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -58,7 +58,7 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
     }
 
     // Don't log metrics if bard isn't configured or the path is part of the ignore-list
-    if (StringUtil.isEmpty(metricsConfig.bardBasePath()) || ignoreEventForPath(path)) {
+    if (StringUtils.isEmpty(metricsConfig.bardBasePath()) || ignoreEventForPath(path)) {
       return;
     }
 

--- a/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
@@ -6,8 +6,8 @@ import bio.terra.model.FileLoadModel;
 import bio.terra.model.IngestRequestModel;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.validation.constraints.NotNull;
-import liquibase.util.StringUtil;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -35,12 +35,12 @@ public class IngestRequestValidator implements Validator {
       validateTableName(ingestRequest.getTable(), errors);
       boolean isPayloadIngest =
           ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY);
-      if (StringUtil.isEmpty(ingestRequest.getPath()) && !isPayloadIngest) {
+      if (StringUtils.isEmpty(ingestRequest.getPath()) && !isPayloadIngest) {
         errors.rejectValue(
             "path", "PathIsMissing", "Path is required when ingesting from a cloud object");
       }
 
-      if (!StringUtil.isEmpty(ingestRequest.getPath()) && isPayloadIngest) {
+      if (!StringUtils.isEmpty(ingestRequest.getPath()) && isPayloadIngest) {
         errors.rejectValue(
             "path", "PathIsPresent", "Path should not be specified when ingesting from an array");
       }
@@ -62,12 +62,12 @@ public class IngestRequestValidator implements Validator {
       }
     } else if (target instanceof BulkLoadRequestModel bulkLoadRequestModel) {
       if (bulkLoadRequestModel.isBulkMode()
-          && StringUtil.isEmpty(bulkLoadRequestModel.getLoadTag())) {
+          && StringUtils.isEmpty(bulkLoadRequestModel.getLoadTag())) {
         errors.rejectValue("loadTag", "MissingLoadTag", "Load tag is required for isBulkMode");
       }
     } else if (target instanceof BulkLoadArrayRequestModel bulkLoadArrayRequestModel) {
       if (bulkLoadArrayRequestModel.isBulkMode()
-          && StringUtil.isEmpty(bulkLoadArrayRequestModel.getLoadTag())) {
+          && StringUtils.isEmpty(bulkLoadArrayRequestModel.getLoadTag())) {
         errors.rejectValue("loadTag", "MissingLoadTag", "Load tag is required for isBulkMode");
       }
     }

--- a/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/IngestRequestValidator.java
@@ -6,7 +6,7 @@ import bio.terra.model.FileLoadModel;
 import bio.terra.model.IngestRequestModel;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.validation.constraints.NotNull;
-import liquibase.util.StringUtils;
+import liquibase.util.StringUtil;
 import org.apache.commons.collections4.ListUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -35,12 +35,12 @@ public class IngestRequestValidator implements Validator {
       validateTableName(ingestRequest.getTable(), errors);
       boolean isPayloadIngest =
           ingestRequest.getFormat().equals(IngestRequestModel.FormatEnum.ARRAY);
-      if (StringUtils.isEmpty(ingestRequest.getPath()) && !isPayloadIngest) {
+      if (StringUtil.isEmpty(ingestRequest.getPath()) && !isPayloadIngest) {
         errors.rejectValue(
             "path", "PathIsMissing", "Path is required when ingesting from a cloud object");
       }
 
-      if (!StringUtils.isEmpty(ingestRequest.getPath()) && isPayloadIngest) {
+      if (!StringUtil.isEmpty(ingestRequest.getPath()) && isPayloadIngest) {
         errors.rejectValue(
             "path", "PathIsPresent", "Path should not be specified when ingesting from an array");
       }
@@ -62,12 +62,12 @@ public class IngestRequestValidator implements Validator {
       }
     } else if (target instanceof BulkLoadRequestModel bulkLoadRequestModel) {
       if (bulkLoadRequestModel.isBulkMode()
-          && StringUtils.isEmpty(bulkLoadRequestModel.getLoadTag())) {
+          && StringUtil.isEmpty(bulkLoadRequestModel.getLoadTag())) {
         errors.rejectValue("loadTag", "MissingLoadTag", "Load tag is required for isBulkMode");
       }
     } else if (target instanceof BulkLoadArrayRequestModel bulkLoadArrayRequestModel) {
       if (bulkLoadArrayRequestModel.isBulkMode()
-          && StringUtils.isEmpty(bulkLoadArrayRequestModel.getLoadTag())) {
+          && StringUtil.isEmpty(bulkLoadArrayRequestModel.getLoadTag())) {
         errors.rejectValue("loadTag", "MissingLoadTag", "Load tag is required for isBulkMode");
       }
     }

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep.java
@@ -14,7 +14,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import java.util.List;
 import java.util.UUID;
-import liquibase.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep extends De
         f -> {
           Blob sourceBlob = GcsPdao.getBlobFromGsPath(storage, f.getGspath(), projectId);
           f.checksumMd5(sourceBlob.getMd5ToHexString());
-          if (StringUtil.isEmpty(f.getChecksumMd5())) {
+          if (StringUtils.isEmpty(f.getChecksumMd5())) {
             logger.warn("File {} has no MD5", f.getGspath());
           }
         });

--- a/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/upgrade/predictableFileIds/ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep.java
@@ -14,7 +14,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import java.util.List;
 import java.util.UUID;
-import liquibase.util.StringUtils;
+import liquibase.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class ConvertToPredictableFileIdsUpdateMissingMd5ChecksumsStep extends De
         f -> {
           Blob sourceBlob = GcsPdao.getBlobFromGsPath(storage, f.getGspath(), projectId);
           f.checksumMd5(sourceBlob.getMd5ToHexString());
-          if (StringUtils.isEmpty(f.getChecksumMd5())) {
+          if (StringUtil.isEmpty(f.getChecksumMd5())) {
             logger.warn("File {} has no MD5", f.getGspath());
           }
         });

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import bio.terra.common.category.Unit;
 import java.util.Arrays;
 import java.util.Collections;
-import liquibase.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.test.context.ActiveProfiles;
@@ -43,7 +43,7 @@ public class ValidationUtilsTest {
   @Test
   public void testDescriptionFormats() throws Exception {
     assertThat(ValidationUtils.isValidDescription("somedescription")).isTrue();
-    assertThat(ValidationUtils.isValidDescription(StringUtil.repeat("X", 5_000))).isFalse();
+    assertThat(ValidationUtils.isValidDescription(StringUtils.repeat("X", 5_000))).isFalse();
   }
 
   @Test

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import bio.terra.common.category.Unit;
 import java.util.Arrays;
 import java.util.Collections;
-import liquibase.util.StringUtils;
+import liquibase.util.StringUtil;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.test.context.ActiveProfiles;
@@ -43,7 +43,7 @@ public class ValidationUtilsTest {
   @Test
   public void testDescriptionFormats() throws Exception {
     assertThat(ValidationUtils.isValidDescription("somedescription")).isTrue();
-    assertThat(ValidationUtils.isValidDescription(StringUtils.repeat("X", 5_000))).isFalse();
+    assertThat(ValidationUtils.isValidDescription(StringUtil.repeat("X", 5_000))).isFalse();
   }
 
   @Test


### PR DESCRIPTION
I recommend going through this PR commit by commit, as I did some cleanup in the build.gradle that is harder to read.

Included changes:
* [Standardize to single quotes and gradle short reference format](https://github.com/DataBiosphere/jade-data-repo/pull/1567/commits/b4983186b67f91f0bedd09dd3553134bd871454c) [Note: Double quotes are used to evaluate expression while single quotes are static ([details](https://stackoverflow.com/questions/15171049/gradle-single-vs-double-quotes)) We tend to switch back and forth arbitrarily, so I was just hoping to make this a little easier to read.]
* Unpin Liquibase-core - this upgrades liquibase-core from 3.8.0 to 4.9.1.
* Switch to using apache common's StringUtils instead of liquibase StringUtil
* Unpin Postgres- This upgrades postgres from 42.2.18 to 42.3.8
* Upgrade Google BOM from 26.26.0 to 26.29.0