### PR TITLE
Use spring HATEOAS to generate URIs for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,7 @@ dependencies {
 
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.hateoas:spring-hateoas'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'

--- a/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/app/configuration/ApplicationConfiguration.java
@@ -385,6 +385,8 @@ public class ApplicationConfiguration {
     return new NamedParameterJdbcTemplate(ds);
   }
 
+  // Use Primary to fix an issue with unqualified ObjectMapper injections in spring-hateoas.
+  @Primary
   @Bean("objectMapper")
   public ObjectMapper objectMapper() {
     return new ObjectMapper()

--- a/src/test/java/bio/terra/app/configuration/UnitTestConfiguration.java
+++ b/src/test/java/bio/terra/app/configuration/UnitTestConfiguration.java
@@ -1,6 +1,5 @@
-package bio.terra.common.fixtures;
+package bio.terra.app.configuration;
 
-import bio.terra.app.configuration.ApplicationConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -70,16 +70,16 @@ class DataRepositoryServiceApiControllerTest {
     return linkTo(object).toUri();
   }
 
-  private static DataRepositoryServiceApiController getDrsApi() {
+  private static DataRepositoryServiceApiController getApi() {
     return methodOn(DataRepositoryServiceApiController.class);
   }
 
   private static URI createGetUri() {
-    return createUri(getDrsApi().getObject(DRS_ID, false));
+    return createUri(getApi().getObject(DRS_ID, false));
   }
 
   private static URI createAccessUri() {
-    return createUri(getDrsApi().getAccessURL(DRS_ID, DRS_ACCESS_ID, null));
+    return createUri(getApi().getAccessURL(DRS_ID, DRS_ACCESS_ID, null));
   }
 
   @Test
@@ -108,11 +108,11 @@ class DataRepositoryServiceApiControllerTest {
   }
 
   private static URI createPostObjectUri() {
-    return createUri(getDrsApi().postObject(DRS_ID, PASSPORT));
+    return createUri(getApi().postObject(DRS_ID, PASSPORT));
   }
 
   private static URI createPostAccessUri() {
-    return createUri(getDrsApi().postAccessURL(DRS_ID, DRS_ACCESS_ID, PASSPORT, null));
+    return createUri(getApi().postAccessURL(DRS_ID, DRS_ACCESS_ID, PASSPORT, null));
   }
 
   @Test

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -65,16 +66,20 @@ class DataRepositoryServiceApiControllerTest {
     when(authenticatedUserRequestFactory.from(any())).thenReturn(TEST_USER);
   }
 
+  private static <T> URI createUri(ResponseEntity<T> object) {
+    return linkTo(object).toUri();
+  }
+
+  private static DataRepositoryServiceApiController getDrsApi() {
+    return methodOn(DataRepositoryServiceApiController.class);
+  }
+
   private static URI createGetUri() {
-    return linkTo(methodOn(DataRepositoryServiceApiController.class).getObject(DRS_ID, false))
-        .toUri();
+    return createUri(getDrsApi().getObject(DRS_ID, false));
   }
 
   private static URI createAccessUri() {
-    return linkTo(
-            methodOn(DataRepositoryServiceApiController.class)
-                .getAccessURL(DRS_ID, DRS_ACCESS_ID, null))
-        .toUri();
+    return createUri(getDrsApi().getAccessURL(DRS_ID, DRS_ACCESS_ID, null));
   }
 
   @Test
@@ -103,15 +108,11 @@ class DataRepositoryServiceApiControllerTest {
   }
 
   private static URI createPostObjectUri() {
-    return linkTo(methodOn(DataRepositoryServiceApiController.class).postObject(DRS_ID, PASSPORT))
-        .toUri();
+    return createUri(getDrsApi().postObject(DRS_ID, PASSPORT));
   }
 
   private static URI createPostAccessUri() {
-    return linkTo(
-            methodOn(DataRepositoryServiceApiController.class)
-                .postAccessURL(DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
-        .toUri();
+    return createUri(getDrsApi().postAccessURL(DRS_ID, DRS_ACCESS_ID, PASSPORT, null));
   }
 
   @Test

--- a/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
@@ -35,10 +35,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
-import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -324,9 +322,7 @@ class SnapshotValidationTest {
      * We check to see if the code is wrapped in quotes to prevent matching on substrings.
      */
     var expectedMatches =
-        Arrays.stream(messageCodes)
-            .map(code -> containsString("'" + code + "'"))
-            .toList();
+        Arrays.stream(messageCodes).map(code -> containsString("'" + code + "'")).toList();
     assertThat("Detail codes are right", details, containsInAnyOrder(expectedMatches));
   }
 }

--- a/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotValidationTest.java
@@ -35,8 +35,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -321,8 +323,10 @@ class SnapshotValidationTest {
      *
      * We check to see if the code is wrapped in quotes to prevent matching on substrings.
      */
-    var expectedMatches =
-        Arrays.stream(messageCodes).map(code -> containsString("'" + code + "'")).toList();
+    List<Matcher<? super String>> expectedMatches =
+        Arrays.stream(messageCodes)
+            .map(code -> containsString("'" + code + "'"))
+            .collect(Collectors.toList());
     assertThat("Detail codes are right", details, containsInAnyOrder(expectedMatches));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetRequestValidatorTest.java
@@ -17,6 +17,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.app.configuration.UnitTestConfiguration;
 import bio.terra.app.controller.ApiValidationExceptionHandler;
 import bio.terra.app.controller.DatasetsApiController;
 import bio.terra.app.controller.GlobalExceptionHandler;
@@ -25,7 +26,6 @@ import bio.terra.app.controller.converters.SqlSortDirectionAscDefaultConverter;
 import bio.terra.app.controller.converters.SqlSortDirectionDescDefaultConverter;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
-import bio.terra.common.fixtures.UnitTestConfiguration;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
@@ -71,25 +71,27 @@ import org.springframework.test.web.servlet.MvcResult;
       SqlSortDirectionDescDefaultConverter.class,
       UnitTestConfiguration.class
     })
+@MockBean({
+  JobService.class,
+  DatasetService.class,
+  IamService.class,
+  FileService.class,
+  AuthenticatedUserRequestFactory.class,
+  SnapshotBuilderService.class,
+})
 @WebMvcTest
 @Tag(Unit.TAG)
 class DatasetRequestValidatorTest {
 
   @Autowired private MockMvc mvc;
 
-  @MockBean private JobService jobService;
-  @MockBean private DatasetService datasetService;
-  @MockBean private IamService iamService;
-  @MockBean private FileService fileService;
-  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
-  @MockBean private SnapshotBuilderService snapshotBuilderService;
   @MockBean private IngestRequestValidator ingestRequestValidator;
   @MockBean private AssetModelValidator assetModelValidator;
   @MockBean private DatasetSchemaUpdateValidator datasetSchemaUpdateValidator;
   @MockBean private DataDeletionRequestValidator dataDeletionRequestValidator;
 
   @BeforeEach
-  void setup() throws Exception {
+  void setup() {
     when(ingestRequestValidator.supports(any())).thenReturn(true);
     when(dataDeletionRequestValidator.supports(any())).thenReturn(true);
     when(assetModelValidator.supports(any())).thenReturn(true);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotRequestValidatorTest.java
@@ -6,11 +6,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.app.configuration.UnitTestConfiguration;
 import bio.terra.app.controller.ApiValidationExceptionHandler;
 import bio.terra.app.controller.GlobalExceptionHandler;
 import bio.terra.app.controller.SnapshotsApiController;
 import bio.terra.common.category.Unit;
-import bio.terra.common.fixtures.UnitTestConfiguration;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.model.JobModel;
 import bio.terra.service.auth.iam.IamService;
@@ -39,17 +39,19 @@ import org.springframework.test.web.servlet.MockMvc;
       GlobalExceptionHandler.class,
       UnitTestConfiguration.class
     })
+@MockBean({
+  SnapshotService.class,
+  IamService.class,
+  FileService.class,
+  ApplicationConfiguration.class,
+  AuthenticatedUserRequestFactory.class,
+  SnapshotBuilderService.class
+})
 @WebMvcTest
 @Tag(Unit.TAG)
 class SnapshotRequestValidatorTest {
   @Autowired private MockMvc mvc;
   @MockBean private JobService jobService;
-  @MockBean private SnapshotService snapshotService;
-  @MockBean private IamService iamService;
-  @MockBean private FileService fileService;
-  @MockBean private ApplicationConfiguration applicationConfiguration;
-  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
-  @MockBean private SnapshotBuilderService snapshotBuilderService;
   @MockBean private IngestRequestValidator ingestRequestValidator;
   @MockBean private AssetModelValidator assetModelValidator;
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotRequestValidatorTest.java
@@ -42,7 +42,6 @@ import org.springframework.test.web.servlet.MockMvc;
       UnitTestConfiguration.class
     })
 @MockBean({
-  SnapshotService.class,
   IamService.class,
   FileService.class,
   ApplicationConfiguration.class,
@@ -54,6 +53,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class SnapshotRequestValidatorTest {
   @Autowired private MockMvc mvc;
   @MockBean private JobService jobService;
+  @MockBean private SnapshotService snapshotService;
   @MockBean private IngestRequestValidator ingestRequestValidator;
   @MockBean private AssetModelValidator assetModelValidator;
 


### PR DESCRIPTION
It's always bugged me that we hardcode URIs in our webmvc tests, and recently I found that spring has a library that can do this for us. I also found that spring has a way to bulk declare all the components that need to be mocked while testing, which we can use for the cases where a mock doesn't need any stubs.

To show what this looks like, I picked a test with a single use case of webmvc. If this seems like a good idea, we can start using it it for new tests too.