### PR TITLE
[DC-937] Cloud Platform Proposal

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -184,7 +184,7 @@ public class DatasetsApiController implements DatasetsApi {
         userRequest,
         IamResourceType.DATASET,
         id.toString(),
-        IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS);
+        IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS);
     datasetService.updateDatasetSnapshotBuilderSettings(id, settings);
     return ResponseEntity.ok(
         datasetService.retrieveDatasetModel(

--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -184,7 +184,7 @@ public class DatasetsApiController implements DatasetsApi {
         userRequest,
         IamResourceType.DATASET,
         id.toString(),
-        IamAction.VIEW_SNAPSHOT_BUILDER_SETTINGS);
+        IamAction.UPDATE_SNAPSHOT_BUILDER_SETTINGS);
     datasetService.updateDatasetSnapshotBuilderSettings(id, settings);
     return ResponseEntity.ok(
         datasetService.retrieveDatasetModel(

--- a/src/main/java/bio/terra/common/CloudPlatformWrapper.java
+++ b/src/main/java/bio/terra/common/CloudPlatformWrapper.java
@@ -58,8 +58,10 @@ public abstract class CloudPlatformWrapper {
   }
 
   public <T> T choose(Map<CloudPlatform, Supplier<T>> cloudMap) {
-    return cloudMap.get(CloudPlatform.GCP).get();
+    return cloudMap.get(getCloudPlatform()).get();
   }
+
+  public abstract <T> T choose(Supplier<T> gcp, Supplier<T> azure);
 
   public abstract void ensureValidRegion(String region, Errors errors);
 
@@ -93,6 +95,11 @@ public abstract class CloudPlatformWrapper {
     @Override
     public boolean isGcp() {
       return true;
+    }
+
+    @Override
+    public <T> T choose(Supplier<T> gcp, Supplier<T> azure) {
+      return gcp.get();
     }
 
     @Override
@@ -138,8 +145,8 @@ public abstract class CloudPlatformWrapper {
     }
 
     @Override
-    public <T> T choose(Map<CloudPlatform, Supplier<T>> cloudMap) {
-      return cloudMap.get(CloudPlatform.AZURE).get();
+    public <T> T choose(Supplier<T> gcp, Supplier<T> azure) {
+      return azure.get();
     }
 
     @Override

--- a/src/main/java/bio/terra/common/CloudPlatformWrapper.java
+++ b/src/main/java/bio/terra/common/CloudPlatformWrapper.java
@@ -11,6 +11,7 @@ import bio.terra.service.dataset.GoogleStorageResource;
 import bio.terra.service.dataset.StorageResource;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -56,8 +57,8 @@ public abstract class CloudPlatformWrapper {
     return false;
   }
 
-  public <T> T choose(Supplier<T> gcp, Supplier<T> azure) {
-    return gcp.get();
+  public <T> T choose(Map<CloudPlatform, Supplier<T>> cloudMap) {
+    return cloudMap.get(CloudPlatform.GCP).get();
   }
 
   public abstract void ensureValidRegion(String region, Errors errors);
@@ -137,8 +138,8 @@ public abstract class CloudPlatformWrapper {
     }
 
     @Override
-    public <T> T choose(Supplier<T> gcp, Supplier<T> azure) {
-      return azure.get();
+    public <T> T choose(Map<CloudPlatform, Supplier<T>> cloudMap) {
+      return cloudMap.get(CloudPlatform.AZURE).get();
     }
 
     @Override

--- a/src/main/java/bio/terra/common/CloudPlatformWrapper.java
+++ b/src/main/java/bio/terra/common/CloudPlatformWrapper.java
@@ -12,6 +12,7 @@ import bio.terra.service.dataset.StorageResource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.springframework.validation.Errors;
 
@@ -53,6 +54,10 @@ public abstract class CloudPlatformWrapper {
 
   public boolean isAzure() {
     return false;
+  }
+
+  public <T> T choose(Supplier<T> gcp, Supplier<T> azure) {
+    return gcp.get();
   }
 
   public abstract void ensureValidRegion(String region, Errors errors);
@@ -129,6 +134,11 @@ public abstract class CloudPlatformWrapper {
     @Override
     public boolean isAzure() {
       return true;
+    }
+
+    @Override
+    public <T> T choose(Supplier<T> gcp, Supplier<T> azure) {
+      return azure.get();
     }
 
     @Override

--- a/src/test/java/bio/terra/common/CloudPlatformWrapperTest.java
+++ b/src/test/java/bio/terra/common/CloudPlatformWrapperTest.java
@@ -5,25 +5,37 @@ import static org.junit.jupiter.api.Assertions.*;
 import bio.terra.common.category.Unit;
 import bio.terra.model.CloudPlatform;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 @Tag(Unit.TAG)
 class CloudPlatformWrapperTest {
 
-  @Test
-  void choose_Gcp() {
-    assertEquals(
-        "GCP",
-        CloudPlatformWrapper.of(CloudPlatform.GCP)
-            .choose(Map.of(CloudPlatform.GCP, () -> "GCP", CloudPlatform.AZURE, () -> "Azure")));
+  @ParameterizedTest
+  @EnumSource(CloudPlatform.class)
+  void choose_Map(CloudPlatform cloudPlatform) {
+    CloudPlatformWrapper cloudWrapper = (CloudPlatformWrapper.of(cloudPlatform));
+    Map<CloudPlatform, Supplier<String>> cloudMap =
+        Map.of(CloudPlatform.GCP, () -> "GCP", CloudPlatform.AZURE, () -> "Azure");
+    if (cloudWrapper.isGcp()) {
+      assertEquals("GCP", cloudWrapper.choose(cloudMap));
+    }
+    if (cloudWrapper.isAzure()) {
+      assertEquals("Azure", cloudWrapper.choose(cloudMap));
+    }
   }
 
-  @Test
-  void choose_Azure() {
-    assertEquals(
-        "Azure",
-        CloudPlatformWrapper.of(CloudPlatform.AZURE)
-            .choose(Map.of(CloudPlatform.GCP, () -> "GCP", CloudPlatform.AZURE, () -> "Azure")));
+  @ParameterizedTest
+  @EnumSource(CloudPlatform.class)
+  void choose(CloudPlatform cloudPlatform) {
+    CloudPlatformWrapper cloudWrapper = (CloudPlatformWrapper.of(cloudPlatform));
+    if (cloudWrapper.isGcp()) {
+      assertEquals("GCP", cloudWrapper.choose(() -> "GCP", () -> "Azure"));
+    }
+    if (cloudWrapper.isAzure()) {
+      assertEquals("Azure", cloudWrapper.choose(() -> "GCP", () -> "Azure"));
+    }
   }
 }

--- a/src/test/java/bio/terra/common/CloudPlatformWrapperTest.java
+++ b/src/test/java/bio/terra/common/CloudPlatformWrapperTest.java
@@ -6,36 +6,33 @@ import bio.terra.common.category.Unit;
 import bio.terra.model.CloudPlatform;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag(Unit.TAG)
 class CloudPlatformWrapperTest {
 
+  public static Stream<Arguments> platformSource() {
+    return Stream.of(
+        Arguments.of(CloudPlatform.GCP, "GCP"), Arguments.of(CloudPlatform.AZURE, "Azure"));
+  }
+
+  static final Map<CloudPlatform, Supplier<String>> CLOUD_MAP =
+      Map.of(CloudPlatform.GCP, () -> "GCP", CloudPlatform.AZURE, () -> "Azure");
+
   @ParameterizedTest
-  @EnumSource(CloudPlatform.class)
-  void choose_Map(CloudPlatform cloudPlatform) {
-    CloudPlatformWrapper cloudWrapper = (CloudPlatformWrapper.of(cloudPlatform));
-    Map<CloudPlatform, Supplier<String>> cloudMap =
-        Map.of(CloudPlatform.GCP, () -> "GCP", CloudPlatform.AZURE, () -> "Azure");
-    if (cloudWrapper.isGcp()) {
-      assertEquals("GCP", cloudWrapper.choose(cloudMap));
-    }
-    if (cloudWrapper.isAzure()) {
-      assertEquals("Azure", cloudWrapper.choose(cloudMap));
-    }
+  @MethodSource("platformSource")
+  void choose_Map(CloudPlatform cloudPlatform, String expected) {
+    assertEquals(expected, CloudPlatformWrapper.of(cloudPlatform).choose(CLOUD_MAP));
   }
 
   @ParameterizedTest
-  @EnumSource(CloudPlatform.class)
-  void choose(CloudPlatform cloudPlatform) {
-    CloudPlatformWrapper cloudWrapper = (CloudPlatformWrapper.of(cloudPlatform));
-    if (cloudWrapper.isGcp()) {
-      assertEquals("GCP", cloudWrapper.choose(() -> "GCP", () -> "Azure"));
-    }
-    if (cloudWrapper.isAzure()) {
-      assertEquals("Azure", cloudWrapper.choose(() -> "GCP", () -> "Azure"));
-    }
+  @MethodSource("platformSource")
+  void choose(CloudPlatform cloudPlatform, String expected) {
+    assertEquals(
+        expected, CloudPlatformWrapper.of(cloudPlatform).choose(() -> "GCP", () -> "Azure"));
   }
 }

--- a/src/test/java/bio/terra/common/CloudPlatformWrapperTest.java
+++ b/src/test/java/bio/terra/common/CloudPlatformWrapperTest.java
@@ -1,0 +1,29 @@
+package bio.terra.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.CloudPlatform;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Unit.TAG)
+class CloudPlatformWrapperTest {
+
+  @Test
+  void choose_Gcp() {
+    assertEquals(
+        "GCP",
+        CloudPlatformWrapper.of(CloudPlatform.GCP)
+            .choose(Map.of(CloudPlatform.GCP, () -> "GCP", CloudPlatform.AZURE, () -> "Azure")));
+  }
+
+  @Test
+  void choose_Azure() {
+    assertEquals(
+        "Azure",
+        CloudPlatformWrapper.of(CloudPlatform.AZURE)
+            .choose(Map.of(CloudPlatform.GCP, () -> "GCP", CloudPlatform.AZURE, () -> "Azure")));
+  }
+}


### PR DESCRIPTION
## What
Adds a "choose" method that takes a map from CloudPlatform to Supplier<T>. 
Adds a "choose" method that takes a two supplier arguments from CloudPlatform to Supplier<T>. 

Implements this functionality in getLoadHistory as an example of how this would work.

## Why
This can be used to make dynamic cloud decisions. This encourages the use of a shared API signatures across cloud implementations.

Document discussing different options: https://docs.google.com/document/d/1Wx5her9asIAGK_qYAQfVIuCORcKqmxRt2DAIAyQJVs4/edit?usp=sharing


