### PR TITLE
DCJ-453: Fix broken b64 token parsing

### DIFF
--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -38,7 +38,8 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} > ${TEMP_CREDENTIALS}
+          jq -r .key ${TEMP_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
 
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Perform cherry-pick"

--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -35,13 +35,10 @@ jobs:
     steps:
       - name: "Authenticate with GCR SA Credentials"
         env:
-          TEMP_CREDENTIALS: /tmp/jade-dev-account.b64
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} > ${TEMP_CREDENTIALS}
-          jq -r .key ${TEMP_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
-
+          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} | jq > ${GOOGLE_APPLICATION_CREDENTIALS}
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Perform cherry-pick"
         run: |

--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -35,6 +35,7 @@ jobs:
     steps:
       - name: "Authenticate with GCR SA Credentials"
         env:
+          TEMP_CREDENTIALS: /tmp/jade-dev-account.b64
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
         run: |
           # write token

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -48,8 +48,8 @@ jobs:
       - name: "Perform IAM policy cleanup for staging"
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.TEST_RUNNER_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
-
+          base64 --decode <<< ${{ secrets.TEST_RUNNER_B64_CREDENTIALS }} > ${TEMP_CREDENTIALS}
+          jq -r .key ${TEMP_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
 
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
@@ -59,7 +59,8 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/jade-dev-account.json
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${TEMP_CREDENTIALS}
+          jq -r .sa ${TEMP_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Build and run Test Runner"
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -1,7 +1,6 @@
 name: DataRepo Staging Smoke Tests
 env:
   K8_CLUSTER: jade-master-us-central1
-  TEMP_CREDENTIALS: /tmp/jade-dev-account.b64
   GOOGLE_APPLICATION_CREDENTIALS: /tmp/staging-test-runner.json
   GOOGLE_CLOUD_PROJECT: terra-datarepo-staging
   GOOGLE_CLOUD_DATA_PROJECT: terra-datarepo-staging-data
@@ -49,8 +48,7 @@ jobs:
       - name: "Perform IAM policy cleanup for staging"
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.TEST_RUNNER_B64_CREDENTIALS }} > ${TEMP_CREDENTIALS}
-          jq -r .key ${TEMP_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          base64 --decode <<< ${{ secrets.TEST_RUNNER_B64_CREDENTIALS }} | jq -r .key > ${GOOGLE_APPLICATION_CREDENTIALS}
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
 
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
@@ -60,8 +58,7 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/jade-dev-account.json
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${TEMP_CREDENTIALS}
-          jq -r .sa ${TEMP_CREDENTIALS} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} | jq -r .sa > ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Build and run Test Runner"
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -48,9 +48,8 @@ jobs:
       - name: "Perform IAM policy cleanup for staging"
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.TEST_RUNNER_B64_CREDENTIALS }} | jq -r .key > ${GOOGLE_APPLICATION_CREDENTIALS}
+          base64 --decode <<< ${{ secrets.TEST_RUNNER_B64_CREDENTIALS }} | jq > ${GOOGLE_APPLICATION_CREDENTIALS}
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
-
           ./tools/cleanupPolicies.sh ${GOOGLE_CLOUD_DATA_PROJECT}
       - name: "Add jade-k8-sa credentials to run as Harry Potter test users"
         env:
@@ -58,7 +57,7 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/jade-dev-account.json
         run: |
           # write token
-          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} | jq -r .sa > ${GOOGLE_APPLICATION_CREDENTIALS}
+          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} | jq > ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Build and run Test Runner"
         run: |
           cd ${GITHUB_WORKSPACE}/${workingDir}

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -1,6 +1,7 @@
 name: DataRepo Staging Smoke Tests
 env:
   K8_CLUSTER: jade-master-us-central1
+  TEMP_CREDENTIALS: /tmp/jade-dev-account.b64
   GOOGLE_APPLICATION_CREDENTIALS: /tmp/staging-test-runner.json
   GOOGLE_CLOUD_PROJECT: terra-datarepo-staging
   GOOGLE_CLOUD_DATA_PROJECT: terra-datarepo-staging-data
@@ -56,7 +57,6 @@ jobs:
       - name: "Add jade-k8-sa credentials to run as Harry Potter test users"
         env:
           # note: hack to overwrite the env var to grab the dev credentials too
-          TEMP_CREDENTIALS: /tmp/jade-dev-account.b64
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/jade-dev-account.json
         run: |
           # write token

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -56,6 +56,7 @@ jobs:
       - name: "Add jade-k8-sa credentials to run as Harry Potter test users"
         env:
           # note: hack to overwrite the env var to grab the dev credentials too
+          TEMP_CREDENTIALS: /tmp/jade-dev-account.b64
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/jade-dev-account.json
         run: |
           # write token


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DCJ-453

## Summary of changes
This PR should fix breaking changes in https://github.com/DataBiosphere/jade-data-repo/pull/1716
In that PR, the raw output from `base64` was pushed to the token file (which, in theory, should work). Parsing it through `jq` seems to fix the format in a way that actually works.

## Testing Strategy
Manually run these actions against this branch:
* https://github.com/DataBiosphere/jade-data-repo/actions/workflows/staging-smoke-tests.yaml
  * Manual run: https://github.com/DataBiosphere/jade-data-repo/actions/runs/9725179368/job/26842187653
* https://github.com/DataBiosphere/jade-data-repo/actions/workflows/cherry-pick-image.yaml

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
