### PR TITLE
[WOR-1552] TDR users should contact Terra Support for help

### DIFF
--- a/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
+++ b/src/main/java/bio/terra/service/job/StairwayExceptionFieldsFactory.java
@@ -11,7 +11,8 @@ import org.apache.commons.lang3.StringUtils;
 
 public class StairwayExceptionFieldsFactory {
 
-  private static final String CONTACT_TEAM_MESSAGE = "Please contact the TDR team for help.";
+  private static final String CONTACT_SUPPORT_MESSAGE =
+      "For further assistance, please contact Terra Support (https://support.terra.bio).";
 
   public static StairwayExceptionFields fromException(Exception ex) {
     String stepName = getStepNameFromStairwayException(ex);
@@ -66,7 +67,7 @@ public class StairwayExceptionFieldsFactory {
     if (errorReportCauses != null) {
       return errorReportCauses;
     }
-    return List.of("The job failed, but not while running a step", CONTACT_TEAM_MESSAGE);
+    return List.of("The job failed, but not while running a step", CONTACT_SUPPORT_MESSAGE);
   }
 
   private static String getStepExceptionMessage(String stepName, Exception exception) {
@@ -82,7 +83,7 @@ public class StairwayExceptionFieldsFactory {
     if (errorReportCauses != null) {
       return errorReportCauses;
     }
-    return List.of("The step failed for an unknown reason.", CONTACT_TEAM_MESSAGE);
+    return List.of("The step failed for an unknown reason.", CONTACT_SUPPORT_MESSAGE);
   }
 
   private static List<String> getErrorReportExceptionCauses(Exception exception) {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1552

When a TDR Stairway flight fails in an unknown way, we've previously instructed users to contact the TDR team for help. 

Now that Terra Support is the first line for user inquiries, we should update this message to avoid unnecessary rerouting of user questions ([example](https://broadinstitute.slack.com/archives/CD4HBRFMG/p1709145114333539)).