### PR TITLE
[DC-1054] Adding a pull-request-template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]
+
+<!-- ### Dependencies --->
+<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->
+
+## Summary of changes:
+<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
+
+### What
+-
+
+### Why
+-
+
+### Testing strategy
+<!-- Note that changes impacting components in Storybook stories can be viewed at
+https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
+The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->
+
+- [ ] <!-- Test case 1 -->
+
+<!-- ### Visual Aids -->
+<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,22 @@
-### Addresses
-Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]
-<!--Please give an abridged version of why this change is needed -->
+<!-- Data Repo Pull Request -->
+<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->
 
+__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]
 
-### Summary of Changes
-<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
+<!-- ## Dependencies -->
+<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->
 
+## Addresses
 
-### Testing Strategy
+## Summary of changes
 
-----
-Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.
+## Testing Strategy
 
+_____________________
+Reminders:
 - Label PR with a Jira ticket number and include a link to the ticket
 - Fill out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
 - PR describes scope of changes
 - Get two approvals from code owners
 - Verify all GitHub Actions pass
+- Validate changes locally or on a BEE

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,7 @@
-<!-- Data Repo Pull Request -->
-<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->
-
 __Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]
-
-<!-- ## Dependencies -->
-<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->
 
 ## Addresses
 
 ## Summary of changes
 
 ## Testing Strategy
-
-_____________________
-Reminders:
-- Label PR with a Jira ticket number and include a link to the ticket
-- Fill out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
-- PR describes scope of changes
-- Get two approvals from code owners
-- Verify all GitHub Actions pass
-- Validate changes locally or on a BEE

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,4 @@ __Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]
 ## Testing Strategy
 
 <!-- Reminder -->
-<!-- Two team members from the Data Custodian Journeys team will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
+<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,19 @@
-### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]
+### Addresses
+Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]
+<!--Please give an abridged version of why this change is needed -->
 
-<!-- ### Dependencies --->
-<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->
 
-## Summary of changes:
+### Summary of Changes
 <!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
 
-### What
--
 
-### Why
--
+### Testing Strategy
 
-### Testing strategy
-<!-- Note that changes impacting components in Storybook stories can be viewed at
-https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
-The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->
+----
+Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.
 
-- [ ] <!-- Test case 1 -->
-
-<!-- ### Visual Aids -->
-<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
+- Label PR with a Jira ticket number and include a link to the ticket
+- Fill out the [Security Risk Assessment](https://sdarq.dsp-appsec.broadinstitute.org/jira-ticket-risk-assesment) (requires Broad Internal network access) and attached the result to the JIRA ticket
+- PR describes scope of changes
+- Get two approvals from code owners
+- Verify all GitHub Actions pass

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,4 +7,4 @@ __Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]
 ## Testing Strategy
 
 <!-- Reminder -->
-<!-- Two team members from Data Custodian Journeys team are automatically assigned the PR review. If you otherwise have two reviewers, you do not need to wait for their review. -->
+<!-- Two team members from the Data Custodian Journeys team will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,6 @@ __Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]
 ## Summary of changes
 
 ## Testing Strategy
+
+<!-- Reminder -->
+<!-- Two team members from Data Custodian Journeys team are automatically assigned the PR review. If you otherwise have two reviewers, you do not need to wait for their review. -->


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1054

## Addresses
Add a pull request template to encourage PR authors to add meaningful pull request descriptions. 

## Summary of changes
- Kept a simple outline of items we want to include in pull request descriptions
- Wanted to stay away from checklists
- We do not yet have a contributing guide for TDR, so we did not include 
- Many other reminders that we could have included are already embedded in our process (for example, we must do a security risk assessment on any jira tickets and checks must pass before you can merge the PR) 

## Testing Strategy
- Met with the DCJ and data exploration team to discuss the changes
- Posted in the #dsp-roundtable-repo-standards channel to allow for further discussion