### PR TITLE
[DCJ-470] Increase Docker memory limit from 2g -> 4g

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -396,7 +396,7 @@ jib {
     // https://www.randori.com/blog/cve-2021-44228/
     // for more information
     container {
-        jvmFlags = ["-Xms1g", "-Xmx2g", "-Dlog4j2.formatMsgNoLookups=true"]
+        jvmFlags = ["-Xms1g", "-Xmx4g", "-Dlog4j2.formatMsgNoLookups=true"]
     }
     container.creationTime = buildTime()
 }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-470

## Addresses

Since the beginning of 2024, TDR Prod backend pods have triggered high memory alerts (>95% of limit) over 50 times.  We'd like to increase the memory limits on our backend pods for increased system reliability and decreased alerting noise.

This PR partially fulfills the ticket above.  We must roll out PRs in the following order:
1. https://github.com/broadinstitute/datarepo-helm/pull/272
2. This PR (because the Docker memory limit should be less than the pod memory limit)

## Summary of changes

- Docker container's memory limit increased from 2g -> 4g
- Docker container's requested memory is unchanged at 1g

## Testing Strategy

Integration tests ran successfully with these Docker settings and the increased pod limit, but I welcome other ideas to verify this change or otherwise build confidence.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
