### PR TITLE
DC-814: Retry on RBS handout resource; Fix deserialization error

### DIFF
--- a/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
+++ b/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
@@ -51,12 +51,10 @@ public class GetResourceBufferProjectStep implements Step {
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
-    } catch (BufferServiceAuthorizationException e) {
-      // If authorization fails, there is no recovering
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
-    } catch (GoogleResourceException e) {
-      // thrown on error when refoldering project
-      // We can consider retrying this if needed
+    } catch (BufferServiceAuthorizationException | GoogleResourceException e) {
+      // BufferServiceAuthorizationException - If authorization fails, there is no recovering
+      // GoogleResourceException - Thrown on error when refoldering project
+      // We can consider retrying this Google exception if needed
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
     }
   }

--- a/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
+++ b/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
@@ -47,7 +47,7 @@ public class GetResourceBufferProjectStep implements Step {
       // Add retry for internal server errors to help with test flakiness
       if (e.getStatusCode() == HttpStatus.NOT_FOUND
           || e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS
-          || e.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR) {
+          || e.getStatusCode().is5xxServerError()) {
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);

--- a/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
+++ b/src/main/java/bio/terra/common/GetResourceBufferProjectStep.java
@@ -44,8 +44,10 @@ public class GetResourceBufferProjectStep implements Step {
     } catch (BufferServiceAPIException e) {
       // The NOT_FOUND status code indicates that Buffer Service is still creating a project and we
       // must retry. Retrying TOO_MANY_REQUESTS gives the service time to recover from load.
+      // Add retry for internal server errors to help with test flakiness
       if (e.getStatusCode() == HttpStatus.NOT_FOUND
-          || e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+          || e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS
+          || e.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR) {
         return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
       }
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -91,7 +91,8 @@ public class DatasetCreateFlight extends Flight {
           new GetResourceBufferProjectStep(
               bufferService,
               googleResourceManagerService,
-              datasetRequest.isEnableSecureMonitoring()));
+              datasetRequest.isEnableSecureMonitoring()),
+          getDefaultExponentialBackoffRetryRule());
 
       // Get or initialize the project where the dataset resources will be created
       addStep(

--- a/src/main/java/bio/terra/service/job/StairwayExceptionSerializer.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionSerializer.java
@@ -12,7 +12,7 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 
 public class StairwayExceptionSerializer implements ExceptionSerializer {
-  private ObjectMapper objectMapper;
+  private final ObjectMapper objectMapper;
 
   public StairwayExceptionSerializer(ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;

--- a/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
@@ -104,14 +104,6 @@ public class BufferService {
       if (e.getCode() == HttpStatus.UNAUTHORIZED.value()) {
         throw new BufferServiceAuthorizationException("Not authorized to access Buffer Service", e);
       } else {
-        // TODO - remove this log
-        // Added to debug issue we're seeing 'Failed to construct exception' error on
-        // BufferServiceAPIException
-        logger.error(
-            "RBS ApiException on handoutResource; Response Body: "
-                + e.getResponseBody()
-                + "; Code: "
-                + e.getCode());
         throw new BufferServiceAPIException(e);
       }
     } catch (GeneralSecurityException e) {

--- a/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/BufferService.java
@@ -104,6 +104,14 @@ public class BufferService {
       if (e.getCode() == HttpStatus.UNAUTHORIZED.value()) {
         throw new BufferServiceAuthorizationException("Not authorized to access Buffer Service", e);
       } else {
+        // TODO - remove this log
+        // Added to debug issue we're seeing 'Failed to construct exception' error on
+        // BufferServiceAPIException
+        logger.error(
+            "RBS ApiException on handoutResource; Response Body: "
+                + e.getResponseBody()
+                + "; Code: "
+                + e.getCode());
         throw new BufferServiceAPIException(e);
       }
     } catch (GeneralSecurityException e) {

--- a/src/main/java/bio/terra/service/resourcemanagement/exception/BufferServiceAPIException.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/exception/BufferServiceAPIException.java
@@ -11,11 +11,17 @@ public class BufferServiceAPIException extends ErrorReportException {
 
   public BufferServiceAPIException(ApiException bufferException) {
     super(
-        "Error from Buffer Service: ",
+        "Error from Buffer Service",
         bufferException,
         Collections.singletonList(bufferException.getResponseBody()),
         HttpStatus.resolve(bufferException.getCode()));
     this.apiException = bufferException;
+  }
+
+  // Used to reconstruct error message when reading job result from stairway
+  public BufferServiceAPIException(String message) {
+    super(message);
+    this.apiException = null;
   }
 
   /** Get the HTTP status code of the underlying response from Buffer Service. */

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -141,7 +141,8 @@ public class SnapshotCreateFlight extends Flight {
           new GetResourceBufferProjectStep(
               bufferService,
               googleResourceManagerService,
-              sourceDataset.isSecureMonitoringEnabled()));
+              sourceDataset.isSecureMonitoringEnabled()),
+          getDefaultExponentialBackoffRetryRule());
 
       // Get or initialize the project where the snapshot resources will be created
       addStep(

--- a/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
@@ -1,7 +1,7 @@
 package bio.terra.service.job;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.resourcemanagement.exception.BufferServiceAPIException;

--- a/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
 
 import bio.terra.common.category.Unit;
+import bio.terra.service.resourcemanagement.exception.BufferServiceAPIException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -23,10 +24,26 @@ public class StairwayExceptionSerializerTest {
   }
 
   @Test
-  public void deserialize() {
+  public void deserializeDataRepoException() {
     var serializedException =
-        "{\"className\":\"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException\",\"message\":\"Error from Buffer Service\",\"errorDetails\":[\"The step failed for an unknown reason.\",\"Please contact the TDR team for help.\"],\"dataRepoException\":true}";
+        """
+        {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",
+        "errorDetails":["The step failed for an unknown reason.","Please contact the TDR team for help."],"dataRepoException":true}
+        """;
     var deserializedException = stairwayExceptionSerializer.deserialize(serializedException);
     assertThat(deserializedException.getMessage(), equalTo("Error from Buffer Service"));
+  }
+
+  @Test
+  public void deserializeErrorCode() {
+    var serializedException =
+        """
+        {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",
+        "errorDetails":["The step failed for an unknown reason.","Please contact the TDR team for help."],"dataRepoException":true,"apiErrorReportException":true,"errorCode":"429"}
+        """;
+    BufferServiceAPIException deserializedException =
+        (BufferServiceAPIException) stairwayExceptionSerializer.deserialize(serializedException);
+    assertThat(deserializedException.getMessage(), equalTo("Error from Buffer Service"));
+    assertThat(deserializedException.getApiExceptionStatus(), equalTo(429));
   }
 }

--- a/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
@@ -4,12 +4,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.buffer.client.ApiException;
 import bio.terra.common.category.Unit;
 import bio.terra.service.resourcemanagement.exception.BufferServiceAPIException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles({"google", "unittest"})
@@ -18,33 +20,45 @@ class StairwayExceptionSerializerTest {
 
   private StairwayExceptionSerializer stairwayExceptionSerializer;
 
+  private String serializedException;
+  private Exception originalException;
+
   @BeforeEach
   void setUp() {
     ObjectMapper objectMapper = new ApplicationConfiguration().objectMapper();
     stairwayExceptionSerializer = new StairwayExceptionSerializer(objectMapper);
+
+    originalException =
+        new BufferServiceAPIException(
+            new ApiException(
+                "No projects are available in the datarepo pool",
+                HttpStatus.NOT_FOUND.value(),
+                null,
+                null));
+    // Fake providing step info in stack trace
+    var fakeStackTrace =
+        new StackTraceElement(
+            "bio.terra.common.GetResourceBufferProjectStep",
+            "handoutResource",
+            "BufferService.java",
+            83);
+    originalException.setStackTrace(new StackTraceElement[] {fakeStackTrace});
+
+    serializedException = stairwayExceptionSerializer.serialize(originalException);
+  }
+
+  @Test
+  void serializeTest() {
+    assertThat(
+        serializedException,
+        equalTo(
+            """
+                {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service","errorDetails":[null],"dataRepoException":true}"""));
   }
 
   @Test
   void deserializeDataRepoException() {
-    var serializedException =
-        """
-        {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",
-        "errorDetails":["The step failed for an unknown reason.","Please contact the TDR team for help."],"dataRepoException":true}
-        """;
     var deserializedException = stairwayExceptionSerializer.deserialize(serializedException);
     assertThat(deserializedException.getMessage(), equalTo("Error from Buffer Service"));
-  }
-
-  @Test
-  void deserializeErrorCode() {
-    var serializedException =
-        """
-        {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",
-        "errorDetails":["The step failed for an unknown reason.","Please contact the TDR team for help."],"dataRepoException":true,"apiErrorReportException":true,"errorCode":"429"}
-        """;
-    BufferServiceAPIException deserializedException =
-        (BufferServiceAPIException) stairwayExceptionSerializer.deserialize(serializedException);
-    assertThat(deserializedException.getMessage(), equalTo("Error from Buffer Service"));
-    assertThat(deserializedException.getApiExceptionStatus(), equalTo(429));
   }
 }

--- a/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.job;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.common.category.Unit;
 import bio.terra.service.resourcemanagement.exception.BufferServiceAPIException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,7 +20,7 @@ public class StairwayExceptionSerializerTest {
 
   @BeforeEach
   void setUp() {
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = new ApplicationConfiguration().objectMapper();
     stairwayExceptionSerializer = new StairwayExceptionSerializer(objectMapper);
   }
 

--- a/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
@@ -7,28 +7,26 @@ import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.buffer.client.ApiException;
 import bio.terra.common.category.Unit;
 import bio.terra.service.resourcemanagement.exception.BufferServiceAPIException;
+import bio.terra.stairway.Step;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles({"google", "unittest"})
 @Tag(Unit.TAG)
 class StairwayExceptionSerializerTest {
 
   private StairwayExceptionSerializer stairwayExceptionSerializer;
 
   private String serializedException;
-  private Exception originalException;
 
   @BeforeEach
   void setUp() {
     ObjectMapper objectMapper = new ApplicationConfiguration().objectMapper();
     stairwayExceptionSerializer = new StairwayExceptionSerializer(objectMapper);
 
-    originalException =
+    var originalException =
         new BufferServiceAPIException(
             new ApiException(
                 "No projects are available in the datarepo pool",
@@ -36,13 +34,10 @@ class StairwayExceptionSerializerTest {
                 null,
                 null));
     // Fake providing step info in stack trace
-    var fakeStackTrace =
-        new StackTraceElement(
-            "bio.terra.common.GetResourceBufferProjectStep",
-            "handoutResource",
-            "BufferService.java",
-            83);
-    originalException.setStackTrace(new StackTraceElement[] {fakeStackTrace});
+    StackTraceElement[] fakeStackTrace = {
+      new StackTraceElement(Step.class.getName(), "method", "file", 0)
+    };
+    originalException.setStackTrace(fakeStackTrace);
 
     serializedException = stairwayExceptionSerializer.serialize(originalException);
   }

--- a/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles({"google", "unittest"})
 @Tag(Unit.TAG)
-public class StairwayExceptionSerializerTest {
+class StairwayExceptionSerializerTest {
 
   private StairwayExceptionSerializer stairwayExceptionSerializer;
 
@@ -25,7 +25,7 @@ public class StairwayExceptionSerializerTest {
   }
 
   @Test
-  public void deserializeDataRepoException() {
+  void deserializeDataRepoException() {
     var serializedException =
         """
         {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",
@@ -36,7 +36,7 @@ public class StairwayExceptionSerializerTest {
   }
 
   @Test
-  public void deserializeErrorCode() {
+  void deserializeErrorCode() {
     var serializedException =
         """
         {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",

--- a/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
@@ -1,0 +1,32 @@
+package bio.terra.service.job;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+
+import bio.terra.common.category.Unit;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"google", "unittest"})
+@Tag(Unit.TAG)
+public class StairwayExceptionSerializerTest {
+
+  private StairwayExceptionSerializer stairwayExceptionSerializer;
+
+  @BeforeEach
+  void setUp() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    stairwayExceptionSerializer = new StairwayExceptionSerializer(objectMapper);
+  }
+
+  @Test
+  public void deserialize() {
+    var serializedException =
+        "{\"className\":\"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException\",\"message\":\"Error from Buffer Service\",\"errorDetails\":[\"The step failed for an unknown reason.\",\"Please contact the TDR team for help.\"],\"dataRepoException\":true}";
+    var deserializedException = stairwayExceptionSerializer.deserialize(serializedException);
+    assertThat(deserializedException.getMessage(), equalTo("Error from Buffer Service"));
+  }
+}


### PR DESCRIPTION
## Background
[DR-3435](https://broadworkbench.atlassian.net/browse/DR-3435)
We're seeing some flakiness in our tests and there are some errors that indicate it's due to issues with RBS ([Resource Buffer Service](https://github.com/DataBiosphere/terra-resource-buffer)). We use a new google project per TDR resource, so we use RBS to stage pre-created google projects to then be assigned to a dataset or snapshot upon creation. 

Note: These errors are only showing up on our integration/RBS tools environment. I don't see any error messages on dev or production with similar messages. 

## Approach
There are two issues as described below. By adding a retry for issue 1, we should effectively no longer see issue 2. But, it would still be good to address this so that we can correctly retrieve this error as a job result.


# Issue 1: Flaky RBS handoutResource endpoint; The Fix: Retry on 404 and 429 Errors

### Retry on RBS Handout Resource
A retry on dataset and snapshot create's GetResourceBufferProjectStep has been added. I borrowed logic from [workspace-manger](https://github.com/DataBiosphere/terra-workspace-manager/blob/a376aad7a021f648d7d688ba9d0555ca54ff9f1a/service/src/main/java/bio/terra/workspace/service/workspace/flight/cloud/gcp/PullProjectFromPoolStep.java#L48) for when to catch and retry. 

Note: I think this logic will need to slightly change with the upgrade to spring boot 3, as we'll move from HttpStatus to HttpsStatusCode. 

**Q: Why do we need to add a retry on our end? Does RBS have any retries?**
Yes, it appears that RBS also has retries on their end. They retry 20 times with 2 second waits [here](https://github.com/DataBiosphere/terra-resource-buffer/blob/03aa4f55e48fdcbd4e24d35534338f0ddc7b1f21/src/main/java/bio/terra/buffer/service/pool/PoolService.java#L115).
This is potentially just not sufficient. An alternate approach here could be to make a change in RBS to increase the number of retries or wait time between retries. 


## Testing

With these changes in place, on a test run we had an instance of successful dataset creation after retry of the handout step.
<img width="1429" alt="image" src="https://github.com/DataBiosphere/jade-data-repo/assets/13254229/f868632e-9c6c-4d04-8a57-67e1d0fda60b">

This proves that on encountering a 404 error, a retry can allow a project to successfully get handed out and for the flight to succeed.
The encountered error:
```
Caused by: bio.terra.buffer.client.ApiException: {"message":"No resource is ready to use at this moment for pool: datarepo_v1. Please try later","statusCode":404,"causes":[]}
	at bio.terra.buffer.client.ApiClient.invokeAPI(ApiClient.java:743)
	at bio.terra.buffer.api.BufferApi.handoutResource(BufferApi.java:122)
	at bio.terra.service.resourcemanagement.BufferService.handoutResource(BufferService.java:84)
```

# Issue 2: Deserialize BufferServiceAPIException when reading stairway error result

### Error in question:
```
bio.terra.service.job.exception.ExceptionSerializerException: Failed to construct exception: bio.terra.service.resourcemanagement.exception.BufferServiceAPIException; Exception message: Error from Buffer Service: 
	at bio.terra.service.job.StairwayExceptionSerializer.deserialize(StairwayExceptionSerializer.java:107)
	at bio.terra.stairway.impl.FlightDao.makeFlightStateList(FlightDao.java:981)
```

### Q: When do we see these `Failed to construct exception` errors?
When this sequence of events occurs:
- DatasetCreate flight fails due to 404 Error from RBS "No resource is ready to use at this moment for pool"
- This is recorded in the job result as a BufferServiceAPIException
- We then go to read the job result and stairway can't deserialize this exception, so we're actually getting the ExceptionSerializerException on hitting the getJobResult endpoint. This happens to also be the error that is bubbled up to the result for connected test failures. 

### Example:
Flight _MddrKGKR3eYzJLP3DG_Tg:
Fails due to 404 - "No resource is ready to use at this moment for pool"
<img width="1415" alt="image" src="https://github.com/DataBiosphere/jade-data-repo/assets/13254229/291f9cd4-a462-474b-9837-07be2be42ecf">

Then, the test checks the job result and it returns the `Failed to construct exception` error:
<img width="1135" alt="image" src="https://github.com/DataBiosphere/jade-data-repo/assets/13254229/c59b4e08-0c82-4257-a2b5-c19fc12d3da9">

### Debugging

This error is originates in the StairwayExceptionSerializer.deserialize(), so I added some logs to understand what was happening in this method. 

We read out the serialized error message from the stairway postgres database. It looks something like the following:

> "{\"className\":\"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException\",\"message\":\"Error from Buffer Service\",\"errorDetails\":[\"The step failed for an unknown reason.\",\"Please contact the TDR team for help.\"],\"dataRepoException\":true}";

In StairwayExceptionSerializer.deserialize(), we try to build an Exception class from this string twice. And if it doesn't work out, we throw the above exception.

[simplified version of the code]
```
deserialize(String seralizedStringFromStairwayDB) {

    // retrieve class name from string
   StairwayExceptionFields fields = objectMapper.readValue(serializedException, StairwayExceptionFields.class);
   Class<?> clazz = Class.forName(fields.getClassName());

   // Is there a constructor for this class with two arguments: string & a list?
   Constructor<?> ctor = clazz.getConstructor(String.class, List.class);
   // catch exception if not; continue

   // Is there a constructor for this class with one argument: a string?
   Constructor<?> ctor = clazz.getConstructor(String.class);
  // If not, throw exception 
}
```

`BufferServiceAPIException` had neither of these options, so it ended up throwing the exception.
Solution: Add constructor with just a string as a parameter!

**Question**: Why doesn't it automatically pick up the constructor that does this in ErrorReportException?
**Answer**: " Constructors are not members, so they are not inherited by subclasses, but the constructor of the superclass can be invoked from the subclass." ([source](https://docs.oracle.com/javase/tutorial/java/IandI/subclasses.html#:~:text=Constructors%20are%20not%20members%2C%20so,be%20invoked%20from%20the%20subclass.))

Note: Moving work towards surfacing the status code and more details from exceptions to a new PR - https://github.com/DataBiosphere/jade-data-repo/pull/1585

### Testing
**Unit Test**
I was able to reproduce the error and the fix with a unit test.

**In action**
During the last test run of this PR, connected tests failed with 500 error from RBS. We correctly received the RBS error, NOT the "failed to construct exception." 
<img width="1136" alt="image" src="https://github.com/DataBiosphere/jade-data-repo/assets/13254229/7be7ef3a-c14b-43a8-a8c5-559d70fe1182">

*This does bring into question our retry: Should we also retry on 500 exceptions from RBS in order to have less flakiness in our tests?
___________
# Are we fixing the test flakiness issue?
So, we've added a retry on 403 & 409s, but on this PR we've still seen many connected tests fail with 500 errors. So, have we actually fixed the test flakiness with this PR?

Example errors that we're still seeing: 
<img width="1046" alt="image" src="https://github.com/DataBiosphere/jade-data-repo/assets/13254229/ac19d3a7-233c-4985-ad34-83f368c8c4cd">


**Would adding a retry on 500 errors help?**
- Running tests to see if we can reproduce with a retry on the 500 errors
