### PR TITLE
DC-951, DC-946, DC-980, DC-1010: Misc query code fixes / cleanups

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -253,13 +253,13 @@ public class SnapshotBuilderService {
   }
 
   record ParentQueryResult(
-      int parentId, int childId, String childName, long code, int count, boolean hasChildren) {
+      int parentId, int childId, String childName, String code, int count, boolean hasChildren) {
     ParentQueryResult(ResultSet rs) throws SQLException {
       this(
           rs.getInt(HierarchyQueryBuilder.PARENT_ID),
           rs.getInt(HierarchyQueryBuilder.CONCEPT_ID),
           rs.getString(HierarchyQueryBuilder.CONCEPT_NAME),
-          rs.getLong(HierarchyQueryBuilder.CONCEPT_CODE),
+          rs.getString(HierarchyQueryBuilder.CONCEPT_CODE),
           rs.getInt(HierarchyQueryBuilder.COUNT),
           rs.getBoolean(HierarchyQueryBuilder.HAS_CHILDREN));
     }
@@ -269,7 +269,7 @@ public class SnapshotBuilderService {
           (int) row.get(HierarchyQueryBuilder.PARENT_ID).getLongValue(),
           (int) row.get(HierarchyQueryBuilder.CONCEPT_ID).getLongValue(),
           row.get(HierarchyQueryBuilder.CONCEPT_NAME).getStringValue(),
-          row.get(HierarchyQueryBuilder.CONCEPT_CODE).getLongValue(),
+          row.get(HierarchyQueryBuilder.CONCEPT_CODE).getStringValue(),
           (int) row.get(HierarchyQueryBuilder.COUNT).getLongValue(),
           row.get(HierarchyQueryBuilder.HAS_CHILDREN).getBooleanValue());
     }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -102,9 +102,7 @@ public class SnapshotBuilderService {
 
     // domain is needed to join with the domain specific occurrence table
     // this does not work for the metadata domain
-    String domainId = getDomainId(conceptId, dataset, userRequest);
-    SnapshotBuilderDomainOption domainOption =
-        getDomainOptionFromSettingsByName(domainId, datasetId);
+    SnapshotBuilderDomainOption domainOption = getDomainOption(conceptId, dataset, userRequest);
 
     Query query =
         queryBuilderFactory
@@ -256,12 +254,15 @@ public class SnapshotBuilderService {
     return enumerateModel;
   }
 
-  record ParentQueryResult(int parentId, int childId, String childName, boolean hasChildren) {
+  record ParentQueryResult(
+      int parentId, int childId, String childName, long code, int count, boolean hasChildren) {
     ParentQueryResult(ResultSet rs) throws SQLException {
       this(
           rs.getInt(HierarchyQueryBuilder.PARENT_ID),
           rs.getInt(HierarchyQueryBuilder.CONCEPT_ID),
           rs.getString(HierarchyQueryBuilder.CONCEPT_NAME),
+          rs.getLong(HierarchyQueryBuilder.CONCEPT_CODE),
+          rs.getInt(HierarchyQueryBuilder.COUNT),
           rs.getBoolean(HierarchyQueryBuilder.HAS_CHILDREN));
     }
 
@@ -270,6 +271,8 @@ public class SnapshotBuilderService {
           (int) row.get(HierarchyQueryBuilder.PARENT_ID).getLongValue(),
           (int) row.get(HierarchyQueryBuilder.CONCEPT_ID).getLongValue(),
           row.get(HierarchyQueryBuilder.CONCEPT_NAME).getStringValue(),
+          row.get(HierarchyQueryBuilder.CONCEPT_CODE).getLongValue(),
+          (int) row.get(HierarchyQueryBuilder.COUNT).getLongValue(),
           row.get(HierarchyQueryBuilder.HAS_CHILDREN).getBooleanValue());
     }
 
@@ -278,14 +281,17 @@ public class SnapshotBuilderService {
           .id(childId)
           .name(childName)
           .hasChildren(hasChildren)
-          .count(1);
+          .code(code)
+          .count(SnapshotBuilderService.fuzzyLowCount(count));
     }
   }
 
   public SnapshotBuilderGetConceptHierarchyResponse getConceptHierarchy(
       UUID datasetId, int conceptId, AuthenticatedUserRequest userRequest) {
     Dataset dataset = datasetService.retrieve(datasetId);
-    var query = queryBuilderFactory.hierarchyQueryBuilder().generateQuery(conceptId);
+
+    var domainOption = getDomainOption(conceptId, dataset, userRequest);
+    var query = queryBuilderFactory.hierarchyQueryBuilder().generateQuery(domainOption, conceptId);
 
     Map<Integer, SnapshotBuilderParentConcept> parents = new HashMap<>();
     runSnapshotBuilderQuery(
@@ -306,5 +312,13 @@ public class SnapshotBuilderService {
     }
 
     return new SnapshotBuilderGetConceptHierarchyResponse().result(List.copyOf(parents.values()));
+  }
+
+  private SnapshotBuilderDomainOption getDomainOption(
+      int conceptId, Dataset dataset, AuthenticatedUserRequest userRequest) {
+    // domain is needed to join with the domain specific occurrence table
+    // this does not work for the metadata domain
+    String domainId = getDomainId(conceptId, dataset, userRequest);
+    return getDomainOptionFromSettingsByName(domainId, dataset.getId());
   }
 }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -100,8 +100,6 @@ public class SnapshotBuilderService {
       UUID datasetId, int conceptId, AuthenticatedUserRequest userRequest) {
     Dataset dataset = datasetService.retrieve(datasetId);
 
-    // domain is needed to join with the domain specific occurrence table
-    // this does not work for the metadata domain
     SnapshotBuilderDomainOption domainOption = getDomainOption(conceptId, dataset, userRequest);
 
     Query query =

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtils.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtils.java
@@ -9,7 +9,7 @@ public class AggregateBQQueryResultsUtils {
     return new SnapshotBuilderConcept()
         .id((int) (row.get(HierarchyQueryBuilder.CONCEPT_ID).getLongValue()))
         .name(row.get(HierarchyQueryBuilder.CONCEPT_NAME).getStringValue())
-        .code(row.get(HierarchyQueryBuilder.CONCEPT_CODE).getLongValue())
+        .code(row.get(HierarchyQueryBuilder.CONCEPT_CODE).getStringValue())
         .hasChildren(row.get(HierarchyQueryBuilder.HAS_CHILDREN).getBooleanValue())
         .count(
             SnapshotBuilderService.fuzzyLowCount(

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtils.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtils.java
@@ -6,20 +6,14 @@ import com.google.cloud.bigquery.FieldValueList;
 
 public class AggregateBQQueryResultsUtils {
   public static SnapshotBuilderConcept toConcept(FieldValueList row) {
-    int count;
-    try {
-      count =
-          SnapshotBuilderService.fuzzyLowCount(
-              (int)
-                  row.get(HierarchyQueryBuilder.COUNT).getLongValue()); // If exists, use its value
-    } catch (IllegalArgumentException e) {
-      count = 1;
-    }
     return new SnapshotBuilderConcept()
         .id((int) (row.get(HierarchyQueryBuilder.CONCEPT_ID).getLongValue()))
         .name(row.get(HierarchyQueryBuilder.CONCEPT_NAME).getStringValue())
+        .code(row.get(HierarchyQueryBuilder.CONCEPT_CODE).getLongValue())
         .hasChildren(row.get(HierarchyQueryBuilder.HAS_CHILDREN).getBooleanValue())
-        .count(count);
+        .count(
+            SnapshotBuilderService.fuzzyLowCount(
+                (int) row.get(HierarchyQueryBuilder.COUNT).getLongValue()));
   }
 
   public static int toCount(FieldValueList row) {

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateSynapseQueryResultsUtils.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateSynapseQueryResultsUtils.java
@@ -21,18 +21,12 @@ public class AggregateSynapseQueryResultsUtils {
   }
 
   public static SnapshotBuilderConcept toConcept(ResultSet rs) {
-    int count;
-    try {
-      count = SnapshotBuilderService.fuzzyLowCount((int) rs.getLong("count"));
-    } catch (SQLException | IllegalArgumentException e) {
-      count = 1;
-    }
-
     return new SnapshotBuilderConcept()
         .name(getField(rs::getString, "concept_name"))
         .id(getField(rs::getLong, "concept_id").intValue())
         .hasChildren(getField(rs::getBoolean, HierarchyQueryBuilder.HAS_CHILDREN))
-        .count(count);
+        .code(getField(rs::getLong, HierarchyQueryBuilder.CONCEPT_CODE))
+        .count(SnapshotBuilderService.fuzzyLowCount(getField(rs::getLong, "count").intValue()));
   }
 
   public static int toCount(ResultSet rs) {

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateSynapseQueryResultsUtils.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/AggregateSynapseQueryResultsUtils.java
@@ -25,7 +25,7 @@ public class AggregateSynapseQueryResultsUtils {
         .name(getField(rs::getString, "concept_name"))
         .id(getField(rs::getLong, "concept_id").intValue())
         .hasChildren(getField(rs::getBoolean, HierarchyQueryBuilder.HAS_CHILDREN))
-        .code(getField(rs::getLong, HierarchyQueryBuilder.CONCEPT_CODE))
+        .code(getField(rs::getString, HierarchyQueryBuilder.CONCEPT_CODE))
         .count(SnapshotBuilderService.fuzzyLowCount(getField(rs::getLong, "count").intValue()));
   }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/ConceptChildrenQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/ConceptChildrenQueryBuilder.java
@@ -24,6 +24,7 @@ public class ConceptChildrenQueryBuilder {
   private static final String DOMAIN_ID = "domain_id";
   private static final String CONCEPT_ID = "concept_id";
   private static final String CONCEPT_NAME = "concept_name";
+  public static final String CONCEPT_CODE = "concept_code";
   private static final String STANDARD_CONCEPT = "standard_concept";
   private static final String ANCESTOR_CONCEPT_ID = "ancestor_concept_id";
   private static final String DESCENDANT_CONCEPT_ID = "descendant_concept_id";
@@ -48,6 +49,7 @@ public class ConceptChildrenQueryBuilder {
     TableVariable concept = TableVariable.forPrimary(TablePointer.fromTableName(CONCEPT));
     FieldVariable conceptName = concept.makeFieldVariable(CONCEPT_NAME);
     FieldVariable conceptId = concept.makeFieldVariable(CONCEPT_ID);
+    FieldVariable conceptCode = concept.makeFieldVariable(CONCEPT_CODE);
 
     // concept_ancestor joined on concept.concept_id = ancestor_concept_id.
     // We use concept_ancestor for the rollup count because we want to include counts
@@ -60,7 +62,7 @@ public class ConceptChildrenQueryBuilder {
     // domain specific occurrence table joined on concept_ancestor.descendant_concept_id =
     // 'domain'_concept_id
     TableVariable domainOccurrence =
-        TableVariable.forJoined(
+        TableVariable.forLeftJoined(
             TablePointer.fromTableName(domainOption.getTableName()),
             domainOption.getColumnName(),
             descendantConceptId);
@@ -70,11 +72,15 @@ public class ConceptChildrenQueryBuilder {
 
     List<SelectExpression> select =
         List.of(
-            conceptName, conceptId, count, HierarchyQueryBuilder.hasChildrenExpression(concept));
+            conceptName,
+            conceptId,
+            conceptCode,
+            count,
+            HierarchyQueryBuilder.hasChildrenExpression(conceptId));
 
     List<TableVariable> tables = List.of(concept, conceptAncestor, domainOccurrence);
 
-    List<FieldVariable> groupBy = List.of(conceptName, conceptId);
+    List<FieldVariable> groupBy = List.of(conceptName, conceptId, conceptCode);
 
     List<OrderByVariable> orderBy =
         List.of(new OrderByVariable(conceptName, OrderByDirection.ASCENDING));

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -74,7 +74,7 @@ public class SearchConceptsQueryBuilder {
 
     var domainClause = createDomainClause(concept, domainOption.getName());
 
-    // SELECT concept_name, concept_id, count, has_children
+    // SELECT concept_name, concept_id, concept_code, count, has_children
     List<SelectExpression> select =
         List.of(
             nameField,
@@ -89,7 +89,7 @@ public class SearchConceptsQueryBuilder {
     List<OrderByVariable> orderBy =
         List.of(new OrderByVariable(countField, OrderByDirection.DESCENDING));
 
-    // GROUP BY c.concept_name, c.concept_id
+    // GROUP BY c.concept_name, c.concept_id, concept_code
     List<FieldVariable> groupBy = List.of(nameField, idField, conceptCode);
 
     FilterVariable where;

--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilder.java
@@ -49,6 +49,7 @@ public class SearchConceptsQueryBuilder {
     var concept = TableVariable.forPrimary(TablePointer.fromTableName(CONCEPT));
     var nameField = concept.makeFieldVariable(CONCEPT_NAME);
     var idField = concept.makeFieldVariable(CONCEPT_ID);
+    var conceptCode = concept.makeFieldVariable(CONCEPT_CODE);
 
     // FROM 'concept' as c
     // JOIN concept_ancestor as c0 ON c0.ancestor_concept_id = c.concept_id
@@ -78,6 +79,7 @@ public class SearchConceptsQueryBuilder {
         List.of(
             nameField,
             idField,
+            conceptCode,
             countField,
             new SelectAlias(new Literal(1), HierarchyQueryBuilder.HAS_CHILDREN));
 
@@ -88,7 +90,7 @@ public class SearchConceptsQueryBuilder {
         List.of(new OrderByVariable(countField, OrderByDirection.DESCENDING));
 
     // GROUP BY c.concept_name, c.concept_id
-    List<FieldVariable> groupBy = List.of(nameField, idField);
+    List<FieldVariable> groupBy = List.of(nameField, idField, conceptCode);
 
     FilterVariable where;
     if (StringUtils.isEmpty(searchText)) {
@@ -124,11 +126,11 @@ public class SearchConceptsQueryBuilder {
         new Literal(searchText));
   }
 
-  static BinaryFilterVariable createDomainClause(
-      TableVariable conceptTableVariable, String domainId) {
-    return new BinaryFilterVariable(
-        conceptTableVariable.makeFieldVariable("domain_id"),
-        BinaryFilterVariable.BinaryOperator.EQUALS,
-        new Literal(domainId));
+  static FilterVariable createDomainClause(TableVariable conceptTableVariable, String domainId) {
+    return BooleanAndOrFilterVariable.and(
+        BinaryFilterVariable.equals(
+            conceptTableVariable.makeFieldVariable("domain_id"), new Literal(domainId)),
+        BinaryFilterVariable.equals(
+            conceptTableVariable.makeFieldVariable("standard_concept"), new Literal("S")));
   }
 }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7306,8 +7306,7 @@ components:
         id:
           type: integer
         code:
-          type: integer
-          format: int64
+          type: string
         name:
           type: string
         count:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7305,6 +7305,9 @@ components:
       properties:
         id:
           type: integer
+        code:
+          type: integer
+          format: int64
         name:
           type: string
         count:

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -157,7 +157,7 @@ class SnapshotBuilderServiceTest {
             .id(2)
             .count(1)
             .hasChildren(true)
-            .code(100L)
+            .code("100")
             .count(99);
     mockRunQueryForGetConcepts(concept("childConcept", 2, true), dataset, "domainId");
 
@@ -370,7 +370,7 @@ class SnapshotBuilderServiceTest {
         .id(id)
         .count(99)
         .hasChildren(hasChildren)
-        .code(100L);
+        .code("100");
   }
 
   @ParameterizedTest

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -357,7 +357,7 @@ class SnapshotBuilderServiceTest {
             Field.of(HierarchyQueryBuilder.PARENT_ID, StandardSQLTypeName.NUMERIC),
             Field.of(HierarchyQueryBuilder.CONCEPT_ID, StandardSQLTypeName.NUMERIC),
             Field.of(HierarchyQueryBuilder.CONCEPT_NAME, StandardSQLTypeName.STRING),
-            Field.of(HierarchyQueryBuilder.CONCEPT_CODE, StandardSQLTypeName.NUMERIC),
+            Field.of(HierarchyQueryBuilder.CONCEPT_CODE, StandardSQLTypeName.STRING),
             Field.of(HierarchyQueryBuilder.COUNT, StandardSQLTypeName.NUMERIC),
             Field.of(HierarchyQueryBuilder.HAS_CHILDREN, StandardSQLTypeName.BOOL));
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,7 +50,6 @@ import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import java.sql.ResultSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,8 +60,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -154,7 +152,13 @@ class SnapshotBuilderServiceTest {
         .thenReturn(settings);
 
     var concept =
-        new SnapshotBuilderConcept().name("childConcept").id(2).count(1).hasChildren(true);
+        new SnapshotBuilderConcept()
+            .name("childConcept")
+            .id(2)
+            .count(1)
+            .hasChildren(true)
+            .code(100L)
+            .count(99);
     mockRunQueryForGetConcepts(concept("childConcept", 2, true), dataset, "domainId");
 
     var response = snapshotBuilderService.getConceptChildren(dataset.getId(), 1, TEST_USER);
@@ -227,6 +231,11 @@ class SnapshotBuilderServiceTest {
   private void mockRunQueryForGetConcepts(
       SnapshotBuilderConcept concept, Dataset dataset, String domainId) {
     mockRunQuery(dataset).thenReturn(List.of(domainId)).thenReturn(List.of(concept));
+  }
+
+  private void mockRunQueryForHierarchy(
+      Dataset dataset, String domainId, List<SnapshotBuilderService.ParentQueryResult> results) {
+    mockRunQuery(dataset).thenReturn(List.of(domainId)).thenReturn(List.copyOf(results));
   }
 
   private <T> org.mockito.stubbing.OngoingStubbing<List<T>> mockRunQuery(Dataset dataset) {
@@ -342,36 +351,26 @@ class SnapshotBuilderServiceTest {
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, "1"),
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, "2"),
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, "name"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "100"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "99"),
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, "true")),
             Field.of(HierarchyQueryBuilder.PARENT_ID, StandardSQLTypeName.NUMERIC),
             Field.of(HierarchyQueryBuilder.CONCEPT_ID, StandardSQLTypeName.NUMERIC),
             Field.of(HierarchyQueryBuilder.CONCEPT_NAME, StandardSQLTypeName.STRING),
+            Field.of(HierarchyQueryBuilder.CONCEPT_CODE, StandardSQLTypeName.NUMERIC),
+            Field.of(HierarchyQueryBuilder.COUNT, StandardSQLTypeName.NUMERIC),
             Field.of(HierarchyQueryBuilder.HAS_CHILDREN, StandardSQLTypeName.BOOL));
 
     assertParentQueryResult(new SnapshotBuilderService.ParentQueryResult(fieldValueList));
   }
 
   static SnapshotBuilderConcept concept(String name, int id, boolean hasChildren) {
-    return new SnapshotBuilderConcept().name(name).id(id).count(1).hasChildren(hasChildren);
-  }
-
-  private <T> void mockRunQueryForHierarchy(CloudPlatform cloudPlatform, List<T> results) {
-    CloudPlatformWrapper.of(cloudPlatform)
-        .choose(
-            () ->
-                when(
-                    bigQueryDatasetPdao.runQuery(
-                        any(),
-                        any(),
-                        argThat(
-                            (ArgumentMatcher<BigQueryDatasetPdao.Converter<T>>) Objects::nonNull))),
-            () ->
-                when(
-                    azureSynapsePdao.runQuery(
-                        any(),
-                        argThat(
-                            (ArgumentMatcher<AzureSynapsePdao.Converter<T>>) Objects::nonNull))))
-        .thenReturn(results);
+    return new SnapshotBuilderConcept()
+        .name(name)
+        .id(id)
+        .count(99)
+        .hasChildren(hasChildren)
+        .code(100L);
   }
 
   @ParameterizedTest
@@ -382,19 +381,23 @@ class SnapshotBuilderServiceTest {
     when(datasetService.retrieve(dataset.getId())).thenReturn(dataset);
     var queryBuilder = mock(HierarchyQueryBuilder.class);
     when(queryBuilderFactory.hierarchyQueryBuilder()).thenReturn(queryBuilder);
-    when(queryBuilder.generateQuery(conceptId)).thenReturn(mock(Query.class));
+    when(queryBuilderFactory.conceptChildrenQueryBuilder())
+        .thenReturn(mock(ConceptChildrenQueryBuilder.class, Mockito.RETURNS_DEEP_STUBS));
+    var domain = new SnapshotBuilderDomainOption();
+    domain.setName("domain");
+    var settings = new SnapshotBuilderSettings().domainOptions(List.of(domain));
+    when(snapshotBuilderSettingsDao.getSnapshotBuilderSettingsByDatasetId(dataset.getId()))
+        .thenReturn(settings);
+    when(queryBuilder.generateQuery(domain, conceptId)).thenReturn(mock(Query.class));
     var concept1 = concept("concept1", 1, true);
     var concept2 = concept("concept2", 2, false);
     var concept3 = concept("concept3", 3, false);
     var results =
         List.of(
-            new SnapshotBuilderService.ParentQueryResult(
-                0, concept1.getId(), concept1.getName(), true),
-            new SnapshotBuilderService.ParentQueryResult(
-                0, concept2.getId(), concept2.getName(), false),
-            new SnapshotBuilderService.ParentQueryResult(
-                concept1.getId(), concept3.getId(), concept3.getName(), false));
-    mockRunQueryForHierarchy(platform, results);
+            createResult(0, concept1),
+            createResult(0, concept2),
+            createResult(concept1.getId(), concept3));
+    mockRunQueryForHierarchy(dataset, domain.getName(), results);
     assertThat(
         snapshotBuilderService.getConceptHierarchy(dataset.getId(), conceptId, TEST_USER),
         equalTo(
@@ -407,5 +410,16 @@ class SnapshotBuilderServiceTest {
                         new SnapshotBuilderParentConcept()
                             .parentId(concept1.getId())
                             .children(List.of(concept3))))));
+  }
+
+  private static SnapshotBuilderService.ParentQueryResult createResult(
+      int parentId, SnapshotBuilderConcept concept) {
+    return new SnapshotBuilderService.ParentQueryResult(
+        parentId,
+        concept.getId(),
+        concept.getName(),
+        concept.getCode(),
+        concept.getCount(),
+        concept.isHasChildren());
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtilsTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtilsTest.java
@@ -52,7 +52,7 @@ class AggregateBQQueryResultsUtilsTest {
             List.of(
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, String.valueOf(expected.getId())),
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, expected.getName()),
-                FieldValue.of(FieldValue.Attribute.PRIMITIVE, String.valueOf(expected.getCode())),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, expected.getCode()),
                 FieldValue.of(
                     FieldValue.Attribute.PRIMITIVE, String.valueOf(expected.isHasChildren())),
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, String.valueOf(expected.getCount()))),

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtilsTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtilsTest.java
@@ -46,7 +46,7 @@ class AggregateBQQueryResultsUtilsTest {
             .id(1)
             .hasChildren(true)
             .count(100)
-            .code(99L);
+            .code("99");
     FieldValueList row =
         FieldValueList.of(
             List.of(
@@ -58,7 +58,7 @@ class AggregateBQQueryResultsUtilsTest {
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, String.valueOf(expected.getCount()))),
             Field.of("concept_id", StandardSQLTypeName.NUMERIC),
             Field.of("concept_name", StandardSQLTypeName.STRING),
-            Field.of("concept_code", StandardSQLTypeName.NUMERIC),
+            Field.of("concept_code", StandardSQLTypeName.STRING),
             Field.of("has_children", StandardSQLTypeName.BOOL),
             Field.of("count", StandardSQLTypeName.NUMERIC));
     assertThat(AggregateBQQueryResultsUtils.toConcept(row), is(expected));

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtilsTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateBQQueryResultsUtilsTest.java
@@ -41,17 +41,24 @@ class AggregateBQQueryResultsUtilsTest {
   @Test
   void toConcept() {
     var expected =
-        new SnapshotBuilderConcept().name("concept_name").id(1).hasChildren(true).count(100);
+        new SnapshotBuilderConcept()
+            .name("concept_name")
+            .id(1)
+            .hasChildren(true)
+            .count(100)
+            .code(99L);
     FieldValueList row =
         FieldValueList.of(
             List.of(
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, String.valueOf(expected.getId())),
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, expected.getName()),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, String.valueOf(expected.getCode())),
                 FieldValue.of(
                     FieldValue.Attribute.PRIMITIVE, String.valueOf(expected.isHasChildren())),
                 FieldValue.of(FieldValue.Attribute.PRIMITIVE, String.valueOf(expected.getCount()))),
             Field.of("concept_id", StandardSQLTypeName.NUMERIC),
             Field.of("concept_name", StandardSQLTypeName.STRING),
+            Field.of("concept_code", StandardSQLTypeName.NUMERIC),
             Field.of("has_children", StandardSQLTypeName.BOOL),
             Field.of("count", StandardSQLTypeName.NUMERIC));
     assertThat(AggregateBQQueryResultsUtils.toConcept(row), is(expected));

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateSynapseQueryResultsUtilsTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateSynapseQueryResultsUtilsTest.java
@@ -63,12 +63,18 @@ class AggregateSynapseQueryResultsUtilsTest {
   @Test
   void toConcept() throws Exception {
     var expected =
-        new SnapshotBuilderConcept().name("concept_name").id(1).hasChildren(true).count(100);
+        new SnapshotBuilderConcept()
+            .name("concept_name")
+            .id(1)
+            .hasChildren(true)
+            .count(100)
+            .code(99L);
 
     ResultSet rs = mock(ResultSet.class);
     when(rs.getLong("count")).thenReturn((long) expected.getCount());
     when(rs.getString("concept_name")).thenReturn(expected.getName());
     when(rs.getLong("concept_id")).thenReturn((long) expected.getId());
+    when(rs.getLong("concept_code")).thenReturn(expected.getCode());
     when(rs.getBoolean(HierarchyQueryBuilder.HAS_CHILDREN)).thenReturn(expected.isHasChildren());
 
     assertThat(

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateSynapseQueryResultsUtilsTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/AggregateSynapseQueryResultsUtilsTest.java
@@ -68,13 +68,13 @@ class AggregateSynapseQueryResultsUtilsTest {
             .id(1)
             .hasChildren(true)
             .count(100)
-            .code(99L);
+            .code("99");
 
     ResultSet rs = mock(ResultSet.class);
     when(rs.getLong("count")).thenReturn((long) expected.getCount());
     when(rs.getString("concept_name")).thenReturn(expected.getName());
     when(rs.getLong("concept_id")).thenReturn((long) expected.getId());
-    when(rs.getLong("concept_code")).thenReturn(expected.getCode());
+    when(rs.getString("concept_code")).thenReturn(expected.getCode());
     when(rs.getBoolean(HierarchyQueryBuilder.HAS_CHILDREN)).thenReturn(expected.isHasChildren());
 
     assertThat(

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/ConceptChildrenQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/ConceptChildrenQueryBuilderTest.java
@@ -17,7 +17,7 @@ class ConceptChildrenQueryBuilderTest {
 
   private static final String GCP_EXPECTED =
       """
-      SELECT c.concept_name, c.concept_id,
+      SELECT c.concept_name, c.concept_id, c.concept_code,
         COUNT(DISTINCT c0.person_id) AS count,
         EXISTS (SELECT 1
           FROM concept_ancestor AS c1
@@ -27,16 +27,16 @@ class ConceptChildrenQueryBuilderTest {
         AS has_children
       FROM concept AS c
         JOIN concept_ancestor AS c3 ON c3.ancestor_concept_id = c.concept_id
-        JOIN condition_occurrence AS c0 ON c0.condition_concept_id = c3.descendant_concept_id
+        LEFT JOIN condition_occurrence AS c0 ON c0.condition_concept_id = c3.descendant_concept_id
       WHERE (c.concept_id IN (SELECT c4.concept_id_2
           FROM concept_relationship AS c4
           WHERE (c4.concept_id_1 = 101 AND c4.relationship_id = 'Subsumes')) AND c.standard_concept = 'S')
-      GROUP BY c.concept_name, c.concept_id
+      GROUP BY c.concept_name, c.concept_id, c.concept_code
       ORDER BY c.concept_name ASC""";
 
   private static final String AZURE_EXPECTED =
       """
-      SELECT c.concept_name, c.concept_id,
+      SELECT c.concept_name, c.concept_id, c.concept_code,
         COUNT(DISTINCT c0.person_id) AS count,
         CASE WHEN EXISTS (SELECT 1
           FROM concept_ancestor AS c1
@@ -46,29 +46,30 @@ class ConceptChildrenQueryBuilderTest {
         THEN 1 ELSE 0 END AS has_children
       FROM concept AS c
         JOIN concept_ancestor AS c3 ON c3.ancestor_concept_id = c.concept_id
-        JOIN condition_occurrence AS c0 ON c0.condition_concept_id = c3.descendant_concept_id
+        LEFT JOIN condition_occurrence AS c0 ON c0.condition_concept_id = c3.descendant_concept_id
       WHERE (c.concept_id IN (SELECT c4.concept_id_2
           FROM concept_relationship AS c4
           WHERE (c4.concept_id_1 = 101 AND c4.relationship_id = 'Subsumes')) AND c.standard_concept = 'S')
-      GROUP BY c.concept_name, c.concept_id
+      GROUP BY c.concept_name, c.concept_id, c.concept_code
       ORDER BY c.concept_name ASC""";
 
-  private SnapshotBuilderDomainOption createDomainOption(
-      String name, int id, String occurrenceTable, String columnName) {
+  public static SnapshotBuilderDomainOption createDomainOption() {
     var option = new SnapshotBuilderDomainOption();
-    option.name(name).id(id).tableName(occurrenceTable).columnName(columnName);
+    option
+        .name("Condition")
+        .id(19)
+        .tableName("condition_occurrence")
+        .columnName("condition_concept_id");
     return option;
   }
 
   @ParameterizedTest
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void buildConceptChildrenQuery(SqlRenderContext context) {
-    SnapshotBuilderDomainOption domainOption =
-        createDomainOption("Condition", 19, "condition_occurrence", "condition_concept_id");
     String sql =
         new QueryBuilderFactory()
             .conceptChildrenQueryBuilder()
-            .buildConceptChildrenQuery(domainOption, 101)
+            .buildConceptChildrenQuery(createDomainOption(), 101)
             .renderSQL(context);
     assertThat(
         sql,

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/HierarchyQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/HierarchyQueryBuilderTest.java
@@ -16,46 +16,55 @@ class HierarchyQueryBuilderTest {
   private static final String GCP_EXPECTED =
       """
       SELECT
-        c.concept_id_1 AS parent_id, c.concept_id_2 AS concept_id, c0.concept_name, c0.concept_code,
-        EXISTS (SELECT 1
-          FROM concept_ancestor AS c1
-                   JOIN concept AS c2 ON c2.concept_id = c1.descendant_concept_id
-          WHERE (c1.ancestor_concept_id = c0.concept_id AND
-                 c1.descendant_concept_id != c0.concept_id AND
-                 c2.standard_concept = 'S'))
-          AS has_children
+          c.concept_id_1 AS parent_id, c.concept_id_2 AS concept_id, c0.concept_name, c0.concept_code,
+             COUNT(DISTINCT c1.person_id) AS count,
+             EXISTS (SELECT 1
+           FROM concept_ancestor AS c2
+                    JOIN concept AS c3 ON c3.concept_id = c2.descendant_concept_id
+           WHERE (c2.ancestor_concept_id = c.concept_id_2 AND
+                  c2.descendant_concept_id != c.concept_id_2 AND
+                  c3.standard_concept = 'S'))
+                 AS has_children
       FROM concept_relationship AS c
-       JOIN concept AS c0 ON c0.concept_id = c.concept_id_2
-       JOIN concept AS c3 ON c3.concept_id = c.concept_id_1
-      WHERE (c.concept_id_1 IN (SELECT c4.ancestor_concept_id
-              FROM concept_ancestor AS c4
-              WHERE (c4.descendant_concept_id = 1 AND c4.ancestor_concept_id != 1)) AND
-          c.relationship_id = 'Subsumes' AND c3.standard_concept = 'S' AND c0.standard_concept = 'S')""";
+               JOIN concept AS c0 ON c0.concept_id = c.concept_id_2
+               JOIN concept AS c4 ON c4.concept_id = c.concept_id_1
+               LEFT JOIN condition_occurrence AS c1 ON c1.condition_concept_id = c.concept_id_2
+      WHERE (c.concept_id_1 IN (SELECT c5.ancestor_concept_id
+           FROM concept_ancestor AS c5
+           WHERE (c5.descendant_concept_id = 1 AND c5.ancestor_concept_id != 1)) AND
+             c.relationship_id = 'Subsumes' AND c4.standard_concept = 'S' AND c0.standard_concept = 'S')
+      GROUP BY c0.concept_name, c.concept_id_1, c.concept_id_2, c0.concept_code
+      ORDER BY c0.concept_name ASC""";
 
   private static final String AZURE_EXPECTED =
       """
-      SELECT
-        c.concept_id_1 AS parent_id, c.concept_id_2 AS concept_id, c0.concept_name, c0.concept_code,
+      SELECT c.concept_id_1 AS parent_id, c.concept_id_2 AS concept_id, c0.concept_name, c0.concept_code,
+        COUNT(DISTINCT c1.person_id) AS count,
         CASE
             WHEN EXISTS (SELECT 1
-              FROM concept_ancestor AS c1
-                       JOIN concept AS c2 ON c2.concept_id = c1.descendant_concept_id
-              WHERE (c1.ancestor_concept_id = c0.concept_id AND
-                     c1.descendant_concept_id != c0.concept_id AND
-                     c2.standard_concept = 'S')) THEN 1
+              FROM concept_ancestor AS c2
+                       JOIN concept AS c3 ON c3.concept_id = c2.descendant_concept_id
+              WHERE (c2.ancestor_concept_id = c.concept_id_2 AND
+                     c2.descendant_concept_id != c.concept_id_2 AND
+                     c3.standard_concept = 'S')) THEN 1
             ELSE 0 END AS has_children
       FROM concept_relationship AS c
-       JOIN concept AS c0 ON c0.concept_id = c.concept_id_2
-       JOIN concept AS c3 ON c3.concept_id = c.concept_id_1
-      WHERE (c.concept_id_1 IN (SELECT c4.ancestor_concept_id
-              FROM concept_ancestor AS c4
-              WHERE (c4.descendant_concept_id = 1 AND c4.ancestor_concept_id != 1)) AND
-          c.relationship_id = 'Subsumes' AND c3.standard_concept = 'S' AND c0.standard_concept = 'S')""";
+         JOIN concept AS c0 ON c0.concept_id = c.concept_id_2
+         JOIN concept AS c4 ON c4.concept_id = c.concept_id_1
+         LEFT JOIN condition_occurrence AS c1 ON c1.condition_concept_id = c.concept_id_2
+      WHERE (c.concept_id_1 IN (SELECT c5.ancestor_concept_id
+               FROM concept_ancestor AS c5
+               WHERE (c5.descendant_concept_id = 1 AND c5.ancestor_concept_id != 1)) AND
+             c.relationship_id = 'Subsumes' AND c4.standard_concept = 'S' AND c0.standard_concept = 'S')
+      GROUP BY c0.concept_name, c.concept_id_1, c.concept_id_2, c0.concept_code
+      ORDER BY c0.concept_name ASC""";
 
   @ParameterizedTest
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void generateQuery(SqlRenderContext context) {
-    var query = new HierarchyQueryBuilder().generateQuery(1);
+    var query =
+        new HierarchyQueryBuilder()
+            .generateQuery(ConceptChildrenQueryBuilderTest.createDomainOption(), 1);
     assertThat(
         query.renderSQL(context),
         equalToCompressingWhiteSpace(context.getPlatform().choose(GCP_EXPECTED, AZURE_EXPECTED)));

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -38,29 +38,26 @@ class SearchConceptsQueryBuilderTest {
 
     String expectedGCPQuery =
         """
-            SELECT c.concept_name, c.concept_id, COUNT(DISTINCT o.person_id) AS count, 1 AS has_children
-            FROM concept AS c
-            JOIN concept_ancestor AS c0 ON c0.ancestor_concept_id = c.concept_id
-            LEFT JOIN observation AS o ON o.observation_concept_id = c0.descendant_concept_id
-            WHERE (c.domain_id = 'Observation'
-            AND (CONTAINS_SUBSTR(c.concept_name, 'cancer')
-            OR CONTAINS_SUBSTR(c.concept_code, 'cancer')))
-            GROUP BY c.concept_name, c.concept_id
-            ORDER BY count DESC
-            LIMIT 100
-       """;
+        SELECT c.concept_name, c.concept_id, c.concept_code, COUNT(DISTINCT o.person_id) AS count, 1 AS has_children
+        FROM concept AS c
+          JOIN concept_ancestor AS c0 ON c0.ancestor_concept_id = c.concept_id
+          LEFT JOIN observation AS o ON o.observation_concept_id = c0.descendant_concept_id
+        WHERE ((c.domain_id = 'Observation' AND c.standard_concept = 'S') AND
+               (CONTAINS_SUBSTR(c.concept_name, 'cancer') OR CONTAINS_SUBSTR(c.concept_code, 'cancer')))
+        GROUP BY c.concept_name, c.concept_id, c.concept_code
+        ORDER BY count DESC
+        LIMIT 100""";
 
     String expectedAzureQuery =
         """
-            SELECT TOP 100 c.concept_name, c.concept_id, COUNT(DISTINCT o.person_id) AS count, 1 AS has_children
-            FROM concept AS c
-            JOIN concept_ancestor AS c0 ON c0.ancestor_concept_id = c.concept_id
-            LEFT JOIN observation AS o ON o.observation_concept_id = c0.descendant_concept_id
-            WHERE (c.domain_id = 'Observation'
-            AND (CHARINDEX('cancer', c.concept_name) > 0
-            OR CHARINDEX('cancer', c.concept_code) > 0))
-            GROUP BY c.concept_name, c.concept_id
-            ORDER BY count DESC""";
+        SELECT TOP 100 c.concept_name, c.concept_id, c.concept_code, COUNT(DISTINCT o.person_id) AS count, 1 AS has_children
+        FROM concept AS c
+          JOIN concept_ancestor AS c0 ON c0.ancestor_concept_id = c.concept_id
+          LEFT JOIN observation AS o ON o.observation_concept_id = c0.descendant_concept_id
+        WHERE ((c.domain_id = 'Observation' AND c.standard_concept = 'S') AND
+               (CHARINDEX('cancer', c.concept_name) > 0 OR CHARINDEX('cancer', c.concept_code) > 0))
+        GROUP BY c.concept_name, c.concept_id, c.concept_code
+        ORDER BY count DESC""";
 
     String actual =
         new QueryBuilderFactory()
@@ -69,7 +66,7 @@ class SearchConceptsQueryBuilderTest {
             .renderSQL(context);
 
     assertThat(
-        "generated SQL for GCP is correct",
+        "generated SQL is correct",
         actual,
         equalToCompressingWhiteSpace(platformWrapper.choose(expectedGCPQuery, expectedAzureQuery)));
   }
@@ -87,14 +84,13 @@ class SearchConceptsQueryBuilderTest {
             .renderSQL(context);
     String expected =
         """
-            c.concept_name, c.concept_id, COUNT(DISTINCT c0.person_id) AS count, 1 AS has_children
-            FROM concept AS c
-            JOIN concept_ancestor AS c1 ON c1.ancestor_concept_id = c.concept_id
-            LEFT JOIN condition_occurrence AS c0 ON c0.condition_concept_id = c1.descendant_concept_id
-            WHERE c.domain_id = 'Condition'
-            GROUP BY c.concept_name, c.concept_id
-            ORDER BY count DESC
-        """;
+        c.concept_name, c.concept_id, c.concept_code, COUNT(DISTINCT c0.person_id) AS count, 1 AS has_children
+        FROM concept AS c
+          JOIN concept_ancestor AS c1 ON c1.ancestor_concept_id = c.concept_id
+          LEFT JOIN condition_occurrence AS c0 ON c0.condition_concept_id = c1.descendant_concept_id
+        WHERE (c.domain_id = 'Condition' AND c.standard_concept = 'S')
+        GROUP BY c.concept_name, c.concept_id, c.concept_code
+        ORDER BY count DESC""";
 
     assertThat(
         "generated SQL for GCP and Azure empty search string is correct",
@@ -134,8 +130,8 @@ class SearchConceptsQueryBuilderTest {
 
     assertThat(
         "generated sql is as expected",
-        SearchConceptsQueryBuilder.createDomainClause(conceptTableVariable, "cancer")
+        SearchConceptsQueryBuilder.createDomainClause(conceptTableVariable, "domain")
             .renderSQL(context),
-        is("c.domain_id = 'cancer'"));
+        is("(c.domain_id = 'domain' AND c.standard_concept = 'S')"));
   }
 }


### PR DESCRIPTION
A few related fixes for the snapshot builder query code:

- add rollup counts to getHierarchy API (DC-951)
- add concept codes to all query responses (getHierarchy, getConcepts, searchConcepts) (DC-980)
- add alphabetic sorting to the getHierarchy response (DC-946)
- only show standard concepts in the search results (DC-1010)

This also adds constant values for non-generated fields so the code that converts the query response data doesn't need to check for missing fields.

The work to add concept codes to the UI is covered in DC-975.