### PR TITLE
[DRAFT] Can we pass more exception details to the user?

### DIFF
--- a/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
+++ b/src/main/java/bio/terra/app/controller/ApiValidationExceptionHandler.java
@@ -76,9 +76,13 @@ public class ApiValidationExceptionHandler extends ResponseEntityExceptionHandle
     final List<String> details;
     Throwable rootCause = ExceptionUtils.getRootCause(ex);
 
-    if (rootCause instanceof ErrorReportException) {
+    if (rootCause instanceof ErrorReportException rootErrorReportException) {
       message = rootCause.getMessage();
-      details = ((ErrorReportException) rootCause).getCauses();
+      details = rootErrorReportException.getCauses();
+      if (rootCause.getCause() != null) {
+        details.add(rootCause.getCause().getMessage());
+      }
+      details.removeIf(StringUtils::isEmpty);
     } else {
       message = status + " - see error details";
       details = Collections.singletonList(rootCause.getMessage());

--- a/src/main/java/bio/terra/app/controller/exception/TooManyRequestsException.java
+++ b/src/main/java/bio/terra/app/controller/exception/TooManyRequestsException.java
@@ -1,10 +1,16 @@
 package bio.terra.app.controller.exception;
 
 import bio.terra.common.exception.ErrorReportException;
+import java.util.List;
+import org.springframework.http.HttpStatus;
 
 /** This exception maps to HttpStatus.TOO_MANY_REQUESTS in the GlobalExceptionHandler. */
 public class TooManyRequestsException extends ErrorReportException {
   public TooManyRequestsException(String message) {
     super(message);
+  }
+
+  public TooManyRequestsException(String message, List<String> causes, HttpStatus status) {
+    super(message, causes, status);
   }
 }

--- a/src/main/java/bio/terra/app/controller/exception/TooManyRequestsException.java
+++ b/src/main/java/bio/terra/app/controller/exception/TooManyRequestsException.java
@@ -10,6 +10,7 @@ public class TooManyRequestsException extends ErrorReportException {
     super(message);
   }
 
+  // Used to reconstruct error message when reading job result from stairway
   public TooManyRequestsException(String message, List<String> causes, HttpStatus status) {
     super(message, causes, status);
   }

--- a/src/main/java/bio/terra/common/ExceptionUtils.java
+++ b/src/main/java/bio/terra/common/ExceptionUtils.java
@@ -12,14 +12,18 @@ public class ExceptionUtils {
    * @return A human-readable version of the object
    */
   public static String formatException(final Exception exception) {
-    if (exception instanceof ErrorReportException) {
+    if (exception instanceof ErrorReportException errorReportException) {
       // Bypass the toString that ErrorReportException has intercepted.
       // Copied from Throwable.toString
       final String className = exception.getClass().getName();
       String message = exception.getLocalizedMessage();
       String mainMessage = (message != null) ? (className + ": " + message) : className;
 
-      List<String> causes = ((ErrorReportException) exception).getCauses();
+      List<String> causes = errorReportException.getCauses();
+      if (errorReportException.getCause() != null) {
+        causes.add(errorReportException.getCause().getMessage());
+      }
+
       return String.format(
           "%s%s",
           mainMessage,

--- a/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateException.java
+++ b/src/main/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateException.java
@@ -3,6 +3,7 @@ package bio.terra.service.dataset.flight.update;
 import bio.terra.common.exception.ErrorReportException;
 import java.util.List;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.http.HttpStatus;
 
 public class DatasetSchemaUpdateException extends ErrorReportException {
 
@@ -12,5 +13,9 @@ public class DatasetSchemaUpdateException extends ErrorReportException {
 
   public DatasetSchemaUpdateException(String message, @Nullable List<String> causes) {
     super(message, causes, null);
+  }
+
+  public DatasetSchemaUpdateException(String message, List<String> causes, HttpStatus status) {
+    super(message, causes, status);
   }
 }

--- a/src/main/java/bio/terra/service/job/StairwayExceptionFields.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionFields.java
@@ -4,10 +4,12 @@ import java.util.List;
 
 // POJO for serializing one level of exception into JSON
 public class StairwayExceptionFields {
+  private boolean apiErrorReportException;
   private boolean isDataRepoException;
   private String className;
   private String message;
   private List<String> errorDetails;
+  private int errorCode;
 
   public boolean isDataRepoException() {
     return isDataRepoException;
@@ -42,6 +44,24 @@ public class StairwayExceptionFields {
 
   public StairwayExceptionFields setErrorDetails(List<String> errorDetails) {
     this.errorDetails = errorDetails;
+    return this;
+  }
+
+  public boolean isApiErrorReportException() {
+    return apiErrorReportException;
+  }
+
+  public StairwayExceptionFields setApiErrorReportException(boolean apiErrorReportException) {
+    this.apiErrorReportException = apiErrorReportException;
+    return this;
+  }
+
+  public int getErrorCode() {
+    return errorCode;
+  }
+
+  public StairwayExceptionFields setErrorCode(int errorCode) {
+    this.errorCode = errorCode;
     return this;
   }
 }

--- a/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
@@ -9,8 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
 public class StairwayExceptionFieldsFactory {

--- a/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
@@ -5,13 +5,15 @@ import bio.terra.service.job.exception.ExceptionSerializerException;
 import bio.terra.service.job.exception.JobExecutionException;
 import bio.terra.service.job.exception.StepExecutionException;
 import bio.terra.stairway.Step;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
 public class StairwayExceptionFieldsFactory {
-
   private static final String CONTACT_TEAM_MESSAGE = "Please contact Terra Support for help.";
 
   public static StairwayExceptionFields fromException(Exception ex) {
@@ -96,15 +98,19 @@ public class StairwayExceptionFieldsFactory {
   }
 
   private static List<String> getErrorReportExceptionCauses(Exception exception) {
-    if (ErrorReportException.class.isAssignableFrom(exception.getClass())) {
-      // Java 17 will make casting unnecessary
-      ErrorReportException errorReportException = (ErrorReportException) exception;
+    if (exception instanceof ErrorReportException errorReportException) {
+      List<String> causes = new ArrayList<>();
       if (!errorReportException.getCauses().isEmpty()) {
-        return errorReportException.getCauses();
+        causes.addAll(errorReportException.getCauses());
       }
+      if (errorReportException.getCause() != null) {
+        causes.add(errorReportException.getCause().getMessage());
+      }
+      causes.removeIf(StringUtils::isEmpty);
+      return causes;
     } else if (StringUtils.isNotEmpty(exception.getMessage())) {
       return List.of(exception.getMessage());
     }
-    return null;
+    return List.of();
   }
 }

--- a/src/main/java/bio/terra/service/policy/exception/PolicyServiceApiException.java
+++ b/src/main/java/bio/terra/service/policy/exception/PolicyServiceApiException.java
@@ -3,6 +3,7 @@ package bio.terra.service.policy.exception;
 import bio.terra.common.exception.ErrorReportException;
 import bio.terra.policy.client.ApiException;
 import java.util.Collections;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 
 /** Wrapper exception for non-200 responses from calls to Terra Policy Service. */
@@ -14,5 +15,9 @@ public class PolicyServiceApiException extends ErrorReportException {
         ex,
         Collections.singletonList(ex.getResponseBody()),
         HttpStatus.resolve(ex.getCode()));
+  }
+
+  public PolicyServiceApiException(String message, List<String> causes, HttpStatus status) {
+    super(message, causes, status);
   }
 }

--- a/src/main/java/bio/terra/service/policy/exception/PolicyServiceApiException.java
+++ b/src/main/java/bio/terra/service/policy/exception/PolicyServiceApiException.java
@@ -17,6 +17,7 @@ public class PolicyServiceApiException extends ErrorReportException {
         HttpStatus.resolve(ex.getCode()));
   }
 
+  // Used to reconstruct error message when reading job result from stairway
   public PolicyServiceApiException(String message, List<String> causes, HttpStatus status) {
     super(message, causes, status);
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/exception/BufferServiceAPIException.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/exception/BufferServiceAPIException.java
@@ -18,7 +18,14 @@ public class BufferServiceAPIException extends ErrorReportException {
         HttpStatus.resolve(bufferException.getCode()));
     this.apiException = bufferException;
   }
-  
+
+
+  // Used to reconstruct error message when reading job result from stairway
+  public BufferServiceAPIException(String message, List<String> causes, HttpStatus status) {
+    super(message, causes, status);
+    this.apiException = new ApiException(status.value(), message, null, null);
+  }
+
   /** Get the HTTP status code of the underlying response from Buffer Service. */
   public int getApiExceptionStatus() {
     if (apiException == null) {

--- a/src/main/java/bio/terra/service/resourcemanagement/exception/BufferServiceAPIException.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/exception/BufferServiceAPIException.java
@@ -3,6 +3,7 @@ package bio.terra.service.resourcemanagement.exception;
 import bio.terra.buffer.client.ApiException;
 import bio.terra.common.exception.ErrorReportException;
 import java.util.Collections;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 
 /** Wrapper exception for non-200 responses from calls to Buffer Service. */
@@ -17,9 +18,12 @@ public class BufferServiceAPIException extends ErrorReportException {
         HttpStatus.resolve(bufferException.getCode()));
     this.apiException = bufferException;
   }
-
+  
   /** Get the HTTP status code of the underlying response from Buffer Service. */
   public int getApiExceptionStatus() {
+    if (apiException == null) {
+      return HttpStatus.INTERNAL_SERVER_ERROR.value();
+    }
     return apiException.getCode();
   }
 }

--- a/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
@@ -1,0 +1,49 @@
+package bio.terra.service.job;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.resourcemanagement.exception.BufferServiceAPIException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"google", "unittest"})
+@Tag(Unit.TAG)
+public class StairwayExceptionSerializerTest {
+
+  private StairwayExceptionSerializer stairwayExceptionSerializer;
+
+  @BeforeEach
+  void setUp() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    stairwayExceptionSerializer = new StairwayExceptionSerializer(objectMapper);
+  }
+
+  @Test
+  public void deserializeDataRepoException() {
+    var serializedException =
+        """
+        {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",
+        "errorDetails":["The step failed for an unknown reason.","Please contact the TDR team for help."],"dataRepoException":true}
+        """;
+    var deserializedException = stairwayExceptionSerializer.deserialize(serializedException);
+    assertThat(deserializedException.getMessage(), equalTo("Error from Buffer Service"));
+  }
+
+  @Test
+  public void deserializeErrorCode() {
+    var serializedException =
+        """
+        {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",
+        "errorDetails":["The step failed for an unknown reason.","Please contact the TDR team for help."],"dataRepoException":true,"apiErrorReportException":true,"errorCode":"429"}
+        """;
+    BufferServiceAPIException deserializedException =
+        (BufferServiceAPIException) stairwayExceptionSerializer.deserialize(serializedException);
+    assertThat(deserializedException.getMessage(), equalTo("Error from Buffer Service"));
+    assertThat(deserializedException.getApiExceptionStatus(), equalTo(429));
+  }
+}

--- a/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionSerializerTest.java
@@ -1,49 +1,73 @@
 package bio.terra.service.job;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
 
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.buffer.client.ApiException;
 import bio.terra.common.category.Unit;
 import bio.terra.service.resourcemanagement.exception.BufferServiceAPIException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles({"google", "unittest"})
 @Tag(Unit.TAG)
-public class StairwayExceptionSerializerTest {
+class StairwayExceptionSerializerTest {
 
   private StairwayExceptionSerializer stairwayExceptionSerializer;
 
+  private String serializedException;
+  private Exception originalException;
+
   @BeforeEach
   void setUp() {
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = new ApplicationConfiguration().objectMapper();
     stairwayExceptionSerializer = new StairwayExceptionSerializer(objectMapper);
+
+    originalException =
+        new BufferServiceAPIException(
+            new ApiException(
+                "No projects are available in the datarepo pool",
+                HttpStatus.NOT_FOUND.value(),
+                null,
+                null));
+    // Fake providing step info in stack trace
+    var fakeStackTrace =
+        new StackTraceElement(
+            "bio.terra.common.GetResourceBufferProjectStep",
+            "handoutResource",
+            "BufferService.java",
+            83);
+    originalException.setStackTrace(new StackTraceElement[] {fakeStackTrace});
+
+    serializedException = stairwayExceptionSerializer.serialize(originalException);
   }
 
   @Test
-  public void deserializeDataRepoException() {
-    var serializedException =
-        """
-        {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",
-        "errorDetails":["The step failed for an unknown reason.","Please contact the TDR team for help."],"dataRepoException":true}
-        """;
+  void serializeTest() {
+    assertThat(
+        serializedException,
+        equalTo(
+            """
+                {"apiErrorReportException":true,"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service","errorDetails":["No projects are available in the datarepo pool"],"errorCode":404,"dataRepoException":true}"""));
+  }
+
+  @Test
+  void deserializeDataRepoException() {
     var deserializedException = stairwayExceptionSerializer.deserialize(serializedException);
     assertThat(deserializedException.getMessage(), equalTo("Error from Buffer Service"));
-  }
-
-  @Test
-  public void deserializeErrorCode() {
-    var serializedException =
-        """
-        {"className":"bio.terra.service.resourcemanagement.exception.BufferServiceAPIException","message":"Error from Buffer Service",
-        "errorDetails":["The step failed for an unknown reason.","Please contact the TDR team for help."],"dataRepoException":true,"apiErrorReportException":true,"errorCode":"429"}
-        """;
-    BufferServiceAPIException deserializedException =
-        (BufferServiceAPIException) stairwayExceptionSerializer.deserialize(serializedException);
-    assertThat(deserializedException.getMessage(), equalTo("Error from Buffer Service"));
-    assertThat(deserializedException.getApiExceptionStatus(), equalTo(429));
+    assertThat(deserializedException instanceof BufferServiceAPIException, equalTo(true));
+    assertThat(
+        "Error code is correctly returned",
+        ((BufferServiceAPIException) deserializedException).getApiExceptionStatus(),
+        equalTo(404));
+    assertThat(
+        "Error details are correctly returned",
+        ((BufferServiceAPIException) deserializedException).getCauses().get(0),
+        equalTo(originalException.getCause().getMessage()));
   }
 }


### PR DESCRIPTION
We have long complained of error messages getting passed to users. It appears this was on purpose - The following is a comment in our codebase:
 
>  This error handler logs the complete error list so we can debug the underlying causes of errors. We do not want to return that to the client, but need it for our own debugging.

I've found that at least in some exceptions, the exception information lives in the "cause". The list of causes can often be empty. 