### PR TITLE
[DC-847][DC-871]Add support for Azure to searchConcepts

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/query/filtervariable/FunctionFilterVariable.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/filtervariable/FunctionFilterVariable.java
@@ -26,7 +26,7 @@ public class FunctionFilterVariable implements FilterVariable {
     }
     if (values.length != 1
         && (functionTemplate == FunctionTemplate.TEXT_EXACT_MATCH
-            || functionTemplate == FunctionTemplate.TEXT_FUZZY_MATCH)) {
+        || functionTemplate == FunctionTemplate.TEXT_FUZZY_MATCH)) {
       throw new IllegalArgumentException(
           "TEXT_EXACT_MATCH/TEXT_FUZZY_MATCH filter can only match one value");
     }
@@ -67,17 +67,17 @@ public class FunctionFilterVariable implements FilterVariable {
 
     @Override
     public String renderSQL(CloudPlatformWrapper platform) {
-      if (platform != null) {
-        if (platform.isAzure()) {
-          return azureTemplate;
-        }
-        if (platform.isGcp()) {
-          return gcpTemplate;
-        }
+      if (platform == null) {
+        throw new InvalidRenderSqlParameter(
+            "SQL cannot be generated because the Cloud Platform is null.");
+      } else if (platform.isAzure()) {
+        return azureTemplate;
+      } else if (platform.isGcp()) {
+        return gcpTemplate;
+      } else {
         throw new NotImplementedException("Cloud Platform not implemented.");
       }
-      throw new InvalidRenderSqlParameter(
-          "SQL cannot be generated because the Cloud Platform is null.");
     }
   }
 }
+

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/filtervariable/FunctionFilterVariable.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/filtervariable/FunctionFilterVariable.java
@@ -23,7 +23,8 @@ public class FunctionFilterVariable implements FilterVariable {
       throw new IllegalArgumentException("Function filter values must have at least one value");
     }
     if (values.length != 1
-        && (functionTemplate == FunctionTemplate.TEXT_EXACT_MATCH
+        && (functionTemplate == FunctionTemplate.TEXT_EXACT_MATCH_GCP
+            || functionTemplate == FunctionTemplate.TEXT_EXACT_MATCH_AZURE
             || functionTemplate == FunctionTemplate.TEXT_FUZZY_MATCH)) {
       throw new IllegalArgumentException(
           "TEXT_EXACT_MATCH/TEXT_FUZZY_MATCH filter can only match one value");
@@ -43,7 +44,8 @@ public class FunctionFilterVariable implements FilterVariable {
   }
 
   public enum FunctionTemplate implements SqlExpression {
-    TEXT_EXACT_MATCH("CONTAINS_SUBSTR(<fieldVariable>, <value>)"),
+    TEXT_EXACT_MATCH_GCP("CONTAINS_SUBSTR(<fieldVariable>, <value>)"),
+    TEXT_EXACT_MATCH_AZURE("CHARINDEX(<value>, <fieldVariable>) > 0"),
     // BigQuery fuzzy match pattern is "bqutil.fn.levenshtein(UPPER(<fieldVariable>),
     // UPPER(<value>))<5"
     TEXT_FUZZY_MATCH("dbo.Levenshtein(UPPER(<fieldVariable>), UPPER(<value>), 5)"),

--- a/src/main/java/bio/terra/service/snapshotbuilder/query/filtervariable/FunctionFilterVariable.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/query/filtervariable/FunctionFilterVariable.java
@@ -26,7 +26,7 @@ public class FunctionFilterVariable implements FilterVariable {
     }
     if (values.length != 1
         && (functionTemplate == FunctionTemplate.TEXT_EXACT_MATCH
-        || functionTemplate == FunctionTemplate.TEXT_FUZZY_MATCH)) {
+            || functionTemplate == FunctionTemplate.TEXT_FUZZY_MATCH)) {
       throw new IllegalArgumentException(
           "TEXT_EXACT_MATCH/TEXT_FUZZY_MATCH filter can only match one value");
     }
@@ -80,4 +80,3 @@ public class FunctionFilterVariable implements FilterVariable {
     }
   }
 }
-

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -13,10 +13,14 @@ import bio.terra.service.snapshotbuilder.query.filtervariable.BinaryFilterVariab
 import bio.terra.service.snapshotbuilder.query.filtervariable.BooleanAndOrFilterVariable;
 import bio.terra.service.snapshotbuilder.query.filtervariable.FunctionFilterVariable;
 import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
 
 public class SearchConceptsQueryBuilder {
 
   private SearchConceptsQueryBuilder() {}
+
+  public static final String CLOUD_PLATFORM_NOT_IMPLEMENTED_MESSAGE =
+      "Cloud platform not implemented";
 
   public static String buildSearchConceptsQuery(
       String domainId,
@@ -43,12 +47,12 @@ public class SearchConceptsQueryBuilder {
     // search concept name clause filters for the search text based on field concept_name
     var searchNameClause =
         createSearchConceptClause(
-            conceptTablePointer, conceptTableVariable, searchText, "concept_name");
+            conceptTablePointer, conceptTableVariable, searchText, "concept_name", platform);
 
     // search concept name clause filters for the search text based on field concept_code
     var searchCodeClause =
         createSearchConceptClause(
-            conceptTablePointer, conceptTableVariable, searchText, "concept_code");
+            conceptTablePointer, conceptTableVariable, searchText, "concept_code", platform);
 
     // SearchConceptNameClause OR searchCodeClause
     List<FilterVariable> searches = List.of(searchNameClause, searchCodeClause);
@@ -73,11 +77,20 @@ public class SearchConceptsQueryBuilder {
       TablePointer conceptTablePointer,
       TableVariable conceptTableVariable,
       String searchText,
-      String columnName) {
-    return new FunctionFilterVariable(
-        FunctionFilterVariable.FunctionTemplate.TEXT_EXACT_MATCH,
-        new FieldVariable(new FieldPointer(conceptTablePointer, columnName), conceptTableVariable),
-        new Literal(searchText));
+      String columnName,
+      CloudPlatformWrapper platform) {
+    FieldVariable fieldVariable =
+        new FieldVariable(new FieldPointer(conceptTablePointer, columnName), conceptTableVariable);
+    Literal search = new Literal(searchText);
+    if (platform.isAzure()) {
+      return new FunctionFilterVariable(
+          FunctionFilterVariable.FunctionTemplate.TEXT_EXACT_MATCH_AZURE, fieldVariable, search);
+    }
+    if (platform.isGcp()) {
+      return new FunctionFilterVariable(
+          FunctionFilterVariable.FunctionTemplate.TEXT_EXACT_MATCH_GCP, fieldVariable, search);
+    }
+    throw new NotImplementedException(CLOUD_PLATFORM_NOT_IMPLEMENTED_MESSAGE);
   }
 
   static BinaryFilterVariable createDomainClause(

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -13,14 +13,10 @@ import bio.terra.service.snapshotbuilder.query.filtervariable.BinaryFilterVariab
 import bio.terra.service.snapshotbuilder.query.filtervariable.BooleanAndOrFilterVariable;
 import bio.terra.service.snapshotbuilder.query.filtervariable.FunctionFilterVariable;
 import java.util.List;
-import org.apache.commons.lang3.NotImplementedException;
 
 public class SearchConceptsQueryBuilder {
 
   private SearchConceptsQueryBuilder() {}
-
-  public static final String CLOUD_PLATFORM_NOT_IMPLEMENTED_MESSAGE =
-      "Cloud platform not implemented";
 
   public static String buildSearchConceptsQuery(
       String domainId,
@@ -47,12 +43,12 @@ public class SearchConceptsQueryBuilder {
     // search concept name clause filters for the search text based on field concept_name
     var searchNameClause =
         createSearchConceptClause(
-            conceptTablePointer, conceptTableVariable, searchText, "concept_name", platform);
+            conceptTablePointer, conceptTableVariable, searchText, "concept_name");
 
     // search concept name clause filters for the search text based on field concept_code
     var searchCodeClause =
         createSearchConceptClause(
-            conceptTablePointer, conceptTableVariable, searchText, "concept_code", platform);
+            conceptTablePointer, conceptTableVariable, searchText, "concept_code");
 
     // SearchConceptNameClause OR searchCodeClause
     List<FilterVariable> searches = List.of(searchNameClause, searchCodeClause);
@@ -77,20 +73,11 @@ public class SearchConceptsQueryBuilder {
       TablePointer conceptTablePointer,
       TableVariable conceptTableVariable,
       String searchText,
-      String columnName,
-      CloudPlatformWrapper platform) {
-    FieldVariable fieldVariable =
-        new FieldVariable(new FieldPointer(conceptTablePointer, columnName), conceptTableVariable);
-    Literal search = new Literal(searchText);
-    if (platform.isAzure()) {
-      return new FunctionFilterVariable(
-          FunctionFilterVariable.FunctionTemplate.TEXT_EXACT_MATCH_AZURE, fieldVariable, search);
-    }
-    if (platform.isGcp()) {
-      return new FunctionFilterVariable(
-          FunctionFilterVariable.FunctionTemplate.TEXT_EXACT_MATCH_GCP, fieldVariable, search);
-    }
-    throw new NotImplementedException(CLOUD_PLATFORM_NOT_IMPLEMENTED_MESSAGE);
+      String columnName) {
+    return new FunctionFilterVariable(
+        FunctionFilterVariable.FunctionTemplate.TEXT_EXACT_MATCH,
+        new FieldVariable(new FieldPointer(conceptTablePointer, columnName), conceptTableVariable),
+        new Literal(searchText));
   }
 
   static BinaryFilterVariable createDomainClause(

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -3,6 +3,7 @@ package bio.terra.integration;
 import static bio.terra.service.filedata.azure.util.AzureBlobIOTestUtility.MIB;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
@@ -381,12 +382,22 @@ public class AzureIntegrationTest extends UsersBase {
     var getConceptResponse = dataRepoFixtures.getConcepts(steward, datasetId, 2);
     List<String> getConceptNames =
         getConceptResponse.getResult().stream().map(SnapshotBuilderConcept::getName).toList();
-    assertThat("Correct number of concepts are returned", getConceptNames, hasSize(2));
     assertThat(
         "expected concepts are returned",
         getConceptNames,
         containsInAnyOrder("concept1", "concept3"));
+
+    // Test searchConcepts
+    var searchConceptResponse =
+        dataRepoFixtures.searchConcepts(steward, datasetId, "Condition", "concept1");
+    List<String> searchConceptNames =
+        searchConceptResponse.getResult().stream().map(SnapshotBuilderConcept::getName).toList();
+    assertThat(
+        "expected concepts are returned",
+        searchConceptNames,
+        contains("concept1"));
   }
+
 
   @Test
   public void datasetIngestFileHappyPath() throws Exception {

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -2,8 +2,8 @@ package bio.terra.integration;
 
 import static bio.terra.service.filedata.azure.util.AzureBlobIOTestUtility.MIB;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
@@ -392,12 +392,8 @@ public class AzureIntegrationTest extends UsersBase {
         dataRepoFixtures.searchConcepts(steward, datasetId, "Condition", "concept1");
     List<String> searchConceptNames =
         searchConceptResponse.getResult().stream().map(SnapshotBuilderConcept::getName).toList();
-    assertThat(
-        "expected concepts are returned",
-        searchConceptNames,
-        contains("concept1"));
+    assertThat("expected concepts are returned", searchConceptNames, contains("concept1"));
   }
-
 
   @Test
   public void datasetIngestFileHappyPath() throws Exception {

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -1866,12 +1866,11 @@ public class DataRepoFixtures {
     assertTrue("concept response is present", response.getResponseObject().isPresent());
     return response.getResponseObject().get();
   }
+
   public SnapshotBuilderGetConceptsResponse searchConcepts(
       TestConfiguration.User user, UUID datasetId, String domainId, String searchText)
       throws Exception {
-    String queryParams =
-        "?searchText=%s"
-            .formatted(searchText);
+    String queryParams = "?searchText=%s".formatted(searchText);
 
     DataRepoResponse<SnapshotBuilderGetConceptsResponse> response =
         dataRepoClient.get(

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -1866,4 +1866,26 @@ public class DataRepoFixtures {
     assertTrue("concept response is present", response.getResponseObject().isPresent());
     return response.getResponseObject().get();
   }
+  public SnapshotBuilderGetConceptsResponse searchConcepts(
+      TestConfiguration.User user, UUID datasetId, String domainId, String searchText)
+      throws Exception {
+    String queryParams =
+        "?searchText=%s"
+            .formatted(searchText);
+
+    DataRepoResponse<SnapshotBuilderGetConceptsResponse> response =
+        dataRepoClient.get(
+            user,
+            "/api/repository/v1/datasets/"
+                + datasetId
+                + "/snapshotBuilder/concepts/"
+                + domainId
+                + "/search"
+                + queryParams,
+            new TypeReference<>() {});
+    assertThat(
+        "search concept job is successful", response.getStatusCode(), equalTo(HttpStatus.OK));
+    assertTrue("concept response is present", response.getResponseObject().isPresent());
+    return response.getResponseObject().get();
+  }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -64,7 +64,7 @@ public class QueryTest {
     String actual = createQueryWithLimit().renderSQL(CloudPlatformWrapper.of(platform));
     String expected = "SELECT t.* FROM table AS t";
     if (cloudPlatformWrapper.isAzure()) {
-      assertThat(actual, is("TOP 25 " + expected));
+      assertThat(actual, is("SELECT TOP 25 t.* FROM table AS t"));
     } else if (cloudPlatformWrapper.isGcp()) {
       assertThat(actual, is(expected + " LIMIT 25"));
     }

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -72,7 +72,8 @@ public class QueryTest {
 
   @Test
   void renderSQLWithLimitNullWrapper() {
-    assertThrows(InvalidRenderSqlParameter.class, () -> createQueryWithLimit().renderSQL(null));
+    Query query = createQueryWithLimit();
+    assertThrows(InvalidRenderSqlParameter.class, () -> query.renderSQL(null));
   }
 
   @ParameterizedTest

--- a/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/query/QueryTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.snapshotbuilder.query;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -64,9 +65,15 @@ public class QueryTest {
     String actual = createQueryWithLimit().renderSQL(CloudPlatformWrapper.of(platform));
     String expected = "SELECT t.* FROM table AS t";
     if (cloudPlatformWrapper.isAzure()) {
-      assertThat(actual, is("SELECT TOP 25 t.* FROM table AS t"));
+      assertThat(
+          "Azure-specific sql generated",
+          actual,
+          equalToCompressingWhiteSpace("SELECT TOP 25 t.* FROM table AS t"));
     } else if (cloudPlatformWrapper.isGcp()) {
-      assertThat(actual, is(expected + " LIMIT 25"));
+      assertThat(
+          "GCP-specific sql generated",
+          actual,
+          equalToCompressingWhiteSpace(expected + " LIMIT 25"));
     }
   }
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -86,8 +86,7 @@ class SearchConceptsQueryBuilderTest {
                 conceptTablePointer,
                 conceptTableVariable,
                 "cancer",
-                "concept_name",
-                CloudPlatformWrapper.of(platform))
+                "concept_name")
             .renderSQL(CloudPlatformWrapper.of(platform));
     if (platformWrapper.isAzure()) {
       assertThat(

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -1,7 +1,6 @@
 package bio.terra.service.snapshotbuilder.utils;
 
 import static bio.terra.service.snapshotbuilder.utils.SearchConceptsQueryBuilder.createSearchConceptClause;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 
@@ -68,7 +67,7 @@ class SearchConceptsQueryBuilderTest {
       assertThat(
           "generated SQL for GCP empty search string is correct",
           actual,
-          equalToCompressingWhiteSpace("SELECT " + expected + "LIMIT 100"));
+          equalToCompressingWhiteSpace("SELECT " + expected + " LIMIT 100"));
     }
   }
 
@@ -87,14 +86,14 @@ class SearchConceptsQueryBuilderTest {
           "generated sql is as expected",
           actual,
           // table name is added when the Query is created
-          equalTo("CHARINDEX('cancer', null.concept_name) > 0"));
+          equalToCompressingWhiteSpace("CHARINDEX('cancer', null.concept_name) > 0"));
     }
     if (platformWrapper.isGcp()) {
       assertThat(
           "generated sql is as expected",
           actual,
           // table name is added when the Query is created
-          equalTo("CONTAINS_SUBSTR(null.concept_name, 'cancer')"));
+          equalToCompressingWhiteSpace("CONTAINS_SUBSTR(null.concept_name, 'cancer')"));
     }
   }
 
@@ -110,6 +109,6 @@ class SearchConceptsQueryBuilderTest {
                 conceptTablePointer, conceptTableVariable, "cancer")
             .renderSQL(CloudPlatformWrapper.of(platform)),
         // table name is added when the Query is created
-        equalTo("null.domain_id = 'cancer'"));
+        equalToCompressingWhiteSpace("null.domain_id = 'cancer'"));
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -30,7 +30,7 @@ class SearchConceptsQueryBuilderTest {
             "condition", "cancer", s -> s, CloudPlatformWrapper.of(platform));
     if (platformWrapper.isGcp()) {
       assertThat(
-          "generated SQL is correct",
+          "generated SQL for GCP is correct",
           actual,
           equalToCompressingWhiteSpace(
               "SELECT c.concept_name, c.concept_id FROM concept AS c "
@@ -41,7 +41,7 @@ class SearchConceptsQueryBuilderTest {
     }
     if (platformWrapper.isAzure()) {
       assertThat(
-          "generated SQL is correct",
+          "generated SQL for Azure is correct",
           actual,
           equalToCompressingWhiteSpace(
               "TOP 100 SELECT c.concept_name, c.concept_id FROM concept AS c "

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -83,10 +83,7 @@ class SearchConceptsQueryBuilderTest {
     TableVariable conceptTableVariable = TableVariable.forPrimary(conceptTablePointer);
     String actual =
         createSearchConceptClause(
-                conceptTablePointer,
-                conceptTableVariable,
-                "cancer",
-                "concept_name")
+                conceptTablePointer, conceptTableVariable, "cancer", "concept_name")
             .renderSQL(CloudPlatformWrapper.of(platform));
     if (platformWrapper.isAzure()) {
       assertThat(

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -1,6 +1,5 @@
 package bio.terra.service.snapshotbuilder.utils;
 
-import static bio.terra.service.snapshotbuilder.utils.SearchConceptsQueryBuilder.createDomainClause;
 import static bio.terra.service.snapshotbuilder.utils.SearchConceptsQueryBuilder.createSearchConceptClause;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -11,7 +10,6 @@ import bio.terra.common.category.Unit;
 import bio.terra.model.CloudPlatform;
 import bio.terra.service.snapshotbuilder.query.TablePointer;
 import bio.terra.service.snapshotbuilder.query.TableVariable;
-import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,7 +42,7 @@ class SearchConceptsQueryBuilderTest {
           "generated SQL for Azure is correct",
           actual,
           equalToCompressingWhiteSpace(
-              "TOP 100 SELECT c.concept_name, c.concept_id FROM concept AS c "
+              "SELECT TOP 100 c.concept_name, c.concept_id FROM concept AS c "
                   + "WHERE (c.domain_id = 'condition' "
                   + "AND (CHARINDEX('cancer', c.concept_name) > 0 "
                   + "OR CHARINDEX('cancer', c.concept_code) > 0))"));
@@ -59,19 +57,19 @@ class SearchConceptsQueryBuilderTest {
         SearchConceptsQueryBuilder.buildSearchConceptsQuery(
             "Condition", "", s -> s, CloudPlatformWrapper.of(platform));
     String expected =
-        "SELECT c.concept_name, c.concept_id FROM concept AS c "
+        "c.concept_name, c.concept_id FROM concept AS c "
             + "WHERE c.domain_id = 'Condition' ";
     if (platformWrapper.isAzure()) {
       assertThat(
           "generated SQL for Azure empty search string is correct",
           actual,
-          equalToCompressingWhiteSpace("TOP 100 " + expected));
+          equalToCompressingWhiteSpace("SELECT TOP 100 " + expected));
     }
     if (platformWrapper.isGcp()) {
       assertThat(
           "generated SQL for GCP empty search string is correct",
           actual,
-          equalToCompressingWhiteSpace(expected + "LIMIT 100"));
+          equalToCompressingWhiteSpace("SELECT " + expected + "LIMIT 100"));
     }
   }
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -57,8 +57,7 @@ class SearchConceptsQueryBuilderTest {
         SearchConceptsQueryBuilder.buildSearchConceptsQuery(
             "Condition", "", s -> s, CloudPlatformWrapper.of(platform));
     String expected =
-        "c.concept_name, c.concept_id FROM concept AS c "
-            + "WHERE c.domain_id = 'Condition' ";
+        "c.concept_name, c.concept_id FROM concept AS c " + "WHERE c.domain_id = 'Condition' ";
     if (platformWrapper.isAzure()) {
       assertThat(
           "generated SQL for Azure empty search string is correct",

--- a/src/test/resources/omop/concept-table-data.json
+++ b/src/test/resources/omop/concept-table-data.json
@@ -1,3 +1,3 @@
-{"concept_id": 1, "concept_name": "concept1"}
-{"concept_id": 2, "concept_name": "concept2"}
-{"concept_id": 3, "concept_name": "concept3"}
+{"concept_id": 1, "domain_id": "Condition", "concept_name": "concept1"}
+{"concept_id": 2, "domain_id": "Condition",  "concept_name": "concept2"}
+{"concept_id": 3, "domain_id": "Condition",  "concept_name": "concept3"}

--- a/src/test/resources/omop/concept-table-data.json
+++ b/src/test/resources/omop/concept-table-data.json
@@ -1,3 +1,3 @@
-{"concept_id": 1, "domain_id": "Condition", "concept_name": "concept1"}
-{"concept_id": 2, "domain_id": "Condition",  "concept_name": "concept2"}
-{"concept_id": 3, "domain_id": "Condition",  "concept_name": "concept3"}
+{"concept_id": 1, "domain_id": "Condition", "concept_name": "concept1", "concept_code": 11}
+{"concept_id": 2, "domain_id": "Condition",  "concept_name": "concept2", "concept_code": 12}
+{"concept_id": 3, "domain_id": "Condition",  "concept_name": "concept3", "concept_code": 13}


### PR DESCRIPTION
Background:
DC-847: The current query code for searchConcepts uses CONTAINS_SUBSTRING which is only valid syntax for GCP.
https://broadworkbench.atlassian.net/browse/DC-847
DC-871: The current implementation of limit is incorrect (because it is in the wrong order) for Azure.
https://broadworkbench.atlassian.net/browse/DC-871

Summary of Changes:
1. Adds to the template for FunctionFilterVariable
2. When renderSQL is called the platform is used to chose the correct string from the template
    - Update tests, add Azure integration test for searchConcepts
4. Changes the renderSQL method on Query to add the limit clause to the correct place (after SELECT)
    - Update tests

Testing:
Updates the expected results of parameterized tests to reflect the cloud specific language.
Adds an azure integration test 
