### PR TITLE
[No Ticket] Document Integration test user credentials Vault path

### DIFF
--- a/src/test/resources/application-integrationtest.properties
+++ b/src/test/resources/application-integrationtest.properties
@@ -14,7 +14,10 @@ it.targetApplicationName=integrationapp
 it.sourceStorageAccountName=tdrintegrationsrc1
 it.ingestRequestContainer=ingestrequests/test
 
-#users
+# QA Common Test Users
+# If you need to log in as one of these users (ex. if integration tests are failing due to a need to
+# accept Terms of Service), the password can be found in Vault:
+# vault read -field=automation_users_passwd secret/dsde/firecloud/qa/common/users
 
 # Stewards
 it.users[0].role=admin


### PR DESCRIPTION
We occasionally have needed to log in as an integration test user when integration tests are failing (ex. when a user needed to accept Terms of Service).

Rather than passing around the password in Slack, documenting the Vault path where the Harry Potter user credentials live in our integration test configuration.