### PR TITLE
DC-824: Fix the liquibase plugin config in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -317,8 +317,9 @@ dependencies {
     // Findbugs annotations, so we can selectively suppress findbugs findings
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
 
-    liquibaseRuntime 'org.liquibase:liquibase-core:4.9.1'
-    liquibaseRuntime 'org.postgresql:postgresql:42.3.8'
+    liquibaseRuntime 'org.liquibase:liquibase-core'
+    liquibaseRuntime 'org.postgresql:postgresql'
+    liquibaseRuntime 'info.picocli:picocli:4.6.1'
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.0-M1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -317,9 +317,9 @@ dependencies {
     // Findbugs annotations, so we can selectively suppress findbugs findings
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
 
-    liquibaseRuntime 'org.liquibase:liquibase-core'
+    liquibaseRuntime 'org.liquibase:liquibase-core:4.25.1'
     liquibaseRuntime 'org.postgresql:postgresql'
-    liquibaseRuntime 'info.picocli:picocli:4.6.1'
+    liquibaseRuntime 'info.picocli:picocli:4.7.5'
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.0-M1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
The liquibase gradle plugin isn't used as part of our build, so it's easy for it to stop working without us noticing. This fixes it so it works again. Its main use is as a quick way to test out liquibase changes locally or reset both the datarepo and stairway databases locally.

See [DATABASE.md](https://github.com/DataBiosphere/jade-data-repo/blob/develop/DATABASE.md) and https://docs.google.com/document/d/1hxT7ZOAY4MKPhjoLLZNJE4IB_3WncsDDYEg8m1myL-I for more information on running the liquibase plugin.