### PR TITLE
[DC-1128] Generate snapshot name if byRequestId

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -180,15 +180,17 @@ public class SnapshotService {
       String snapshotAccessRequestName =
           Optional.ofNullable(snapshotAccessRequestResponse.getSnapshotName()).orElse("");
 
-      // We take the first 474 characters of the name, because the UUID is 36 characters long, so
-      // the name is 474 characters + the underscore + 36 characters for the UUID, totalling to a
-      // max of 511.
-      String generatedName =
-          String.format(
-              "%s_%s",
-              snapshotAccessRequestName.substring(
-                  0, Math.min(473, snapshotAccessRequestName.length())),
-              snapshotAccessRequestResponse.getId().toString());
+      String cleanedId = snapshotAccessRequestResponse.getId().toString().replace('-', '_');
+      String cleanedName =
+          StringUtils.truncate(
+              snapshotAccessRequestName
+                  .replaceAll(dashesAndSpacesRegex, "_")
+                  .replaceAll(nonAlphaNumericRegex, "")
+                  .trim(),
+              511 - 1 - cleanedId.length());
+      String separator = cleanedName.length() > 0 ? "_" : "";
+
+      String generatedName = String.format("%s%s%s", cleanedName, separator, cleanedId);
 
       return StringUtils.strip(
           generatedName

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -120,6 +120,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SnapshotService {
   private static final Logger logger = LoggerFactory.getLogger(SnapshotService.class);
+  private static final int SNAPSHOT_NAME_MAX_LENGTH = 511;
   private final JobService jobService;
   private final DatasetService datasetService;
   private final FireStoreDependencyDao dependencyDao;
@@ -187,7 +188,7 @@ public class SnapshotService {
                   .replaceAll(dashesAndSpacesRegex, "_")
                   .replaceAll(nonAlphaNumericRegex, "")
                   .trim(),
-              511 - 1 - cleanedId.length());
+              SNAPSHOT_NAME_MAX_LENGTH - 1 - cleanedId.length());
       String separator = cleanedName.length() > 0 ? "_" : "";
 
       String generatedName = String.format("%s%s%s", cleanedName, separator, cleanedId);

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -167,7 +167,7 @@ public class SnapshotService {
     this.snapshotBuilderSettingsDao = snapshotBuilderSettingsDao;
   }
 
-  public String generateUpdatedSnapshotNameIfByRequest(SnapshotRequestModel model) {
+  public String getSnapshotName(SnapshotRequestModel model) {
     SnapshotRequestContentsModel contentsModel = model.getContents().get(0);
     if (contentsModel.getMode() == SnapshotRequestContentsModel.ModeEnum.BYREQUESTID) {
       SnapshotAccessRequestResponse snapshotAccessRequestResponse =
@@ -200,7 +200,7 @@ public class SnapshotService {
       SnapshotRequestModel snapshotRequestModel,
       Dataset dataset,
       AuthenticatedUserRequest userReq) {
-    snapshotRequestModel.setName(generateUpdatedSnapshotNameIfByRequest(snapshotRequestModel));
+    snapshotRequestModel.setName(getSnapshotName(snapshotRequestModel));
     if (snapshotRequestModel.getProfileId() == null) {
       snapshotRequestModel.setProfileId(dataset.getDefaultProfileId());
       logger.warn(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -191,14 +191,7 @@ public class SnapshotService {
               SNAPSHOT_NAME_MAX_LENGTH - 1 - cleanedId.length());
       String separator = cleanedName.length() > 0 ? "_" : "";
 
-      String generatedName = cleanedName + separator + cleanedId;
-
-      return StringUtils.strip(
-          generatedName
-              .replaceAll(dashesAndSpacesRegex, "_")
-              .replaceAll(nonAlphaNumericRegex, "")
-              .trim(),
-          "_");
+      return cleanedName + separator + cleanedId;
     }
     return model.getName();
   }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -191,7 +191,7 @@ public class SnapshotService {
               SNAPSHOT_NAME_MAX_LENGTH - 1 - cleanedId.length());
       String separator = cleanedName.length() > 0 ? "_" : "";
 
-      String generatedName = String.format("%s%s%s", cleanedName, separator, cleanedId);
+      String generatedName = cleanedName + separator + cleanedId;
 
       return StringUtils.strip(
           generatedName

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -175,17 +175,21 @@ public class SnapshotService {
       String dashesAndSpacesRegex = "[- ]+";
       String nonAlphaNumericRegex = "\\W";
 
-      return org.springframework.util.StringUtils.trimTrailingCharacter(
-          org.springframework.util.StringUtils.trimLeadingCharacter(
-              String.format(
-                      "%s_%s",
-                      snapshotAccessRequestResponse.getSnapshotName(),
-                      snapshotAccessRequestResponse.getId().toString())
-                  .replaceAll(dashesAndSpacesRegex, "_")
-                  .replaceAll(nonAlphaNumericRegex, "")
-                  .trim(),
-              '_'),
-          '_');
+      // We take the first 474 characters of the name, because the UUID is 36 characters long, so
+      // the name is 474 characters + the underscore + 36 characters for the UUID, totalling to a
+      // max of 511.
+      String generatedName =
+          String.format(
+              "%s_%s",
+              snapshotAccessRequestResponse.getSnapshotName().substring(0, 473),
+              snapshotAccessRequestResponse.getId().toString());
+
+      return StringUtils.strip(
+          generatedName
+              .replaceAll(dashesAndSpacesRegex, "_")
+              .replaceAll(nonAlphaNumericRegex, "")
+              .trim(),
+          "_");
     }
     return model.getName();
   }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -184,10 +184,12 @@ public class SnapshotService {
       String cleanedId = snapshotAccessRequestResponse.getId().toString().replace('-', '_');
       String cleanedName =
           StringUtils.truncate(
-              snapshotAccessRequestName
-                  .replaceAll(dashesAndSpacesRegex, "_")
-                  .replaceAll(nonAlphaNumericRegex, "")
-                  .trim(),
+              StringUtils.strip(
+                  snapshotAccessRequestName
+                      .replaceAll(dashesAndSpacesRegex, "_")
+                      .replaceAll(nonAlphaNumericRegex, "")
+                      .trim(),
+                  "_"),
               SNAPSHOT_NAME_MAX_LENGTH - 1 - cleanedId.length());
       String separator = cleanedName.length() > 0 ? "_" : "";
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -106,6 +106,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
@@ -175,13 +176,18 @@ public class SnapshotService {
       String dashesAndSpacesRegex = "[- ]+";
       String nonAlphaNumericRegex = "\\W";
 
+      // Handle null as empty string.
+      String snapshotAccessRequestName =
+          Optional.ofNullable(snapshotAccessRequestResponse.getSnapshotName()).orElse("");
+
       // We take the first 474 characters of the name, because the UUID is 36 characters long, so
       // the name is 474 characters + the underscore + 36 characters for the UUID, totalling to a
       // max of 511.
       String generatedName =
           String.format(
               "%s_%s",
-              snapshotAccessRequestResponse.getSnapshotName().substring(0, 473),
+              snapshotAccessRequestName.substring(
+                  0, Math.min(473, snapshotAccessRequestName.length())),
               snapshotAccessRequestResponse.getId().toString());
 
       return StringUtils.strip(

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -459,7 +459,7 @@ public class AzureIntegrationTest extends UsersBase {
         approveSnapshotAccessRequest(makeSnapshotAccessRequest().getId());
 
     SnapshotSummaryModel snapshotSummaryByRequest =
-        makeSnapshotFromRequest(approvedSnapshotAccessRequest.getId());
+        makeSnapshotFromRequest(approvedSnapshotAccessRequest);
 
     String columnName = "datarepo_row_id";
     List<Object> personSnapshotRows =
@@ -509,12 +509,17 @@ public class AzureIntegrationTest extends UsersBase {
     return accessRequest;
   }
 
-  private SnapshotSummaryModel makeSnapshotFromRequest(UUID requestSnapshotId) throws Exception {
+  private SnapshotSummaryModel makeSnapshotFromRequest(
+      SnapshotAccessRequestResponse snapshotAccessRequestResponse) throws Exception {
     SnapshotRequestModel requestSnapshot =
         jsonLoader.loadObject(
             "omop/snapshot-request-model-by-request-id.json", SnapshotRequestModel.class);
     requestSnapshot.getContents().get(0).setDatasetName(datasetName);
-    requestSnapshot.getContents().get(0).getRequestIdSpec().setSnapshotRequestId(requestSnapshotId);
+    requestSnapshot
+        .getContents()
+        .get(0)
+        .getRequestIdSpec()
+        .setSnapshotRequestId(snapshotAccessRequestResponse.getId());
 
     SnapshotSummaryModel snapshotSummary =
         dataRepoFixtures.createSnapshotWithRequest(
@@ -522,7 +527,15 @@ public class AzureIntegrationTest extends UsersBase {
     UUID snapshotByRequestId = snapshotSummary.getId();
     snapshotIds.add(snapshotByRequestId);
     recordStorageAccount(steward, CollectionType.SNAPSHOT, snapshotByRequestId);
-    assertThat("Snapshot exists", snapshotSummary.getName(), equalTo(requestSnapshot.getName()));
+    assertThat(
+        "Snapshot exists",
+        snapshotSummary.getName(),
+        equalTo(
+            String.format(
+                    "%s_%s",
+                    snapshotAccessRequestResponse.getSnapshotName(),
+                    snapshotAccessRequestResponse.getId())
+                .replace('-', '_')));
     return snapshotSummary;
   }
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1090,7 +1090,9 @@ class SnapshotServiceTest {
     JobBuilder jobBuilder = mock(JobBuilder.class);
     String jobId = mockJobService(request, jobBuilder);
     SnapshotAccessRequestResponse snapshotAccessRequestResponse =
-        new SnapshotAccessRequestResponse().status(SnapshotAccessRequestStatus.APPROVED);
+        new SnapshotAccessRequestResponse()
+            .status(SnapshotAccessRequestStatus.APPROVED)
+            .id(snapshotAccessRequestId);
     when(snapshotRequestDao.getById(snapshotAccessRequestId))
         .thenReturn(snapshotAccessRequestResponse);
     when(snapshotDao.retrieveSnapshot(snapshotAccessRequestResponse.getSourceSnapshotId()))

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1388,7 +1388,7 @@ class SnapshotServiceTest {
   }
 
   @Test
-  void generateUpdatedSnapshotNameIfByRequestOnlyAffectsByRequest() {
+  void getSnapshotNameForNonRequest() {
     SnapshotRequestContentsModel contentsModel =
         new SnapshotRequestContentsModel().mode(SnapshotRequestContentsModel.ModeEnum.BYFULLVIEW);
     String name = "a-e$2";
@@ -1399,7 +1399,7 @@ class SnapshotServiceTest {
   }
 
   @Test
-  void generateUpdatedSnapshotNameIfByRequest() {
+  void getSnapshotNameForByRequest() {
     String uuidAsString = "2c297e7c-b303-4243-af6a-76cd9d3b0ca8";
     UUID uuid = UUID.fromString(uuidAsString);
     SnapshotRequestContentsModel contentsModel =

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1395,7 +1395,7 @@ class SnapshotServiceTest {
     SnapshotRequestModel snapshotRequestModel =
         new SnapshotRequestModel().name(name).contents(List.of(contentsModel));
 
-    assertThat(service.generateUpdatedSnapshotNameIfByRequest(snapshotRequestModel), is(name));
+    assertThat(service.getSnapshotName(snapshotRequestModel), is(name));
   }
 
   @Test
@@ -1414,8 +1414,7 @@ class SnapshotServiceTest {
     when(snapshotRequestDao.getById(uuid))
         .thenReturn(new SnapshotAccessRequestResponse().snapshotName(" a$%").id(uuid));
 
-    assertThat(
-        service.generateUpdatedSnapshotNameIfByRequest(snapshotRequestModel), is(expectedName));
+    assertThat(service.getSnapshotName(snapshotRequestModel), is(expectedName));
   }
 
   private void testPreview(int totalRowCount, int filteredRowCount) {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1385,6 +1385,37 @@ class SnapshotServiceTest {
     assertThat(sourceDataset, is(dataset));
   }
 
+  @Test
+  void generateUpdatedSnapshotNameIfByRequestOnlyAffectsByRequest() {
+    SnapshotRequestContentsModel contentsModel =
+        new SnapshotRequestContentsModel().mode(SnapshotRequestContentsModel.ModeEnum.BYFULLVIEW);
+    String name = "a-e$2";
+    SnapshotRequestModel snapshotRequestModel =
+        new SnapshotRequestModel().name(name).contents(List.of(contentsModel));
+
+    assertThat(service.generateUpdatedSnapshotNameIfByRequest(snapshotRequestModel), is(name));
+  }
+
+  @Test
+  void generateUpdatedSnapshotNameIfByRequest() {
+    String uuidAsString = "2c297e7c-b303-4243-af6a-76cd9d3b0ca8";
+    UUID uuid = UUID.fromString(uuidAsString);
+    SnapshotRequestContentsModel contentsModel =
+        new SnapshotRequestContentsModel()
+            .mode(SnapshotRequestContentsModel.ModeEnum.BYREQUESTID)
+            .requestIdSpec(new SnapshotRequestIdModel().snapshotRequestId(uuid));
+    String name = " a-e$2-";
+    String expectedName = "a_2c297e7c_b303_4243_af6a_76cd9d3b0ca8";
+    SnapshotRequestModel snapshotRequestModel =
+        new SnapshotRequestModel().name(name).contents(List.of(contentsModel));
+
+    when(snapshotRequestDao.getById(uuid))
+        .thenReturn(new SnapshotAccessRequestResponse().snapshotName(" a$%").id(uuid));
+
+    assertThat(
+        service.generateUpdatedSnapshotNameIfByRequest(snapshotRequestModel), is(expectedName));
+  }
+
   private void testPreview(int totalRowCount, int filteredRowCount) {
     SnapshotPreviewModel snapshotPreviewModel =
         service.retrievePreview(

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -395,7 +395,9 @@ public class BigQueryPdaoTest {
     SnapshotSummaryModel snapshotSummary =
         connectedOperations.createSnapshot(datasetSummaryModel, requestModel, "");
     Snapshot snapshot = snapshotService.retrieve(snapshotSummary.getId());
-    assertThat(snapshot.getName(), is(requestModel.getName()));
+    assertThat(
+        snapshot.getName(),
+        is(snapshotService.generateUpdatedSnapshotNameIfByRequest(requestModel)));
     assertThat(snapshot.getTables().size(), is(equalTo(3)));
     BigQueryProject bigQuerySnapshotProject =
         TestUtils.bigQueryProjectForSnapshotName(snapshotDao, snapshot.getName());

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -395,9 +395,7 @@ public class BigQueryPdaoTest {
     SnapshotSummaryModel snapshotSummary =
         connectedOperations.createSnapshot(datasetSummaryModel, requestModel, "");
     Snapshot snapshot = snapshotService.retrieve(snapshotSummary.getId());
-    assertThat(
-        snapshot.getName(),
-        is(snapshotService.generateUpdatedSnapshotNameIfByRequest(requestModel)));
+    assertThat(snapshot.getName(), is(snapshotService.getSnapshotName(requestModel)));
     assertThat(snapshot.getTables().size(), is(equalTo(3)));
     BigQueryProject bigQuerySnapshotProject =
         TestUtils.bigQueryProjectForSnapshotName(snapshotDao, snapshot.getName());


### PR DESCRIPTION
Ticket link: https://broadworkbench.atlassian.net/browse/DC-1128

## Addresses
This addresses the issue of ensuring all snapshots created by request follow the same name format, borrowing names from the Request object. This removes that burden from the front-end

## Changes
Creates a new method for generating the name, which is called from the createSnapshot endpoint

## Testing strategy
Unit tests of the new method.