### PR TITLE
DC-888: Snapshot Builder - Group all participant counts between 1 and 19

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -125,7 +125,7 @@ public class SnapshotBuilderService {
         .result(new SnapshotBuilderCountResponseResult().total(fuzzyLowCount(rollupCount)));
   }
 
-  // if the rollup count is 0 OR >20, then we will return the actual value
+  // if the rollup count is 0 OR >=20, then we will return the actual value
   // if the rollup count is between 1 and 19, we will return 19 and in the UI we will display <20
   // This helps reduce the risk of re-identification
   int fuzzyLowCount(int rollupCount) {

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -122,7 +122,14 @@ public class SnapshotBuilderService {
             cohorts.stream().map(SnapshotBuilderCohort::getCriteriaGroups).toList(),
             userRequest);
     return new SnapshotBuilderCountResponse()
-        .result(new SnapshotBuilderCountResponseResult().total(Math.max(rollupCount, 20)));
+        .result(new SnapshotBuilderCountResponseResult().total(fuzzyLowCount(rollupCount)));
+  }
+
+  // if the rollup count is 0 OR >20, then we will return the actual value
+  // if the rollup count is between 1 and 19, we will return 19 and in the UI we will display <20
+  // This helps reduce the risk of re-identification
+  int fuzzyLowCount(int rollupCount) {
+    return rollupCount == 0 ? rollupCount : Math.max(rollupCount, 19);
   }
 
   public EnumerateSnapshotAccessRequest enumerateByDatasetId(UUID id) {

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.snapshotbuilder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -36,12 +37,15 @@ import bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderFactory;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -225,5 +229,25 @@ class SnapshotBuilderServiceTest {
             dataset.getId(), List.of(List.of()), TEST_USER);
     assertThat(
         "rollup count should be response from stubbed query runner", rollupCount, equalTo(5));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void fuzzyLowCount(int rollupCount, int expectedFuzzyLowCount) {
+    assertThat(
+        "fuzzyLowCount should match rollup count unless rollup count is between 1 and 19, inclusive. Then, it should return 19.",
+        snapshotBuilderService.fuzzyLowCount(rollupCount),
+        equalTo(expectedFuzzyLowCount));
+  }
+
+  private static Stream<Arguments> fuzzyLowCount() {
+    return Stream.of(
+        arguments(0, 0),
+        arguments(1, 19),
+        arguments(3, 19),
+        arguments(18, 19),
+        arguments(19, 19),
+        arguments(20, 20),
+        arguments(21, 21));
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-888
_______
### The Changes
If the rollup count is 0 OR >=20, then we will return the actual value
If the rollup count is between 1 and 19, we will return 19 and in the UI we will display "less than 20"
This helps reduce the risk of re-identification of patients. 