### PR TITLE
DC-836 - Fix unit test for Query Builder Limit Clauses - Different query per platform

### DIFF
--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -71,12 +71,6 @@ class SearchConceptsQueryBuilderTest {
     }
   }
 
-  @Test
-  void renderSQLWithLimitNullWrapper() {
-    assertThrows(
-        InvalidRenderSqlParameter.class, () -> QueryTest.createQueryWithLimit().renderSQL(null));
-  }
-
   @ParameterizedTest
   @EnumSource(CloudPlatform.class)
   void testCreateSearchConceptClause(CloudPlatform platform) {

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -1,20 +1,18 @@
 package bio.terra.service.snapshotbuilder.utils;
 
-import static bio.terra.service.snapshotbuilder.query.QueryTest.createQueryWithLimit;
-import static bio.terra.service.snapshotbuilder.utils.SearchConceptsQueryBuilder.createDomainClause;
-import static bio.terra.service.snapshotbuilder.utils.SearchConceptsQueryBuilder.createSearchConceptClause;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.category.Unit;
 import bio.terra.model.CloudPlatform;
+import bio.terra.service.snapshotbuilder.query.QueryTest;
 import bio.terra.service.snapshotbuilder.query.TablePointer;
 import bio.terra.service.snapshotbuilder.query.TableVariable;
 import bio.terra.service.snapshotbuilder.query.exceptions.InvalidRenderSqlParameter;
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
 class SearchConceptsQueryBuilderTest {
-
   @ParameterizedTest
   @EnumSource(CloudPlatform.class)
   void buildSearchConceptsQuery(CloudPlatform platform) {
@@ -34,39 +31,50 @@ class SearchConceptsQueryBuilderTest {
         SearchConceptsQueryBuilder.buildSearchConceptsQuery(
             "condition", "cancer", s -> s, CloudPlatformWrapper.of(platform));
     String expected =
-        "SELECT c.concept_name, c.concept_id FROM concept AS c "
-            + "WHERE (c.domain_id = 'condition' "
-            + "AND (CONTAINS_SUBSTR(c.concept_name, 'cancer') "
-            + "OR CONTAINS_SUBSTR(c.concept_code, 'cancer')))";
-    if (platformWrapper.isGcp()) {
-      assertThat(
-          "generated SQL for GCP is correct",
-          actual,
-          equalToCompressingWhiteSpace(expected + " LIMIT 100"));
-    } else if (platformWrapper.isAzure()) {
-      assertThat(
-          "generated SQL for Azure is correct",
-          actual,
-          equalToCompressingWhiteSpace("TOP 100 " + expected));
-    }
+        formatSQLWithLimit(
+            "SELECT c.concept_name, c.concept_id FROM concept AS c "
+                + "WHERE (c.domain_id = 'condition' "
+                + "AND (CONTAINS_SUBSTR(c.concept_name, 'cancer') "
+                + "OR CONTAINS_SUBSTR(c.concept_code, 'cancer')))",
+            platformWrapper);
+    assertThat(
+        "generated SQL for search concepts query is correct",
+        actual,
+        equalToCompressingWhiteSpace(expected));
   }
 
   @ParameterizedTest
   @EnumSource(CloudPlatform.class)
   void buildSearchConceptsQueryEmpty(CloudPlatform platform) {
     CloudPlatformWrapper cloudPlatformWrapper = CloudPlatformWrapper.of(platform);
-    String actual = createQueryWithLimit().renderSQL(CloudPlatformWrapper.of(platform));
-    String expected = "SELECT t.* FROM table AS t";
-    if (cloudPlatformWrapper.isAzure()) {
-      assertThat(actual, is("TOP 25 " + expected));
+    String actual =
+        SearchConceptsQueryBuilder.buildSearchConceptsQuery(
+            "Condition", "", s -> s, CloudPlatformWrapper.of(platform));
+    String expected =
+        formatSQLWithLimit(
+            "SELECT c.concept_name, c.concept_id FROM concept AS c WHERE c.domain_id = 'Condition'",
+            cloudPlatformWrapper);
+    assertThat(
+        "generated SQL for empty search concepts query is correct",
+        actual,
+        equalToCompressingWhiteSpace(expected));
+  }
+
+  String formatSQLWithLimit(String sql, CloudPlatformWrapper cloudPlatformWrapper) {
+      int limit= 100;
+      if (cloudPlatformWrapper.isAzure()) {
+      return String.format("TOP %d %s", limit, sql);
     } else if (cloudPlatformWrapper.isGcp()) {
-      assertThat(actual, is(expected + " LIMIT 25"));
+      return String.format("%s LIMIT %d", sql, limit);
+    } else {
+      throw new NotImplementedException("Cloud platform not implemented");
     }
   }
 
   @Test
   void renderSQLWithLimitNullWrapper() {
-    assertThrows(InvalidRenderSqlParameter.class, () -> createQueryWithLimit().renderSQL(null));
+    assertThrows(
+        InvalidRenderSqlParameter.class, () -> QueryTest.createQueryWithLimit().renderSQL(null));
   }
 
   @ParameterizedTest
@@ -77,7 +85,7 @@ class SearchConceptsQueryBuilderTest {
 
     assertThat(
         "generated sql is as expected",
-        createSearchConceptClause(
+        SearchConceptsQueryBuilder.createSearchConceptClause(
                 conceptTablePointer, conceptTableVariable, "cancer", "concept_name")
             .renderSQL(CloudPlatformWrapper.of(platform)),
         // table name is added when the Query is created
@@ -92,7 +100,8 @@ class SearchConceptsQueryBuilderTest {
 
     assertThat(
         "generated sql is as expected",
-        createDomainClause(conceptTablePointer, conceptTableVariable, "cancer")
+        SearchConceptsQueryBuilder.createDomainClause(
+                conceptTablePointer, conceptTableVariable, "cancer")
             .renderSQL(CloudPlatformWrapper.of(platform)),
         // table name is added when the Query is created
         equalTo("null.domain_id = 'cancer'"));

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -3,18 +3,14 @@ package bio.terra.service.snapshotbuilder.utils;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.category.Unit;
 import bio.terra.model.CloudPlatform;
-import bio.terra.service.snapshotbuilder.query.QueryTest;
 import bio.terra.service.snapshotbuilder.query.TablePointer;
 import bio.terra.service.snapshotbuilder.query.TableVariable;
-import bio.terra.service.snapshotbuilder.query.exceptions.InvalidRenderSqlParameter;
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -61,8 +57,8 @@ class SearchConceptsQueryBuilderTest {
   }
 
   String formatSQLWithLimit(String sql, CloudPlatformWrapper cloudPlatformWrapper) {
-      int limit= 100;
-      if (cloudPlatformWrapper.isAzure()) {
+    int limit = 100;
+    if (cloudPlatformWrapper.isAzure()) {
       return String.format("TOP %d %s", limit, sql);
     } else if (cloudPlatformWrapper.isGcp()) {
       return String.format("%s LIMIT %d", sql, limit);


### PR DESCRIPTION
Follow on to DC-846 - https://github.com/DataBiosphere/jade-data-repo/pull/1599

We had a few PRs in flight and one was merged before merging in the latest from develop. This is team norm given that our tests take so long to run and this was a very simple fix! 

- This PR was merged: https://github.com/DataBiosphere/jade-data-repo/pull/1599/files
- Then, PR was merged: https://github.com/DataBiosphere/jade-data-repo/pull/1600. The second PR adds a test that includes GCP specific LIMIT logic. However, the previous PR added logic to make the generated SQL cloud specific. So, the unit test failed.
