### PR TITLE
DC-1056: Minor cleanups to cohort count builder and API types

### DIFF
--- a/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilder.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilder.java
@@ -47,22 +47,20 @@ public class CriteriaQueryBuilder {
   }
 
   FilterVariable generateFilter(SnapshotBuilderProgramDataRangeCriteria rangeCriteria) {
-    String columnName = getProgramDataOptionColumnName(rangeCriteria.getId());
-    return new BooleanAndOrFilterVariable(
-        BooleanAndOrFilterVariable.LogicalOperator.AND,
-        List.of(
-            new BinaryFilterVariable(
-                getFieldVariableForRootTable(columnName),
-                BinaryFilterVariable.BinaryOperator.GREATER_THAN_OR_EQUAL,
-                new Literal(rangeCriteria.getLow())),
-            new BinaryFilterVariable(
-                getFieldVariableForRootTable(columnName),
-                BinaryFilterVariable.BinaryOperator.LESS_THAN_OR_EQUAL,
-                new Literal(rangeCriteria.getHigh()))));
+    FieldVariable rangeVariable =
+        getFieldVariableForRootTable(getProgramDataOptionColumnName(rangeCriteria.getId()));
+    return BooleanAndOrFilterVariable.and(
+        new BinaryFilterVariable(
+            rangeVariable,
+            BinaryFilterVariable.BinaryOperator.GREATER_THAN_OR_EQUAL,
+            new Literal(rangeCriteria.getLow())),
+        new BinaryFilterVariable(
+            rangeVariable,
+            BinaryFilterVariable.BinaryOperator.LESS_THAN_OR_EQUAL,
+            new Literal(rangeCriteria.getHigh())));
   }
 
   FilterVariable generateFilter(SnapshotBuilderProgramDataListCriteria listCriteria) {
-
     if (listCriteria.getValues().isEmpty()) {
       // select all values of list criteria
       return FilterVariable.alwaysTrueFilter();
@@ -133,7 +131,7 @@ public class CriteriaQueryBuilder {
 
   FilterVariable generateAndOrFilterForCriteriaGroup(SnapshotBuilderCriteriaGroup criteriaGroup) {
     return new BooleanAndOrFilterVariable(
-        Objects.requireNonNullElse(criteriaGroup.isMeetAll(), false)
+        criteriaGroup.isMeetAll()
             ? BooleanAndOrFilterVariable.LogicalOperator.AND
             : BooleanAndOrFilterVariable.LogicalOperator.OR,
         criteriaGroup.getCriteria().stream().map(this::generateFilterForCriteria).toList());
@@ -141,7 +139,7 @@ public class CriteriaQueryBuilder {
 
   FilterVariable generateFilterForCriteriaGroup(SnapshotBuilderCriteriaGroup criteriaGroup) {
     FilterVariable andOrFilterVariable = generateAndOrFilterForCriteriaGroup(criteriaGroup);
-    return Objects.requireNonNullElse(criteriaGroup.isMustMeet(), true)
+    return criteriaGroup.isMustMeet()
         ? andOrFilterVariable
         : new NotFilterVariable(andOrFilterVariable);
   }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7516,6 +7516,7 @@ components:
 
     SnapshotBuilderCohort:
       type: object
+      required: [ criteriaGroups ]
       properties:
         name:
           type: string
@@ -7527,6 +7528,7 @@ components:
 
     SnapshotBuilderCriteriaGroup:
       type: object
+      required: [ criteria, mustMeet, meetAll ]
       properties:
         name:
           type: string
@@ -7538,8 +7540,6 @@ components:
           type: boolean
         meetAll:
           type: boolean
-        count:
-          type: number
       description: Criteria Group specifying a Cohort.
 
     SnapshotBuilderCriteria:


### PR DESCRIPTION
After looking into DC-1056 I found that the code was already working as expected. There were some minor cleanups I added while looking into this.

- the `criteriaGroup` field in `SnapshotBuilderCohort` and the fields `criteria`, `mustMeet`, `meetAll` in  `SnapshotBuilderCriteriaGroup` weren't marked as required, but should be. These fields are already declared as non-optional in the UI code.
- the `count` field in `SnapshotBuilderCriteriaGroup` is unused in the TDR code, and isn't declared in the UI code, so it can be removed.