### PR TITLE
[DC-827] Use IDs rather than strings for domain and program data

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilder.java
@@ -41,10 +41,10 @@ public class CriteriaQueryBuilder {
           17, new OccurrenceTable("device_exposure", "device_concept_id"),
           13, new OccurrenceTable("drug_exposure", "drug_concept_id"));
 
-  private static OccurrenceTable getOccurrenceTableFromDomain(Integer domain) {
-    OccurrenceTable occurrenceTable = DOMAIN_TO_OCCURRENCE_TABLE.get(domain);
+  private static OccurrenceTable getOccurrenceTableFromDomain(int domainId) {
+    OccurrenceTable occurrenceTable = DOMAIN_TO_OCCURRENCE_TABLE.get(domainId);
     if (occurrenceTable == null) {
-      throw new BadRequestException(String.format("Domain %s is not found in dataset", domain));
+      throw new BadRequestException(String.format("Domain %s is not found in dataset", domainId));
     }
     return occurrenceTable;
   }
@@ -89,7 +89,7 @@ public class CriteriaQueryBuilder {
         listCriteria.getValues().stream().map(Literal::new).toArray(Literal[]::new));
   }
 
-  String getProgramDataOptionColumnName(Integer id) {
+  String getProgramDataOptionColumnName(int id) {
     return snapshotBuilderSettings.getProgramDataOptions().stream()
         .filter(programDataOption -> Objects.equals(programDataOption.getId(), id))
         .findFirst()

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilder.java
@@ -86,16 +86,15 @@ public class CriteriaQueryBuilder {
     return new FunctionFilterVariable(
         FunctionFilterVariable.FunctionTemplate.IN,
         getFieldVariableForRootTable(getProgramDataOptionColumnName(listCriteria.getId())),
-        listCriteria.getValues().stream()
-            .map(Literal::new)
-            .toArray(Literal[]::new));
+        listCriteria.getValues().stream().map(Literal::new).toArray(Literal[]::new));
   }
 
   String getProgramDataOptionColumnName(Integer id) {
     return snapshotBuilderSettings.getProgramDataOptions().stream()
         .filter(programDataOption -> Objects.equals(programDataOption.getId(), id))
         .findFirst()
-        .orElseThrow(() -> new BadRequestException(String.format("Invalid program data ID given: %d", id)))
+        .orElseThrow(
+            () -> new BadRequestException(String.format("Invalid program data ID given: %d", id)))
         .getColumnName();
   }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilder.java
@@ -95,7 +95,7 @@ public class CriteriaQueryBuilder {
     return snapshotBuilderSettings.getProgramDataOptions().stream()
         .filter(programDataOption -> Objects.equals(programDataOption.getId(), id))
         .findFirst()
-        .orElseThrow()
+        .orElseThrow(() -> new BadRequestException(String.format("Invalid program data ID given: %d", id)))
         .getColumnName();
   }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderFactory.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderFactory.java
@@ -1,12 +1,15 @@
 package bio.terra.service.snapshotbuilder.utils;
 
+import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.service.snapshotbuilder.query.TableNameGenerator;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CriteriaQueryBuilderFactory {
   public CriteriaQueryBuilder createCriteriaQueryBuilder(
-      String rootTableName, TableNameGenerator tableNameGenerator) {
-    return new CriteriaQueryBuilder(rootTableName, tableNameGenerator);
+      String rootTableName,
+      TableNameGenerator tableNameGenerator,
+      SnapshotBuilderSettings snapshotBuilderSettings) {
+    return new CriteriaQueryBuilder(rootTableName, tableNameGenerator, snapshotBuilderSettings);
   }
 }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7353,6 +7353,7 @@ components:
       type: object
       required:
         - kind
+        - id
       properties:
         kind:
           type: string
@@ -7360,7 +7361,8 @@ components:
         name:
           type: string
         id:
-          type: number
+          description: the ID of either the domain or program data entry
+          type: integer
       discriminator:
         propertyName: kind
         mapping:
@@ -7376,7 +7378,7 @@ components:
             values:
               type: array
               items:
-                type: number
+                type: integer
       description: List format program data, part of a CriteriaGroup.
 
     SnapshotBuilderProgramDataRangeCriteria:
@@ -7385,9 +7387,9 @@ components:
         - type: object
           properties:
             low:
-              type: number
+              type: integer
             high:
-              type: number
+              type: integer
       description: Range format program data, part of a CriteriaGroup.
 
     SnapshotBuilderDomainCriteria:
@@ -7395,8 +7397,8 @@ components:
         - $ref: '#/components/schemas/SnapshotBuilderCriteria'
         - type: object
           properties:
-            domainName:
-              type: string
+            conceptId:
+              type: integer
       description: Selection of a domain concept id, part of a CriteriaGroup.
 
     DuosFirecloudGroupModel:

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -47,6 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @Tag(Unit.TAG)
 class SnapshotBuilderServiceTest {
   @Mock private SnapshotRequestDao snapshotRequestDao;
+  @Mock private SnapshotBuilderSettingsDao snapshotBuilderSettingsDao;
   private SnapshotBuilderService snapshotBuilderService;
   @Mock private DatasetService datasetService;
   @Mock private BigQueryDatasetPdao bigQueryDatasetPdao;
@@ -61,6 +62,7 @@ class SnapshotBuilderServiceTest {
     snapshotBuilderService =
         new SnapshotBuilderService(
             snapshotRequestDao,
+            snapshotBuilderSettingsDao,
             datasetService,
             bigQueryDatasetPdao,
             azureSynapsePdao,
@@ -204,7 +206,7 @@ class SnapshotBuilderServiceTest {
             List.of(tableVariable));
     var criteriaQueryBuilderMock = mock(CriteriaQueryBuilder.class);
     when(datasetService.retrieve(dataset.getId())).thenReturn(dataset);
-    when(criteriaQueryBuilderFactory.createCriteriaQueryBuilder(any(), any()))
+    when(criteriaQueryBuilderFactory.createCriteriaQueryBuilder(any(), any(), any()))
         .thenReturn(criteriaQueryBuilderMock);
     when(criteriaQueryBuilderMock.generateRollupCountsQueryForCriteriaGroupsList(any()))
         .thenReturn(query);

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -130,6 +130,7 @@ public class SnapshotBuilderTestData {
             new SnapshotBuilderCriteriaGroup()
                 .addCriteriaItem(
                     new SnapshotBuilderProgramDataListCriteria()
+                        .id(0)
                         .kind(SnapshotBuilderCriteria.KindEnum.LIST))
                 .addCriteriaItem(
                     new SnapshotBuilderDomainCriteria()
@@ -137,6 +138,7 @@ public class SnapshotBuilderTestData {
                         .kind(SnapshotBuilderCriteria.KindEnum.DOMAIN))
                 .addCriteriaItem(
                     new SnapshotBuilderProgramDataRangeCriteria()
+                        .id(1)
                         .kind(SnapshotBuilderCriteria.KindEnum.RANGE)));
   }
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -133,7 +133,7 @@ public class SnapshotBuilderTestData {
                         .kind(SnapshotBuilderCriteria.KindEnum.LIST))
                 .addCriteriaItem(
                     new SnapshotBuilderDomainCriteria()
-                        .domainName("condition")
+                        .id(19)
                         .kind(SnapshotBuilderCriteria.KindEnum.DOMAIN))
                 .addCriteriaItem(
                     new SnapshotBuilderProgramDataRangeCriteria()

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
@@ -10,8 +10,11 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.model.SnapshotBuilderCriteria;
 import bio.terra.model.SnapshotBuilderCriteriaGroup;
 import bio.terra.model.SnapshotBuilderDomainCriteria;
+import bio.terra.model.SnapshotBuilderDomainOption;
 import bio.terra.model.SnapshotBuilderProgramDataListCriteria;
+import bio.terra.model.SnapshotBuilderProgramDataOption;
 import bio.terra.model.SnapshotBuilderProgramDataRangeCriteria;
+import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.service.snapshotbuilder.query.FilterVariable;
 import bio.terra.service.snapshotbuilder.query.Query;
 import java.math.BigDecimal;
@@ -27,9 +30,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class CriteriaQueryBuilderTest {
   CriteriaQueryBuilder criteriaQueryBuilder;
 
+  private static final SnapshotBuilderSettings SNAPSHOT_BUILDER_SETTINGS =
+      new SnapshotBuilderSettings()
+          .domainOptions(List.of(new SnapshotBuilderDomainOption().id(19)))
+          .programDataOptions(
+              List.of(
+                  new SnapshotBuilderProgramDataOption()
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.LIST)
+                      .columnName("list_column_name")
+                      .id(1),
+                  new SnapshotBuilderProgramDataOption()
+                      .kind(SnapshotBuilderProgramDataOption.KindEnum.RANGE)
+                      .columnName("range_column_name")
+                      .id(0)));
+
   @BeforeEach
   void setup() {
-    criteriaQueryBuilder = new CriteriaQueryBuilder("person", s -> s);
+    criteriaQueryBuilder = new CriteriaQueryBuilder("person", s -> s, SNAPSHOT_BUILDER_SETTINGS);
   }
 
   @Test
@@ -72,7 +89,8 @@ class CriteriaQueryBuilderTest {
 
   @Test
   void generateFilterForDomainCriteriaThrowsIfGivenUnknownDomain() {
-    SnapshotBuilderDomainCriteria domainCriteria = generateDomainCriteria().domainName("unknown");
+    SnapshotBuilderDomainCriteria domainCriteria =
+        (SnapshotBuilderDomainCriteria) generateDomainCriteria().id(1000);
     assertThrows(
         BadRequestException.class,
         () -> criteriaQueryBuilder.generateFilter(domainCriteria),
@@ -185,7 +203,7 @@ class CriteriaQueryBuilderTest {
   @Test
   void generateFilterForCriteriaGroups() {
     FilterVariable filterVariable =
-        new CriteriaQueryBuilder("person", null)
+        new CriteriaQueryBuilder("person", null, SNAPSHOT_BUILDER_SETTINGS)
             .generateFilterForCriteriaGroups(
                 List.of(
                     new SnapshotBuilderCriteriaGroup()
@@ -208,7 +226,7 @@ class CriteriaQueryBuilderTest {
   @Test
   void generateRollupCountsQueryForCriteriaGroupsList() {
     Query query =
-        new CriteriaQueryBuilder("person", s -> s)
+        new CriteriaQueryBuilder("person", s -> s, SNAPSHOT_BUILDER_SETTINGS)
             .generateRollupCountsQueryForCriteriaGroupsList(
                 List.of(
                     List.of(
@@ -218,7 +236,7 @@ class CriteriaQueryBuilderTest {
                                     generateDomainCriteria(),
                                     generateListCriteria(),
                                     generateRangeCriteria(),
-                                    generateDomainCriteria().domainName("Drug")))
+                                    generateDomainCriteria().id(13)))
                             .meetAll(true)
                             .mustMeet(true))));
     assertThat(
@@ -231,8 +249,8 @@ class CriteriaQueryBuilderTest {
   private static SnapshotBuilderDomainCriteria generateDomainCriteria() {
     return (SnapshotBuilderDomainCriteria)
         new SnapshotBuilderDomainCriteria()
-            .domainName("Condition")
-            .id(new BigDecimal(0))
+            .conceptId(0)
+            .id(19)
             .name("domain_column_name")
             .kind(SnapshotBuilderCriteria.KindEnum.DOMAIN);
   }
@@ -242,7 +260,7 @@ class CriteriaQueryBuilderTest {
         new SnapshotBuilderProgramDataRangeCriteria()
             .low(new BigDecimal(0))
             .high(new BigDecimal(100))
-            .id(new BigDecimal(0))
+            .id(0)
             .name("range_column_name")
             .kind(SnapshotBuilderCriteria.KindEnum.RANGE);
   }
@@ -251,7 +269,7 @@ class CriteriaQueryBuilderTest {
     return (SnapshotBuilderProgramDataListCriteria)
         new SnapshotBuilderProgramDataListCriteria()
             .values(List.of(new BigDecimal(0), new BigDecimal(1), new BigDecimal(2)))
-            .id(new BigDecimal(0))
+            .id(1)
             .name("list_column_name")
             .kind(SnapshotBuilderCriteria.KindEnum.LIST);
   }

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
@@ -17,7 +17,6 @@ import bio.terra.model.SnapshotBuilderProgramDataRangeCriteria;
 import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.service.snapshotbuilder.query.FilterVariable;
 import bio.terra.service.snapshotbuilder.query.Query;
-import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -258,8 +257,8 @@ class CriteriaQueryBuilderTest {
   private static SnapshotBuilderProgramDataRangeCriteria generateRangeCriteria() {
     return (SnapshotBuilderProgramDataRangeCriteria)
         new SnapshotBuilderProgramDataRangeCriteria()
-            .low(new BigDecimal(0))
-            .high(new BigDecimal(100))
+            .low(0)
+            .high(100)
             .id(0)
             .name("range_column_name")
             .kind(SnapshotBuilderCriteria.KindEnum.RANGE);
@@ -268,7 +267,7 @@ class CriteriaQueryBuilderTest {
   private static SnapshotBuilderProgramDataListCriteria generateListCriteria() {
     return (SnapshotBuilderProgramDataListCriteria)
         new SnapshotBuilderProgramDataListCriteria()
-            .values(List.of(new BigDecimal(0), new BigDecimal(1), new BigDecimal(2)))
+            .values(List.of(0, 1, 2))
             .id(1)
             .name("list_column_name")
             .kind(SnapshotBuilderCriteria.KindEnum.LIST);


### PR DESCRIPTION
This shifts us to passing up IDs for both programDataCriteria and domainCriteria - this is important because it allows us to:
1. Control input - if you can only pass up Integers than we don't need to worry as much about SQL Injection for these fields
2. Provide a source of truth that should be globally unique per type

I also shift from `number` to `integer` for many of our criteria entries, since that will help reduce boilerplate, and integer is more correct for the ID fields/entries.