### PR TITLE
DC-1055: More Junit 5 migrations

### DIFF
--- a/src/test/java/bio/terra/common/TestUtils.java
+++ b/src/test/java/bio/terra/common/TestUtils.java
@@ -378,4 +378,12 @@ public final class TestUtils {
       throw new RuntimeException(e);
     }
   }
+
+  public static <T> T loadObject(final String resourcePath, final TypeReference<T> typeReference) {
+    try {
+      return objectMapper.readerFor(typeReference).readValue(loadJson(resourcePath));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/src/test/java/bio/terra/common/TestUtils.java
+++ b/src/test/java/bio/terra/common/TestUtils.java
@@ -43,7 +43,9 @@ import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.storage.Acl;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -52,7 +54,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.shaded.com.google.common.base.Charsets;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -354,5 +358,16 @@ public final class TestUtils {
   public static <T> T extractValueFromPrivateObject(Object object, String fieldName) {
     return objectMapper.convertValue(
         ReflectionTestUtils.getField(object, fieldName), new TypeReference<>() {});
+  }
+
+  public static String loadJson(final String resourcePath) {
+    try (InputStream stream = TestUtils.class.getClassLoader().getResourceAsStream(resourcePath)) {
+      if (stream == null) {
+        throw new FileNotFoundException(resourcePath);
+      }
+      return IOUtils.toString(stream, Charsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/test/java/bio/terra/common/TestUtils.java
+++ b/src/test/java/bio/terra/common/TestUtils.java
@@ -46,6 +46,7 @@ import com.google.cloud.storage.StorageOptions;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -56,7 +57,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.curator.shaded.com.google.common.base.Charsets;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -365,7 +365,7 @@ public final class TestUtils {
       if (stream == null) {
         throw new FileNotFoundException(resourcePath);
       }
-      return IOUtils.toString(stream, Charsets.UTF_8);
+      return IOUtils.toString(stream, StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/bio/terra/common/TestUtils.java
+++ b/src/test/java/bio/terra/common/TestUtils.java
@@ -370,4 +370,12 @@ public final class TestUtils {
       throw new RuntimeException(e);
     }
   }
+
+  public static <T> T loadObject(final String resourcePath, final Class<T> resourceClass) {
+    try {
+      return objectMapper.readerFor(resourceClass).readValue(loadJson(resourcePath));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/src/test/java/bio/terra/common/fixtures/UnitTestConfiguration.java
+++ b/src/test/java/bio/terra/common/fixtures/UnitTestConfiguration.java
@@ -1,0 +1,28 @@
+package bio.terra.common.fixtures;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("unittest")
+@Configuration
+public class UnitTestConfiguration {
+
+  private final ObjectMapper objectMapper = new ApplicationConfiguration().objectMapper();
+
+  @Bean("tdrServiceAccountEmail")
+  public String tdrServiceAccountEmail() {
+    // Provide a default value for the service account email when running a spring-context aware
+    // unit test to avoid having to set it in the test environment.
+    return "";
+  }
+
+  @Bean("objectMapper")
+  public ObjectMapper objectMapper() {
+    // Provide the same objectmapper that the application configuration provides. Without this,
+    // the default Jackson objectmapper is used, which is configured differently.
+    return objectMapper;
+  }
+}

--- a/src/test/java/bio/terra/service/common/AssetUtils.java
+++ b/src/test/java/bio/terra/service/common/AssetUtils.java
@@ -1,28 +1,19 @@
 package bio.terra.service.common;
 
 import bio.terra.common.Relationship;
-import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.common.TestUtils;
 import bio.terra.service.dataset.AssetColumn;
 import bio.terra.service.dataset.AssetRelationship;
 import bio.terra.service.dataset.AssetSpecification;
 import bio.terra.service.dataset.AssetTable;
 import bio.terra.service.dataset.DatasetTable;
 import bio.terra.service.tabulardata.WalkRelationship;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.stereotype.Component;
 
-@Component
 public class AssetUtils {
-  private final JsonLoader jsonLoader;
 
-  public AssetUtils(JsonLoader jsonLoader) {
-    this.jsonLoader = jsonLoader;
-  }
-
-  public AssetSpecification buildTestAssetSpec() throws IOException {
+  public static AssetSpecification buildTestAssetSpec() {
     AssetTable assetTable_sample = setUpAssetTable("ingest-test-dataset-table-sample.json");
     AssetTable assetTable_participant =
         setUpAssetTable("ingest-test-dataset-table-participant.json");
@@ -41,7 +32,8 @@ public class AssetUtils {
                 .orElseThrow());
   }
 
-  public WalkRelationship buildExampleWalkRelationship(AssetSpecification assetSpecification) {
+  public static WalkRelationship buildExampleWalkRelationship(
+      AssetSpecification assetSpecification) {
     DatasetTable participantTable =
         assetSpecification.getAssetTableByName("participant").getTable();
     DatasetTable sampleTable = assetSpecification.getAssetTableByName("sample").getTable();
@@ -59,12 +51,13 @@ public class AssetUtils {
     return WalkRelationship.ofAssetRelationship(sampleParticipantRelationship);
   }
 
-  private AssetTable setUpAssetTable(String resourcePath) throws IOException {
-    DatasetTable datasetTable = jsonLoader.loadObject(resourcePath, DatasetTable.class);
+  private static AssetTable setUpAssetTable(String resourcePath) {
+    DatasetTable datasetTable = TestUtils.loadObject(resourcePath, DatasetTable.class);
     datasetTable.id(UUID.randomUUID());
-    List<AssetColumn> columns = new ArrayList<>();
-    datasetTable.getColumns().stream()
-        .forEach(c -> columns.add(new AssetColumn().datasetColumn(c).datasetTable(datasetTable)));
+    List<AssetColumn> columns =
+        datasetTable.getColumns().stream()
+            .map(c -> new AssetColumn().datasetColumn(c).datasetTable(datasetTable))
+            .toList();
     return new AssetTable().datasetTable(datasetTable).columns(columns);
   }
 }

--- a/src/test/java/bio/terra/service/dataset/AssetModelValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/AssetModelValidatorTest.java
@@ -40,15 +40,15 @@ import org.springframework.test.web.servlet.MockMvc;
 @Tag(Unit.TAG)
 class AssetModelValidatorTest {
   @MockBean private JobService jobService;
-  @MockBean private DatasetRequestValidator datasetRequestValidator;
   @MockBean private DatasetService datasetService;
   @MockBean private IamService iamService;
   @MockBean private FileService fileService;
   @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockBean private SnapshotBuilderService snapshotBuilderService;
   @MockBean private IngestRequestValidator ingestRequestValidator;
   @MockBean private DataDeletionRequestValidator dataDeletionRequestValidator;
   @MockBean private DatasetSchemaUpdateValidator datasetSchemaUpdateValidator;
-  @MockBean private SnapshotBuilderService snapshotBuilderService;
+  @MockBean private DatasetRequestValidator datasetRequestValidator;
 
   @Autowired private MockMvc mvc;
 

--- a/src/test/java/bio/terra/service/dataset/AssetModelValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/AssetModelValidatorTest.java
@@ -16,7 +16,6 @@ import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.job.JobService;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
-import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -77,13 +76,13 @@ class AssetModelValidatorTest {
   @Test
   void testInvalidAssetCreateRequest() throws Exception {
     ErrorModel errorModel = expectBadAssetCreateRequest("{}");
-    checkValidationErrorModel(errorModel, List.of("NotNull", "NotNull", "NotNull"));
+    checkValidationErrorModel(errorModel, "NotNull", "NotNull", "NotNull");
   }
 
   @Test
   void testDuplicateColumnAssetCreateRequest() throws Exception {
     String jsonModel = TestUtils.loadJson("dataset-asset-duplicate-column.json");
     ErrorModel errorModel = expectBadAssetCreateRequest(jsonModel);
-    checkValidationErrorModel(errorModel, List.of("DuplicateColumnNames"));
+    checkValidationErrorModel(errorModel, "DuplicateColumnNames");
   }
 }

--- a/src/test/java/bio/terra/service/dataset/AssetModelValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/AssetModelValidatorTest.java
@@ -1,68 +1,89 @@
 package bio.terra.service.dataset;
 
 import static bio.terra.service.dataset.ValidatorTestUtils.checkValidationErrorModel;
-import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.app.controller.ApiValidationExceptionHandler;
+import bio.terra.app.controller.DatasetsApiController;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
-import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.model.ErrorModel;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.job.JobService;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
+import java.util.List;
 import java.util.UUID;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
-@AutoConfigureMockMvc
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-public class AssetModelValidatorTest {
+@ContextConfiguration(
+    classes = {
+      AssetModelValidator.class,
+      DatasetsApiController.class,
+      ApiValidationExceptionHandler.class
+    })
+@WebMvcTest
+@Tag(Unit.TAG)
+class AssetModelValidatorTest {
+  @MockBean private JobService jobService;
+  @MockBean private DatasetRequestValidator datasetRequestValidator;
+  @MockBean private DatasetService datasetService;
+  @MockBean private IamService iamService;
+  @MockBean private FileService fileService;
+  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockBean private IngestRequestValidator ingestRequestValidator;
+  @MockBean private DataDeletionRequestValidator dataDeletionRequestValidator;
+  @MockBean private DatasetSchemaUpdateValidator datasetSchemaUpdateValidator;
+  @MockBean private SnapshotBuilderService snapshotBuilderService;
 
   @Autowired private MockMvc mvc;
-  @Autowired private JsonLoader jsonLoader;
+
+  @BeforeEach
+  void beforeEach() {
+    when(ingestRequestValidator.supports(any())).thenReturn(true);
+    when(datasetRequestValidator.supports(any())).thenReturn(true);
+    when(dataDeletionRequestValidator.supports(any())).thenReturn(true);
+    when(datasetSchemaUpdateValidator.supports(any())).thenReturn(true);
+  }
 
   private ErrorModel expectBadAssetCreateRequest(String jsonModel) throws Exception {
-    MvcResult result =
+    String responseBody =
         mvc.perform(
                 post("/api/repository/v1/datasets/" + UUID.randomUUID() + "/assets")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(jsonModel))
             .andExpect(status().is4xxClientError())
-            .andReturn();
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
 
-    MockHttpServletResponse response = result.getResponse();
-    String responseBody = response.getContentAsString();
-
-    assertTrue(
-        "Error model was returned on failure", StringUtils.contains(responseBody, "message"));
-
-    ErrorModel errorModel = TestUtils.mapFromJson(responseBody, ErrorModel.class);
-    return errorModel;
+    return TestUtils.mapFromJson(responseBody, ErrorModel.class);
   }
 
   @Test
-  public void testInvalidAssetCreateRequest() throws Exception {
+  void testInvalidAssetCreateRequest() throws Exception {
     ErrorModel errorModel = expectBadAssetCreateRequest("{}");
-    checkValidationErrorModel(errorModel, new String[] {"NotNull", "NotNull", "NotNull"});
+    checkValidationErrorModel(errorModel, List.of("NotNull", "NotNull", "NotNull"));
   }
 
   @Test
-  public void testDuplicateColumnAssetCreateRequest() throws Exception {
-    String jsonModel = jsonLoader.loadJson("dataset-asset-duplicate-column.json");
+  void testDuplicateColumnAssetCreateRequest() throws Exception {
+    String jsonModel = TestUtils.loadJson("dataset-asset-duplicate-column.json");
     ErrorModel errorModel = expectBadAssetCreateRequest(jsonModel);
-    checkValidationErrorModel(errorModel, new String[] {"DuplicateColumnNames"});
+    checkValidationErrorModel(errorModel, List.of("DuplicateColumnNames"));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DataDeletionRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DataDeletionRequestValidatorTest.java
@@ -118,6 +118,7 @@ class DataDeletionRequestValidatorTest {
         .andReturn();
   }
 
+  @Test
   void goodJsonArraySpecTest() throws Exception {
     mvc.perform(
             post("/api/repository/v1/datasets/{id}/deletes", UUID.randomUUID())

--- a/src/test/java/bio/terra/service/dataset/DataDeletionRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DataDeletionRequestValidatorTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.app.controller.ApiValidationExceptionHandler;
+import bio.terra.app.controller.DatasetsApiController;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
@@ -21,37 +23,47 @@ import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.JobModel;
 import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.filedata.FileService;
 import bio.terra.service.job.JobService;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-@AutoConfigureMockMvc
-public class DataDeletionRequestValidatorTest {
+@ContextConfiguration(
+    classes = {
+      DataDeletionRequestValidator.class,
+      DatasetsApiController.class,
+      ApiValidationExceptionHandler.class
+    })
+@WebMvcTest
+@Tag(Unit.TAG)
+class DataDeletionRequestValidatorTest {
 
   @Autowired private MockMvc mvc;
-  @MockBean private DatasetService datasetService;
   @MockBean private JobService jobService;
-  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockBean private DatasetService datasetService;
   @MockBean private IamService iamService;
+  @MockBean private FileService fileService;
+  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockBean private SnapshotBuilderService snapshotBuilderService;
+  @MockBean private IngestRequestValidator ingestRequestValidator;
+  @MockBean private AssetModelValidator assetModelValidator;
+  @MockBean private DatasetSchemaUpdateValidator datasetSchemaUpdateValidator;
+  @MockBean private DatasetRequestValidator datasetRequestValidator;
 
   private DataDeletionRequest goodGcsRequest;
   private DataDeletionRequest goodJsonArrayRequest;
@@ -59,8 +71,13 @@ public class DataDeletionRequestValidatorTest {
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeEach
+  void setup() throws Exception {
+    when(ingestRequestValidator.supports(any())).thenReturn(true);
+    when(datasetRequestValidator.supports(any())).thenReturn(true);
+    when(assetModelValidator.supports(any())).thenReturn(true);
+    when(datasetSchemaUpdateValidator.supports(any())).thenReturn(true);
+
     when(authenticatedUserRequestFactory.from(any())).thenReturn(TEST_USER);
     when(datasetService.retrieveDatasetSummary(any())).thenReturn(new DatasetSummaryModel());
     when(datasetService.deleteTabularData(any(), any(), any())).thenReturn("mock-job-id");
@@ -92,7 +109,7 @@ public class DataDeletionRequestValidatorTest {
   }
 
   @Test
-  public void goodGcsFileSpecTest() throws Exception {
+  void goodGcsFileSpecTest() throws Exception {
     mvc.perform(
             post("/api/repository/v1/datasets/{id}/deletes", UUID.randomUUID())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -101,7 +118,7 @@ public class DataDeletionRequestValidatorTest {
         .andReturn();
   }
 
-  public void goodJsonArraySpecTest() throws Exception {
+  void goodJsonArraySpecTest() throws Exception {
     mvc.perform(
             post("/api/repository/v1/datasets/{id}/deletes", UUID.randomUUID())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -111,7 +128,7 @@ public class DataDeletionRequestValidatorTest {
   }
 
   @Test
-  public void badGcsFileSpecTest() throws Exception {
+  void badGcsFileSpecTest() throws Exception {
     DataDeletionRequest badGcsRequest =
         goodGcsRequest.tables(
             List.of(
@@ -156,7 +173,7 @@ public class DataDeletionRequestValidatorTest {
   }
 
   @Test
-  public void badJsonArraySpecTest() throws Exception {
+  void badJsonArraySpecTest() throws Exception {
     DataDeletionRequest badJsonRequest =
         goodJsonArrayRequest.tables(
             List.of(
@@ -192,7 +209,7 @@ public class DataDeletionRequestValidatorTest {
   }
 
   @Test
-  public void testBadRequest() throws Exception {
+  void testBadRequest() throws Exception {
     DataDeletionRequest badRequest = new DataDeletionRequest().addTablesItem(null);
     MvcResult result =
         mvc.perform(

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -25,6 +25,7 @@ import bio.terra.app.controller.converters.SqlSortDirectionAscDefaultConverter;
 import bio.terra.app.controller.converters.SqlSortDirectionDescDefaultConverter;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.UnitTestConfiguration;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
@@ -41,8 +42,6 @@ import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.job.JobService;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,7 +68,8 @@ import org.springframework.test.web.servlet.MvcResult;
       GlobalExceptionHandler.class,
       EnumerateSortByParamConverter.class,
       SqlSortDirectionAscDefaultConverter.class,
-      SqlSortDirectionDescDefaultConverter.class
+      SqlSortDirectionDescDefaultConverter.class,
+      UnitTestConfiguration.class
     })
 @WebMvcTest
 @Tag(Unit.TAG)
@@ -87,8 +87,6 @@ class DatasetRequestValidatorTest {
   @MockBean private AssetModelValidator assetModelValidator;
   @MockBean private DatasetSchemaUpdateValidator datasetSchemaUpdateValidator;
   @MockBean private DataDeletionRequestValidator dataDeletionRequestValidator;
-
-  @Autowired private ObjectMapper objectMapper;
 
   @BeforeEach
   void setup() throws Exception {
@@ -160,7 +158,6 @@ class DatasetRequestValidatorTest {
   void testJsonParsingErrors() throws Exception {
     // Force the ObjectMapper to throw an exception when it encounters an unknown property,
     // to match the configuration that the controller uses.
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
     String invalidSchema =
         """
             {"name":"no_response",

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -11,13 +11,21 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.app.controller.ApiValidationExceptionHandler;
+import bio.terra.app.controller.DatasetsApiController;
+import bio.terra.app.controller.GlobalExceptionHandler;
+import bio.terra.app.controller.converters.EnumerateSortByParamConverter;
+import bio.terra.app.controller.converters.SqlSortDirectionAscDefaultConverter;
+import bio.terra.app.controller.converters.SqlSortDirectionDescDefaultConverter;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
-import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
 import bio.terra.model.ColumnModel;
@@ -29,32 +37,66 @@ import bio.terra.model.RelationshipModel;
 import bio.terra.model.RelationshipTermModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.filedata.FileService;
+import bio.terra.service.job.JobService;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
-@AutoConfigureMockMvc
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-public class DatasetRequestValidatorTest {
+@ContextConfiguration(
+    classes = {
+      DatasetRequestValidator.class,
+      DatasetsApiController.class,
+      ApiValidationExceptionHandler.class,
+      GlobalExceptionHandler.class,
+      EnumerateSortByParamConverter.class,
+      SqlSortDirectionAscDefaultConverter.class,
+      SqlSortDirectionDescDefaultConverter.class
+    })
+@WebMvcTest
+@Tag(Unit.TAG)
+class DatasetRequestValidatorTest {
 
   @Autowired private MockMvc mvc;
-  @Autowired private JsonLoader jsonLoader;
+
+  @MockBean private JobService jobService;
+  @MockBean private DatasetService datasetService;
+  @MockBean private IamService iamService;
+  @MockBean private FileService fileService;
+  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockBean private SnapshotBuilderService snapshotBuilderService;
+  @MockBean private IngestRequestValidator ingestRequestValidator;
+  @MockBean private AssetModelValidator assetModelValidator;
+  @MockBean private DatasetSchemaUpdateValidator datasetSchemaUpdateValidator;
+  @MockBean private DataDeletionRequestValidator dataDeletionRequestValidator;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setup() throws Exception {
+    when(ingestRequestValidator.supports(any())).thenReturn(true);
+    when(dataDeletionRequestValidator.supports(any())).thenReturn(true);
+    when(assetModelValidator.supports(any())).thenReturn(true);
+    when(datasetSchemaUpdateValidator.supports(any())).thenReturn(true);
+  }
 
   private ErrorModel expectBadDatasetCreateRequest(DatasetRequestModel datasetRequest)
       throws Exception {
@@ -71,8 +113,7 @@ public class DatasetRequestValidatorTest {
 
     assertThat("Error model was returned on failure", responseBody, containsString("message"));
 
-    ErrorModel errorModel = TestUtils.mapFromJson(responseBody, ErrorModel.class);
-    return errorModel;
+    return TestUtils.mapFromJson(responseBody, ErrorModel.class);
   }
 
   private void expectBadDatasetEnumerateRequest(
@@ -107,7 +148,7 @@ public class DatasetRequestValidatorTest {
   }
 
   @Test
-  public void testInvalidDatasetRequest() throws Exception {
+  void testInvalidDatasetRequest() throws Exception {
     mvc.perform(
             post("/api/repository/v1/datasets")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -116,13 +157,17 @@ public class DatasetRequestValidatorTest {
   }
 
   @Test
-  public void testJsonParsingErrors() throws Exception {
+  void testJsonParsingErrors() throws Exception {
+    // Force the ObjectMapper to throw an exception when it encounters an unknown property,
+    // to match the configuration that the controller uses.
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
     String invalidSchema =
-        "{\"name\":\"no_response\","
-            + "\"description\":\"Invalid dataset schema leads to no response body\","
-            + "\"defaultProfileId\":\"390e7a85-d47f-4531-b612-165fc977d3bd\","
-            + "\"schema\":{\"tables\":[{\"name\":\"table\",\"columns\":"
-            + "[{\"name\":\"column\",\"datatype\":\"fileref\",\"is_array\":true}]}]}}";
+        """
+            {"name":"no_response",
+            "description":"Invalid dataset schema leads to no response body",
+            "defaultProfileId":"390e7a85-d47f-4531-b612-165fc977d3bd",
+            "schema":{"tables":[{"name":"table","columns":
+            [{"name":"column","datatype":"fileref","is_array":true}]}]}}""";
     MvcResult result =
         mvc.perform(
                 post("/api/repository/v1/datasets")
@@ -140,7 +185,7 @@ public class DatasetRequestValidatorTest {
   }
 
   @Test
-  public void testDuplicateTableNames() throws Exception {
+  void testDuplicateTableNames() throws Exception {
     ColumnModel column = new ColumnModel().name("id").datatype(TableDataType.STRING);
     TableModel table =
         new TableModel().name("duplicate").columns(Collections.singletonList(column));
@@ -150,15 +195,13 @@ public class DatasetRequestValidatorTest {
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
         errorModel,
-        new String[] {
-          "DuplicateTableNames",
-          "InvalidRelationshipTermTable",
-          "InvalidRelationshipTermTable",
-          "InvalidAssetTable",
-          "InvalidAssetTableColumn",
-          "InvalidAssetTableColumn",
-          "InvalidRootColumn"
-        });
+        "DuplicateTableNames",
+        "InvalidRelationshipTermTable",
+        "InvalidRelationshipTermTable",
+        "InvalidAssetTable",
+        "InvalidAssetTableColumn",
+        "InvalidAssetTableColumn",
+        "InvalidRootColumn");
   }
 
   /**
@@ -174,23 +217,23 @@ public class DatasetRequestValidatorTest {
   }
 
   @Test
-  public void testInvalidTableName() throws Exception {
+  void testInvalidTableName() throws Exception {
     DatasetRequestModel req = buildDatasetRequest();
 
     // Table names with leading underscores are invalid
     List<String> invalidPatternNames = List.of("_", "_a_column", "_1_column");
     for (String name : invalidPatternNames) {
       checkValidationErrorModel(
-          expectBadDatasetCreateRequest(withNamedTable(req, name)), new String[] {"Pattern"});
+          expectBadDatasetCreateRequest(withNamedTable(req, name)), "Pattern");
     }
 
     // Table names over 63 characters are invalid
     checkValidationErrorModel(
-        expectBadDatasetCreateRequest(withNamedTable(req, "a".repeat(64))), new String[] {"Size"});
+        expectBadDatasetCreateRequest(withNamedTable(req, "a".repeat(64))), "Size");
   }
 
   @Test
-  public void testDuplicateColumnNames() throws Exception {
+  void testDuplicateColumnNames() throws Exception {
     ColumnModel column = new ColumnModel().name("id").datatype(TableDataType.STRING);
     TableModel table = new TableModel().name("table").columns(Arrays.asList(column, column));
 
@@ -199,19 +242,17 @@ public class DatasetRequestValidatorTest {
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
         errorModel,
-        new String[] {
-          "DuplicateColumnNames",
-          "InvalidRelationshipTermTable",
-          "InvalidRelationshipTermTable",
-          "InvalidAssetTable",
-          "InvalidAssetTableColumn",
-          "InvalidAssetTableColumn",
-          "InvalidRootColumn"
-        });
+        "DuplicateColumnNames",
+        "InvalidRelationshipTermTable",
+        "InvalidRelationshipTermTable",
+        "InvalidAssetTable",
+        "InvalidAssetTableColumn",
+        "InvalidAssetTableColumn",
+        "InvalidRootColumn");
   }
 
   @Test
-  public void testInvalidKeyType() throws Exception {
+  void testInvalidKeyType() throws Exception {
     DatasetRequestModel req = buildDatasetRequest();
     TableModel testTable = req.getSchema().getTables().get(0);
     testTable.setPrimaryKey(List.of("id", "age"));
@@ -226,16 +267,14 @@ public class DatasetRequestValidatorTest {
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
         errorModel,
-        new String[] {
-          "InvalidPrimaryKey",
-          "InvalidPrimaryKey",
-          "InvalidPrimaryKey",
-          "InvalidRelationshipColumnType"
-        });
+        "InvalidPrimaryKey",
+        "InvalidPrimaryKey",
+        "InvalidPrimaryKey",
+        "InvalidRelationshipColumnType");
   }
 
   @Test
-  public void testInvalidColumnMode() throws Exception {
+  void testInvalidColumnMode() throws Exception {
     DatasetRequestModel req = buildDatasetRequest();
     TableModel testTable = req.getSchema().getTables().get(0);
     // Test that a required, array_of column causes a validation error
@@ -251,7 +290,7 @@ public class DatasetRequestValidatorTest {
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
-        errorModel, new String[] {"InvalidPrimaryKey", "InvalidColumnMode", "InvalidColumnMode"});
+        errorModel, "InvalidPrimaryKey", "InvalidColumnMode", "InvalidColumnMode");
   }
 
   /**
@@ -267,40 +306,40 @@ public class DatasetRequestValidatorTest {
   }
 
   @Test
-  public void testInvalidColumnName() throws Exception {
+  void testInvalidColumnName() throws Exception {
     DatasetRequestModel req = buildDatasetRequest();
 
     // Table names with leading numbers or leading underscores are invalid
     List<String> invalidPatternNames = List.of("_", "_a_column", "_1_column", "1", "1_column");
     for (String name : invalidPatternNames) {
       checkValidationErrorModel(
-          expectBadDatasetCreateRequest(withNamedColumn(req, name)), new String[] {"Pattern"});
+          expectBadDatasetCreateRequest(withNamedColumn(req, name)), "Pattern");
     }
 
     // Column names over 63 characters are invalid
     checkValidationErrorModel(
-        expectBadDatasetCreateRequest(withNamedColumn(req, "a".repeat(64))), new String[] {"Size"});
+        expectBadDatasetCreateRequest(withNamedColumn(req, "a".repeat(64))), "Size");
   }
 
   @Test
-  public void testDuplicateAssetNames() throws Exception {
+  void testDuplicateAssetNames() throws Exception {
     DatasetRequestModel req = buildDatasetRequest();
     req.getSchema().assets(Arrays.asList(buildAsset(), buildAsset()));
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"DuplicateAssetNames"});
+    checkValidationErrorModel(errorModel, "DuplicateAssetNames");
   }
 
   @Test
-  public void testDuplicateRelationshipNames() throws Exception {
+  void testDuplicateRelationshipNames() throws Exception {
     DatasetRequestModel req = buildDatasetRequest();
     RelationshipModel relationship = buildParticipantSampleRelationship();
     req.getSchema().relationships(Arrays.asList(relationship, relationship));
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"DuplicateRelationshipNames"});
+    checkValidationErrorModel(errorModel, "DuplicateRelationshipNames");
   }
 
   @Test
-  public void testInvalidAssetTable() throws Exception {
+  void testInvalidAssetTable() throws Exception {
     AssetTableModel invalidAssetTable =
         new AssetTableModel().name("mismatched_table_name").columns(Collections.emptyList());
 
@@ -314,12 +353,11 @@ public class DatasetRequestValidatorTest {
     DatasetRequestModel req = buildDatasetRequest();
     req.getSchema().assets(Collections.singletonList(asset));
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(
-        errorModel, new String[] {"NotNull", "InvalidAssetTable", "InvalidRootColumn"});
+    checkValidationErrorModel(errorModel, "NotNull", "InvalidAssetTable", "InvalidRootColumn");
   }
 
   @Test
-  public void testInvalidAssetTableColumn() throws Exception {
+  void testInvalidAssetTableColumn() throws Exception {
     // participant is a valid table but date_collected is in the sample table
     AssetTableModel invalidAssetTable =
         new AssetTableModel()
@@ -337,12 +375,11 @@ public class DatasetRequestValidatorTest {
     DatasetRequestModel req = buildDatasetRequest();
     req.getSchema().assets(Collections.singletonList(asset));
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(
-        errorModel, new String[] {"InvalidAssetTableColumn", "InvalidRootColumn"});
+    checkValidationErrorModel(errorModel, "InvalidAssetTableColumn", "InvalidRootColumn");
   }
 
   @Test
-  public void testArrayAssetRootColumn() throws Exception {
+  void testArrayAssetRootColumn() throws Exception {
     ColumnModel arrayColumn =
         new ColumnModel().name("array_data").arrayOf(true).datatype(TableDataType.STRING);
 
@@ -370,11 +407,11 @@ public class DatasetRequestValidatorTest {
 
     req.getSchema().setAssets(Collections.singletonList(asset));
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"InvalidArrayRootColumn"});
+    checkValidationErrorModel(errorModel, "InvalidArrayRootColumn");
   }
 
   @Test
-  public void testInvalidFollowsRelationship() throws Exception {
+  void testInvalidFollowsRelationship() throws Exception {
     AssetModel asset =
         new AssetModel()
             .name("bad_follows")
@@ -385,12 +422,11 @@ public class DatasetRequestValidatorTest {
     req.getSchema().assets(Collections.singletonList(asset));
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
-        errorModel,
-        new String[] {"NotNull", "NotNull", "NoRootTable", "InvalidFollowsRelationship"});
+        errorModel, "NotNull", "NotNull", "NoRootTable", "InvalidFollowsRelationship");
   }
 
   @Test
-  public void testInvalidRelationshipTermTableColumn() throws Exception {
+  void testInvalidRelationshipTermTableColumn() throws Exception {
     // participant_id is part of the sample table, not participant
     RelationshipTermModel mismatchedTerm =
         new RelationshipTermModel().table("participant").column("participant_id");
@@ -404,11 +440,11 @@ public class DatasetRequestValidatorTest {
     DatasetRequestModel req = buildDatasetRequest();
     req.getSchema().relationships(Collections.singletonList(mismatchedRelationship));
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"InvalidRelationshipTermTableColumn"});
+    checkValidationErrorModel(errorModel, "InvalidRelationshipTermTableColumn");
   }
 
   @Test
-  public void testNoRootTable() throws Exception {
+  void testNoRootTable() throws Exception {
     AssetModel noRoot =
         new AssetModel()
             .name("bad")
@@ -418,12 +454,12 @@ public class DatasetRequestValidatorTest {
     DatasetRequestModel req = buildDatasetRequest();
     req.getSchema().assets(Collections.singletonList(noRoot));
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"NotNull", "NotNull", "NoRootTable"});
+    checkValidationErrorModel(errorModel, "NotNull", "NotNull", "NoRootTable");
   }
 
   @Test
-  public void testTableSchemaInvalidDataType() throws Exception {
-    String invalidSchema = jsonLoader.loadJson("./dataset/create/invalid-schema.json");
+  void testTableSchemaInvalidDataType() throws Exception {
+    String invalidSchema = TestUtils.loadJson("./dataset/create/invalid-schema.json");
     MvcResult result =
         mvc.perform(
                 post("/api/repository/v1/datasets")
@@ -444,30 +480,30 @@ public class DatasetRequestValidatorTest {
   }
 
   @Test
-  public void testDatasetNameInvalid() throws Exception {
+  void testDatasetNameInvalid() throws Exception {
     ErrorModel errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name("no spaces"));
-    checkValidationErrorModel(errorModel, new String[] {"Pattern"});
+    checkValidationErrorModel(errorModel, "Pattern");
 
     errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name("no-dashes"));
-    checkValidationErrorModel(errorModel, new String[] {"Pattern"});
+    checkValidationErrorModel(errorModel, "Pattern");
 
     errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(""));
-    checkValidationErrorModel(errorModel, new String[] {"Size", "Pattern"});
+    checkValidationErrorModel(errorModel, "Size", "Pattern");
 
     // Make a 512 character string, it should be considered too long by the validation.
     String tooLong = "a".repeat(512);
     errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(tooLong));
-    checkValidationErrorModel(errorModel, new String[] {"Size"});
+    checkValidationErrorModel(errorModel, "Size");
   }
 
   @Test
-  public void testDatasetNameMissing() throws Exception {
+  void testDatasetNameMissing() throws Exception {
     ErrorModel errorModel = expectBadDatasetCreateRequest(buildDatasetRequest().name(null));
-    checkValidationErrorModel(errorModel, new String[] {"NotNull", "DatasetNameMissing"});
+    checkValidationErrorModel(errorModel, "NotNull", "DatasetNameMissing");
   }
 
   @Test
-  public void testDatasetEnumerateValidations() throws Exception {
+  void testDatasetEnumerateValidations() throws Exception {
     String expected = "Invalid enumerate parameter(s).";
     String expectedEnum = "Invalid enum parameter: %s.";
     expectBadDatasetEnumerateRequest(
@@ -510,7 +546,7 @@ public class DatasetRequestValidatorTest {
   }
 
   @Test
-  public void testMissingPrimaryKeyColumn() throws Exception {
+  void testMissingPrimaryKeyColumn() throws Exception {
     TableModel table =
         new TableModel()
             .name("table")
@@ -523,12 +559,11 @@ public class DatasetRequestValidatorTest {
         .assets(Collections.emptyList());
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(
-        errorModel, new String[] {"MissingPrimaryKeyColumn", "IncompleteSchemaDefinition"});
+    checkValidationErrorModel(errorModel, "MissingPrimaryKeyColumn", "IncompleteSchemaDefinition");
   }
 
   @Test
-  public void testNonRequiredPrimaryKeyColumn() throws Exception {
+  void testNonRequiredPrimaryKeyColumn() throws Exception {
     TableModel table =
         new TableModel()
             .name("table")
@@ -547,11 +582,11 @@ public class DatasetRequestValidatorTest {
         .assets(Collections.emptyList());
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"OptionalPrimaryKeyColumn"});
+    checkValidationErrorModel(errorModel, "OptionalPrimaryKeyColumn");
   }
 
   @Test
-  public void testDatePartitionWithBadOptions() throws Exception {
+  void testDatePartitionWithBadOptions() throws Exception {
     TableModel table =
         new TableModel()
             .name("table")
@@ -568,13 +603,13 @@ public class DatasetRequestValidatorTest {
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
         errorModel,
-        new String[] {
-          "MissingDatePartitionOptions", "InvalidIntPartitionOptions", "IncompleteSchemaDefinition"
-        });
+        "MissingDatePartitionOptions",
+        "InvalidIntPartitionOptions",
+        "IncompleteSchemaDefinition");
   }
 
   @Test
-  public void testDatePartitionWithMissingColumn() throws Exception {
+  void testDatePartitionWithMissingColumn() throws Exception {
     TableModel table =
         new TableModel()
             .name("table")
@@ -589,11 +624,11 @@ public class DatasetRequestValidatorTest {
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
-        errorModel, new String[] {"InvalidDatePartitionColumnName", "IncompleteSchemaDefinition"});
+        errorModel, "InvalidDatePartitionColumnName", "IncompleteSchemaDefinition");
   }
 
   @Test
-  public void testDatePartitionWithMismatchedType() throws Exception {
+  void testDatePartitionWithMismatchedType() throws Exception {
     ColumnModel column = new ColumnModel().name("column").datatype(TableDataType.INT64);
     TableModel table =
         new TableModel()
@@ -608,11 +643,11 @@ public class DatasetRequestValidatorTest {
         .assets(Collections.emptyList());
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"InvalidDatePartitionColumnType"});
+    checkValidationErrorModel(errorModel, "InvalidDatePartitionColumnType");
   }
 
   @Test
-  public void testIntPartitionWithBadOptions() throws Exception {
+  void testIntPartitionWithBadOptions() throws Exception {
     TableModel table =
         new TableModel()
             .name("table")
@@ -628,13 +663,13 @@ public class DatasetRequestValidatorTest {
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
         errorModel,
-        new String[] {
-          "InvalidDatePartitionOptions", "MissingIntPartitionOptions", "IncompleteSchemaDefinition"
-        });
+        "InvalidDatePartitionOptions",
+        "MissingIntPartitionOptions",
+        "IncompleteSchemaDefinition");
   }
 
   @Test
-  public void testIntPartitionWithMissingColumn() throws Exception {
+  void testIntPartitionWithMissingColumn() throws Exception {
     TableModel table =
         new TableModel()
             .name("table")
@@ -650,11 +685,11 @@ public class DatasetRequestValidatorTest {
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
-        errorModel, new String[] {"InvalidIntPartitionColumnName", "IncompleteSchemaDefinition"});
+        errorModel, "InvalidIntPartitionColumnName", "IncompleteSchemaDefinition");
   }
 
   @Test
-  public void testIntPartitionWithMismatchedType() throws Exception {
+  void testIntPartitionWithMismatchedType() throws Exception {
     ColumnModel column = new ColumnModel().name("column").datatype(TableDataType.TIMESTAMP);
     TableModel table =
         new TableModel()
@@ -674,11 +709,11 @@ public class DatasetRequestValidatorTest {
         .assets(Collections.emptyList());
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"InvalidIntPartitionColumnType"});
+    checkValidationErrorModel(errorModel, "InvalidIntPartitionColumnType");
   }
 
   @Test
-  public void testIntPartitionWithBadRange() throws Exception {
+  void testIntPartitionWithBadRange() throws Exception {
     ColumnModel column = new ColumnModel().name("column").datatype(TableDataType.INT64);
     TableModel table =
         new TableModel()
@@ -699,11 +734,11 @@ public class DatasetRequestValidatorTest {
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
-        errorModel, new String[] {"InvalidIntPartitionRange", "InvalidIntPartitionInterval"});
+        errorModel, "InvalidIntPartitionRange", "InvalidIntPartitionInterval");
   }
 
   @Test
-  public void testIntPartitionTooManyPartitions() throws Exception {
+  void testIntPartitionTooManyPartitions() throws Exception {
     ColumnModel column = new ColumnModel().name("column").datatype(TableDataType.INT64);
     TableModel table =
         new TableModel()
@@ -723,11 +758,11 @@ public class DatasetRequestValidatorTest {
         .assets(Collections.emptyList());
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"TooManyIntPartitions"});
+    checkValidationErrorModel(errorModel, "TooManyIntPartitions");
   }
 
   @Test
-  public void testPartitionOptionsWithoutMode() throws Exception {
+  void testPartitionOptionsWithoutMode() throws Exception {
     TableModel table =
         new TableModel()
             .name("table")
@@ -744,13 +779,13 @@ public class DatasetRequestValidatorTest {
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
     checkValidationErrorModel(
         errorModel,
-        new String[] {
-          "InvalidDatePartitionOptions", "InvalidIntPartitionOptions", "IncompleteSchemaDefinition"
-        });
+        "InvalidDatePartitionOptions",
+        "InvalidIntPartitionOptions",
+        "IncompleteSchemaDefinition");
   }
 
   @Test
-  public void testNoTablesProvided() throws Exception {
+  void testNoTablesProvided() throws Exception {
     DatasetRequestModel req = buildDatasetRequest();
     req.getSchema()
         .tables(Collections.emptyList())
@@ -758,11 +793,11 @@ public class DatasetRequestValidatorTest {
         .assets(Collections.emptyList());
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"IncompleteSchemaDefinition"});
+    checkValidationErrorModel(errorModel, "IncompleteSchemaDefinition");
   }
 
   @Test
-  public void testNoColumnsProvided() throws Exception {
+  void testNoColumnsProvided() throws Exception {
     TableModel table = new TableModel().name("table").columns(Collections.emptyList());
     DatasetRequestModel req = buildDatasetRequest();
     req.getSchema()
@@ -771,6 +806,6 @@ public class DatasetRequestValidatorTest {
         .assets(Collections.emptyList());
 
     ErrorModel errorModel = expectBadDatasetCreateRequest(req);
-    checkValidationErrorModel(errorModel, new String[] {"IncompleteSchemaDefinition"});
+    checkValidationErrorModel(errorModel, "IncompleteSchemaDefinition");
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -156,8 +156,6 @@ class DatasetRequestValidatorTest {
 
   @Test
   void testJsonParsingErrors() throws Exception {
-    // Force the ObjectMapper to throw an exception when it encounters an unknown property,
-    // to match the configuration that the controller uses.
     String invalidSchema =
         """
             {"name":"no_response",

--- a/src/test/java/bio/terra/service/dataset/DatasetUtilsTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetUtilsTest.java
@@ -1,60 +1,59 @@
 package bio.terra.service.dataset;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import bio.terra.common.PdaoConstant;
+import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
-import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.DatasetRequestModel;
 import java.util.Arrays;
 import java.util.UUID;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
-@AutoConfigureMockMvc
-@ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-public class DatasetUtilsTest {
-
-  @Autowired private JsonLoader jsonLoader;
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class DatasetUtilsTest {
 
   @Test
-  public void generateAuxTableNameTest() {
+  void generateAuxTableNameTest() {
     DatasetTable testTable = new DatasetTable().name("my_cool_table");
     String auxName1 = DatasetUtils.generateAuxTableName(testTable, "test");
     String auxName2 = DatasetUtils.generateAuxTableName(testTable, "test");
 
     for (String name : Arrays.asList(auxName1, auxName2)) {
-      Assert.assertThat(name, Matchers.startsWith(PdaoConstant.PDAO_PREFIX));
-      Assert.assertThat(name, Matchers.containsString(testTable.getName()));
-      Assert.assertThat(name, Matchers.containsString("test"));
-      Assert.assertThat(name, Matchers.not(Matchers.containsString("-")));
+      assertThat(
+          name,
+          allOf(
+              startsWith(PdaoConstant.PDAO_PREFIX),
+              containsString(testTable.getName()),
+              containsString("test"),
+              not(containsString("-"))));
     }
 
-    Assert.assertNotEquals(auxName1, auxName2);
+    assertNotEquals(auxName1, auxName2);
   }
 
   @Test
-  public void convertDatasetTest() throws Exception {
+  void convertDatasetTest() {
     UUID fakeProfileId = UUID.randomUUID();
     DatasetRequestModel datasetRequest =
-        jsonLoader
-            .loadObject("ingest-test-dataset.json", DatasetRequestModel.class)
+        TestUtils.loadObject("ingest-test-dataset.json", DatasetRequestModel.class)
             .defaultProfileId(fakeProfileId)
             .cloudPlatform(CloudPlatform.GCP);
     Dataset convertedDataset = DatasetUtils.convertRequestWithGeneratedNames(datasetRequest);
     for (DatasetTable table : convertedDataset.getTables()) {
-      Assert.assertNotNull(table.getRawTableName());
-      Assert.assertNotNull(table.getSoftDeleteTableName());
+      assertNotNull(table.getRawTableName());
+      assertNotNull(table.getSoftDeleteTableName());
     }
   }
 }

--- a/src/test/java/bio/terra/service/dataset/IngestRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/IngestRequestValidatorTest.java
@@ -53,7 +53,7 @@ import org.springframework.test.web.servlet.MvcResult;
     })
 @WebMvcTest
 @Tag(Unit.TAG)
-class DatasetIngestRequestValidatorTest {
+class IngestRequestValidatorTest {
 
   @Autowired private MockMvc mvc;
   @MockBean private JobService jobService;

--- a/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/ValidateAssetUnitTest.java
@@ -2,176 +2,136 @@ package bio.terra.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import bio.terra.app.usermetrics.UserLoggingMetrics;
 import bio.terra.common.Relationship;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.DatasetFixtures;
 import bio.terra.model.AssetModel;
 import bio.terra.model.TableDataType;
-import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.exception.InvalidAssetException;
-import bio.terra.service.filedata.azure.AzureSynapsePdao;
-import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
-import bio.terra.service.filedata.google.gcs.GcsPdao;
-import bio.terra.service.job.JobService;
-import bio.terra.service.load.LoadService;
-import bio.terra.service.profile.ProfileDao;
-import bio.terra.service.profile.ProfileService;
-import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
-import bio.terra.service.resourcemanagement.ResourceService;
-import bio.terra.service.snapshotbuilder.SnapshotBuilderSettingsDao;
-import bio.terra.service.tabulardata.azure.StorageTableService;
-import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
-import bio.terra.service.tabulardata.google.bigquery.BigQueryTransactionPdao;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {DatasetService.class})
-@ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-public class ValidateAssetUnitTest {
-  @MockBean private DatasetDao datasetDao;
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class ValidateAssetUnitTest {
 
-  @Autowired private DatasetService datasetService;
-
-  @MockBean private SnapshotBuilderSettingsDao snapshotBuilderSettingsDao;
-  @MockBean private DatasetJsonConversion datasetJsonConversion;
-  @MockBean private JobService jobService;
-  @MockBean private LoadService loadService;
-  @MockBean private ProfileDao profileDao;
-  @MockBean private StorageTableService storageTableService;
-  @MockBean private BigQueryTransactionPdao bigQueryTransactionPdao;
-  @MockBean private BigQueryDatasetPdao bigQueryDatasetPdao;
-  @MockBean private MetadataDataAccessUtils metadataDataAccessUtils;
-  @MockBean private ResourceService resourceService;
-  @MockBean private GcsPdao gcsPdao;
-  @MockBean private ObjectMapper objectMapper;
-  @MockBean private AzureBlobStorePdao azureBlobStorePdao;
-  @MockBean private ProfileService profileService;
-  @MockBean private UserLoggingMetrics loggingMetrics;
-  @MockBean private IamService iamService;
-  @MockBean private DatasetTableDao datasetTableDao;
-  @MockBean private AzureSynapsePdao azureSynapsePdao;
-
-  private String tableName = "tableName1";
-  private String tableName2 = "tableName2";
-  private String col1Name = "col1";
-  private String col2Name = "col2";
-  private String col3Name = "col3";
-  private String relationshipName = "rel1";
+  private static final String TABLE_NAME = "tableName1";
+  private static final String TABLE_NAME_2 = "tableName2";
+  private static final String COL_1_NAME = "col1";
+  private static final String COL_2_NAME = "col2";
+  private static final String COL_3_NAME = "col3";
+  private static final String RELATIONSHIP_NAME = "rel1";
   private Dataset dataset;
   private AssetModel assetModel;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     dataset =
         new Dataset()
             .tables(
                 List.of(
                     DatasetFixtures.generateDatasetTable(
-                        tableName, TableDataType.STRING, List.of(col1Name, col2Name)),
+                        TABLE_NAME, TableDataType.STRING, List.of(COL_1_NAME, COL_2_NAME)),
                     DatasetFixtures.generateDatasetTable(
-                        tableName2, TableDataType.STRING, List.of(col3Name))))
-            .relationships(List.of(new Relationship().name(relationshipName)));
+                        TABLE_NAME_2, TableDataType.STRING, List.of(COL_3_NAME))))
+            .relationships(List.of(new Relationship().name(RELATIONSHIP_NAME)));
 
     assetModel =
         new AssetModel()
             .name("assetName")
-            .rootTable(tableName)
-            .rootColumn(col1Name)
+            .rootTable(TABLE_NAME)
+            .rootColumn(COL_1_NAME)
             .tables(
-                List.of(DatasetFixtures.generateAssetTable(tableName, List.of(col1Name, col2Name))))
-            .follow(List.of(relationshipName));
+                List.of(
+                    DatasetFixtures.generateAssetTable(
+                        TABLE_NAME, List.of(COL_1_NAME, COL_2_NAME))))
+            .follow(List.of(RELATIONSHIP_NAME));
   }
 
   @Test
-  public void validateAssetModel() {
+  void validateAssetModel() {
     dataset.validateDatasetAssetSpecification(assetModel);
   }
 
   @Test
-  public void testTwoTables() {
+  void testTwoTables() {
     assetModel.tables(
         List.of(
-            DatasetFixtures.generateAssetTable(tableName, List.of(col1Name, col2Name)),
-            DatasetFixtures.generateAssetTable(tableName2, List.of(col3Name))));
+            DatasetFixtures.generateAssetTable(TABLE_NAME, List.of(COL_1_NAME, COL_2_NAME)),
+            DatasetFixtures.generateAssetTable(TABLE_NAME_2, List.of(COL_3_NAME))));
     dataset.validateDatasetAssetSpecification(assetModel);
   }
 
-  @Test(expected = InvalidAssetException.class)
-  public void testTwoTablesInvalidOverlap() {
+  @Test
+  void testTwoTablesInvalidOverlap() {
     // col3 is only in table2, not table2
     assetModel.tables(
         List.of(
-            DatasetFixtures.generateAssetTable(tableName, List.of(col1Name, col3Name)),
-            DatasetFixtures.generateAssetTable(tableName2, List.of(col3Name))));
+            DatasetFixtures.generateAssetTable(TABLE_NAME, List.of(COL_1_NAME, COL_3_NAME)),
+            DatasetFixtures.generateAssetTable(TABLE_NAME_2, List.of(COL_3_NAME))));
     testAssetModel(
-        "invalid column", "Column " + col3Name + " does not exist in table " + tableName);
+        "invalid column", "Column " + COL_3_NAME + " does not exist in table " + TABLE_NAME);
   }
 
   @Test
-  public void testNoFollow() {
+  void testNoFollow() {
     assetModel.follow(null);
     dataset.validateDatasetAssetSpecification(assetModel);
   }
 
   @Test
-  public void testEmptyFollowList() {
+  void testEmptyFollowList() {
     assetModel.follow(Collections.emptyList());
     dataset.validateDatasetAssetSpecification(assetModel);
   }
 
-  @Test(expected = InvalidAssetException.class)
-  public void testInvalidColumn() {
+  @Test
+  void testInvalidColumn() {
     String invalidColumn = "InvalidCol";
     assetModel.tables(
-        List.of(DatasetFixtures.generateAssetTable(tableName, List.of(col1Name, invalidColumn))));
+        List.of(
+            DatasetFixtures.generateAssetTable(TABLE_NAME, List.of(COL_1_NAME, invalidColumn))));
     testAssetModel(
-        "invalid column", "Column " + invalidColumn + " does not exist in table " + tableName);
+        "invalid column", "Column " + invalidColumn + " does not exist in table " + TABLE_NAME);
   }
 
-  @Test(expected = InvalidAssetException.class)
-  public void testInvalidTable() {
+  @Test
+  void testInvalidTable() {
     String invalidTable = "invalidTable";
     assetModel.tables(
-        List.of(DatasetFixtures.generateAssetTable(invalidTable, List.of(col1Name, col2Name))));
+        List.of(DatasetFixtures.generateAssetTable(invalidTable, List.of(COL_1_NAME, COL_2_NAME))));
     testAssetModel("invalid table", "Table " + invalidTable + " does not exist in dataset.");
   }
 
-  @Test(expected = InvalidAssetException.class)
-  public void testInvalidRootTable() {
+  @Test
+  void testInvalidRootTable() {
     String invalidRootTable = "InvalidRootTable";
     assetModel.rootTable(invalidRootTable);
     testAssetModel(
         "invalid root table", "Root table " + invalidRootTable + " does not exist in dataset.");
   }
 
-  @Test(expected = InvalidAssetException.class)
-  public void testInvalidRootColumn() {
+  @Test
+  void testInvalidRootColumn() {
     String invalidRootColumn = "InvalidRootColumn";
     assetModel.rootColumn(invalidRootColumn);
     testAssetModel(
         "invalid root column",
-        "Root column " + invalidRootColumn + " does not exist in table " + tableName);
+        "Root column " + invalidRootColumn + " does not exist in table " + TABLE_NAME);
   }
 
-  @Test(expected = InvalidAssetException.class)
-  public void testInvalidFollowRelationship() {
+  @Test
+  void testInvalidFollowRelationship() {
     String invalidFollowRelationship = "InvalidRelationship";
-    assetModel.follow(List.of(relationshipName, invalidFollowRelationship));
+    assetModel.follow(List.of(RELATIONSHIP_NAME, invalidFollowRelationship));
     testAssetModel(
         "invalid relationship",
         "Relationship specified in follow list '"
@@ -179,52 +139,51 @@ public class ValidateAssetUnitTest {
             + "' does not exist in dataset's list of relationships");
   }
 
-  @Test(expected = InvalidAssetException.class)
-  public void testMultipleErrors() {
+  @Test
+  void testMultipleErrors() {
     String invalidRootTable = "InvalidRootTable";
     assetModel.rootTable(invalidRootTable);
     String invalidColumn = "InvalidCol";
     String invalidColumn2 = "InvalidCol2";
     assetModel.tables(
         List.of(
-            DatasetFixtures.generateAssetTable(tableName, List.of(invalidColumn, invalidColumn2))));
-    try {
-      dataset.validateDatasetAssetSpecification(assetModel);
-    } catch (InvalidAssetException ex) {
-      assertThat(
-          "At least one validation error caught for asset",
-          ex.getMessage(),
-          containsString("Invalid asset create request. See causes list for details."));
-      assertThat("3 errors found", ex.getCauses().size(), equalTo(3));
-      assertThat(
-          "Validation of asset model should fail on invalid root table",
-          ex.getCauses().get(0),
-          containsString("Root table " + invalidRootTable + " does not exist in dataset."));
-      assertThat(
-          "Validation of asset model should fail on invalid column",
-          ex.getCauses().get(1),
-          containsString("Column " + invalidColumn + " does not exist in table " + tableName));
-      assertThat(
-          "Validation of asset model should fail on second invalid column",
-          ex.getCauses().get(2),
-          containsString("Column " + invalidColumn2 + " does not exist in table " + tableName));
-      throw ex;
-    }
+            DatasetFixtures.generateAssetTable(
+                TABLE_NAME, List.of(invalidColumn, invalidColumn2))));
+    InvalidAssetException ex =
+        assertThrows(
+            InvalidAssetException.class,
+            () -> dataset.validateDatasetAssetSpecification(assetModel));
+    assertThat(
+        "At least one validation error caught for asset",
+        ex.getMessage(),
+        containsString("Invalid asset create request. See causes list for details."));
+    assertThat("3 errors found", ex.getCauses(), hasSize(3));
+    assertThat(
+        "Validation of asset model should fail on invalid root table",
+        ex.getCauses().get(0),
+        containsString("Root table " + invalidRootTable + " does not exist in dataset."));
+    assertThat(
+        "Validation of asset model should fail on invalid column",
+        ex.getCauses().get(1),
+        containsString("Column " + invalidColumn + " does not exist in table " + TABLE_NAME));
+    assertThat(
+        "Validation of asset model should fail on second invalid column",
+        ex.getCauses().get(2),
+        containsString("Column " + invalidColumn2 + " does not exist in table " + TABLE_NAME));
   }
 
   private void testAssetModel(String itemChecked, String expectedErrorMessage) {
-    try {
-      dataset.validateDatasetAssetSpecification(assetModel);
-    } catch (InvalidAssetException ex) {
-      assertThat(
-          "At least one validation error caught for asset",
-          ex.getMessage(),
-          containsString("Invalid asset create request. See causes list for details."));
-      assertThat(
-          "Validation of asset model should fail on " + itemChecked,
-          ex.getCauses().get(0),
-          containsString(expectedErrorMessage));
-      throw ex;
-    }
+    InvalidAssetException ex =
+        assertThrows(
+            InvalidAssetException.class,
+            () -> dataset.validateDatasetAssetSpecification(assetModel));
+    assertThat(
+        "At least one validation error caught for asset",
+        ex.getMessage(),
+        containsString("Invalid asset create request. See causes list for details."));
+    assertThat(
+        "Validation of asset model should fail on " + itemChecked,
+        ex.getCauses().get(0),
+        containsString(expectedErrorMessage));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/ValidatorTestUtils.java
+++ b/src/test/java/bio/terra/service/dataset/ValidatorTestUtils.java
@@ -12,11 +12,7 @@ import org.hamcrest.Matcher;
 
 public class ValidatorTestUtils {
 
-  public static void checkValidationErrorModel(ErrorModel errorModel, String[] messageCodes) {
-    checkValidationErrorModel(errorModel, Arrays.asList(messageCodes));
-  }
-
-  public static void checkValidationErrorModel(ErrorModel errorModel, List<String> messageCodes) {
+  public static void checkValidationErrorModel(ErrorModel errorModel, String... messageCodes) {
     List<String> details = errorModel.getErrorDetail();
     assertThat(
         "Main message is right",
@@ -30,7 +26,7 @@ public class ValidatorTestUtils {
      * We check to see if the code is wrapped in quotes to prevent matching on substrings.
      */
     List<Matcher<? super String>> expectedMatches =
-        messageCodes.stream()
+        Arrays.stream(messageCodes)
             .map(code -> containsString("'" + code + "'"))
             .collect(Collectors.toList());
     assertThat("Detail codes are right", details, containsInAnyOrder(expectedMatches));

--- a/src/test/java/bio/terra/service/dataset/ValidatorTestUtils.java
+++ b/src/test/java/bio/terra/service/dataset/ValidatorTestUtils.java
@@ -13,6 +13,10 @@ import org.hamcrest.Matcher;
 public class ValidatorTestUtils {
 
   public static void checkValidationErrorModel(ErrorModel errorModel, String[] messageCodes) {
+    checkValidationErrorModel(errorModel, Arrays.asList(messageCodes));
+  }
+
+  public static void checkValidationErrorModel(ErrorModel errorModel, List<String> messageCodes) {
     List<String> details = errorModel.getErrorDetail();
     assertThat(
         "Main message is right",
@@ -26,7 +30,7 @@ public class ValidatorTestUtils {
      * We check to see if the code is wrapped in quotes to prevent matching on substrings.
      */
     List<Matcher<? super String>> expectedMatches =
-        Arrays.stream(messageCodes)
+        messageCodes.stream()
             .map(code -> containsString("'" + code + "'"))
             .collect(Collectors.toList());
     assertThat("Detail codes are right", details, containsInAnyOrder(expectedMatches));

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoUnitTest.java
@@ -81,8 +81,8 @@ class AzureSynapsePdaoUnitTest {
   }
 
   private void mockSynapse() {
-    var synapse = mock(AzureResourceConfiguration.Synapse.class);
-    when(azureResourceConfiguration.synapse()).thenReturn(synapse);
+    when(azureResourceConfiguration.synapse())
+        .thenReturn(mock(AzureResourceConfiguration.Synapse.class));
   }
 
   private void mockUpdate(int value) {
@@ -170,10 +170,10 @@ class AzureSynapsePdaoUnitTest {
     Map<String, Long> tableRowCounts = new HashMap<>();
     // Pre-populate 'FROM' table's row count
     tableRowCounts.put("participant", 2L);
-    AzureSynapsePdao azureSynapsePadoSpy = spy(azureSynapsePdao);
-    doReturn(3).when(azureSynapsePadoSpy).executeSynapseQuery(any());
+    AzureSynapsePdao azureSynapsePdaoSpy = spy(azureSynapsePdao);
+    doReturn(3).when(azureSynapsePdaoSpy).executeSynapseQuery(any());
 
-    azureSynapsePadoSpy.createSnapshotParquetFilesByRelationship(
+    azureSynapsePdaoSpy.createSnapshotParquetFilesByRelationship(
         UUID.randomUUID(),
         assetSpec,
         walkRelationship,
@@ -259,11 +259,11 @@ class AzureSynapsePdaoUnitTest {
     List<SnapshotTable> tables = List.of(snapshotTable1);
     Map<String, Long> tableRowCounts = new HashMap<>();
     tableRowCounts.put(snapshotTable1.getName(), 3L);
-    AzureSynapsePdao azureSynapsePadoSpy = spy(azureSynapsePdao);
+    AzureSynapsePdao azureSynapsePdaoSpy = spy(azureSynapsePdao);
     ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
-    doReturn(3).when(azureSynapsePadoSpy).executeSynapseQuery(queryCaptor.capture());
+    doReturn(3).when(azureSynapsePdaoSpy).executeSynapseQuery(queryCaptor.capture());
     UUID snapshotId = UUID.randomUUID();
-    azureSynapsePadoSpy.createSnapshotRowIdsParquetFile(
+    azureSynapsePdaoSpy.createSnapshotRowIdsParquetFile(
         tables, snapshotId, "snapshotDataSourceName1", tableRowCounts);
     var expected =
         """
@@ -356,11 +356,11 @@ class AzureSynapsePdaoUnitTest {
     mockSynapse();
     SnapshotTable snapshotTable1 = new SnapshotTable().name("table1").id(UUID.randomUUID());
     List<SnapshotTable> tables = List.of(snapshotTable1);
-    AzureSynapsePdao azureSynapsePadoSpy = spy(azureSynapsePdao);
-    doReturn(3).when(azureSynapsePadoSpy).executeSynapseQuery(any());
+    AzureSynapsePdao azureSynapsePdaoSpy = spy(azureSynapsePdao);
+    doReturn(3).when(azureSynapsePdaoSpy).executeSynapseQuery(any());
 
     Map<String, Long> tableRowCounts =
-        azureSynapsePadoSpy.createSnapshotParquetFiles(
+        azureSynapsePdaoSpy.createSnapshotParquetFiles(
             tables,
             UUID.randomUUID(),
             "datasetDataSourceName1",
@@ -373,13 +373,13 @@ class AzureSynapsePdaoUnitTest {
   @Test
   void testCreateSnapshotParquetFilesNoRows() throws SQLException {
     mockSynapse();
-    AzureSynapsePdao azureSynapsePadoSpy = spy(azureSynapsePdao);
-    doThrow(SQLServerException.class).when(azureSynapsePadoSpy).executeSynapseQuery(any());
+    AzureSynapsePdao azureSynapsePdaoSpy = spy(azureSynapsePdao);
+    doThrow(SQLServerException.class).when(azureSynapsePdaoSpy).executeSynapseQuery(any());
     SnapshotTable snapshotTable1 = new SnapshotTable().name("table1").id(UUID.randomUUID());
     List<SnapshotTable> tables = List.of(snapshotTable1);
 
     Map<String, Long> tableRowCounts =
-        azureSynapsePadoSpy.createSnapshotParquetFiles(
+        azureSynapsePdaoSpy.createSnapshotParquetFiles(
             tables,
             UUID.randomUUID(),
             "datasetDataSourceName1",
@@ -399,10 +399,10 @@ class AzureSynapsePdaoUnitTest {
                     .sasToken(
                         "sp=r&st=2021-07-14T19:31:16Z&se=2021-07-15T03:31:16Z&spr=https&sv=2020-08-04&sr=b&sig=mysig")
                     .url("https://fake.url"));
-    AzureSynapsePdao azureSynapsePadoSpy = spy(azureSynapsePdao);
-    doNothing().when(azureSynapsePadoSpy).getOrCreateExternalDataSource(any(), any(), any());
+    AzureSynapsePdao azureSynapsePdaoSpy = spy(azureSynapsePdao);
+    doNothing().when(azureSynapsePdaoSpy).getOrCreateExternalDataSource(any(), any(), any());
     assertThat(
-        azureSynapsePadoSpy.getOrCreateExternalDataSourceForResource(
+        azureSynapsePdaoSpy.getOrCreateExternalDataSourceForResource(
             accessInfoModel, id, TEST_USER),
         equalTo(String.format("ds-%s-%s", id, TEST_USER.getEmail())));
   }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
@@ -33,9 +33,7 @@ class BatchOperationTest {
     ApplicationConfiguration appConfiguration = mock(ApplicationConfiguration.class);
     ConfigurationService configurationService =
         new ConfigurationService(
-            mock(SamConfiguration.class),
-            resourceConfiguration,
-            appConfiguration);
+            mock(SamConfiguration.class), resourceConfiguration, appConfiguration);
 
     fireStoreUtils = new FireStoreUtils(configurationService, appConfiguration);
   }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/BatchOperationTest.java
@@ -1,63 +1,57 @@
 package bio.terra.service.filedata.google.firestore;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.category.Unit;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
-import bio.terra.service.filedata.google.gcs.GcsConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
-import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(properties = {"datarepo.testWithEmbeddedDatabase=false"})
-@AutoConfigureMockMvc
-@ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-public class BatchOperationTest {
-
-  @Autowired private SamConfiguration samConfiguration;
-  @Autowired private GcsConfiguration gcsConfiguration;
-  @Autowired private ApplicationConfiguration appConfiguration;
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class BatchOperationTest {
 
   private FireStoreUtils fireStoreUtils;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     // Use fewer firestoreRetries for testing
     GoogleResourceConfiguration resourceConfiguration =
         new GoogleResourceConfiguration("jade-data-repo", 600, 4, false, "123456", "78910");
+    ApplicationConfiguration appConfiguration = mock(ApplicationConfiguration.class);
     ConfigurationService configurationService =
-        new ConfigurationService(samConfiguration, resourceConfiguration, appConfiguration);
+        new ConfigurationService(
+            mock(SamConfiguration.class),
+            resourceConfiguration,
+            appConfiguration);
 
     fireStoreUtils = new FireStoreUtils(configurationService, appConfiguration);
   }
 
   @Test
-  public void batchSuccessTest() throws Exception {
+  void batchSuccessTest() throws Exception {
     // Make sure batch operation works without any retries
     FakeApiFuture.initialize(0); // never throw
 
     List<String> inputs = makeInputs(10);
     List<String> outputs = fireStoreUtils.batchOperation(inputs, input -> new FakeApiFuture());
-    assertThat("correct output size", outputs.size(), equalTo(inputs.size()));
+    assertThat("correct output size", outputs, hasSize(inputs.size()));
   }
 
   @Test
-  public void batchRetrySuccessTest() throws Exception {
+  void batchRetrySuccessTest() throws Exception {
     // make sure batch operation works with some retries
     // 15 retries should fail entirely on the first loop, half on the second loop,
     // and succeed on the third loop.
@@ -65,23 +59,21 @@ public class BatchOperationTest {
 
     List<String> inputs = makeInputs(10);
     List<String> outputs = fireStoreUtils.batchOperation(inputs, input -> new FakeApiFuture());
-    assertThat("correct output size", outputs.size(), equalTo(inputs.size()));
+    assertThat("correct output size", outputs, hasSize(inputs.size()));
   }
 
-  @Test(expected = FileSystemExecutionException.class)
-  public void batchFailureTest() throws Exception {
+  @Test
+  void batchFailureTest() {
     // make sure batch operation works with some retries
     // 25 retries should fail entirely four times through and give up
     FakeApiFuture.initialize(25);
     List<String> inputs = makeInputs(5);
-    fireStoreUtils.batchOperation(inputs, input -> new FakeApiFuture());
+    assertThrows(
+        FileSystemExecutionException.class,
+        () -> fireStoreUtils.batchOperation(inputs, input -> new FakeApiFuture()));
   }
 
   private List<String> makeInputs(int count) {
-    List<String> inputs = new ArrayList<>();
-    for (int i = 0; i < count; i++) {
-      inputs.add("in" + i);
-    }
-    return inputs;
+    return IntStream.range(0, count).mapToObj(i -> "in" + i).toList();
   }
 }

--- a/src/test/java/bio/terra/service/profile/azure/AzureAuthzServiceTest.java
+++ b/src/test/java/bio/terra/service/profile/azure/AzureAuthzServiceTest.java
@@ -14,16 +14,16 @@ import com.azure.resourcemanager.resources.models.GenericResources;
 import com.google.cloud.resourcemanager.ResourceManagerException;
 import java.util.Map;
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-@Category(Unit.class)
-public class AzureAuthzServiceTest {
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class AzureAuthzServiceTest {
 
   private static final String USER_EMAIL = "";
   private static final UUID SUBSCRIPTION_ID =
@@ -41,10 +41,8 @@ public class AzureAuthzServiceTest {
 
   private AzureAuthzService azureAuthzService;
 
-  @Before
-  public void setUp() throws Exception {
-    when(genericResource.properties())
-        .thenReturn(Map.of("parameters", Map.of(AUTH_PARAM_KEY, Map.of("value", USER_EMAIL))));
+  @BeforeEach
+  void setUp() {
     when(resourceManager.genericResources()).thenReturn(genericResources);
     when(resourceConfiguration.getClient(SUBSCRIPTION_ID)).thenReturn(resourceManager);
     when(genericResources.getById(RESOURCE_ID, resourceConfiguration.apiVersion()))
@@ -52,8 +50,14 @@ public class AzureAuthzServiceTest {
     azureAuthzService = new AzureAuthzService(resourceConfiguration);
   }
 
+  private void mockGenericResourceProperties() {
+    when(genericResource.properties())
+        .thenReturn(Map.of("parameters", Map.of(AUTH_PARAM_KEY, Map.of("value", USER_EMAIL))));
+  }
+
   @Test
-  public void testValidateHappyPath() {
+  void testValidateHappyPath() {
+    mockGenericResourceProperties();
     assertThat(
         azureAuthzService.canAccess(
             AuthenticatedUserRequest.builder()
@@ -68,7 +72,8 @@ public class AzureAuthzServiceTest {
   }
 
   @Test
-  public void testValidateUserDoesNotHaveAccess() {
+  void testValidateUserDoesNotHaveAccess() {
+    mockGenericResourceProperties();
     assertThat(
         azureAuthzService.canAccess(
             AuthenticatedUserRequest.builder()
@@ -83,7 +88,7 @@ public class AzureAuthzServiceTest {
   }
 
   @Test
-  public void testValidateResourceNotFound() {
+  void testValidateResourceNotFound() {
     when(genericResources.getById(RESOURCE_ID, resourceConfiguration.apiVersion()))
         .thenThrow(ResourceManagerException.class);
 

--- a/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtilsTest.java
@@ -4,11 +4,13 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import bio.terra.app.model.AzureCloudResource;
 import bio.terra.app.model.AzureRegion;
 import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.AccessInfoParquetModel;
 import bio.terra.model.BillingProfileModel;
@@ -21,42 +23,34 @@ import bio.terra.service.profile.ProfileService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import java.util.List;
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-@Category(Unit.class)
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
 class MetadataDataAccessUtilsTest {
   private static final AuthenticatedUserRequest TEST_USER =
-      AuthenticatedUserRequest.builder()
-          .setSubjectId("DatasetUnit")
-          .setEmail("dataset@unit.com")
-          .setToken("token")
-          .build();
+      AuthenticationFixtures.randomUserRequest();
 
-  @InjectMocks private MetadataDataAccessUtils metadataDataAccessUtils;
+  private MetadataDataAccessUtils metadataDataAccessUtils;
 
   @Mock private static ResourceService resourceService;
 
   @Mock private static AzureBlobStorePdao azureBlobStorePdao;
-  @Mock private static ProfileService profileService;
 
   private Dataset azureDataset;
-  private DatasetSummary azureDatasetSummary;
-  private BillingProfileModel defaultProfileModel;
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeEach
+  void setup() {
     UUID azureDatsetId = UUID.randomUUID();
     UUID billingProfileModelId = UUID.randomUUID();
-    defaultProfileModel =
+    BillingProfileModel defaultProfileModel =
         new BillingProfileModel().profileName("default profile").id(billingProfileModelId);
-    azureDatasetSummary =
+    DatasetSummary azureDatasetSummary =
         new DatasetSummary()
             .storage(
                 List.of(
@@ -71,11 +65,12 @@ class MetadataDataAccessUtilsTest {
         new Dataset(azureDatasetSummary).tables(List.of(sampleTable)).name("test-dataset");
 
     metadataDataAccessUtils =
-        new MetadataDataAccessUtils(resourceService, azureBlobStorePdao, profileService);
+        new MetadataDataAccessUtils(
+            resourceService, azureBlobStorePdao, mock(ProfileService.class));
   }
 
   @Test
-  public void testAzureAccessInfo() {
+  void testAzureAccessInfo() {
     AzureStorageAccountResource storageAccountResource =
         new AzureStorageAccountResource()
             .resourceId(UUID.randomUUID())

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureApplicationDeploymentServiceTest.java
@@ -22,22 +22,16 @@ import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.resources.models.GenericResource;
 import com.azure.resourcemanager.resources.models.GenericResources;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
-@ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-public class AzureApplicationDeploymentServiceTest {
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class AzureApplicationDeploymentServiceTest {
 
   @Mock private AzureResourceDao resourceDao;
   @Mock private GenericResource genericResource;
@@ -47,15 +41,15 @@ public class AzureApplicationDeploymentServiceTest {
 
   private AzureApplicationDeploymentService service;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp() throws Exception {
     service =
         new AzureApplicationDeploymentService(
             resourceDao, resourceConfiguration, new ApplicationConfiguration().objectMapper());
   }
 
   @Test
-  public void testGetOrRegisterApplicationDeployment() {
+  void testGetOrRegisterApplicationDeployment() {
     BillingProfileModel billingProfileModel = ProfileFixtures.randomAzureBillingProfile();
     when(genericResource.properties())
         .thenReturn(

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureContainerPdaoTest.java
@@ -13,16 +13,16 @@ import bio.terra.common.category.Unit;
 import bio.terra.model.BillingProfileModel;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobContainerProperties;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-@Category(Unit.class)
-public class AzureContainerPdaoTest {
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class AzureContainerPdaoTest {
 
   @Mock private AzureAuthService authService;
   @Mock private BlobContainerClient blobContainerClient;
@@ -30,8 +30,8 @@ public class AzureContainerPdaoTest {
   private BillingProfileModel billingProfile;
   private AzureContainerPdao dao;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp() {
 
     billingProfile = new BillingProfileModel();
     storageAccountResource =
@@ -46,7 +46,7 @@ public class AzureContainerPdaoTest {
   }
 
   @Test
-  public void testGetContainer() {
+  void testGetContainer() {
     BlobContainerProperties properties = mock(BlobContainerProperties.class);
     when(blobContainerClient.exists()).thenReturn(true);
     when(properties.getETag()).thenReturn("TAG");
@@ -61,7 +61,7 @@ public class AzureContainerPdaoTest {
   }
 
   @Test
-  public void testCreateContainer() {
+  void testCreateContainer() {
     BlobContainerProperties properties = mock(BlobContainerProperties.class);
     when(blobContainerClient.exists()).thenReturn(false);
     when(properties.getETag()).thenReturn("TAG");
@@ -76,7 +76,7 @@ public class AzureContainerPdaoTest {
   }
 
   @Test
-  public void testDeleteContainer() {
+  void testDeleteContainer() {
     dao.deleteContainer(billingProfile, storageAccountResource);
     verify(blobContainerClient).deleteIfExists();
   }

--- a/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/azure/AzureStorageAccountServiceTest.java
@@ -29,25 +29,16 @@ import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.resourcemanager.storage.models.StorageAccounts;
 import java.util.List;
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
-@ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
-public class AzureStorageAccountServiceTest {
-  private final Logger logger = LoggerFactory.getLogger(AzureStorageAccountServiceTest.class);
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class AzureStorageAccountServiceTest {
   private static final String MANAGED_GROUP_NAME = "mgd-grp-1";
   private static final String STORAGE_ACCOUNT_NAME = "sa1";
   private static final String APPLICATION_DEPLOYMENT_NAME = "appdeployment";
@@ -61,42 +52,45 @@ public class AzureStorageAccountServiceTest {
   @Mock private ProfileDao profileDao;
   @Mock private StorageAccounts storageAccounts;
   @Mock private StorageAccount storageAccount;
-  @Mock private AzureResourceManager client;
 
   private BillingProfileModel billingProfileModel;
   private AzureApplicationDeploymentResource applicationResource;
 
   private AzureStorageAccountService service;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp() {
     service = new AzureStorageAccountService(resourceDao, resourceConfiguration, profileDao);
 
     billingProfileModel = ProfileFixtures.randomAzureBillingProfile();
-    when(profileDao.getBillingProfileById(billingProfileModel.getId()))
-        .thenReturn(billingProfileModel);
     applicationResource =
         new AzureApplicationDeploymentResource()
             .profileId(billingProfileModel.getId())
             .azureResourceGroupName(MANAGED_GROUP_NAME)
             .azureApplicationDeploymentName(APPLICATION_DEPLOYMENT_NAME)
             .storageAccountSkuType(STORAGE_SKU_TYPE);
+  }
 
+  private void mockApis() {
+    when(profileDao.getBillingProfileById(billingProfileModel.getId()))
+        .thenReturn(billingProfileModel);
     // Mock Azure client calls
+    AzureResourceManager client = mock(AzureResourceManager.class);
     when(client.storageAccounts()).thenReturn(storageAccounts);
     when(resourceConfiguration.getClient(billingProfileModel.getSubscriptionId()))
         .thenReturn(client);
   }
 
   @Test
-  public void testGetStorageAccountResourceById() {
+  void testGetStorageAccountResourceById() {
     UUID storageAccountId = UUID.randomUUID();
     service.getStorageAccountResourceById(storageAccountId, false);
     verify(resourceDao, times(1)).retrieveStorageAccountById(storageAccountId);
   }
 
   @Test
-  public void testGetStorageAccountResourceByIdAndCheckCloudFound() {
+  void testGetStorageAccountResourceByIdAndCheckCloudFound() {
+    mockApis();
     UUID storageAccountId = UUID.randomUUID();
     when(resourceDao.retrieveStorageAccountById(storageAccountId))
         .thenReturn(
@@ -111,7 +105,8 @@ public class AzureStorageAccountServiceTest {
   }
 
   @Test
-  public void testGetStorageAccountResourceByIdAndCheckCloudNotFound() {
+  void testGetStorageAccountResourceByIdAndCheckCloudNotFound() {
+    mockApis();
     UUID storageAccountId = UUID.randomUUID();
     when(resourceDao.retrieveStorageAccountById(storageAccountId))
         .thenReturn(
@@ -128,7 +123,8 @@ public class AzureStorageAccountServiceTest {
   }
 
   @Test
-  public void tesGetOrCreateStorageAccountCase1() throws InterruptedException {
+  void tesGetOrCreateStorageAccountCase1() throws InterruptedException {
+    mockApis();
     String flight = ShortUUID.get();
     when(resourceDao.getStorageAccount(
             STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
@@ -148,7 +144,8 @@ public class AzureStorageAccountServiceTest {
   }
 
   @Test
-  public void tesGetOrCreateStorageAccountCase2() {
+  void tesGetOrCreateStorageAccountCase2() {
+    mockApis();
     String flight = ShortUUID.get();
     when(resourceDao.getStorageAccount(
             STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
@@ -164,19 +161,15 @@ public class AzureStorageAccountServiceTest {
 
     assertThrows(
         StorageAccountLockException.class,
-        () -> {
-          try {
+        () ->
             service.getOrCreateStorageAccount(
-                STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
-        },
+                STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight),
         "Storage account locked by flightId: " + flight);
   }
 
   @Test
-  public void tesGetOrCreateStorageAccountCase3() throws InterruptedException {
+  void tesGetOrCreateStorageAccountCase3() throws InterruptedException {
+    mockApis();
     String flight = ShortUUID.get();
     when(resourceDao.getStorageAccount(
             STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
@@ -197,12 +190,8 @@ public class AzureStorageAccountServiceTest {
   }
 
   @Test
-  public void tesGetOrCreateStorageAccountCase4() {
-    logger.info("Case 4 is not reachable");
-  }
-
-  @Test
-  public void tesGetOrCreateStorageAccountCase5() {
+  void tesGetOrCreateStorageAccountCase5() {
+    mockApis();
     String flight = ShortUUID.get();
     when(resourceDao.getStorageAccount(
             STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
@@ -215,20 +204,16 @@ public class AzureStorageAccountServiceTest {
 
     assertThrows(
         CorruptMetadataException.class,
-        () -> {
-          try {
+        () ->
             service.getOrCreateStorageAccount(
-                STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
-        },
+                STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight),
         "Storage account does not exist, metadata out of sync with cloud state: "
             + STORAGE_ACCOUNT_NAME);
   }
 
   @Test
-  public void tesGetOrCreateStorageAccountCase6() {
+  void tesGetOrCreateStorageAccountCase6() {
+    mockApis();
     String flight = ShortUUID.get();
     when(resourceDao.getStorageAccount(
             STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
@@ -243,19 +228,15 @@ public class AzureStorageAccountServiceTest {
 
     assertThrows(
         StorageAccountLockException.class,
-        () -> {
-          try {
+        () ->
             service.getOrCreateStorageAccount(
-                STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-          }
-        },
+                STORAGE_ACCOUNT_NAME, COLLECTION_ID, applicationResource, REGION, flight),
         "Storage account locked by flightId: " + flight);
   }
 
   @Test
-  public void tesGetOrCreateStorageAccountCase7() throws InterruptedException {
+  void tesGetOrCreateStorageAccountCase7() throws InterruptedException {
+    mockApis();
     String flight = ShortUUID.get();
     when(resourceDao.getStorageAccount(
             STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
@@ -278,7 +259,8 @@ public class AzureStorageAccountServiceTest {
   }
 
   @Test
-  public void tesGetOrCreateStorageAccountCase8() throws InterruptedException {
+  void tesGetOrCreateStorageAccountCase8() throws InterruptedException {
+    mockApis();
     String flight = ShortUUID.get();
     when(resourceDao.getStorageAccount(
             STORAGE_ACCOUNT_NAME, COLLECTION_ID, APPLICATION_DEPLOYMENT_NAME))
@@ -332,7 +314,7 @@ public class AzureStorageAccountServiceTest {
   }
 
   @Test
-  public void listStorageAccountPerAppDeployment() {
+  void listStorageAccountPerAppDeployment() {
     UUID appId = UUID.randomUUID();
     List<AzureStorageAccountResource> storageAccounts =
         List.of(

--- a/src/test/java/bio/terra/service/tabulardata/WalkRelationshipTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/WalkRelationshipTest.java
@@ -6,11 +6,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import bio.terra.common.category.Unit;
-import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.service.common.AssetUtils;
 import bio.terra.service.dataset.AssetSpecification;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -21,14 +18,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
 class WalkRelationshipTest {
-  private final AssetUtils assetUtils = new AssetUtils(new JsonLoader(new ObjectMapper()));
-
   private WalkRelationship walkRelationship;
 
   @BeforeEach
-  void setup() throws IOException {
-    AssetSpecification assetSpecification = assetUtils.buildTestAssetSpec();
-    walkRelationship = assetUtils.buildExampleWalkRelationship(assetSpecification);
+  void setup() {
+    AssetSpecification assetSpecification = AssetUtils.buildTestAssetSpec();
+    walkRelationship = AssetUtils.buildExampleWalkRelationship(assetSpecification);
   }
 
   @Test


### PR DESCRIPTION
This PR migrates more unit tests to JUnit 5

- migrate all unit tests except for embedded database tests
- where possible, tests were changed to not use a spring context
- spring context tests were changed to use `@ContextConfiguration` to limit the number of autowired components