### PR TITLE
[DC-1120]Update Snapshot Builder Settings to include Dataset Table Name and Relationships

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -735,7 +735,6 @@ public class SnapshotService {
     Set<String> missing = new HashSet<>(includedTableNames);
     allTables.stream()
         .map(SnapshotBuilderDatasetConceptSet::getName)
-        .toList()
         .forEach(missing::remove);
     if (!missing.isEmpty()) {
       throw new IllegalArgumentException("Unknown value set names: " + missing);

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -712,11 +712,17 @@ public class SnapshotService {
           assetModel.addTablesItem(
               new AssetTableModel().name(table.getDatasetTableName()).columns(table.getColumns()));
           // First add all person <-> occurrence relationships
-          assetModel.addFollowItem(table.getPrimaryTableRelationship());
+          if (table.getPrimaryTableRelationship() != null) {
+            assetModel.addFollowItem(table.getPrimaryTableRelationship());
+          }
         });
     // Second, add all occurrence <-> concept relationships
     tables.forEach(
-        table -> table.getSecondaryTableRelationships().forEach(assetModel::addFollowItem));
+        table -> {
+          if (table.getSecondaryTableRelationships() != null) {
+            table.getSecondaryTableRelationships().forEach(assetModel::addFollowItem);
+          }
+        });
 
     assetModel.addTablesItem(new AssetTableModel().name("concept"));
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -733,9 +733,7 @@ public class SnapshotService {
             .getDatasetConceptSets();
 
     Set<String> missing = new HashSet<>(includedTableNames);
-    allTables.stream()
-        .map(SnapshotBuilderDatasetConceptSet::getName)
-        .forEach(missing::remove);
+    allTables.stream().map(SnapshotBuilderDatasetConceptSet::getName).forEach(missing::remove);
     if (!missing.isEmpty()) {
       throw new IllegalArgumentException("Unknown value set names: " + missing);
     }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -34,7 +34,7 @@ import bio.terra.model.ResourceLocks;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotAccessRequestStatus;
-import bio.terra.model.SnapshotBuilderFeatureValueGroup;
+import bio.terra.model.SnapshotBuilderOutputTable;
 import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.model.SnapshotBuilderTable;
 import bio.terra.model.SnapshotIdsAndRolesModel;
@@ -722,18 +722,18 @@ public class SnapshotService {
 
   @VisibleForTesting
   List<SnapshotBuilderTable> pullTables(SnapshotAccessRequestResponse snapshotRequestModel) {
-    var valueSets = snapshotRequestModel.getSnapshotSpecification().getValueSets();
-    var valueSetNames = valueSets.stream().map(SnapshotBuilderFeatureValueGroup::getName).toList();
+    var tables = snapshotRequestModel.getSnapshotSpecification().getOutputTables();
+    var tableNames = tables.stream().map(SnapshotBuilderOutputTable::getName).toList();
 
     Map<String, SnapshotBuilderTable> tableMap = populateManualTableMap();
 
-    Set<String> missing = new HashSet<>(valueSetNames);
+    Set<String> missing = new HashSet<>(tableNames);
     missing.removeAll(tableMap.keySet());
     if (!missing.isEmpty()) {
       throw new IllegalArgumentException("Unknown value set names: " + missing);
     }
 
-    return valueSetNames.stream().map(tableMap::get).toList();
+    return tableNames.stream().map(tableMap::get).toList();
   }
 
   private Map<String, SnapshotBuilderTable> populateManualTableMap() {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7216,10 +7216,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SnapshotBuilderProgramDataOption'
-        featureValueGroups:
-          type: array
-          items:
-            $ref: '#/components/schemas/SnapshotBuilderFeatureValueGroup'
         datasetConceptSets:
           type: array
           items:
@@ -7308,14 +7304,11 @@ components:
         ⚠️ A concept set provided for the dataset, usually used to access tables that are not searchable as domains
       required:
         - name
-        - featureValueGroupName
       properties:
         name:
           type: string
-        featureValueGroupName:
-          type: string
-        concept:
-          $ref: '#/components/schemas/SnapshotBuilderConcept'
+        table:
+          $ref: '#/components/schemas/SnapshotBuilderTable'
 
     SnapshotBuilderDomainOption:
       allOf:
@@ -7391,17 +7384,17 @@ components:
           items:
             $ref: '#/components/schemas/SnapshotBuilderParentConcept'
 
-    SnapshotBuilderFeatureValueGroup:
+    SnapshotBuilderOutputTable:
       type: object
       description: >
         ⚠️ Describes a set of columns for a table with given name
       required:
         - name
-        - values
+        - columns
       properties:
         name:
           type: string
-        values:
+        columns:
           type: array
           items:
             type: string
@@ -7510,14 +7503,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SnapshotBuilderCohort'
-        conceptSets:
+        outputTables:
           type: array
           items:
-            $ref: '#/components/schemas/SnapshotBuilderDatasetConceptSet'
-        valueSets:
-          type: array
-          items:
-            $ref: '#/components/schemas/SnapshotBuilderFeatureValueGroup'
+            $ref: '#/components/schemas/SnapshotBuilderOutputTable'
       description: Specification of cohort and participant data for a requested snapshot.
 
     SnapshotBuilderCohort:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7207,6 +7207,7 @@ components:
         - programDataOptions
         - featureValueGroups
         - datasetConceptSets
+        - rootTable
       properties:
         domainOptions:
           type: array
@@ -7221,6 +7222,10 @@ components:
           items:
             $ref:
               '#/components/schemas/SnapshotBuilderDatasetConceptSet'
+        rootTable:
+          $ref: '#/components/schemas/SnapshotBuilderRootTable'
+        dictionaryTable:
+          $ref: '#/components/schemas/SnapshotBuilderTable'
 
     SnapshotBuilderOption:
       type: object
@@ -7419,6 +7424,18 @@ components:
           type: array
           items:
             type: string
+
+    SnapshotBuilderRootTable:
+      allOf:
+        - $ref: '#/components/schemas/SnapshotBuilderTable'
+        - type: object
+          required:
+            - rootColumn
+          properties:
+            rootColumn:
+              type: string
+          description: >
+                The primary column in the root table that is used to join with other tables
 
     EnumerateSnapshotAccessRequest:
       type: object

--- a/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
@@ -37,7 +37,6 @@ import bio.terra.model.SnapshotBuilderCountResponse;
 import bio.terra.model.SnapshotBuilderCountResponseResult;
 import bio.terra.model.SnapshotBuilderGetConceptHierarchyResponse;
 import bio.terra.model.SnapshotBuilderParentConcept;
-import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.model.SnapshotModel;
 import bio.terra.model.SnapshotPreviewModel;
 import bio.terra.model.SnapshotRequestModel;
@@ -497,7 +496,7 @@ class SnapshotsApiControllerTest {
   @Test
   void updateSnapshotSnapshotBuilderSettings() throws Exception {
     mockValidators();
-    var snapshotBuilderSettings = new SnapshotBuilderSettings();
+    var snapshotBuilderSettings = SnapshotBuilderTestData.SETTINGS;
     mvc.perform(
             put(SNAPSHOT_BUILDER_SETTINGS_ENDPOINT, SNAPSHOT_ID)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -516,7 +515,7 @@ class SnapshotsApiControllerTest {
     mvc.perform(
             put(SNAPSHOT_BUILDER_SETTINGS_ENDPOINT, SNAPSHOT_ID)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
+                .content(TestUtils.mapToJson(SnapshotBuilderTestData.SETTINGS)))
         .andExpect(status().isForbidden());
 
     verifyAuthorizationCall(iamAction);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1478,9 +1478,8 @@ class SnapshotServiceTest {
     var accessRequestResponse =
         SnapshotBuilderTestData.createSnapshotAccessRequestResponse(sourceSnapshotId);
     accessRequestResponse.id(snapshotAccessRequestId);
-    when(settingsDao.getBySnapshotId(sourceSnapshotId))
-        .thenReturn(SnapshotBuilderTestData.SETTINGS);
-    var firstTable = service.pullTables(accessRequestResponse).get(0);
+    var firstTable =
+        service.pullTables(accessRequestResponse, SnapshotBuilderTestData.SETTINGS).get(0);
     assertThat(firstTable.getDatasetTableName(), is("drug_exposure"));
     // Must preserve relationship order
     assertThat(firstTable.getPrimaryTableRelationship(), equalTo("fpk_person_drug"));

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -50,7 +50,7 @@ import bio.terra.model.PolicyResponse;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotAccessRequestStatus;
-import bio.terra.model.SnapshotBuilderFeatureValueGroup;
+import bio.terra.model.SnapshotBuilderOutputTable;
 import bio.terra.model.SnapshotBuilderRequest;
 import bio.terra.model.SnapshotIdsAndRolesModel;
 import bio.terra.model.SnapshotLinkDuosDatasetResponse;
@@ -1338,9 +1338,8 @@ class SnapshotServiceTest {
             new SnapshotAccessRequestResponse()
                 .snapshotSpecification(
                     new SnapshotBuilderRequest()
-                        .addValueSetsItem(new SnapshotBuilderFeatureValueGroup().name("Drug"))
-                        .addValueSetsItem(
-                            new SnapshotBuilderFeatureValueGroup().name("Condition"))));
+                        .addOutputTablesItem(new SnapshotBuilderOutputTable().name("Drug"))
+                        .addOutputTablesItem(new SnapshotBuilderOutputTable().name("Condition"))));
 
     Snapshot actual = service.makeSnapshotFromSnapshotRequest(snapshotRequestModel, dataset);
     SnapshotSource snapshotSource = new SnapshotSource().dataset(dataset);

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -22,6 +22,7 @@ import bio.terra.model.SnapshotBuilderProgramDataRangeCriteria;
 import bio.terra.model.SnapshotBuilderProgramDataRangeOption;
 import bio.terra.model.SnapshotBuilderRequest;
 import bio.terra.model.SnapshotBuilderSettings;
+import bio.terra.model.SnapshotBuilderTable;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SnapshotRequestIdModel;
 import bio.terra.model.SnapshotRequestModel;
@@ -33,7 +34,8 @@ import bio.terra.service.snapshotbuilder.query.table.Concept;
 import bio.terra.service.snapshotbuilder.query.table.Person;
 import bio.terra.service.snapshotbuilder.utils.constants.ConditionOccurrence;
 import bio.terra.service.snapshotbuilder.utils.constants.DrugExposure;
-import bio.terra.service.snapshotbuilder.utils.constants.ObservationOccurrence;
+import bio.terra.service.snapshotbuilder.utils.constants.Measurement;
+import bio.terra.service.snapshotbuilder.utils.constants.Observation;
 import bio.terra.service.snapshotbuilder.utils.constants.ProcedureOccurrence;
 import java.util.List;
 import java.util.UUID;
@@ -122,8 +124,8 @@ public class SnapshotBuilderTestData {
                           .hasChildren(true)),
                   generateSnapshotBuilderDomainOption(
                       OBSERVATION_DOMAIN_ID,
-                      ObservationOccurrence.TABLE_NAME,
-                      ObservationOccurrence.OBSERVATION_CONCEPT_ID,
+                      Observation.TABLE_NAME,
+                      Observation.OBSERVATION_CONCEPT_ID,
                       "Observation",
                       new SnapshotBuilderConcept()
                           .id(300)
@@ -170,8 +172,53 @@ public class SnapshotBuilderTestData {
                       List.of(new SnapshotBuilderProgramDataListItem().id(43).name("unused 3")))))
           .datasetConceptSets(
               List.of(
-                  new SnapshotBuilderDatasetConceptSet().name("Demographics"),
-                  new SnapshotBuilderDatasetConceptSet().name("All surveys")));
+                  new SnapshotBuilderDatasetConceptSet()
+                      .name("Drug")
+                      .table(
+                          new SnapshotBuilderTable()
+                              .datasetTableName(DrugExposure.TABLE_NAME)
+                              .primaryTableRelationship("fpk_person_drug")
+                              .secondaryTableRelationships(
+                                  List.of(
+                                      "fpk_drug_concept",
+                                      "fpk_drug_type_concept",
+                                      "fpk_drug_route_concept",
+                                      "fpk_drug_concept_s"))),
+                  new SnapshotBuilderDatasetConceptSet()
+                      .name("Condition")
+                      .table(
+                          new SnapshotBuilderTable()
+                              .datasetTableName(ConditionOccurrence.TABLE_NAME)
+                              .primaryTableRelationship("fpk_person_condition")
+                              .secondaryTableRelationships(
+                                  List.of(
+                                      "fpk_condition_concept",
+                                      "fpk_condition_type_concept",
+                                      "fpk_condition_status_concept",
+                                      "fpk_condition_concept_s"))),
+                  new SnapshotBuilderDatasetConceptSet()
+                      .name("Procedure")
+                      .table(
+                          new SnapshotBuilderTable()
+                              .datasetTableName(ProcedureOccurrence.TABLE_NAME)),
+                  new SnapshotBuilderDatasetConceptSet()
+                      .name("Observation")
+                      .table(new SnapshotBuilderTable().datasetTableName(Observation.TABLE_NAME)),
+                  new SnapshotBuilderDatasetConceptSet()
+                      .name("Measurement")
+                      .table(new SnapshotBuilderTable().datasetTableName(Measurement.TABLE_NAME)),
+                  new SnapshotBuilderDatasetConceptSet()
+                      .name("Visit")
+                      .table(new SnapshotBuilderTable().datasetTableName("visit_occurrence")),
+                  new SnapshotBuilderDatasetConceptSet()
+                      .name("Device")
+                      .table(new SnapshotBuilderTable().datasetTableName("device_exposure")),
+                  new SnapshotBuilderDatasetConceptSet()
+                      .name("Demographics")
+                      .table(new SnapshotBuilderTable().datasetTableName(Person.TABLE_NAME)),
+                  new SnapshotBuilderDatasetConceptSet()
+                      .name("Genomics")
+                      .table(new SnapshotBuilderTable().datasetTableName("sample"))));
 
   public static final Column PERSON_ID_COLUMN =
       new Column().name("person_id").type(TableDataType.INTEGER);

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -13,8 +13,8 @@ import bio.terra.model.SnapshotBuilderCriteriaGroup;
 import bio.terra.model.SnapshotBuilderDatasetConceptSet;
 import bio.terra.model.SnapshotBuilderDomainCriteria;
 import bio.terra.model.SnapshotBuilderDomainOption;
-import bio.terra.model.SnapshotBuilderFeatureValueGroup;
 import bio.terra.model.SnapshotBuilderOption;
+import bio.terra.model.SnapshotBuilderOutputTable;
 import bio.terra.model.SnapshotBuilderProgramDataListCriteria;
 import bio.terra.model.SnapshotBuilderProgramDataListItem;
 import bio.terra.model.SnapshotBuilderProgramDataListOption;
@@ -168,21 +168,10 @@ public class SnapshotBuilderTestData {
                       Person.RACE_CONCEPT_ID,
                       "Race",
                       List.of(new SnapshotBuilderProgramDataListItem().id(43).name("unused 3")))))
-          .featureValueGroups(
-              List.of(
-                  new SnapshotBuilderFeatureValueGroup().name("Condition"),
-                  new SnapshotBuilderFeatureValueGroup().name("Observation"),
-                  new SnapshotBuilderFeatureValueGroup().name("Procedure"),
-                  new SnapshotBuilderFeatureValueGroup().name("Surveys"),
-                  new SnapshotBuilderFeatureValueGroup().name("Person")))
           .datasetConceptSets(
               List.of(
-                  new SnapshotBuilderDatasetConceptSet()
-                      .name("Demographics")
-                      .featureValueGroupName("Person"),
-                  new SnapshotBuilderDatasetConceptSet()
-                      .name("All surveys")
-                      .featureValueGroupName("Surveys")));
+                  new SnapshotBuilderDatasetConceptSet().name("Demographics"),
+                  new SnapshotBuilderDatasetConceptSet().name("All surveys")));
 
   public static final Column PERSON_ID_COLUMN =
       new Column().name("person_id").type(TableDataType.INTEGER);
@@ -362,12 +351,8 @@ public class SnapshotBuilderTestData {
   public static SnapshotBuilderRequest createSnapshotBuilderRequest() {
     return new SnapshotBuilderRequest()
         .addCohortsItem(createCohort())
-        .addConceptSetsItem(
-            new SnapshotBuilderDatasetConceptSet()
-                .name("conceptSet")
-                .featureValueGroupName("featureValueGroupName"))
-        .addValueSetsItem(new SnapshotBuilderFeatureValueGroup().name("Drug"))
-        .addValueSetsItem(new SnapshotBuilderFeatureValueGroup().name("Condition"));
+        .addOutputTablesItem(new SnapshotBuilderOutputTable().name("Drug"))
+        .addOutputTablesItem(new SnapshotBuilderOutputTable().name("Condition"));
   }
 
   public static SnapshotAccessRequest createSnapshotAccessRequest(UUID sourceSnapshotId) {

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -35,7 +35,6 @@ import bio.terra.service.snapshotbuilder.query.table.Concept;
 import bio.terra.service.snapshotbuilder.query.table.Person;
 import bio.terra.service.snapshotbuilder.utils.constants.ConditionOccurrence;
 import bio.terra.service.snapshotbuilder.utils.constants.DrugExposure;
-import bio.terra.service.snapshotbuilder.utils.constants.Measurement;
 import bio.terra.service.snapshotbuilder.utils.constants.Observation;
 import bio.terra.service.snapshotbuilder.utils.constants.ProcedureOccurrence;
 import java.util.List;
@@ -207,7 +206,7 @@ public class SnapshotBuilderTestData {
                       .table(new SnapshotBuilderTable().datasetTableName(Observation.TABLE_NAME)),
                   new SnapshotBuilderDatasetConceptSet()
                       .name("Measurement")
-                      .table(new SnapshotBuilderTable().datasetTableName(Measurement.TABLE_NAME)),
+                      .table(new SnapshotBuilderTable().datasetTableName("measurement")),
                   new SnapshotBuilderDatasetConceptSet()
                       .name("Visit")
                       .table(new SnapshotBuilderTable().datasetTableName("visit_occurrence")),

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -21,6 +21,7 @@ import bio.terra.model.SnapshotBuilderProgramDataListOption;
 import bio.terra.model.SnapshotBuilderProgramDataRangeCriteria;
 import bio.terra.model.SnapshotBuilderProgramDataRangeOption;
 import bio.terra.model.SnapshotBuilderRequest;
+import bio.terra.model.SnapshotBuilderRootTable;
 import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.model.SnapshotBuilderTable;
 import bio.terra.model.SnapshotRequestContentsModel;
@@ -218,7 +219,13 @@ public class SnapshotBuilderTestData {
                       .table(new SnapshotBuilderTable().datasetTableName(Person.TABLE_NAME)),
                   new SnapshotBuilderDatasetConceptSet()
                       .name("Genomics")
-                      .table(new SnapshotBuilderTable().datasetTableName("sample"))));
+                      .table(new SnapshotBuilderTable().datasetTableName("sample"))))
+          .rootTable(
+              (SnapshotBuilderRootTable)
+                  new SnapshotBuilderRootTable()
+                      .rootColumn(Person.PERSON_ID)
+                      .datasetTableName(Person.TABLE_NAME))
+          .dictionaryTable(new SnapshotBuilderTable().datasetTableName(Concept.TABLE_NAME));
 
   public static final Column PERSON_ID_COLUMN =
       new Column().name("person_id").type(TableDataType.INTEGER);

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/constants/Measurement.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/constants/Measurement.java
@@ -1,0 +1,8 @@
+package bio.terra.service.snapshotbuilder.utils.constants;
+
+public class Measurement {
+  private Measurement() {}
+
+  public static final String TABLE_NAME = "measurement";
+  public static final String MEASUREMENT_CONCEPT_ID = "measurement_concept_id";
+}

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/constants/Measurement.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/constants/Measurement.java
@@ -1,8 +1,0 @@
-package bio.terra.service.snapshotbuilder.utils.constants;
-
-public class Measurement {
-  private Measurement() {}
-
-  public static final String TABLE_NAME = "measurement";
-  public static final String MEASUREMENT_CONCEPT_ID = "measurement_concept_id";
-}

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/constants/Observation.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/constants/Observation.java
@@ -1,0 +1,8 @@
+package bio.terra.service.snapshotbuilder.utils.constants;
+
+public final class Observation {
+  private Observation() {}
+
+  public static final String TABLE_NAME = "observation";
+  public static final String OBSERVATION_CONCEPT_ID = "observation_concept_id";
+}

--- a/src/test/java/bio/terra/service/snapshotbuilder/utils/constants/ObservationOccurrence.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/utils/constants/ObservationOccurrence.java
@@ -1,8 +1,0 @@
-package bio.terra.service.snapshotbuilder.utils.constants;
-
-public final class ObservationOccurrence {
-  private ObservationOccurrence() {}
-
-  public static final String TABLE_NAME = "observation_occurrence";
-  public static final String OBSERVATION_CONCEPT_ID = "observation_concept_id";
-}

--- a/src/test/resources/omop/settings.json
+++ b/src/test/resources/omop/settings.json
@@ -259,18 +259,24 @@
           "fpk_observation_type_concept",
           "fpk_observation_value"]
       }
-    },{
-      "name": "Demographics",
-      "table": {
-        "datasetTableName": "person",
-        "columns": [],
-        "secondaryTableRelationships": ["fpk_person_gender_concept",
-          "fpk_person_race_concept",
-          "fpk_person_ethnicity_concept",
-          "fpk_person_gender_concept_s",
-          "fpk_person_race_concept_s",
-          "fpk_person_ethnicity_concept_s"]
-      }
     }
-  ]
+  ],
+  "rootTable":  {
+    "datasetTableName": "person",
+    "rootColumn": "person_id",
+    "columns": [],
+    "secondaryTableRelationships": [
+      "fpk_person_gender_concept",
+      "fpk_person_race_concept",
+      "fpk_person_ethnicity_concept",
+      "fpk_person_gender_concept_s",
+      "fpk_person_race_concept_s",
+      "fpk_person_ethnicity_concept_s"
+    ]
+  },
+  "dictionaryTable": {
+    "datasetTableName": "concept",
+    "columns": [],
+    "secondaryTableRelationships": []
+  }
 }

--- a/src/test/resources/omop/settings.json
+++ b/src/test/resources/omop/settings.json
@@ -252,13 +252,11 @@
         "columns": [],
         "primaryTableRelationship": "fpk_person_observation",
         "secondaryTableRelationships": [
-          "fpk_observation_period_person",
           "fpk_observation_concept",
           "fpk_observation_concept_s",
           "fpk_observation_unit",
           "fpk_observation_qualifier",
           "fpk_observation_type_concept",
-          "fpk_observation_period_concept",
           "fpk_observation_value"]
       }
     },{
@@ -266,7 +264,12 @@
       "table": {
         "datasetTableName": "person",
         "columns": [],
-        "secondaryTableRelationships": ["fpk_person_ethnicity_concept", "fpk_person_ethnicity_concept_s", "fpk_person_race_concept"]
+        "secondaryTableRelationships": ["fpk_person_gender_concept",
+          "fpk_person_race_concept",
+          "fpk_person_ethnicity_concept",
+          "fpk_person_gender_concept_s",
+          "fpk_person_race_concept_s",
+          "fpk_person_ethnicity_concept_s"]
       }
     }
   ]

--- a/src/test/resources/omop/settings.json
+++ b/src/test/resources/omop/settings.json
@@ -268,13 +268,6 @@
         "columns": [],
         "secondaryTableRelationships": ["fpk_person_ethnicity_concept", "fpk_person_ethnicity_concept_s", "fpk_person_race_concept"]
       }
-    },{
-      "name": "Genomics",
-      "table": {
-        "datasetTableName": "sample",
-        "columns": [],
-        "primaryTableRelationship": "fpk_person_sample"
-      }
     }
   ]
 }

--- a/src/test/resources/omop/settings.json
+++ b/src/test/resources/omop/settings.json
@@ -176,7 +176,7 @@
       "table": {
         "datasetTableName": "drug_exposure",
         "columns": [],
-        "primaryTableRelationship": "fpk_drug_person",
+        "primaryTableRelationship": "fpk_person_drug",
         "secondaryTableRelationships": [
           "fpk_drug_type_concept",
           "fpk_drug_concept",
@@ -188,7 +188,7 @@
       "table": {
         "datasetTableName": "measurement",
         "columns": [],
-        "primaryTableRelationship": "fpk_measurement_person",
+        "primaryTableRelationship": "fpk_person_measurement",
         "secondaryTableRelationships": [
           "fpk_measurement_concept",
           "fpk_measurement_unit",
@@ -202,7 +202,7 @@
       "table": {
         "datasetTableName": "visit_occurrence",
         "columns": [],
-        "primaryTableRelationship": "fpk_visit_person",
+        "primaryTableRelationship": "fpk_person_visit",
         "secondaryTableRelationships": [
           "fpk_visit_preceding",
           "fpk_visit_concept_s",
@@ -215,7 +215,7 @@
       "table": {
         "datasetTableName": "device_exposure",
         "columns": [],
-        "primaryTableRelationship": "fpk_device_person",
+        "primaryTableRelationship": "fpk_person_device",
         "secondaryTableRelationships": [
           "fpk_device_concept",
           "fpk_device_concept_s",
@@ -226,7 +226,7 @@
       "table": {
         "datasetTableName": "procedure_occurrence",
         "columns": [],
-        "primaryTableRelationship": "fpk_procedure_person",
+        "primaryTableRelationship": "fpk_person_procedure",
         "secondaryTableRelationships": [
           "fpk_procedure_concept",
           "fpk_procedure_concept_s",
@@ -238,7 +238,7 @@
       "table": {
         "datasetTableName": "condition_occurrence",
         "columns": [],
-        "primaryTableRelationship": "fpk_condition_person",
+        "primaryTableRelationship": "fpk_person_condition",
         "secondaryTableRelationships": [
           "fpk_condition_concept",
           "fpk_condition_type_concept",
@@ -250,7 +250,7 @@
       "table": {
         "datasetTableName": "observation",
         "columns": [],
-        "primaryTableRelationship": "fpk_observation_person",
+        "primaryTableRelationship": "fpk_person_observation",
         "secondaryTableRelationships": [
           "fpk_observation_period_person",
           "fpk_observation_concept",
@@ -273,7 +273,7 @@
       "table": {
         "datasetTableName": "sample",
         "columns": [],
-        "primaryTableRelationship": "fpk_sample_person"
+        "primaryTableRelationship": "fpk_person_sample"
       }
     }
   ]

--- a/src/test/resources/omop/settings.json
+++ b/src/test/resources/omop/settings.json
@@ -170,37 +170,110 @@
       ]
     }
   ],
-  "featureValueGroups": [
-    {
-      "name": "Drug",
-      "values": []
-    },{
-      "name": "Measurement",
-      "values": []
-    },{
-      "name": "Visit",
-      "values": []
-    },{
-      "name": "Device",
-      "values": []
-    },{
-      "name": "Procedure",
-      "values": []
-    },{
-      "name": "Condition",
-      "values": []
-    },{
-      "name": "Observation",
-      "values": []
-    },{
-      "name": "Person",
-      "values": []
-    }
-  ],
   "datasetConceptSets": [
     {
+      "name": "Drug",
+      "table": {
+        "datasetTableName": "drug_exposure",
+        "columns": [],
+        "primaryTableRelationship": "fpk_drug_person",
+        "secondaryTableRelationships": [
+          "fpk_drug_type_concept",
+          "fpk_drug_concept",
+          "fpk_drug_route_concept",
+          "fpk_drug_concept_s"]
+      }
+    },{
+      "name": "Measurement",
+      "table": {
+        "datasetTableName": "measurement",
+        "columns": [],
+        "primaryTableRelationship": "fpk_measurement_person",
+        "secondaryTableRelationships": [
+          "fpk_measurement_concept",
+          "fpk_measurement_unit",
+          "fpk_measurement_concept_s",
+          "fpk_measurement_value",
+          "fpk_measurement_type_concept",
+          "fpk_measurement_operator"]
+      }
+    },{
+      "name": "Visit",
+      "table": {
+        "datasetTableName": "visit_occurrence",
+        "columns": [],
+        "primaryTableRelationship": "fpk_visit_person",
+        "secondaryTableRelationships": [
+          "fpk_visit_preceding",
+          "fpk_visit_concept_s",
+          "fpk_visit_type_concept",
+          "fpk_visit_concept",
+          "fpk_visit_discharge"]
+      }
+    },{
+      "name": "Device",
+      "table": {
+        "datasetTableName": "device_exposure",
+        "columns": [],
+        "primaryTableRelationship": "fpk_device_person",
+        "secondaryTableRelationships": [
+          "fpk_device_concept",
+          "fpk_device_concept_s",
+          "fpk_device_type_concept"]
+      }
+    },{
+      "name": "Procedure",
+      "table": {
+        "datasetTableName": "procedure_occurrence",
+        "columns": [],
+        "primaryTableRelationship": "fpk_procedure_person",
+        "secondaryTableRelationships": [
+          "fpk_procedure_concept",
+          "fpk_procedure_concept_s",
+          "fpk_procedure_type_concept",
+          "fpk_procedure_modifier"]
+      }
+    },{
+      "name": "Condition",
+      "table": {
+        "datasetTableName": "condition_occurrence",
+        "columns": [],
+        "primaryTableRelationship": "fpk_condition_person",
+        "secondaryTableRelationships": [
+          "fpk_condition_concept",
+          "fpk_condition_status_concept",
+          "fpk_condition_concept_s"]
+      }
+    },{
+      "name": "Observation",
+      "table": {
+        "datasetTableName": "observation",
+        "columns": [],
+        "primaryTableRelationship": "fpk_observation_person",
+        "secondaryTableRelationships": [
+          "fpk_observation_period_person",
+          "fpk_observation_concept",
+          "fpk_observation_concept_s",
+          "fpk_observation_unit",
+          "fpk_observation_qualifier",
+          "fpk_observation_type_concept",
+          "fpk_observation_period_concept",
+          "fpk_observation_value"]
+      }
+    },{
       "name": "Demographics",
-      "featureValueGroupName": "Person"
+      "table": {
+        "datasetTableName": "person",
+        "columns": [],
+        "secondaryTableRelationships": ["fpk_person_ethnicity_concept", "fpk_person_ethnicity_concept_s", "fpk_person_race_concept"]
+      }
+    },{
+      "name": "Genomics",
+      "table": {
+        "datasetTableName": "sample",
+        "columns": [],
+        "primaryTableRelationship": "fpk_sample_person"
+      }
     }
   ]
 }

--- a/src/test/resources/omop/settings.json
+++ b/src/test/resources/omop/settings.json
@@ -241,6 +241,7 @@
         "primaryTableRelationship": "fpk_condition_person",
         "secondaryTableRelationships": [
           "fpk_condition_concept",
+          "fpk_condition_type_concept",
           "fpk_condition_status_concept",
           "fpk_condition_concept_s"]
       }

--- a/src/test/resources/omop/snapshot-access-request.json
+++ b/src/test/resources/omop/snapshot-access-request.json
@@ -1,5 +1,29 @@
-{"sourceSnapshotId": "00000000-0000-0000-0000-000000000000",
+{
+  "sourceSnapshotId": "00000000-0000-0000-0000-000000000000",
   "name": "simple_snapshot_access_request",
   "researchPurposeStatement": "purpose",
-  "snapshotBuilderRequest": {"cohorts": [{"name": "test", "criteriaGroups": [{"name": "Group 1", "meetAll": false, "criteria": [], "mustMeet": true}]}], "valueSets": [{"name": "Condition", "values": []}], "conceptSets": [{"name": "Condition", "concept": {"id": 19, "code": null, "name": "Condition", "hasChildren": false}, "featureValueGroupName": "Condition"}]}
+  "snapshotBuilderRequest": {
+    "cohorts": [
+      {
+        "name": "test",
+        "criteriaGroups": [
+          {
+            "name": "Group 1",
+            "meetAll": false,
+            "criteria": [ ],
+            "mustMeet": true
+          }
+        ]
+      }
+    ],
+    "outputTables": [
+      {
+        "name": "Condition",
+        "columns": [
+          "Condition Column 1",
+          "Condition Column 2"
+        ]
+      }
+    ]
+  }
 }

--- a/tools/setupResourceScripts/files/OMOPDataset/snapshot-access-request.json
+++ b/tools/setupResourceScripts/files/OMOPDataset/snapshot-access-request.json
@@ -1,5 +1,29 @@
-{"sourceSnapshotId": "00000000-0000-0000-0000-000000000000",
+{
+  "sourceSnapshotId": "00000000-0000-0000-0000-000000000000",
   "name": "simple_snapshot_access_request",
   "researchPurposeStatement": "purpose",
-  "snapshotBuilderRequest": {"cohorts": [{"name": "test", "criteriaGroups": [{"name": "Group 1", "meetAll": false, "criteria": [], "mustMeet": true}]}], "valueSets": [{"name": "Condition", "values": []}], "conceptSets": [{"name": "Condition", "concept": {"id": 19, "code": null, "name": "Condition", "hasChildren": false}, "featureValueGroupName": "Condition"}]}
+  "snapshotBuilderRequest": {
+    "cohorts": [
+      {
+        "name": "test",
+        "criteriaGroups": [
+          {
+            "name": "Group 1",
+            "meetAll": false,
+            "criteria": [ ],
+            "mustMeet": true
+          }
+        ]
+      }
+    ],
+    "outputTables": [
+      {
+        "name": "Condition",
+        "columns": [
+          "Condition Column 1",
+          "Condition Column 2"
+        ]
+      }
+    ]
+  }
 }

--- a/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
+++ b/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
@@ -259,18 +259,24 @@
           "fpk_observation_type_concept",
           "fpk_observation_value"]
       }
-    },{
-      "name": "Demographics",
-      "table": {
-        "datasetTableName": "person",
-        "columns": [],
-        "secondaryTableRelationships": ["fpk_person_gender_concept",
-          "fpk_person_race_concept",
-          "fpk_person_ethnicity_concept",
-          "fpk_person_gender_concept_s",
-          "fpk_person_race_concept_s",
-          "fpk_person_ethnicity_concept_s"]
-      }
     }
-  ]
+  ],
+  "rootTable":  {
+    "datasetTableName": "person",
+    "rootColumn": "person_id",
+    "columns": [],
+    "secondaryTableRelationships": [
+      "fpk_person_gender_concept",
+      "fpk_person_race_concept",
+      "fpk_person_ethnicity_concept",
+      "fpk_person_gender_concept_s",
+      "fpk_person_race_concept_s",
+      "fpk_person_ethnicity_concept_s"
+    ]
+  },
+  "dictionaryTable": {
+    "datasetTableName": "concept",
+    "columns": [],
+    "secondaryTableRelationships": []
+  }
 }

--- a/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
+++ b/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
@@ -252,13 +252,11 @@
         "columns": [],
         "primaryTableRelationship": "fpk_person_observation",
         "secondaryTableRelationships": [
-          "fpk_observation_period_person",
           "fpk_observation_concept",
           "fpk_observation_concept_s",
           "fpk_observation_unit",
           "fpk_observation_qualifier",
           "fpk_observation_type_concept",
-          "fpk_observation_period_concept",
           "fpk_observation_value"]
       }
     },{
@@ -266,7 +264,12 @@
       "table": {
         "datasetTableName": "person",
         "columns": [],
-        "secondaryTableRelationships": ["fpk_person_ethnicity_concept", "fpk_person_ethnicity_concept_s", "fpk_person_race_concept"]
+        "secondaryTableRelationships": ["fpk_person_gender_concept",
+          "fpk_person_race_concept",
+          "fpk_person_ethnicity_concept",
+          "fpk_person_gender_concept_s",
+          "fpk_person_race_concept_s",
+          "fpk_person_ethnicity_concept_s"]
       }
     }
   ]

--- a/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
+++ b/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
@@ -268,13 +268,6 @@
         "columns": [],
         "secondaryTableRelationships": ["fpk_person_ethnicity_concept", "fpk_person_ethnicity_concept_s", "fpk_person_race_concept"]
       }
-    },{
-      "name": "Genomics",
-      "table": {
-        "datasetTableName": "sample",
-        "columns": [],
-        "primaryTableRelationship": "fpk_person_sample"
-      }
     }
   ]
 }

--- a/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
+++ b/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
@@ -176,7 +176,7 @@
       "table": {
         "datasetTableName": "drug_exposure",
         "columns": [],
-        "primaryTableRelationship": "fpk_drug_person",
+        "primaryTableRelationship": "fpk_person_drug",
         "secondaryTableRelationships": [
           "fpk_drug_type_concept",
           "fpk_drug_concept",
@@ -188,7 +188,7 @@
       "table": {
         "datasetTableName": "measurement",
         "columns": [],
-        "primaryTableRelationship": "fpk_measurement_person",
+        "primaryTableRelationship": "fpk_person_measurement",
         "secondaryTableRelationships": [
           "fpk_measurement_concept",
           "fpk_measurement_unit",
@@ -202,7 +202,7 @@
       "table": {
         "datasetTableName": "visit_occurrence",
         "columns": [],
-        "primaryTableRelationship": "fpk_visit_person",
+        "primaryTableRelationship": "fpk_person_visit",
         "secondaryTableRelationships": [
           "fpk_visit_preceding",
           "fpk_visit_concept_s",
@@ -215,7 +215,7 @@
       "table": {
         "datasetTableName": "device_exposure",
         "columns": [],
-        "primaryTableRelationship": "fpk_device_person",
+        "primaryTableRelationship": "fpk_person_device",
         "secondaryTableRelationships": [
           "fpk_device_concept",
           "fpk_device_concept_s",
@@ -226,7 +226,7 @@
       "table": {
         "datasetTableName": "procedure_occurrence",
         "columns": [],
-        "primaryTableRelationship": "fpk_procedure_person",
+        "primaryTableRelationship": "fpk_person_procedure",
         "secondaryTableRelationships": [
           "fpk_procedure_concept",
           "fpk_procedure_concept_s",
@@ -238,7 +238,7 @@
       "table": {
         "datasetTableName": "condition_occurrence",
         "columns": [],
-        "primaryTableRelationship": "fpk_condition_person",
+        "primaryTableRelationship": "fpk_person_condition",
         "secondaryTableRelationships": [
           "fpk_condition_concept",
           "fpk_condition_type_concept",
@@ -250,7 +250,7 @@
       "table": {
         "datasetTableName": "observation",
         "columns": [],
-        "primaryTableRelationship": "fpk_observation_person",
+        "primaryTableRelationship": "fpk_person_observation",
         "secondaryTableRelationships": [
           "fpk_observation_period_person",
           "fpk_observation_concept",
@@ -273,7 +273,7 @@
       "table": {
         "datasetTableName": "sample",
         "columns": [],
-        "primaryTableRelationship": "fpk_sample_person"
+        "primaryTableRelationship": "fpk_person_sample"
       }
     }
   ]

--- a/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
+++ b/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
@@ -170,37 +170,110 @@
       ]
     }
   ],
-  "featureValueGroups": [
-    {
-      "name": "Drug",
-      "values": []
-    },{
-      "name": "Measurement",
-      "values": []
-    },{
-      "name": "Visit",
-      "values": []
-    },{
-      "name": "Device",
-      "values": []
-    },{
-      "name": "Procedure",
-      "values": []
-    },{
-      "name": "Condition",
-      "values": []
-    },{
-      "name": "Observation",
-      "values": []
-    },{
-      "name": "Person",
-      "values": []
-    }
-  ],
   "datasetConceptSets": [
     {
+      "name": "Drug",
+      "table": {
+        "datasetTableName": "drug_exposure",
+        "columns": [],
+        "primaryTableRelationship": "fpk_drug_person",
+        "secondaryTableRelationships": [
+          "fpk_drug_type_concept",
+          "fpk_drug_concept",
+          "fpk_drug_route_concept",
+          "fpk_drug_concept_s"]
+      }
+    },{
+      "name": "Measurement",
+      "table": {
+        "datasetTableName": "measurement",
+        "columns": [],
+        "primaryTableRelationship": "fpk_measurement_person",
+        "secondaryTableRelationships": [
+          "fpk_measurement_concept",
+          "fpk_measurement_unit",
+          "fpk_measurement_concept_s",
+          "fpk_measurement_value",
+          "fpk_measurement_type_concept",
+          "fpk_measurement_operator"]
+      }
+    },{
+      "name": "Visit",
+      "table": {
+        "datasetTableName": "visit_occurrence",
+        "columns": [],
+        "primaryTableRelationship": "fpk_visit_person",
+        "secondaryTableRelationships": [
+          "fpk_visit_preceding",
+          "fpk_visit_concept_s",
+          "fpk_visit_type_concept",
+          "fpk_visit_concept",
+          "fpk_visit_discharge"]
+      }
+    },{
+      "name": "Device",
+      "table": {
+        "datasetTableName": "device_exposure",
+        "columns": [],
+        "primaryTableRelationship": "fpk_device_person",
+        "secondaryTableRelationships": [
+          "fpk_device_concept",
+          "fpk_device_concept_s",
+          "fpk_device_type_concept"]
+      }
+    },{
+      "name": "Procedure",
+      "table": {
+        "datasetTableName": "procedure_occurrence",
+        "columns": [],
+        "primaryTableRelationship": "fpk_procedure_person",
+        "secondaryTableRelationships": [
+          "fpk_procedure_concept",
+          "fpk_procedure_concept_s",
+          "fpk_procedure_type_concept",
+          "fpk_procedure_modifier"]
+      }
+    },{
+      "name": "Condition",
+      "table": {
+        "datasetTableName": "condition_occurrence",
+        "columns": [],
+        "primaryTableRelationship": "fpk_condition_person",
+        "secondaryTableRelationships": [
+          "fpk_condition_concept",
+          "fpk_condition_status_concept",
+          "fpk_condition_concept_s"]
+      }
+    },{
+      "name": "Observation",
+      "table": {
+        "datasetTableName": "observation",
+        "columns": [],
+        "primaryTableRelationship": "fpk_observation_person",
+        "secondaryTableRelationships": [
+          "fpk_observation_period_person",
+          "fpk_observation_concept",
+          "fpk_observation_concept_s",
+          "fpk_observation_unit",
+          "fpk_observation_qualifier",
+          "fpk_observation_type_concept",
+          "fpk_observation_period_concept",
+          "fpk_observation_value"]
+      }
+    },{
       "name": "Demographics",
-      "featureValueGroupName": "Person"
+      "table": {
+        "datasetTableName": "person",
+        "columns": [],
+        "secondaryTableRelationships": ["fpk_person_ethnicity_concept", "fpk_person_ethnicity_concept_s", "fpk_person_race_concept"]
+      }
+    },{
+      "name": "Genomics",
+      "table": {
+        "datasetTableName": "sample",
+        "columns": [],
+        "primaryTableRelationship": "fpk_sample_person"
+      }
     }
   ]
 }

--- a/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
+++ b/tools/setupResourceScripts/files/OMOPDataset/snapshot_builder_settings.json
@@ -241,6 +241,7 @@
         "primaryTableRelationship": "fpk_condition_person",
         "secondaryTableRelationships": [
           "fpk_condition_concept",
+          "fpk_condition_type_concept",
           "fpk_condition_status_concept",
           "fpk_condition_concept_s"]
       }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/1120

## Summary of Changes
1. Update snapshot builder settings
- Remove "featureValueGroups"
- Rework datasetConceptSets
- Remove "featureValueGroupName"
- Add “table” object that follows the model of the “SnapshotBuilderTable” that includes datasetTableName, columns and relationships
- We’ll leave columns empty for now so that all columns are included in the asset
2. Rework the Snapshot Builder Access Request
- Remove "conceptSets"
- Rename "valueSets" to "outputTables" and the “values” list to instead be “columns”
- Return an empty list for “columns” for now.
3. Update how the asset is generated on snapshot create by request id
- Remove the manual mapping between the concept name and the table object
- Instead, pull the table object from snapshot builder settings based on the name of the outputTable/ConceptSet

There will be a follow up UI change to handle changes to settings/access request - Not yet complete

## Testing Strategy
1. Updated existing snapshotServiceTests
2. Integration and connected tests as they are should test this already since this is not adding functionality but replacing hardcoded functionality
