### PR TITLE
DCJ-476: Bypass vault in actions

### DIFF
--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -38,7 +38,7 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} | jq > ${GOOGLE_APPLICATION_CREDENTIALS}
+          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Perform cherry-pick"
         run: |

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -41,8 +41,6 @@ jobs:
         with:
           actions_subcommand: 'bumper'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
           version_file_path: build.gradle
           version_variable_name: version
           # Sets the author of the version bump commit to broadbot. This is used in our skip job logic.
@@ -94,8 +92,6 @@ jobs:
         with:
           actions_subcommand: 'gradlebuild'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
         uses: broadinstitute/datarepo-actions/actions/main@0.73.0
         with:
@@ -122,8 +118,6 @@ jobs:
         with:
           actions_subcommand: 'alpharelease'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
           alpharelease: ${{ needs.bump_version.outputs.api_image_tag }} # creates gcr build with semver tag
           gcr_google_project: 'broad-jade-dev'
 

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -97,6 +97,7 @@ jobs:
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
       - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
         uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
         with:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'bumper'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
@@ -88,12 +88,12 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: datarepo-helm-definitions
       - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gradlebuild'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
       - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'deploytagupdate'
           helm_env_prefix: dev
@@ -114,7 +114,7 @@ jobs:
           path: jade-data-repo-ui
           ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'alpharelease'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.73.0
         with:
           actions_subcommand: 'bumper'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
           version_file_path: build.gradle
@@ -92,6 +93,7 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.73.0
         with:
           actions_subcommand: 'gradlebuild'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Update Version in helm for Dev Env"
@@ -119,6 +121,7 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.73.0
         with:
           actions_subcommand: 'alpharelease'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
           alpharelease: ${{ needs.bump_version.outputs.api_image_tag }} # creates gcr build with semver tag

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm-definitions/integration/integration-6/datarepo-api.yaml image.tag ${{ steps.apiprevioustag.outputs.tag }}"
       - name: "[datarepo-helm-definitions] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.74.0
         env:
           COMMIT_MESSAGE: "Datarepo api tag version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm-definitions
@@ -95,7 +95,7 @@ jobs:
         with:
           args: yq w -i datarepo-helm/charts/datarepo-api/Chart.yaml version ${{ steps.chartversion.outputs.chartversion }}"
       - name: "[datarepo-helm] Merge chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.74.0
         env:
           COMMIT_MESSAGE: "Datarepo api version update: ${{ steps.apiprevioustag.outputs.tag }}"
           GITHUB_REPO: datarepo-helm

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -181,6 +181,7 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gradlebuild' # creates gcr build with git_hash tag
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
       - name: "Deploy to cluster with Helm"
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
@@ -190,6 +191,7 @@ jobs:
           helm_datarepo_ui_chart_version: 0.0.347
           helm_gcloud_sqlproxy_chart_version: 0.19.13
           helm_oidc_proxy_chart_version: 0.0.44
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
       - name: "Fetch gitHash for deployed integration version"
         id: configuration
         run: |
@@ -212,6 +214,7 @@ jobs:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testIntegration'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
         env:
           AZURE_CREDENTIALS_APPLICATIONID: ${{ env.AZURE_CREDENTIALS_APPLICATIONID }}
           AZURE_CREDENTIALS_HOMETENANTID: ${{ env.AZURE_CREDENTIALS_HOMETENANTID }}
@@ -220,6 +223,7 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
       - name: "Clean whitelisted Runner IP"
         if: always()
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -78,7 +78,7 @@ jobs:
           path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-unit }}
       - name: "Run unit tests and sonar scan via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -121,7 +121,7 @@ jobs:
           # write vault token
           base64 --decode <<< ${{ secrets.B64_RBS_APPLICATION_CREDENTIALS }} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
       - name: "Run connected tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -167,21 +167,21 @@ jobs:
           path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-build-integration
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gcp_whitelist'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
       - name: "Check for an available namespace to deploy API to and set state lock"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
       - name: "Build docker container via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gradlebuild' # creates gcr build with git_hash tag
       - name: "Deploy to cluster with Helm"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'helmdeploy'
           helm_create_secret_manager_secret_version: 0.0.8
@@ -196,17 +196,17 @@ jobs:
           echo "git_hash=${git_hash}" >> $GITHUB_OUTPUT
           echo "Latest git hash for this branch: $git_hash"
       - name: "Wait for deployment to come back online"
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.74.0
         timeout-minutes: 20
         env:
           DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
           DEPLOYMENT_TYPE: 'api'
       - name: "Run Test Runner smoke tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
       - name: "Run integration tests via Gradle"
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
@@ -216,12 +216,12 @@ jobs:
           AZURE_CREDENTIALS_HOMETENANTID: ${{ env.AZURE_CREDENTIALS_HOMETENANTID }}
       - name: "Clean state lock from used Namespace on API deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
   report-to-sherlock:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -83,6 +83,7 @@ jobs:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'check'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
@@ -127,6 +128,7 @@ jobs:
           actions_subcommand: 'gradleinttest'
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testConnected'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Temp: Archive all junit test reports"
@@ -172,6 +174,7 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.73.0
         with:
           actions_subcommand: 'gcp_whitelist'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -84,8 +84,6 @@ jobs:
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'check'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
   test_connected:
     name: "Run connected tests"
@@ -129,8 +127,6 @@ jobs:
           pgport: ${{ job.services.postgres.ports[5432] }}
           test_to_run: 'testConnected'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
       - name: "Temp: Archive all junit test reports"
         uses: actions/upload-artifact@v2
         if: always()
@@ -175,8 +171,6 @@ jobs:
         with:
           actions_subcommand: 'gcp_whitelist'
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-          role_id: ${{ secrets.ROLE_ID }}
-          secret_id: ${{ secrets.SECRET_ID }}
       - name: "Check for an available namespace to deploy API to and set state lock"
         uses: broadinstitute/datarepo-actions/actions/main@0.73.0
         with:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -208,6 +208,7 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gradletestrunnersmoketest'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
       - name: "Run integration tests via Gradle"
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -176,6 +176,7 @@ jobs:
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
       - name: "Build docker container via Gradle"
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
@@ -224,6 +225,7 @@ jobs:
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: deploy_test_integration

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: "Perform IAM policy cleanup for staging"
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.TEST_RUNNER_B64_CREDENTIALS }} | jq > ${GOOGLE_APPLICATION_CREDENTIALS}
+          base64 --decode <<< ${{ secrets.TEST_RUNNER_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
       - name: "Add jade-k8-sa credentials to run as Harry Potter test users"
@@ -57,7 +57,7 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/jade-dev-account.json
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} | jq > ${GOOGLE_APPLICATION_CREDENTIALS}
+          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Build and run Test Runner"
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DCJ-476

## Summary of changes
This PR passes a token to the actions to bypass vault
Requires the following PRs:
* ~https://github.com/broadinstitute/datarepo-actions/pull/85~ (merged)

### TODO
* When this PR is merged, we'll need to update https://github.com/DataBiosphere/jade-data-repo-ui/blob/develop/.github/workflows/dev-image-update.yaml#L95 to point to the newest version defined here.

## Testing Strategy
Currently exploring this repeating ~[SamRetryIntegrationTest](https://scans.gradle.com/s/r654vatifk5uq/tests/task/:testIntegration/details/bio.terra.service.auth.iam.sam.SamRetryIntegrationTest)~ [SamRetryIntegrationTest](https://scans.gradle.com/s/qc6d6zp4rl4kc/tests/task/:testIntegration/details/bio.terra.service.auth.iam.sam.SamRetryIntegrationTest/retrySyncDatasetPolicies?top-execution=1) test failure.

**Update**. This test is a secondary failure (`NoSuchElementException`) of the recent Sam changes. Once https://github.com/broadinstitute/sam/pull/1480 is merged, we should be able to re-run tests.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
