### PR TITLE
DC-850: Fix container build / bumper github action

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -24,7 +24,7 @@ jobs:
   bump_version:
     runs-on: ubuntu-latest
     outputs:
-      api_image_tag: 1.595.0
+      api_image_tag: ${{ steps.bumperstep.outputs.tag }}
     if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - name: Checkout Develop branch of jade-data-repo
@@ -32,16 +32,16 @@ jobs:
         with:
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
-#      - name: "Bump the tag to a new version"
-#        id: bumperstep
-#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-#        with:
-#          actions_subcommand: 'bumper'
-#          role_id: ${{ secrets.ROLE_ID }}
-#          secret_id: ${{ secrets.SECRET_ID }}
-#          version_file_path: build.gradle
-#          version_variable_name: version
-#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+      - name: "Bump the tag to a new version"
+        id: bumperstep
+        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        with:
+          actions_subcommand: 'bumper'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+          version_file_path: build.gradle
+          version_variable_name: version
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 
   build_client_and_publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -146,7 +146,7 @@ jobs:
       id-token: write
 
   cherry_pick_image_to_production_gcr:
-    needs: bump_version
+    needs: [bump_version, build_container_and_publish]
     uses: ./.github/workflows/cherry-pick-image.yaml
     secrets: inherit
     with:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -156,7 +156,7 @@ jobs:
 
   helm_tag_bumper:
     needs:
-      - bump_version
+      - build_container_and_publish
       # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
       # too, and we don't want to be deploying to datarepo-dev twice simultaneously
       - set-app-version-in-dev

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -120,10 +120,19 @@ jobs:
           alpharelease: ${{ needs.bump_version.outputs.api_image_tag }} # creates gcr build with semver tag
           gcr_google_project: 'broad-jade-dev'
 
+  cherry_pick_image_to_production_gcr:
+    needs: [bump_version, build_container_and_publish]
+    uses: ./.github/workflows/cherry-pick-image.yaml
+    secrets: inherit
+    with:
+      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
+      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
+      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
+
   report-to-sherlock:
     name: Report App Version to DevOps
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: [bump_version, build_container_and_publish]
+    needs: [bump_version, cherry_pick_image_to_production_gcr]
     with:
       new-version: ${{ needs.bump_version.outputs.api_image_tag }}
       chart-name: datarepo
@@ -144,15 +153,6 @@ jobs:
       sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
     permissions:
       id-token: write
-
-  cherry_pick_image_to_production_gcr:
-    needs: [bump_version, build_container_and_publish]
-    uses: ./.github/workflows/cherry-pick-image.yaml
-    secrets: inherit
-    with:
-      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
-      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
-      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
 
   helm_tag_bumper:
     needs:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -24,7 +24,7 @@ jobs:
   bump_version:
     runs-on: ubuntu-latest
     outputs:
-      api_image_tag: ${{ steps.bumperstep.outputs.tag }}
+      api_image_tag: 1.595.0
     if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - name: Checkout Develop branch of jade-data-repo
@@ -32,16 +32,16 @@ jobs:
         with:
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
-      - name: "Bump the tag to a new version"
-        id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-        with:
-          actions_subcommand: 'bumper'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-          version_file_path: build.gradle
-          version_variable_name: version
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+#      - name: "Bump the tag to a new version"
+#        id: bumperstep
+#        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+#        with:
+#          actions_subcommand: 'bumper'
+#          role_id: ${{ secrets.ROLE_ID }}
+#          secret_id: ${{ secrets.SECRET_ID }}
+#          version_file_path: build.gradle
+#          version_variable_name: version
+#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 
   build_client_and_publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -20,14 +20,58 @@ on:
       - '.github/workflows/dev-image-update.yaml'
       - '.swagger-codegen-ignore'
 jobs:
-  update_image:
+
+  bump_version:
+    runs-on: ubuntu-latest
     outputs:
       api_image_tag: ${{ steps.bumperstep.outputs.tag }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
     if: "!contains( github.event.sender.login, 'broadbot')"
+    steps:
+      - name: Checkout Develop branch of jade-data-repo
+        uses: actions/checkout@v3
+        with:
+          ref: develop
+          token: ${{ secrets.BROADBOT_TOKEN }}
+      - name: "Bump the tag to a new version"
+        id: bumperstep
+        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        with:
+          actions_subcommand: 'bumper'
+          role_id: ${{ secrets.ROLE_ID }}
+          secret_id: ${{ secrets.SECRET_ID }}
+          version_file_path: build.gradle
+          version_variable_name: version
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+
+  build_client_and_publish:
+    runs-on: ubuntu-latest
+    needs:
+        - bump_version
+    steps:
+      - name: Checkout Develop branch of jade-data-repo
+        uses: actions/checkout@v3
+        with:
+          ref: develop
+          token: ${{ secrets.BROADBOT_TOKEN }}
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: "Publish to Artifactory"
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ':datarepo-client:artifactoryPublish'
+        env:
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ENABLE_SUBPROJECT_TASKS: true
+
+  build_container_and_publish:
+    runs-on: ubuntu-latest
+    needs:
+      - bump_version
     steps:
       - name: Checkout Develop branch of jade-data-repo
         uses: actions/checkout@v3
@@ -40,30 +84,6 @@ jobs:
           repository: 'broadinstitute/datarepo-helm-definitions'
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-      - name: "Bump the tag to a new version"
-        id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-        with:
-          actions_subcommand: 'bumper'
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
-          version_file_path: build.gradle
-          version_variable_name: version
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-      - name: "Publish to Artifactory"
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: ':datarepo-client:artifactoryPublish'
-        env:
-          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ENABLE_SUBPROJECT_TASKS: true
       - name: "Build new delevop docker image"
         uses: broadinstitute/datarepo-actions/actions/main@0.70.0
         with:
@@ -83,7 +103,7 @@ jobs:
           max_attempts: 5
           command: |
             git fetch --all --tags
-            git checkout ${{ steps.bumperstep.outputs.tag }}
+            git checkout ${{ needs.bump_version.outputs.api_image_tag }}
       - name: 'Release Candidate Container Build: Checkout DataBiosphere/jade-data-repo-ui repo'
         uses: actions/checkout@v3
         with:
@@ -97,16 +117,15 @@ jobs:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
-          alpharelease: ${{ steps.bumperstep.outputs.tag }} # creates gcr build with semver tag
+          alpharelease: ${{ needs.bump_version.outputs.api_image_tag }} # creates gcr build with semver tag
           gcr_google_project: 'broad-jade-dev'
 
   report-to-sherlock:
     name: Report App Version to DevOps
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs:
-      - update_image
+    needs: [bump_version, build_container_and_publish]
     with:
-      new-version: ${{ needs.update_image.outputs.api_image_tag }}
+      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
       chart-name: datarepo
     permissions:
       contents: read
@@ -115,10 +134,10 @@ jobs:
   set-app-version-in-dev:
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs:
-      - update_image
+      - bump_version
       - report-to-sherlock
     with:
-      new-version: ${{ needs.update_image.outputs.api_image_tag }}
+      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
       chart-name: datarepo
       environment-name: dev
     secrets:
@@ -127,19 +146,19 @@ jobs:
       id-token: write
 
   cherry_pick_image_to_production_gcr:
-    needs: update_image
+    needs: bump_version
     uses: ./.github/workflows/cherry-pick-image.yaml
     secrets: inherit
     with:
-      gcr_tag: ${{ needs.update_image.outputs.api_image_tag }}
+      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
       source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
       target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
 
   helm_tag_bumper:
     needs:
-      - update_image
+      - bump_version
       # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
-      # too and we don't want to be deploying to datarepo-dev twice simultaneously
+      # too, and we don't want to be deploying to datarepo-dev twice simultaneously
       - set-app-version-in-dev
     uses: ./.github/workflows/helmtagbumper.yaml
     secrets: inherit
@@ -148,7 +167,9 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - update_image
+      - bump_version
+      - build_client_and_publish
+      - build_container_and_publish
       - report-to-sherlock
       - set-app-version-in-dev
       - cherry_pick_image_to_production_gcr


### PR DESCRIPTION
The previous fix didn't work because the datarepo action to build the docker container failed due to the JDK 17 change. This separates the container build from the client build to prevent this problem. The bumper task was also refactored into its own job, and a new dependency was added so that the sherlock publish now requires the cherry-pick step to have passed.