### PR TITLE
DC-982: Configure intellij to download javadocs for libraries by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,12 @@ spotbugsTest {
     }
 }
 
+idea {
+    module {
+        downloadJavadoc = true
+    }
+}
+
 jacocoTestReport {
     reports {
         // sonarqube requires XML coverage output to upload coverage data


### PR DESCRIPTION
This change adds a gradle configuration for IntelliJ that configures the jade-data-repo module to download javadocs for libraries by default. With this setting enabled, the IntelliJ command `Quick Documentation` can display the javadoc for a library method or class in a popup window.

This setting can be done locally in the IntelliJ project settings but that setting is transient and would be overwritten whenever the gradle dependency configuration changed.