### PR TITLE
DC-869 - Remove step that deploys dev tag to datarepo-helm-definitions

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -82,23 +82,12 @@ jobs:
         with:
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
-      - name: 'Checkout datarepo-helm-definitions repo'
-        uses: actions/checkout@v3
-        with:
-          repository: 'broadinstitute/datarepo-helm-definitions'
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          path: datarepo-helm-definitions
       - name: "Build new delevop docker image"
         uses: broadinstitute/datarepo-actions/actions/main@0.70.0
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
-      - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
-        with:
-          actions_subcommand: 'deploytagupdate'
-          helm_env_prefix: dev
       - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
         uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
         with:


### PR DESCRIPTION
We instead report versions to sherlock. 

Closing: This step also tags the gcr image that we might need elsewhere

related PR: https://github.com/broadinstitute/datarepo-helm-definitions/pull/480