### PR TITLE
[DC-1033] Database work to support Snapshot Id in snapshot access requests

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -75,7 +75,7 @@ public class SnapshotBuilderService {
 
   public SnapshotAccessRequestResponse createSnapshotRequest(
       UUID id, SnapshotAccessRequest snapshotAccessRequest, String email) {
-    return snapshotRequestDao.create(id, snapshotAccessRequest, email);
+    return snapshotRequestDao.create_old(id, snapshotAccessRequest, email);
   }
 
   private <T> List<T> runSnapshotBuilderQuery(
@@ -150,7 +150,7 @@ public class SnapshotBuilderService {
   }
 
   public EnumerateSnapshotAccessRequest enumerateByDatasetId(UUID id) {
-    return convertToEnumerateModel(snapshotRequestDao.enumerateByDatasetId(id));
+    return convertToEnumerateModel(snapshotRequestDao.enumerateByDatasetId_old(id));
   }
 
   public SnapshotBuilderGetConceptsResponse searchConcepts(

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -46,7 +46,7 @@ public class SnapshotRequestDao {
           new SnapshotAccessRequestResponse()
               .id(rs.getObject(ID, UUID.class))
               .datasetId(rs.getObject(DATASET_ID, UUID.class))
-              .snapshotId(rs.getObject(ID, UUID.class))
+              .snapshotId(rs.getObject(SNAPSHOT_ID, UUID.class))
               .snapshotName(rs.getString(SNAPSHOT_NAME))
               .snapshotResearchPurpose(rs.getString(SNAPSHOT_RESEARCH_PURPOSE))
               .snapshotSpecification(mapRequestFromJson(rs.getString(SNAPSHOT_SPECIFICATION)))
@@ -119,7 +119,7 @@ public class SnapshotRequestDao {
     try {
       return jdbcTemplate.query(sql, params, responseMapper);
     } catch (EmptyResultDataAccessException ex) {
-      throw new NotFoundException("No snapshot requests found for given dataset id", ex);
+      throw new NotFoundException("No snapshot requests found for given snapshot id", ex);
     }
   }
 
@@ -155,10 +155,11 @@ public class SnapshotRequestDao {
     return getById(id);
   }
   /**
-   * @param snapshotId
-   * @param request
-   * @param email
-   * @return
+   * Create a new Snapshot Access Request for the given snapshot id.
+   * @param snapshotId associated with the snapshot request.
+   * @param request the snapshot access request.
+   * @param email the email of the user creating the request.
+   * @return the created snapshot access request response.
    */
   @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
   public SnapshotAccessRequestResponse createV2(
@@ -186,7 +187,7 @@ public class SnapshotRequestDao {
     try {
       jdbcTemplate.update(sql, params, keyHolder);
     } catch (DataIntegrityViolationException ex) {
-      throw new NotFoundException("Dataset with given dataset id does not exist.");
+      throw new NotFoundException("Snapshot with given snapshot id does not exist.");
     }
     UUID id = keyHolder.getId();
     return getById(id);

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -156,6 +156,7 @@ public class SnapshotRequestDao {
   }
   /**
    * Create a new Snapshot Access Request for the given snapshot id.
+   *
    * @param snapshotId associated with the snapshot request.
    * @param request the snapshot access request.
    * @param email the email of the user creating the request.

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7375,20 +7375,12 @@ components:
     SnapshotAccessRequestResponse:
       type: object
       description: The response object for a submitted SnapshotAccessRequest.
-      required:
-        - id
-        - snapshotName
-        - snapshotResearchPurpose
-        - snapshotSpecification
-        - createdBy
-        - createdDate
-        - status
       properties:
         id:
           $ref: '#/components/schemas/UniqueIdProperty'
         datasetId:
           $ref: '#/components/schemas/UniqueIdProperty'
-        snapshotId:
+        sourceSnapshotId:
           $ref: '#/components/schemas/UniqueIdProperty'
         snapshotName:
           type: string

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7377,7 +7377,6 @@ components:
       description: The response object for a submitted SnapshotAccessRequest.
       required:
         - id
-        - datasetId
         - snapshotName
         - snapshotResearchPurpose
         - snapshotSpecification
@@ -7388,6 +7387,8 @@ components:
         id:
           $ref: '#/components/schemas/UniqueIdProperty'
         datasetId:
+          $ref: '#/components/schemas/UniqueIdProperty'
+        snapshotId:
           $ref: '#/components/schemas/UniqueIdProperty'
         snapshotName:
           type: string

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -77,4 +77,5 @@
     <include file="changesets/20230519_drsalias.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20230906_snapshotbuildersettings.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20231129_snapshotrequests.yaml" relativeToChangelogFile="true" />
+  <include file="changesets/20240426_addsnapshotidtorequest.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -78,5 +78,5 @@
     <include file="changesets/20230906_snapshotbuildersettings.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20231129_snapshotrequests.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240419_addsnapshotidtosettings.yaml" relativeToChangelogFile="true" />
-  <include file="changesets/20240426_addsnapshotidtorequest.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20240426_addsnapshotidtorequest.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20240426_addsnapshotidtorequest.yaml
+++ b/src/main/resources/db/changesets/20240426_addsnapshotidtorequest.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_snapshot_id_to_request
+      author: rjohanek
+      changes:
+        - addColumn:
+            tableName: snapshot_request
+            columns:
+              - column:
+                  name: snapshot_id
+                  type: ${uuid_type}
+                  constraints:
+                    unique: true
+                    foreignKeyName: fk_snapshot_snapshot_request
+                    references: snapshot(id)
+                    deleteCascade: true
+        - dropNotNullConstraint:
+            tableName: snapshot_request
+            columnName: dataset_id

--- a/src/main/resources/db/changesets/20240426_addsnapshotidtorequest.yaml
+++ b/src/main/resources/db/changesets/20240426_addsnapshotidtorequest.yaml
@@ -7,10 +7,10 @@ databaseChangeLog:
             tableName: snapshot_request
             columns:
               - column:
-                  name: snapshot_id
+                  name: source_snapshot_id
                   type: ${uuid_type}
                   constraints:
-                    foreignKeyName: fk_snapshot_snapshot_request
+                    foreignKeyName: fk_source_snapshot_snapshot_request
                     references: snapshot(id)
                     deleteCascade: true
         - dropNotNullConstraint:

--- a/src/main/resources/db/changesets/20240426_addsnapshotidtorequest.yaml
+++ b/src/main/resources/db/changesets/20240426_addsnapshotidtorequest.yaml
@@ -10,7 +10,6 @@ databaseChangeLog:
                   name: snapshot_id
                   type: ${uuid_type}
                   constraints:
-                    unique: true
                     foreignKeyName: fk_snapshot_snapshot_request
                     references: snapshot(id)
                     deleteCascade: true

--- a/src/test/java/bio/terra/common/fixtures/DaoOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/DaoOperations.java
@@ -28,6 +28,7 @@ public class DaoOperations {
   private final SnapshotService snapshotService;
 
   public static final String DATASET_MINIMAL = "dataset-minimal.json";
+  public static final String SNAPSHOT_MINIMAL = "snapshot-from-dataset-minimal.json";
 
   public DaoOperations(
       JsonLoader jsonLoader,

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -94,7 +94,7 @@ class SnapshotBuilderServiceTest {
     UUID datasetId = UUID.randomUUID();
     String email = "user@gmail.com";
     SnapshotAccessRequestResponse response = new SnapshotAccessRequestResponse();
-    when(snapshotRequestDao.create(
+    when(snapshotRequestDao.create_old(
             datasetId, SnapshotBuilderTestData.createSnapshotAccessRequest(), email))
         .thenReturn(response);
 
@@ -111,7 +111,7 @@ class SnapshotBuilderServiceTest {
     SnapshotAccessRequestResponse responseItem =
         SnapshotBuilderTestData.createSnapshotAccessRequestResponse();
     List<SnapshotAccessRequestResponse> response = List.of(responseItem);
-    when(snapshotRequestDao.enumerateByDatasetId(datasetId)).thenReturn(response);
+    when(snapshotRequestDao.enumerateByDatasetId_old(datasetId)).thenReturn(response);
 
     EnumerateSnapshotAccessRequestItem expectedItem =
         new EnumerateSnapshotAccessRequestItem()

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderSettingsDaoTest.java
@@ -38,7 +38,7 @@ class SnapshotBuilderSettingsDaoTest {
   void setup() throws IOException {
     dataset = daoOperations.createDataset(DaoOperations.DATASET_MINIMAL);
     snapshotBuilderSettingsDao.upsertByDatasetId(dataset.getId(), SnapshotBuilderTestData.SETTINGS);
-    snapshot = daoOperations.createAndIngestSnapshot(dataset, "snapshot-from-dataset-minimal.json");
+    snapshot = daoOperations.createAndIngestSnapshot(dataset, DaoOperations.SNAPSHOT_MINIMAL);
     snapshotBuilderSettingsDao.upsertBySnapshotId(
         snapshot.getId(), SnapshotBuilderTestData.SETTINGS);
   }


### PR DESCRIPTION
### Ticket: 
https://broadworkbench.atlassian.net/browse/DC-1033

### Summary of Changes:
- add snapshot_id column to the snapshot request table
       - **Question:** Do we think snapshot_id is clear enough? it contrasts with id (the id of the snapshot request), so that might be clear enough, but we could also call it something like base_snapshot_id if we think that is more easily understood

- make dataset_id column nullable in the snapshot request table

- reflect these database changes in the SnapshotAccessRequestResponse type

- add dao method for creating with an associated snapshot id
       - **Question:** I called this createV2, I figure the name doesn't matter too much since we will be removing the other create soon and then can rename this create. But, we could also call this something more specific like createFromSnapshot if we think that is better.

- add dao method for enumerating by an associate snapshot id

- add tests of new dao methods
       - **Question:** some of these tests use the verifyResponseContents method. I added a isV2 variable to this, to check the snapshot id instead of the dataset id. Again, this will be removed with follow on work to more completely to snapshot ids, but there may be a better solution in the mean time. 