### PR TITLE
[DR-3457][DR-3458] Parallelize azure table writes and fix drs files

### DIFF
--- a/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/AzureSynapsePdao.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -515,7 +516,7 @@ public class AzureSynapsePdao {
     return Optional.of(drsId.getFsObjectId());
   }
 
-  public List<String> getRefIdsForSnapshot(Snapshot snapshot) {
+  public Set<String> getRefIdsForSnapshot(Snapshot snapshot) {
     return snapshot.getTables().stream()
         .filter(table -> table.getRowCount() > 0)
         .flatMap(
@@ -529,7 +530,7 @@ public class AzureSynapsePdao {
                       column ->
                           getRefIds(tableName, column, snapshot.getCollectionType()).stream());
             })
-        .collect(Collectors.toList());
+        .collect(Collectors.toSet());
   }
 
   public String getOrCreateExternalDataSourceForResource(

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -459,7 +459,7 @@ public class TableDao {
       TableServiceClient snapshotTableServiceClient,
       UUID datasetId,
       String datasetName,
-      UUID snapshotId,
+      Snapshot snapshot,
       List<String> refIds) {
 
     directoryDao.addEntriesToSnapshot(
@@ -467,8 +467,9 @@ public class TableDao {
         snapshotTableServiceClient,
         datasetId,
         datasetName,
-        snapshotId,
-        refIds);
+        snapshot.getId(),
+        refIds,
+        snapshot.hasGlobalFileIds());
   }
 
   // TODO: Implement computeDirectory to recursively compute the size and checksums of a directory

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDao.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -460,7 +461,7 @@ public class TableDao {
       UUID datasetId,
       String datasetName,
       Snapshot snapshot,
-      List<String> refIds) {
+      Set<String> refIds) {
 
     directoryDao.addEntriesToSnapshot(
         datasetTableServiceClient,

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDependencyDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDependencyDao.java
@@ -1,5 +1,6 @@
 package bio.terra.service.filedata.azure.tables;
 
+import bio.terra.common.FutureUtils;
 import bio.terra.service.common.azure.StorageTableName;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.google.firestore.FireStoreDependency;
@@ -10,13 +11,16 @@ import com.azure.data.tables.models.ListEntitiesOptions;
 import com.azure.data.tables.models.TableEntity;
 import com.azure.data.tables.models.TableTransactionAction;
 import com.azure.data.tables.models.TableTransactionActionType;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,8 +29,12 @@ public class TableDependencyDao {
 
   private static final int MAX_FILTER_CLAUSES = 15;
 
+  private final AsyncTaskExecutor azureTableThreadpool;
+
   @Autowired
-  public TableDependencyDao() {}
+  public TableDependencyDao(AsyncTaskExecutor azureTableThreadpool) {
+    this.azureTableThreadpool = azureTableThreadpool;
+  }
 
   public void storeSnapshotFileDependencies(
       TableServiceClient tableServiceClient, UUID datasetId, UUID snapshotId, List<String> refIds) {
@@ -38,53 +46,59 @@ public class TableDependencyDao {
     TableClient tableClient = tableServiceClient.getTableClient(dependencyTableName);
     // The partition size is one less than the MAX_FILTER_CLAUSES to account for the snapshotId
     // filter
-    ListUtils.partition(refIds, MAX_FILTER_CLAUSES - 1)
-        .forEach(
-            refIdChunk -> {
-              String filter =
-                  refIdChunk.stream()
-                          // maybe wrap or cause in parenthesis
-                          .map(
-                              refId ->
-                                  String.format(
-                                      "%s eq '%s'", FireStoreDependency.FILE_ID_FIELD_NAME, refId))
-                          .collect(Collectors.joining(" or "))
-                      + String.format(
-                          " and %s eq '%s'",
-                          FireStoreDependency.SNAPSHOT_ID_FIELD_NAME, snapshotId);
-              List<TableEntity> entities =
-                  TableServiceClientUtils.filterTable(
-                      tableServiceClient, dependencyTableName, filter);
-              List<String> existing =
-                  entities.stream()
-                      .map(e -> e.getProperty(FireStoreDependency.FILE_ID_FIELD_NAME).toString())
-                      .toList();
-              // Create any entities that do not already exist
-              List<TableTransactionAction> batchEntities =
-                  refIdChunk.stream()
-                      .distinct()
-                      .filter(id -> !existing.contains(id))
-                      .map(
-                          refId -> {
-                            FireStoreDependency fireStoreDependency =
-                                new FireStoreDependency()
-                                    .snapshotId(snapshotId.toString())
-                                    .fileId(refId)
-                                    .refCount(1L);
-                            TableEntity fireStoreDependencyEntity =
-                                FireStoreDependency.toTableEntity(fireStoreDependency);
-                            return new TableTransactionAction(
-                                TableTransactionActionType.UPSERT_REPLACE,
-                                fireStoreDependencyEntity);
-                          })
-                      .toList();
-              if (!batchEntities.isEmpty()) {
-                // This can happen if retrying a failed transaction.  This would cause an
-                // IllegalArgumentException with message "A transaction must contain at least one
-                // operation"
-                tableClient.submitTransaction(batchEntities);
-              }
-            });
+    List<Future<Void>> futures = new ArrayList<>();
+    for (List<String> refIdChunk : ListUtils.partition(refIds, MAX_FILTER_CLAUSES - 1)) {
+      futures.add(
+          azureTableThreadpool.submit(
+              () -> {
+                String filter =
+                    refIdChunk.stream()
+                            // maybe wrap or cause in parenthesis
+                            .map(
+                                refId ->
+                                    String.format(
+                                        "%s eq '%s'",
+                                        FireStoreDependency.FILE_ID_FIELD_NAME, refId))
+                            .collect(Collectors.joining(" or "))
+                        + String.format(
+                            " and %s eq '%s'",
+                            FireStoreDependency.SNAPSHOT_ID_FIELD_NAME, snapshotId);
+                List<TableEntity> entities =
+                    TableServiceClientUtils.filterTable(
+                        tableServiceClient, dependencyTableName, filter);
+                List<String> existing =
+                    entities.stream()
+                        .map(e -> e.getProperty(FireStoreDependency.FILE_ID_FIELD_NAME).toString())
+                        .toList();
+                // Create any entities that do not already exist
+                List<TableTransactionAction> batchEntities =
+                    refIdChunk.stream()
+                        .distinct()
+                        .filter(id -> !existing.contains(id))
+                        .map(
+                            refId -> {
+                              FireStoreDependency fireStoreDependency =
+                                  new FireStoreDependency()
+                                      .snapshotId(snapshotId.toString())
+                                      .fileId(refId)
+                                      .refCount(1L);
+                              TableEntity fireStoreDependencyEntity =
+                                  FireStoreDependency.toTableEntity(fireStoreDependency);
+                              return new TableTransactionAction(
+                                  TableTransactionActionType.UPSERT_REPLACE,
+                                  fireStoreDependencyEntity);
+                            })
+                        .toList();
+                if (!batchEntities.isEmpty()) {
+                  // This can happen if retrying a failed transaction.  This would cause an
+                  // IllegalArgumentException with message "A transaction must contain at least one
+                  // operation"
+                  tableClient.submitTransaction(batchEntities);
+                }
+                return null;
+              }));
+    }
+    FutureUtils.waitFor(futures);
   }
 
   public void deleteSnapshotFileDependencies(

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -14,6 +14,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /** Configuration for working with Azure resources */
 @EnableConfigurationProperties
@@ -24,7 +27,8 @@ public record AzureResourceConfiguration(
     int maxRetries,
     int retryTimeoutSeconds,
     String apiVersion,
-    Monitoring monitoring) {
+    Monitoring monitoring,
+    Threading threading) {
 
   /**
    * Given a user tenant Id, return Azure credentials
@@ -158,6 +162,20 @@ public record AzureResourceConfiguration(
       boolean initialize,
       int connectRetryInterval,
       int connectRetryCount) {}
+
+  public record Threading(int numTableThreads) {}
+
+  @Bean("azureTableThreadpool")
+  public AsyncTaskExecutor azureTableThreadpool() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(threading().numTableThreads());
+    executor.setMaxPoolSize(threading().numTableThreads());
+    executor.setKeepAliveSeconds(0);
+    executor.setQueueCapacity(threading().numTableThreads());
+    executor.setThreadNamePrefix("az-table-thread-");
+    executor.initialize();
+    return executor;
+  }
 
   /** Track the monitoring-related configuration */
   public record Monitoring(

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDataStep.java
@@ -15,7 +15,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.azure.data.tables.TableServiceClient;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class CreateSnapshotStorageTableDataStep implements Step {
@@ -60,7 +60,7 @@ public class CreateSnapshotStorageTableDataStep implements Step {
     TableServiceClient snapshotTableServiceClient =
         azureAuthService.getTableServiceClient(snapshotStorageAuthInfo);
 
-    List<String> refIds = azureSynapsePdao.getRefIdsForSnapshot(snapshot);
+    Set<String> refIds = azureSynapsePdao.getRefIdsForSnapshot(snapshot);
 
     tableDao.addFilesToSnapshot(
         datasetTableServiceClient,

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDataStep.java
@@ -67,7 +67,7 @@ public class CreateSnapshotStorageTableDataStep implements Step {
         snapshotTableServiceClient,
         datasetId,
         datasetName,
-        snapshotId,
+        snapshot,
         refIds);
 
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDependenciesStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDependenciesStep.java
@@ -14,7 +14,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.azure.data.tables.TableServiceClient;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class CreateSnapshotStorageTableDependenciesStep implements Step {
@@ -49,7 +49,7 @@ public class CreateSnapshotStorageTableDependenciesStep implements Step {
     UUID snapshotId = workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_ID, UUID.class);
     Snapshot snapshot = snapshotService.retrieve(snapshotId);
 
-    List<String> refIds = azureSynapsePdao.getRefIdsForSnapshot(snapshot);
+    Set<String> refIds = azureSynapsePdao.getRefIdsForSnapshot(snapshot);
     tableDependencyDao.storeSnapshotFileDependencies(
         datasetTableServiceClient, datasetId, snapshotId, refIds);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -130,6 +130,8 @@ azure.synapse.encryptionKey=
 azure.synapse.initialize=false
 azure.synapse.connectRetryInterval=15
 azure.synapse.connectRetryCount=20
+# Number of concurrent operations on Azure storage tables.  Note operations can be batches of operations.
+azure.threading.numTableThreads=1000
 azure.apiVersion=2021-07-01
 azure.maxRetries=3
 azure.retryTimeoutSeconds=3600

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -343,7 +344,7 @@ public class AzureSynapsePdaoConnectedTest {
     snapshotTable.rowCount(snapshotRowIds.size());
     snapshot.snapshotTables(List.of(snapshotTable));
 
-    List<String> refIds = azureSynapsePdao.getRefIdsForSnapshot(snapshot);
+    Set<String> refIds = azureSynapsePdao.getRefIdsForSnapshot(snapshot);
     assertThat("4 fileRefs Returned.", refIds.size(), equalTo(4));
 
     // Make sure all are valid UUIDs

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -67,6 +67,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -123,6 +124,10 @@ public class AzureBlobStorePdaoTest {
   @MockBean private AzureAuthService azureAuthService;
   @MockBean private GcsPdao gcsPdao;
   @MockBean private GcsProjectFactory gcsProjectFactory;
+
+  @MockBean(name = "azureTableThreadpool")
+  private AsyncTaskExecutor asyncTaskExecutor;
+
   @Autowired private AzureBlobStorePdao dao;
 
   @MockBean

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDaoConnectedTest.java
@@ -27,7 +27,9 @@ import com.azure.data.tables.TableServiceClientBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
@@ -60,7 +62,7 @@ public class TableDaoConnectedTest {
   private Dataset dataset;
   private UUID snapshotId;
   private Snapshot snapshot;
-  private List<String> refIds;
+  private Set<String> refIds;
   private String loadTag;
   private int numFilesToLoad;
   private String targetBasePathFormat = "/%s/%s/file-%s.json";
@@ -84,7 +86,7 @@ public class TableDaoConnectedTest {
             .buildClient();
     datasetId = UUID.randomUUID();
     dataset = new Dataset().id(datasetId).name(Names.randomizeName("dataset"));
-    refIds = new ArrayList<>();
+    refIds = new HashSet<>();
     snapshotId = UUID.randomUUID();
     snapshot =
         new Snapshot()
@@ -249,7 +251,7 @@ public class TableDaoConnectedTest {
     }
 
     // Make the snapshot file system
-    List<String> fileIdList = new ArrayList<>();
+    Set<String> fileIdList = new HashSet<>();
     for (FireStoreDirectoryEntry fireStoreDirectoryEntry : snapObjects) {
       fileIdList.add(fireStoreDirectoryEntry.getFileId());
     }

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyConnectedTest.java
@@ -14,7 +14,7 @@ import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.TableServiceClientBuilder;
 import com.azure.data.tables.models.TableEntity;
 import com.azure.data.tables.models.TableServiceException;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,7 +44,7 @@ public class TableDependencyConnectedTest {
   private static final UUID SNAPSHOT_ID = UUID.randomUUID();
   private static final UUID SNAPSHOT_ID2 = UUID.randomUUID();
   private static final String FILE_ID = UUID.randomUUID().toString();
-  private static final List<String> REF_IDS = List.of(FILE_ID);
+  private static final Set<String> REF_IDS = Set.of(FILE_ID);
 
   @Before
   public void setUp() {

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyDaoTest.java
@@ -24,7 +24,7 @@ import com.azure.data.tables.models.ListEntitiesOptions;
 import com.azure.data.tables.models.TableEntity;
 import com.azure.data.tables.models.TableItem;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.Before;
@@ -80,7 +80,7 @@ public class TableDependencyDaoTest {
     UUID datasetId = UUID.randomUUID();
     UUID snapshotId = UUID.randomUUID();
     String refId = UUID.randomUUID().toString();
-    dao.storeSnapshotFileDependencies(tableServiceClient, datasetId, snapshotId, List.of(refId));
+    dao.storeSnapshotFileDependencies(tableServiceClient, datasetId, snapshotId, Set.of(refId));
     verify(tableClient, times(1)).submitTransaction(any());
   }
 
@@ -103,7 +103,7 @@ public class TableDependencyDaoTest {
     when(mockPagedIterable.stream()).thenReturn(Stream.of(fireStoreDependencyEntity));
     when(tableClient.listEntities(any(), any(), any())).thenReturn(mockPagedIterable);
 
-    dao.storeSnapshotFileDependencies(tableServiceClient, datasetId, snapshotId, List.of(refId));
+    dao.storeSnapshotFileDependencies(tableServiceClient, datasetId, snapshotId, Set.of(refId));
     verify(tableClient, times(0)).upsertEntity(any());
     verify(tableClient, times(0)).submitTransaction(any());
   }

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableFileDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableFileDaoTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
@@ -18,7 +17,6 @@ import com.azure.data.tables.models.TableEntity;
 import com.azure.data.tables.models.TableServiceException;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -37,7 +35,7 @@ public class TableFileDaoTest {
 
   @Mock private TableServiceClient tableServiceClient;
   @Mock private TableClient tableClient;
-  private final TableFileDao dao = new TableFileDao(mock(ExecutorService.class));
+  private final TableFileDao dao = new TableFileDao(Runnable::run);
   private final TableEntity entity =
       new TableEntity(PARTITION_KEY, FILE_ID)
           .addProperty(FireStoreFile.FILE_ID_FIELD_NAME, FILE_ID)


### PR DESCRIPTION
This PR fixes a couple of things that are limiting Nate for AnVIL ingestion work:

- Speeding up operations drastically around writing to Azure storage tables (see commit 1)
- Making sure that the drs file path for Azure snapshots that use global DRS ids aren't prefixed with the source dataset name (this is to ensure that the file paths look the same regardless of what the source dataset is).  E.g. before a drs object might have returned like:
```
{
  "id": "v2_foo",
  "name": "my_file",
  "self_uri": "drs://data.terra.bio/v2_foo",
  "size": 1234,
  "created_time": "2023-08-15T14:01:56.426Z",
  "updated_time": "2023-08-19T14:04:56.426Z",
  "version": "0",
  "mime_type": null,
  "checksums": [],
  "access_methods": [],
  "aliases": [
    "/dataset1/mydir/foo",
    "/dataset2/mydir/foo"
  ]
}
```
(note the last value)

would now just return
```
{
  "id": "v2_foo",
  "name": "my_file",
  "self_uri": "drs://data.terra.bio/v2_foo",
  "size": 1234,
  "created_time": "2023-08-15T14:01:56.426Z",
  "updated_time": "2023-08-19T14:04:56.426Z",
  "version": "0",
  "mime_type": null,
  "checksums": [],
  "access_methods": [],
  "aliases": [
    "/mydir/foo"
  ]
}
```

Both commits have more detailed descriptions but the TLDR is that this should make Nate's jobs that have been taking hours take minutes and the DRS resolution for files that are in both GCP and Azure snapshots should now have a single valid localization path.  The perf changes are also very mechanical.  The main thing is to move the inserts into runnables that return futures.
