### PR TITLE
[DC-1158]DuplicateException when creating snapshot with DAC and policies

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/flight/SnapshotPolicyStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/SnapshotPolicyStep.java
@@ -1,9 +1,9 @@
 package bio.terra.service.snapshot.flight;
 
+import bio.terra.policy.model.TpsObjectType;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.policy.PolicyService;
-import bio.terra.service.policy.exception.PolicyConflictException;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
@@ -30,11 +30,7 @@ public abstract class SnapshotPolicyStep implements Step {
       UUID snapshotId = getSnapshotId(flightContext);
       TpsPolicyInput protectedDataPolicy = PolicyService.getProtectedDataPolicyInput();
       TpsPolicyInputs policyInputs = new TpsPolicyInputs().addInputsItem(protectedDataPolicy);
-      try {
-        policyService.createSnapshotPao(snapshotId, policyInputs);
-      } catch (PolicyConflictException ex) {
-        logger.warn("Policy access object already exists for snapshot {}", snapshotId);
-      }
+      policyService.createOrUpdatePao(snapshotId, TpsObjectType.SNAPSHOT, policyInputs);
     }
     return StepResult.getStepResultSuccess();
   }

--- a/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/CreateSnapshotPolicyStepTest.java
@@ -2,15 +2,14 @@ package bio.terra.service.policy.flight;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import bio.terra.common.category.Unit;
+import bio.terra.policy.model.TpsObjectType;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.policy.PolicyService;
-import bio.terra.service.policy.exception.PolicyConflictException;
 import bio.terra.service.snapshot.flight.create.CreateSnapshotPolicyStep;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
@@ -39,20 +38,10 @@ class CreateSnapshotPolicyStepTest {
     CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, true, SNAPSHOT_ID);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
+    verify(policyService).createOrUpdatePao(SNAPSHOT_ID, TpsObjectType.SNAPSHOT, policies);
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verify(policyService).deletePaoIfExists(SNAPSHOT_ID);
-  }
-
-  @Test
-  void testProtectedDataPolicyAlreadyExists() throws Exception {
-    CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, true, SNAPSHOT_ID);
-    var exception = new PolicyConflictException("Policy access object already exists");
-    doThrow(exception).when(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
-    StepResult doResult = step.doStep(flightContext);
-    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
   }
 
   @Test
@@ -60,7 +49,7 @@ class CreateSnapshotPolicyStepTest {
     CreateSnapshotPolicyStep step = new CreateSnapshotPolicyStep(policyService, false, SNAPSHOT_ID);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService, never()).createSnapshotPao(SNAPSHOT_ID, policies);
+    verify(policyService, never()).createOrUpdatePao(SNAPSHOT_ID, TpsObjectType.SNAPSHOT, policies);
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     verify(policyService, never()).deletePaoIfExists(SNAPSHOT_ID);

--- a/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
+++ b/src/test/java/bio/terra/service/policy/flight/DeleteSnapshotPolicyStepTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
+import bio.terra.policy.model.TpsObjectType;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
 import bio.terra.service.dataset.Dataset;
@@ -64,7 +65,7 @@ public class DeleteSnapshotPolicyStepTest {
 
     StepResult undoResult = step.undoStep(flightContext);
     assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(policyService).createSnapshotPao(SNAPSHOT_ID, policies);
+    verify(policyService).createOrUpdatePao(SNAPSHOT_ID, TpsObjectType.SNAPSHOT, policies);
   }
 
   @Test


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1158

## Summary of changes
- change createSnapshotPao to createOrUpdatePao with type snapshot

## Testing Strategy
Locally, I created a full view snapshot with this payload:
```
{
	"name": "testingFullViewSnapshotAXINWithDACs",
	"description": "testing adding dac and policies",
	"contents": [{
		"datasetName": "GCP_OMOP_Dataset",
		"mode": "byFullView"
	}],
	"policies": {
		"stewards": ["DataRepoAdmins@dev.test.firecloud.org"],
		"readers": ["CatalogAdmins-dev@dev.test.firecloud.org", "datanauts@dev.test.firecloud.org"]
	},
	"dataAccessControlGroups": ["datanauts"]
}
```
This created snapshot with id: 3ac09c52-90c6-4321-87e8-2d2f65070a9b
When the flight completed successfully, I checked the policies on the snapshot: 
```
{
  "policies": [
    {
      "name": "discoverer",
      "members": []
    },
    {
      "name": "reader",
      "members": [
        "CatalogAdmins-dev@dev.test.firecloud.org",
        "datanauts@dev.test.firecloud.org"
      ]
    },
    {
      "name": "admin",
      "members": [
        "DataRepoAdmins@dev.test.firecloud.org"
      ]
    },
    {
      "name": "aggregate_data_reader",
      "members": []
    },
    {
      "name": "steward",
      "members": [
        "rjohanekdev@gmail.com",
        "DataRepoAdmins@dev.test.firecloud.org"
      ]
    }
  ],
  "authDomain": [
    "datanauts"
  ],
  "workspaces": [],
  "inaccessibleWorkspaces": []
}
```
And, I checked that the auth domain / data access controls were included on the resource in sam by hitting the getAuthDomainV2 endpoint on dev with the datasnapshot type and id 3ac09c52-90c6-4321-87e8-2d2f65070a9b:
```
[
  "datanauts"
]

```
<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
