### PR TITLE
[DCJ-443] Clean up failed partial ingests for Azure

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -285,7 +285,9 @@ public class DatasetIngestFlight extends Flight {
       addStep(
           new IngestValidateScratchTableFilerefsStep(
               azureAuthService, datasetService, azureSynapsePdao, tableDirectoryDao));
-      addStep(new IngestCreateParquetFilesStep(azureSynapsePdao, datasetService));
+      addStep(
+          new IngestCreateParquetFilesStep(
+              azureSynapsePdao, azureBlobStorePdao, datasetService, userReq));
       addStep(new IngestCleanAzureStep(azureSynapsePdao, azureBlobStorePdao, userReq));
       addStep(
           new PerformPayloadIngestStep(

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStep.java
@@ -106,8 +106,7 @@ public class IngestCreateParquetFilesStep implements Step {
     AzureStorageAccountResource storageAccountResource =
         workingMap.get(
             CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
-    String parquetFilePath =
-        FolderType.METADATA.getPath(workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class));
+    String parquetFilePath = workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class);
     azureBlobStorePdao.deleteMetadataParquet(parquetFilePath, storageAccountResource, userRequest);
 
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateScratchParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateScratchParquetFilesStep.java
@@ -82,8 +82,7 @@ public class IngestCreateScratchParquetFilesStep implements Step {
     AzureStorageAccountResource storageAccountResource =
         workingMap.get(
             CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
-    String scratchParquetFile =
-        FolderType.SCRATCH.getPath(workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class));
+    String scratchParquetFile = workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class);
     azureBlobStorePdao.deleteScratchParquet(
         scratchParquetFile, storageAccountResource, userRequest);
 

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateScratchParquetFilesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestCreateScratchParquetFilesStep.java
@@ -82,9 +82,8 @@ public class IngestCreateScratchParquetFilesStep implements Step {
     AzureStorageAccountResource storageAccountResource =
         workingMap.get(
             CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, AzureStorageAccountResource.class);
-    String scratchParquetFile = workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class);
-    azureBlobStorePdao.deleteScratchParquet(
-        scratchParquetFile, storageAccountResource, userRequest);
+    String parquetFilePath = workingMap.get(IngestMapKeys.PARQUET_FILE_PATH, String.class);
+    azureBlobStorePdao.deleteScratchParquet(parquetFilePath, storageAccountResource, userRequest);
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobService.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobService.java
@@ -1,0 +1,44 @@
+package bio.terra.service.filedata.azure.blobstore;
+
+import bio.terra.service.filedata.azure.util.BlobContainerClientFactory;
+import bio.terra.service.filedata.azure.util.BlobCrl;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import com.azure.core.credential.TokenCredential;
+import com.azure.storage.common.policy.RequestRetryOptions;
+import com.azure.storage.common.policy.RetryPolicyType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AzureBlobService {
+  private final AzureResourceConfiguration resourceConfiguration;
+
+  @Autowired
+  public AzureBlobService(AzureResourceConfiguration resourceConfiguration) {
+    this.resourceConfiguration = resourceConfiguration;
+  }
+
+  public RequestRetryOptions getRetryOptions() {
+    return new RequestRetryOptions(
+        RetryPolicyType.EXPONENTIAL,
+        this.resourceConfiguration.maxRetries(),
+        this.resourceConfiguration.retryTimeoutSeconds(),
+        null,
+        null,
+        null);
+  }
+
+  public BlobCrl getBlobCrl(BlobContainerClientFactory destinationClientFactory) {
+    return new BlobCrl(destinationClientFactory);
+  }
+
+  public BlobContainerClientFactory getSourceClientFactory(String url) {
+    return new BlobContainerClientFactory(url, getRetryOptions());
+  }
+
+  public BlobContainerClientFactory getSourceClientFactory(
+      String accountName, TokenCredential azureCredential, String containerName) {
+    return new BlobContainerClientFactory(
+        accountName, azureCredential, containerName, getRetryOptions());
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -36,7 +36,6 @@ import bio.terra.service.resourcemanagement.azure.AzureResourceDao;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
 import bio.terra.service.resourcemanagement.exception.AzureResourceException;
-import com.azure.core.credential.TokenCredential;
 import com.azure.core.util.polling.LongRunningOperationStatus;
 import com.azure.core.util.polling.PollResponse;
 import com.azure.storage.blob.BlobUrlParts;
@@ -44,8 +43,6 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.sas.BlobSasPermission;
-import com.azure.storage.common.policy.RequestRetryOptions;
-import com.azure.storage.common.policy.RetryPolicyType;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import com.google.common.annotations.VisibleForTesting;
@@ -84,6 +81,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
   private final AzureResourceConfiguration resourceConfiguration;
   private final AzureResourceDao azureResourceDao;
   private final AzureAuthService azureAuthService;
+  private final AzureBlobService azureBlobService;
   private final FileIdService fileIdService;
   private final GcsProjectFactory gcsProjectFactory;
   private final GcsPdao gcsPdao;
@@ -95,6 +93,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
       AzureResourceConfiguration resourceConfiguration,
       AzureResourceDao azureResourceDao,
       AzureAuthService azureAuthService,
+      AzureBlobService azureBlobService,
       FileIdService fileIdService,
       GcsProjectFactory gcsProjectFactory,
       GcsPdao gcsPdao) {
@@ -103,19 +102,10 @@ public class AzureBlobStorePdao implements CloudFileReader {
     this.resourceConfiguration = resourceConfiguration;
     this.azureResourceDao = azureResourceDao;
     this.azureAuthService = azureAuthService;
+    this.azureBlobService = azureBlobService;
     this.fileIdService = fileIdService;
     this.gcsProjectFactory = gcsProjectFactory;
     this.gcsPdao = gcsPdao;
-  }
-
-  private RequestRetryOptions getRetryOptions() {
-    return new RequestRetryOptions(
-        RetryPolicyType.EXPONENTIAL,
-        this.resourceConfiguration.maxRetries(),
-        this.resourceConfiguration.retryTimeoutSeconds(),
-        null,
-        null,
-        null);
   }
 
   public FSFileInfo copyFile(
@@ -140,7 +130,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
                     .setWritePermission(true),
                 userRequest.getEmail()));
 
-    BlobCrl blobCrl = getBlobCrl(targetClientFactory);
+    BlobCrl blobCrl = azureBlobService.getBlobCrl(targetClientFactory);
 
     // Read the leaf node of the source file to use as a way to name the file we store
     String fileName = getLastNameFromPath(UriUtils.toUri(fileLoadModel.getSourcePath()).getPath());
@@ -327,10 +317,10 @@ public class AzureBlobStorePdao implements CloudFileReader {
   public BlobContainerClientFactory buildSourceClientFactory(UUID tenantId, String blobUrl) {
     BlobUrlParts blobUrlParts = BlobUrlParts.parse(blobUrl);
     if (isSignedUrl(blobUrlParts)) {
-      return getSourceClientFactory(blobUrl);
+      return azureBlobService.getSourceClientFactory(blobUrl);
     } else {
       // Use application level authentication
-      return getSourceClientFactory(
+      return azureBlobService.getSourceClientFactory(
           blobUrlParts.getAccountName(),
           resourceConfiguration.getAppToken(tenantId),
           blobUrlParts.getBlobContainerName());
@@ -354,7 +344,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
                 new BlobSasPermission().setReadPermission(true).setDeletePermission(true),
                 userRequest.getEmail()));
     String blobName = getBlobName(fileId, fileName);
-    BlobCrl blobCrl = getBlobCrl(destinationClientFactory);
+    BlobCrl blobCrl = azureBlobService.getBlobCrl(destinationClientFactory);
     return blobCrl.deleteBlob(blobName);
   }
 
@@ -382,7 +372,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
               blobParts.getAccountName(), storageAccountResource.getName()));
     }
     String blobName = blobParts.getBlobName();
-    BlobCrl blobCrl = getBlobCrl(destinationClientFactory);
+    BlobCrl blobCrl = azureBlobService.getBlobCrl(destinationClientFactory);
     boolean success = blobCrl.deleteBlob(blobName);
     var parentBlob = Paths.get(blobName).getParent();
     if (parentBlob != null) {
@@ -418,7 +408,7 @@ public class AzureBlobStorePdao implements CloudFileReader {
                 userRequest.getEmail()));
 
     String blobName = blobParts.getBlobName();
-    BlobCrl blobCrl = getBlobCrl(destinationClientFactory);
+    BlobCrl blobCrl = azureBlobService.getBlobCrl(destinationClientFactory);
 
     return blobCrl.deleteBlobsWithPrefix(blobName);
   }
@@ -446,7 +436,8 @@ public class AzureBlobStorePdao implements CloudFileReader {
    */
   public List<String> listChildren(String signedUrl) {
     var blobName = BlobUrlParts.parse(signedUrl).getBlobName();
-    return getSourceClientFactory(signedUrl)
+    return azureBlobService
+        .getSourceClientFactory(signedUrl)
         .getBlobContainerClient()
         // List children of the parquet directory
         .listBlobs(new ListBlobsOptions().setPrefix(blobName + "/"), Duration.ofMinutes(5))
@@ -513,10 +504,11 @@ public class AzureBlobStorePdao implements CloudFileReader {
       AzureStorageAccountResource storageAccountResource,
       BlobSasTokenOptions blobSasTokenOptions) {
 
-    return new BlobContainerClientFactory(
+    String signedUrl =
         azureContainerPdao.getDestinationContainerSignedUrl(
-            profileModel, storageAccountResource, blobSasTokenOptions),
-        getRetryOptions());
+            profileModel, storageAccountResource, blobSasTokenOptions);
+
+    return azureBlobService.getSourceClientFactory(signedUrl);
   }
 
   public BlobUrlParts getOrSignUrlForSourceFactory(
@@ -581,23 +573,6 @@ public class AzureBlobStorePdao implements CloudFileReader {
     return AzureUriUtils.getUriFromBlobUrlParts(
         BlobUrlParts.parse(
             targetDataClientFactory.getBlobSasUrlFactory().createSasUrlForBlob(blobName, options)));
-  }
-
-  @VisibleForTesting
-  BlobCrl getBlobCrl(BlobContainerClientFactory destinationClientFactory) {
-    return new BlobCrl(destinationClientFactory);
-  }
-
-  @VisibleForTesting
-  BlobContainerClientFactory getSourceClientFactory(String url) {
-    return new BlobContainerClientFactory(url, getRetryOptions());
-  }
-
-  @VisibleForTesting
-  BlobContainerClientFactory getSourceClientFactory(
-      String accountName, TokenCredential azureCredential, String containerName) {
-    return new BlobContainerClientFactory(
-        accountName, azureCredential, containerName, getRetryOptions());
   }
 
   /** Detects if a URL is a signed URL */

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -390,7 +390,10 @@ public class AzureBlobStorePdao implements CloudFileReader {
       AuthenticatedUserRequest userRequest) {
     String blobUrl =
         String.format(
-            "%s/%s", storageAccountResource.getStorageAccountUrl(), folderType.getPath(blobPath));
+            "%s/%s/%s",
+            storageAccountResource.getStorageAccountUrl(),
+            storageAccountResource.getTopLevelContainer(),
+            folderType.getPath(blobPath));
     BlobUrlParts blobParts = BlobUrlParts.parse(blobUrl);
 
     BillingProfileModel profileModel =

--- a/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdao.java
@@ -393,15 +393,14 @@ public class AzureBlobStorePdao implements CloudFileReader {
     return success;
   }
 
-  public boolean deleteScratchParquet(
+  public boolean deleteBlobParquet(
+      FolderType folderType,
       String blobPath,
       AzureStorageAccountResource storageAccountResource,
       AuthenticatedUserRequest userRequest) {
-
     String blobUrl =
         String.format(
-            "%s/%s",
-            storageAccountResource.getStorageAccountUrl(), FolderType.SCRATCH.getPath(blobPath));
+            "%s/%s", storageAccountResource.getStorageAccountUrl(), folderType.getPath(blobPath));
     BlobUrlParts blobParts = BlobUrlParts.parse(blobUrl);
 
     BillingProfileModel profileModel =
@@ -422,6 +421,22 @@ public class AzureBlobStorePdao implements CloudFileReader {
     BlobCrl blobCrl = getBlobCrl(destinationClientFactory);
 
     return blobCrl.deleteBlobsWithPrefix(blobName);
+  }
+
+  public boolean deleteScratchParquet(
+      String blobPath,
+      AzureStorageAccountResource storageAccountResource,
+      AuthenticatedUserRequest userRequest) {
+
+    return deleteBlobParquet(FolderType.SCRATCH, blobPath, storageAccountResource, userRequest);
+  }
+
+  public boolean deleteMetadataParquet(
+      String blobPath,
+      AzureStorageAccountResource storageAccountResource,
+      AuthenticatedUserRequest userRequest) {
+
+    return deleteBlobParquet(FolderType.METADATA, blobPath, storageAccountResource, userRequest);
   }
 
   /**

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
@@ -11,6 +11,7 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BulkLoadArrayResultModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestRequestModel.FormatEnum;
+import bio.terra.model.IngestResponseModel;
 import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
@@ -145,14 +146,21 @@ class IngestCreateParquetFilesStepTest {
     flightMap.put(IngestMapKeys.COMBINED_FAILED_ROW_COUNT, 10);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    IngestResponseModel ingestResponse =
+        flightMap.get(JobMapKeys.RESPONSE.getKeyName(), IngestResponseModel.class);
+    assertThat(ingestResponse.getBadRowCount(), equalTo(10L));
   }
 
   @Test
   void testDoStepWithCombinedFileIngest() throws InterruptedException {
+    BulkLoadArrayResultModel bulkLoadArrayResultModel = new BulkLoadArrayResultModel();
     flightMap.put(IngestMapKeys.NUM_BULK_LOAD_FILE_MODELS, 1);
-    flightMap.put(IngestMapKeys.BULK_LOAD_RESULT, new BulkLoadArrayResultModel());
+    flightMap.put(IngestMapKeys.BULK_LOAD_RESULT, bulkLoadArrayResultModel);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    IngestResponseModel ingestResponse =
+        flightMap.get(JobMapKeys.RESPONSE.getKeyName(), IngestResponseModel.class);
+    assertThat(ingestResponse.getLoadResult(), equalTo(bulkLoadArrayResultModel));
   }
 
   @Test
@@ -166,5 +174,8 @@ class IngestCreateParquetFilesStepTest {
     inputParameters.put(JobMapKeys.REQUEST.getKeyName(), ingestRequestModel);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    IngestResponseModel ingestResponse =
+        flightMap.get(JobMapKeys.RESPONSE.getKeyName(), IngestResponseModel.class);
+    assertThat(ingestResponse.getPath(), equalTo(null));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
@@ -48,6 +48,7 @@ class IngestCreateParquetFilesStepTest {
       AuthenticationFixtures.randomUserRequest();
   private IngestCreateParquetFilesStep step;
   private FlightMap flightMap;
+  private FlightMap inputParameters;
 
   private static final String FLIGHT_ID = "flightId";
   private static final UUID DATASET_ID = UUID.randomUUID();
@@ -80,14 +81,16 @@ class IngestCreateParquetFilesStepTest {
         new AzureStorageAccountResource().applicationResource(applicationResource);
 
     flightMap = new FlightMap();
-    flightMap.put(JobMapKeys.DATASET_ID.getKeyName(), DATASET_ID.toString());
     flightMap.put(IngestMapKeys.PARQUET_FILE_PATH, PARQUET_FILE_PATH);
-    flightMap.put(JobMapKeys.REQUEST.getKeyName(), ingestRequestModel);
     flightMap.put(IngestMapKeys.AZURE_ROWS_FAILED_VALIDATION, 0);
     flightMap.put(CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, storageAccountResource);
 
+    inputParameters = new FlightMap();
+    inputParameters.put(JobMapKeys.DATASET_ID.getKeyName(), DATASET_ID.toString());
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), ingestRequestModel);
+
     when(flightContext.getWorkingMap()).thenReturn(flightMap);
-    when(flightContext.getInputParameters()).thenReturn(flightMap);
+    when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getFlightId()).thenReturn(FLIGHT_ID);
     when(datasetService.retrieve(DATASET_ID)).thenReturn(dataset);
   }
@@ -134,7 +137,7 @@ class IngestCreateParquetFilesStepTest {
             .table(DATASET_TABLE_NAME)
             .path(PARQUET_FILE_PATH)
             .format(FormatEnum.ARRAY);
-    flightMap.put(JobMapKeys.REQUEST.getKeyName(), ingestRequestModel);
+    inputParameters.put(JobMapKeys.REQUEST.getKeyName(), ingestRequestModel);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
   }

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
@@ -1,0 +1,141 @@
+package bio.terra.service.dataset.flight.ingest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.BulkLoadArrayResultModel;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.model.IngestRequestModel.FormatEnum;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.filedata.azure.AzureSynapsePdao;
+import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class IngestCreateParquetFilesStepTest {
+  @Mock private AzureSynapsePdao azureSynapsePdao;
+  @Mock private AzureBlobStorePdao azureBlobStorePdao;
+  @Mock private DatasetService datasetService;
+
+  @Mock private FlightContext flightContext;
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private IngestCreateParquetFilesStep step;
+  private FlightMap flightMap;
+
+  private static final String FLIGHT_ID = "flightId";
+  private static final UUID DATASET_ID = UUID.randomUUID();
+  private static final String PARQUET_FILE_PATH = "parquetFilePath";
+  private static final String DATASET_TABLE_NAME = "datasetTableName";
+
+  private static final UUID SUBSCRIPTION_ID = UUID.randomUUID();
+  private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+  private static final String APPLICATION_DEPLOYMENT_ID =
+      String.format("subscriptions/%s/resourceGroups/%s", SUBSCRIPTION_ID, RESOURCE_GROUP_NAME);
+
+  @BeforeEach
+  public void setup() {
+    step =
+        new IngestCreateParquetFilesStep(
+            azureSynapsePdao, azureBlobStorePdao, datasetService, TEST_USER);
+
+    IngestRequestModel ingestRequestModel =
+        new IngestRequestModel()
+            .table(DATASET_TABLE_NAME)
+            .path(PARQUET_FILE_PATH)
+            .format(FormatEnum.CSV);
+    DatasetTable datasetTable = new DatasetTable().name(DATASET_TABLE_NAME);
+    Dataset dataset =
+        new Dataset().name(DATASET_ID.toString()).id(DATASET_ID).tables(List.of(datasetTable));
+    AzureApplicationDeploymentResource applicationResource =
+        new AzureApplicationDeploymentResource()
+            .azureApplicationDeploymentId(APPLICATION_DEPLOYMENT_ID);
+    AzureStorageAccountResource storageAccountResource =
+        new AzureStorageAccountResource().applicationResource(applicationResource);
+
+    flightMap = new FlightMap();
+    flightMap.put(JobMapKeys.DATASET_ID.getKeyName(), DATASET_ID.toString());
+    flightMap.put(IngestMapKeys.PARQUET_FILE_PATH, PARQUET_FILE_PATH);
+    flightMap.put(JobMapKeys.REQUEST.getKeyName(), ingestRequestModel);
+    flightMap.put(IngestMapKeys.AZURE_ROWS_FAILED_VALIDATION, 0);
+    flightMap.put(CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE, storageAccountResource);
+
+    when(flightContext.getWorkingMap()).thenReturn(flightMap);
+    when(flightContext.getInputParameters()).thenReturn(flightMap);
+    when(flightContext.getFlightId()).thenReturn(FLIGHT_ID);
+    when(datasetService.retrieve(DATASET_ID)).thenReturn(dataset);
+  }
+
+  @Test
+  void testDoAndUndoStepSuccess() throws InterruptedException, SQLException {
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(azureSynapsePdao).createFinalParquetFiles(any(), any(), any(), any(), any());
+    StepResult undoResult = step.undoStep(flightContext);
+    verify(azureSynapsePdao).dropTables(any());
+    verify(azureBlobStorePdao).deleteMetadataParquet(any(), any(), any());
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void testDoStepSQLException() throws InterruptedException, SQLException {
+    when(azureSynapsePdao.createFinalParquetFiles(any(), any(), any(), any(), any()))
+        .thenThrow(SQLException.class);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void testDoStepWithCombinedFailedRowCount() throws InterruptedException {
+    flightMap.put(IngestMapKeys.COMBINED_FAILED_ROW_COUNT, 10);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void testDoStepWithCombinedFileIngest() throws InterruptedException {
+    flightMap.put(IngestMapKeys.NUM_BULK_LOAD_FILE_MODELS, 1);
+    flightMap.put(IngestMapKeys.BULK_LOAD_RESULT, new BulkLoadArrayResultModel());
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void testDoStepWithPayloadIngest() throws InterruptedException {
+    // Override the IngestRequestModel using the ARRAY format
+    IngestRequestModel ingestRequestModel =
+        new IngestRequestModel()
+            .table(DATASET_TABLE_NAME)
+            .path(PARQUET_FILE_PATH)
+            .format(FormatEnum.ARRAY);
+    flightMap.put(JobMapKeys.REQUEST.getKeyName(), ingestRequestModel);
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
@@ -119,7 +119,7 @@ class IngestCreateParquetFilesStepTest {
     StepResult undoResult = step.undoStep(flightContext);
     verify(azureSynapsePdao).dropTables(dropTables);
     verify(azureBlobStorePdao)
-        .deleteMetadataParquet(parquetFilePath, storageAccountResource, TEST_USER);
+        .deleteMetadataParquet(PARQUET_FILE_PATH, storageAccountResource, TEST_USER);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
   }
 

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobServiceTest.java
@@ -1,0 +1,98 @@
+package bio.terra.service.filedata.azure.blobstore;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.filedata.azure.util.BlobContainerClientFactory;
+import bio.terra.service.filedata.azure.util.BlobCrl;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.common.policy.RequestRetryOptions;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class AzureBlobServiceTest {
+  @Mock private AzureResourceConfiguration resourceConfiguration;
+
+  private static final int MAX_RETRIES = 2;
+  private static final int RETRY_TIMEOUT_SECONDS = 5;
+
+  private static final String ACCOUNT_NAME = "accountName";
+  private static final String CONTAINER_NAME = "containerName";
+  private static final String BLOB_NAME = "blobName";
+  private static final String STORAGE_URL =
+      "https://%s.blob.core.windows.net/%s".formatted(ACCOUNT_NAME, CONTAINER_NAME);
+  private static final String SIGNED_URL =
+      "https://%s.blob.core.windows.net/%s/%s?sig=SIGNATURE"
+          .formatted(ACCOUNT_NAME, CONTAINER_NAME, BLOB_NAME);
+
+  private AzureBlobService azureBlobService;
+
+  @BeforeEach
+  public void setup() {
+    azureBlobService = new AzureBlobService(resourceConfiguration);
+    when(resourceConfiguration.maxRetries()).thenReturn(MAX_RETRIES);
+    when(resourceConfiguration.retryTimeoutSeconds()).thenReturn(RETRY_TIMEOUT_SECONDS);
+  }
+
+  @Test
+  public void testGetRetryOptions() {
+    RequestRetryOptions requestRetryOptions = azureBlobService.getRetryOptions();
+
+    Duration expectedTimeout = Duration.ofSeconds(RETRY_TIMEOUT_SECONDS);
+    assertThat(requestRetryOptions.getMaxTries(), equalTo(MAX_RETRIES));
+    assertThat(requestRetryOptions.getTryTimeoutDuration(), equalTo(expectedTimeout));
+  }
+
+  @Test
+  public void testGetBlobCrl() {
+    RequestRetryOptions retryOptions = azureBlobService.getRetryOptions();
+
+    BlobContainerClientFactory destinationClientFactory =
+        new BlobContainerClientFactory(SIGNED_URL, retryOptions);
+    BlobCrl blobCrl = azureBlobService.getBlobCrl(destinationClientFactory);
+
+    assertNotNull(blobCrl);
+  }
+
+  @Test
+  public void testGetSourceClientFactory() {
+    BlobContainerClientFactory blobContainerClientFactory =
+        azureBlobService.getSourceClientFactory(SIGNED_URL);
+    BlobContainerClient blobContainerClient = blobContainerClientFactory.getBlobContainerClient();
+
+    assertThat(blobContainerClient.getAccountName(), equalTo(ACCOUNT_NAME));
+    assertThat(blobContainerClient.getBlobContainerUrl(), equalTo(STORAGE_URL));
+    assertThat(blobContainerClient.getBlobContainerName(), equalTo(CONTAINER_NAME));
+  }
+
+  @Test
+  public void testGetSourceClientFactoryWithCredential() {
+    TokenCredential azureCredential =
+        new ClientSecretCredentialBuilder()
+            .clientId("clientId")
+            .clientSecret("clientSecret")
+            .tenantId("tenantId")
+            .build();
+
+    BlobContainerClientFactory blobContainerClientFactory =
+        azureBlobService.getSourceClientFactory(ACCOUNT_NAME, azureCredential, CONTAINER_NAME);
+    BlobContainerClient blobContainerClient = blobContainerClientFactory.getBlobContainerClient();
+
+    assertThat(blobContainerClient.getAccountName(), equalTo(ACCOUNT_NAME));
+    assertThat(blobContainerClient.getBlobContainerUrl(), equalTo(STORAGE_URL));
+    assertThat(blobContainerClient.getBlobContainerName(), equalTo(CONTAINER_NAME));
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobServiceTest.java
@@ -41,14 +41,14 @@ class AzureBlobServiceTest {
   private AzureBlobService azureBlobService;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     azureBlobService = new AzureBlobService(resourceConfiguration);
     when(resourceConfiguration.maxRetries()).thenReturn(MAX_RETRIES);
     when(resourceConfiguration.retryTimeoutSeconds()).thenReturn(RETRY_TIMEOUT_SECONDS);
   }
 
   @Test
-  public void testGetRetryOptions() {
+  void testGetRetryOptions() {
     RequestRetryOptions requestRetryOptions = azureBlobService.getRetryOptions();
 
     Duration expectedTimeout = Duration.ofSeconds(RETRY_TIMEOUT_SECONDS);
@@ -57,7 +57,7 @@ class AzureBlobServiceTest {
   }
 
   @Test
-  public void testGetBlobCrl() {
+  void testGetBlobCrl() {
     RequestRetryOptions retryOptions = azureBlobService.getRetryOptions();
 
     BlobContainerClientFactory destinationClientFactory =
@@ -68,7 +68,7 @@ class AzureBlobServiceTest {
   }
 
   @Test
-  public void testGetSourceClientFactory() {
+  void testGetSourceClientFactory() {
     BlobContainerClientFactory blobContainerClientFactory =
         azureBlobService.getSourceClientFactory(SIGNED_URL);
     BlobContainerClient blobContainerClient = blobContainerClientFactory.getBlobContainerClient();
@@ -79,7 +79,7 @@ class AzureBlobServiceTest {
   }
 
   @Test
-  public void testGetSourceClientFactoryWithCredential() {
+  void testGetSourceClientFactoryWithCredential() {
     TokenCredential azureCredential =
         new ClientSecretCredentialBuilder()
             .clientId("clientId")

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -124,6 +124,7 @@ public class AzureBlobStorePdaoTest {
   @MockBean private AzureAuthService azureAuthService;
   @MockBean private GcsPdao gcsPdao;
   @MockBean private GcsProjectFactory gcsProjectFactory;
+  @MockBean private AzureBlobService azureBlobService;
 
   @MockBean(name = "azureTableThreadpool")
   private AsyncTaskExecutor asyncTaskExecutor;
@@ -160,10 +161,10 @@ public class AzureBlobStorePdaoTest {
     blobCrl = mock(BlobCrl.class);
     doReturn(targetBlobContainerFactory).when(dao).getTargetDataClientFactory(any(), any(), any());
     doReturn(sourceBlobContainerFactory)
-        .when(dao)
+        .when(azureBlobService)
         .getSourceClientFactory(anyString(), any(), anyString());
-    doReturn(sourceBlobContainerFactory).when(dao).getSourceClientFactory(any());
-    doReturn(blobCrl).when(dao).getBlobCrl(any());
+    doReturn(sourceBlobContainerFactory).when(azureBlobService).getSourceClientFactory(any());
+    doReturn(blobCrl).when(azureBlobService).getBlobCrl(any());
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -160,11 +160,10 @@ public class AzureBlobStorePdaoTest {
     sourceBlobContainerFactory = mock(BlobContainerClientFactory.class);
     blobCrl = mock(BlobCrl.class);
     doReturn(targetBlobContainerFactory).when(dao).getTargetDataClientFactory(any(), any(), any());
-    doReturn(sourceBlobContainerFactory)
-        .when(azureBlobService)
-        .getSourceClientFactory(anyString(), any(), anyString());
-    doReturn(sourceBlobContainerFactory).when(azureBlobService).getSourceClientFactory(any());
-    doReturn(blobCrl).when(azureBlobService).getBlobCrl(any());
+    when(azureBlobService.getSourceClientFactory(anyString(), any(), anyString()))
+        .thenReturn(sourceBlobContainerFactory);
+    when(azureBlobService.getSourceClientFactory(any())).thenReturn(sourceBlobContainerFactory);
+    when(azureBlobService.getBlobCrl(any())).thenReturn(blobCrl);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoUnitTest.java
@@ -81,43 +81,48 @@ class AzureBlobStorePdaoUnitTest {
         new AzureStorageAccountResource()
             .applicationResource(applicationDeploymentResource)
             .name("storageAccountResourceName")
+            .topLevelContainer("containerId")
             .profileId(BILLING_PROFILE_ID);
   }
 
-  void mocksForDeleteBlobParquet() {
+  void mocksForDeleteBlobParquet(FolderType folderType, String blobPath) {
     when(profileDao.getBillingProfileById(BILLING_PROFILE_ID)).thenReturn(billingProfileModel);
     when(azureContainerPdao.getDestinationContainerSignedUrl(any(), any(), any()))
         .thenReturn(SIGNED_URL);
 
     BlobCrl blobCrl = mock(BlobCrl.class);
     when(azureBlobService.getBlobCrl(any())).thenReturn(blobCrl);
-    when(blobCrl.deleteBlobsWithPrefix(any())).thenReturn(true);
+    when(blobCrl.deleteBlobsWithPrefix(folderType.getPath(blobPath))).thenReturn(true);
   }
 
   @Test
   void testDeleteBlobParquet() {
-    mocksForDeleteBlobParquet();
+    FolderType folderType = FolderType.DATA;
+    String blobPath = "parquetBlobPath";
+    mocksForDeleteBlobParquet(folderType, blobPath);
     boolean result =
         azureBlobStorePdao.deleteBlobParquet(
-            FolderType.SCRATCH, "parquetBlobPath", storageAccountResource, TEST_USER);
+            folderType, blobPath, storageAccountResource, TEST_USER);
     assertTrue(result);
   }
 
   @Test
   void testDeleteScratchParquet() {
-    mocksForDeleteBlobParquet();
+    FolderType folderType = FolderType.SCRATCH;
+    String blobPath = folderType.getPath("parquetScratchPath");
+    mocksForDeleteBlobParquet(folderType, blobPath);
     boolean result =
-        azureBlobStorePdao.deleteScratchParquet(
-            "parquetScratchPath", storageAccountResource, TEST_USER);
+        azureBlobStorePdao.deleteScratchParquet(blobPath, storageAccountResource, TEST_USER);
     assertTrue(result);
   }
 
   @Test
   void testDeleteMetadataParquet() {
-    mocksForDeleteBlobParquet();
+    FolderType folderType = FolderType.METADATA;
+    String blobPath = folderType.getPath("parquetMetadataPath");
+    mocksForDeleteBlobParquet(folderType, blobPath);
     boolean result =
-        azureBlobStorePdao.deleteMetadataParquet(
-            "parquetMetadataPath", storageAccountResource, TEST_USER);
+        azureBlobStorePdao.deleteMetadataParquet(blobPath, storageAccountResource, TEST_USER);
     assertTrue(result);
   }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoUnitTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.filedata.azure.blobstore;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -87,7 +88,8 @@ class AzureBlobStorePdaoUnitTest {
 
   void mocksForDeleteBlobParquet(FolderType folderType, String blobPath) {
     when(profileDao.getBillingProfileById(BILLING_PROFILE_ID)).thenReturn(billingProfileModel);
-    when(azureContainerPdao.getDestinationContainerSignedUrl(any(), any(), any()))
+    when(azureContainerPdao.getDestinationContainerSignedUrl(
+            eq(billingProfileModel), eq(storageAccountResource), any()))
         .thenReturn(SIGNED_URL);
 
     BlobCrl blobCrl = mock(BlobCrl.class);

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoUnitTest.java
@@ -59,7 +59,7 @@ class AzureBlobStorePdaoUnitTest {
   private AzureBlobStorePdao azureBlobStorePdao;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     billingProfileModel = new BillingProfileModel().id(BILLING_PROFILE_ID);
     azureBlobStorePdao =
         new AzureBlobStorePdao(
@@ -84,7 +84,7 @@ class AzureBlobStorePdaoUnitTest {
             .profileId(BILLING_PROFILE_ID);
   }
 
-  private void mocksForDeleteBlobParquet() {
+  void mocksForDeleteBlobParquet() {
     when(profileDao.getBillingProfileById(BILLING_PROFILE_ID)).thenReturn(billingProfileModel);
     when(azureContainerPdao.getDestinationContainerSignedUrl(any(), any(), any()))
         .thenReturn(SIGNED_URL);
@@ -95,7 +95,7 @@ class AzureBlobStorePdaoUnitTest {
   }
 
   @Test
-  public void testDeleteBlobParquet() {
+  void testDeleteBlobParquet() {
     mocksForDeleteBlobParquet();
     boolean result =
         azureBlobStorePdao.deleteBlobParquet(
@@ -104,7 +104,7 @@ class AzureBlobStorePdaoUnitTest {
   }
 
   @Test
-  public void testDeleteScratchParquet() {
+  void testDeleteScratchParquet() {
     mocksForDeleteBlobParquet();
     boolean result =
         azureBlobStorePdao.deleteScratchParquet(
@@ -113,7 +113,7 @@ class AzureBlobStorePdaoUnitTest {
   }
 
   @Test
-  public void testDeleteMetadataParquet() {
+  void testDeleteMetadataParquet() {
     mocksForDeleteBlobParquet();
     boolean result =
         azureBlobStorePdao.deleteMetadataParquet(

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoUnitTest.java
@@ -1,0 +1,123 @@
+package bio.terra.service.filedata.azure.blobstore;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.service.filedata.FileIdService;
+import bio.terra.service.filedata.azure.util.BlobCrl;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.filedata.google.gcs.GcsProjectFactory;
+import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.resourcemanagement.azure.AzureApplicationDeploymentResource;
+import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.azure.AzureContainerPdao;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
+import bio.terra.service.resourcemanagement.azure.AzureResourceDao;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAccountResource.FolderType;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class AzureBlobStorePdaoUnitTest {
+  @Mock private ProfileDao profileDao;
+  @Mock private AzureContainerPdao azureContainerPdao;
+  @Mock private AzureResourceConfiguration azureResourceConfiguration;
+  @Mock private AzureResourceDao azureResourceDao;
+  @Mock private AzureAuthService azureAuthService;
+  @Mock private AzureBlobService azureBlobService;
+  @Mock private FileIdService fileIdService;
+  @Mock private GcsProjectFactory gcsProjectFactory;
+  @Mock private GcsPdao gcsPdao;
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+
+  private static final UUID BILLING_PROFILE_ID = UUID.randomUUID();
+  private static final UUID SUBSCRIPTION_ID = UUID.randomUUID();
+  private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+  private static final String APPLICATION_DEPLOYMENT_ID =
+      String.format("subscriptions/%s/resourceGroups/%s", SUBSCRIPTION_ID, RESOURCE_GROUP_NAME);
+  private static final String SIGNED_URL =
+      "https://signedUrl.blob.core.windows.net/uuid/blobPath?sig=SIGNATURE";
+
+  private BillingProfileModel billingProfileModel;
+  private AzureApplicationDeploymentResource applicationDeploymentResource;
+  private AzureStorageAccountResource storageAccountResource;
+  private AzureBlobStorePdao azureBlobStorePdao;
+
+  @BeforeEach
+  public void setup() {
+    billingProfileModel = new BillingProfileModel().id(BILLING_PROFILE_ID);
+    azureBlobStorePdao =
+        new AzureBlobStorePdao(
+            profileDao,
+            azureContainerPdao,
+            azureResourceConfiguration,
+            azureResourceDao,
+            azureAuthService,
+            azureBlobService,
+            fileIdService,
+            gcsProjectFactory,
+            gcsPdao);
+
+    applicationDeploymentResource =
+        new AzureApplicationDeploymentResource()
+            .azureApplicationDeploymentId(APPLICATION_DEPLOYMENT_ID)
+            .azureResourceGroupName(RESOURCE_GROUP_NAME);
+    storageAccountResource =
+        new AzureStorageAccountResource()
+            .applicationResource(applicationDeploymentResource)
+            .name("storageAccountResourceName")
+            .profileId(BILLING_PROFILE_ID);
+  }
+
+  private void mocksForDeleteBlobParquet() {
+    when(profileDao.getBillingProfileById(BILLING_PROFILE_ID)).thenReturn(billingProfileModel);
+    when(azureContainerPdao.getDestinationContainerSignedUrl(any(), any(), any()))
+        .thenReturn(SIGNED_URL);
+
+    BlobCrl blobCrl = mock(BlobCrl.class);
+    when(azureBlobService.getBlobCrl(any())).thenReturn(blobCrl);
+    when(blobCrl.deleteBlobsWithPrefix(any())).thenReturn(true);
+  }
+
+  @Test
+  public void testDeleteBlobParquet() {
+    mocksForDeleteBlobParquet();
+    boolean result =
+        azureBlobStorePdao.deleteBlobParquet(
+            FolderType.SCRATCH, "parquetBlobPath", storageAccountResource, TEST_USER);
+    assertTrue(result);
+  }
+
+  @Test
+  public void testDeleteScratchParquet() {
+    mocksForDeleteBlobParquet();
+    boolean result =
+        azureBlobStorePdao.deleteScratchParquet(
+            "parquetScratchPath", storageAccountResource, TEST_USER);
+    assertTrue(result);
+  }
+
+  @Test
+  public void testDeleteMetadataParquet() {
+    mocksForDeleteBlobParquet();
+    boolean result =
+        azureBlobStorePdao.deleteMetadataParquet(
+            "parquetMetadataPath", storageAccountResource, TEST_USER);
+    assertTrue(result);
+  }
+}


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DCJ-443

## Summary

Cleans up failed partial ingests for Azure

## Testing strategy

Unit testing with full coverage and manually.

### Failure

1. In `IngestCreateParquetFilesStep.doStep`, return `new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL);` instead of returning `StepResult.getStepResultSuccess();` to force trigger the `undoStep`
2. `bootRun` a local Terra Data Repo and place a breakpoint on the `return StepResult.getStepResultSuccess();` in the `undoStep`
3. Create an Azure billing profile, Azure dataset, and ingest test data in the local instance. I did this by writing a script which automatically selects a billing profile based on the cloud and creates the appropriate dataset, test data, and ingests the data.
4. Verify that the breakpoint is ultimately hit in the `undoStep` after running the `doStep`, and that the expected variables are loaded.
5. Verify that the table metadata directories are empty in the Azure storage container corresponding to the dataset.

### Success

1. Ensure that the `IngestCreateParquetFilesStep.doStep` returns `StepResult.getStepResultSuccess();`
2. Repeat step 2 from earlier
3. Repeat step 3 from earlier
4. Verify that the breakpoint is NOT hit as the ingest completes successfully.
5. Verify that the table metadata directories are not empty in the Azure storage container corresponding to the dataset.