### PR TITLE
[DC-983] Fix snapshot request to allow concept

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7249,6 +7249,8 @@ components:
           type: string
         featureValueGroupName:
           type: string
+        concept:
+          $ref: '#/components/schemas/SnapshotBuilderConcept'
 
     SnapshotBuilderDomainOption:
       allOf:


### PR DESCRIPTION
This adds concept as an optional field to `SnapshotBuilderConceptSet`. I chose to add it to the API, rather than remove it from the front end because I thought this might be information we need for snapshot creation. Another option we could do would be to think a bit more about the snapshot builder and what we need - maybe all we need is a domain ID, and that's actually the optional field to add (and then do the UI work to massage the object into shape)