### PR TITLE
[DCJ-28] Use Sherlock to Slack DCJ team on failures, retries

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -4,10 +4,6 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
   # This must be defined for the bash redirection
   GOOGLE_SA_CERT: 'jade-dev-account.pem'
-  # Skip entire workflow if commit is authored by broadbot
-  # broadbot is only used for automated commits, like version bumps
-  # We don't want to trigger a version bump/deploy to dev for those
-  SHOULD_RUN_WORKFLOW: ${{ !contains( github.event.sender.login, 'broadbot') }}
 
 on:
   workflow_dispatch: {}
@@ -30,7 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       api_image_tag: ${{ steps.bumperstep.outputs.tag }}
-    if: ${{ env.SHOULD_RUN_WORKFLOW }}
+    # Skip entire workflow if commit is authored by broadbot
+    # broadbot is only used for automated commits, like version bumps
+    # We don't want to trigger a version bump/deploy to dev for those
+    if: ${{ !contains( github.event.sender.login, 'broadbot') }}
     steps:
       - name: Checkout Develop branch of jade-data-repo
         uses: actions/checkout@v3
@@ -168,13 +167,3 @@ jobs:
       - set-app-version-in-dev
     uses: ./.github/workflows/helmtagbumper.yaml
     secrets: inherit
-
-  report-workflow:
-    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
-    if: ${{ env.SHOULD_RUN_WORKFLOW }}
-    with:
-      relates-to-chart-releases: 'datarepo-dev'
-      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
-      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
-    permissions:
-      id-token: write

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -4,6 +4,11 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
   # This must be defined for the bash redirection
   GOOGLE_SA_CERT: 'jade-dev-account.pem'
+  # Skip entire workflow if commit is authored by broadbot
+  # broadbot is only used for automated commits, like version bumps
+  # We don't want to trigger a version bump/deploy to dev for those
+  SHOULD_RUN_WORKFLOW: ${{ !contains( github.event.sender.login, 'broadbot') }}
+
 on:
   workflow_dispatch: {}
   push:
@@ -25,10 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       api_image_tag: ${{ steps.bumperstep.outputs.tag }}
-    # Skip entire workflow if commit is authored by broadbot
-    # broadbot is only used for automated commits, like version bumps
-    # We don't want to trigger a version bump/deploy to dev for those
-    if: ${{ !contains( github.event.sender.login, 'broadbot') }}
+    if: ${{ env.SHOULD_RUN_WORKFLOW }}
     steps:
       - name: Checkout Develop branch of jade-data-repo
         uses: actions/checkout@v3
@@ -167,25 +169,12 @@ jobs:
     uses: ./.github/workflows/helmtagbumper.yaml
     secrets: inherit
 
-  action_notify:
-    runs-on: ubuntu-latest
-    if: ${{ always() && !contains( github.event.sender.login, 'broadbot') }}
-    needs:
-      - bump_version
-      - build_client_and_publish
-      - build_container_and_publish
-      - report-to-sherlock
-      - set-app-version-in-dev
-      - cherry_pick_image_to_production_gcr
-      - helm_tag_bumper
-    steps:
-      - name: Slack job status
-        uses: broadinstitute/action-slack@v3.15.0
-        with:
-          status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job
-          username: "Data Repo tests"
-          text: "Dev Image Update"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    if: ${{ env.SHOULD_RUN_WORKFLOW }}
+    with:
+      relates-to-chart-releases: 'datarepo-dev'
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+    permissions:
+      id-token: write

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -4,7 +4,6 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
   # This must be defined for the bash redirection
   GOOGLE_SA_CERT: 'jade-dev-account.pem'
-
 on:
   workflow_dispatch: {}
   push:

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -1,15 +1,7 @@
 name: Update API Helm Image Tags
 on:
-  workflow_dispatch:
-    inputs:
-      notify-slack:
-        default: true
-        type: boolean
-  workflow_call:
-    inputs:
-      notify-slack:
-        default: false
-        type: boolean
+  workflow_dispatch: {}
+  workflow_call: {}
 jobs:
 # new integration image updater
   integration_helm_tag_update:
@@ -62,16 +54,6 @@ jobs:
           GITHUB_REPO: datarepo-helm-definitions
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
-      - name: "Notify Slack"
-        if: ${{ inputs.notify-slack && always() }}
-        uses: broadinstitute/action-slack@v3.8.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          fields: job,repo,message,author,took
-          author_name: "[API] [datarepo-helm-definitions] Version update for Integration namespaces"
   datarepo_helm_chart_update:
     runs-on: ubuntu-20.04
     steps:
@@ -119,13 +101,3 @@ jobs:
           GITHUB_REPO: datarepo-helm
           SWITCH_DIRECTORIES: true
           MERGE_BRANCH: master
-      - name: "Notify Slack"
-        if: ${{ inputs.notify-slack && always() }}
-        uses: broadinstitute/action-slack@v3.8.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          fields: job,repo,message,author,took
-          author_name: "[API] [datarepo-helm] Version update for Helm Charts"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -282,7 +282,8 @@ jobs:
           retention-days: 10
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
-    if: ${{ github.ref == 'refs/heads/develop' }}
+    ## DO NOT MERGE: removing conditional so that I can demo the change to Slacking via Sherlock.
+    ## if: ${{ github.ref == 'refs/heads/develop' }}
     with:
       relates-to-chart-releases: 'datarepo-dev'
       notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -240,7 +240,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
   publish_test_reports:
-    name: "Save execution reports and notify"
+    name: "Save execution reports"
     timeout-minutes: 60
     needs:
       - test_check

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -282,8 +282,7 @@ jobs:
           retention-days: 10
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
-    ## DO NOT MERGE: removing conditional so that I can demo the change to Slacking via Sherlock.
-    ## if: ${{ github.ref == 'refs/heads/develop' }}
+    if: ${{ github.ref == 'refs/heads/develop' }}
     with:
       relates-to-chart-releases: 'datarepo-dev'
       notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -251,12 +251,6 @@ jobs:
         os: [ubuntu-latest]
     if: always()
     runs-on: ${{ matrix.os }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      RUN_STATUS: >-
-        ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
-      SLACK_FIELDS: repo,commit,workflow
     steps:
       - name: "Load unit test cache"
         uses: actions/cache@v3
@@ -286,12 +280,12 @@ jobs:
           name: junit-test-reports
           path: build/reports
           retention-days: 10
-      - name: "Notify Jade Slack on nightly test run"
-        if: ${{ github.event_name == 'schedule' && always() }}
-        uses: broadinstitute/action-slack@v3.15.0
-        with:
-          status: ${{ env.RUN_STATUS }}
-          channel: "#jade-alerts"
-          username: "Data Repo tests"
-          text: "Nightly Unit, Connected and Integration tests"
-          fields: ${{ env.SLACK_FIELDS }}
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    if: ${{ github.ref == 'refs/heads/develop' }}
+    with:
+      relates-to-chart-releases: 'datarepo-dev'
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+    permissions:
+      id-token: write

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -1,4 +1,4 @@
-## On each release, publish a corresponding version of Python client to
+## Publish a corresponding version of Python client to
 ## https://pypi.org/project/data-repo-client/
 ##
 ## To manage the data-repo-client project in PyPi, you must have a PyPi account
@@ -8,9 +8,6 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   workflow_dispatch: {}
-  push:
-    branches:
-      - develop
 
 env:
   NODE_VERSION: 20
@@ -64,15 +61,11 @@ jobs:
         with:
           packages_dir: ./data-repo-client/dist
           skip_existing: true
-      - name: Notify Jade Slack
-        if: always()
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#jade-spam"
-          username: "Data Repo publish"
-          text: "Publish Python client to PyPi"
-          fields: repo,message,commit,author,action,eventName,ref,workflow
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    with:
+      relates-to-chart-releases: 'datarepo-dev'
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+    permissions:
+      id-token: write

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -7,7 +7,19 @@ env:
   JADE_USER_EMAIL: staging-tdr-user@notarealemail.org
   TDR_LOG_APPENDER: Console-Standard
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      relates-to-chart-releases:
+        description: 'optional: Chart releases (chart instances) related to or affected by the calling workflow'
+        required: false
+        type: string
+        default: 'datarepo-staging'
+      notify-slack-channels-upon-workflow-completion:
+        description: 'optional: comma separated slack channel(s) to notify on completion'
+        required: false
+        type: string
+        default: '#dsde-qa'
+
 jobs:
   test-runner-staging:
     runs-on: ubuntu-latest
@@ -87,27 +99,13 @@ jobs:
           ./gradlew uploadResults --args="BroadJadeDev.json tmp/TestRunnerResults"
 
           cd ${GITHUB_WORKSPACE}/${workingDir}
-      - name: "Notify Jade Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#jade-alerts"
-          username: "Data Repo tests"
-          text: "Staging smoke tests"
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-      - name: "Notify QA Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#dsde-qa"
-          username: "Data Repo tests"
-          text: "Staging smoke tests"
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    with:
+      relates-to-chart-releases: ${{ inputs.relates-to-chart-releases }}
+      notify-slack-channels-upon-workflow-completion: ${{ inputs.notify-slack-channels-upon-workflow-completion }}
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+    permissions:
+      id-token: write


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-28

## Background

The Data Custodian Journeys team will be responsible for stewarding TDR.  We are revisiting all of the existing Slack notifications emitted to old Jade channels, and updating them following these [principles](https://docs.google.com/spreadsheets/d/1yXp_-mVaVHrBvY9reD05O4iTjO97X-JdPQUQvUEefxc/edit#gid=0):

- Notifications adding to positive signal (on workflow success) should be the exception (deployments, expected emissions to #dsde-qa) rather than the rule.  Generally, we want to know about failures and retries (which usually run when an initial attempt has failed, so we want to know that they succeed).
- Emit notifications to DCJ's public team channel [#dsp-data-custodian-journeys](https://broadinstitute.enterprise.slack.com/archives/C06SG4VM746), rather than spinning out a separate alerts channel (if the noise warrants a channel, we can pursue that later)
- Favor DevOps-maintained solutions ([Sherlock](https://docs.google.com/document/d/1G6-whnNJvON6Qq1b3VvRJFC7M9M-gu2dAVrQHDyp9Us/edit#heading=h.of3udlxcz8rt), [Beehive Slack deploy hooks](https://beehive.dsp-devops.broadinstitute.org/environments/dev/chart-releases/datarepo/deploy-hooks/new)) over custom Slack messages using legacy webhooks

This could mean that we lose out on some customization options, or end up losing signal on a process that we ultimately want to add back in. We've decided that these are acceptable trade-offs given the current noise, and we remain open to adjusting our notification strategy in the future.

## Changes

### Derive Slack notification channel list from [Github variable](https://github.com/DataBiosphere/jade-data-repo/settings/variables/actions)

Rather than hard-coding it everywhere.  This means that we can change the destination without code changes if needed.  E.g. if #dsp-data-exploration also wants to receive these notifications, we can add their channel in.

This isn't private information, so it needn't be a secret.

<img width="1363" alt="Screenshot 2024-04-18 at 5 08 34 PM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/df1730bb-2be0-42f4-b11f-3986094177a0">

### Python client publishing to be handled by Beehive Github Actions deploy hook

This workflow is best suited to run as a Beehive deployment hook on datarepo-dev, only triggered once after a successful deployment.

Previously, it was running on both the merge commit and corresponding broadbot tag bump commit to develop.  I believe this yields a [fencepost error](https://simple.wikipedia.org/wiki/Off-by-one_error) where Python client changes are incorrectly attributed to the preceding semver.

<img width="686" alt="Screenshot 2024-04-18 at 5 16 50 PM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/4c7844d6-b0ee-4aa0-9614-68966b771f08">

### Notifications on dev deployments to be handled by Beehive Slack deploy hook

These will be very similar to the ones emitted to #workbench-resilience-dev for all of Sherlock's known deployments to dev.  When I configure this hook, I will set it up to tag people with commits being deployed.

<img width="387" alt="Screenshot 2024-04-18 at 5 34 56 PM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/ecc74b93-762d-4712-b757-5e1fe5b55989">

### Sherlock for all remaining Slack notifications

DCJ team channel notified via Sherlock for:
- Failure or retries of Python client publishing
- Failure or retries of nightly test runs ([manual demonstration](https://broadinstitute.slack.com/archives/C06SG4VM746/p1713480108394309))
- Failure or retries of staging smoke tests

QA channel notified via Sherlock for completion of staging smoke tests.

Thanks @jack-r-warren for all of the help, including taking care of https://broadworkbench.atlassian.net/browse/DDO-3617 which allows us to request Slack notifications on retries from Sherlock :tada:

## Follow-On Work

- [x] After approval but before merge, add a [Beehive Github Actions deploy hook](https://beehive.dsp-devops.broadinstitute.org/environments/dev/chart-releases/datarepo/deploy-hooks/new) on successful deployments of datarepo-dev that publishes the Python client. https://beehive.dsp-devops.broadinstitute.org/environments/dev/chart-releases/datarepo/deploy-hooks/github-actions/39
- [x] After approval but before merge, add a [Beehive Slack deploy hook](https://beehive.dsp-devops.broadinstitute.org/environments/dev/chart-releases/datarepo/deploy-hooks/new) on datarepo-dev that notifies #dsp-data-custodian-journeys https://beehive.dsp-devops.broadinstitute.org/environments/dev/chart-releases/datarepo/deploy-hooks/slack/29
- [x] After approval, https://github.com/DataBiosphere/jade-data-repo-ui/pull/1645
- [x] After approval, https://github.com/broadinstitute/datarepo-helm/pull/268
- [x] After merge and successful Slack notifications, https://github.com/broadinstitute/terraform-ap-deployments/pull/1512
- [ ] Ultimately archive #jade-spam and #jade-alerts
