### PR TITLE
[DCJ-442] Expand thread pool queue capacity and add unit tests

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -163,7 +163,7 @@ public record AzureResourceConfiguration(
       int connectRetryInterval,
       int connectRetryCount) {}
 
-  public record Threading(int numTableThreads) {}
+  public record Threading(int numTableThreads, int maxQueueSize) {}
 
   @Bean("azureTableThreadpool")
   public AsyncTaskExecutor azureTableThreadpool() {
@@ -171,7 +171,7 @@ public record AzureResourceConfiguration(
     executor.setCorePoolSize(threading().numTableThreads());
     executor.setMaxPoolSize(threading().numTableThreads());
     executor.setKeepAliveSeconds(0);
-    executor.setQueueCapacity(threading().numTableThreads());
+    executor.setQueueCapacity(threading().maxQueueSize());
     executor.setThreadNamePrefix("az-table-thread-");
     executor.initialize();
     return executor;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -132,6 +132,7 @@ azure.synapse.connectRetryInterval=15
 azure.synapse.connectRetryCount=20
 # Number of concurrent operations on Azure storage tables.  Note operations can be batches of operations.
 azure.threading.numTableThreads=1000
+azure.threading.maxQueueSize=10000
 azure.apiVersion=2021-07-01
 azure.maxRetries=3
 azure.retryTimeoutSeconds=3600

--- a/src/test/java/bio/terra/app/configuration/AzureResourceConfigurationTest.java
+++ b/src/test/java/bio/terra/app/configuration/AzureResourceConfigurationTest.java
@@ -1,0 +1,33 @@
+package bio.terra.app.configuration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration.Threading;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Tag(Unit.TAG)
+public class AzureResourceConfigurationTest {
+  private static final int NUM_TABLE_THREADS = 3;
+  private static final int MAX_QUEUE_SIZE = 5;
+
+  @Test
+  void azureTableThreadPool() {
+    Threading threading = new Threading(NUM_TABLE_THREADS, MAX_QUEUE_SIZE);
+    AzureResourceConfiguration config =
+        new AzureResourceConfiguration(null, null, 0, 0, null, null, threading);
+    AsyncTaskExecutor genericExecutor = config.azureTableThreadpool();
+    assertThat(genericExecutor, instanceOf(ThreadPoolTaskExecutor.class));
+    ThreadPoolTaskExecutor azureTableThreadPool = (ThreadPoolTaskExecutor) genericExecutor;
+    assertThat(azureTableThreadPool.getCorePoolSize(), equalTo(NUM_TABLE_THREADS));
+    assertThat(azureTableThreadPool.getMaxPoolSize(), equalTo(NUM_TABLE_THREADS));
+    assertThat(azureTableThreadPool.getKeepAliveSeconds(), equalTo(0));
+    assertThat(azureTableThreadPool.getQueueCapacity(), equalTo(MAX_QUEUE_SIZE));
+  }
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-442

### Summary

The `application.properties` contains an `azure.threading.numTableThreads` property. This property does not seem to be currently set as an environment variable in https://github.com/broadinstitute/datarepo-helm , https://github.com/broadinstitute/datarepo-helm-definitions , or https://github.com/broadinstitute/terra-helmfile . 

After confirming the above, I next created a new property called `maxQueueSize` to specifically only set the queue capacity. To avoid this size being completely unbounded, I currently set it to 10x the size of `numTableThreads`.

Finally, I also added some basic unit tests which are similar to `drsConfigurationTest` to cover the new functionality.