### PR TITLE
[DC-780]Update RenderSQL to generate full table names for Big Query

### DIFF
--- a/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
+++ b/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
@@ -21,10 +21,11 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
   @Override
   public String visitTable_expr(SQLParser.Table_exprContext ctx) {
     String datasetName = getNameFromContext(ctx.dataset_name());
+    String bqDatasetName = prefixDatasetName(datasetName);
     DatasetModel dataset = getDatasetByName(datasetName);
     String tableName = getNameFromContext(ctx.table_name());
-    String bqTableName = generateTableName(dataset, tableName);
-    String alias = generateAlias(bqTableName, tableName);
+    String bqTableName = generateTableName(dataset, datasetName, tableName);
+    String alias = generateAlias(bqDatasetName, tableName);
     return String.format("%s AS `%s`", bqTableName, alias);
   }
 
@@ -38,12 +39,17 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
   }
 
   public static TableNameGenerator bqTableName(DatasetModel dataset) {
-    return (tableName) -> generateTableName(dataset, tableName);
+    return (tableName) -> generateTableName(dataset, dataset.getName(), tableName);
   }
 
-  private static String generateTableName(DatasetModel dataset, String tableName) {
+  private static String generateTableName(
+      DatasetModel dataset, String datasetName, String tableName) {
     String dataProjectId = dataset.getDataProject();
-    String bqDatasetName = PdaoConstant.PDAO_PREFIX + dataset.getName();
+    String bqDatasetName = prefixDatasetName(datasetName);
     return String.format("`%s.%s.%s`", dataProjectId, bqDatasetName, tableName);
+  }
+
+  private static String prefixDatasetName(String datasetName) {
+    return PdaoConstant.PDAO_PREFIX + datasetName;
   }
 }

--- a/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
+++ b/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
@@ -4,9 +4,9 @@ import bio.terra.common.PdaoConstant;
 import bio.terra.grammar.DatasetAwareVisitor;
 import bio.terra.grammar.SQLParser;
 import bio.terra.model.DatasetModel;
+import bio.terra.service.snapshotbuilder.query.TableNameGenerator;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 
 public class BigQueryVisitor extends DatasetAwareVisitor {
 
@@ -37,7 +37,7 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
     return String.format("`%s`.%s", alias, columnName);
   }
 
-  public static Function<String, String> bqTableName(DatasetModel dataset) {
+  public static TableNameGenerator bqTableName(DatasetModel dataset) {
     return (tableName) -> generateTableName(dataset, tableName);
   }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/TableNameGenerator.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/TableNameGenerator.java
@@ -1,0 +1,5 @@
+package bio.terra.service.snapshotbuilder.query;
+
+public interface TableNameGenerator {
+  String generate(String tableName);
+}

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/TablePointer.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/TablePointer.java
@@ -1,19 +1,17 @@
 package bio.terra.service.snapshotbuilder.query;
 
 import java.util.List;
-import java.util.function.Function;
 
 public record TablePointer(
-    String tableName, Filter filter, String sql, Function<String, String> generateTableName)
+    String tableName, Filter filter, String sql, TableNameGenerator generateTableName)
     implements SqlExpression {
 
-  public static TablePointer fromTableName(
-      String tableName, Function<String, String> generateTableName) {
+  public static TablePointer fromTableName(String tableName, TableNameGenerator generateTableName) {
     return new TablePointer(tableName, null, null, generateTableName);
   }
 
   public static TablePointer fromRawSql(String sql) {
-    return new TablePointer(null, null, sql, Function.identity());
+    return new TablePointer(null, null, sql, s -> s);
   }
 
   @Override
@@ -22,7 +20,7 @@ public record TablePointer(
       return "(" + sql + ")";
     }
     if (filter == null) {
-      return generateTableName.apply(tableName);
+      return generateTableName.generate(tableName);
     }
 
     TablePointer tablePointerWithoutFilter =

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/TablePointer.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/TablePointer.java
@@ -7,10 +7,6 @@ public record TablePointer(
     String tableName, Filter filter, String sql, Function<String, String> generateTableName)
     implements SqlExpression {
 
-  public static TablePointer fromTableName(String tableName) {
-    return new TablePointer(tableName, null, null, Function.identity());
-  }
-
   public static TablePointer fromTableName(
       String tableName, Function<String, String> generateTableName) {
     return new TablePointer(tableName, null, null, generateTableName);

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/FieldPointerTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/FieldPointerTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.is;
 import bio.terra.common.category.Unit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +14,7 @@ class FieldPointerTest {
 
   @Test
   void buildVariable() {
-    TablePointer table = new TablePointer("table", null, null, Function.identity());
+    TablePointer table = QueryTestUtils.fromTableName("table");
     var fieldPointer = FieldPointer.allFields(table);
     TableVariable primaryTable = TableVariable.forPrimary(table);
     var fieldVariable = fieldPointer.buildVariable(primaryTable, null);
@@ -25,7 +24,7 @@ class FieldPointerTest {
 
   @Test
   void buildVariableForeign() {
-    TablePointer table = new TablePointer("table", null, null, Function.identity());
+    TablePointer table = QueryTestUtils.fromTableName("table");
     var fieldPointer = FieldPointer.foreignColumn(table, "column");
     TableVariable primaryTable = TableVariable.forPrimary(table);
     List<TableVariable> tables = new ArrayList<>();

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/FieldPointerTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/FieldPointerTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import bio.terra.common.category.Unit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +15,7 @@ class FieldPointerTest {
 
   @Test
   void buildVariable() {
-    TablePointer table = new TablePointer("table", null, null);
+    TablePointer table = new TablePointer("table", null, null, Function.identity());
     var fieldPointer = FieldPointer.allFields(table);
     TableVariable primaryTable = TableVariable.forPrimary(table);
     var fieldVariable = fieldPointer.buildVariable(primaryTable, null);
@@ -24,7 +25,7 @@ class FieldPointerTest {
 
   @Test
   void buildVariableForeign() {
-    TablePointer table = new TablePointer("table", null, null);
+    TablePointer table = new TablePointer("table", null, null, Function.identity());
     var fieldPointer = FieldPointer.foreignColumn(table, "column");
     TableVariable primaryTable = TableVariable.forPrimary(table);
     List<TableVariable> tables = new ArrayList<>();

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/FieldVariableTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/FieldVariableTest.java
@@ -14,7 +14,7 @@ class FieldVariableTest {
 
   @Test
   void renderSQL() {
-    var table = TablePointer.fromTableName("table");
+    var table = QueryTestUtils.fromTableName("table");
 
     var fieldPointer = new FieldPointer(table, "field");
     var tableVariable = TableVariable.forPrimary(table);
@@ -40,7 +40,7 @@ class FieldVariableTest {
 
   @Test
   void renderSqlForOrderBy() {
-    var table = TablePointer.fromTableName("table");
+    var table = QueryTestUtils.fromTableName("table");
     var tableVariable = TableVariable.forPrimary(table);
     TableVariable.generateAliases(List.of(tableVariable));
     var fieldVariableFunctionWrapper =
@@ -50,7 +50,7 @@ class FieldVariableTest {
 
   @Test
   void renderSqlForWhere() {
-    TablePointer table = TablePointer.fromTableName("table");
+    TablePointer table = QueryTestUtils.fromTableName("table");
     var fieldPointer = new FieldPointer(table, "field");
     var tableVariable = TableVariable.forPrimary(table);
     TableVariable.generateAliases(List.of(tableVariable));
@@ -70,7 +70,7 @@ class FieldVariableTest {
     assertThat(new FieldVariable(fieldPointer, null).getAliasOrColumnName(), is("foo"));
     assertThat(new FieldVariable(fieldPointer, null, "bar").getAliasOrColumnName(), is("bar"));
     var fieldPointerForeignKey =
-        FieldPointer.foreignColumn(TablePointer.fromTableName(null), "baz");
+        FieldPointer.foreignColumn(QueryTestUtils.fromTableName(null), "baz");
     assertThat(new FieldVariable(fieldPointerForeignKey, null).getAliasOrColumnName(), is("baz"));
   }
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/OrderByVariableTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/OrderByVariableTest.java
@@ -14,7 +14,7 @@ class OrderByVariableTest {
 
   @NotNull
   private static FieldVariable createVariable() {
-    TablePointer table = TablePointer.fromTableName("table");
+    TablePointer table = QueryTestUtils.fromTableName("table");
     TableVariable tableVariable = TableVariable.forPrimary(table);
     var fieldVariable = new FieldVariable(new FieldPointer(table, "column"), tableVariable);
     TableVariable.generateAliases(List.of(tableVariable));

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -5,10 +5,15 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+import bio.terra.common.PdaoConstant;
 import bio.terra.common.category.Unit;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetModel;
 import bio.terra.service.snapshotbuilder.query.filtervariable.BinaryFilterVariable;
 import bio.terra.service.snapshotbuilder.query.filtervariable.BooleanAndOrFilterVariable;
+import bio.terra.service.snapshotbuilder.query.filtervariable.SubQueryFilterVariable;
 import java.util.List;
+import java.util.function.Function;
 import javax.validation.constraints.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -121,5 +126,53 @@ public class QueryTest {
             containsString(
                 "(c.condition_concept_id = 316139 OR c0.ancestor_concept_id = 316139 OR c.condition_concept_id = 4311280 OR c0.ancestor_concept_id = 4311280)"),
             containsString("AND p.year_of_birth < 1983")));
+  }
+
+  @Test
+  void renderSQLWithDatasetModel() {
+    DatasetModel dataset =
+        new DatasetModel().name("name").dataProject("project").cloudPlatform(CloudPlatform.GCP);
+    TablePointer conceptTablePointer =
+        new TablePointer("concept", null, null, generateTableName(dataset));
+    TableVariable conceptTableVariable = TableVariable.forPrimary(conceptTablePointer);
+    FieldPointer nameFieldPointer = new FieldPointer(conceptTablePointer, "concept_name");
+    FieldVariable nameFieldVariable = new FieldVariable(nameFieldPointer, conceptTableVariable);
+    FieldPointer idFieldPointer = new FieldPointer(conceptTablePointer, "concept_id");
+    FieldVariable idFieldVariable = new FieldVariable(idFieldPointer, conceptTableVariable);
+
+    TablePointer tablePointer =
+        new TablePointer("concept_ancestor", null, null, generateTableName(dataset));
+    TableVariable tableVariable = TableVariable.forPrimary(tablePointer);
+    FieldPointer fieldPointer = new FieldPointer(tablePointer, "descendant_concept_id");
+    FieldVariable fieldVariable = new FieldVariable(fieldPointer, tableVariable);
+    BinaryFilterVariable whereClause =
+        new BinaryFilterVariable(
+            new FieldVariable(new FieldPointer(tablePointer, "ancestor_concept_id"), tableVariable),
+            BinaryFilterVariable.BinaryOperator.EQUALS,
+            new Literal(100));
+    Query subQuery = new Query(List.of(fieldVariable), List.of(tableVariable), whereClause);
+    SubQueryFilterVariable subQueryFilterVariable =
+        new SubQueryFilterVariable(idFieldVariable, SubQueryFilterVariable.Operator.IN, subQuery);
+    Query query =
+        new Query(
+            List.of(nameFieldVariable, idFieldVariable),
+            List.of(conceptTableVariable),
+            subQueryFilterVariable);
+    String sql = query.renderSQL();
+    assertThat(
+        sql,
+        is(
+            "SELECT c.concept_name, c.concept_id FROM `project.datarepo_name.concept` AS c "
+                + "WHERE c.concept_id IN "
+                + "(SELECT c.descendant_concept_id FROM `project.datarepo_name.concept_ancestor` AS c "
+                + "WHERE c.ancestor_concept_id = 100)"));
+  }
+
+  public static Function<String, String> generateTableName(DatasetModel dataset) {
+    return (tableName) -> {
+      String dataProjectId = dataset.getDataProject();
+      String bqDatasetName = PdaoConstant.PDAO_PREFIX + dataset.getName();
+      return String.format("`%s.%s.%s`", dataProjectId, bqDatasetName, tableName);
+    };
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -5,15 +5,14 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-import bio.terra.common.PdaoConstant;
 import bio.terra.common.category.Unit;
+import bio.terra.grammar.google.BigQueryVisitor;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.DatasetModel;
 import bio.terra.service.snapshotbuilder.query.filtervariable.BinaryFilterVariable;
 import bio.terra.service.snapshotbuilder.query.filtervariable.BooleanAndOrFilterVariable;
 import bio.terra.service.snapshotbuilder.query.filtervariable.SubQueryFilterVariable;
 import java.util.List;
-import java.util.function.Function;
 import javax.validation.constraints.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -133,7 +132,7 @@ public class QueryTest {
     DatasetModel dataset =
         new DatasetModel().name("name").dataProject("project").cloudPlatform(CloudPlatform.GCP);
     TablePointer conceptTablePointer =
-        new TablePointer("concept", null, null, generateTableName(dataset));
+        new TablePointer("concept", null, null, BigQueryVisitor.bqTableName(dataset));
     TableVariable conceptTableVariable = TableVariable.forPrimary(conceptTablePointer);
     FieldPointer nameFieldPointer = new FieldPointer(conceptTablePointer, "concept_name");
     FieldVariable nameFieldVariable = new FieldVariable(nameFieldPointer, conceptTableVariable);
@@ -141,7 +140,7 @@ public class QueryTest {
     FieldVariable idFieldVariable = new FieldVariable(idFieldPointer, conceptTableVariable);
 
     TablePointer tablePointer =
-        new TablePointer("concept_ancestor", null, null, generateTableName(dataset));
+        new TablePointer("concept_ancestor", null, null, BigQueryVisitor.bqTableName(dataset));
     TableVariable tableVariable = TableVariable.forPrimary(tablePointer);
     FieldPointer fieldPointer = new FieldPointer(tablePointer, "descendant_concept_id");
     FieldVariable fieldVariable = new FieldVariable(fieldPointer, tableVariable);
@@ -166,13 +165,5 @@ public class QueryTest {
                 + "WHERE c.concept_id IN "
                 + "(SELECT c.descendant_concept_id FROM `project.datarepo_name.concept_ancestor` AS c "
                 + "WHERE c.ancestor_concept_id = 100)"));
-  }
-
-  public static Function<String, String> generateTableName(DatasetModel dataset) {
-    return (tableName) -> {
-      String dataProjectId = dataset.getDataProject();
-      String bqDatasetName = PdaoConstant.PDAO_PREFIX + dataset.getName();
-      return String.format("`%s.%s.%s`", dataProjectId, bqDatasetName, tableName);
-    };
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -23,7 +23,7 @@ public class QueryTest {
 
   @NotNull
   public static Query createQuery() {
-    TablePointer tablePointer = TablePointer.fromTableName("table");
+    TablePointer tablePointer = QueryTestUtils.fromTableName("table");
     TableVariable tableVariable = TableVariable.forPrimary(tablePointer);
     return new Query(
         List.of(new FieldVariable(FieldPointer.allFields(tablePointer), tableVariable)),
@@ -37,7 +37,7 @@ public class QueryTest {
 
   @Test
   void renderSqlGroupBy() {
-    TablePointer tablePointer = TablePointer.fromTableName("table");
+    TablePointer tablePointer = QueryTestUtils.fromTableName("table");
     TableVariable tableVariable = TableVariable.forPrimary(tablePointer);
     FieldPointer fieldPointer = new FieldPointer(tablePointer, "field");
     FieldVariable fieldVariable = new FieldVariable(fieldPointer, tableVariable);
@@ -47,17 +47,17 @@ public class QueryTest {
 
   @Test
   void renderComplexSQL() {
-    TablePointer tablePointer = TablePointer.fromTableName("person");
+    TablePointer tablePointer = QueryTestUtils.fromTableName("person");
     TableVariable tableVariable = TableVariable.forPrimary(tablePointer);
 
-    TablePointer conditionOccurrencePointer = TablePointer.fromTableName("condition_occurrence");
+    TablePointer conditionOccurrencePointer = QueryTestUtils.fromTableName("condition_occurrence");
     TableVariable conditionOccurrenceVariable =
         TableVariable.forJoined(
             conditionOccurrencePointer,
             "person_id",
             new FieldVariable(new FieldPointer(tablePointer, "person_id"), tableVariable));
 
-    TablePointer conditionAncestorPointer = TablePointer.fromTableName("condition_ancestor");
+    TablePointer conditionAncestorPointer = QueryTestUtils.fromTableName("condition_ancestor");
     TableVariable conditionAncestorVariable =
         TableVariable.forJoined(
             conditionAncestorPointer,

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTestUtils.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTestUtils.java
@@ -1,0 +1,9 @@
+package bio.terra.service.snapshotbuilder.query;
+
+import java.util.function.Function;
+
+public class QueryTestUtils {
+  public static TablePointer fromTableName(String tableName) {
+    return TablePointer.fromTableName(tableName, Function.identity());
+  }
+}

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTestUtils.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTestUtils.java
@@ -1,9 +1,7 @@
 package bio.terra.service.snapshotbuilder.query;
 
-import java.util.function.Function;
-
 public class QueryTestUtils {
   public static TablePointer fromTableName(String tableName) {
-    return TablePointer.fromTableName(tableName, Function.identity());
+    return TablePointer.fromTableName(tableName, s -> s);
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/TablePointerTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/TablePointerTest.java
@@ -7,7 +7,6 @@ import bio.terra.common.category.Unit;
 import bio.terra.grammar.google.BigQueryVisitor;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.DatasetModel;
-import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -17,8 +16,7 @@ class TablePointerTest {
   @Test
   void renderSQL() {
     var tablePointer =
-        new TablePointer(
-            "table", (primaryTable, tables) -> () -> "filter", null, Function.identity());
+        new TablePointer("table", (primaryTable, tables) -> () -> "filter", null, s -> s);
     assertThat(tablePointer.renderSQL(), is("(SELECT t.* FROM table AS t WHERE filter)"));
   }
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/TablePointerTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/TablePointerTest.java
@@ -4,6 +4,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import bio.terra.common.category.Unit;
+import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetModel;
+import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +16,23 @@ class TablePointerTest {
   @Test
   void renderSQL() {
     var tablePointer =
-        new TablePointer("table", (primaryTable, tables) -> (FilterVariable) () -> "filter", null);
+        new TablePointer(
+            "table", (primaryTable, tables) -> () -> "filter", null, Function.identity());
     assertThat(tablePointer.renderSQL(), is("(SELECT t.* FROM table AS t WHERE filter)"));
+  }
+
+  @Test
+  void renderSQLWithDatasetModel() {
+    DatasetModel dataset =
+        new DatasetModel().name("name").dataProject("project").cloudPlatform(CloudPlatform.GCP);
+    var tablePointer =
+        new TablePointer(
+            "table",
+            (primaryTable, tables) -> () -> "filter",
+            null,
+            QueryTest.generateTableName(dataset));
+    assertThat(
+        tablePointer.renderSQL(),
+        is("(SELECT t.* FROM `project.datarepo_name.table` AS t WHERE filter)"));
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/TablePointerTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/TablePointerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import bio.terra.common.category.Unit;
+import bio.terra.grammar.google.BigQueryVisitor;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.DatasetModel;
 import java.util.function.Function;
@@ -30,7 +31,7 @@ class TablePointerTest {
             "table",
             (primaryTable, tables) -> () -> "filter",
             null,
-            QueryTest.generateTableName(dataset));
+            BigQueryVisitor.bqTableName(dataset));
     assertThat(
         tablePointer.renderSQL(),
         is("(SELECT t.* FROM `project.datarepo_name.table` AS t WHERE filter)"));

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/TableVariableTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/TableVariableTest.java
@@ -13,19 +13,19 @@ class TableVariableTest {
 
   @Test
   void renderSQLForPrimary() {
-    TableVariable tableVariable = TableVariable.forPrimary(TablePointer.fromTableName("table"));
+    TableVariable tableVariable = TableVariable.forPrimary(QueryTestUtils.fromTableName("table"));
     TableVariable.generateAliases(List.of(tableVariable));
     assertThat(tableVariable.renderSQL(), equalToIgnoringCase("table as t"));
   }
 
   @Test
   void renderSQLForJoined() {
-    TablePointer parentTable = TablePointer.fromTableName("parentTable");
+    TablePointer parentTable = QueryTestUtils.fromTableName("parentTable");
     TableVariable parentTableVariable = TableVariable.forPrimary(parentTable);
     FieldVariable joinFieldOnParent =
         new FieldVariable(
             new FieldPointer(parentTable, "parentJoinField"), parentTableVariable, null);
-    TablePointer tablePointer = TablePointer.fromTableName("table");
+    TablePointer tablePointer = QueryTestUtils.fromTableName("table");
     TableVariable tableVariable =
         TableVariable.forJoined(tablePointer, "joinField", joinFieldOnParent);
     TableVariable.generateAliases(List.of(tableVariable, parentTableVariable));

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/BinaryFilterVariableTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/BinaryFilterVariableTest.java
@@ -10,6 +10,7 @@ import bio.terra.service.snapshotbuilder.query.Literal;
 import bio.terra.service.snapshotbuilder.query.TablePointer;
 import bio.terra.service.snapshotbuilder.query.TableVariable;
 import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +21,8 @@ class BinaryFilterVariableTest {
   void renderSQL() {
     var binaryOperator = BinaryFilterVariable.BinaryOperator.EQUALS;
     var literal = new Literal("foo");
-    TableVariable tableVariable = TableVariable.forPrimary(new TablePointer("table", null, null));
+    TableVariable tableVariable =
+        TableVariable.forPrimary(new TablePointer("table", null, null, Function.identity()));
     TableVariable.generateAliases(List.of(tableVariable));
     var filterVariable =
         new BinaryFilterVariable(

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/BinaryFilterVariableTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/BinaryFilterVariableTest.java
@@ -7,10 +7,9 @@ import bio.terra.common.category.Unit;
 import bio.terra.service.snapshotbuilder.query.FieldPointer;
 import bio.terra.service.snapshotbuilder.query.FieldVariable;
 import bio.terra.service.snapshotbuilder.query.Literal;
-import bio.terra.service.snapshotbuilder.query.TablePointer;
+import bio.terra.service.snapshotbuilder.query.QueryTestUtils;
 import bio.terra.service.snapshotbuilder.query.TableVariable;
 import java.util.List;
-import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -21,8 +20,7 @@ class BinaryFilterVariableTest {
   void renderSQL() {
     var binaryOperator = BinaryFilterVariable.BinaryOperator.EQUALS;
     var literal = new Literal("foo");
-    TableVariable tableVariable =
-        TableVariable.forPrimary(new TablePointer("table", null, null, Function.identity()));
+    TableVariable tableVariable = TableVariable.forPrimary(QueryTestUtils.fromTableName("table"));
     TableVariable.generateAliases(List.of(tableVariable));
     var filterVariable =
         new BinaryFilterVariable(

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/BooleanAndOrFilterVariableTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/BooleanAndOrFilterVariableTest.java
@@ -7,7 +7,7 @@ import bio.terra.common.category.Unit;
 import bio.terra.service.snapshotbuilder.query.FieldPointer;
 import bio.terra.service.snapshotbuilder.query.FieldVariable;
 import bio.terra.service.snapshotbuilder.query.Literal;
-import bio.terra.service.snapshotbuilder.query.TablePointer;
+import bio.terra.service.snapshotbuilder.query.QueryTestUtils;
 import bio.terra.service.snapshotbuilder.query.TableVariable;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
@@ -19,8 +19,8 @@ class BooleanAndOrFilterVariableTest {
   private final BooleanAndOrFilterVariable variable;
 
   BooleanAndOrFilterVariableTest() {
-    TableVariable table1 = TableVariable.forPrimary(TablePointer.fromTableName("table1"));
-    TableVariable table2 = TableVariable.forPrimary(TablePointer.fromTableName("table2"));
+    TableVariable table1 = TableVariable.forPrimary(QueryTestUtils.fromTableName("table1"));
+    TableVariable table2 = TableVariable.forPrimary(QueryTestUtils.fromTableName("table2"));
     TableVariable.generateAliases(List.of(table1, table2));
     variable =
         new BooleanAndOrFilterVariable(

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/FunctionFilterVariableTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/FunctionFilterVariableTest.java
@@ -7,7 +7,7 @@ import bio.terra.common.category.Unit;
 import bio.terra.service.snapshotbuilder.query.FieldPointer;
 import bio.terra.service.snapshotbuilder.query.FieldVariable;
 import bio.terra.service.snapshotbuilder.query.Literal;
-import bio.terra.service.snapshotbuilder.query.TablePointer;
+import bio.terra.service.snapshotbuilder.query.QueryTestUtils;
 import bio.terra.service.snapshotbuilder.query.TableVariable;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
@@ -18,7 +18,7 @@ class FunctionFilterVariableTest {
 
   @Test
   void renderSQL() {
-    TableVariable table = TableVariable.forPrimary(TablePointer.fromTableName("table"));
+    TableVariable table = TableVariable.forPrimary(QueryTestUtils.fromTableName("table"));
     TableVariable.generateAliases(List.of(table));
     var filterVariable =
         new FunctionFilterVariable(

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/SubQueryFilterVariableTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/filtervariable/SubQueryFilterVariableTest.java
@@ -7,7 +7,7 @@ import bio.terra.common.category.Unit;
 import bio.terra.service.snapshotbuilder.query.FieldPointer;
 import bio.terra.service.snapshotbuilder.query.FieldVariable;
 import bio.terra.service.snapshotbuilder.query.QueryTest;
-import bio.terra.service.snapshotbuilder.query.TablePointer;
+import bio.terra.service.snapshotbuilder.query.QueryTestUtils;
 import bio.terra.service.snapshotbuilder.query.TableVariable;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
@@ -21,7 +21,7 @@ class SubQueryFilterVariableTest {
     var subQuery = QueryTest.createQuery();
 
     var fieldPointer = new FieldPointer(null, "field");
-    var tableVariable = TableVariable.forPrimary(TablePointer.fromTableName("x"));
+    var tableVariable = TableVariable.forPrimary(QueryTestUtils.fromTableName("x"));
     TableVariable.generateAliases(List.of(tableVariable));
     var fieldVariable = new FieldVariable(fieldPointer, tableVariable);
     var filter =


### PR DESCRIPTION
Background:
As a part of https://broadworkbench.atlassian.net/browse/DC-780 sql table names need to be prefixed for Azure and GCP. This PR is an intermediate step in the solution for that ticket. 

Changes: 
https://broadworkbench.atlassian.net/browse/DC-803 
Update renderSQL to generate full table names to be used for big query and azure. Right now tests include generating full table names for big query only. The solution takes a function object that generates the full table name so it is generalizable for Azure as well. But the function object for Azure has not yet been created.
