### PR TITLE
[DC-915] Include Count when Search Text is Empty

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -60,13 +60,6 @@ public class SearchConceptsQueryBuilder {
 
     List<FieldVariable> groupBy = List.of(nameField, idField);
 
-    // if the search test is empty do not include the search clauses
-    // return all concepts in the specified domain
-    if (searchText == null || searchText.isEmpty()) {
-      Query query = new Query(select, tables, domainClause, groupBy, orderBy, 100);
-      return query.renderSQL(platform);
-    }
-
     // search concept name clause filters for the search text based on field concept_name
     var searchNameClause =
         createSearchConceptClause(
@@ -93,7 +86,9 @@ public class SearchConceptsQueryBuilder {
     // WHERE concept.name CONTAINS {{name}} GROUP BY c.name, c.concept_id
     // ORDER BY count DESC
 
-    Query query = new Query(select, tables, where, groupBy, orderBy, 100);
+    Query query =
+        new Query(
+            select, tables, searchText.isEmpty() ? domainClause : where, groupBy, orderBy, 100);
 
     return query.renderSQL(platform);
   }

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -39,7 +39,7 @@ public class SearchConceptsQueryBuilder {
     var domainOccurenceTableVariable =
         TableVariable.forJoined(domainOccurrencePointer, occurrenceTable.idColumnName(), idField);
 
-    var personIdField =
+    var countField =
         new FieldVariable(
             new FieldPointer(
                 domainOccurrencePointer, CriteriaQueryBuilder.PERSON_ID_FIELD_NAME, "COUNT"),
@@ -51,12 +51,12 @@ public class SearchConceptsQueryBuilder {
     var domainClause =
         createDomainClause(conceptTablePointer, conceptTableVariable, domainOption.getCategory());
 
-    List<FieldVariable> select = List.of(nameField, idField, personIdField);
+    List<FieldVariable> select = List.of(nameField, idField, countField);
 
     List<TableVariable> tables = List.of(conceptTableVariable, domainOccurenceTableVariable);
 
     List<OrderByVariable> orderBy =
-        List.of(new OrderByVariable(personIdField, OrderByDirection.DESCENDING));
+        List.of(new OrderByVariable(countField, OrderByDirection.DESCENDING));
 
     List<FieldVariable> groupBy = List.of(nameField, idField);
 
@@ -77,7 +77,7 @@ public class SearchConceptsQueryBuilder {
         createSearchConceptClause(
             conceptTablePointer, conceptTableVariable, searchText, "concept_code");
 
-    // SearchConceptNameClause OR searchCodeClause
+    // (searchNameClause OR searchCodeClause)
     List<FilterVariable> searches = List.of(searchNameClause, searchCodeClause);
     BooleanAndOrFilterVariable searchClause =
         new BooleanAndOrFilterVariable(BooleanAndOrFilterVariable.LogicalOperator.OR, searches);

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -63,14 +63,7 @@ public class SearchConceptsQueryBuilder {
     // if the search test is empty do not include the search clauses
     // return all concepts in the specified domain
     if (searchText == null || searchText.isEmpty()) {
-      Query query =
-          new Query(
-              select,
-              tables,
-              domainClause,
-              groupBy,
-              orderBy,
-              100);
+      Query query = new Query(select, tables, domainClause, groupBy, orderBy, 100);
       return query.renderSQL(platform);
     }
 
@@ -100,14 +93,7 @@ public class SearchConceptsQueryBuilder {
     // WHERE concept.name CONTAINS {{name}} GROUP BY c.name, c.concept_id
     // ORDER BY count DESC
 
-    Query query =
-        new Query(
-            select,
-            tables,
-            where,
-            groupBy,
-            orderBy,
-            100);
+    Query query = new Query(select, tables, where, groupBy, orderBy, 100);
 
     return query.renderSQL(platform);
   }

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -76,8 +76,13 @@ public class SearchConceptsQueryBuilder {
 
     // domainClause AND (searchNameClause OR searchCodeClause)
     List<FilterVariable> allFilters = List.of(domainClause, searchClause);
-    BooleanAndOrFilterVariable where =
-        new BooleanAndOrFilterVariable(BooleanAndOrFilterVariable.LogicalOperator.AND, allFilters);
+
+    FilterVariable where;
+    if (searchText.isEmpty()) {
+      where = domainClause;
+    } else {
+      where = new BooleanAndOrFilterVariable(BooleanAndOrFilterVariable.LogicalOperator.AND, allFilters);
+    }
 
     // SELECT concept_name, concept_id, COUNT(DISTINCT person_id) as count
     // FROM concept JOIN domain_occurrence ON domain_occurrence.concept_id =
@@ -85,9 +90,7 @@ public class SearchConceptsQueryBuilder {
     // WHERE concept.name CONTAINS {{name}} GROUP BY c.name, c.concept_id
     // ORDER BY count DESC
 
-    Query query =
-        new Query(
-            select, tables, searchText.isEmpty() ? domainClause : where, groupBy, orderBy, 100);
+    Query query = new Query(select, tables, where, groupBy, orderBy, 100);
 
     return query.renderSQL(platform);
   }

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -53,7 +53,7 @@ public class SearchConceptsQueryBuilder {
 
     List<FieldVariable> select = List.of(nameField, idField, personIdField);
 
-    List<TableVariable> tables = List.of(conceptTableVariable, domainOccurenceTableVariable)
+    List<TableVariable> tables = List.of(conceptTableVariable, domainOccurenceTableVariable);
 
     List<OrderByVariable> orderBy =
         List.of(new OrderByVariable(personIdField, OrderByDirection.DESCENDING));

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -81,7 +81,9 @@ public class SearchConceptsQueryBuilder {
     if (searchText.isEmpty()) {
       where = domainClause;
     } else {
-      where = new BooleanAndOrFilterVariable(BooleanAndOrFilterVariable.LogicalOperator.AND, allFilters);
+      where =
+          new BooleanAndOrFilterVariable(
+              BooleanAndOrFilterVariable.LogicalOperator.AND, allFilters);
     }
 
     // SELECT concept_name, concept_id, COUNT(DISTINCT person_id) as count

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -75,7 +75,11 @@ class SearchConceptsQueryBuilderTest {
         SearchConceptsQueryBuilder.buildSearchConceptsQuery(
             domainOption, "", s -> s, CloudPlatformWrapper.of(platform));
     String expected =
-        "c.concept_name, c.concept_id FROM concept AS c " + "WHERE c.domain_id = 'Condition' ";
+        "c.concept_name, c.concept_id, COUNT(DISTINCT c0.person_id) AS count "
+            + "FROM concept AS c  JOIN condition_occurrence AS c0 ON c0.condition_concept_id = c.concept_id "
+            + "WHERE c.domain_id = 'Condition' "
+            + "GROUP BY c.concept_name, c.concept_id "
+            + "ORDER BY count DESC";
     if (platformWrapper.isAzure()) {
       assertThat(
           "generated SQL for Azure empty search string is correct",


### PR DESCRIPTION
Originally, the count field was not included if searchText did not exist. This PR cleans up the code with stronger variable names and including the `COUNT` field along with adding `groupBy` and `orderBy` in query.

Big Query: 
![Screenshot 2024-03-12 at 9 35 06 AM](https://github.com/DataBiosphere/jade-data-repo/assets/63474660/5be6bc5b-52ba-449d-ade4-a41fc524e07b)

[Azure (code)](https://web.azuresynapse.net/en/authoring/analyze/sqlscripts/Search%20Text%20is%20Empty?workspace=%2Fsubscriptions%2Fd82a79ac-62e3-4b57-857e-9caec35cc9ea%2FresourceGroups%2Ftdr%2Fproviders%2FMicrosoft.Synapse%2Fworkspaces%2Ftdrsynapse1): 
![Screenshot 2024-03-12 at 9 48 34 AM](https://github.com/DataBiosphere/jade-data-repo/assets/63474660/2765449d-0f87-4f38-bd66-82f1eb42155b)


GCP Test: 

https://github.com/DataBiosphere/jade-data-repo/assets/63474660/730b50d8-e1b2-4c60-94cf-669595a21d67

Azure Test:

https://github.com/DataBiosphere/jade-data-repo/assets/63474660/1ba790a5-5304-4cde-80ca-9b3ca2e7a05a






