### PR TITLE
DC-1041: Update snapshot_request table to require source_snapshot_id and remove dataset_id column

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -88,10 +88,10 @@ public class SnapshotRequestDao {
   }
 
   /**
-   * Return the list of Snapshot Requests associated with the given dataset id.
+   * Return the list of Snapshot Requests associated with the given snapshot id.
    *
    * @param authorizedResources snapshot requests that the user has permission to see.
-   * @return the list of snapshot requests, empty if none, or an exception if the dataset does not
+   * @return the list of snapshot requests, empty if none, or an exception if the snapshot does not
    *     exist.
    */
   @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
@@ -120,7 +120,7 @@ public class SnapshotRequestDao {
   public SnapshotAccessRequestResponse create(SnapshotAccessRequest request, String email) {
     String jsonValue;
     try {
-      jsonValue = objectMapper.writeValueAsString(request.getDatasetRequest());
+      jsonValue = objectMapper.writeValueAsString(request.getSnapshotBuilderRequest());
     } catch (JsonProcessingException e) {
       throw new BadRequestException("Could not write snapshot access request to json", e);
     }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -33,7 +33,6 @@ public class SnapshotRequestDao {
   private final ObjectMapper objectMapper;
   private static final String SOURCE_SNAPSHOT_ID = "source_snapshot_id";
   private static final String ID = "id";
-  private static final String DATASET_ID = "dataset_id";
   private static final String SNAPSHOT_NAME = "snapshot_name";
   private static final String SNAPSHOT_RESEARCH_PURPOSE = "snapshot_research_purpose";
   private static final String SNAPSHOT_SPECIFICATION = "snapshot_specification";
@@ -47,7 +46,6 @@ public class SnapshotRequestDao {
       (rs, rowNum) ->
           new SnapshotAccessRequestResponse()
               .id(rs.getObject(ID, UUID.class))
-              .datasetId(rs.getObject(DATASET_ID, UUID.class))
               .sourceSnapshotId(rs.getObject(SOURCE_SNAPSHOT_ID, UUID.class))
               .snapshotName(rs.getString(SNAPSHOT_NAME))
               .snapshotResearchPurpose(rs.getString(SNAPSHOT_RESEARCH_PURPOSE))

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7493,7 +7493,7 @@ components:
           type: string
         researchPurposeStatement:
           type: string
-        datasetRequest:
+        snapshotBuilderRequest:
           $ref: '#/components/schemas/SnapshotBuilderRequest'
       description: Request for access to a snapshot.
 

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -80,5 +80,5 @@
     <include file="changesets/20240419_addsnapshotidtosettings.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240426_addsnapshotidtorequest.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240507_dropandaddsnapshotbuilderconstraints.yaml" relativeToChangelogFile="true" />
-    <include file="changesets/20240510_dropsnapshotrequestdatasetid.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20240510_dropsnapshotrequestdatasetidaddconstraint.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -80,4 +80,5 @@
     <include file="changesets/20240419_addsnapshotidtosettings.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240426_addsnapshotidtorequest.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240507_dropandaddsnapshotbuilderconstraints.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20240510_dropsnapshotrequestdatasetid.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20240510_dropsnapshotrequestdatasetid.yaml
+++ b/src/main/resources/db/changesets/20240510_dropsnapshotrequestdatasetid.yaml
@@ -1,8 +1,0 @@
-databaseChangeLog:
-  - changeSet:
-      id: drop_snapshot_request_dataset_id_column
-      author: sholden
-      changes:
-        - dropColumn:
-            columnName: dataset_id
-            tableName: snapshot_request

--- a/src/main/resources/db/changesets/20240510_dropsnapshotrequestdatasetid.yaml
+++ b/src/main/resources/db/changesets/20240510_dropsnapshotrequestdatasetid.yaml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+  - changeSet:
+      id: drop_snapshot_request_dataset_id_column
+      author: sholden
+      changes:
+        - dropColumn:
+            columnName: dataset_id
+            tableName: snapshot_request

--- a/src/main/resources/db/changesets/20240510_dropsnapshotrequestdatasetidaddconstraint.yaml
+++ b/src/main/resources/db/changesets/20240510_dropsnapshotrequestdatasetidaddconstraint.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: drop_snapshot_request_dataset_id_column_add_constraint
+      author: sholden
+      changes:
+        - dropColumn:
+            columnName: dataset_id
+            tableName: snapshot_request
+        - delete:
+            tableName: snapshot_request
+            where: source_snapshot_id IS NULL
+        -  addNotNullConstraint:
+            columnName: source_snapshot_id
+            tableName: snapshot_request

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -234,7 +234,7 @@ public class SnapshotBuilderTestData {
         .sourceSnapshotId(sourceSnapshotId)
         .name("name")
         .researchPurposeStatement("purpose")
-        .datasetRequest(createSnapshotBuilderRequest());
+        .snapshotBuilderRequest(createSnapshotBuilderRequest());
   }
 
   public static SnapshotAccessRequestResponse createSnapshotAccessRequestResponse(UUID snapshotId) {
@@ -244,7 +244,7 @@ public class SnapshotBuilderTestData {
         .sourceSnapshotId(request.getSourceSnapshotId())
         .snapshotName(request.getName())
         .snapshotResearchPurpose(request.getResearchPurposeStatement())
-        .snapshotSpecification(request.getDatasetRequest())
+        .snapshotSpecification(request.getSnapshotBuilderRequest())
         .createdDate("date")
         .createdBy("user@gmail.com")
         .status(SnapshotAccessRequestStatus.SUBMITTED);

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
@@ -165,7 +165,7 @@ class SnapshotRequestDaoTest {
         "We can retrieve the snapshot request",
         snapshotRequestDao.getById(response.getId()),
         equalTo(response));
-    // delete the source dataset
+    // delete the source snapshot
     // This should also delete the snapshot request
     daoOperations.deleteSnapshot(snapshot.getId());
     assertThrows(NotFoundException.class, () -> snapshotRequestDao.getById(response.getId()));


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-1041
________
Now that  DC-1033: Database work to support Snapshot Id in snapshot access requests is done. We want to remove the datasetId column altogether and make the snapshotId column required.

This PR adds a database change that:
- Removes the dataset_id column
- Deletes any entries in the snapshot_requests table that do not have a source_snapshot_id column (we can do this because we do not have any production data in the column. I tested this operation out locally with existing data with a null source_snapshot_id column)
- Requires the source_snapshot_id column 
