### PR TITLE
DC-1092: Use assertEquals() to enable intellij <Click to see difference> in test output

### DIFF
--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/ConceptChildrenQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/ConceptChildrenQueryBuilderTest.java
@@ -1,14 +1,12 @@
 package bio.terra.service.snapshotbuilder.utils;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
+import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertSameQuery;
 
 import bio.terra.common.category.Unit;
 import bio.terra.model.SnapshotBuilderDomainOption;
 import bio.terra.service.snapshotbuilder.query.SqlRenderContext;
 import bio.terra.service.snapshotbuilder.query.SqlRenderContextProvider;
 import bio.terra.service.snapshotbuilder.utils.constants.ConditionOccurrence;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -72,9 +70,8 @@ class ConceptChildrenQueryBuilderTest {
             .conceptChildrenQueryBuilder()
             .buildConceptChildrenQuery(createDomainOption(), 101)
             .renderSQL(context);
-    assertThat(
-        sql,
-        equalToCompressingWhiteSpace(context.getPlatform().choose(GCP_EXPECTED, AZURE_EXPECTED)));
+
+    assertSameQuery(context.getPlatform().choose(GCP_EXPECTED, AZURE_EXPECTED), sql);
   }
 
   @ParameterizedTest
@@ -90,6 +87,6 @@ class ConceptChildrenQueryBuilderTest {
         SELECT c.domain_id
         FROM concept AS c
         WHERE c.concept_id = 101""";
-    assertThat(sql, Matchers.equalToCompressingWhiteSpace(expected));
+    assertSameQuery(expected, sql);
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/ConceptChildrenQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/ConceptChildrenQueryBuilderTest.java
@@ -1,6 +1,6 @@
 package bio.terra.service.snapshotbuilder.utils;
 
-import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertSameQuery;
+import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertQueryEquals;
 
 import bio.terra.common.category.Unit;
 import bio.terra.model.SnapshotBuilderDomainOption;
@@ -71,7 +71,7 @@ class ConceptChildrenQueryBuilderTest {
             .buildConceptChildrenQuery(createDomainOption(), 101)
             .renderSQL(context);
 
-    assertSameQuery(context.getPlatform().choose(GCP_EXPECTED, AZURE_EXPECTED), sql);
+    assertQueryEquals(context.getPlatform().choose(GCP_EXPECTED, AZURE_EXPECTED), sql);
   }
 
   @ParameterizedTest
@@ -87,6 +87,6 @@ class ConceptChildrenQueryBuilderTest {
         SELECT c.domain_id
         FROM concept AS c
         WHERE c.concept_id = 101""";
-    assertSameQuery(expected, sql);
+    assertQueryEquals(expected, sql);
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
@@ -42,7 +42,7 @@ class CriteriaQueryBuilderTest {
     return toBeStripped.replaceAll("\\s+", " ").trim();
   }
 
-  public static void assertSameQuery(String expectedSql, String actualSql) {
+  public static void assertQueryEquals(String expectedSql, String actualSql) {
     assertEquals(stripSpaces(expectedSql), stripSpaces(actualSql), "The sql generated is correct");
   }
 
@@ -52,7 +52,7 @@ class CriteriaQueryBuilderTest {
     SnapshotBuilderProgramDataRangeCriteria rangeCriteria = generateYearOfBirthRangeCriteria();
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(rangeCriteria);
 
-    assertSameQuery(
+    assertQueryEquals(
         "(p.year_of_birth >= 0 AND p.year_of_birth <= 100)", filterVariable.renderSQL(context));
   }
 
@@ -63,7 +63,7 @@ class CriteriaQueryBuilderTest {
         generateEthnicityListCriteria(List.of(0, 1, 2));
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(listCriteria);
 
-    assertSameQuery("p.ethnicity_concept_id IN (0,1,2)", filterVariable.renderSQL(context));
+    assertQueryEquals("p.ethnicity_concept_id IN (0,1,2)", filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -72,7 +72,7 @@ class CriteriaQueryBuilderTest {
     SnapshotBuilderProgramDataListCriteria listCriteria = generateEthnicityListCriteria(List.of());
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(listCriteria);
 
-    assertSameQuery("1=1", filterVariable.renderSQL(context));
+    assertQueryEquals("1=1", filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -84,7 +84,7 @@ class CriteriaQueryBuilderTest {
 
     String expectedSql =
         "p.person_id IN (SELECT co.person_id FROM condition_occurrence AS co  JOIN concept_ancestor AS ca ON ca.descendant_concept_id = co.condition_concept_id WHERE ca.ancestor_concept_id = 0)";
-    assertSameQuery(expectedSql, filterVariable.renderSQL(context));
+    assertQueryEquals(expectedSql, filterVariable.renderSQL(context));
   }
 
   @Test
@@ -103,7 +103,7 @@ class CriteriaQueryBuilderTest {
         generateDomainCriteria(SnapshotBuilderTestData.CONDITION_OCCURRENCE_DOMAIN_ID);
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilterForCriteria(criteria);
 
-    assertSameQuery(
+    assertQueryEquals(
         "p.person_id IN (SELECT co.person_id FROM condition_occurrence AS co JOIN concept_ancestor AS ca ON ca.descendant_concept_id = co.condition_concept_id WHERE ca.ancestor_concept_id = 0)",
         filterVariable.renderSQL(context));
   }
@@ -145,7 +145,7 @@ class CriteriaQueryBuilderTest {
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateAndOrFilterForCriteriaGroup(criteriaGroup);
 
-    assertSameQuery(
+    assertQueryEquals(
         "(p.ethnicity_concept_id IN (0,1,2) AND (p.year_of_birth >= 0 AND p.year_of_birth <= 100))",
         filterVariable.renderSQL(context));
   }
@@ -162,7 +162,7 @@ class CriteriaQueryBuilderTest {
             .meetAll(false);
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateAndOrFilterForCriteriaGroup(criteriaGroup);
-    assertSameQuery(
+    assertQueryEquals(
         "(p.ethnicity_concept_id IN (0,1,2) OR (p.year_of_birth >= 0 AND p.year_of_birth <= 100))",
         filterVariable.renderSQL(context));
   }
@@ -181,7 +181,7 @@ class CriteriaQueryBuilderTest {
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateFilterForCriteriaGroup(criteriaGroup);
 
-    assertSameQuery(
+    assertQueryEquals(
         "(p.ethnicity_concept_id IN (0,1,2) AND (p.year_of_birth >= 0 AND p.year_of_birth <= 100))",
         filterVariable.renderSQL(context));
   }
@@ -200,7 +200,7 @@ class CriteriaQueryBuilderTest {
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateFilterForCriteriaGroup(criteriaGroup);
 
-    assertSameQuery(
+    assertQueryEquals(
         "(NOT (p.ethnicity_concept_id IN (0,1,2) AND (p.year_of_birth >= 0 AND p.year_of_birth <= 100)))",
         filterVariable.renderSQL(context));
   }
@@ -220,7 +220,7 @@ class CriteriaQueryBuilderTest {
                     .meetAll(true)
                     .mustMeet(true)));
 
-    assertSameQuery(
+    assertQueryEquals(
         "(((p.year_of_birth >= 0 AND p.year_of_birth <= 100)) AND (p.ethnicity_concept_id IN (0,1,2)))",
         filterVariable.renderSQL(context));
   }
@@ -259,7 +259,7 @@ class CriteriaQueryBuilderTest {
                 JOIN concept_ancestor AS ca1
                 ON ca1.descendant_concept_id = po.procedure_concept_id
               WHERE ca1.ancestor_concept_id = 0))))""";
-    assertSameQuery(expectedSql, query.renderSQL(context));
+    assertQueryEquals(expectedSql, query.renderSQL(context));
   }
 
   private static SnapshotBuilderDomainCriteria generateDomainCriteria(int domainId) {

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
@@ -1,6 +1,5 @@
 package bio.terra.service.snapshotbuilder.utils;
 
-import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertSameQuery;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
@@ -1,7 +1,7 @@
 package bio.terra.service.snapshotbuilder.utils;
 
+import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertSameQuery;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,12 +31,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
 class CriteriaQueryBuilderTest {
-  CriteriaQueryBuilder criteriaQueryBuilder;
+  private CriteriaQueryBuilder criteriaQueryBuilder;
 
   @BeforeEach
   void setup() {
     criteriaQueryBuilder =
         new CriteriaQueryBuilder(Person.TABLE_NAME, SnapshotBuilderTestData.SETTINGS);
+  }
+
+  public static String stripSpaces(String toBeStripped) {
+    return toBeStripped.replaceAll("\\s+", " ").trim();
+  }
+
+  public static void assertSameQuery(String expectedSql, String actualSql) {
+    assertEquals(stripSpaces(expectedSql), stripSpaces(actualSql), "The sql generated is correct");
   }
 
   @ParameterizedTest
@@ -45,10 +53,8 @@ class CriteriaQueryBuilderTest {
     SnapshotBuilderProgramDataRangeCriteria rangeCriteria = generateYearOfBirthRangeCriteria();
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(rangeCriteria);
 
-    assertThat(
-        "The sql generated is correct",
-        filterVariable.renderSQL(context),
-        equalToCompressingWhiteSpace("(p.year_of_birth >= 0 AND p.year_of_birth <= 100)"));
+    assertSameQuery(
+        "(p.year_of_birth >= 0 AND p.year_of_birth <= 100)", filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -58,10 +64,7 @@ class CriteriaQueryBuilderTest {
         generateEthnicityListCriteria(List.of(0, 1, 2));
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(listCriteria);
 
-    assertThat(
-        "The sql generated is correct",
-        filterVariable.renderSQL(context),
-        equalToCompressingWhiteSpace("p.ethnicity_concept_id IN (0,1,2)"));
+    assertSameQuery("p.ethnicity_concept_id IN (0,1,2)", filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -70,10 +73,7 @@ class CriteriaQueryBuilderTest {
     SnapshotBuilderProgramDataListCriteria listCriteria = generateEthnicityListCriteria(List.of());
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilter(listCriteria);
 
-    assertThat(
-        "The sql generated is correct",
-        filterVariable.renderSQL(context),
-        equalToCompressingWhiteSpace("1=1"));
+    assertSameQuery("1=1", filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -85,10 +85,7 @@ class CriteriaQueryBuilderTest {
 
     String expectedSql =
         "p.person_id IN (SELECT co.person_id FROM condition_occurrence AS co  JOIN concept_ancestor AS ca ON ca.descendant_concept_id = co.condition_concept_id WHERE ca.ancestor_concept_id = 0)";
-    assertThat(
-        "The sql generated is correct",
-        filterVariable.renderSQL(context),
-        equalToCompressingWhiteSpace(expectedSql));
+    assertSameQuery(expectedSql, filterVariable.renderSQL(context));
   }
 
   @Test
@@ -107,12 +104,9 @@ class CriteriaQueryBuilderTest {
         generateDomainCriteria(SnapshotBuilderTestData.CONDITION_OCCURRENCE_DOMAIN_ID);
     FilterVariable filterVariable = criteriaQueryBuilder.generateFilterForCriteria(criteria);
 
-    String sql = filterVariable.renderSQL(context);
-    assertThat(
-        "The sql generated is correct",
-        sql,
-        equalToCompressingWhiteSpace(
-            "p.person_id IN (SELECT co.person_id FROM condition_occurrence AS co JOIN concept_ancestor AS ca ON ca.descendant_concept_id = co.condition_concept_id WHERE ca.ancestor_concept_id = 0)"));
+    assertSameQuery(
+        "p.person_id IN (SELECT co.person_id FROM condition_occurrence AS co JOIN concept_ancestor AS ca ON ca.descendant_concept_id = co.condition_concept_id WHERE ca.ancestor_concept_id = 0)",
+        filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -152,11 +146,9 @@ class CriteriaQueryBuilderTest {
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateAndOrFilterForCriteriaGroup(criteriaGroup);
 
-    assertThat(
-        "The sql generated is correct",
-        filterVariable.renderSQL(context),
-        equalToCompressingWhiteSpace(
-            "(p.ethnicity_concept_id IN (0,1,2) AND (p.year_of_birth >= 0 AND p.year_of_birth <= 100))"));
+    assertSameQuery(
+        "(p.ethnicity_concept_id IN (0,1,2) AND (p.year_of_birth >= 0 AND p.year_of_birth <= 100))",
+        filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -171,11 +163,9 @@ class CriteriaQueryBuilderTest {
             .meetAll(false);
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateAndOrFilterForCriteriaGroup(criteriaGroup);
-    assertThat(
-        "The sql generated is correct",
-        filterVariable.renderSQL(context),
-        equalToCompressingWhiteSpace(
-            "(p.ethnicity_concept_id IN (0,1,2) OR (p.year_of_birth >= 0 AND p.year_of_birth <= 100))"));
+    assertSameQuery(
+        "(p.ethnicity_concept_id IN (0,1,2) OR (p.year_of_birth >= 0 AND p.year_of_birth <= 100))",
+        filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -192,11 +182,9 @@ class CriteriaQueryBuilderTest {
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateFilterForCriteriaGroup(criteriaGroup);
 
-    assertThat(
-        "The sql generated is correct",
-        filterVariable.renderSQL(context),
-        equalToCompressingWhiteSpace(
-            "(p.ethnicity_concept_id IN (0,1,2) AND (p.year_of_birth >= 0 AND p.year_of_birth <= 100))"));
+    assertSameQuery(
+        "(p.ethnicity_concept_id IN (0,1,2) AND (p.year_of_birth >= 0 AND p.year_of_birth <= 100))",
+        filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -213,11 +201,9 @@ class CriteriaQueryBuilderTest {
     FilterVariable filterVariable =
         criteriaQueryBuilder.generateFilterForCriteriaGroup(criteriaGroup);
 
-    assertThat(
-        "The sql generated is correct",
-        filterVariable.renderSQL(context),
-        equalToCompressingWhiteSpace(
-            "(NOT (p.ethnicity_concept_id IN (0,1,2) AND (p.year_of_birth >= 0 AND p.year_of_birth <= 100)))"));
+    assertSameQuery(
+        "(NOT (p.ethnicity_concept_id IN (0,1,2) AND (p.year_of_birth >= 0 AND p.year_of_birth <= 100)))",
+        filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -235,11 +221,9 @@ class CriteriaQueryBuilderTest {
                     .meetAll(true)
                     .mustMeet(true)));
 
-    assertThat(
-        "The sql generated is correct",
-        filterVariable.renderSQL(context),
-        equalToCompressingWhiteSpace(
-            "(((p.year_of_birth >= 0 AND p.year_of_birth <= 100)) AND (p.ethnicity_concept_id IN (0,1,2)))"));
+    assertSameQuery(
+        "(((p.year_of_birth >= 0 AND p.year_of_birth <= 100)) AND (p.ethnicity_concept_id IN (0,1,2)))",
+        filterVariable.renderSQL(context));
   }
 
   @ParameterizedTest
@@ -277,14 +261,6 @@ class CriteriaQueryBuilderTest {
                 ON ca1.descendant_concept_id = po.procedure_concept_id
               WHERE ca1.ancestor_concept_id = 0))))""";
     assertSameQuery(expectedSql, query.renderSQL(context));
-  }
-
-  public static String stripSpaces(String toBeStripped) {
-    return toBeStripped.replaceAll("\\s+", " ").trim();
-  }
-
-  public static void assertSameQuery(String expectedSql, String actualSql) {
-    assertEquals(stripSpaces(expectedSql), stripSpaces(actualSql), "The sql generated is correct");
   }
 
   private static SnapshotBuilderDomainCriteria generateDomainCriteria(int domainId) {

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/CriteriaQueryBuilderTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.snapshotbuilder.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.category.Unit;
@@ -275,10 +276,15 @@ class CriteriaQueryBuilderTest {
                 JOIN concept_ancestor AS ca1
                 ON ca1.descendant_concept_id = po.procedure_concept_id
               WHERE ca1.ancestor_concept_id = 0))))""";
-    assertThat(
-        "The sql generated is correct",
-        query.renderSQL(context),
-        equalToCompressingWhiteSpace(expectedSql));
+    assertSameQuery(expectedSql, query.renderSQL(context));
+  }
+
+  public static String stripSpaces(String toBeStripped) {
+    return toBeStripped.replaceAll("\\s+", " ").trim();
+  }
+
+  public static void assertSameQuery(String expectedSql, String actualSql) {
+    assertEquals(stripSpaces(expectedSql), stripSpaces(actualSql), "The sql generated is correct");
   }
 
   private static SnapshotBuilderDomainCriteria generateDomainCriteria(int domainId) {

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/HierarchyQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/HierarchyQueryBuilderTest.java
@@ -1,6 +1,6 @@
 package bio.terra.service.snapshotbuilder.utils;
 
-import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertSameQuery;
+import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertQueryEquals;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.snapshotbuilder.query.SqlRenderContext;
@@ -66,7 +66,7 @@ class HierarchyQueryBuilderTest {
     var query =
         new HierarchyQueryBuilder()
             .generateQuery(ConceptChildrenQueryBuilderTest.createDomainOption(), 1);
-    assertSameQuery(
+    assertQueryEquals(
         context.getPlatform().choose(GCP_EXPECTED, AZURE_EXPECTED), query.renderSQL(context));
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/HierarchyQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/HierarchyQueryBuilderTest.java
@@ -1,7 +1,6 @@
 package bio.terra.service.snapshotbuilder.utils;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
+import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertSameQuery;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.snapshotbuilder.query.SqlRenderContext;
@@ -67,8 +66,7 @@ class HierarchyQueryBuilderTest {
     var query =
         new HierarchyQueryBuilder()
             .generateQuery(ConceptChildrenQueryBuilderTest.createDomainOption(), 1);
-    assertThat(
-        query.renderSQL(context),
-        equalToCompressingWhiteSpace(context.getPlatform().choose(GCP_EXPECTED, AZURE_EXPECTED)));
+    assertSameQuery(
+        context.getPlatform().choose(GCP_EXPECTED, AZURE_EXPECTED), query.renderSQL(context));
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -1,6 +1,6 @@
 package bio.terra.service.snapshotbuilder.utils;
 
-import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertSameQuery;
+import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertQueryEquals;
 import static bio.terra.service.snapshotbuilder.utils.SearchConceptsQueryBuilder.createSearchConceptClause;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -107,7 +107,7 @@ class SearchConceptsQueryBuilderTest {
             .buildSearchConceptsQuery(domainOption, "cancer")
             .renderSQL(context);
 
-    assertSameQuery(context.getPlatform().choose(expectedGcp, expectedAzure), actual);
+    assertQueryEquals(context.getPlatform().choose(expectedGcp, expectedAzure), actual);
   }
 
   @ParameterizedTest
@@ -141,7 +141,7 @@ class SearchConceptsQueryBuilderTest {
         GROUP BY c.concept_name, c.concept_id, c.concept_code
         ORDER BY count DESC""";
 
-    assertSameQuery(context.getPlatform().choose(gcpExpected, azureExpected), actual);
+    assertQueryEquals(context.getPlatform().choose(gcpExpected, azureExpected), actual);
   }
 
   @ParameterizedTest
@@ -156,7 +156,7 @@ class SearchConceptsQueryBuilderTest {
     var expectedGCPQuery = "CONTAINS_SUBSTR(c.concept_name, 'cancer')";
     var expectedAzureQuery = "CHARINDEX('cancer', c.concept_name) > 0";
 
-    assertSameQuery(context.getPlatform().choose(expectedGCPQuery, expectedAzureQuery), actual);
+    assertQueryEquals(context.getPlatform().choose(expectedGCPQuery, expectedAzureQuery), actual);
   }
 
   @ParameterizedTest

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/SearchConceptsQueryBuilderTest.java
@@ -1,11 +1,10 @@
 package bio.terra.service.snapshotbuilder.utils;
 
+import static bio.terra.service.snapshotbuilder.utils.CriteriaQueryBuilderTest.assertSameQuery;
 import static bio.terra.service.snapshotbuilder.utils.SearchConceptsQueryBuilder.createSearchConceptClause;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.Matchers.is;
 
-import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.category.Unit;
 import bio.terra.model.SnapshotBuilderDomainOption;
 import bio.terra.service.snapshotbuilder.query.SqlRenderContext;
@@ -108,10 +107,7 @@ class SearchConceptsQueryBuilderTest {
             .buildSearchConceptsQuery(domainOption, "cancer")
             .renderSQL(context);
 
-    assertThat(
-        "generated SQL is correct",
-        actual,
-        equalToCompressingWhiteSpace(context.getPlatform().choose(expectedGcp, expectedAzure)));
+    assertSameQuery(context.getPlatform().choose(expectedGcp, expectedAzure), actual);
   }
 
   @ParameterizedTest
@@ -145,16 +141,12 @@ class SearchConceptsQueryBuilderTest {
         GROUP BY c.concept_name, c.concept_id, c.concept_code
         ORDER BY count DESC""";
 
-    assertThat(
-        "generated SQL for GCP and Azure empty search string is correct",
-        actual,
-        equalToCompressingWhiteSpace(context.getPlatform().choose(gcpExpected, azureExpected)));
+    assertSameQuery(context.getPlatform().choose(gcpExpected, azureExpected), actual);
   }
 
   @ParameterizedTest
   @ArgumentsSource(SqlRenderContextProvider.class)
   void testCreateSearchConceptClause(SqlRenderContext context) {
-    CloudPlatformWrapper platformWrapper = context.getPlatform();
     TableVariable conceptTableVariable =
         TableVariable.forPrimary(TablePointer.fromTableName(Concept.TABLE_NAME));
     String actual =
@@ -164,12 +156,7 @@ class SearchConceptsQueryBuilderTest {
     var expectedGCPQuery = "CONTAINS_SUBSTR(c.concept_name, 'cancer')";
     var expectedAzureQuery = "CHARINDEX('cancer', c.concept_name) > 0";
 
-    assertThat(
-        "generated sql is as expected",
-        actual,
-        // table name is added when the Query is created
-        equalToCompressingWhiteSpace(
-            platformWrapper.choose(() -> expectedGCPQuery, () -> expectedAzureQuery)));
+    assertSameQuery(context.getPlatform().choose(expectedGCPQuery, expectedAzureQuery), actual);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Using the hamcrest matcher `equalToCompressingWhiteSpace()` lets us compare query strings without worrying about stripping whitespace, but Intellij doesn't recognize its output as a diff-able result, and doesn't provide the `Click to see difference` hyperlink in the test output.

I tried making a custom matcher whose output matches the regular expressions in the intelliij source code (see https://github.com/JetBrains/intellij-community/blob/master/plugins/testng_rt/src/com/intellij/rt/testng/TestNGExpectedPatterns.java#L23) but that didn't work. I also tried stripping whitespace from both and then using `assertThat(expectedSql, is(sql))` but that didn't work either. This version uses `assertEquals()` and does work.

Output in test results:

![image](https://github.com/DataBiosphere/jade-data-repo/assets/1799360/4d41d5bf-edbb-48ae-9a55-3beea0ff8e9f)

Diff window generated by Click to see difference:

![image](https://github.com/DataBiosphere/jade-data-repo/assets/1799360/b4c1e6e1-8fb2-4a11-b329-8978b6b875a9)

If this seems like a good approach, I can extend the PR to use it everywhere we compare query strings.