### PR TITLE
[DCJ-5] No concurrent GHA test runs on the same branch

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -36,6 +36,13 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 4 * * *' # run at 4 AM UTC, 12PM EST.
+
+concurrency:
+  # Don't run this workflow concurrently on the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # For PRs, don't wait for completion of existing runs, cancel them instead
+  cancel-in-progress: ${{ github.event_name == "pull_request" }}
+
 jobs:
   test_check:
     name: "Checkout, verify and run unit tests"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-5

GHA's default behavior is that if multiple commits are pushed to a repository in quick succession, each push could trigger a separate workflow run, and these runs will execute concurrently.

We especially wish to limit concurrency for our Unit, Smoke, Connected and Integration test suite. Integration tests in particular can take 1 - 2 hours to run and occupy one of four fixed k8s namespaces. If all namespaces are occupied, other runs of this action must wait until one frees up.

This commit makes it so that this GHA does not run concurrently on the same branch.  Within PRs, existing runs are cancelled.  In this case,  if multiple commits are pushed to TDR in quick succession, only the last workflow run will be allowed to complete.

Sherlock reference: https://github.com/broadinstitute/sherlock/blob/main/.github/workflows/sherlock-build.yaml#L55

GitHub’s docs: https://docs.github.com/en/actions/using-jobs/using-concurrency