### PR TITLE
[DCJ-440] Expand IamUnauthorizedException messages to include resource type, ID

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -141,7 +141,8 @@ public class IamService {
     String userEmail = userReq.getEmail();
     if (!isAuthorized(userReq, iamResourceType, resourceId, action)) {
       throw new IamForbiddenException(
-          "User '" + userEmail + "' does not have required action: " + action);
+          "User '%s' does not have required action '%s' on the %s with ID %s"
+              .formatted(userEmail, action, iamResourceType.getSamResourceName(), resourceId));
     }
   }
 
@@ -157,7 +158,8 @@ public class IamService {
     String userEmail = userReq.getEmail();
     if (!hasAnyActions(userReq, iamResourceType, resourceId)) {
       throw new IamForbiddenException(
-          "User '" + userEmail + "' does not have any actions on the resource");
+          "User '%s' does not hold any actions on the %s with ID %s"
+              .formatted(userEmail, iamResourceType.getSamResourceName(), resourceId));
     }
   }
 
@@ -201,7 +203,8 @@ public class IamService {
 
     if (!unavailableActions.isEmpty()) {
       throw new IamForbiddenException(
-          "User '" + userEmail + "' is missing required actions (returned in details)",
+          "User '%s' is missing required actions on the %s with ID %s (returned in details)"
+              .formatted(userEmail, iamResourceType.getSamResourceName(), resourceId),
           unavailableActions);
     }
   }

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -129,7 +129,7 @@ class IamServiceTest {
     assertThat(
         "Error message reflects cause",
         thrown.getMessage(),
-        containsString("does not have required action: " + action));
+        containsString("does not have required action '%s'".formatted(action)));
   }
 
   @Test
@@ -149,7 +149,7 @@ class IamServiceTest {
     assertThat(
         "Error message reflects cause",
         thrown.getMessage(),
-        containsString("does not have any actions"));
+        containsString("does not hold any actions"));
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-440

This will make it clearer to users what resource they are unauthorized to use. In particular, this helps in cases where a user must be authorized to use a different resource than the one they're taking direct action on.

A concrete example which has confused both internal and external users: in order to create a snapshot…
- A user must be authorized to create a snapshot from the root dataset
- A user must be authorized to use the billing profile (by default, this is the billing profile associated with the dataset)

The snapshot creation error message when the user is unauthorized to use the billing profile looked like this:
```
User 'brubensttest@gmail.com' does not have required action: link
```

And now would look like this:
```
User 'brubensttest@gmail.com' does not have required action 'link' on spend-profile with ID AAAA-BBBB-…
```

**Future Opportunities**
- Consider checking billing profile access prior to launching a Stairway flight, so that the command fails fast.  I wanted to restrict the scope of this work to messaging improvements, however.