### PR TITLE
[DC-756] Add type for domain criteria

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7321,7 +7321,7 @@ components:
         - $ref: '#/components/schemas/SnapshotBuilderCriteria'
         - type: object
           properties:
-            domain:
+            domainName:
               type: string
       description: Selection of a domain concept id, part of a CriteriaGroup.
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7292,7 +7292,7 @@ components:
         mapping:
           list: '#/components/schemas/SnapshotBuilderProgramDataListCriteria'
           range: '#/components/schemas/SnapshotBuilderProgramDataRangeCriteria'
-          domain: '#/components/schemas/SnapshotBuilderCriteria'
+          domain: '#/components/schemas/SnapshotBuilderDomainCriteria'
 
     SnapshotBuilderProgramDataListCriteria:
       allOf:
@@ -7315,6 +7315,15 @@ components:
             high:
               type: number
       description: Range format program data, part of a CriteriaGroup.
+
+    SnapshotBuilderDomainCriteria:
+      allOf:
+        - $ref: '#/components/schemas/SnapshotBuilderCriteria'
+        - type: object
+          properties:
+            domain:
+              type: string
+      description: Selection of a domain concept id, part of a CriteriaGroup.
 
     DuosFirecloudGroupModel:
       type: object

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -11,6 +11,7 @@ import bio.terra.model.SnapshotBuilderConcept;
 import bio.terra.model.SnapshotBuilderCriteria;
 import bio.terra.model.SnapshotBuilderCriteriaGroup;
 import bio.terra.model.SnapshotBuilderDatasetConceptSet;
+import bio.terra.model.SnapshotBuilderDomainCriteria;
 import bio.terra.model.SnapshotBuilderDomainOption;
 import bio.terra.model.SnapshotBuilderFeatureValueGroup;
 import bio.terra.model.SnapshotBuilderProgramDataListCriteria;
@@ -131,7 +132,7 @@ public class SnapshotBuilderTestData {
                     new SnapshotBuilderProgramDataListCriteria()
                         .kind(SnapshotBuilderCriteria.KindEnum.LIST))
                 .addCriteriaItem(
-                    new SnapshotBuilderCriteria().kind(SnapshotBuilderCriteria.KindEnum.DOMAIN))
+                    new SnapshotBuilderDomainCriteria().domain("condition").kind(SnapshotBuilderCriteria.KindEnum.DOMAIN))
                 .addCriteriaItem(
                     new SnapshotBuilderProgramDataRangeCriteria()
                         .kind(SnapshotBuilderCriteria.KindEnum.RANGE)));

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -132,7 +132,9 @@ public class SnapshotBuilderTestData {
                     new SnapshotBuilderProgramDataListCriteria()
                         .kind(SnapshotBuilderCriteria.KindEnum.LIST))
                 .addCriteriaItem(
-                    new SnapshotBuilderDomainCriteria().domain("condition").kind(SnapshotBuilderCriteria.KindEnum.DOMAIN))
+                    new SnapshotBuilderDomainCriteria()
+                        .domain("condition")
+                        .kind(SnapshotBuilderCriteria.KindEnum.DOMAIN))
                 .addCriteriaItem(
                     new SnapshotBuilderProgramDataRangeCriteria()
                         .kind(SnapshotBuilderCriteria.KindEnum.RANGE)));

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -133,7 +133,7 @@ public class SnapshotBuilderTestData {
                         .kind(SnapshotBuilderCriteria.KindEnum.LIST))
                 .addCriteriaItem(
                     new SnapshotBuilderDomainCriteria()
-                        .domain("condition")
+                        .domainName("condition")
                         .kind(SnapshotBuilderCriteria.KindEnum.DOMAIN))
                 .addCriteriaItem(
                     new SnapshotBuilderProgramDataRangeCriteria()


### PR DESCRIPTION
This type is important for being able to identify the occurrence table for a domain criteria entry. With the cross section of the `id` and `domain`, we can probably generate something like: `SELECT * FROM {DOMAIN_OCCURRENCE_TABLE} WHERE {DOMAIN_CONCEPT_ID} = {id}`

This is important because without knowing the ID, we will have no clue where to go to look the entries up for people who have a relationship to the selected concept.