### PR TITLE
[DCJ-456] Azure ingests in replace or merge mode should fail fast

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -5523,13 +5523,13 @@ components:
             - merge
           description: >
             Approach for how to treat updates to the target table:
-             * `append` - Default: only ever insert rows, regardless of whether or not the primary key value exists
-             * `replace` - If a primary key is present on the table, treat rows with matching primary keys
+             * `append` (GCP, Azure) - Default: only ever insert rows, regardless of whether or not the primary key value exists
+             * `replace` (GCP only) - If a primary key is present on the table, treat rows with matching primary keys
                          as updates. If duplicate IDs are found in your ingest, the ingest job
                          will fail. If your rows specify `datarepo_row_id`, it will be ignored and
                          TDR will generate new row IDs for your new records. Note: the full new
                          record must be specified.
-             * `merge` - If a primary key is present on the table, treat rows with matching primary keys
+             * `merge` (GCP only) - If a primary key is present on the table, treat rows with matching primary keys
                          as partial updates. Any fields specified will overwrite their current values
                          in the matching table row. If your rows specify `datarepo_row_id`, it will
                          be ignored and TDR will generate new row IDs for your new records. Each

--- a/src/test/java/bio/terra/service/dataset/IngestRequestValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/IngestRequestValidatorTest.java
@@ -20,6 +20,7 @@ import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadFileModel;
 import bio.terra.model.BulkLoadRequestModel;
 import bio.terra.model.CloudPlatform;
+import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.service.auth.iam.IamService;
@@ -89,11 +90,9 @@ class IngestRequestValidatorTest {
 
   @Test
   void testAzureIngestRequestParameters() throws Exception {
-    Dataset dataset = mock(Dataset.class);
-    DatasetSummary datasetSummary = mock(DatasetSummary.class);
-    when(datasetSummary.getStorageCloudPlatform()).thenReturn(CloudPlatform.AZURE);
-    when(dataset.getDatasetSummary()).thenReturn(datasetSummary);
-    when(datasetService.retrieve(any())).thenReturn(dataset);
+    DatasetSummaryModel datasetSummary = mock(DatasetSummaryModel.class);
+    when(datasetSummary.getCloudPlatform()).thenReturn(CloudPlatform.AZURE);
+    when(datasetService.retrieveDatasetSummary(any())).thenReturn(datasetSummary);
 
     var nullIngest =
         new IngestRequestModel()


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-456

## Addresses

Presently, tabular data can only be ingested into an Azure dataset via `append` mode.

To increase system reliability and reduce user confusion, TDR should fail fast for Azure ingest requests that use unsupported update strategies `replace` or `merge`.

Azure ingest support documents have also been updated to reflect the current state of our product: https://support.terra.bio/hc/en-us/articles/23460453585819-How-to-ingest-and-update-TDR-data-with-APIs

## Summary of changes

- Updated Swagger documentation for `ingestDataset` to call out that only `append` mode ingests are supported for Azure datasets.
- Expanded Azure ingest input parameter validation to check that a supported update strategy was used.  If not, fail before submitting the flight with an error detail element like `Ingests to Azure datasets can only use 'append' as an update strategy, was 'merge'.`.
- In `DatasetsApiController.ingestDataset`, moved the dataset authorization check before ingest parameter validation, because a failing parameter validation check could expose that the underlying dataset is Azure-backed.

## Testing Strategy

Added unit tests for `DatasetsApiController.ingestDataset`, verifying behavior for all combinations of dataset cloud platform and update strategy.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->