### PR TITLE
DR-3454 Snapshot/Dataset Retrieve Query Refactors

### DIFF
--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -2,6 +2,7 @@ package bio.terra.common;
 
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.model.EnumerateSortByParam;
+import bio.terra.model.TableDataType;
 import bio.terra.service.dataset.exception.InvalidDatasetException;
 import bio.terra.service.snapshot.exception.CorruptMetadataException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -149,6 +150,29 @@ public final class DaoUtils {
     @Override
     public UUID mapRow(ResultSet rs, int rowNum) throws SQLException {
       return rs.getObject(this.columnLabel, UUID.class);
+    }
+  }
+
+  /**
+   * Common RowMapper for mapping a column row. This assumes that all fields are prefixed with
+   * column_ in the result set (e.g. name should be selected as column_name).
+   */
+  public static class TableColumnMapper implements RowMapper<Column> {
+    private final Table table;
+
+    public TableColumnMapper(Table table) {
+      this.table = table;
+    }
+
+    @Override
+    public Column mapRow(ResultSet rs, int rowNum) throws SQLException {
+      return new Column()
+          .id(rs.getObject("column_id", UUID.class))
+          .table(table)
+          .name(rs.getString("column_name"))
+          .type(TableDataType.fromValue(rs.getString("column_type")))
+          .arrayOf(rs.getBoolean("column_array_of"))
+          .required(rs.getBoolean("column_required"));
     }
   }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetTableDao.java
@@ -18,14 +18,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -36,23 +37,48 @@ public class DatasetTableDao {
   private static final Logger logger = LoggerFactory.getLogger(DatasetTableDao.class);
 
   private static final String sqlInsertTable =
-      "INSERT INTO dataset_table "
-          + "(name, raw_table_name, soft_delete_table_name, row_metadata_table_name, dataset_id, primary_key, bigquery_partition_config) "
-          + "VALUES (:name, :raw_table_name, :soft_delete_table_name, :row_metadata_table_name, :dataset_id, :primary_key, "
-          + "cast(:bigquery_partition_config AS jsonb))";
+      """
+  INSERT INTO dataset_table
+  (name, raw_table_name, soft_delete_table_name, row_metadata_table_name, dataset_id, primary_key, bigquery_partition_config)
+  VALUES (:name, :raw_table_name, :soft_delete_table_name, :row_metadata_table_name, :dataset_id, :primary_key,
+  cast(:bigquery_partition_config AS jsonb))
+  """;
+
   private static final String sqlInsertColumn =
-      "INSERT INTO dataset_column "
-          + "(table_id, name, type, array_of, required, ordinal) "
-          + "VALUES (:table_id, :name, :type, :array_of, :required, :ordinal)";
+      """
+  INSERT INTO dataset_column
+  (table_id, name, type, array_of, required, ordinal)
+  VALUES (:table_id, :name, :type, :array_of, :required, :ordinal)
+  """;
+
   private static final String sqlSelectTable =
-      "SELECT id, name, raw_table_name, soft_delete_table_name, row_metadata_table_name, primary_key, bigquery_partition_config::text, "
-          + "(bigquery_partition_config->>'version')::bigint AS bigquery_partition_config_version "
-          + "FROM dataset_table WHERE dataset_id = :dataset_id";
+      """
+  SELECT t.id table_id,
+         t.name table_name,
+         t.raw_table_name table_raw_table_name,
+         t.soft_delete_table_name table_soft_delete_table_name,
+         t.row_metadata_table_name table_row_metadata_table_name,
+         t.primary_key table_primary_key,
+         t.bigquery_partition_config::text table_bigquery_partition_config,
+         (bigquery_partition_config->>'version')::bigint AS table_bigquery_partition_config_version,
+         c.id column_id,
+         c.name column_name,
+         c.type column_type,
+         c.array_of column_array_of,
+         c.required column_required
+  FROM dataset_table t
+    INNER JOIN dataset_column c ON t.id = c.table_id
+  WHERE dataset_id = :dataset_id
+  ORDER BY t.ctid, c.ordinal
+  """;
+
   private static final String sqlSelectColumn =
-      "SELECT id, name, type, array_of, required "
-          + "FROM dataset_column "
-          + "WHERE table_id = :table_id "
-          + "ORDER BY ordinal";
+      """
+  SELECT id column_id, name column_name, type column_type, array_of column_array_of, required column_required
+  FROM dataset_column
+  WHERE table_id = :table_id
+  ORDER BY ordinal
+  """;
 
   private static final String sqlDeleteTable =
       "DELETE FROM dataset_table WHERE id = :table_id AND dataset_id = :dataset_id";
@@ -176,45 +202,64 @@ public class DatasetTableDao {
 
   public List<DatasetTable> retrieveTables(UUID parentId) {
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("dataset_id", parentId);
-    return jdbcTemplate.query(
+    Map<UUID, DatasetTable> tableMap = new TreeMap<>();
+    jdbcTemplate.query(
         sqlSelectTable,
         params,
         (rs, rowNum) -> {
+          UUID tableId = rs.getObject("table_id", UUID.class);
           DatasetTable table =
-              new DatasetTable()
-                  .id(rs.getObject("id", UUID.class))
-                  .name(rs.getString("name"))
-                  .rawTableName(rs.getString("raw_table_name"))
-                  .softDeleteTableName(rs.getString("soft_delete_table_name"))
-                  .rowMetadataTableName(rs.getString("row_metadata_table_name"));
+              tableMap.computeIfAbsent(
+                  tableId,
+                  (id) -> {
+                    try {
+                      DatasetTable t =
+                          new DatasetTable()
+                              .id(id)
+                              .name(rs.getString("table_name"))
+                              .rawTableName(rs.getString("table_raw_table_name"))
+                              .softDeleteTableName(rs.getString("table_soft_delete_table_name"))
+                              .rowMetadataTableName(rs.getString("table_row_metadata_table_name"))
+                              .columns(new ArrayList<>())
+                              .primaryKey(new ArrayList<>());
 
-          List<Column> columns = retrieveColumns(table);
-          table.columns(columns);
+                      // Extract BigQuery partition config
+                      long bqPartitionVersion =
+                          rs.getLong("table_bigquery_partition_config_version");
+                      String bqPartitionConfig = rs.getString("table_bigquery_partition_config");
+                      if (bqPartitionVersion == 1) {
+                        try {
+                          t.bigQueryPartitionConfig(
+                              objectMapper.readValue(
+                                  bqPartitionConfig, BigQueryPartitionConfigV1.class));
+                        } catch (Exception ex) {
+                          throw new CorruptMetadataException(
+                              "Malformed BigQuery partition config", ex);
+                        }
+                      } else {
+                        throw new CorruptMetadataException(
+                            "Unknown BigQuery partition config version: " + bqPartitionVersion);
+                      }
+                      return t;
+                    } catch (SQLException e) {
+                      throw new RuntimeException(e);
+                    }
+                  });
 
-          Map<String, Column> columnMap =
-              columns.stream().collect(Collectors.toMap(Column::getName, Function.identity()));
+          // Add column to table
+          Column column = getColumnRowMapper(table).mapRow(rs, rowNum);
+          table.getColumns().add(column);
 
-          List<String> primaryKey = DaoUtils.getStringList(rs, "primary_key");
-          List<Column> naturalKeyColumns =
-              primaryKey.stream().map(columnMap::get).collect(Collectors.toList());
-          table.primaryKey(naturalKeyColumns);
-
-          long bqPartitionVersion = rs.getLong("bigquery_partition_config_version");
-          String bqPartitionConfig = rs.getString("bigquery_partition_config");
-          if (bqPartitionVersion == 1) {
-            try {
-              table.bigQueryPartitionConfig(
-                  objectMapper.readValue(bqPartitionConfig, BigQueryPartitionConfigV1.class));
-            } catch (Exception ex) {
-              throw new CorruptMetadataException("Malformed BigQuery partition config", ex);
-            }
-          } else {
-            throw new CorruptMetadataException(
-                "Unknown BigQuery partition config version: " + bqPartitionVersion);
+          // Add primary key to table if appropriate
+          List<String> primaryKey = DaoUtils.getStringList(rs, "table_primary_key");
+          if (primaryKey.contains(column.getName())) {
+            table.getPrimaryKey().add(column);
           }
 
           return table;
         });
+
+    return List.copyOf(tableMap.values());
   }
 
   List<String> retrieveColumnNames(Table table, boolean includeDataRepoRowId) {
@@ -230,13 +275,17 @@ public class DatasetTableDao {
     return jdbcTemplate.query(
         sqlSelectColumn,
         new MapSqlParameterSource().addValue("table_id", table.getId()),
-        (rs, rowNum) ->
-            new Column()
-                .id(rs.getObject("id", UUID.class))
-                .table(table)
-                .name(rs.getString("name"))
-                .type(TableDataType.fromValue(rs.getString("type")))
-                .arrayOf(rs.getBoolean("array_of"))
-                .required(rs.getBoolean("required")));
+        getColumnRowMapper(table));
+  }
+
+  private RowMapper<Column> getColumnRowMapper(Table table) {
+    return (rs, rowNum) ->
+        new Column()
+            .id(rs.getObject("column_id", UUID.class))
+            .table(table)
+            .name(rs.getString("column_name"))
+            .type(TableDataType.fromValue(rs.getString("column_type")))
+            .arrayOf(rs.getBoolean("column_array_of"))
+            .required(rs.getBoolean("column_required"));
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTable.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTable.java
@@ -4,6 +4,7 @@ import bio.terra.common.Column;
 import bio.terra.common.Table;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -65,5 +66,26 @@ public class SnapshotTable implements Table {
   public SnapshotTable primaryKey(List<Column> primaryKey) {
     this.primaryKey = primaryKey;
     return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SnapshotTable that = (SnapshotTable) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(columns, that.columns)
+        && Objects.equals(primaryKey, that.primaryKey)
+        && Objects.equals(rowCount, that.rowCount);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, columns, primaryKey, rowCount);
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
@@ -5,21 +5,21 @@ import bio.terra.common.Column;
 import bio.terra.common.DaoKeyHolder;
 import bio.terra.common.DaoUtils;
 import bio.terra.common.Table;
-import bio.terra.model.TableDataType;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -110,14 +110,28 @@ public class SnapshotTableDao {
     }
   }
 
-  public List<SnapshotTable> retrieveTables(UUID parentId) {
-    MapSqlParameterSource params = new MapSqlParameterSource().addValue("snapshot_id", parentId);
+  public List<SnapshotTable> retrieveTables(UUID snapshotId) {
+    MapSqlParameterSource params = new MapSqlParameterSource().addValue("snapshot_id", snapshotId);
+    // A tree map is used here to preserve the order from the SQL query
     Map<UUID, SnapshotTable> tableMap = new TreeMap<>();
+    // Order is not important here, so we use a HashMap
+    Map<UUID, List<String>> primaryKeyMap = new HashMap<>();
     jdbcTemplate.query(
         sqlSelectTable,
         params,
         (rs, rowNum) -> {
           UUID tableId = rs.getObject("table_id", UUID.class);
+          List<String> primaryKeyColumns =
+              primaryKeyMap.computeIfAbsent(
+                  tableId,
+                  (id) -> {
+                    try {
+                      return DaoUtils.getStringList(rs, "table_primary_key");
+                    } catch (SQLException e) {
+                      throw new IllegalArgumentException(
+                          "Failed to extract primary key information", e);
+                    }
+                  });
           SnapshotTable table =
               tableMap.computeIfAbsent(
                   tableId,
@@ -128,20 +142,27 @@ public class SnapshotTableDao {
                           .name(rs.getString("table_name"))
                           .rowCount(rs.getLong("table_row_count"))
                           .columns(new ArrayList<>())
-                          .primaryKey(new ArrayList<>());
+                          .primaryKey(
+                              // Null values will all be replaced.
+                              // This is safe since validation is done on table creation
+                              // and columns cannot be removed.
+                              new ArrayList<>(
+                                  IntStream.range(0, primaryKeyColumns.size())
+                                      .mapToObj(i -> (Column) null)
+                                      .toList()));
+
                     } catch (SQLException e) {
-                      throw new RuntimeException(e);
+                      throw new IllegalArgumentException("Failed to extract table information", e);
                     }
                   });
 
           // Add column to table
-          Column column = getColumnRowMapper(table).mapRow(rs, rowNum);
+          Column column = new DaoUtils.TableColumnMapper(table).mapRow(rs, rowNum);
           table.getColumns().add(column);
 
-          // Add primary key to table if appropriate
-          List<String> primaryKey = DaoUtils.getStringList(rs, "table_primary_key");
-          if (primaryKey.contains(column.getName())) {
-            table.getPrimaryKey().add(column);
+          int pkIndex = primaryKeyColumns.indexOf(column.getName());
+          if (pkIndex != -1) {
+            table.getPrimaryKey().set(pkIndex, column);
           }
 
           return table;
@@ -153,17 +174,6 @@ public class SnapshotTableDao {
     return jdbcTemplate.query(
         sqlSelectColumn,
         new MapSqlParameterSource().addValue("table_id", table.getId()),
-        getColumnRowMapper(table));
-  }
-
-  private RowMapper<Column> getColumnRowMapper(Table table) {
-    return (rs, rowNum) ->
-        new Column()
-            .id(rs.getObject("column_id", UUID.class))
-            .table(table)
-            .name(rs.getString("column_name"))
-            .type(TableDataType.fromValue(rs.getString("column_type")))
-            .arrayOf(rs.getBoolean("column_array_of"))
-            .required(rs.getBoolean("column_required"));
+        new DaoUtils.TableColumnMapper(table));
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotTableDao.java
@@ -8,16 +8,18 @@ import bio.terra.common.Table;
 import bio.terra.model.TableDataType;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -27,20 +29,36 @@ public class SnapshotTableDao {
   private static final Logger logger = LoggerFactory.getLogger(SnapshotTableDao.class);
 
   private static final String sqlInsertTable =
-      "INSERT INTO snapshot_table "
-          + "(name, parent_id, primary_key) "
-          + "VALUES (:name, :parent_id, :primary_key)";
+      """
+  INSERT INTO snapshot_table
+  (name, parent_id, primary_key)
+  VALUES (:name, :parent_id, :primary_key)
+  """;
+
   private static final String sqlInsertColumn =
-      "INSERT INTO snapshot_column "
-          + "(table_id, name, type, array_of, required, ordinal) "
-          + "VALUES (:table_id, :name, :type, :array_of, :required, :ordinal)";
+      """
+  INSERT INTO snapshot_column
+  (table_id, name, type, array_of, required, ordinal)
+  VALUES (:table_id, :name, :type, :array_of, :required, :ordinal)
+  """;
+
   private static final String sqlSelectTable =
-      "SELECT id, name, row_count, primary_key FROM snapshot_table WHERE parent_id = :parent_id";
+      """
+  SELECT t.id table_id, t.name table_name, t.row_count table_row_count, t.primary_key table_primary_key,
+         c.id column_id, c.name column_name, c.type column_type, c.array_of column_array_of, c.required column_required
+  FROM snapshot_table t
+     INNER JOIN snapshot_column c ON t.id = c.table_id
+  WHERE parent_id = :snapshot_id
+  ORDER BY t.ctid, c.ordinal
+  """;
+
   private static final String sqlSelectColumn =
-      "SELECT id, name, type, array_of, required "
-          + "FROM snapshot_column "
-          + "WHERE table_id = :table_id "
-          + "ORDER BY ordinal";
+      """
+  SELECT id column_id, name column_name, type column_type, array_of column_array_of, required column_required
+  FROM snapshot_column
+  WHERE table_id = :table_id
+  ORDER BY ordinal
+  """;
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
   private final DataSource jdbcDataSource;
@@ -93,42 +111,59 @@ public class SnapshotTableDao {
   }
 
   public List<SnapshotTable> retrieveTables(UUID parentId) {
-    MapSqlParameterSource params = new MapSqlParameterSource().addValue("parent_id", parentId);
-    return jdbcTemplate.query(
+    MapSqlParameterSource params = new MapSqlParameterSource().addValue("snapshot_id", parentId);
+    Map<UUID, SnapshotTable> tableMap = new TreeMap<>();
+    jdbcTemplate.query(
         sqlSelectTable,
         params,
         (rs, rowNum) -> {
+          UUID tableId = rs.getObject("table_id", UUID.class);
           SnapshotTable table =
-              new SnapshotTable()
-                  .id(rs.getObject("id", UUID.class))
-                  .name(rs.getString("name"))
-                  .rowCount(rs.getLong("row_count"));
-          List<Column> columns = retrieveColumns(table);
-          table.columns(columns);
+              tableMap.computeIfAbsent(
+                  tableId,
+                  (id) -> {
+                    try {
+                      return new SnapshotTable()
+                          .id(id)
+                          .name(rs.getString("table_name"))
+                          .rowCount(rs.getLong("table_row_count"))
+                          .columns(new ArrayList<>())
+                          .primaryKey(new ArrayList<>());
+                    } catch (SQLException e) {
+                      throw new RuntimeException(e);
+                    }
+                  });
 
-          Map<String, Column> columnMap =
-              columns.stream().collect(Collectors.toMap(Column::getName, Function.identity()));
+          // Add column to table
+          Column column = getColumnRowMapper(table).mapRow(rs, rowNum);
+          table.getColumns().add(column);
 
-          List<String> primaryKey = DaoUtils.getStringList(rs, "primary_key");
-          List<Column> naturalKeyColumns =
-              primaryKey.stream().map(columnMap::get).collect(Collectors.toList());
-          table.primaryKey(naturalKeyColumns);
+          // Add primary key to table if appropriate
+          List<String> primaryKey = DaoUtils.getStringList(rs, "table_primary_key");
+          if (primaryKey.contains(column.getName())) {
+            table.getPrimaryKey().add(column);
+          }
 
           return table;
         });
+    return List.copyOf(tableMap.values());
   }
 
   public List<Column> retrieveColumns(Table table) {
     return jdbcTemplate.query(
         sqlSelectColumn,
         new MapSqlParameterSource().addValue("table_id", table.getId()),
-        (rs, rowNum) ->
-            new Column()
-                .id(rs.getObject("id", UUID.class))
-                .table(table)
-                .name(rs.getString("name"))
-                .type(TableDataType.fromValue(rs.getString("type")))
-                .arrayOf(rs.getBoolean("array_of"))
-                .required(rs.getBoolean("required")));
+        getColumnRowMapper(table));
+  }
+
+  private RowMapper<Column> getColumnRowMapper(Table table) {
+    return (rs, rowNum) ->
+        new Column()
+            .id(rs.getObject("column_id", UUID.class))
+            .table(table)
+            .name(rs.getString("column_name"))
+            .type(TableDataType.fromValue(rs.getString("column_type")))
+            .arrayOf(rs.getBoolean("column_array_of"))
+            .required(rs.getBoolean("column_required"));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -53,10 +53,8 @@ import bio.terra.stairway.ShortUUID;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -524,23 +522,28 @@ public class DatasetDaoTest {
 
     assertThat(
         "single-column primary keys are set correctly",
-        variants.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()),
-        equalTo(Collections.singletonList("id")));
+        variants.getPrimaryKey(),
+        containsInAnyOrder(variants.getColumnByName("id").get()));
 
     assertThat(
         "dual-column primary keys are set correctly",
-        metaAnalysis.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()),
-        equalTo(Arrays.asList("variant_id", "phenotype")));
+        metaAnalysis.getPrimaryKey(),
+        containsInAnyOrder(
+            metaAnalysis.getColumnByName("variant_id").get(),
+            metaAnalysis.getColumnByName("phenotype").get()));
 
     assertThat(
         "many-column primary keys are set correctly",
-        freqAnalysis.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()),
-        equalTo(Arrays.asList("variant_id", "ancestry", "phenotype")));
+        freqAnalysis.getPrimaryKey(),
+        containsInAnyOrder(
+            freqAnalysis.getColumnByName("variant_id").get(),
+            freqAnalysis.getColumnByName("ancestry").get(),
+            freqAnalysis.getColumnByName("phenotype").get()));
   }
 
   protected void assertTablesInRelationship(Dataset dataset) {
-    String sqlFrom = "SELECT from_table " + "FROM dataset_relationship WHERE id = :id";
-    String sqlTo = "SELECT to_table " + "FROM dataset_relationship WHERE id = :id";
+    String sqlFrom = "SELECT from_table FROM dataset_relationship WHERE id = :id";
+    String sqlTo = "SELECT to_table FROM dataset_relationship WHERE id = :id";
     dataset
         .getRelationships()
         .forEach(

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -523,22 +523,22 @@ public class DatasetDaoTest {
     assertThat(
         "single-column primary keys are set correctly",
         variants.getPrimaryKey(),
-        containsInAnyOrder(variants.getColumnByName("id").get()));
+        contains(variants.getColumnByName("id").orElseThrow()));
 
     assertThat(
         "dual-column primary keys are set correctly",
         metaAnalysis.getPrimaryKey(),
-        containsInAnyOrder(
-            metaAnalysis.getColumnByName("variant_id").get(),
-            metaAnalysis.getColumnByName("phenotype").get()));
+        contains(
+            metaAnalysis.getColumnByName("variant_id").orElseThrow(),
+            metaAnalysis.getColumnByName("phenotype").orElseThrow()));
 
     assertThat(
         "many-column primary keys are set correctly",
         freqAnalysis.getPrimaryKey(),
-        containsInAnyOrder(
-            freqAnalysis.getColumnByName("variant_id").get(),
-            freqAnalysis.getColumnByName("ancestry").get(),
-            freqAnalysis.getColumnByName("phenotype").get()));
+        contains(
+            freqAnalysis.getColumnByName("variant_id").orElseThrow(),
+            freqAnalysis.getColumnByName("ancestry").orElseThrow(),
+            freqAnalysis.getColumnByName("phenotype").orElseThrow()));
   }
 
   protected void assertTablesInRelationship(Dataset dataset) {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -261,16 +261,14 @@ public class SnapshotDaoTest {
         source.getSnapshotMapTables().stream()
             .filter(t -> t.getFromTable().getName().equals("thetable"))
             .findFirst()
-            .orElseThrow(AssertionError::new);
+            .orElseThrow();
     Table datasetTable =
         dataset.getTables().stream()
             .filter(t -> t.getName().equals("thetable"))
             .findFirst()
-            .orElseThrow(AssertionError::new);
-    SnapshotTable snapshotTable1 =
-        fromDb.getTableByName("thetable").orElseThrow(AssertionError::new);
-    SnapshotTable snapshotTable2 =
-        fromDb.getTableByName("anothertable").orElseThrow(AssertionError::new);
+            .orElseThrow();
+    SnapshotTable snapshotTable1 = fromDb.getTableByName("thetable").orElseThrow();
+    SnapshotTable snapshotTable2 = fromDb.getTableByName("anothertable").orElseThrow();
 
     assertThat(
         "correct map table dataset table",

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -88,6 +88,8 @@ public class SnapshotDaoTest {
 
   @Autowired private SnapshotDao snapshotDao;
 
+  @Autowired private SnapshotTableDao snapshotTableDao;
+
   @Autowired private DatasetDao datasetDao;
 
   @Autowired private ProfileDao profileDao;
@@ -265,16 +267,10 @@ public class SnapshotDaoTest {
             .filter(t -> t.getName().equals("thetable"))
             .findFirst()
             .orElseThrow(AssertionError::new);
-    Table snapshotTable1 =
-        snapshot.getTables().stream()
-            .filter(t -> t.getName().equals("thetable"))
-            .findFirst()
-            .orElseThrow(AssertionError::new);
-    Table snapshotTable2 =
-        snapshot.getTables().stream()
-            .filter(t -> t.getName().equals("anothertable"))
-            .findFirst()
-            .orElseThrow(AssertionError::new);
+    SnapshotTable snapshotTable1 =
+        fromDb.getTableByName("thetable").orElseThrow(AssertionError::new);
+    SnapshotTable snapshotTable2 =
+        fromDb.getTableByName("anothertable").orElseThrow(AssertionError::new);
 
     assertThat(
         "correct map table dataset table",
@@ -329,6 +325,17 @@ public class SnapshotDaoTest {
         "Second table columns are in descending order of name",
         snapshotTable2.getColumns().stream().map(Column::getName).toList(),
         contains("anothercolumn3", "anothercolumn2", "anothercolumn1"));
+
+    // Verify snapshot column can be fetched by individual table
+    assertThat(
+        "First table columns can be fetched",
+        snapshotTableDao.retrieveColumns(snapshotTable1),
+        equalTo(snapshotTable1.getColumns()));
+
+    assertThat(
+        "Second table columns can be fetched",
+        snapshotTableDao.retrieveColumns(snapshotTable2),
+        equalTo(snapshotTable2.getColumns()));
   }
 
   @Test


### PR DESCRIPTION
This PR implements the query proposal from this doc:
https://docs.google.com/document/d/1vmp81uoqS_qtswT0Jo7y76y8GRZwAdGqzRd4XiVyPP8/edit#heading=h.pjsggzrj5awt

This is to reduce load on the database.  This PR aims to reduce 1:N queries (e.g. loops that call sql queries).

While I haven't been able to really observe the load benefit in the wild, I can say that for individual requests (e.g. get dataset and get snapshot) benefits:

Before fix:
- Get dataset: ~400ms
- Get Snapshot: ~650ms

After fix:
- Get dataset: ~300ms
- Get Snapshot: ~300ms

So I expect to get some benefit just on perf in addition to taking load off of the DB which will help in general.

The areas that I focused on were:
- Combining table and column queries into one for datasets and snapshots and
- Combining the query that build mappings for snapshots into one

Oh, and I also converted some the other bigger queries in the various daos into multiline strings
