### PR TITLE
[DCJ-507] Update Stairway dependency for context-aware work queue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,10 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
 
     implementation 'bio.terra:terra-common-lib:1.1.14-SNAPSHOT'
+    implementation 'bio.terra:stairway-gcp:1.1.10-SNAPSHOT' // DO NOT MERGE:
+    // Temporarily pulling in Stairway dependency directly for a full integration test run.
+    // Following that, I will update the Stairway dependency in TCL, and bump TCL in TDR
+    // (TDR gets its Stairway dependency transitively from TCL).
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
     implementation 'bio.terra:terra-policy-client:1.0.11-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -210,11 +210,7 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.2.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
 
-    implementation 'bio.terra:terra-common-lib:1.1.14-SNAPSHOT'
-    implementation 'bio.terra:stairway-gcp:1.1.10-SNAPSHOT' // DO NOT MERGE:
-    // Temporarily pulling in Stairway dependency directly for a full integration test run.
-    // Following that, I will update the Stairway dependency in TCL, and bump TCL in TDR
-    // (TDR gets its Stairway dependency transitively from TCL).
+    implementation 'bio.terra:terra-common-lib:1.1.15-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
     implementation 'bio.terra:terra-policy-client:1.0.11-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-507

## Addresses

Context-aware Stairway previously assumed that the calling thread would have mapped diagnostic context (MDC) to persist to the child threads spawned for flight execution.

This was not the case when Stairway is configured with a work queue enabled (e.g. GCP Pub-Sub). Here, flight information was written to the pub-sub topic without the calling thread's context, so when a message was processed and deserialized any logs emitted from that flight would be missing context set by the original calling thread (e.g. request ID).

Where we've felt this impact in TDR:

- Child flights submitted within the execution of a parent flight are missing the calling thread's context in its logs.
- While this is an uncommon pattern for flight execution, it is used when facilitating combined data ingests to datasets: the parent flight ingests tabular data, and child flights are spawned for each file being ingested.
- Much of our attention has been on debugging combined data ingests to Azure datasets: the inability to filter for all connected parent and child flight logs in GCP log console by request ID (`jsonPayload.requestId`) is slowing down investigative progress.

## Summary of changes

Upgrades Terra Common Lib: https://github.com/DataBiosphere/terra-common-lib/pull/189
So that we get our transitive dependency on Stairway updated: https://github.com/DataBiosphere/stairway/pull/152

## Testing Strategy

TDR's deployed environments (integration, dev, staging, prod) have all configured work queues for their Stairways:
- This is dictated by `TERRA_COMMON_KUBERNETES_INKUBERNETES` environment variable set to true: https://github.com/broadinstitute/datarepo-helm/blob/6515f7dd8749653373085f9d117203d4d0d2dcc5/charts/datarepo-api/templates/api-deployment.yaml#L165-L166
- … which Terra Common Lib then considers when initializing Stairway on TDR's behalf.  If the calling service is running `inKubernetes`, then it will configure a GCP Pub-Sub queue as the backing work queue: https://github.com/DataBiosphere/terra-common-lib/blob/cefb57e6d71d92be761d826f5d477ad85c6256ca/src/main/java/bio/terra/common/stairway/StairwayComponent.java#L139

When observing the active integration test run logs for this PR, I found a run of a `FileIngestBulkFlight` which kicks off child `FileIngestWorkerFlight`s.  I was able to successfully filter logs by the request ID to get all logs for the parent and children flights :tada:

https://cloudlogging.app.goo.gl/CEEUJTXjw7Jv7rkQ7

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
