### PR TITLE
[DC-801] Added createdBy in EnumerateSnapshotRequest

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -66,8 +66,7 @@ public class SnapshotBuilderService {
               .createdDate(response.getCreatedDate())
               .name(response.getSnapshotName())
               .researchPurpose(response.getSnapshotResearchPurpose())
-              .createdBy(response.getCreatedBy())
-      );
+              .createdBy(response.getCreatedBy()));
     }
     return enumerateModel;
   }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -65,7 +65,9 @@ public class SnapshotBuilderService {
               .status(response.getStatus())
               .createdDate(response.getCreatedDate())
               .name(response.getSnapshotName())
-              .researchPurpose(response.getSnapshotResearchPurpose()));
+              .researchPurpose(response.getSnapshotResearchPurpose())
+              .createdBy(response.getCreatedBy())
+      );
     }
     return enumerateModel;
   }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7152,6 +7152,7 @@ components:
         - createdDate
         - name
         - researchPurpose
+        - createdBy
       properties:
         id:
           $ref: '#/components/schemas/UniqueIdProperty'
@@ -7162,6 +7163,8 @@ components:
         name:
           type: string
         researchPurpose:
+          type: string
+        createdBy:
           type: string
 
     SnapshotAccessRequestResponse:

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -57,7 +57,8 @@ class SnapshotBuilderServiceTest {
             .status(responseItem.getStatus())
             .createdDate(responseItem.getCreatedDate())
             .name(responseItem.getSnapshotName())
-            .researchPurpose(responseItem.getSnapshotResearchPurpose());
+            .researchPurpose(responseItem.getSnapshotResearchPurpose())
+            .createdBy(responseItem.getCreatedBy());
     EnumerateSnapshotAccessRequest expected =
         new EnumerateSnapshotAccessRequest().addItemsItem(expectedItem);
 


### PR DESCRIPTION
In order to include the user that created the snapshot request in the results, we have to add the `SnapshotAccessRequestResponse ` `createdBy` field to the EnumerateSnapshotAccessRequestItem in `convertToEnumerateModel()`. The addition of the `createdBy` field can be seen in the .yaml file!

Jira Ticket - https://broadworkbench.atlassian.net/browse/DC-801

