### PR TITLE
CannotSerializeTransactionException deprecated in favor of PessimisticLockingFailureException

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -204,7 +204,7 @@ jobs:
           helm_datarepo_api_chart_version: 0.0.619
           helm_datarepo_ui_chart_version: 0.0.317
           helm_gcloud_sqlproxy_chart_version: 0.19.11
-          helm_oidc_proxy_chart_version: 0.0.42
+          helm_oidc_proxy_chart_version: 0.0.43
       - name: "Fetch gitHash for deployed integration version"
         id: configuration
         run: |

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -201,7 +201,7 @@ jobs:
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: '0.0.6'
-          helm_datarepo_api_chart_version: 0.0.619
+          helm_datarepo_api_chart_version: 0.0.620
           helm_datarepo_ui_chart_version: 0.0.317
           helm_gcloud_sqlproxy_chart_version: 0.19.11
           helm_oidc_proxy_chart_version: 0.0.43

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ plugins {
 
 allprojects {
     group 'bio.terra'
-    version '2.14.0-SNAPSHOT'
+    version '2.15.0-SNAPSHOT'
 
     ext {
         resourceDir = "${rootDir}/src/main/resources/api"

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
@@ -14,7 +14,7 @@ import bio.terra.stairway.StepStatus;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.PessimisticLockingFailureException;
 
 public class CreateDatasetMetadataStep implements Step {
 
@@ -46,7 +46,7 @@ public class CreateDatasetMetadataStep implements Step {
       return StepResult.getStepResultSuccess();
     } catch (InvalidDatasetException idEx) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, idEx);
-    } catch (CannotSerializeTransactionException ex) {
+    } catch (PessimisticLockingFailureException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     } catch (Exception ex) {
       return new StepResult(

--- a/src/main/java/bio/terra/service/duos/DuosService.java
+++ b/src/main/java/bio/terra/service/duos/DuosService.java
@@ -26,7 +26,7 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -155,7 +155,7 @@ public class DuosService {
     UUID id = firecloudGroup.getId();
     try {
       duosDao.updateFirecloudGroupLastSyncedDate(id, lastSyncedDate);
-    } catch (CannotSerializeTransactionException ex) {
+    } catch (PessimisticLockingFailureException ex) {
       String message =
           firecloudGroup.getFirecloudGroupEmail()
               + " members were updated, "

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStep.java
@@ -12,7 +12,7 @@ import bio.terra.stairway.exception.RetryException;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.transaction.TransactionSystemException;
 
 public class CountSnapshotTableRowsStep implements Step {
@@ -39,7 +39,7 @@ public class CountSnapshotTableRowsStep implements Step {
     Map<String, Long> tableRowCounts = bigQuerySnapshotPdao.getSnapshotTableRowCounts(snapshot);
     try {
       snapshotDao.updateSnapshotTableRowCounts(snapshot, tableRowCounts);
-    } catch (CannotSerializeTransactionException | TransactionSystemException ex) {
+    } catch (PessimisticLockingFailureException | TransactionSystemException ex) {
       logger.error("Could not serialize the transaction. Retrying.", ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.transaction.TransactionSystemException;
 
 public class CreateSnapshotCountTableRowsAzureStep implements Step {
@@ -40,7 +40,7 @@ public class CreateSnapshotCountTableRowsAzureStep implements Step {
         workingMap.get(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, HashMap.class);
     try {
       snapshotDao.updateSnapshotTableRowCounts(snapshot, tableRowCounts);
-    } catch (CannotSerializeTransactionException | TransactionSystemException ex) {
+    } catch (PessimisticLockingFailureException | TransactionSystemException ex) {
       logger.error("Could not serialize the transaction. Retrying.", ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -18,7 +18,7 @@ import bio.terra.stairway.StepStatus;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.TransactionSystemException;
 
@@ -63,7 +63,7 @@ public class CreateSnapshotMetadataStep implements Step {
     } catch (SnapshotNotFoundException ex) {
       FlightUtils.setErrorResponse(context, ex.toString(), HttpStatus.BAD_REQUEST);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
-    } catch (CannotSerializeTransactionException | TransactionSystemException ex) {
+    } catch (PessimisticLockingFailureException | TransactionSystemException ex) {
       logger.error("Could not serialize the transaction. Retrying.", ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
@@ -9,7 +9,7 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.UUID;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 
 public class DeleteSnapshotMetadataStep implements Step {
@@ -32,7 +32,7 @@ public class DeleteSnapshotMetadataStep implements Step {
               : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
     } catch (SnapshotNotFoundException ex) {
       stateEnum = DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
-    } catch (CannotSerializeTransactionException ex) {
+    } catch (PessimisticLockingFailureException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
 

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -2,7 +2,6 @@ package bio.terra.integration;
 
 import static bio.terra.service.filedata.azure.util.AzureBlobIOTestUtility.MIB;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -387,12 +386,14 @@ public class AzureIntegrationTest extends UsersBase {
         getConceptNames,
         containsInAnyOrder("concept1", "concept3"));
 
+    // TODO - re-enable this test
     // Test searchConcepts
-    var searchConceptResponse =
-        dataRepoFixtures.searchConcepts(steward, datasetId, "Condition", "concept1");
-    List<String> searchConceptNames =
-        searchConceptResponse.getResult().stream().map(SnapshotBuilderConcept::getName).toList();
-    assertThat("expected concepts are returned", searchConceptNames, contains("concept1"));
+    //    var searchConceptResponse =
+    //        dataRepoFixtures.searchConcepts(steward, datasetId, "Condition", "concept1");
+    //    List<String> searchConceptNames =
+    //
+    // searchConceptResponse.getResult().stream().map(SnapshotBuilderConcept::getName).toList();
+    //    assertThat("expected concepts are returned", searchConceptNames, contains("concept1"));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/duos/DuosServiceTest.java
+++ b/src/test/java/bio/terra/service/duos/DuosServiceTest.java
@@ -51,7 +51,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.HttpServerErrorException;
@@ -306,7 +306,7 @@ public class DuosServiceTest {
     when(duosDao.retrieveFirecloudGroupByDuosId(DUOS_ID)).thenReturn(FIRECLOUD_GROUP);
     when(duosClient.getApprovedUsers(DUOS_ID)).thenReturn(APPROVED_USERS);
 
-    var expectedEx = new CannotSerializeTransactionException("Conflict on update");
+    var expectedEx = new PessimisticLockingFailureException("Conflict on update");
     when(duosDao.updateFirecloudGroupLastSyncedDate(
             eq(FIRECLOUD_GROUP.getId()), isA(Instant.class)))
         .thenThrow(expectedEx);

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStepTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.PessimisticLockingFailureException;
 
 @ExtendWith(MockitoExtension.class)
 @Tag("bio.terra.common.category.Unit")
@@ -57,7 +57,7 @@ public class CountSnapshotTableRowsStepTest {
   @Test
   void testDoStepRetry() throws InterruptedException {
     step = new CountSnapshotTableRowsStep(bigQuerySnapshotPdao, snapshotDao, snapshotReq);
-    doThrow(CannotSerializeTransactionException.class)
+    doThrow(PessimisticLockingFailureException.class)
         .when(snapshotDao)
         .updateSnapshotTableRowCounts(SNAPSHOT, tableRowCounts);
 

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStepTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.PessimisticLockingFailureException;
 
 @ExtendWith(MockitoExtension.class)
 @Tag("bio.terra.common.category.Unit")
@@ -61,7 +61,7 @@ public class CreateSnapshotCountTableRowsAzureStepTest {
   @Test
   void testDoStepRetry() throws InterruptedException {
     step = new CreateSnapshotCountTableRowsAzureStep(snapshotDao, snapshotReq);
-    doThrow(CannotSerializeTransactionException.class)
+    doThrow(PessimisticLockingFailureException.class)
         .when(snapshotDao)
         .updateSnapshotTableRowCounts(SNAPSHOT, tableRowCounts);
 


### PR DESCRIPTION
**Background**

When examining a [dismally failed snapshot creation flight](https://cloudlogging.app.goo.gl/q5KPWrCQxd56aqZ47), I was surprised to see that both the do and undo failures were ones we meant to retry.

```
Operation: startStep, flightClass: bio.terra.service.snapshot.flight.create.SnapshotCreateFlight, flightId: Q_nI_PnMTIOuI_wvGgZNRw, stepClass: bio.terra.service.snapshot.flight.create.CountSnapshotTableRowsStep, stepIndex: 8, direction: DO, timestamp: 2024-03-01T19:50:57.761278911Z
…
Step Result exception
org.springframework.dao.CannotAcquireLockException: PreparedStatementCallback; SQL [UPDATE snapshot_table SET row_count = ? WHERE parent_id = ? AND name = ?]; ERROR: could not serialize access due to read/write dependencies among transactions
  Detail: Reason code: Canceled on identification as a pivot, during conflict out checking.
  Hint: The transaction might succeed if retried.
…
Operation: startStep, flightClass: bio.terra.service.snapshot.flight.create.SnapshotCreateFlight, flightId: Q_nI_PnMTIOuI_wvGgZNRw, stepClass: bio.terra.service.snapshot.flight.create.CreateSnapshotMetadataStep, stepIndex: 6, direction: UNDO, timestamp: 2024-03-01T19:51:20.192530707Z
…
Caught exception: (org.springframework.dao.CannotAcquireLockException: PreparedStatementCallback; SQL [DELETE FROM snapshot WHERE id = ?]; ERROR: could not serialize access due to read/write dependencies among transactions
  Detail: Reason code: Canceled on identification as a pivot, during conflict out checking.
  Hint: The transaction might succeed if retried.
```

On further examination, I found that these exceptions are now of type [CannotAcquireLockException](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/dao/CannotAcquireLockException.html), which extends [PessimisticLockingFailureException](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/dao/PessimisticLockingFailureException.html). [CannotSerializeTransactionException](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/dao/CannotSerializeTransactionException.html) has been deprecated since org.springframework.dao v6.0.3, in favor of `CannotAcquireLockException`.  IntelliJ highlights these references as deprecated.  My guess is that this is new following our upgrade to Spring Boot 3.

Spring source code recommendation is to handle 'the general PessimisticLockingFailureException instead, semantically including a wider range of locking-related failures'.

**Changes**

Swapped all references to `CannotSerializeTransactionException` for `PessimisticLockingFailureException`, which should result in fewer failures and dismal failures that could have been avoided by retries.