### PR TITLE
[DR-3442] Add a timeout to firestore future execution

### DIFF
--- a/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
@@ -119,6 +119,9 @@ public class ApplicationConfiguration {
   /** Sizes of batches of query results from firestore */
   private int firestoreQueryBatchSize;
 
+  /** Maximum time that a request to Firestore should take */
+  private int firestoreFutureTimeoutSeconds;
+
   /** Time in seconds of auth cache timeout */
   private int authCacheTimeoutSeconds;
 
@@ -312,6 +315,14 @@ public class ApplicationConfiguration {
 
   public void setFirestoreQueryBatchSize(int firestoreQueryBatchSize) {
     this.firestoreQueryBatchSize = firestoreQueryBatchSize;
+  }
+
+  public int getFirestoreFutureTimeoutSeconds() {
+    return firestoreFutureTimeoutSeconds;
+  }
+
+  public void setFirestoreFutureTimeoutSeconds(int firestoreFutureTimeoutSeconds) {
+    this.firestoreFutureTimeoutSeconds = firestoreFutureTimeoutSeconds;
   }
 
   public int getAuthCacheTimeoutSeconds() {

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -46,6 +46,8 @@ public class FireStoreUtils {
   public static final int MAX_FIRESTORE_BATCH_SIZE = 500;
 
   private final ConfigurationService configurationService;
+  // The number of seconds to wait for a Firestore future to complete. Having an explicit timeout
+  // avoids jobs getting deadlocked forever which has been known to happen
   private final long futureTimoutSeconds;
 
   @Autowired

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -2,6 +2,7 @@ package bio.terra.service.filedata.google.firestore;
 
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_QUERY_BATCH_SIZE;
 
+import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -43,11 +45,14 @@ public class FireStoreUtils {
   // Firestore limits batches to 500
   public static final int MAX_FIRESTORE_BATCH_SIZE = 500;
 
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
+  private final long futureTimoutSeconds;
 
   @Autowired
-  public FireStoreUtils(ConfigurationService configurationService) {
+  public FireStoreUtils(
+      ConfigurationService configurationService, ApplicationConfiguration configuration) {
     this.configurationService = configurationService;
+    this.futureTimoutSeconds = configuration.getFirestoreFutureTimeoutSeconds();
   }
 
   public int getFirestoreRetries() {
@@ -254,14 +259,15 @@ public class FireStoreUtils {
         ApiFuture<T> future = futures.get(i);
         if (future != null) {
           try {
-            outputs.set(i, future.get());
+            outputs.set(i, future.get(futureTimoutSeconds, TimeUnit.SECONDS));
             completeCount++;
           } catch (DeadlineExceededException
               | UnavailableException
               | AbortedException
               | InternalException
               | StatusRuntimeException
-              | ExecutionException ex) {
+              | ExecutionException
+              | TimeoutException ex) {
             if (shouldRetry(ex, true)) {
               logger.warn(
                   "[batchOperation] Retry-able error in firestore future get - input: "
@@ -321,6 +327,7 @@ public class FireStoreUtils {
         || throwable instanceof StatusRuntimeException
         || throwable instanceof GoogleResourceException
         || throwable instanceof StorageException
+        || throwable instanceof TimeoutException
         || (isBatch && throwable instanceof AbortedException)) {
       return true;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -74,6 +74,7 @@ datarepo.firestoreSnapshotBatchSize=500
 datarepo.snapshotCacheSize=200
 datarepo.firestoreValidateBatchSize=500
 datarepo.firestoreQueryBatchSize=500
+datarepo.firestoreFutureTimeoutSeconds=120
 datarepo.authCacheTimeoutSeconds=60
 datarepo.gcs.bucket=broad-jade-dev-data
 datarepo.gcs.region=us-central1

--- a/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
@@ -44,7 +44,7 @@ public class BatchOperationTest {
         new ConfigurationService(
             samConfiguration, gcsConfiguration, resourceConfiguration, appConfiguration);
 
-    fireStoreUtils = new FireStoreUtils(configurationService);
+    fireStoreUtils = new FireStoreUtils(configurationService, appConfiguration);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FakeApiFuture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FakeApiFuture.java
@@ -1,14 +1,12 @@
 package bio.terra.service.filedata.google.firestore;
 
-import static io.grpc.Status.Code.DEADLINE_EXCEEDED;
-
 import com.google.api.core.ApiFuture;
-import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.rpc.DeadlineExceededException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.jetbrains.annotations.NotNull;
 
 // Fake future class testing fire store batchOperation.
 // This is not thread safe!
@@ -47,19 +45,15 @@ public class FakeApiFuture implements ApiFuture<String> {
 
   @Override
   public String get() throws InterruptedException, ExecutionException, DeadlineExceededException {
-    if (FakeApiFuture.shouldThrow()) {
-      throw new DeadlineExceededException(
-          "test",
-          new IllegalArgumentException("test"),
-          GrpcStatusCode.of(DEADLINE_EXCEEDED),
-          false);
-    }
-    return "abc";
+    throw new RuntimeException("TDR should only use the timeout version of get");
   }
 
   @Override
-  public String get(long timeout, TimeUnit unit)
+  public String get(long timeout, @NotNull TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return null;
+    if (FakeApiFuture.shouldThrow()) {
+      throw new TimeoutException("test");
+    }
+    return "abc";
   }
 }


### PR DESCRIPTION
This PR adds a new `firestoreFutureTimeoutSeconds` TDR property to TDR.  This will cause a running Firestore operation to timeout after the specified time. The default is 120 seconds which should be largely enough for any single given Firestore operation.

This will help jobs to not become stuck which has been happening with greater frequency of late with bulk ingest.

I didn't really add any unit testing but I've been able to manually test in the wild with a dummy Firestore operation that I made take a long time and also was able to reproduce the blockage that Nate saw and the flight recovered nicely.

I've also followed Olivia's advice to break apart this change from adding an explicit executor (and other perf improvements) so that we can get this change in more quickly...there's some good news there but I want to take a little more time to do some more testing