### PR TITLE
DC-850: fix issue where datarepo-client subproject build was failing

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -29,12 +29,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
       - name: Checkout Develop branch of jade-data-repo
         uses: actions/checkout@v3
         with:
@@ -46,6 +40,12 @@ jobs:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
 #      - name: "Bump the tag to a new version"
 #        id: bumperstep
 #        uses: broadinstitute/datarepo-actions/actions/main@0.70.0

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -29,6 +29,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
       - name: Checkout Develop branch of jade-data-repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -21,8 +21,8 @@ on:
       - '.swagger-codegen-ignore'
 jobs:
   update_image:
-    outputs:
-      api_image_tag: ${{ steps.bumperstep.outputs.tag }}
+#    outputs:
+#      api_image_tag: ${{ steps.bumperstep.outputs.tag }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -40,121 +40,121 @@ jobs:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
-      - name: "Bump the tag to a new version"
-        id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-        with:
-          actions_subcommand: 'bumper'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-          version_file_path: build.gradle
-          version_variable_name: version
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+#      - name: "Bump the tag to a new version"
+#        id: bumperstep
+#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+#        with:
+#          actions_subcommand: 'bumper'
+#          role_id: ${{ secrets.ROLE_ID }}
+#          secret_id: ${{ secrets.SECRET_ID }}
+#          version_file_path: build.gradle
+#          version_variable_name: version
+#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
       - name: "Publish to Artifactory"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: ':datarepo-client:artifactoryPublish'
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
-      - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-        with:
-          actions_subcommand: 'gradlebuild'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-      - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-        with:
-          actions_subcommand: 'deploytagupdate'
-          helm_env_prefix: dev
-      - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
-        uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
-        with:
-          timeout_minutes: 1
-          polling_interval_seconds: 5
-          max_attempts: 5
-          command: |
-            git fetch --all --tags
-            git checkout ${{ steps.bumperstep.outputs.tag }}
-      - name: 'Release Candidate Container Build: Checkout DataBiosphere/jade-data-repo-ui repo'
-        uses: actions/checkout@v3
-        with:
-          repository: 'DataBiosphere/jade-data-repo-ui'
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          path: jade-data-repo-ui
-          ref: develop
-      - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-        with:
-          actions_subcommand: 'alpharelease'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-          alpharelease: ${{ steps.bumperstep.outputs.tag }} # creates gcr build with semver tag
-          gcr_google_project: 'broad-jade-dev'
+#      - name: "Build new develop docker image"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+#        with:
+#          actions_subcommand: 'gradlebuild'
+#          role_id: ${{ secrets.ROLE_ID }}
+#          secret_id: ${{ secrets.SECRET_ID }}
+#      - name: "Update Version in helm for Dev Env"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+#        with:
+#          actions_subcommand: 'deploytagupdate'
+#          helm_env_prefix: dev
+#      - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
+#        uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
+#        with:
+#          timeout_minutes: 1
+#          polling_interval_seconds: 5
+#          max_attempts: 5
+#          command: |
+#            git fetch --all --tags
+#            git checkout ${{ steps.bumperstep.outputs.tag }}
+#      - name: 'Release Candidate Container Build: Checkout DataBiosphere/jade-data-repo-ui repo'
+#        uses: actions/checkout@v3
+#        with:
+#          repository: 'DataBiosphere/jade-data-repo-ui'
+#          token: ${{ secrets.BROADBOT_TOKEN }}
+#          path: jade-data-repo-ui
+#          ref: develop
+#      - name: 'Release Candidate Container Build: Create release candidate images'
+#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+#        with:
+#          actions_subcommand: 'alpharelease'
+#          role_id: ${{ secrets.ROLE_ID }}
+#          secret_id: ${{ secrets.SECRET_ID }}
+#          alpharelease: ${{ steps.bumperstep.outputs.tag }} # creates gcr build with semver tag
+#          gcr_google_project: 'broad-jade-dev'
 
-  report-to-sherlock:
-    name: Report App Version to DevOps
-    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs:
-      - update_image
-    with:
-      new-version: ${{ needs.update_image.outputs.api_image_tag }}
-      chart-name: datarepo
-    permissions:
-      contents: read
-      id-token: write
+#  report-to-sherlock:
+#    name: Report App Version to DevOps
+#    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+#    needs:
+#      - update_image
+#    with:
+#      new-version: ${{ needs.update_image.outputs.api_image_tag }}
+#      chart-name: datarepo
+#    permissions:
+#      contents: read
+#      id-token: write
 
-  set-app-version-in-dev:
-    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs:
-      - update_image
-      - report-to-sherlock
-    with:
-      new-version: ${{ needs.update_image.outputs.api_image_tag }}
-      chart-name: datarepo
-      environment-name: dev
-    secrets:
-      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
-    permissions:
-      id-token: write
+#  set-app-version-in-dev:
+#    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+#    needs:
+#      - update_image
+#      - report-to-sherlock
+#    with:
+#      new-version: ${{ needs.update_image.outputs.api_image_tag }}
+#      chart-name: datarepo
+#      environment-name: dev
+#    secrets:
+#      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+#    permissions:
+#      id-token: write
 
-  cherry_pick_image_to_production_gcr:
-    needs: update_image
-    uses: ./.github/workflows/cherry-pick-image.yaml
-    secrets: inherit
-    with:
-      gcr_tag: ${{ needs.update_image.outputs.api_image_tag }}
-      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
-      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
+#  cherry_pick_image_to_production_gcr:
+#    needs: update_image
+#    uses: ./.github/workflows/cherry-pick-image.yaml
+#    secrets: inherit
+#    with:
+#      gcr_tag: ${{ needs.update_image.outputs.api_image_tag }}
+#      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
+#      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
 
-  helm_tag_bumper:
-    needs:
-      - update_image
-      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
-      # too and we don't want to be deploying to datarepo-dev twice simultaneously
-      - set-app-version-in-dev
-    uses: ./.github/workflows/helmtagbumper.yaml
-    secrets: inherit
+#  helm_tag_bumper:
+#    needs:
+#      - update_image
+#      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
+#      # too and we don't want to be deploying to datarepo-dev twice simultaneously
+#      - set-app-version-in-dev
+#    uses: ./.github/workflows/helmtagbumper.yaml
+#    secrets: inherit
 
-  action_notify:
-    runs-on: ubuntu-latest
-    if: always()
-    needs:
-      - update_image
-      - report-to-sherlock
-      - set-app-version-in-dev
-      - cherry_pick_image_to_production_gcr
-      - helm_tag_bumper
-    steps:
-      - name: Slack job status
-        uses: broadinstitute/action-slack@v3.15.0
-        with:
-          status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job
-          username: "Data Repo tests"
-          text: "Dev Image Update"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#  action_notify:
+#    runs-on: ubuntu-latest
+#    if: always()
+#    needs:
+#      - update_image
+#      - report-to-sherlock
+#      - set-app-version-in-dev
+#      - cherry_pick_image_to_production_gcr
+#      - helm_tag_bumper
+#    steps:
+#      - name: Slack job status
+#        uses: broadinstitute/action-slack@v3.15.0
+#        with:
+#          status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+#          fields: repo,message,commit,author,action,eventName,ref,workflow,job
+#          username: "Data Repo tests"
+#          text: "Dev Image Update"
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -21,8 +21,8 @@ on:
       - '.swagger-codegen-ignore'
 jobs:
   update_image:
-#    outputs:
-#      api_image_tag: ${{ steps.bumperstep.outputs.tag }}
+    outputs:
+      api_image_tag: ${{ steps.bumperstep.outputs.tag }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -46,121 +46,121 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
-#      - name: "Bump the tag to a new version"
-#        id: bumperstep
-#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-#        with:
-#          actions_subcommand: 'bumper'
-#          role_id: ${{ secrets.ROLE_ID }}
-#          secret_id: ${{ secrets.SECRET_ID }}
-#          version_file_path: build.gradle
-#          version_variable_name: version
-#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-      - name: "Publish to Artifactory"
-        uses: gradle/gradle-build-action@v3
+      - name: "Bump the tag to a new version"
+        id: bumperstep
+        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
         with:
-          arguments: '--info --scan :datarepo-client:artifactoryPublish'
+          actions_subcommand: 'bumper'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+          version_file_path: build.gradle
+          version_variable_name: version
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+      - name: "Publish to Artifactory"
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ':datarepo-client:artifactoryPublish'
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ENABLE_SUBPROJECT_TASKS: true
-#      - name: "Build new develop docker image"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-#        with:
-#          actions_subcommand: 'gradlebuild'
-#          role_id: ${{ secrets.ROLE_ID }}
-#          secret_id: ${{ secrets.SECRET_ID }}
-#      - name: "Update Version in helm for Dev Env"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-#        with:
-#          actions_subcommand: 'deploytagupdate'
-#          helm_env_prefix: dev
-#      - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
-#        uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
-#        with:
-#          timeout_minutes: 1
-#          polling_interval_seconds: 5
-#          max_attempts: 5
-#          command: |
-#            git fetch --all --tags
-#            git checkout ${{ steps.bumperstep.outputs.tag }}
-#      - name: 'Release Candidate Container Build: Checkout DataBiosphere/jade-data-repo-ui repo'
-#        uses: actions/checkout@v3
-#        with:
-#          repository: 'DataBiosphere/jade-data-repo-ui'
-#          token: ${{ secrets.BROADBOT_TOKEN }}
-#          path: jade-data-repo-ui
-#          ref: develop
-#      - name: 'Release Candidate Container Build: Create release candidate images'
-#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-#        with:
-#          actions_subcommand: 'alpharelease'
-#          role_id: ${{ secrets.ROLE_ID }}
-#          secret_id: ${{ secrets.SECRET_ID }}
-#          alpharelease: ${{ steps.bumperstep.outputs.tag }} # creates gcr build with semver tag
-#          gcr_google_project: 'broad-jade-dev'
+      - name: "Build new delevop docker image"
+        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        with:
+          actions_subcommand: 'gradlebuild'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+      - name: "Update Version in helm for Dev Env"
+        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        with:
+          actions_subcommand: 'deploytagupdate'
+          helm_env_prefix: dev
+      - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
+        uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
+        with:
+          timeout_minutes: 1
+          polling_interval_seconds: 5
+          max_attempts: 5
+          command: |
+            git fetch --all --tags
+            git checkout ${{ steps.bumperstep.outputs.tag }}
+      - name: 'Release Candidate Container Build: Checkout DataBiosphere/jade-data-repo-ui repo'
+        uses: actions/checkout@v3
+        with:
+          repository: 'DataBiosphere/jade-data-repo-ui'
+          token: ${{ secrets.BROADBOT_TOKEN }}
+          path: jade-data-repo-ui
+          ref: develop
+      - name: 'Release Candidate Container Build: Create release candidate images'
+        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        with:
+          actions_subcommand: 'alpharelease'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+          alpharelease: ${{ steps.bumperstep.outputs.tag }} # creates gcr build with semver tag
+          gcr_google_project: 'broad-jade-dev'
 
-#  report-to-sherlock:
-#    name: Report App Version to DevOps
-#    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-#    needs:
-#      - update_image
-#    with:
-#      new-version: ${{ needs.update_image.outputs.api_image_tag }}
-#      chart-name: datarepo
-#    permissions:
-#      contents: read
-#      id-token: write
+  report-to-sherlock:
+    name: Report App Version to DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs:
+      - update_image
+    with:
+      new-version: ${{ needs.update_image.outputs.api_image_tag }}
+      chart-name: datarepo
+    permissions:
+      contents: read
+      id-token: write
 
-#  set-app-version-in-dev:
-#    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-#    needs:
-#      - update_image
-#      - report-to-sherlock
-#    with:
-#      new-version: ${{ needs.update_image.outputs.api_image_tag }}
-#      chart-name: datarepo
-#      environment-name: dev
-#    secrets:
-#      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
-#    permissions:
-#      id-token: write
+  set-app-version-in-dev:
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs:
+      - update_image
+      - report-to-sherlock
+    with:
+      new-version: ${{ needs.update_image.outputs.api_image_tag }}
+      chart-name: datarepo
+      environment-name: dev
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: write
 
-#  cherry_pick_image_to_production_gcr:
-#    needs: update_image
-#    uses: ./.github/workflows/cherry-pick-image.yaml
-#    secrets: inherit
-#    with:
-#      gcr_tag: ${{ needs.update_image.outputs.api_image_tag }}
-#      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
-#      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
+  cherry_pick_image_to_production_gcr:
+    needs: update_image
+    uses: ./.github/workflows/cherry-pick-image.yaml
+    secrets: inherit
+    with:
+      gcr_tag: ${{ needs.update_image.outputs.api_image_tag }}
+      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
+      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
 
-#  helm_tag_bumper:
-#    needs:
-#      - update_image
-#      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
-#      # too and we don't want to be deploying to datarepo-dev twice simultaneously
-#      - set-app-version-in-dev
-#    uses: ./.github/workflows/helmtagbumper.yaml
-#    secrets: inherit
+  helm_tag_bumper:
+    needs:
+      - update_image
+      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
+      # too and we don't want to be deploying to datarepo-dev twice simultaneously
+      - set-app-version-in-dev
+    uses: ./.github/workflows/helmtagbumper.yaml
+    secrets: inherit
 
-#  action_notify:
-#    runs-on: ubuntu-latest
-#    if: always()
-#    needs:
-#      - update_image
-#      - report-to-sherlock
-#      - set-app-version-in-dev
-#      - cherry_pick_image_to_production_gcr
-#      - helm_tag_bumper
-#    steps:
-#      - name: Slack job status
-#        uses: broadinstitute/action-slack@v3.15.0
-#        with:
-#          status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
-#          fields: repo,message,commit,author,action,eventName,ref,workflow,job
-#          username: "Data Repo tests"
-#          text: "Dev Image Update"
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  action_notify:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - update_image
+      - report-to-sherlock
+      - set-app-version-in-dev
+      - cherry_pick_image_to_production_gcr
+      - helm_tag_bumper
+    steps:
+      - name: Slack job status
+        uses: broadinstitute/action-slack@v3.15.0
+        with:
+          status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job
+          username: "Data Repo tests"
+          text: "Dev Image Update"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: "Publish to Artifactory"
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: ':datarepo-client:artifactoryPublish'
+          arguments: '--info --scan :datarepo-client:artifactoryPublish'
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -3,12 +3,11 @@ plugins {
     id 'maven-publish'
     id 'com.jfrog.artifactory' version '4.32.0'
     id 'org.hidetake.swagger.generator'
-    id 'org.springframework.boot' version '3.2.2'
 }
 
 java {
-    sourceCompatibility = 11
-    targetCompatibility = 11
+    sourceCompatibility = 17
+    targetCompatibility = 17
 }
 
 // TODO: there may be a better way to supply these values than envvars.

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -6,8 +6,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = 17
-    targetCompatibility = 17
+    sourceCompatibility = 11
+    targetCompatibility = 11
 }
 
 // TODO: there may be a better way to supply these values than envvars.

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'maven-publish'
     id 'com.jfrog.artifactory' version '4.32.0'
     id 'org.hidetake.swagger.generator'
+    id 'org.springframework.boot' version '3.2.2'
 }
 
 java {


### PR DESCRIPTION
The client subproject build was failing when trying to run the gradle task that pushes the client .jar to artifactory. It turns out that the changes to the project now require JDK 17, and the client subproject was using JDK 11, which is the default JVM in the ubuntu-latest image. Adding a job to explicitly set up JDK 17 fixes this problem.

Note that this wasn't an issue for the main project, as it had already been updated to JDK 17 via a change to the datarepo-actions and doesn't use the java in the `ubuntu-latest` image. https://github.com/broadinstitute/datarepo-actions/pull/72

Failing build: https://github.com/DataBiosphere/jade-data-repo/actions/runs/7888933476/job/21527561449
Passing build: https://github.com/DataBiosphere/jade-data-repo/actions/runs/7892179015/job/21538097580