### PR TITLE
[DCJ-13] Add resilience to concurrent load tag lock attempts

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -382,7 +382,7 @@ public class DatasetIngestFlight extends Flight {
     addOptionalCombinedIngestStep(new VerifyBillingAccountAccessStep(googleBillingService));
 
     // Lock the load.
-    addOptionalCombinedIngestStep(new LoadLockStep(loadService));
+    addOptionalCombinedIngestStep(new LoadLockStep(loadService), randomBackoffRetry);
 
     if (!dataset.isSelfHosted()) {
       // Get or create a Google project for files to be ingested into.
@@ -522,7 +522,7 @@ public class DatasetIngestFlight extends Flight {
             appConfig.getMaxBadLoadFileLineErrorsReported()));
 
     // Lock the load.
-    addOptionalCombinedIngestStep(new LoadLockStep(loadService));
+    addOptionalCombinedIngestStep(new LoadLockStep(loadService), randomBackoffRetry);
 
     // Make a link between the Storage Account and Dataset in our database.
     addOptionalCombinedIngestStep(

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -161,8 +161,8 @@ public class FileIngestBulkFlight extends Flight {
     addStep(new IngestFileValidateCloudPlatformStep(dataset));
     // If loading in bulk mode, request an exclusive lock on the dataset
     addStep(new LockDatasetStep(datasetService, datasetUuid, !isBulkMode), randomBackoffRetry);
-    if (!isBulkMode) { // retry?
-      addStep(new LoadLockStep(loadService));
+    if (!isBulkMode) {
+      addStep(new LoadLockStep(loadService), randomBackoffRetry);
     }
     CloudFileReader cloudFileReader = (platform.isGcp()) ? gcsPdao : azureBlobStorePdao;
     addStep(

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestBulkFlight.java
@@ -161,7 +161,7 @@ public class FileIngestBulkFlight extends Flight {
     addStep(new IngestFileValidateCloudPlatformStep(dataset));
     // If loading in bulk mode, request an exclusive lock on the dataset
     addStep(new LockDatasetStep(datasetService, datasetUuid, !isBulkMode), randomBackoffRetry);
-    if (!isBulkMode) {
+    if (!isBulkMode) { // retry?
       addStep(new LoadLockStep(loadService));
     }
     CloudFileReader cloudFileReader = (platform.isGcp()) ? gcsPdao : azureBlobStorePdao;

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/FileIngestFlight.java
@@ -131,7 +131,7 @@ public class FileIngestFlight extends FileIngestTypeFlight {
     }
     addStep(new IngestFileValidateCloudPlatformStep(dataset));
     addStep(new LockDatasetStep(datasetService, datasetId, true), randomBackoffRetry);
-    addStep(new LoadLockStep(loadService));
+    addStep(new LoadLockStep(loadService), randomBackoffRetry);
     addStep(new IngestFileIdStep());
 
     CloudFileReader cloudFileReader = (platform.isGcp()) ? gcsPdao : azureBlobStorePdao;

--- a/src/test/java/bio/terra/service/job/StairwayExceptionFieldsFactoryTest.java
+++ b/src/test/java/bio/terra/service/job/StairwayExceptionFieldsFactoryTest.java
@@ -1,0 +1,48 @@
+package bio.terra.service.job;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.load.exception.LoadLockedException;
+import bio.terra.stairway.Step;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag(Unit.TAG)
+class StairwayExceptionFieldsFactoryTest {
+
+  static Stream<Arguments> fromException() {
+    var stepClass = Step.class;
+    StackTraceElement[] stackTrace = {
+      new StackTraceElement("jdk.internal.reflect.GeneratedMethodAccessor980", "method", "file", 0),
+      new StackTraceElement(stepClass.getName(), "method", "file", 0)
+    };
+
+    var exceptionWithEmptyMessage = new LoadLockedException("");
+    exceptionWithEmptyMessage.setStackTrace(stackTrace);
+    var fallbackMessage =
+        StairwayExceptionFieldsFactory.getFallbackStepExceptionMessage(
+            stepClass.getSimpleName(), exceptionWithEmptyMessage);
+
+    var originalExceptionMessage = "Message from original exception";
+    var exceptionWithMessage = new LoadLockedException(originalExceptionMessage);
+    exceptionWithMessage.setStackTrace(stackTrace);
+
+    return Stream.of(
+        // 1. An exception with an empty message will craft a replacement message
+        Arguments.of(exceptionWithEmptyMessage, fallbackMessage),
+        // 2. An exception with a message will pass along the message
+        Arguments.of(exceptionWithMessage, originalExceptionMessage));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void fromException(Exception originalException, String expectedMessage) {
+    var actual = StairwayExceptionFieldsFactory.fromException(originalException);
+    assertThat(actual.getMessage(), equalTo(expectedMessage));
+  }
+}

--- a/src/test/java/bio/terra/service/load/flight/LoadLockStepTest.java
+++ b/src/test/java/bio/terra/service/load/flight/LoadLockStepTest.java
@@ -1,0 +1,82 @@
+package bio.terra.service.load.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.exception.ConflictException;
+import bio.terra.service.load.LoadService;
+import bio.terra.service.load.exception.LoadLockedException;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class LoadLockStepTest {
+  @Mock private LoadService loadService;
+  @Mock private FlightContext flightContext;
+  private LoadLockStep step;
+  private FlightMap workingMap;
+
+  private static final String FLIGHT_ID = "flightId";
+  private static final String LOAD_TAG = "loadTag";
+  private static final UUID LOAD_ID = UUID.randomUUID();
+
+  @BeforeEach
+  void setup() {
+    workingMap = new FlightMap();
+    when(flightContext.getFlightId()).thenReturn(FLIGHT_ID);
+    when(loadService.getLoadTag(flightContext)).thenReturn(LOAD_TAG);
+
+    step = new LoadLockStep(loadService);
+  }
+
+  @Test
+  void doStep_success() throws InterruptedException {
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(loadService.lockLoad(LOAD_TAG, FLIGHT_ID)).thenReturn(LOAD_ID);
+
+    StepResult doResult = step.doStep(flightContext);
+
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    assertThat(doResult.getException().isPresent(), equalTo(false));
+
+    assertThat(workingMap.get(LoadMapKeys.LOAD_ID, UUID.class), equalTo(LOAD_ID));
+  }
+
+  @Test
+  void doStep_retryLoadLockedException() throws InterruptedException {
+    var exception = new LoadLockedException("Load tag is locked by another flight");
+    doThrow(exception).when(loadService).lockLoad(LOAD_TAG, FLIGHT_ID);
+
+    StepResult doResult = step.doStep(flightContext);
+
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+    Optional<Exception> actualMaybeException = doResult.getException();
+    assertThat(actualMaybeException.isPresent(), equalTo(true));
+    assertThat(actualMaybeException.get(), equalTo(exception));
+    assertThat(workingMap.get(LoadMapKeys.LOAD_ID, UUID.class), equalTo(null));
+  }
+
+  @Test
+  void doStep_throwsUnhandledException() throws InterruptedException {
+    doThrow(ConflictException.class).when(loadService).lockLoad(LOAD_TAG, FLIGHT_ID);
+
+    assertThrows(ConflictException.class, () -> step.doStep(flightContext));
+
+    assertThat(workingMap.get(LoadMapKeys.LOAD_ID, UUID.class), equalTo(null));
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-13

A user is reporting issues attempting to ingest files to a dataset concurrently using the same load tag ([Slack](https://broadinstitute.slack.com/archives/CBJJ7U293/p1712598103743309)).

Logs for a related flight in TDR Prod (requires Firecloud account): https://cloudlogging.app.goo.gl/P3aK9uermQ8WMmtQ7

TDR does not allow concurrent file ingests using the same load tag, but in looking at our code I found two opportunities to add resilience to this process to minimize undue burden on such callers.

(Previously logged issue is somewhat related, but I don’t think it’s at play here: [DR-3426 Load tags span datasets](https://broadworkbench.atlassian.net/browse/DR-3426))

### 1. If an attempt to obtain a load tag lock fails, retry

Previously, attempts to lock the load tag within a Stairway step would fail the flight straightaway.  But if a lock is present on the load tag, it's worth it to retry as the lock could be removed soon.

#### Changes
- Reused our existing `randomBackoffRetry` rule when adding `LoadLockStep` to flights
- Modified `LoadLockStep` to handle `LoadLockException`s as retryable
- Added unit tests

### 2. Fix exception serialization

When a Stairway step throws an exception, we massage it before serializing it and writing it to the database.  This has included walking the stack trace elements to find out what Step threw the exception.

A `ClassNotFoundException` in this process would previously result in a new exception being thrown, and a dismal flight failure that obscured the original issue.

But we can legitimately see unknown classes in the stack trace (such as from reflection) which should not prevent our search for the source Step.  Example exception which previously threw on `jdk.internal.reflect.GeneratedMethodAccessor980`:

```
Step Result exception
bio.terra.service.load.exception.LoadLockedException: Load 'SM-NKIZ7-24-03-15_16-02-19-SM-NKIZ7.files' is locked by flight 'uEoAG5uQRTaFq4ov_OE-RQ'
	at bio.terra.service.load.LoadDao.lockLoad(LoadDao.java:102)
	at jdk.internal.reflect.GeneratedMethodAccessor980.invoke(Unknown Source)…
	at bio.terra.service.load.LoadService.lockLoad(LoadService.java:35)
	at bio.terra.service.load.flight.LoadLockStep.doStep(LoadLockStep.java:23)
```

#### Changes
- Log `ClassNotFoundException` instead of throwing it when walking a Step exception's stack trace elements as part of serializing the exception
- Added unit tests