### PR TITLE
[DCJ-444] Azure ingest validates filerefs before publishing tabular data

### DIFF
--- a/src/main/java/bio/terra/common/Column.java
+++ b/src/main/java/bio/terra/common/Column.java
@@ -146,7 +146,7 @@ public class Column {
     Column column = (Column) o;
     return arrayOf == column.arrayOf
         && required == column.required
-        && id.equals(column.id)
+        && Objects.equals(id, column.id)
         && Objects.equals(table, column.table)
         && Objects.equals(name, column.name)
         && type == column.type;

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -282,10 +282,10 @@ public class DatasetIngestFlight extends Flight {
           new IngestCreateScratchParquetFilesStep(
               azureSynapsePdao, azureBlobStorePdao, datasetService, userReq));
       addStep(new IngestValidateScratchTableStep(azureSynapsePdao, datasetService));
-      addStep(new IngestCreateParquetFilesStep(azureSynapsePdao, datasetService));
       addStep(
-          new IngestValidateAzureRefsStep(
+          new IngestValidateScratchTableFilerefsStep(
               azureAuthService, datasetService, azureSynapsePdao, tableDirectoryDao));
+      addStep(new IngestCreateParquetFilesStep(azureSynapsePdao, datasetService));
       addStep(new IngestCleanAzureStep(azureSynapsePdao, azureBlobStorePdao, userReq));
       addStep(
           new PerformPayloadIngestStep(

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureAuthService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureAuthService.java
@@ -121,9 +121,9 @@ public class AzureAuthService {
 
   public TableServiceClient getTableServiceClient(AzureStorageAuthInfo storageAuthInfo) {
     return getTableServiceClient(
-        storageAuthInfo.getSubscriptionId(),
-        storageAuthInfo.getResourceGroupName(),
-        storageAuthInfo.getStorageAccountResourceName());
+        storageAuthInfo.subscriptionId(),
+        storageAuthInfo.resourceGroupName(),
+        storageAuthInfo.storageAccountResourceName());
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAuthInfo.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureStorageAuthInfo.java
@@ -3,46 +3,14 @@ package bio.terra.service.resourcemanagement.azure;
 import bio.terra.model.BillingProfileModel;
 import java.util.UUID;
 
-public class AzureStorageAuthInfo {
-  private UUID subscriptionId;
-  private String resourceGroupName;
-  private String storageAccountResourceName;
-
+public record AzureStorageAuthInfo(
+    UUID subscriptionId, String resourceGroupName, String storageAccountResourceName) {
   public static AzureStorageAuthInfo azureStorageAuthInfoBuilder(
       BillingProfileModel profileModel, AzureStorageAccountResource storageAccountResource) {
-    return new AzureStorageAuthInfo()
-        .subscriptionId(profileModel.getSubscriptionId())
-        .resourceGroupName(
-            storageAccountResource.getApplicationResource().getAzureResourceGroupName())
-        .storageAccountResourceName(storageAccountResource.getName());
-  }
-
-  public AzureStorageAuthInfo() {}
-
-  public UUID getSubscriptionId() {
-    return subscriptionId;
-  }
-
-  public AzureStorageAuthInfo subscriptionId(UUID subscriptionId) {
-    this.subscriptionId = subscriptionId;
-    return this;
-  }
-
-  public String getResourceGroupName() {
-    return resourceGroupName;
-  }
-
-  public AzureStorageAuthInfo resourceGroupName(String resourceGroupName) {
-    this.resourceGroupName = resourceGroupName;
-    return this;
-  }
-
-  public String getStorageAccountResourceName() {
-    return storageAccountResourceName;
-  }
-
-  public AzureStorageAuthInfo storageAccountResourceName(String storageAccountResourceName) {
-    this.storageAccountResourceName = storageAccountResourceName;
-    return this;
+    UUID subscriptionId = profileModel.getSubscriptionId();
+    String resourceGroupName =
+        storageAccountResource.getApplicationResource().getAzureResourceGroupName();
+    String storageAccountResourceName = storageAccountResource.getName();
+    return new AzureStorageAuthInfo(subscriptionId, resourceGroupName, storageAccountResourceName);
   }
 }

--- a/src/test/java/bio/terra/common/ColumnTest.java
+++ b/src/test/java/bio/terra/common/ColumnTest.java
@@ -1,0 +1,31 @@
+package bio.terra.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import bio.terra.common.category.Unit;
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Unit.TAG)
+class ColumnTest {
+  @Test
+  void equals_compareIds() {
+    assertThat("Columns with the default ID value are equal", new Column(), equalTo(new Column()));
+    assertThat(
+        "Columns with the same null ID are equal",
+        new Column().id(null),
+        equalTo(new Column().id(null)));
+    UUID id = UUID.randomUUID();
+    assertThat(
+        "Columns with the same non-null ID are equal",
+        new Column().id(id),
+        equalTo(new Column().id(id)));
+    assertThat(
+        "Columns with different IDs are not equal",
+        new Column().id(id),
+        not(equalTo(new Column().id(UUID.randomUUID()))));
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestValidateScratchTableFilerefsStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestValidateScratchTableFilerefsStepTest.java
@@ -1,0 +1,186 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.CollectionType;
+import bio.terra.common.Column;
+import bio.terra.common.category.Unit;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.model.TableDataType;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.exception.InvalidFileRefException;
+import bio.terra.service.dataset.flight.ingest.IngestUtils;
+import bio.terra.service.dataset.flight.ingest.IngestValidateScratchTableFilerefsStep;
+import bio.terra.service.filedata.azure.AzureSynapsePdao;
+import bio.terra.service.filedata.azure.tables.TableDirectoryDao;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAuthInfo;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.azure.data.tables.TableServiceClient;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class IngestValidateScratchTableFilerefsStepTest {
+  @Mock private AzureAuthService azureAuthService;
+  @Mock private DatasetService datasetService;
+  @Mock private AzureSynapsePdao azureSynapsePdao;
+  @Mock private TableDirectoryDao tableDirectoryDao;
+  @Mock private TableServiceClient tableServiceClient;
+  @Mock private FlightContext flightContext;
+  private static final String FLIGHT_ID = "a_flight_id";
+  private static final String SCRATCH_TABLE_NAME =
+      IngestUtils.getSynapseScratchTableName(FLIGHT_ID);
+  private static final UUID DATASET_ID = UUID.randomUUID();
+  private static final String TABLE_NAME = "table_to_populate";
+  private static final Column STRING_COLUMN =
+      new Column().name("a_string_column").type(TableDataType.STRING);
+  private static final Column FILEREF_COLUMN =
+      new Column().name("a_fileref_column").type(TableDataType.FILEREF);
+  private static final String INVALID_REFID = "invalid_refid";
+  private static final String VALID_REFID = "valid_refid";
+
+  @BeforeEach
+  void setup() {
+    AzureStorageAuthInfo datasetStorageAuthInfo =
+        new AzureStorageAuthInfo(UUID.randomUUID(), "rg_name", "sa_name");
+
+    when(flightContext.getFlightId()).thenReturn(FLIGHT_ID);
+
+    FlightMap inputParameters = new FlightMap();
+    inputParameters.put(
+        JobMapKeys.REQUEST.getKeyName(), new IngestRequestModel().table(TABLE_NAME));
+    inputParameters.put(JobMapKeys.DATASET_ID.getKeyName(), DATASET_ID);
+    when(flightContext.getInputParameters()).thenReturn(inputParameters);
+
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(CommonMapKeys.DATASET_STORAGE_AUTH_INFO, datasetStorageAuthInfo);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+
+    when(azureAuthService.getTableServiceClient(datasetStorageAuthInfo))
+        .thenReturn(tableServiceClient);
+  }
+
+  /** Mock dataset retrieval to include a single table with the specified columns. */
+  private void mockDatasetWithColumns(Column... columns) {
+    DatasetTable table = new DatasetTable().name(TABLE_NAME).columns(Arrays.asList(columns));
+    Dataset dataset = new Dataset().id(DATASET_ID).tables(List.of(table));
+    when(datasetService.retrieve(DATASET_ID)).thenReturn(dataset);
+  }
+
+  /**
+   * Verify that we obtained fileref IDs from our fileref column in our scratch table, and only our
+   * fileref column.
+   */
+  private void verifyFilerefIdFetch() {
+    verify(azureSynapsePdao)
+        .getRefIds(
+            SCRATCH_TABLE_NAME, Column.toSynapseColumn(FILEREF_COLUMN), CollectionType.DATASET);
+    verifyNoMoreInteractions(azureSynapsePdao);
+  }
+
+  @Test
+  void doStep_noFilerefColumns_success() throws InterruptedException {
+    mockDatasetWithColumns(STRING_COLUMN);
+
+    IngestValidateScratchTableFilerefsStep step =
+        new IngestValidateScratchTableFilerefsStep(
+            azureAuthService, datasetService, azureSynapsePdao, tableDirectoryDao);
+
+    StepResult stepResult = step.doStep(flightContext);
+    assertThat(
+        "An ingest to a table with no fileref columns succeeds",
+        stepResult.getStepStatus(),
+        equalTo(StepStatus.STEP_RESULT_SUCCESS));
+
+    // Our scratch table has no fileref columns, so the step does not have anything to check.
+    verifyNoInteractions(azureSynapsePdao);
+  }
+
+  @Test
+  void doStep_validFileref_success() throws InterruptedException {
+    mockDatasetWithColumns(STRING_COLUMN, FILEREF_COLUMN);
+
+    List<String> filerefs = List.of(VALID_REFID);
+    when(azureSynapsePdao.getRefIds(
+            SCRATCH_TABLE_NAME, Column.toSynapseColumn(FILEREF_COLUMN), CollectionType.DATASET))
+        .thenReturn(filerefs);
+    when(tableDirectoryDao.validateRefIds(tableServiceClient, DATASET_ID, filerefs))
+        .thenReturn(List.of());
+
+    IngestValidateScratchTableFilerefsStep step =
+        new IngestValidateScratchTableFilerefsStep(
+            azureAuthService, datasetService, azureSynapsePdao, tableDirectoryDao);
+
+    StepResult stepResult = step.doStep(flightContext);
+    assertThat(
+        "Step succeeds when all filerefs in the scratch table are valid",
+        stepResult.getStepStatus(),
+        equalTo(StepStatus.STEP_RESULT_SUCCESS));
+
+    verifyFilerefIdFetch();
+  }
+
+  private static Stream<List<String>> doStep_invalidFileref_throwsInvalidFileRefException() {
+    return Stream.of(
+        List.of(INVALID_REFID), // Only an invalid fileref
+        List.of(VALID_REFID, INVALID_REFID) // Both valid and invalid filerefs
+        );
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void doStep_invalidFileref_throwsInvalidFileRefException(List<String> filerefs) {
+    mockDatasetWithColumns(STRING_COLUMN, FILEREF_COLUMN);
+
+    when(azureSynapsePdao.getRefIds(
+            SCRATCH_TABLE_NAME, Column.toSynapseColumn(FILEREF_COLUMN), CollectionType.DATASET))
+        .thenReturn(filerefs);
+    when(tableDirectoryDao.validateRefIds(tableServiceClient, DATASET_ID, filerefs))
+        .thenReturn(List.of(INVALID_REFID));
+
+    IngestValidateScratchTableFilerefsStep step =
+        new IngestValidateScratchTableFilerefsStep(
+            azureAuthService, datasetService, azureSynapsePdao, tableDirectoryDao);
+
+    InvalidFileRefException exception =
+        assertThrows(
+            InvalidFileRefException.class,
+            () -> step.doStep(flightContext),
+            "Step throws when 1+ filerefs in the scratch table are invalid");
+    List<String> actualInvalidFilerefs = exception.getCauses();
+    assertThat("Exactly one fileref is invalid", actualInvalidFilerefs, hasSize(1));
+    assertThat(
+        "Our expected invalid fileref is recorded as a failure cause",
+        actualInvalidFilerefs.get(0),
+        containsString(INVALID_REFID));
+
+    verifyFilerefIdFetch();
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-444

## Background

TDR’s `DatasetIngestFlight` is used to facilitate tabular data ingest.  Files can be ingested along with the tabular data in the same ingest call, but if the files have been uploaded to the dataset already then their file reference UUIDs can be specified directly.

When ingesting to an Azure dataset, this flight previously did the following in order (relevant subset of steps):
- Create scratch (staging) Parquet files which contain the tabular data being ingested.
- Validate the rows in the scratch Parquet files. If any are invalid, then fail the flight and undo the previous steps.
- Promote the scratch Parquet files to their final published location: at this point, a user is able to see the ingested records in their dataset.
- Validate that any file references in the published Parquet files point to real files in the dataset.  If not, then fail the flight and undo the previous steps.

## Changes

This PR publishes the Parquet files as late as we can in the flight to minimize the chance of a user seeing data from an ingest that may ultimately fail.  (Ticketed separately is the issue that the Parquet publication step does not currently delete its published files on undo.)

In service of this, I updated the flight so that TDR validates file references off of the scratch Parquet files prior to their publication.

1. Modify `IngestValidateAzureRefsStep` to validate the file references present in the staging table, rather than off of published Parquet files.
2. Rename to `IngestValidateScratchTableFilerefsStep` for clarity.
3. Reorder flight so that this step comes before `IngestCreateParquetFilesStep`: this way if an attempted ingest contains invalid file references, TDR will not have published the final Parquet files.  At no point during such a flight or after its rollback would users see the tabular data in their dataset.

## Automated Testing

I expanded unit tests:
- Ensure that the step order in flight construction has fileref validation happening before Parquet publishing
- Verify fileref validation behavior across a number of conditions in a new unit test class for our modified step

## Not part of this PR:
- Expansion of `IngestCreateParquetFilesStep.undoStep` to fully clean up after itself by deleting its published Parquet files

## Demonstration

I deployed this feature branch to my BEE, which already had an Azure dataset created: https://data.okotsopo.bee.envs-terra.bio/datasets/f0bd48c2-0967-4731-8987-475fc7e91940

If you register onto my BEE's Terra and would like access to this dataset, let me know! https://terra.okotsopo.bee.envs-terra.bio/

To this dataset, I attempted the following ingests.

### 1. Tabular data ingest contains invalid file references only

I achieved the expected result: flight fails before final Parquet files are published.  The record never shows up in the table.

```
POST https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/datasets/f0bd48c2-0967-4731-8987-475fc7e91940/ingest
{
  "table": "table",
  "records": [
    {"id": "a fileref that doesn't exist in the dataset: this ingest should fail and leave no trace", "new_column1": "f0bd48c2-0967-4731-8987-475fc7e91940"}
  ],
  "format": "array"
}
```

Job result:
```
GET https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/jobs/yEpHjz4dQNGDi__s9pLjSw
{
  "id": "yEpHjz4dQNGDi__s9pLjSw",
  "description": "Ingest tabular data to table in dataset id f0bd48c2-0967-4731-8987-475fc7e91940",
  "job_status": "failed",
  "status_code": 200,
  "submitted": "2024-06-14T15:24:25.591193Z",
  "completed": "2024-06-14T15:24:41.630003Z",
  "class_name": "bio.terra.service.dataset.flight.ingest.DatasetIngestFlight"
}

GET https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/jobs/yEpHjz4dQNGDi__s9pLjSw/result
{
  "message": "Invalid file ids found during ingest (1 returned in details)",
  "errorDetail": [
    "{refId: f0bd48c2-0967-4731-8987-475fc7e91940, columnName: new_column1}"
  ]
}
```
### 2. Tabular data ingest contains invalid and valid file references

I achieved the expected result: flight fails before final Parquet files are published.  The record never shows up in the table.

First, I ingested a file into the dataset via [Azure signed URL](https://portal.azure.com/#view/Microsoft_Azure_Storage/BlobPropertiesBladeV2/storageAccountId/%2Fsubscriptions%2Ff557c728-871d-408c-a28b-eb6b2141a087%2FresourceGroups%2FdevTestingMrg20230921%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Flz813a3d637adefec2c6e88f/path/sc-0207547b-6134-43fa-bad7-03cfef670dfd%2Fhelloworld.txt/isDeleted~/false/tabToload~/4):
```
POST https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/datasets/f0bd48c2-0967-4731-8987-475fc7e91940/files
{
  "source_path": "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-0207547b-6134-43fa-bad7-03cfef670dfd/helloworld.txt?<SAS_token>",
  "target_path": "/helloworld.txt",
  "profileId": "1bae39ea-d643-4f30-868d-41dd76aca2e8",
  "loadTag": "20240614:11:28-helloworld",
  "description": "A dummy file from my Azure workspace."
}
```
Job result shows the file was ingested with UUID `d49e4d16-0d86-482f-bc06-db8b002a8b61`:
```
GET https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/jobs/Q14AS4WwQqiD01iuGxR1jw
{
  "id": "Q14AS4WwQqiD01iuGxR1jw",
  "description": "Ingest file /helloworld.txt",
  "job_status": "succeeded",
  "status_code": 200,
  "submitted": "2024-06-14T15:28:57.467069Z",
  "completed": "2024-06-14T15:29:05.403723Z",
  "class_name": "bio.terra.service.filedata.flight.ingest.FileIngestFlight"
}

GET https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/jobs/Q14AS4WwQqiD01iuGxR1jw/result
{
  "fileId": "d49e4d16-0d86-482f-bc06-db8b002a8b61",
  "collectionId": "f0bd48c2-0967-4731-8987-475fc7e91940",
  "path": "/helloworld.txt",
  "size": 26,
  "checksums": [
    {
      "checksum": "f14235f5bf45732201e2b49d58166f8d",
      "type": "md5"
    }
  ],
  "created": "2024-06-14T15:28:59Z",
  "description": "A dummy file from my Azure workspace.",
  "fileType": "file",
  "fileDetail": {
    "datasetId": "f0bd48c2-0967-4731-8987-475fc7e91940",
    "mimeType": null,
    "accessUrl": "https://tdrokjjmxxrxzdkluxdsslri.blob.core.windows.net/f0bd48c2-0967-4731-8987-475fc7e91940/data/d49e4d16-0d86-482f-bc06-db8b002a8b61/helloworld.txt",
    "loadTag": "20240614:11:28-helloworld"
  },
  "directoryDetail": null
}
```

Then I specified its UUID in a tabular data ingest, along with another record that specified an invalid fileref:
```
POST https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/datasets/f0bd48c2-0967-4731-8987-475fc7e91940/ingest
{
  "table": "table",
  "records": [
    {"id": "a fileref that doesn't exist in the dataset: this ingest should fail and leave no trace", "new_column1": "f0bd48c2-0967-4731-8987-475fc7e91940"},
    {"id": "a fileref that exists in the dataset: but because of the row above, this ingest should fail and leave no trace", "new_column1": "d49e4d16-0d86-482f-bc06-db8b002a8b61"}
  ],
  "format": "array"
}
```
Job result correctly flags the invalid fileref, and not the valid fileref:
```
GET https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/jobs/bP5Rd95_TreznCJPAc1OOA
{
  "id": "bP5Rd95_TreznCJPAc1OOA",
  "description": "Ingest tabular data to table in dataset id f0bd48c2-0967-4731-8987-475fc7e91940",
  "job_status": "failed",
  "status_code": 200,
  "submitted": "2024-06-14T15:30:42.233764Z",
  "completed": "2024-06-14T15:30:52.203621Z",
  "class_name": "bio.terra.service.dataset.flight.ingest.DatasetIngestFlight"
}

GET https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/jobs/bP5Rd95_TreznCJPAc1OOA/result
{
  "message": "Invalid file ids found during ingest (1 returned in details)",
  "errorDetail": [
    "{refId: f0bd48c2-0967-4731-8987-475fc7e91940, columnName: new_column1}"
  ]
}
```

### 3. Tabular data ingest contains valid file references only

I achieved the expected result: flight succeeds.  The record and only this record is visible in the table.

<img width="1719" alt="Screenshot 2024-06-14 at 12 28 48 PM" src="https://github.com/DataBiosphere/jade-data-repo/assets/79769153/ccaaa2ca-f9cb-4c06-b127-39511d2c5f0e">

```
POST https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/datasets/f0bd48c2-0967-4731-8987-475fc7e91940/ingest
{
  "table": "table",
  "records": [
    {"id": "a fileref that exists in the dataset, specified by its UUID", "new_column1": "d49e4d16-0d86-482f-bc06-db8b002a8b61"}
  ],
  "format": "array"
}
```

Job result:
```
GET https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/jobs/-4fpqYvpQCWo8lVQii8XBg
{
  "id": "-4fpqYvpQCWo8lVQii8XBg",
  "description": "Ingest tabular data to table in dataset id f0bd48c2-0967-4731-8987-475fc7e91940",
  "job_status": "succeeded",
  "status_code": 200,
  "submitted": "2024-06-14T15:31:53.504040Z",
  "completed": "2024-06-14T15:32:04.261901Z",
  "class_name": "bio.terra.service.dataset.flight.ingest.DatasetIngestFlight"
}

GET https://data.okotsopo.bee.envs-terra.bio/api/repository/v1/jobs/-4fpqYvpQCWo8lVQii8XBg/result
{
  "dataset_id": "f0bd48c2-0967-4731-8987-475fc7e91940",
  "dataset": "20240520_okotsopo_azure_files",
  "table": "table",
  "path": null,
  "load_tag": "load-at-2024-06-14T15:31:42.656610222Z",
  "row_count": 1,
  "bad_row_count": 0,
  "load_result": null
}
```