### PR TITLE
DC-1080 - Add users to the SAM group on Snapshot Create by Request Id

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -258,6 +258,20 @@ public interface IamProviderInterface {
 
   /**
    * @param accessToken valid oauth token for the account modifying the group policy members
+   * @param groupName name of Sam/Firecloud managed group
+   * @param policyName name of Sam/Firecloud managed group policy
+   * @param emailAddresses user emails which will overwrite group policy contents. This list will
+   *     also include the current authenticated user
+   */
+  void overwriteGroupPolicyEmailsIncludeRequestingUser(
+      String accessToken,
+      AuthenticatedUserRequest userRequest,
+      String groupName,
+      String policyName,
+      List<String> emailAddresses)
+      throws InterruptedException;
+  /**
+   * @param accessToken valid oauth token for the account modifying the group policy members
    * @param groupName name of Firecloud managed group
    * @param policyName name of Firecloud managed group policy
    * @param emailAddresses user emails which will overwrite group policy contents

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -258,10 +258,12 @@ public interface IamProviderInterface {
 
   /**
    * @param accessToken valid oauth token for the account modifying the group policy members
+   * @param userRequest information about the requesting user - we'll use this to pull the user's
+   *     email and add it to the group
    * @param groupName name of Sam/Firecloud managed group
    * @param policyName name of Sam/Firecloud managed group policy
    * @param emailAddresses user emails which will overwrite group policy contents. This list will
-   *     also include the current authenticated user
+   *     also include the current authenticated user.
    */
   void overwriteGroupPolicyEmailsIncludeRequestingUser(
       String accessToken,

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -458,6 +458,26 @@ public class IamService {
   }
 
   /**
+   * Overwrite group membership to include listed emails AND the current user's email AND admin
+   * emails
+   *
+   * @param groupName Sam/Firecloud managed group
+   * @param policyName name of Sam/Firecloud managed group policy
+   * @param emailAddresses emails which the TDR SA will set as group policy members
+   */
+  public void overwriteGroupPolicyEmailsIncludeRequestingUser(
+      AuthenticatedUserRequest userRequest,
+      String groupName,
+      String policyName,
+      List<String> emailAddresses) {
+    String tdrSaAccessToken = googleCredentialsService.getApplicationDefaultAccessToken(SCOPES);
+    callProvider(
+        () ->
+            iamProvider.overwriteGroupPolicyEmailsIncludeRequestingUser(
+                tdrSaAccessToken, userRequest, groupName, policyName, emailAddresses));
+  }
+
+  /**
    * @param groupName Firecloud managed group
    * @param policyName name of Firecloud managed group policy
    * @param emailAddresses emails which the TDR SA will set as group policy members

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -458,9 +458,10 @@ public class IamService {
   }
 
   /**
-   * Overwrite group membership to include listed emails AND the current user's email AND admin
-   * emails
+   * Overwrite group membership to include listed emails AND the current user's email
    *
+   * @param userRequest current authenticated user - we'll use this to pull the requesting user's *
+   *     email and add it to the group
    * @param groupName Sam/Firecloud managed group
    * @param policyName name of Sam/Firecloud managed group policy
    * @param emailAddresses emails which the TDR SA will set as group policy members

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -712,9 +712,7 @@ public class SamIam implements IamProviderInterface {
     List<String> emails = new ArrayList<>(emailAddresses);
     UserStatusInfo userStatusInfo = getUserInfoAndVerify(userReq);
     emails.add(userStatusInfo.getUserEmail());
-    SamRetry.retry(
-        configurationService,
-        () -> overwriteGroupPolicyEmailsInner(accessToken, groupName, policyName, emails));
+    overwriteGroupPolicyEmails(accessToken, groupName, policyName, emails);
   }
 
   @Override

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -702,6 +702,22 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
+  public void overwriteGroupPolicyEmailsIncludeRequestingUser(
+      String accessToken,
+      AuthenticatedUserRequest userReq,
+      String groupName,
+      String policyName,
+      List<String> emailAddresses)
+      throws InterruptedException {
+    List<String> emails = new ArrayList<>(emailAddresses);
+    UserStatusInfo userStatusInfo = getUserInfoAndVerify(userReq);
+    emails.add(userStatusInfo.getUserEmail());
+    SamRetry.retry(
+        configurationService,
+        () -> overwriteGroupPolicyEmailsInner(accessToken, groupName, policyName, emails));
+  }
+
+  @Override
   public void overwriteGroupPolicyEmails(
       String accessToken, String groupName, String policyName, List<String> emailAddresses)
       throws InterruptedException {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -11,6 +11,7 @@ import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.common.SqlSortDirection;
 import bio.terra.common.Table;
+import bio.terra.common.ValidationUtils;
 import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -275,6 +276,11 @@ public class SnapshotService {
     if (flightId != null && jobService.unauthRetrieveJobState(flightId) != FlightStatus.ERROR) {
       throw new ValidationException(
           "Snapshot Create Flight with id %s is still running".formatted(flightId));
+    }
+    var requesterEmail = snapshotAccessRequest.getCreatedBy();
+    if (requesterEmail == null || !ValidationUtils.isValidEmail(requesterEmail)) {
+      throw new ValidationException(
+          "The createdBy email supplied on the access request is not valid.");
     }
   }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
@@ -1,0 +1,46 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.service.snapshotbuilder.SnapshotRequestDao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class CreateSnapshotAddEmailsToSamGroupStep extends DefaultUndoStep {
+  private final AuthenticatedUserRequest userRequest;
+  private final IamService iamService;
+  private final SnapshotRequestDao snapshotRequestDao;
+
+  private final UUID snapshotRequestId;
+
+  public CreateSnapshotAddEmailsToSamGroupStep(
+      AuthenticatedUserRequest userRequest,
+      IamService iamService,
+      SnapshotRequestDao snapshotRequestDao,
+      UUID snapshotRequestId) {
+    this.userRequest = userRequest;
+    this.iamService = iamService;
+    this.snapshotRequestDao = snapshotRequestDao;
+    this.snapshotRequestId = snapshotRequestId;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    FlightMap workingMap = context.getWorkingMap();
+    String groupName =
+        workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_FIRECLOUD_GROUP_NAME, String.class);
+    List<String> emailsToAddToGroup = new ArrayList<>();
+    emailsToAddToGroup.add(userRequest.getEmail());
+    emailsToAddToGroup.add(snapshotRequestDao.getById(snapshotRequestId).getCreatedBy());
+    iamService.overwriteGroupPolicyEmails(groupName, IamRole.MEMBER.toString(), emailsToAddToGroup);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
@@ -10,7 +10,6 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
@@ -18,7 +18,6 @@ public class CreateSnapshotAddEmailsToSamGroupStep extends DefaultUndoStep {
   private final AuthenticatedUserRequest userRequest;
   private final IamService iamService;
   private final SnapshotRequestDao snapshotRequestDao;
-
   private final UUID snapshotRequestId;
 
   public CreateSnapshotAddEmailsToSamGroupStep(
@@ -37,10 +36,10 @@ public class CreateSnapshotAddEmailsToSamGroupStep extends DefaultUndoStep {
     FlightMap workingMap = context.getWorkingMap();
     String groupName =
         workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_FIRECLOUD_GROUP_NAME, String.class);
-    List<String> emailsToAddToGroup = new ArrayList<>();
-    emailsToAddToGroup.add(userRequest.getEmail());
-    emailsToAddToGroup.add(snapshotRequestDao.getById(snapshotRequestId).getCreatedBy());
-    iamService.overwriteGroupPolicyEmails(groupName, IamRole.MEMBER.toString(), emailsToAddToGroup);
+    List<String> emailsToAddToGroup =
+        List.of(snapshotRequestDao.getById(snapshotRequestId).getCreatedBy());
+    iamService.overwriteGroupPolicyEmailsIncludeRequestingUser(
+        userRequest, groupName, IamRole.MEMBER.toString(), emailsToAddToGroup);
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
@@ -19,6 +19,17 @@ public class CreateSnapshotAddEmailsToSamGroupStep extends DefaultUndoStep {
   private final SnapshotRequestDao snapshotRequestDao;
   private final UUID snapshotRequestId;
 
+  /**
+   * For Snapshot byRequestId, add two emails to the SAM group: (1) Snapshot Creator (The email
+   * associated with the userRequest) and (2) Snapshot Request Creator (The email in the createdBy
+   * field on the snapshot request)
+   *
+   * @param userRequest authenticated user request for the user that is creating the snapshot
+   * @param iamService
+   * @param snapshotRequestDao
+   * @param snapshotRequestId id of the snapshot request, used together with the snapshotRequestDao
+   *     to get the snapshot request, which contains the createdBy field
+   */
   public CreateSnapshotAddEmailsToSamGroupStep(
       AuthenticatedUserRequest userRequest,
       IamService iamService,

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -268,6 +268,12 @@ public class SnapshotCreateFlight extends Flight {
         addStep(new CreateSnapshotSamGroupNameStep(snapshotId, iamService));
         addStep(new CreateSnapshotSamGroupStep(iamService));
         addStep(
+            new CreateSnapshotAddEmailsToSamGroupStep(
+                userReq,
+                iamService,
+                snapshotRequestDao,
+                contents.getRequestIdSpec().getSnapshotRequestId()));
+        addStep(
             platform.choose(
                 () ->
                     new CreateSnapshotByRequestIdGcpStep(

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -841,6 +841,25 @@ class SamIamTest {
     }
 
     @Test
+    void setGroupMembershipWithAdmin() throws ApiException, InterruptedException {
+      final String snapshotRequesterEmail = "requester@a.com";
+      final String requestApproverId = "userid";
+      final String requestApproverEmail = "a@a.com";
+      mockUserInfo(requestApproverId, requestApproverEmail);
+      var expectedListOfEmails =
+          List.of(snapshotRequesterEmail, requestApproverEmail, samConfig.adminsGroupEmail());
+
+      samIam.overwriteGroupPolicyEmailsIncludeRequestingUser(
+          TEST_USER.getToken(), // In a real use case, this would be the TDR SA Token
+          TEST_USER, // While this would be the user making the request
+          GROUP_NAME,
+          IamRole.MEMBER.toString(),
+          List.of(snapshotRequesterEmail));
+      verify(samGroupApi)
+          .overwriteGroupPolicyEmails(GROUP_NAME, IamRole.MEMBER.toString(), expectedListOfEmails);
+    }
+
+    @Test
     void testOverwriteGroupPolicyEmails() throws InterruptedException, ApiException {
       String accessToken = TEST_USER.getToken();
       String policyName = IamRole.MEMBER.toString();

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -841,13 +841,13 @@ class SamIamTest {
     }
 
     @Test
-    void setGroupMembershipWithAdmin() throws ApiException, InterruptedException {
+    void overwriteGroupPolicyEmailsIncludeRequestingUser()
+        throws ApiException, InterruptedException {
       final String snapshotRequesterEmail = "requester@a.com";
       final String requestApproverId = "userid";
       final String requestApproverEmail = "a@a.com";
       mockUserInfo(requestApproverId, requestApproverEmail);
-      var expectedListOfEmails =
-          List.of(snapshotRequesterEmail, requestApproverEmail, samConfig.adminsGroupEmail());
+      var expectedListOfEmails = List.of(snapshotRequesterEmail, requestApproverEmail);
 
       samIam.overwriteGroupPolicyEmailsIncludeRequestingUser(
           TEST_USER.getToken(), // In a real use case, this would be the TDR SA Token

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -87,7 +87,7 @@ class SamIamTest {
   private static final String GROUP_NAME = "firecloud_group_name";
   private static final String ADMIN_EMAIL = "samAdminGroupEmail@a.com";
   private final SamConfiguration samConfig =
-      new SamConfiguration("https://sam.dsde-dev.broadinstitute.org", ADMIN_EMAIL, 10, 30, 60);
+      new SamConfiguration("https://sam.dsde-dev.broadinstitute.org", ADMIN_EMAIL, 0, 0, 0);
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -620,7 +620,9 @@ class SnapshotServiceTest {
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
     SnapshotAccessRequestResponse accessRequestResponse =
-        new SnapshotAccessRequestResponse().status(SnapshotAccessRequestStatus.APPROVED);
+        new SnapshotAccessRequestResponse()
+            .status(SnapshotAccessRequestStatus.APPROVED)
+            .createdBy("email@a.com");
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
 
     assertDoesNotThrow(() -> service.validateForByRequestIdMode(snapshotRequestContentsModel));
@@ -635,6 +637,7 @@ class SnapshotServiceTest {
     SnapshotAccessRequestResponse accessRequestResponse =
         new SnapshotAccessRequestResponse()
             .status(SnapshotAccessRequestStatus.APPROVED)
+            .createdBy("email@a.com")
             .flightid(flightId);
 
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
@@ -688,6 +691,21 @@ class SnapshotServiceTest {
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
     // any flight status that isn't error or fatal
     when(jobService.unauthRetrieveJobState(flightId)).thenReturn(FlightStatus.READY);
+    assertThrows(
+        ValidationException.class,
+        () -> service.validateForByRequestIdMode(snapshotRequestContentsModel));
+  }
+
+  @Test
+  void validateForByRequestIdIdModeCreatedByEmail() {
+    UUID snapshotAccessRequestId = UUID.randomUUID();
+    SnapshotRequestContentsModel snapshotRequestContentsModel =
+        makeByRequestIdContentsModel(snapshotAccessRequestId);
+    SnapshotAccessRequestResponse accessRequestResponse =
+        new SnapshotAccessRequestResponse()
+            .status(SnapshotAccessRequestStatus.APPROVED)
+            .createdBy("notanemail.com");
+    when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
     assertThrows(
         ValidationException.class,
         () -> service.validateForByRequestIdMode(snapshotRequestContentsModel));
@@ -1094,6 +1112,7 @@ class SnapshotServiceTest {
     SnapshotAccessRequestResponse snapshotAccessRequestResponse =
         new SnapshotAccessRequestResponse()
             .status(SnapshotAccessRequestStatus.APPROVED)
+            .createdBy("email@a.com")
             .id(snapshotAccessRequestId);
     when(snapshotRequestDao.getById(snapshotAccessRequestId))
         .thenReturn(snapshotAccessRequestResponse);

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
@@ -31,10 +31,7 @@ class CreateSnapshotAddEmailsToSamGroupStepTest {
   @Mock private IamService iamService;
   @Mock private SnapshotRequestDao snapshotRequestDao;
   @Mock private FlightContext flightContext;
-  private static final String RESEARCHER_EMAIL = "researcher@gmail.com";
-
   private static final String GROUP_NAME = "groupName";
-
   private CreateSnapshotAddEmailsToSamGroupStep step;
   private UUID snapshotRequestId;
   private static final AuthenticatedUserRequest TEST_USER =
@@ -53,8 +50,9 @@ class CreateSnapshotAddEmailsToSamGroupStepTest {
 
   @Test
   void doStep() throws InterruptedException {
-    var emailsToAdd = List.of(RESEARCHER_EMAIL);
-    var request = new SnapshotAccessRequestResponse().createdBy(RESEARCHER_EMAIL);
+    var researcherEmail = "researcher@gmail.com";
+    var emailsToAdd = List.of(researcherEmail);
+    var request = new SnapshotAccessRequestResponse().createdBy(researcherEmail);
     when(snapshotRequestDao.getById(snapshotRequestId)).thenReturn(request);
     assertEquals(step.doStep(flightContext), StepResult.getStepResultSuccess());
     verify(iamService)

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
@@ -1,0 +1,63 @@
+package bio.terra.service.snapshot.flight.create;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.SnapshotAccessRequestResponse;
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.service.snapshotbuilder.SnapshotRequestDao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Tag(Unit.TAG)
+@ExtendWith(MockitoExtension.class)
+class CreateSnapshotAddEmailsToSamGroupStepTest {
+
+  @Mock private IamService iamService;
+  @Mock private SnapshotRequestDao snapshotRequestDao;
+  @Mock private FlightContext flightContext;
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private static final String RESEARCHER_EMAIL = "researcher@gmail.com";
+
+  private static final String GROUP_NAME = "groupName";
+
+  private CreateSnapshotAddEmailsToSamGroupStep step;
+  private UUID snapshotRequestId;
+
+  @BeforeEach
+  void setUp() {
+    FlightMap workingMap = new FlightMap();
+    snapshotRequestId = UUID.randomUUID();
+    step =
+        new CreateSnapshotAddEmailsToSamGroupStep(
+            TEST_USER, iamService, snapshotRequestDao, snapshotRequestId);
+    workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_FIRECLOUD_GROUP_NAME, GROUP_NAME);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void doStep() throws InterruptedException {
+    var emailsToAdd = List.of(TEST_USER.getEmail(), RESEARCHER_EMAIL);
+    var request = new SnapshotAccessRequestResponse().createdBy(RESEARCHER_EMAIL);
+    when(snapshotRequestDao.getById(snapshotRequestId)).thenReturn(request);
+    assertEquals(step.doStep(flightContext), StepResult.getStepResultSuccess());
+    verify(iamService)
+        .overwriteGroupPolicyEmails(GROUP_NAME, IamRole.MEMBER.toString(), emailsToAdd);
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
@@ -31,14 +31,14 @@ class CreateSnapshotAddEmailsToSamGroupStepTest {
   @Mock private IamService iamService;
   @Mock private SnapshotRequestDao snapshotRequestDao;
   @Mock private FlightContext flightContext;
-  private static final AuthenticatedUserRequest TEST_USER =
-      AuthenticationFixtures.randomUserRequest();
   private static final String RESEARCHER_EMAIL = "researcher@gmail.com";
 
   private static final String GROUP_NAME = "groupName";
 
   private CreateSnapshotAddEmailsToSamGroupStep step;
   private UUID snapshotRequestId;
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
 
   @BeforeEach
   void setUp() {
@@ -53,11 +53,12 @@ class CreateSnapshotAddEmailsToSamGroupStepTest {
 
   @Test
   void doStep() throws InterruptedException {
-    var emailsToAdd = List.of(TEST_USER.getEmail(), RESEARCHER_EMAIL);
+    var emailsToAdd = List.of(RESEARCHER_EMAIL);
     var request = new SnapshotAccessRequestResponse().createdBy(RESEARCHER_EMAIL);
     when(snapshotRequestDao.getById(snapshotRequestId)).thenReturn(request);
     assertEquals(step.doStep(flightContext), StepResult.getStepResultSuccess());
     verify(iamService)
-        .overwriteGroupPolicyEmails(GROUP_NAME, IamRole.MEMBER.toString(), emailsToAdd);
+        .overwriteGroupPolicyEmailsIncludeRequestingUser(
+            TEST_USER, GROUP_NAME, IamRole.MEMBER.toString(), emailsToAdd);
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlightTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlightTest.java
@@ -135,6 +135,7 @@ class SnapshotCreateFlightTest {
             "CreateSnapshotMetadataStep",
             "CreateSnapshotSamGroupNameStep",
             "CreateSnapshotSamGroupStep",
+            "CreateSnapshotAddEmailsToSamGroupStep",
             "CreateSnapshotByRequestIdGcpStep",
             "CountSnapshotTableRowsStep",
             "SnapshotAuthzIamStep",


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1080


## Addresses
When we create a snapshot based on a cohort builder request, we want to give the the requester(s) and the data custodian access on the resulting snapshot. This is completed in a series of steps which is explained further in [this spike doc](https://docs.google.com/document/d/1yRHjzJ1XsNFFc4itWEpDvybGoloXIT6pzwPsZWs7vSk/edit).
We've already made changes to create the group (https://github.com/DataBiosphere/jade-data-repo/pull/1721). This PR addresses the next step, which is to add the relevant users to the Sam group so that they eventually will be on the DAC/allowlist for the snapshot. 

## Summary of changes
- On snapshot create flight construction, validate that the email set in the "createdBy" field on the snapshot access request.
- Given the Sam group created in the previous step (https://github.com/DataBiosphere/jade-data-repo/pull/1721), add users to this group
- We want to add two users to the group: (1) The user that submitted the snapshot access request (we'll find their email in the 'createdBy' field on the request) and (2) The user that approves the snapshot request. **Note:** this means that TDR admins will not have access to view the snapshot in the TDR UI and they cannot use the retrieveSnapshot endpoint. But, they will still have access to the policy actions. We could improve the TDR UI experience in a separate ticket: https://broadworkbench.atlassian.net/browse/DC-1181
- SamIam Test speedup 🎉 

## Testing Strategy
- Unit tests
- Manual testing - we cannot currently look up this group on the created snapshot, so it would be difficult to automate this test. 

Manual test (updated july 10th):
- Ran setup tdr resources script (Let's say the request was made by researcher@email.com - redacting the actual email I used) 
- approved access request (Let's say this was done by custodian@email.com - redacting the actual email I used)
- created snapshot byRequestId (also requested by custodian@email.com)
- Snapshot created: 764dfce6-af52-4481-a643-4f252e96f3d0
- Logged into terra with both account and we can see the group from both acount:
- --researcher@email.com
![image](https://github.com/DataBiosphere/jade-data-repo/assets/13254229/c4652071-e934-4ca7-9266-6f70435413e6)
- -- custodian@email.com
![image](https://github.com/DataBiosphere/jade-data-repo/assets/13254229/de8eac23-41de-462b-af13-831f5e2bcb50)

