### PR TITLE
[DC-756] fix bq count bug

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtils.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtils.java
@@ -21,7 +21,7 @@ public class AggregateBQQueryResultsUtils {
 
   public static List<Integer> rollupCountsMapper(TableResult result) {
     return StreamSupport.stream(result.iterateAll().spliterator(), false)
-        .map(row -> Integer.valueOf(row.get(0).getStringValue()))
+        .map(row -> (int) row.get(0).getLongValue())
         .toList();
   }
 }

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtils.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtils.java
@@ -21,7 +21,7 @@ public class AggregateBQQueryResultsUtils {
 
   public static List<Integer> rollupCountsMapper(TableResult result) {
     return StreamSupport.stream(result.iterateAll().spliterator(), false)
-        .map(row -> (Integer) row.get(0).getValue())
+        .map(row -> Integer.valueOf(row.get(0).getStringValue()))
         .toList();
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtilsTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtilsTest.java
@@ -26,7 +26,8 @@ class AggregateBQQueryResultsUtilsTest {
     Schema schema = Schema.of(Field.of("count_name", StandardSQLTypeName.INT64));
     Page<FieldValueList> page =
         BigQueryPdaoUnitTest.mockPage(
-            List.of(FieldValueList.of(List.of(FieldValue.of(FieldValue.Attribute.PRIMITIVE, 5)))));
+            List.of(
+                FieldValueList.of(List.of(FieldValue.of(FieldValue.Attribute.PRIMITIVE, "5")))));
 
     TableResult table = new TableResult(schema, 1, page);
     assertThat(


### PR DESCRIPTION
The default return value type for count from bq is actually a `String`, not a numeric value. However, if we use `getLongValue` rather than `getValue` then the BQ library handles the type conversion for us. Another option would be to `getNumericValue().intValue()`, but I thought this seemed cleaner/aligned with some other examples I saw in the codebase.