### PR TITLE
DC-1005: Remove comments; clarify test helper method names

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7492,8 +7492,6 @@ components:
         kind:
           type: string
           enum: [ list, range, domain ]
-        name:
-          type: string
         id:
           description: the ID of either the domain or program data entry
           type: integer

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -339,17 +339,17 @@ class DatasetsApiControllerTest {
     return Stream.of(
         arguments(
             """
-            {"kind":"domain","name":"name","id":0}""",
+            {"kind":"domain","id":0}""",
             SnapshotBuilderCriteria.class,
             SnapshotBuilderCriteria.KindEnum.DOMAIN),
         arguments(
             """
-            {"kind":"list","name":"name","id":0,"values":[]}""",
+            {"kind":"list","id":0,"values":[]}""",
             SnapshotBuilderProgramDataListCriteria.class,
             SnapshotBuilderCriteria.KindEnum.LIST),
         arguments(
             """
-            {"kind":"range","name":"name","id":0,"low":0,"high":10}""",
+            {"kind":"range","id":0,"low":0,"high":10}""",
             SnapshotBuilderProgramDataRangeCriteria.class,
             SnapshotBuilderCriteria.KindEnum.RANGE));
   }
@@ -362,7 +362,6 @@ class DatasetsApiControllerTest {
       SnapshotBuilderCriteria.KindEnum kind)
       throws Exception {
     SnapshotBuilderCriteria criteria = TestUtils.mapFromJson(json, criteriaClass);
-    assertThat(criteria.getName(), equalTo("name"));
     assertThat(criteria.getKind(), equalTo(kind));
   }
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -80,12 +80,20 @@ public class SnapshotBuilderTestData {
     return rangeOption;
   }
 
+  public static final int CONDITION_OCCURRENCE_DOMAIN_ID = 10;
+  public static final int PROCEDURE_OCCURRENCE_DOMAIN_ID = 11;
+  public static final int OBSERVATION_DOMAIN_ID = 12;
+  public static final int YEAR_OF_BIRTH_PROGRAM_DATA_ID = 1;
+  public static final int ETHNICITY_PROGRAM_DATA_ID = 2;
+  public static final int GENDER_PROGRAM_DATA_ID = 3;
+  public static final int RACE_PROGRAM_DATA_ID = 4;
+
   public static final SnapshotBuilderSettings SETTINGS =
       new SnapshotBuilderSettings()
           .domainOptions(
               List.of(
                   generateSnapshotBuilderDomainOption(
-                      10,
+                      CONDITION_OCCURRENCE_DOMAIN_ID,
                       ConditionOccurrence.TABLE_NAME,
                       ConditionOccurrence.CONDITION_CONCEPT_ID,
                       "Condition",
@@ -95,7 +103,7 @@ public class SnapshotBuilderTestData {
                           .count(100)
                           .hasChildren(true)),
                   generateSnapshotBuilderDomainOption(
-                      11,
+                      PROCEDURE_OCCURRENCE_DOMAIN_ID,
                       ProcedureOccurrence.TABLE_NAME,
                       ProcedureOccurrence.PROCEDURE_CONCEPT_ID,
                       "Procedure",
@@ -105,7 +113,7 @@ public class SnapshotBuilderTestData {
                           .count(100)
                           .hasChildren(true)),
                   generateSnapshotBuilderDomainOption(
-                      12,
+                      OBSERVATION_DOMAIN_ID,
                       Observation.TABLE_NAME,
                       Observation.OBSERVATION_CONCEPT_ID,
                       "Observation",
@@ -117,21 +125,26 @@ public class SnapshotBuilderTestData {
           .programDataOptions(
               List.of(
                   generateSnapshotBuilderProgramDataRangeOption(
-                      1, Person.TABLE_NAME, Person.YEAR_OF_BIRTH, "Year of birth", 0, 100),
+                      YEAR_OF_BIRTH_PROGRAM_DATA_ID,
+                      Person.TABLE_NAME,
+                      Person.YEAR_OF_BIRTH,
+                      "Year of birth",
+                      0,
+                      100),
                   generateSnapshotBuilderProgramDataListOption(
-                      2,
+                      ETHNICITY_PROGRAM_DATA_ID,
                       Person.TABLE_NAME,
                       Person.ETHNICITY_CONCEPT_ID,
                       "Ethnicity",
                       List.of(new SnapshotBuilderProgramDataListItem().id(40).name("unused"))),
                   generateSnapshotBuilderProgramDataListOption(
-                      3,
+                      GENDER_PROGRAM_DATA_ID,
                       Person.TABLE_NAME,
                       Person.GENDER_CONCEPT_ID,
                       "Gender Identity",
                       List.of(new SnapshotBuilderProgramDataListItem().id(41).name("unused 2"))),
                   generateSnapshotBuilderProgramDataListOption(
-                      4,
+                      RACE_PROGRAM_DATA_ID,
                       Person.TABLE_NAME,
                       Person.RACE_CONCEPT_ID,
                       "Race",

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
@@ -102,7 +102,7 @@ class CriteriaQueryBuilderTest {
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void generateFilterIdentifiesDomainCriteria(SqlRenderContext context) {
     SnapshotBuilderCriteria criteria =
-        generateDomainCriteria(10, 0); // Domain 10 = condition_occurrence
+        generateDomainCriteria(SnapshotBuilderTestData.CONDITION_OCCURRENCE_DOMAIN_ID, 0);
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilterForCriteria(criteria);
 
     String sql = filterVariable.renderSQL(context);
@@ -253,11 +253,11 @@ class CriteriaQueryBuilderTest {
                             .criteria(
                                 List.of(
                                     generateDomainCriteria(
-                                        10, 0), // Domain 10 = condition_occurrence
+                                        SnapshotBuilderTestData.CONDITION_OCCURRENCE_DOMAIN_ID, 0),
                                     generateEthnicityListCriteria(List.of(0, 1, 2)),
                                     generateYearOfBirthRangeCriteria(),
                                     generateDomainCriteria(
-                                        11, 0))) // Domain 11 = procedure_occurrence
+                                        SnapshotBuilderTestData.PROCEDURE_OCCURRENCE_DOMAIN_ID, 0)))
                             .meetAll(true)
                             .mustMeet(true))));
     String expectedSql =

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
@@ -41,7 +41,7 @@ class CriteriaQueryBuilderTest {
   @ParameterizedTest
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void generateFilterForRangeCriteria(SqlRenderContext context) {
-    SnapshotBuilderProgramDataRangeCriteria rangeCriteria = generateRangeCriteria();
+    SnapshotBuilderProgramDataRangeCriteria rangeCriteria = generateYearOfBirthRangeCriteria();
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(rangeCriteria);
 
     assertThat(
@@ -53,7 +53,8 @@ class CriteriaQueryBuilderTest {
   @ParameterizedTest
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void generateFilterForListCriteria(SqlRenderContext context) {
-    SnapshotBuilderProgramDataListCriteria listCriteria = generateListCriteria(List.of(0, 1, 2));
+    SnapshotBuilderProgramDataListCriteria listCriteria =
+        generateEthnicityListCriteria(List.of(0, 1, 2));
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(listCriteria);
 
     assertThat(
@@ -65,7 +66,7 @@ class CriteriaQueryBuilderTest {
   @ParameterizedTest
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void generateFilterForListCriteriaWithEmptyValues(SqlRenderContext context) {
-    SnapshotBuilderProgramDataListCriteria listCriteria = generateListCriteria(List.of());
+    SnapshotBuilderProgramDataListCriteria listCriteria = generateEthnicityListCriteria(List.of());
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(listCriteria);
 
     assertThat(
@@ -77,7 +78,7 @@ class CriteriaQueryBuilderTest {
   @ParameterizedTest
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void generateFilterForDomainCriteria(SqlRenderContext context) {
-    SnapshotBuilderDomainCriteria domainCriteria = generateDomainCriteria();
+    SnapshotBuilderDomainCriteria domainCriteria = generateDomainCriteria(10, 0);
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(domainCriteria);
 
     String expectedSql =
@@ -90,8 +91,7 @@ class CriteriaQueryBuilderTest {
 
   @Test
   void generateFilterForDomainCriteriaThrowsIfGivenUnknownDomain() {
-    SnapshotBuilderDomainCriteria domainCriteria =
-        (SnapshotBuilderDomainCriteria) generateDomainCriteria().id(1000);
+    SnapshotBuilderDomainCriteria domainCriteria = generateDomainCriteria(1000, 0);
     assertThrows(
         BadRequestException.class,
         () -> criteriaQueryBuilder.generateFilter(domainCriteria),
@@ -101,7 +101,8 @@ class CriteriaQueryBuilderTest {
   @ParameterizedTest
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void generateFilterIdentifiesDomainCriteria(SqlRenderContext context) {
-    SnapshotBuilderCriteria criteria = generateDomainCriteria();
+    SnapshotBuilderCriteria criteria =
+        generateDomainCriteria(10, 0); // Domain 10 = condition_occurrence
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilterForCriteria(criteria);
 
     String sql = filterVariable.renderSQL(context);
@@ -115,7 +116,7 @@ class CriteriaQueryBuilderTest {
   @ParameterizedTest
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void generateFilterIdentifiesRangeCriteria(SqlRenderContext context) {
-    SnapshotBuilderCriteria criteria = generateRangeCriteria();
+    SnapshotBuilderCriteria criteria = generateYearOfBirthRangeCriteria();
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilterForCriteria(criteria);
 
     assertThat(
@@ -127,7 +128,7 @@ class CriteriaQueryBuilderTest {
   @ParameterizedTest
   @ArgumentsSource(QueryTestUtils.Contexts.class)
   void generateFilterIdentifiesListCriteria(SqlRenderContext context) {
-    SnapshotBuilderCriteria criteria = generateListCriteria(List.of(0, 1, 2));
+    SnapshotBuilderCriteria criteria = generateEthnicityListCriteria(List.of(0, 1, 2));
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilterForCriteria(criteria);
 
     assertThat(
@@ -141,7 +142,10 @@ class CriteriaQueryBuilderTest {
   void generateAndOrFilterForCriteriaGroupHandlesMeetAllTrue(SqlRenderContext context) {
     SnapshotBuilderCriteriaGroup criteriaGroup =
         new SnapshotBuilderCriteriaGroup()
-            .criteria(List.of(generateListCriteria(List.of(0, 1, 2)), generateRangeCriteria()))
+            .criteria(
+                List.of(
+                    generateEthnicityListCriteria(List.of(0, 1, 2)),
+                    generateYearOfBirthRangeCriteria()))
             .meetAll(true);
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateAndOrFilterForCriteriaGroup(criteriaGroup);
@@ -158,7 +162,10 @@ class CriteriaQueryBuilderTest {
   void generateAndOrFilterForCriteriaGroupHandlesMeetAllFalse(SqlRenderContext context) {
     SnapshotBuilderCriteriaGroup criteriaGroup =
         new SnapshotBuilderCriteriaGroup()
-            .criteria(List.of(generateListCriteria(List.of(0, 1, 2)), generateRangeCriteria()))
+            .criteria(
+                List.of(
+                    generateEthnicityListCriteria(List.of(0, 1, 2)),
+                    generateYearOfBirthRangeCriteria()))
             .meetAll(false);
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateAndOrFilterForCriteriaGroup(criteriaGroup);
@@ -174,7 +181,10 @@ class CriteriaQueryBuilderTest {
   void generateFilterForCriteriaGroupHandlesMustMeetTrue(SqlRenderContext context) {
     SnapshotBuilderCriteriaGroup criteriaGroup =
         new SnapshotBuilderCriteriaGroup()
-            .criteria(List.of(generateListCriteria(List.of(0, 1, 2)), generateRangeCriteria()))
+            .criteria(
+                List.of(
+                    generateEthnicityListCriteria(List.of(0, 1, 2)),
+                    generateYearOfBirthRangeCriteria()))
             .meetAll(true)
             .mustMeet(true);
     FilterVariable filterVariable =
@@ -192,7 +202,10 @@ class CriteriaQueryBuilderTest {
   void generateFilterForCriteriaGroupHandlesMustMeetFalse(SqlRenderContext context) {
     SnapshotBuilderCriteriaGroup criteriaGroup =
         new SnapshotBuilderCriteriaGroup()
-            .criteria(List.of(generateListCriteria(List.of(0, 1, 2)), generateRangeCriteria()))
+            .criteria(
+                List.of(
+                    generateEthnicityListCriteria(List.of(0, 1, 2)),
+                    generateYearOfBirthRangeCriteria()))
             .meetAll(true)
             .mustMeet(false);
     FilterVariable filterVariable =
@@ -213,11 +226,11 @@ class CriteriaQueryBuilderTest {
             .generateFilterForCriteriaGroups(
                 List.of(
                     new SnapshotBuilderCriteriaGroup()
-                        .criteria(List.of(generateRangeCriteria()))
+                        .criteria(List.of(generateYearOfBirthRangeCriteria()))
                         .meetAll(true)
                         .mustMeet(true),
                     new SnapshotBuilderCriteriaGroup()
-                        .criteria(List.of(generateListCriteria(List.of(0, 1, 2))))
+                        .criteria(List.of(generateEthnicityListCriteria(List.of(0, 1, 2))))
                         .meetAll(true)
                         .mustMeet(true)));
 
@@ -239,13 +252,14 @@ class CriteriaQueryBuilderTest {
                         new SnapshotBuilderCriteriaGroup()
                             .criteria(
                                 List.of(
-                                    generateDomainCriteria(),
-                                    generateListCriteria(List.of(0, 1, 2)),
-                                    generateRangeCriteria(),
-                                    generateDomainCriteria().id(11)))
+                                    generateDomainCriteria(
+                                        10, 0), // Domain 10 = condition_occurrence
+                                    generateEthnicityListCriteria(List.of(0, 1, 2)),
+                                    generateYearOfBirthRangeCriteria(),
+                                    generateDomainCriteria(
+                                        11, 0))) // Domain 11 = procedure_occurrence
                             .meetAll(true)
                             .mustMeet(true))));
-    // FIXME: is query correct? It doesn't contain the concept IDs 11 and 10.
     String expectedSql =
         """
       SELECT COUNT(DISTINCT p.person_id)
@@ -269,16 +283,16 @@ class CriteriaQueryBuilderTest {
         equalToCompressingWhiteSpace(expectedSql));
   }
 
-  private static SnapshotBuilderDomainCriteria generateDomainCriteria() {
+  private static SnapshotBuilderDomainCriteria generateDomainCriteria(int domainId, int conceptId) {
     return (SnapshotBuilderDomainCriteria)
         new SnapshotBuilderDomainCriteria()
-            .conceptId(0)
-            .id(10)
+            .conceptId(conceptId)
+            .id(domainId)
             .name("domain_column_name")
             .kind(SnapshotBuilderCriteria.KindEnum.DOMAIN);
   }
 
-  private static SnapshotBuilderProgramDataRangeCriteria generateRangeCriteria() {
+  private static SnapshotBuilderProgramDataRangeCriteria generateYearOfBirthRangeCriteria() {
     return (SnapshotBuilderProgramDataRangeCriteria)
         new SnapshotBuilderProgramDataRangeCriteria()
             .low(0)
@@ -288,7 +302,8 @@ class CriteriaQueryBuilderTest {
             .kind(SnapshotBuilderCriteria.KindEnum.RANGE);
   }
 
-  private static SnapshotBuilderProgramDataListCriteria generateListCriteria(List<Integer> values) {
+  private static SnapshotBuilderProgramDataListCriteria generateEthnicityListCriteria(
+      List<Integer> values) {
     return (SnapshotBuilderProgramDataListCriteria)
         new SnapshotBuilderProgramDataListCriteria()
             .values(values)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-1005
____

### Summary
The task for this ticket was to investigate a particular query and make sure that it is getting generated correctly. But, I think the query looks correct (and I'll explain my reasoning below). So, the changes in this PR include removing the FIXME comment and slightly reworking a few test methods.  I think we can rework the test methods to have more descriptive names and accept relevant parameters. 

### Query appears to be correct
The comment in question:
> // FIXME: is query correct? It doesn't contain the concept IDs 11 and 10.

Query Builder Code in Question:
```
    Query query =
        new CriteriaQueryBuilder(Person.TABLE_NAME, SnapshotBuilderTestData.SETTINGS)
            .generateRollupCountsQueryForCriteriaGroupsList(
                List.of(
                    List.of(
                        new SnapshotBuilderCriteriaGroup()
                            .criteria(
                                List.of(
                                    generateDomainCriteria(),
                                    generateListCriteria(List.of(0, 1, 2)),
                                    generateRangeCriteria(),
                                    generateDomainCriteria().id(11)))
                            .meetAll(true)
                            .mustMeet(true))));
```

- generateDomainCriteria() by default creates a domain criteria group with **domain id 10** and concept id 0. Domain id 10 maps to the condition_occurrence domain. 
- generateDomainCriteria().id(11) overrides the *domain* id to 11, which maps to the procedure_occurrence domain. The concept id is still 0. 
- generateListCriteria(List.of(0, 1, 2)) maps to the ethnicity program data criteria group
- generateRangeCriteria() maps to the year of birth program data criteria group, with a range from 0 to 100. 


So, if we break down the generated query, I think we correctly get two domain criteria queries against the condition_occurrence and the procedure_occurrence tables, both looking for concept_id 0, plus the ethnicity and year of birth clauses.

![image](https://github.com/DataBiosphere/jade-data-repo/assets/13254229/1a85cec3-ac93-4b46-9e38-7dca2b4484f3)

### Included Code Changes
- Remove the // FIXME comment
- Rework the generateDomainCriteria test helper method to accept domain id and concept id parameters so that we're clearly setting these values. And, I've added comments to map between the numeric domain id and the more readable domain name
- Rename `generateListCriteria` to `generateEthnicityListCriteria`
- Rename `generateRangeCriteria` to  `generateYearOfBirthRangeCriteria`
