### PR TITLE
[DCJ-15] Make DCJ team the default codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,13 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
+# Documentation with syntax examples:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # These owners will be the default owners for everything in the repo.
-*       @DataBiosphere/jadeteam
+*       @DataBiosphere/data-custodian-journeys
 
 # Order is important. The last matching pattern has the most precedence.
-# So if a pull request only touches javascript files, only these owners
-# will be requested to review.
-#*.js    @octocat @github/js
-
-# You can also use email addresses if you prefer.
-#docs/*  docs@example.com
+# So if a pull request only touches files in a `/snapshotbuilder` directory
+# such as `/src/main/../snapshotbuilder` or `/src/test/../snapshotbuilder`,
+# only these owners will be requested to review.
+**/snapshotbuilder @DataBiosphere/data-explorer-eng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,10 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # These owners will be the default owners for everything in the repo.
-*       @DataBiosphere/data-custodian-journeys
+*       @DataBiosphere/data-custodian-journeys @DataBiosphere/data-explorer-eng
 
 # Order is important. The last matching pattern has the most precedence.
-# So if a pull request only touches files in a `/snapshotbuilder` directory
+# Example: if a pull request only touches files in a `/snapshotbuilder` directory
 # such as `/src/main/../snapshotbuilder` or `/src/test/../snapshotbuilder`,
 # only these owners will be requested to review.
-**/snapshotbuilder @DataBiosphere/data-explorer-eng
+# **/snapshotbuilder @DataBiosphere/data-explorer-eng

--- a/docs/jade-getting-started.md
+++ b/docs/jade-getting-started.md
@@ -31,7 +31,7 @@ access.
 - DataBiosphere: Join the `#github` Slack channel, click the lightning bolt in the
 channel header, and select `Join DataBiosphere`.  Once you've been granted access
 to DataBiosphere, ask a team member to add your github user to the
-[DataBiosphere/jadeteam group](https://github.com/orgs/DataBiosphere/teams/jadeteam).
+[DataBiosphere/data-custodian-journeys group](https://github.com/orgs/DataBiosphere/teams/data-custodian-journeys).
 This will give you admin access to our repositories.
 - Google Groups: Ask a team member for access to Google Groups including `jade-internal` and `dsde-engineering`.
 

--- a/docs/jade-getting-started.md
+++ b/docs/jade-getting-started.md
@@ -29,10 +29,13 @@ encounter a permission error, it is likely because you are missing appropriate
 access.
 
 - DataBiosphere: Join the `#github` Slack channel, click the lightning bolt in the
-channel header, and select `Join DataBiosphere`.  Once you've been granted access
-to DataBiosphere, ask a team member to add your github user to the
-[DataBiosphere/data-custodian-journeys group](https://github.com/orgs/DataBiosphere/teams/data-custodian-journeys).
-This will give you admin access to our repositories.
+channel header, and select `Join DataBiosphere`. Once you've been granted access to DataBiosphere,
+you should have write access to our repositories via membership in the
+[DataBiosphere/broadwrite team](https://github.com/orgs/DataBiosphere/teams/broadwrite).
+This level of permission should be sufficient for most contributions from across DSP.
+  - If needed, repository admin access is conferred via membership in the
+  [DataBiosphere/data-custodian-journeys team](https://github.com/orgs/DataBiosphere/teams/data-custodian-journeys),
+  among others.
 - Google Groups: Ask a team member for access to Google Groups including `jade-internal` and `dsde-engineering`.
 
 ## 3. Connect accounts


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-15

- Make @DataBiosphere/data-custodian-journeys (new Github team) the default codeowners
- Make @DataBiosphere/data-explorer-eng (existing Github team) codeowners of files in `snapshotbuilder` directories

### New Github Team

Here is the membership of our new team. Admins can modify membership and team settings:
<img width="1432" alt="Screenshot 2024-04-26 at 11 17 41 AM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/650edc6f-b4a7-4605-b5cc-82bf9090bb35">

I have made this team an [admin](https://github.com/DataBiosphere/jade-data-repo/settings/access?query=data-custodian-journeys) of this repository:
<img width="1398" alt="Screenshot 2024-04-26 at 11 33 46 AM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/8351f114-8c2b-4f41-8bb2-5ac6baf0ca46">

I also made the DE team a [writer](https://github.com/DataBiosphere/jade-data-repo/settings/access?query=data-explorer-eng) on this repository (required to make them codeowners):
<img width="1375" alt="Screenshot 2024-04-26 at 11 37 29 AM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/058d9c72-c910-4cd5-ba84-f804c3fbbe44">

### Code Review Settings

I have configured the new DCJ team so that 2 reviews are automatically requested when the team is a codeowner, rotating through reviewers via a load balancer strategy.  Sebastian and Gideon (our contractors) are members of this team but exempt from review requests:
<img width="1261" alt="Screenshot 2024-04-26 at 11 18 05 AM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/2e056666-8171-497a-9fe9-b0caff768741">

An example: I requested a review from the DCJ team on this open PR: https://github.com/DataBiosphere/jade-data-repo/pull/1647.  The load balancer automatically assigned Florian and Greg, and removed the request from the team.

More information on code review settings: https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team

### Scheduled Reminders

I have configured a [Slack scheduled reminder](https://github.com/orgs/DataBiosphere/teams/data-custodian-journeys/settings/reminders/72975) to #dsp-data-custodian-journeys on stale pull requests:
<img width="1344" alt="Screenshot 2024-04-26 at 11 35 21 AM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/0245988c-6e80-43ca-a01a-e3081a578ed7">