### PR TITLE
[DCJ-506] TDR FutureUtils shouldn't mask ExecutionExceptions

### DIFF
--- a/src/main/java/bio/terra/common/FutureUtils.java
+++ b/src/main/java/bio/terra/common/FutureUtils.java
@@ -74,7 +74,7 @@ public final class FutureUtils {
                       foundFailure.compareAndSet(null, ere);
                     } else {
                       foundFailure.compareAndSet(
-                          null, new ApiException("Error executing thread", e));
+                          null, new ApiException(e.getMessage(), e.getCause()));
                     }
                   }
                   return null;

--- a/src/test/java/bio/terra/common/FutureUtilsTest.java
+++ b/src/test/java/bio/terra/common/FutureUtilsTest.java
@@ -141,7 +141,8 @@ class FutureUtilsTest {
   @Test
   void testWaitFor_RuntimeException() {
     final Executor delayedExecutor = CompletableFuture.delayedExecutor(1, TimeUnit.SECONDS);
-    final RuntimeException rootCause = new RuntimeException("Injected error");
+    final String rootCauseMessage = "Injected error";
+    final RuntimeException rootCause = new RuntimeException(rootCauseMessage);
     final List<Future<String>> futures =
         List.of(
             CompletableFuture.completedFuture("Completed successfully"),
@@ -149,7 +150,8 @@ class FutureUtilsTest {
             CompletableFuture.supplyAsync(() -> "Should be cancelled with delay", delayedExecutor));
     assertThatThrownBy(() -> FutureUtils.waitFor(futures))
         .isInstanceOf(ApiException.class)
-        .hasMessage("Error executing thread")
+        .hasMessageStartingWith(rootCause.getClass().getName())
+        .hasMessageEndingWith(rootCauseMessage)
         .hasRootCause(rootCause);
     // Make sure that at least one task after the failure was cancelled
     assertThat(IterableUtils.countMatches(futures, Future::isCancelled)).isPositive();
@@ -170,7 +172,7 @@ class FutureUtilsTest {
   }
 
   @Test
-  void testWaitFor_nulLFiltering() {
+  void testWaitFor_nullFiltering() {
     String expected = "Expected";
     final List<Future<String>> futures =
         List.of(


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-506
(Inspired by https://broadworkbench.atlassian.net/browse/DCJ-503)

## Addresses

Previously, `ExecutionExceptions` thrown by `Future`s polled by TDR's `FutureUtils` would be communicated to end users with the message "Error executing thread".

This doesn't help the end user: they want to know what caused the execution error, not that it was executed using a threadpool.

## Summary of changes

If a `Future` monitored by `FutureUtils` throws an `ExecutionException`, TDR will now return an exception that elevates the root cause to the end user.

## Testing Strategy

Updated unit tests.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
