### PR TITLE
DC-866: Change search API parameter `domainId` to use the concept ID instead of the concept name

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -579,7 +579,7 @@ public class DatasetsApiController implements DatasetsApi {
 
   @Override
   public ResponseEntity<SnapshotBuilderGetConceptsResponse> searchConcepts(
-      UUID id, String domainId, String searchText) {
+      UUID id, Integer domainId, String searchText) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     iamService.verifyAuthorization(
         userRequest,

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -137,7 +137,7 @@ public class SnapshotBuilderService {
   }
 
   public SnapshotBuilderGetConceptsResponse searchConcepts(
-      UUID datasetId, String domainId, String searchText, AuthenticatedUserRequest userRequest) {
+      UUID datasetId, int domainId, String searchText, AuthenticatedUserRequest userRequest) {
     Dataset dataset = datasetService.retrieve(datasetId);
     TableNameGenerator tableNameGenerator = getTableNameGenerator(dataset, userRequest);
     SnapshotBuilderSettings snapshotBuilderSettings =
@@ -145,7 +145,7 @@ public class SnapshotBuilderService {
 
     SnapshotBuilderDomainOption snapshotBuilderDomainOption =
         snapshotBuilderSettings.getDomainOptions().stream()
-            .filter(domainOption -> domainOption.getName().equals(domainId))
+            .filter(domainOption -> domainOption.getId() == domainId)
             .findFirst()
             .orElseThrow(
                 () ->

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -4592,11 +4592,11 @@ paths:
             type: string
             format: uuid
         - in: path
-          description: A domain id.
+          description: The concept ID of the domain
           name: domainId
           required: true
           schema:
-            type: string
+            type: integer
         - in: query
           description: User specified text to search concepts for.
           name: searchText

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -454,11 +454,13 @@ class DatasetsApiControllerTest {
   void testSearchConcepts(String searchText) throws Exception {
     SnapshotBuilderGetConceptsResponse expected = makeGetConceptsResponse();
 
-    when(snapshotBuilderService.searchConcepts(DATASET_ID, "condition", searchText, TEST_USER))
+    var domainId = 1234;
+
+    when(snapshotBuilderService.searchConcepts(DATASET_ID, domainId, searchText, TEST_USER))
         .thenReturn(expected);
     String actualJson =
         mvc.perform(
-                get(SEARCH_CONCEPTS_ENDPOINT, DATASET_ID, "condition")
+                get(SEARCH_CONCEPTS_ENDPOINT, DATASET_ID, domainId)
                     .queryParam("searchText", searchText))
             .andExpect(status().isOk())
             .andReturn()

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -160,7 +160,8 @@ class SnapshotBuilderServiceTest {
     var concepts = List.of(new SnapshotBuilderConcept().name("concept1").id(1));
     mockRunQueryForConcepts(cloudPlatform, concepts, dataset);
     var response =
-        snapshotBuilderService.searchConcepts(dataset.getId(), "condition", "cancer", TEST_USER);
+        snapshotBuilderService.searchConcepts(
+            dataset.getId(), domainOption.getId(), "cancer", TEST_USER);
     assertThat(
         "searchConcepts returns the expected response", response.getResult(), equalTo(concepts));
   }


### PR DESCRIPTION
The search API requires a domain when searching for concepts. It currently accepts `string`, but it should instead accept `integer`.

Earlier in development, it made sense to use a string for this parameter since that was what was used to `JOIN` the tables in SQL. We now have code that uses the domain option from the settings object, which has the domain name inside it, so the parameter doesn't need to be the domain name anymore.

Note that this is a breaking API change and requires the `terra-ui` PR https://github.com/DataBiosphere/terra-ui/pull/4755 to change the API call.