### PR TITLE
DC-1015: Add endpoint to approve snapshot access requests

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotAccessRequestApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotAccessRequestApiController.java
@@ -70,6 +70,14 @@ public class SnapshotAccessRequestApiController implements SnapshotAccessRequest
     return ResponseEntity.ok(snapshotBuilderService.rejectRequest(id));
   }
 
+  @Override
+  public ResponseEntity<SnapshotAccessRequestResponse> approveSnapshotAccessRequest(UUID id) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    iamService.verifyAuthorization(
+        userRequest, IamResourceType.SNAPSHOT_BUILDER_REQUEST, id.toString(), IamAction.APPROVE);
+    return ResponseEntity.ok(snapshotBuilderService.approveRequest(id));
+  }
+
   private AuthenticatedUserRequest getAuthenticatedInfo() {
     return authenticatedUserRequestFactory.from(request);
   }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -351,6 +351,10 @@ public class SnapshotBuilderService {
     return snapshotRequestDao.update(id, SnapshotAccessRequestStatus.REJECTED);
   }
 
+  public SnapshotAccessRequestResponse approveRequest(UUID id) {
+    return snapshotRequestDao.update(id, SnapshotAccessRequestStatus.APPROVED);
+  }
+
   private SnapshotBuilderDomainOption getDomainOption(
       int conceptId, Snapshot snapshot, AuthenticatedUserRequest userRequest) {
     // domain is needed to join with the domain specific occurrence table

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3060,13 +3060,13 @@ paths:
     put:
       tags:
         - SnapshotAccessRequest
-      description: As a custodian, reject a snapshot access request. Approve should be done via 'createSnapshot'.
+      description: As a custodian, reject a snapshot access request.
       operationId: rejectSnapshotAccessRequest
       parameters:
         - $ref: '#/components/parameters/Id'
       responses:
         200:
-          description: The request has been made.
+          description: The request has been rejected.
           content:
             application/json:
               schema:
@@ -3085,6 +3085,51 @@ paths:
                 $ref: '#/components/schemas/ErrorModel'
         403:
           description: Unauthorized - missing permissions to reject snapshot request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: No snapshot request found that meets the request parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+  /api/repository/v1/snapshotAccessRequests/{id}/approve:
+    put:
+      tags:
+        - SnapshotAccessRequest
+      description: As a custodian, approve a snapshot access request.
+      operationId: approveSnapshotAccessRequest
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: The request has been approved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SnapshotAccessRequestResponse'
+        400:
+          description: Bad request - invalid id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        401:
+          description: Unauthorized - snapshot request does not exist or missing permissions to view.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: Unauthorized - missing permissions to approve snapshot request.
           content:
             application/json:
               schema:

--- a/src/test/java/bio/terra/app/controller/SnapshotAccessRequestApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotAccessRequestApiControllerTest.java
@@ -53,6 +53,7 @@ class SnapshotAccessRequestApiControllerTest {
   private static final String ENDPOINT = "/api/repository/v1/snapshotAccessRequests";
 
   private static final String REJECT_ENDPOINT = ENDPOINT + "/{id}/reject";
+  private static final String APPROVE_ENDPOINT = ENDPOINT + "/{id}/approve";
 
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
@@ -119,12 +120,25 @@ class SnapshotAccessRequestApiControllerTest {
   }
 
   @Test
-  void testRejecteSnapshotRequest() throws Exception {
+  void testApproveAndRejectSnapshotRequest() throws Exception {
     UUID id = UUID.randomUUID();
     SnapshotAccessRequestResponse response = new SnapshotAccessRequestResponse().id(id);
     when(snapshotBuilderService.rejectRequest(id)).thenReturn(response);
+    testUpdateStatus(id, response, REJECT_ENDPOINT);
+  }
+
+  @Test
+  void testApproveSnapshotRequest() throws Exception {
+    UUID id = UUID.randomUUID();
+    SnapshotAccessRequestResponse response = new SnapshotAccessRequestResponse().id(id);
+    when(snapshotBuilderService.approveRequest(id)).thenReturn(response);
+    testUpdateStatus(id, response, APPROVE_ENDPOINT);
+  }
+
+  private void testUpdateStatus(UUID id, SnapshotAccessRequestResponse response, String endpoint)
+      throws Exception {
     String actualJson =
-        mvc.perform(put(REJECT_ENDPOINT, id))
+        mvc.perform(put(endpoint, id))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -106,7 +106,7 @@ class SnapshotBuilderServiceTest {
   }
 
   @Test
-  void createSnapshotRequest() {
+  void createRequest() {
     UUID snapshotId = UUID.randomUUID();
     SnapshotAccessRequestResponse response = new SnapshotAccessRequestResponse();
     when(snapshotRequestDao.create(
@@ -122,7 +122,7 @@ class SnapshotBuilderServiceTest {
   }
 
   @Test
-  void createSnapshotRequestRollsBackIfSamFails() {
+  void createRequestRollsBackIfSamFails() {
     UUID snapshotId = UUID.randomUUID();
     UUID snapshotRequestId = UUID.randomUUID();
     SnapshotAccessRequestResponse response =
@@ -141,7 +141,7 @@ class SnapshotBuilderServiceTest {
   }
 
   @Test
-  void enumerateSnapshotRequests() {
+  void enumerateRequests() {
     SnapshotAccessRequestResponse responseItem =
         SnapshotBuilderTestData.createSnapshotAccessRequestResponse(UUID.randomUUID());
     List<SnapshotAccessRequestResponse> response = List.of(responseItem);
@@ -427,10 +427,17 @@ class SnapshotBuilderServiceTest {
   }
 
   @Test
-  void testRejectSnapshotAccessRequest() {
+  void testRejectRequest() {
     UUID id = UUID.randomUUID();
     snapshotBuilderService.rejectRequest(id);
     verify(snapshotRequestDao).update(id, SnapshotAccessRequestStatus.REJECTED);
+  }
+
+  @Test
+  void testApproveRequest() {
+    UUID id = UUID.randomUUID();
+    snapshotBuilderService.approveRequest(id);
+    verify(snapshotRequestDao).update(id, SnapshotAccessRequestStatus.APPROVED);
   }
 
   static SnapshotBuilderConcept concept(String name, int id, boolean hasChildren) {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DC-1015

Adds an approval endpoint to SnapshotAccesssRequestApiController
Adds a method to SnapshotBuilderService to call into the DAO to update the status of the request
Adds tests
