### PR TITLE
DC-902: Bump datarepo-actions version to fix issue with google apt-key

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -89,13 +89,13 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
@@ -116,7 +116,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'bumper'
           role_id: ${{ secrets.ROLE_ID }}
@@ -89,13 +89,13 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'gradlebuild'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
@@ -116,7 +116,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'alpharelease'
           role_id: ${{ secrets.ROLE_ID }}

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "[datarepo-helm-definitions] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.71.0
         env:
           COMMIT_MESSAGE: "Datarepo api tag version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -113,7 +113,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
       - name: "[datarepo-helm] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.71.0
         env:
           COMMIT_MESSAGE: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -70,7 +70,7 @@ jobs:
           path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests and sonar scan via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -126,7 +126,7 @@ jobs:
           # write vault token
           base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
       - name: "Run connected tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -182,22 +182,22 @@ jobs:
           secrets: |
             secret/dsde/datarepo/integration/azure-application-secrets client-secret | AZURE_CREDENTIALS_SECRET
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gradlebuild' # creates gcr build with git_hash tag
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -212,17 +212,17 @@ jobs:
           echo "git_hash=${git_hash}" >> $GITHUB_OUTPUT
           echo "Latest git hash for this branch: $git_hash"
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.71.0
         timeout-minutes: 20
         env:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run integration tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -232,12 +232,12 @@ jobs:
           AZURE_CREDENTIALS_HOMETENANTID: ${{ env.AZURE_CREDENTIALS_HOMETENANTID }}
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
+        uses: broadinstitute/datarepo-actions/actions/main@0.71.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
   report-to-sherlock:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -70,7 +70,7 @@ jobs:
           path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests and sonar scan via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -126,7 +126,7 @@ jobs:
           # write vault token
           base64 --decode <<< ${B64_RBS_APPLICATION_CREDENTIALS} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
       - name: "Run connected tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -182,22 +182,22 @@ jobs:
           secrets: |
             secret/dsde/datarepo/integration/azure-application-secrets client-secret | AZURE_CREDENTIALS_SECRET
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'gradlebuild' # creates gcr build with git_hash tag
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
@@ -218,11 +218,11 @@ jobs:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run integration tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -232,12 +232,12 @@ jobs:
           AZURE_CREDENTIALS_HOMETENANTID: ${{ env.AZURE_CREDENTIALS_HOMETENANTID }}
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.70.0
+        uses: broadinstitute/datarepo-actions/actions/main@sh/main-fix
         with:
           actions_subcommand: 'gcp_whitelist_clean'
   report-to-sherlock:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-902
______
This PR bumps our repo to the latest version of the [datarepo-actions](https://github.com/broadinstitute/datarepo-actions). 

Details about the root issue can be found in the `[datarepo-actions PR](https://github.com/broadinstitute/datarepo-actions/pull/82)`. Our github actions fail without this fix. 