### PR TITLE
Add LIMIT functionality for SQL Queries for Azure

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
@@ -121,7 +121,8 @@ public record Query(
           throw new NotImplementedException("Cloud Platform not implemented.");
         }
       } else {
-        throw new InvalidRenderSqlParameter("SQL cannot be generated because the Cloud Platform is null.");
+        throw new InvalidRenderSqlParameter(
+            "SQL cannot be generated because the Cloud Platform is null.");
       }
     }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
@@ -109,7 +109,7 @@ public record Query(
       sql += " " + having.renderSQL(platform);
     }
 
-    if (limit != null) {
+    if (limit != null && platform != null) {
       if (platform.isGcp()) {
         sql += " LIMIT " + limit;
       } else if (platform.isAzure()) {

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
@@ -5,6 +5,7 @@ import bio.terra.service.snapshotbuilder.query.filtervariable.HavingFilterVariab
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.NotImplementedException;
 import org.stringtemplate.v4.ST;
 
 public record Query(
@@ -109,11 +110,17 @@ public record Query(
       sql += " " + having.renderSQL(platform);
     }
 
-    if (limit != null && platform != null) {
-      if (platform.isGcp()) {
-        sql += " LIMIT " + limit;
-      } else if (platform.isAzure()) {
-        sql = "TOP " + limit + " " + sql;
+    if (limit != null) {
+      if (platform != null) {
+        if (platform.isGcp()) {
+          sql += " LIMIT " + limit;
+        } else if (platform.isAzure()) {
+          sql = "TOP " + limit + " " + sql;
+        } else {
+          throw new NotImplementedException("Cloud Platform not implemented.");
+        }
+      } else {
+        throw new RuntimeException("SQL cannot be generated because the Cloud Platform is null.");
       }
     }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
@@ -1,6 +1,7 @@
 package bio.terra.service.snapshotbuilder.query;
 
 import bio.terra.common.CloudPlatformWrapper;
+import bio.terra.service.snapshotbuilder.query.exceptions.InvalidRenderSqlParameter;
 import bio.terra.service.snapshotbuilder.query.filtervariable.HavingFilterVariable;
 import java.util.Comparator;
 import java.util.List;
@@ -120,7 +121,7 @@ public record Query(
           throw new NotImplementedException("Cloud Platform not implemented.");
         }
       } else {
-        throw new RuntimeException("SQL cannot be generated because the Cloud Platform is null.");
+        throw new InvalidRenderSqlParameter("SQL cannot be generated because the Cloud Platform is null.");
       }
     }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/Query.java
@@ -109,11 +109,12 @@ public record Query(
       sql += " " + having.renderSQL(platform);
     }
 
-    // TODO: DC-836 Implement LIMIT for Azure (TOP N + sql)
-    //  This means passing in the platform to renderSQL
-    //  and refactoring the current TableVariable and tableNameGenerator work
     if (limit != null) {
-      sql += " LIMIT " + limit;
+      if (platform.isGcp()) {
+        sql += " LIMIT " + limit;
+      } else if (platform.isAzure()) {
+        sql = "TOP " + limit + " " + sql;
+      }
     }
 
     return sql;

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/exceptions/InvalidRenderSqlParameter.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/exceptions/InvalidRenderSqlParameter.java
@@ -1,0 +1,9 @@
+package bio.terra.service.snapshotbuilder.query.exceptions;
+
+import bio.terra.common.exception.InternalServerErrorException;
+
+public class InvalidRenderSqlParameter extends InternalServerErrorException {
+  public InvalidRenderSqlParameter(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.category.Unit;
@@ -70,18 +71,7 @@ public class QueryTest {
 
   @Test
   void renderSQLWithLimitNullWrapper() {
-    String actual = createQueryWithLimit().renderSQL(null);
-    String expected = "SELECT t.* FROM table AS t";
-    assertThat(actual, is(expected));
-  }
-
-  @Test
-  void renderSQLWithLimitNullPlatform() {
-    // default platform is GCP
-    CloudPlatformWrapper cloudPlatformWrapper = CloudPlatformWrapper.of((String) null);
-    String actual = createQueryWithLimit().renderSQL(cloudPlatformWrapper);
-    String expected = "SELECT t.* FROM table AS t LIMIT 25";
-    assertThat(actual, is(expected));
+    assertThrows(RuntimeException.class, () ->createQueryWithLimit().renderSQL(null));
   }
 
   @ParameterizedTest

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -13,6 +13,7 @@ import bio.terra.service.snapshotbuilder.query.filtervariable.BooleanAndOrFilter
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -65,6 +66,22 @@ public class QueryTest {
     } else if (cloudPlatformWrapper.isGcp()) {
       assertThat(actual, is(expected + " LIMIT 25"));
     }
+  }
+
+  @Test
+  void renderSQLWithLimitNullWrapper() {
+    String actual = createQueryWithLimit().renderSQL(null);
+    String expected = "SELECT t.* FROM table AS t";
+    assertThat(actual, is(expected));
+  }
+
+  @Test
+  void renderSQLWithLimitNullPlatform() {
+    // default platform is GCP
+    CloudPlatformWrapper cloudPlatformWrapper = CloudPlatformWrapper.of((String) null);
+    String actual = createQueryWithLimit().renderSQL(cloudPlatformWrapper);
+    String expected = "SELECT t.* FROM table AS t LIMIT 25";
+    assertThat(actual, is(expected));
   }
 
   @ParameterizedTest

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -71,7 +71,7 @@ public class QueryTest {
 
   @Test
   void renderSQLWithLimitNullWrapper() {
-    assertThrows(RuntimeException.class, () ->createQueryWithLimit().renderSQL(null));
+    assertThrows(RuntimeException.class, () -> createQueryWithLimit().renderSQL(null));
   }
 
   @ParameterizedTest

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.category.Unit;
 import bio.terra.model.CloudPlatform;
+import bio.terra.service.snapshotbuilder.query.exceptions.InvalidRenderSqlParameter;
 import bio.terra.service.snapshotbuilder.query.filtervariable.BinaryFilterVariable;
 import bio.terra.service.snapshotbuilder.query.filtervariable.BooleanAndOrFilterVariable;
 import jakarta.validation.constraints.NotNull;
@@ -71,7 +72,7 @@ public class QueryTest {
 
   @Test
   void renderSQLWithLimitNullWrapper() {
-    assertThrows(RuntimeException.class, () -> createQueryWithLimit().renderSQL(null));
+    assertThrows(InvalidRenderSqlParameter.class, () -> createQueryWithLimit().renderSQL(null));
   }
 
   @ParameterizedTest

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -57,9 +57,14 @@ public class QueryTest {
   @ParameterizedTest
   @EnumSource(CloudPlatform.class)
   void renderSQLWithLimit(CloudPlatform platform) {
-    assertThat(
-        createQueryWithLimit().renderSQL(CloudPlatformWrapper.of(platform)),
-        is("SELECT t.* FROM table AS t LIMIT 25"));
+    CloudPlatformWrapper cloudPlatformWrapper = CloudPlatformWrapper.of(platform);
+    String actual = createQueryWithLimit().renderSQL(CloudPlatformWrapper.of(platform));
+    String expected = "SELECT t.* FROM table AS t";
+    if (cloudPlatformWrapper.isAzure()) {
+      assertThat(actual, is("TOP 25 " + expected));
+    } else if (cloudPlatformWrapper.isGcp()) {
+      assertThat(actual, is(expected + " LIMIT 25"));
+    }
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Background:
Synapse/Azure queries need to use T-SQL which is different from the SQL used in queries to GCP. The code implemented the functionality for limits on queries by adding LIMIT {n} at the end of the query. This does not work for Azure. Queries to Azure need to start with TOP {n} to implement the same functionality. This PR adds that ability.
https://broadworkbench.atlassian.net/browse/DC-836

Testing:
Parameterized test for basic query with limit.

Open question: do we want to add a limit to the getConcepts endpoint? At this point in time are we concerned with this endpoint returning too many responses to be handles by the UI?
