### PR TITLE
[DC-1047] Make fields non optional and fix typos data-repository.openapi file

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -2756,13 +2756,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionModel'
         400:
-          description: Bad request - invalid query pameters
+          description: Bad request - invalid query parameters
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
         403:
-          description: No permission to read transaction from this datasset
+          description: No permission to read transaction from this dataset
           content:
             application/json:
               schema:
@@ -2813,13 +2813,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobModel'
         400:
-          description: Bad request - invalid transaction terminat request, badly formed or unrecognized state
+          description: Bad request - invalid transaction terminate request, badly formed or unrecognized state
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
         403:
-          description: No permission to terminate the transaction for this datasset
+          description: No permission to terminate the transaction for this dataset
           content:
             application/json:
               schema:
@@ -2835,7 +2835,7 @@ paths:
       tags:
         - datasets
         - repository
-      description: Add an asset definiion to a dataset
+      description: Add an asset definition to a dataset
       operationId: addDatasetAssetSpecifications
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -7230,6 +7230,7 @@ components:
         - domainOptions
         - programDataOptions
         - featureValueGroups
+        - datasetConceptSets
       properties:
         domainOptions:
           type: array
@@ -7346,6 +7347,8 @@ components:
         - type: object
           required:
             - root
+            - conceptCount
+            - participantCount
           properties:
             root:
               $ref: '#/components/schemas/SnapshotBuilderConcept'

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -40,6 +40,8 @@ public class SnapshotBuilderTestData {
     SnapshotBuilderDomainOption domainOption = new SnapshotBuilderDomainOption();
     domainOption
         .root(root)
+        .conceptCount(100)
+        .participantCount(100)
         .id(id)
         .tableName(tableName)
         .columnName(columnName)


### PR DESCRIPTION
- make `conceptCount` and `participantCount` non-optional in SnapshotBuilderDomainOption. 
- make `datasetConceptSets` non-optional in SnapshotBuilderSettings
- fix typos
- adjust test data to include `conceptCount` and `participantCount`