### PR TITLE
[DR-3436] TDR's nightly dev integration tests shouldn't block release

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -308,12 +308,3 @@ jobs:
           username: "Data Repo tests"
           text: "Nightly Unit, Connected and Integration tests"
           fields: ${{ env.SLACK_FIELDS }}
-      - name: "Notify QA Slack on nightly test run"
-        if: ${{ github.event_name == 'schedule' && always() }}
-        uses: broadinstitute/action-slack@v3.15.0
-        with:
-          status: ${{ env.RUN_STATUS }}
-          channel: "#dsde-qa"
-          username: "Data Repo tests"
-          text: "Nightly Unit, Connected and Integration tests"
-          fields: ${{ env.SLACK_FIELDS }}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3436

We have [confirmed with QA](https://broadinstitute.slack.com/archives/C53JYBV9A/p1706134176186459) that TDR’s nightly unit, connected, and integration tests (dev environment) do not need to be considered a release blocker.  Example:

https://broadinstitute.slack.com/archives/C53JYBV9A/p1706077370117829

Justification:
- These tests already must pass on PRs before merge
- We have a suite of [smoke tests that run on staging](https://beehive.dsp-devops.broadinstitute.org/environments/staging/chart-releases/datarepo/deploy-hooks) as a deploy hook: historically, any major issues have been caught by these smoke tests

So I have removed the Slack alert to #dsde-qa for this test run.