### PR TITLE
DC-938 - Increase header size to to 32KB to enable users to have google profile pictures set

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 server.contextPath=
 server.port=8080
+server.max-http-request-header-size=32KB
 spring.datasource.tomcat.test-on-borrow=true
 spring.datasource.tomcat.validation-query=SELECT 1
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-938
_________

Following the precedence of other repos, I'm increasing the max header size to 32KB in order to fix a bug where users that have a photo for their profile picture cannot log into the data repo ui. They run into a 400 error related to the header size being too long. 
