### PR TITLE
DCJ-396: Update Sam client to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
 
     implementation 'bio.terra:terra-common-lib:1.1.11-SNAPSHOT'
-    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.204'
+    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
     implementation 'bio.terra:terra-policy-client:1.0.11-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'
     implementation 'bio.terra:externalcreds-client-resttemplate:1.3.0-SNAPSHOT'

--- a/datarepo-clienttests/build.gradle
+++ b/datarepo-clienttests/build.gradle
@@ -32,7 +32,7 @@ dependencies {
         jersey = "3.1.3"
 
         datarepoClient = "1.343.0-SNAPSHOT"
-        samClient = "v0.0.204"
+        samClient = "v0.0.241"
     }
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junit}")

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -751,7 +751,7 @@ class SamIamTest {
                       """
                             {GooglePubSub=class SubsystemStatus {
                                 ok: true
-                                messages: null
+                                messages: []
                                 additionalProperties: null
                             }}""")));
     }


### PR DESCRIPTION
Minor library update to facilitate https://broadworkbench.atlassian.net/browse/DCJ-396

This version of the Sam client includes support for https://sam.dsde-dev.broadinstitute.org/#/Admin/resourceTypeAdminPermission which is necessary to support customer service API requests.