### PR TITLE
DC-851: add stub service code for get concept heirarchy API

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -44,6 +44,7 @@ import bio.terra.model.SnapshotAccessRequest;
 import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotBuilderCountRequest;
 import bio.terra.model.SnapshotBuilderCountResponse;
+import bio.terra.model.SnapshotBuilderGetConceptHierarchyResponse;
 import bio.terra.model.SnapshotBuilderGetConceptsResponse;
 import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.model.SqlSortDirectionAscDefault;
@@ -587,6 +588,19 @@ public class DatasetsApiController implements DatasetsApi {
         IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS); // TODO: change once SQL is sanitized
     return ResponseEntity.ok(
         snapshotBuilderService.searchConcepts(id, domainId, searchText, userRequest));
+  }
+
+  @Override
+  public ResponseEntity<SnapshotBuilderGetConceptHierarchyResponse> getConceptHierarchy(
+      UUID id, Integer conceptId) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    iamService.verifyAuthorization(
+        userRequest,
+        IamResourceType.DATASET,
+        id.toString(),
+        IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS);
+    return ResponseEntity.ok(
+        snapshotBuilderService.getConceptHierarchy(id, conceptId, userRequest));
   }
 
   private void validateIngestParams(IngestRequestModel ingestRequestModel, UUID datasetId) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7230,6 +7230,10 @@ components:
           type: integer
         hasChildren:
           type: boolean
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/SnapshotBuilderConcept'
 
     SnapshotBuilderGetConceptHierarchyResponse:
       type: object
@@ -7237,21 +7241,7 @@ components:
         ⚠️ The response object for the getConceptHierarchy endpoint
       properties:
         result:
-          type: array
-          items:
-            $ref: '#/components/schemas/SnapshotBuilderConceptAndChildren'
-
-    SnapshotBuilderConceptAndChildren:
-        type: object
-        description: >
-            ⚠️ An object describing a concept and its children in the Snapshot Builder
-        properties:
-          concept:
-            $ref: '#/components/schemas/SnapshotBuilderConcept'
-          children:
-            type: array
-            items:
-                $ref: '#/components/schemas/SnapshotBuilderConcept'
+          $ref: '#/components/schemas/SnapshotBuilderConcept'
 
     SnapshotBuilderProgramDataOption:
       type: object

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4643,6 +4643,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+
+  /api/repository/v1/datasets/{id}/snapshotBuilder/conceptHierarchy/{conceptId}:
+    get:
+      tags:
+        - datasets
+        - repository
+      description: >
+        Given a concept ID, return the hierarchy of concepts above it. For each set of concepts,
+        return all sibling concepts at that level. The first concept returned is the root of the
+        hierarchy.
+      operationId: getConceptHierarchy
+      parameters:
+        - in: path
+          description: The UUID of the dataset.
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          description: A dataset concept id.
+          name: conceptId
+          required: true
+          schema:
+            type: integer
+      responses:
+        200:
+          description: The concepts that define the hierarchy that contain this concept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SnapshotBuilderGetConceptHierarchyResponse'
+        400:
+          description: Bad request - invalid id, badly formed IamResourceType.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        401:
+          description: Unauthorized - dataset does not exist or missing permissions to view.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: Unauthorized - missing permissions to view snapshot builder settings.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: No dataset found that meets the request parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+
   /api/repository/v1/datasets/{id}/snapshotBuilder/count:
     post:
       tags:
@@ -7167,6 +7230,28 @@ components:
           type: integer
         hasChildren:
           type: boolean
+
+    SnapshotBuilderGetConceptHierarchyResponse:
+      type: object
+      description: >
+        ⚠️ The response object for the getConceptHierarchy endpoint
+      properties:
+        result:
+          type: array
+          items:
+            $ref: '#/components/schemas/SnapshotBuilderConceptAndChildren'
+
+    SnapshotBuilderConceptAndChildren:
+        type: object
+        description: >
+            ⚠️ An object describing a concept and its children in the Snapshot Builder
+        properties:
+          concept:
+            $ref: '#/components/schemas/SnapshotBuilderConcept'
+          children:
+            type: array
+            items:
+                $ref: '#/components/schemas/SnapshotBuilderConcept'
 
     SnapshotBuilderProgramDataOption:
       type: object

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4650,9 +4650,8 @@ paths:
         - datasets
         - repository
       description: >
-        Given a concept ID, return the hierarchy of concepts above it. For each set of concepts,
-        return all sibling concepts at that level. The first concept returned is the root of the
-        hierarchy.
+        Given a concept ID, return the root of the tree of concepts that contain this concept.
+        For each element in the path, all sibling concepts are returned.
       operationId: getConceptHierarchy
       parameters:
         - in: path


### PR DESCRIPTION
Add stub code to support the snapshot builder `getConceptHierarchy` API.

Given a concept, this API returns the concept tree that contains it, starting at the root of the concept's domain. For each concept on the path to the specified concept, all sibling concepts are returned as well, so the UI can display the tree that leads to the concept immediately without needing to make another API call.

No unit tests were added for the stub code, as it will be deleted in a future PR, so coverage for this PR is low.