### PR TITLE
DCJ-396: Add infrastructure to support Sam Resource Type Admin Permission checks

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/AdminAuthorizedCacheKey.java
+++ b/src/main/java/bio/terra/service/auth/iam/AdminAuthorizedCacheKey.java
@@ -1,6 +1,0 @@
-package bio.terra.service.auth.iam;
-
-import bio.terra.common.iam.AuthenticatedUserRequest;
-
-public record AdminAuthorizedCacheKey(
-    AuthenticatedUserRequest userReq, IamResourceType iamResourceType, IamAction action) {}

--- a/src/main/java/bio/terra/service/auth/iam/AdminAuthorizedCacheKey.java
+++ b/src/main/java/bio/terra/service/auth/iam/AdminAuthorizedCacheKey.java
@@ -1,0 +1,6 @@
+package bio.terra.service.auth.iam;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+
+public record AdminAuthorizedCacheKey(
+    AuthenticatedUserRequest userReq, IamResourceType iamResourceType, IamAction action) {}

--- a/src/main/java/bio/terra/service/auth/iam/IamAction.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamAction.java
@@ -16,6 +16,7 @@ public enum IamAction {
   ALTER_POLICIES,
   UPDATE_PASSPORT_IDENTIFIER,
   UPDATE_AUTH_DOMAIN,
+  ADMIN_READ_SUMMARY_INFORMATION,
   // datarepo (admin-only actions)
   LIST_JOBS,
   DELETE_JOBS,

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -294,4 +294,15 @@ public interface IamProviderInterface {
       String billingProfileId,
       ManagedResourceGroupCoordinates managedResourceGroupCoordinates)
       throws InterruptedException;
+
+  /**
+   * @param userReq The AuthenticatedUserRequest
+   * @param iamResourceType The IamResourceType
+   * @param action The IamAction
+   * @return boolean value if the user is authorized to perform the action on the resource type
+   * @throws InterruptedException throws if sam retry fails due to interruption
+   */
+  boolean getResourceTypeAdminPermission(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, IamAction action)
+      throws InterruptedException;
 }

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamApiService.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamApiService.java
@@ -8,6 +8,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
+import org.broadinstitute.dsde.workbench.client.sam.api.AdminApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.AzureApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.GroupApi;
@@ -47,6 +48,10 @@ public class SamApiService {
 
   public StatusApi statusApi() {
     return new StatusApi(createUnauthApiClient());
+  }
+
+  public AdminApi adminApi(String accessToken) {
+    return new AdminApi(createApiClient(accessToken));
   }
 
   public AzureApi azureApi(String accessToken) {

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -775,6 +775,23 @@ public class SamIam implements IamProviderInterface {
         .createManagedResourceGroup(billingProfileId, managedResourceGroupCoordinates);
   }
 
+  @Override
+  public boolean getResourceTypeAdminPermission(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, IamAction action)
+      throws InterruptedException {
+    return SamRetry.retry(
+        configurationService,
+        () -> getResourceTypeAdminPermissionInner(userReq, iamResourceType, action));
+  }
+
+  private boolean getResourceTypeAdminPermissionInner(
+      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, IamAction action)
+      throws ApiException {
+    return samApiService
+        .adminApi(userReq.getToken())
+        .resourceTypeAdminPermission(iamResourceType.getSamResourceName(), action.toString());
+  }
+
   private UserStatusInfo getUserInfoAndVerify(AuthenticatedUserRequest userReq) {
     UserStatusInfo userStatusInfo = getUserInfo(userReq);
     if (!userStatusInfo.isEnabled()) {

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -219,5 +220,28 @@ class IamServiceTest {
                 .stewards(policies.getStewards())
                 .readers(expectedReaders)
                 .discoverers(policies.getDiscoverers())));
+  }
+
+  @Test
+  void testVerifyResourceTypeAdminAuthorizedTrue() throws InterruptedException {
+    when(iamProvider.getResourceTypeAdminPermission(
+            TEST_USER, IamResourceType.DATASNAPSHOT, IamAction.ADMIN_READ_SUMMARY_INFORMATION))
+        .thenReturn(true);
+    assertDoesNotThrow(
+        () ->
+            iamService.verifyResourceTypeAdminAuthorized(
+                TEST_USER, IamResourceType.DATASNAPSHOT, IamAction.ADMIN_READ_SUMMARY_INFORMATION));
+  }
+
+  @Test
+  void testVerifyResourceTypeAdminAuthorizedFalse() throws InterruptedException {
+    when(iamProvider.getResourceTypeAdminPermission(
+            TEST_USER, IamResourceType.DATASNAPSHOT, IamAction.ADMIN_READ_SUMMARY_INFORMATION))
+        .thenReturn(false);
+    assertThrows(
+        IamForbiddenException.class,
+        () ->
+            iamService.verifyResourceTypeAdminAuthorized(
+                TEST_USER, IamResourceType.DATASNAPSHOT, IamAction.ADMIN_READ_SUMMARY_INFORMATION));
   }
 }

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamApiServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamApiServiceTest.java
@@ -45,6 +45,7 @@ class SamApiServiceTest {
     authorizedApiClients =
         Map.of(
             "ResourcesApi", samApiService.resourcesApi(TOKEN).getApiClient(),
+            "AdminApi", samApiService.adminApi(TOKEN).getApiClient(),
             "AzureApi", samApiService.azureApi(TOKEN).getApiClient(),
             "GoogleApi", samApiService.googleApi(TOKEN).getApiClient(),
             "UsersApi", samApiService.usersApi(TOKEN).getApiClient(),

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.AdminApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.AzureApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.GroupApi;
@@ -865,6 +866,39 @@ class SamIamTest {
           new ApiException(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "Group not found");
       doThrow(samEx).when(samGroupApi).deleteGroup(groupName);
       assertThrows(IamNotFoundException.class, () -> samIam.deleteGroup(accessToken, groupName));
+    }
+  }
+
+  @Nested
+  class TestAdminApi {
+
+    @Mock private AdminApi samAdminApi;
+
+    @BeforeEach
+    void setUp() {
+      when(samApiService.adminApi(TEST_USER.getToken())).thenReturn(samAdminApi);
+    }
+
+    @Test
+    void testGetResourceTypeAdminPermissionAllowed() throws InterruptedException {
+      when(samIam.getResourceTypeAdminPermission(
+              TEST_USER, IamResourceType.DATASNAPSHOT, IamAction.ADMIN_READ_SUMMARY_INFORMATION))
+          .thenReturn(true);
+      boolean allowed =
+          samIam.getResourceTypeAdminPermission(
+              TEST_USER, IamResourceType.DATASNAPSHOT, IamAction.ADMIN_READ_SUMMARY_INFORMATION);
+      assertTrue(allowed);
+    }
+
+    @Test
+    void testGetResourceTypeAdminPermissionNotAllowed() throws InterruptedException {
+      when(samIam.getResourceTypeAdminPermission(
+              TEST_USER, IamResourceType.DATASNAPSHOT, IamAction.ADMIN_READ_SUMMARY_INFORMATION))
+          .thenReturn(false);
+      boolean allowed =
+          samIam.getResourceTypeAdminPermission(
+              TEST_USER, IamResourceType.DATASNAPSHOT, IamAction.ADMIN_READ_SUMMARY_INFORMATION);
+      assertFalse(allowed);
     }
   }
 }


### PR DESCRIPTION
## Addresses
Supports https://broadworkbench.atlassian.net/browse/DCJ-396 but does not complete that ticket.

## Summary
Sam has added a new admin check for a resource type and action to facilitate supporting customer support personnel. This PR only covers the Sam and Iam plumbing necessary to make those checks. Future PRs will implement actual snapshot and dataset calls using this authorization plumbing instead of the existing plumbing which is designed for traditional end user access.