### PR TITLE
DC-911: minor profile script updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,5 +26,11 @@ ij_java_imports_layout = $*,|,*
 ij_java_names_count_to_use_import_on_demand = 1000
 ij_java_wrap_comments = true
 
+[*.py]
+indent_size = 4
+# black line length is 88, not PEP8's 79.
+max_line_length = 88
+ij_visual_guides = 88
+
 [build.gradle]
 indent_size=4

--- a/tools/profile_endpoints.py
+++ b/tools/profile_endpoints.py
@@ -305,7 +305,7 @@ if __name__ == "__main__":
         "--authenticate",
         type=bool,
         default=False,
-        help="If false, use current gcloud authentication. If true, authenticate with "
+        help="If False, use current gcloud authentication. If True, authenticate with "
              "gcloud auth login.",
     )
 

--- a/tools/profile_endpoints.py
+++ b/tools/profile_endpoints.py
@@ -305,7 +305,8 @@ if __name__ == "__main__":
         "--authenticate",
         type=bool,
         default=False,
-        help="If true, authenticate using gcloud auth login",
+        help="If false, use current gcloud authentication. If true, authenticate with "
+             "gcloud auth login.",
     )
 
     args = parser.parse_args()

--- a/tools/profile_endpoints.py
+++ b/tools/profile_endpoints.py
@@ -1,3 +1,4 @@
+import argparse
 import subprocess
 import requests
 import time
@@ -26,8 +27,15 @@ with different domain IDs and search texts.
 """
 
 # Constants
-UUID = "c672c3c9-ab54-4e19-827c-f2af329da814" # Azure Synapse UUID
-DATAREPO_URL = "https://jade.datarepo-dev.broadinstitute.org"
+DATASETS = {
+    "gcp": "0f2d1f2f-0544-4aaf-ac2a-13f2bd538f09",
+    "azure":  "c672c3c9-ab54-4e19-827c-f2af329da814",
+}
+
+HOSTS = {
+    "local": "http://localhost:8080",
+    "datarepo_dev": "https://jade.datarepo-dev.broadinstitute.org",
+}
 
 
 def run_command(command):
@@ -126,7 +134,8 @@ def make_post_request(endpoint_url, token, body):
     url = f"{DATAREPO_URL}/api/repository/v1/datasets/{UUID}/snapshotBuilder/{endpoint_url}"
     headers = {
         "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",  # Indicating the request body is in JSON format
+        "Content-Type": "application/json",
+        # Indicating the request body is in JSON format
     }
     start_time = time.time()
     try:
@@ -274,7 +283,36 @@ def profile_get_concepts(token):
 
 # Main function
 if __name__ == "__main__":
-    authenticate()
+
+    # Create the parser
+    parser = argparse.ArgumentParser(
+        description="Profile endpoints for a specific host and dataset")
+
+    # Add the arguments
+    parser.add_argument('--host',
+                        type=str,
+                        choices=HOSTS.keys(),
+                        default='local',
+                        help='The host to profile')
+
+    parser.add_argument('--dataset',
+                        type=str,
+                        choices=DATASETS.keys(),
+                        default='gcp',
+                        help='The dataset to profile')
+
+    parser.add_argument('--authenticate',
+                        type=bool,
+                        default=False,
+                        help='If true, authenticate using gcloud auth login')
+
+    args = parser.parse_args()
+
+    UUID = DATASETS[args.dataset]
+    DATAREPO_URL = HOSTS[args.host]
+
+    if (args.authenticate):
+        authenticate()
 
     # Obtain access token
     access_token = get_access_token()

--- a/tools/profile_endpoints.py
+++ b/tools/profile_endpoints.py
@@ -34,7 +34,7 @@ DATASETS = {
 
 HOSTS = {
     "local": "http://localhost:8080",
-    "datarepo_dev": "https://jade.datarepo-dev.broadinstitute.org",
+    "dev": "https://jade.datarepo-dev.broadinstitute.org",
 }
 
 

--- a/tools/profile_endpoints.py
+++ b/tools/profile_endpoints.py
@@ -29,7 +29,7 @@ with different domain IDs and search texts.
 # Constants
 DATASETS = {
     "gcp": "0f2d1f2f-0544-4aaf-ac2a-13f2bd538f09",
-    "azure":  "c672c3c9-ab54-4e19-827c-f2af329da814",
+    "azure": "c672c3c9-ab54-4e19-827c-f2af329da814",
 }
 
 HOSTS = {
@@ -53,9 +53,10 @@ def run_command(command):
         if result.returncode == 0:
             return result.stdout.strip()
         else:
-            raise Exception(
-                f"Command failed with exit code {result.returncode}: {result.stderr}"
+            print(
+                f"Command '{command}' failed with exit code {result.returncode}: {result.stderr}"
             )
+            return None
     except Exception as e:
         print(f"Error executing command: {e}")
         return None
@@ -127,15 +128,12 @@ def make_post_request(endpoint_url, token, body):
         endpoint_url (str): The endpoint URL to request.
         token (str): The access token for authentication.
         body (dict): The request body to send in the POST request.
-
-    Returns:
-        tuple: A tuple containing the response object and the time taken for the request in seconds.
     """
     url = f"{DATAREPO_URL}/api/repository/v1/datasets/{UUID}/snapshotBuilder/{endpoint_url}"
     headers = {
         "Authorization": f"Bearer {token}",
+        # The request body is in JSON format
         "Content-Type": "application/json",
-        # Indicating the request body is in JSON format
     }
     start_time = time.time()
     try:
@@ -159,14 +157,11 @@ def profile_get_snapshot_builder_count(token):
 
     Args:
         token (str): The access token for authentication.
-
-    Returns:
-        str: A string indicating the average time taken for the request.
     """
     print("Profiling getSnapshotBuilderCount endpoint")
 
     # Define the bodies for the POST request
-    bodys = [
+    bodies = [
         {
             "cohorts": [
                 {
@@ -228,7 +223,7 @@ def profile_get_snapshot_builder_count(token):
         },
     ]
 
-    for body in bodys:
+    for body in bodies:
         make_post_request("count", token, body)
 
 
@@ -286,32 +281,39 @@ if __name__ == "__main__":
 
     # Create the parser
     parser = argparse.ArgumentParser(
-        description="Profile endpoints for a specific host and dataset")
+        description="Profile endpoints for a specific host and dataset"
+    )
 
     # Add the arguments
-    parser.add_argument('--host',
-                        type=str,
-                        choices=HOSTS.keys(),
-                        default='local',
-                        help='The host to profile')
+    parser.add_argument(
+        "--host",
+        type=str,
+        choices=HOSTS.keys(),
+        default="local",
+        help="The host to profile",
+    )
 
-    parser.add_argument('--dataset',
-                        type=str,
-                        choices=DATASETS.keys(),
-                        default='gcp',
-                        help='The dataset to profile')
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        choices=DATASETS.keys(),
+        default="gcp",
+        help="The dataset to profile",
+    )
 
-    parser.add_argument('--authenticate',
-                        type=bool,
-                        default=False,
-                        help='If true, authenticate using gcloud auth login')
+    parser.add_argument(
+        "--authenticate",
+        type=bool,
+        default=False,
+        help="If true, authenticate using gcloud auth login",
+    )
 
     args = parser.parse_args()
 
     UUID = DATASETS[args.dataset]
     DATAREPO_URL = HOSTS[args.host]
 
-    if (args.authenticate):
+    if args.authenticate:
         authenticate()
 
     # Obtain access token


### PR DESCRIPTION
While working on DC-911 I wanted to test both GCP and azure and wanted to run the tests against my local deployment, so I added some arguments to support this.

```
❯ python tools/profile_endpoints.py --help
usage: profile_endpoints.py [-h] [--host {local,dev}] [--dataset {gcp,azure}] [--authenticate AUTHENTICATE]

Profile endpoints for a specific host and dataset

options:
  -h, --help            show this help message and exit
  --host {local,dev}    The host to profile
  --dataset {gcp,azure}
                        The dataset to profile
  --authenticate AUTHENTICATE
                        If false, use current gcloud authentication. If true, authenticate with gcloud auth login.
```