### PR TITLE
DC-999: Create snapshots in setup script; Use python client for snapshot builder

### DIFF
--- a/tools/setupResourceScripts/requirements.txt
+++ b/tools/setupResourceScripts/requirements.txt
@@ -1,2 +1,2 @@
-data-repo-client>=1.313
+data-repo-client>=2.43.0
 google-cloud-bigquery

--- a/tools/setupResourceScripts/setup_tdr_resources.py
+++ b/tools/setupResourceScripts/setup_tdr_resources.py
@@ -112,7 +112,7 @@ def add_billing_profile_members(clients, profile_id):
   clients.profiles_api.add_profile_policy_member(profile_id,
     "owner",
     {
-      'email': 'JadeStewards-dev@dev.test.firecloud.org'})
+      'email': 'DataRepoTestResourceAccess@dev.test.firecloud.org'})
 
 
 def dataset_ingest_json(clients, dataset_id, dataset_to_upload):

--- a/tools/setupResourceScripts/setup_tdr_resources.py
+++ b/tools/setupResourceScripts/setup_tdr_resources.py
@@ -227,14 +227,9 @@ def delete_dataset_if_exists(name, clients):
 
 
 def add_snapshot_builder_settings(clients, dataset_id, directory, snapshot_builder_settings_file):
-  with open(
-    os.path.join("files", directory, snapshot_builder_settings_file)) as dataset_schema_json:
-    # In order to use the client API, we need to publish the updated python client library
-    response = requests.post(f"{clients.api_client.configuration.host}/api/repository/v1/datasets/{dataset_id}/snapshotBuilder/settings", json=json.load(dataset_schema_json), headers={"Authorization": f"Bearer {clients.api_client.configuration.access_token}"})
-    if response.status_code != 200:
-      print(f"Failed to update snapshot builder settings. {response.json}")
-      print(response.json())
-  return response.json()
+  with open(os.path.join("files", directory, snapshot_builder_settings_file)) as dataset_schema_json:
+    clients.datasets_api.update_dataset_snapshot_builder_settings(dataset_id, json.load(dataset_schema_json))
+    print(f"Snapshot builder settings were updated")
 
 
 def main():

--- a/tools/setupResourceScripts/setup_tdr_resources.py
+++ b/tools/setupResourceScripts/setup_tdr_resources.py
@@ -229,7 +229,7 @@ def delete_dataset_if_exists(name, clients):
 def add_snapshot_builder_settings(clients, dataset_id, directory, snapshot_builder_settings_file):
   with open(os.path.join("files", directory, snapshot_builder_settings_file)) as dataset_schema_json:
     clients.datasets_api.update_dataset_snapshot_builder_settings(dataset_id, json.load(dataset_schema_json))
-    print(f"Snapshot builder settings were updated")
+  print(f"Snapshot builder settings were updated")
 
 
 def main():

--- a/tools/setupResourceScripts/suites/datarepo_azure_datasets.json
+++ b/tools/setupResourceScripts/suites/datarepo_azure_datasets.json
@@ -15,14 +15,14 @@
     ],
     "upload_prefix": "gs://jade-testdata-useastregion/V2F_GWAS_Summary_Statistics",
     "format": "array",
-    "stewards": ["JadeStewards-dev@dev.test.firecloud.org"],
+    "stewards": ["DataRepoTestResourceAccess@dev.test.firecloud.org"],
     "custodians": [],
     "snapshot_creators": [],
     "snapshots": [
       {
         "name": "AzureV2FStats",
         "description": "Test Azure Snapshot",
-        "readers": ["JadeStewards-dev@dev.test.firecloud.org"]
+        "readers": ["DataRepoTestResourceAccess@dev.test.firecloud.org"]
       }
     ]
   }

--- a/tools/setupResourceScripts/suites/datarepo_azure_omop_datasets.json
+++ b/tools/setupResourceScripts/suites/datarepo_azure_omop_datasets.json
@@ -8,7 +8,15 @@
       "stewards": ["DataRepoAdmins@dev.test.firecloud.org"],
       "custodians": [],
       "snapshot_creators": [],
-      "snapshots": [],
+      "snapshots": [
+        {
+          "name": "Azure_OMOP_Snapshot",
+          "description": "Test Azure Snapshot with OMOP data",
+          "readers": [
+            "JadeStewards-dev@dev.test.firecloud.org"
+          ]
+        }
+      ],
       "snapshotBuilderSettings": "dataset_snapshot_builder_settings.json"
     }
 ]

--- a/tools/setupResourceScripts/suites/datarepo_azure_omop_datasets.json
+++ b/tools/setupResourceScripts/suites/datarepo_azure_omop_datasets.json
@@ -5,16 +5,14 @@
       "cloud_platform": "azure",
       "tables": ["person","procedure_occurrence","condition_occurrence", "drug_exposure", "domain", "concept", "concept_ancestor"],
       "format": "array",
-      "stewards": ["DataRepoAdmins@dev.test.firecloud.org"],
+      "stewards": [],
       "custodians": [],
       "snapshot_creators": [],
       "snapshots": [
         {
           "name": "Azure_OMOP_Snapshot",
           "description": "Test Azure Snapshot with OMOP data",
-          "readers": [
-            "DataRepoTestResourceAccess@dev.test.firecloud.org"
-          ]
+          "readers": []
         }
       ],
       "snapshotBuilderSettings": "dataset_snapshot_builder_settings.json"

--- a/tools/setupResourceScripts/suites/datarepo_azure_omop_datasets.json
+++ b/tools/setupResourceScripts/suites/datarepo_azure_omop_datasets.json
@@ -13,7 +13,7 @@
           "name": "Azure_OMOP_Snapshot",
           "description": "Test Azure Snapshot with OMOP data",
           "readers": [
-            "JadeStewards-dev@dev.test.firecloud.org"
+            "DataRepoTestResourceAccess@dev.test.firecloud.org"
           ]
         }
       ],

--- a/tools/setupResourceScripts/suites/datarepo_datasets.json
+++ b/tools/setupResourceScripts/suites/datarepo_datasets.json
@@ -15,14 +15,14 @@
     ],
     "upload_prefix": "gs://jade-testdata-useastregion/V2F_GWAS_Summary_Statistics",
     "format": "array",
-    "stewards": ["JadeStewards-dev@dev.test.firecloud.org"],
+    "stewards": ["DataRepoTestResourceAccess@dev.test.firecloud.org"],
     "custodians": [],
     "snapshot_creators": [],
     "snapshots": [
       {
         "name": "V2FGWASSummaryStatisticsSnapshot",
         "description": "Test Sansphot",
-        "readers": ["JadeStewards-dev@dev.test.firecloud.org"]
+        "readers": ["DataRepoTestResourceAccess@dev.test.firecloud.org"]
       }
     ]
   },
@@ -34,6 +34,6 @@
     "format": "array",
     "stewards": [],
     "custodians": [],
-    "snapshot_creators": ["JadeStewards-dev@dev.test.firecloud.org"]
+    "snapshot_creators": ["DataRepoTestResourceAccess@dev.test.firecloud.org"]
   }
 ]

--- a/tools/setupResourceScripts/suites/datarepo_gcp_omop_datasets.json
+++ b/tools/setupResourceScripts/suites/datarepo_gcp_omop_datasets.json
@@ -5,16 +5,14 @@
       "cloud_platform": "gcp",
       "tables": ["person","procedure_occurrence","condition_occurrence", "drug_exposure", "domain", "concept", "concept_ancestor"],
       "format": "array",
-      "stewards": ["DataRepoAdmins@dev.test.firecloud.org"],
+      "stewards": [],
       "custodians": [],
       "snapshot_creators": [],
       "snapshots": [
         {
           "name": "GCP_OMOP_Snapshot",
           "description": "Test GCP Snapshot with OMOP data",
-          "readers": [
-            "DataRepoTestResourceAccess@dev.test.firecloud.org"
-          ]
+          "readers": []
         }
       ],
       "snapshotBuilderSettings": "dataset_snapshot_builder_settings.json"

--- a/tools/setupResourceScripts/suites/datarepo_gcp_omop_datasets.json
+++ b/tools/setupResourceScripts/suites/datarepo_gcp_omop_datasets.json
@@ -8,7 +8,15 @@
       "stewards": ["DataRepoAdmins@dev.test.firecloud.org"],
       "custodians": [],
       "snapshot_creators": [],
-      "snapshots": [],
+      "snapshots": [
+        {
+          "name": "GCP_OMOP_Snapshot",
+          "description": "Test GCP Snapshot with OMOP data",
+          "readers": [
+            "JadeStewards-dev@dev.test.firecloud.org"
+          ]
+        }
+      ],
       "snapshotBuilderSettings": "dataset_snapshot_builder_settings.json"
     }
 ]

--- a/tools/setupResourceScripts/suites/datarepo_gcp_omop_datasets.json
+++ b/tools/setupResourceScripts/suites/datarepo_gcp_omop_datasets.json
@@ -13,7 +13,7 @@
           "name": "GCP_OMOP_Snapshot",
           "description": "Test GCP Snapshot with OMOP data",
           "readers": [
-            "JadeStewards-dev@dev.test.firecloud.org"
+            "DataRepoTestResourceAccess@dev.test.firecloud.org"
           ]
         }
       ],


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-999
______
### Summary
Since we are going to be basing the cohort builder on snapshots, we'll need snapshots available for testing. These changes add a spec so that snapshots are created alongside the OMOP datasets. Additionally, I've switch from using a curl command to the python client endpoint now that we are publishing the python client again. 

### Testing
Example resources created with changes to script:
* [GCP OMOP dataset](https://jade.datarepo-dev.broadinstitute.org/datasets/9ba7be86-056e-47b5-81e6-1f2953c639fd) (with slight name change) -- I've confirmed the snapshot builder settings were correctly set on the dataset.
* [GCP OMOP full view snapshot](https://jade.datarepo-dev.broadinstitute.org/snapshots/94d461f5-c559-4645-9cf6-68c32bd5eebd)
* [Azure OMOP dataset](https://jade.datarepo-dev.broadinstitute.org/datasets/c832b131-5db8-4be5-9af2-63b9c2d40434) -- confirmed snapshot builder settings
* [Azure OMOP snapshot](https://jade.datarepo-dev.broadinstitute.org/snapshots/3700f49e-1ad8-4a78-a539-6337ad7698bd)