### PR TITLE
[DR-3481] Upgrade TCL for disabled OTEL metrics export

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.2.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
 
-    implementation 'bio.terra:terra-common-lib:1.1.15-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.17-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
     implementation 'bio.terra:terra-policy-client:1.0.11-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DR-3481

## Addresses

The default OpenTelemetry exporter is the OTLP exporter, which we don't use and outputs errors every minute like:
```
ERROR [OkHttp http://localhost:4318/...] i.o.e.internal.http.HttpExporter: Failed to export metrics. The request could not be executed. Full error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4318
```
It has been disabled in TCL.

## Summary of changes

Upgrade TCL to get https://github.com/DataBiosphere/terra-common-lib/pull/192

## Testing Strategy

When running `./gradlew bootRun` locally, I no longer see the "Failed to export metrics" error logs emitted every minute.

This branch was deployed to the `integration-2` namespace to run integration tests.  These logs were no longer observed there following the deployment: https://cloudlogging.app.goo.gl/G5FPzobvPtoYy2tq6

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
