### PR TITLE
DCJ-275 Update Terra Common Lib to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.2.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
 
-    implementation 'bio.terra:terra-common-lib:1.1.10-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.11-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-a91acd0'
     implementation 'bio.terra:terra-policy-client:1.0.11-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DCJ-275

## Summary
- Update TCL to the latest version which should address the bouncy-castle vulnerability warning. 
- Requires https://github.com/DataBiosphere/terra-common-lib/pull/179 and https://github.com/DataBiosphere/terra-common-lib/commit/bc5d9a9c1901c0af99734e3691e148a36a7f5790
- Successful manual SCA run here: https://github.com/broadinstitute/dsp-appsec-sourceclear-github-actions/actions/runs/8971314670/job/24636782079