### PR TITLE
[DC-861] Add support for empty string to SearchConcepts

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -33,7 +33,8 @@ public class SearchConceptsQueryBuilder {
 
     // if the search test is empty do not include the search clauses
     // return all concepts in the specified domain
-    if (searchText.isEmpty()) {
+    if (searchText == null || searchText.isEmpty()) {
+      // TODO: DC-845 Implement pagination, remove hardcoded limit
       Query query =
           new Query(List.of(nameField, idField), List.of(conceptTableVariable), domainClause, 100);
       return query.renderSQL(platform);

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -38,37 +38,35 @@ public class SearchConceptsQueryBuilder {
       Query query =
           new Query(List.of(nameField, idField), List.of(conceptTableVariable), domainClause, 100);
       return query.renderSQL(platform);
-    } else {
-
-      // search concept name clause filters for the search text based on field concept_name
-      var searchNameClause =
-          createSearchConceptClause(
-              conceptTablePointer, conceptTableVariable, searchText, "concept_name");
-
-      // search concept name clause filters for the search text based on field concept_code
-      var searchCodeClause =
-          createSearchConceptClause(
-              conceptTablePointer, conceptTableVariable, searchText, "concept_code");
-
-      // SearchConceptNameClause OR searchCodeClause
-      List<FilterVariable> searches = List.of(searchNameClause, searchCodeClause);
-      BooleanAndOrFilterVariable searchClause =
-          new BooleanAndOrFilterVariable(BooleanAndOrFilterVariable.LogicalOperator.OR, searches);
-
-      // domainClause AND (searchNameClause OR searchCodeClause)
-      List<FilterVariable> allFilters = List.of(domainClause, searchClause);
-      BooleanAndOrFilterVariable whereClause =
-          new BooleanAndOrFilterVariable(
-              BooleanAndOrFilterVariable.LogicalOperator.AND, allFilters);
-
-      // select nameField, idField from conceptTable WHERE
-      // domainClause AND (searchNameClause OR searchCodeClause)
-      // TODO: DC-845 Implement pagination, remove hardcoded limit
-      Query query =
-          new Query(List.of(nameField, idField), List.of(conceptTableVariable), whereClause, 100);
-
-      return query.renderSQL(platform);
     }
+
+    // search concept name clause filters for the search text based on field concept_name
+    var searchNameClause =
+        createSearchConceptClause(
+            conceptTablePointer, conceptTableVariable, searchText, "concept_name");
+
+    // search concept name clause filters for the search text based on field concept_code
+    var searchCodeClause =
+        createSearchConceptClause(
+            conceptTablePointer, conceptTableVariable, searchText, "concept_code");
+
+    // SearchConceptNameClause OR searchCodeClause
+    List<FilterVariable> searches = List.of(searchNameClause, searchCodeClause);
+    BooleanAndOrFilterVariable searchClause =
+        new BooleanAndOrFilterVariable(BooleanAndOrFilterVariable.LogicalOperator.OR, searches);
+
+    // domainClause AND (searchNameClause OR searchCodeClause)
+    List<FilterVariable> allFilters = List.of(domainClause, searchClause);
+    BooleanAndOrFilterVariable whereClause =
+        new BooleanAndOrFilterVariable(BooleanAndOrFilterVariable.LogicalOperator.AND, allFilters);
+
+    // select nameField, idField from conceptTable WHERE
+    // domainClause AND (searchNameClause OR searchCodeClause)
+    // TODO: DC-845 Implement pagination, remove hardcoded limit
+    Query query =
+        new Query(List.of(nameField, idField), List.of(conceptTableVariable), whereClause, 100);
+
+    return query.renderSQL(platform);
   }
 
   static FunctionFilterVariable createSearchConceptClause(

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4604,7 +4604,7 @@ paths:
         - in: query
           description: User specified text to search concepts for.
           name: searchText
-          required: true
+          required: false
           schema:
             type: string
       responses:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4579,7 +4579,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
-  /api/repository/v1/datasets/{id}/snapshotBuilder/concepts/{domainId}/{searchText}:
+  /api/repository/v1/datasets/{id}/snapshotBuilder/concepts/{domainId}/search:
     get:
       tags:
         - datasets
@@ -4601,7 +4601,7 @@ paths:
           required: true
           schema:
             type: string
-        - in: path
+        - in: query
           description: User specified text to search concepts for.
           name: searchText
           required: true

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4604,7 +4604,6 @@ paths:
         - in: query
           description: User specified text to search concepts for.
           name: searchText
-          required: false
           schema:
             type: string
       responses:

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -441,36 +441,21 @@ class DatasetsApiControllerTest {
     verifyAuthorizationCall(IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS);
   }
 
-  @Test
-  void testSearchConcepts() throws Exception {
+  private static Stream<String> searchTextArguments() {
+    return Stream.of("cancer", "", null);
+  }
+
+  @ParameterizedTest
+  @MethodSource("searchTextArguments")
+  void testSearchConcepts(String searchText) throws Exception {
     SnapshotBuilderGetConceptsResponse expected = makeGetConceptsResponse();
 
-    when(snapshotBuilderService.searchConcepts(DATASET_ID, "condition", "cancer", TEST_USER))
+    when(snapshotBuilderService.searchConcepts(DATASET_ID, "condition", searchText, TEST_USER))
         .thenReturn(expected);
     String actualJson =
         mvc.perform(
                 get(SEARCH_CONCEPTS_ENDPOINT, DATASET_ID, "condition")
-                    .queryParam("searchText", "cancer"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-    SnapshotBuilderGetConceptsResponse actual =
-        TestUtils.mapFromJson(actualJson, SnapshotBuilderGetConceptsResponse.class);
-    assertThat("Concept list and sql is returned", actual, equalTo(expected));
-
-    verifyAuthorizationCall(IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS);
-  }
-
-  @Test
-  void testSearchConceptsEmptyString() throws Exception {
-    SnapshotBuilderGetConceptsResponse expected = makeGetConceptsResponse();
-
-    when(snapshotBuilderService.searchConcepts(DATASET_ID, "condition", "", TEST_USER))
-        .thenReturn(expected);
-    String actualJson =
-        mvc.perform(
-                get(SEARCH_CONCEPTS_ENDPOINT, DATASET_ID, "condition").queryParam("searchText", ""))
+                    .queryParam("searchText", searchText))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -115,7 +115,7 @@ class DatasetsApiControllerTest {
   private static final String GET_COUNT_ENDPOINT =
       RETRIEVE_DATASET_ENDPOINT + "/snapshotBuilder/count";
   private static final String SEARCH_CONCEPTS_ENDPOINT =
-      RETRIEVE_DATASET_ENDPOINT + "/snapshotBuilder/concepts/{domainId}/{searchText}";
+      RETRIEVE_DATASET_ENDPOINT + "/snapshotBuilder/concepts/{domainId}/search";
   private static final SqlSortDirectionAscDefault DIRECTION = SqlSortDirectionAscDefault.ASC;
   private static final UUID DATASET_ID = UUID.randomUUID();
   private static final Integer CONCEPT_ID = 0;
@@ -448,7 +448,29 @@ class DatasetsApiControllerTest {
     when(snapshotBuilderService.searchConcepts(DATASET_ID, "condition", "cancer", TEST_USER))
         .thenReturn(expected);
     String actualJson =
-        mvc.perform(get(SEARCH_CONCEPTS_ENDPOINT, DATASET_ID, "condition", "cancer"))
+        mvc.perform(
+                get(SEARCH_CONCEPTS_ENDPOINT, DATASET_ID, "condition")
+                    .queryParam("searchText", "cancer"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    SnapshotBuilderGetConceptsResponse actual =
+        TestUtils.mapFromJson(actualJson, SnapshotBuilderGetConceptsResponse.class);
+    assertThat("Concept list and sql is returned", actual, equalTo(expected));
+
+    verifyAuthorizationCall(IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS);
+  }
+
+  @Test
+  void testSearchConceptsEmptyString() throws Exception {
+    SnapshotBuilderGetConceptsResponse expected = makeGetConceptsResponse();
+
+    when(snapshotBuilderService.searchConcepts(DATASET_ID, "condition", "", TEST_USER))
+        .thenReturn(expected);
+    String actualJson =
+        mvc.perform(
+                get(SEARCH_CONCEPTS_ENDPOINT, DATASET_ID, "condition").queryParam("searchText", ""))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -27,10 +27,10 @@ class SearchConceptsQueryBuilderTest {
     assertThat(
         "generated SQL is correct",
         SearchConceptsQueryBuilder.buildSearchConceptsQuery(
-            "Condition", "cancer", s -> s, CloudPlatformWrapper.of(platform)),
+            "condition", "cancer", s -> s, CloudPlatformWrapper.of(platform)),
         equalToCompressingWhiteSpace(
             "SELECT c.concept_name, c.concept_id FROM concept AS c "
-                + "WHERE (c.domain_id = 'Condition' "
+                + "WHERE (c.domain_id = 'condition' "
                 + "AND (CONTAINS_SUBSTR(c.concept_name, 'cancer') "
                 + "OR CONTAINS_SUBSTR(c.concept_code, 'cancer'))) "
                 + "LIMIT 100"));

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -27,12 +27,25 @@ class SearchConceptsQueryBuilderTest {
     assertThat(
         "generated SQL is correct",
         SearchConceptsQueryBuilder.buildSearchConceptsQuery(
-            "condition", "cancer", s -> s, CloudPlatformWrapper.of(platform)),
+            "Condition", "cancer", s -> s, CloudPlatformWrapper.of(platform)),
         equalToCompressingWhiteSpace(
             "SELECT c.concept_name, c.concept_id FROM concept AS c "
-                + "WHERE (c.domain_id = 'condition' "
+                + "WHERE (c.domain_id = 'Condition' "
                 + "AND (CONTAINS_SUBSTR(c.concept_name, 'cancer') "
                 + "OR CONTAINS_SUBSTR(c.concept_code, 'cancer'))) "
+                + "LIMIT 100"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(CloudPlatform.class)
+  void buildSearchConceptsQueryEmpty(CloudPlatform platform) {
+    assertThat(
+        "generated SQL for empty search string is correct",
+        SearchConceptsQueryBuilder.buildSearchConceptsQuery(
+            "Condition", "", s -> s, CloudPlatformWrapper.of(platform)),
+        equalToCompressingWhiteSpace(
+            "SELECT c.concept_name, c.concept_id FROM concept AS c "
+                + "WHERE c.domain_id = 'Condition' "
                 + "LIMIT 100"));
   }
 


### PR DESCRIPTION
Background:
In a recent PR Evan discovered searchConcepts does not support the empty string being passed in.  https://github.com/DataBiosphere/terra-ui/pull/4660 
This functionality is needed for the loading of the initial search page.

Changes:
This PR adds support for empty string in searchConcepts endpoint by only rendering the search clauses if the string is not empty. 

Testing:
I added a test of the searchConceptsQueryBuilder (where the change is implemented).
I also tested the newly generated query in BigQuery.

Question:
Do I need to make the searchText field not required for the API in order to support the empty string?