### PR TITLE
 [DR-3430] [CVE-2022-225857] Pin snakeyaml to 1.33

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,10 +174,6 @@ configurations {
     runtimeClasspath
 }
 
-// Fix for CVE-2023-1370 which identifies a vulnerability in json-smart 2.4.8
-// 2.4.9 fixes the vulnerability and 2.4.10 fixes an additional bug
-// This override can be removed when we upgrade to spring-boot v2.6.15+, v2.7.10+, or v3.0.5+
-ext['json-smart.version'] = '2.4.10'
 // Fix for CVE-2022-25857 which identifies a vulnerability in snake-yaml 1.30
 // This override can likely be removed or bumped to 2.0 when we upgrade to spring boot 3
 ext['snakeyaml.version'] = '1.33'

--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,9 @@ configurations {
 // 2.4.9 fixes the vulnerability and 2.4.10 fixes an additional bug
 // This override can be removed when we upgrade to spring-boot v2.6.15+, v2.7.10+, or v3.0.5+
 ext['json-smart.version'] = '2.4.10'
+// Fix for CVE-2022-25857 which identifies a vulnerability in snake-yaml 1.30
+// This override can likely be removed or bumped to 2.0 when we upgrade to spring boot 3
+ext['snakeyaml.version'] = '1.33'
 
 dependencies {
     // TODO: Unpack the "starter" and include just what we use


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3430

This PR pins Spring Boot transitive dependency snakeyaml to 1.33 to address https://nvd.nist.gov/vuln/detail/CVE-2022-25857 (fixed in 1.31).

Bumping the pin any higher to 2.0 prevents TDR from running:
```
Caused by: java.lang.NoSuchMethodError: org.yaml.snakeyaml.constructor.SafeConstructor: method 'void <init>()' not found
        at liquibase.parser.core.yaml.YamlChangeLogParser.parse(YamlChangeLogParser.java:23)
        at liquibase.changelog.DatabaseChangeLog.include(DatabaseChangeLog.java:587)
        at liquibase.changelog.DatabaseChangeLog.handleChildNode(DatabaseChangeLog.java:363)
        at liquibase.changelog.DatabaseChangeLog.load(DatabaseChangeLog.java:318)
        at liquibase.parser.core.xml.AbstractChangeLogParser.parse(AbstractChangeLogParser.java:23)
        at liquibase.Liquibase.getDatabaseChangeLog(Liquibase.java:369)
```

We should reevaluate this pin after upgrading TDR to Spring Boot 3.

While here, I removed a pin of json-smart that was no longer needed, following our recent upgrade to Spring Boot 2.7.18 :tada: