### PR TITLE
Example of Spark executable along with calling application.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -277,6 +277,7 @@ dependencies {
     implementation 'com.azure:azure-storage-common:12.24.1'
     implementation 'com.azure:azure-storage-file-datalake:12.18.1'
     implementation 'com.azure:azure-data-tables:12.3.18'
+    implementation 'com.azure:azure-analytics-synapse-spark:1.0.0-beta.4'
 
     implementation platform('io.sentry:sentry-bom:6.25.0') //import bom
     implementation('io.sentry:sentry-spring-boot-starter')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,4 @@
 rootProject.name = 'jade-data-repo'
 include 'datarepo-client'
+include 'datarepo-jakarta-client'
+include 'synapse-spark'

--- a/src/main/java/bio/terra/RunTheThing.java
+++ b/src/main/java/bio/terra/RunTheThing.java
@@ -1,0 +1,78 @@
+package bio.terra;
+
+import com.azure.analytics.synapse.spark.SparkBatchClient;
+import com.azure.analytics.synapse.spark.SparkClientBuilder;
+import com.azure.analytics.synapse.spark.models.SparkBatchJob;
+import com.azure.analytics.synapse.spark.models.SparkBatchJobOptions;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class RunTheThing {
+
+  public static void main(String[] args) {
+    TokenCredential credential =
+        new ClientSecretCredentialBuilder()
+            .clientId(System.getenv("AZURE_CREDENTIALS_APPLICATIONID"))
+            .tenantId(System.getenv("AZURE_CREDENTIALS_HOMETENANTID"))
+            .clientSecret(System.getenv("AZURE_CREDENTIALS_SECRET"))
+            .build();
+
+    SparkBatchClient batchClient =
+        new SparkClientBuilder()
+            // Note, we currently store something like
+            //         tdr-snps-int-east-us-ondemand.sql.azuresynapse.net
+            // and instead want that value to be the base workspace url., e.g.
+            // https://tdr-snps-int-east-us.dev.azuresynapse.net
+            // We'll want a new config var for that but for now, hacking the URL :)
+
+            .endpoint(
+                "https://"
+                    + System.getenv("AZURE_SYNAPSE_WORKSPACENAME").replace("-ondemand.sql", ".dev"))
+            // This is hard coded for now but should be a config value
+            .sparkPoolName("testpool")
+            .credential(credential)
+            .buildSparkBatchClient();
+
+    SparkBatchJobOptions options =
+        new SparkBatchJobOptions()
+            .setName("test run")
+            .setFile(
+                // The format is:
+                // abfss://<container>@<storage-account>.dfs.core.windows.net/<path>
+                "abfss://exec@tdrsnpsintsaeastus.dfs.core.windows.net/synapse-spark-2.6.0-SNAPSHOT.jar")
+            .setClassName("bio.terra.datarepo.io.AzParquetReader")
+            .setArguments(
+                List.of(
+                    // Same format as above
+                    "--tdr.source.path abfss://2ff51f42-647d-409c-ba4e-5c288c7d555d@tdrslqwwpfikxdzadsrfvmjt.dfs.core.windows.net/metadata/parquet/data/*",
+                    // This is a container of storage account SAS token (file SAS tokens don't work)
+                    // for the file above
+                    "--tdr.source.sas <Sas token>"))
+            .setConfiguration(Map.of("spark.jars.packages", "org.apache.hadoop:hadoop-azure:3.3.4"))
+            .setDriverMemory("1g")
+            .setDriverCores(1)
+            .setExecutorMemory("1g")
+            .setExecutorCores(1)
+            .setExecutorCount(1);
+
+    SparkBatchJob sparkBatchJob = batchClient.createSparkBatchJob(options);
+    // Poll job
+    while (!Set.of("dead", "success")
+        .contains(batchClient.getSparkBatchJob(sparkBatchJob.getId()).getState())) {
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+
+    SparkBatchJob finalSparkBatchJob = batchClient.getSparkBatchJob(sparkBatchJob.getId());
+    System.out.println(
+        "Job state: " + batchClient.getSparkBatchJob(finalSparkBatchJob.getId()).getState());
+
+    finalSparkBatchJob.getLogLines().forEach(System.out::println);
+  }
+}

--- a/synapse-spark/build.gradle
+++ b/synapse-spark/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'java'
+}
+
+java {
+    sourceCompatibility = 8
+    targetCompatibility = 8
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    ext {
+        sparkSqlVersion = "3.3.4"
+    }
+
+    compileOnly "org.apache.spark:spark-sql_2.13:${sparkSqlVersion}"
+}
+

--- a/synapse-spark/src/main/java/bio/terra/datarepo/io/AzParquetReader.java
+++ b/synapse-spark/src/main/java/bio/terra/datarepo/io/AzParquetReader.java
@@ -1,0 +1,69 @@
+package bio.terra.datarepo.io;
+
+
+import static org.apache.spark.sql.types.DataTypes.IntegerType;
+import static org.apache.spark.sql.types.DataTypes.StringType;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+public class AzParquetReader {
+  // To use, build the jar using:
+  // ./gradlew :synapse-spark:jar
+  // Then upload the jar to
+  // https://tdrsnpsintsaeastus.blob.core.windows.net/exec
+  // Spark will read the jar from there
+
+  public static void main(String[] args) {
+    // Create your Spark session
+    SparkSession spark = SparkSession.builder().appName("AZ Parquet Reader").getOrCreate();
+
+    // How to log
+    spark.log().info("Hello, World!");
+
+    // Parse the arguments.  This is gross and can totally be cleaned up!
+    String sourceUrl = null;
+    // Note on the Sas token: it has to be a container or storage account SAS token
+    // (with Read + List and eventually create + write), not a blob Sas token
+    String sourceSasToken = null;
+    for (String arg: args) {
+      if (arg.startsWith("--tdr.source.path")) {
+        sourceUrl = arg.split(" ")[1];
+      } else if (arg.startsWith("--tdr.source.sas")) {
+        sourceSasToken = arg.split(" ")[1];
+      }
+      spark.log().info(arg);
+    }
+    spark.log().info("Source URL: " + sourceUrl);
+    spark.log().info("Source SAS: " + sourceSasToken);
+
+    // Maybe we can use BlobUrlParts.parse(sourceUrl);
+    String storageAccount = sourceUrl.split(".dfs.core.windows.net")[0].split("@")[1];
+    spark.conf().set("fs.azure.account.auth.type", "SAS");
+    spark.log().info("Storage account: " + storageAccount);
+
+    // Set configuration to read from the storage account using a Sas token
+    spark.sparkContext().hadoopConfiguration()
+        .set(String.format("fs.azure.account.auth.type.%s.dfs.core.windows.net", storageAccount), "SAS");
+    spark.sparkContext().hadoopConfiguration().set("fs.azure.sas.token.provider.type", "com.microsoft.azure.synapse.tokenlibrary.ConfBasedSASProvider");
+    spark.conf()
+        .set(String.format("spark.storage.synapse.%s.dfs.core.windows.net.sas", storageAccount),
+            sourceSasToken);
+
+    // Read the parquet file
+    // Note that we need to specify a schema or it fails trying to read the UUID column
+    Dataset<Row> parquet = spark.read()
+        .schema(new StructType()
+                .add(new StructField("datarepo_row_id", StringType, false, Metadata.empty()))
+                .add(new StructField("id", IntegerType, false, Metadata.empty()))
+                .add(new StructField("data", StringType, false, Metadata.empty())))
+        .parquet(sourceUrl);
+
+    // For now just log the record counts
+    spark.log().info("File has " + parquet.count() + " records");
+  }
+}


### PR DESCRIPTION
Here's an example of:
- A class that can be jar-ed and run from Spark that just reads a Parquet director and counts all of the rows and logs the result
- A class that invokes a Spark job.

I've tried to document as well as I could but happy to help walk through it!

Note: to use, you need to be sure that you grant:
- "Storage Blob Data Contributor" to the application running the spark submit job (integration in this example) on the tdrsnpsintsaeastus storage account (which stores the executable jar file)
- "Storage Blob Data Contributor" to the Synapse managed identity on the tdrsnpsintsaeastus storage account (which stores the executable jar file)
- "Synapse Apache Spark Administrator" to the application running the spark submit job (integration in this example) to the Synapse workspace (note: that last one has to be done from inside Synapse Studio)

Just run the "RunTheThingApp" with the environment variables from `./render-configs.sh -a integration  -i` and you should be good to go!

You can then monitor the run from Synapse Studio in the Monitor > Apache Spark Applications blade:
![image](https://github.com/DataBiosphere/jade-data-repo/assets/5633787/f2576bf3-9ca2-4aea-93cd-864fb0fe066d)

And see outputs of the logs in the driver logs:
![image](https://github.com/DataBiosphere/jade-data-repo/assets/5633787/6295f3c1-46a1-46d3-9afe-7feb7e8ff06b)
