### PR TITLE
DCJ-453: Use GH secrets instead of vault

### DIFF
--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -1,3 +1,6 @@
+# Note that this action is called from the UI build process:
+# https://github.com/DataBiosphere/jade-data-repo-ui/blob/develop/.github/workflows/dev-image-update.yaml#L95
+# Changes merged here require a version bump in that action.
 name: cherry-pick-image
 on:
   workflow_call:

--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -30,21 +30,12 @@ jobs:
   cherry-pick-image:
     runs-on: ubuntu-latest
     steps:
-      - name: "Import Vault Secrets for GCR Service Account"
-        uses: hashicorp/vault-action@v2.5.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.ROLE_ID }}
-          secretId: ${{ secrets.SECRET_ID }}
-          secrets: |
-            secret/dsde/datarepo/dev/gcr-sa-b64 key | B64_APPLICATION_CREDENTIALS ;
       - name: "Authenticate with GCR SA Credentials"
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
         run: |
-          # write vault tokens
-          base64 --decode <<< ${B64_APPLICATION_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          # write token
+          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
 
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Perform cherry-pick"

--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -1,3 +1,6 @@
+# Note that this action is called from the UI build process:
+# https://github.com/DataBiosphere/jade-data-repo-ui/blob/develop/.github/workflows/dev-image-update.yaml#L95
+# Changes merged here require a version bump in that action.
 name: cherry-pick-image
 on:
   workflow_call:
@@ -30,21 +33,12 @@ jobs:
   cherry-pick-image:
     runs-on: ubuntu-latest
     steps:
-      - name: "Import Vault Secrets for GCR Service Account"
-        uses: hashicorp/vault-action@v2.5.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.ROLE_ID }}
-          secretId: ${{ secrets.SECRET_ID }}
-          secrets: |
-            secret/dsde/datarepo/dev/gcr-sa-b64 key | B64_APPLICATION_CREDENTIALS ;
       - name: "Authenticate with GCR SA Credentials"
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
         run: |
-          # write vault tokens
-          base64 --decode <<< ${B64_APPLICATION_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          # write token
+          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
 
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Perform cherry-pick"

--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -1,6 +1,3 @@
-# Note that this action is called from the UI build process:
-# https://github.com/DataBiosphere/jade-data-repo-ui/blob/develop/.github/workflows/dev-image-update.yaml#L95
-# Changes merged here require a version bump in that action.
 name: cherry-pick-image
 on:
   workflow_call:
@@ -33,12 +30,21 @@ jobs:
   cherry-pick-image:
     runs-on: ubuntu-latest
     steps:
+      - name: "Import Vault Secrets for GCR Service Account"
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.ROLE_ID }}
+          secretId: ${{ secrets.SECRET_ID }}
+          secrets: |
+            secret/dsde/datarepo/dev/gcr-sa-b64 key | B64_APPLICATION_CREDENTIALS ;
       - name: "Authenticate with GCR SA Credentials"
         env:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
         run: |
-          # write token
-          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          # write vault tokens
+          base64 --decode <<< ${B64_APPLICATION_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
 
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Perform cherry-pick"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -34,7 +34,7 @@ on:
       - '**.gradle'
       - 'Dockerfile'
       - 'datarepo-clienttests/**'
-      - '.github/workflows/int-and-connected-test-run.yml'
+      - '.github/workflows/**'
       - '.swagger-codegen-ignore'
   workflow_dispatch: {}
   schedule:

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -45,39 +45,21 @@ jobs:
         run: |
           git checkout ${{ steps.configuration.outputs.staging_version }}
           echo "Current branch is ${{ github.ref }}"
-      - name: "Import Vault staging secrets"
-        uses: hashicorp/vault-action@v2.5.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.STAGING_ROLE_ID }}
-          secretId: ${{ secrets.STAGING_SECRET_ID }}
-          secrets: |
-            secret/dsde/datarepo/staging/test-runner-sa key | B64_APPLICATION_CREDENTIALS ;
       - name: "Perform IAM policy cleanup for staging"
         run: |
-          # write vault tokens
-          base64 --decode <<< ${B64_APPLICATION_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          # write token
+          base64 --decode <<< ${{ secrets.TEST_RUNNER_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
 
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
 
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
-      - name: "Import Vault dev secrets"
-        uses: hashicorp/vault-action@v2.5.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.ROLE_ID }}
-          secretId: ${{ secrets.SECRET_ID }}
-          secrets: |
-            secret/dsde/datarepo/dev/sa-key-b64 sa | B64_APPLICATION_CREDENTIALS ;
       - name: "Add jade-k8-sa credentials to run as Harry Potter test users"
         env:
           # note: hack to overwrite the env var to grab the dev credentials too
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/jade-dev-account.json
         run: |
-          # write vault tokens
-          base64 --decode <<< ${B64_APPLICATION_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          # write token
+          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Build and run Test Runner"
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DCJ-453

## Summary
This PR moves two actions off of using a vault action to get secret values from Broad's local vault instance. Instead, these secrets have been migrated to GH secrets for easier management.

