### PR TITLE
DC-1171 - Delete Sam Group on Snapshot delete

### DIFF
--- a/src/main/java/bio/terra/app/controller/GlobalExceptionHandler.java
+++ b/src/main/java/bio/terra/app/controller/GlobalExceptionHandler.java
@@ -107,7 +107,7 @@ public class GlobalExceptionHandler {
     // the conversion,
     // but want to add in a logging message that there's an escaped SAM ApiException somewhere.
     logger.error("SAM ApiException caught outside the service/iam package", ex);
-    ErrorReportException drex = SamIam.convertSAMExToDataRepoEx(ex);
+    ErrorReportException drex = SamIam.convertSamExToDataRepoEx(ex);
     return buildErrorModel(drex);
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -164,7 +164,7 @@ public interface IamProviderInterface {
       throws InterruptedException;
 
   // -- auth domain support --
-  List<String> retrieveAuthDomain(
+  List<String> retrieveAuthDomains(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
       throws InterruptedException;
 

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -334,9 +334,10 @@ public class IamService {
   }
 
   // -- auth domain support --
-  public List<String> retrieveAuthDomain(
+  public List<String> retrieveAuthDomains(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId) {
-    return callProvider(() -> iamProvider.retrieveAuthDomain(userReq, iamResourceType, resourceId));
+    return callProvider(
+        () -> iamProvider.retrieveAuthDomains(userReq, iamResourceType, resourceId));
   }
 
   public void patchAuthDomain(

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -626,7 +626,7 @@ public class SamIam implements IamProviderInterface {
           .userEmail(samInfo.getUserEmail())
           .enabled(samInfo.getEnabled());
     } catch (ApiException ex) {
-      throw convertSAMExToDataRepoEx(ex);
+      throw convertSamExToDataRepoEx(ex);
     }
   }
 
@@ -854,10 +854,10 @@ public class SamIam implements IamProviderInterface {
    * Converts a SAM-specific ApiException to a DataRepo-specific common exception, based on the HTTP
    * status code.
    */
-  public static ErrorReportException convertSAMExToDataRepoEx(final ApiException samEx) {
-    logger.warn("SAM client exception code: {}", samEx.getCode());
-    logger.warn("SAM client exception message: {}", samEx.getMessage());
-    logger.warn("SAM client exception details: {}", samEx.getResponseBody());
+  public static ErrorReportException convertSamExToDataRepoEx(final ApiException samEx) {
+    logger.warn("Sam client exception code: {}", samEx.getCode());
+    logger.warn("Sam client exception message: {}", samEx.getMessage());
+    logger.warn("Sam client exception details: {}", samEx.getResponseBody());
 
     // Sometimes the sam message is buried several levels down inside of the error report object.
     String message = null;
@@ -865,7 +865,7 @@ public class SamIam implements IamProviderInterface {
       ErrorReport errorReport = objectMapper.readValue(samEx.getResponseBody(), ErrorReport.class);
       message = extractErrorMessage(errorReport);
     } catch (JsonProcessingException | IllegalArgumentException ex) {
-      message = Objects.requireNonNullElse(samEx.getMessage(), "SAM client exception");
+      message = Objects.requireNonNullElse(samEx.getMessage(), "Sam client exception");
     }
 
     switch (samEx.getCode()) {

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -426,7 +426,7 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
-  public List<String> retrieveAuthDomain(
+  public List<String> retrieveAuthDomains(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
       throws InterruptedException {
     return SamRetry.retry(

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamRetry.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamRetry.java
@@ -90,7 +90,7 @@ class SamRetry {
   }
 
   private void handleApiException(ApiException ex) {
-    ErrorReportException rex = SamIam.convertSAMExToDataRepoEx(ex);
+    ErrorReportException rex = SamIam.convertSamExToDataRepoEx(ex);
     if (!(rex instanceof IamInternalServerErrorException)) {
       throw rex;
     }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -794,8 +794,8 @@ public class SnapshotService {
         .submitAndWait(AddAuthDomainResponseModel.class);
   }
 
-  public List<String> getAuthDomains(UUID snapshotId, AuthenticatedUserRequest userReq) {
-    return iamService.retrieveAuthDomain(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
+  public List<String> retrieveAuthDomains(UUID snapshotId, AuthenticatedUserRequest userReq) {
+    return iamService.retrieveAuthDomains(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
   }
 
   /**
@@ -809,7 +809,7 @@ public class SnapshotService {
     List<SamPolicyModel> samPolicyModels =
         iamService.retrievePolicies(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
     List<String> authDomain =
-        iamService.retrieveAuthDomain(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
+        iamService.retrieveAuthDomains(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
     List<WorkspacePolicyModel> accessibleWorkspaces = new ArrayList<>();
     List<InaccessibleWorkspacePolicyModel> inaccessibleWorkspaces = new ArrayList<>();
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -794,6 +794,10 @@ public class SnapshotService {
         .submitAndWait(AddAuthDomainResponseModel.class);
   }
 
+  public List<String> getAuthDomains(UUID snapshotId, AuthenticatedUserRequest userReq) {
+    return iamService.retrieveAuthDomain(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
+  }
+
   /**
    * @param snapshotId snapshot UUID
    * @param userReq authenticated user

--- a/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
@@ -14,6 +14,7 @@ public final class SnapshotWorkingMapKeys extends ProjectCreatingFlightKeys {
   public static final String SNAPSHOT_EXISTS = "snapshotExists";
   public static final String SNAPSHOT_HAS_GOOGLE_PROJECT = "snapshotHasGoogleProject";
   public static final String SNAPSHOT_HAS_AZURE_STORAGE_ACCOUNT = "snapshotHasStorageAccount";
+  public static final String SNAPSHOT_AUTH_DOMAIN_GROUPS = "snapshotAuthDomainGroups";
   public static final String DATASET_EXISTS = "datasetExists";
   public static final String STORAGE_ACCOUNT_RESOURCE_NAME = "storageAccountResourceName";
   public static final String STORAGE_ACCOUNT_RESOURCE_TLC = "storageAccountResourceTlc";

--- a/src/main/java/bio/terra/service/snapshot/flight/authDomain/AddSnapshotAuthDomainSetResponseStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/authDomain/AddSnapshotAuthDomainSetResponseStep.java
@@ -28,7 +28,7 @@ public class AddSnapshotAuthDomainSetResponseStep extends DefaultUndoStep {
   @Override
   public StepResult doStep(FlightContext context) {
     List<String> authDomain =
-        iamService.retrieveAuthDomain(userRequest, IamResourceType.DATASNAPSHOT, snapshotId);
+        iamService.retrieveAuthDomains(userRequest, IamResourceType.DATASNAPSHOT, snapshotId);
     AddAuthDomainResponseModel response = new AddAuthDomainResponseModel().authDomain(authDomain);
     FlightUtils.setResponse(context, response, HttpStatus.OK);
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/authDomain/AddSnapshotAuthDomainStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/authDomain/AddSnapshotAuthDomainStep.java
@@ -40,7 +40,7 @@ public class AddSnapshotAuthDomainStep extends DefaultUndoStep {
                 SnapshotWorkingMapKeys.SNAPSHOT_DATA_ACCESS_CONTROL_GROUPS,
                 new TypeReference<>() {});
     List<String> existingAuthDomain =
-        iamService.retrieveAuthDomain(userRequest, IamResourceType.DATASNAPSHOT, snapshotId);
+        iamService.retrieveAuthDomains(userRequest, IamResourceType.DATASNAPSHOT, snapshotId);
     if (!existingAuthDomain.isEmpty()) {
       return new StepResult(
           StepStatus.STEP_RESULT_FAILURE_FATAL,

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteSamGroupStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteSamGroupStep.java
@@ -1,0 +1,51 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.auth.iam.exception.IamNotFoundException;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public class DeleteSnapshotDeleteSamGroupStep extends DefaultUndoStep {
+  private final IamService iamService;
+
+  private final UUID snapshotId;
+
+  /**
+   * On Snapshot Create byRequestId, we generate a Sam Group and set it as an auth domain On delete
+   * of the Snapshot, we need to delete this Sam group that we created We do not want to delete any
+   * other auth domain groups that may have been added to the snapshot
+   *
+   * @param iamService
+   * @param snapshotId
+   */
+  public DeleteSnapshotDeleteSamGroupStep(IamService iamService, UUID snapshotId) {
+    this.iamService = iamService;
+    this.snapshotId = snapshotId;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    List<String> authDomains =
+        context
+            .getWorkingMap()
+            .get(SnapshotWorkingMapKeys.SNAPSHOT_AUTH_DOMAIN_GROUPS, new TypeReference<>() {});
+    // Only delete the Sam group if it matches the expected naming pattern
+    var expectedName = IamService.constructSamGroupName(snapshotId.toString());
+    if (Objects.nonNull(authDomains) && authDomains.contains(expectedName)) {
+      try {
+        // Only delete the group that we created as a part of snapshot create
+        iamService.deleteGroup(expectedName);
+      } catch (IamNotFoundException ex) {
+        // if group does not exist, nothing to delete
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteSamGroupStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteSamGroupStep.java
@@ -11,16 +11,18 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DeleteSnapshotDeleteSamGroupStep extends DefaultUndoStep {
+  private static Logger logger = LoggerFactory.getLogger(DeleteSnapshotDeleteSamGroupStep.class);
   private final IamService iamService;
-
   private final UUID snapshotId;
 
   /**
-   * On Snapshot Create byRequestId, we generate a Sam Group and set it as an auth domain On delete
-   * of the Snapshot, we need to delete this Sam group that we created We do not want to delete any
-   * other auth domain groups that may have been added to the snapshot
+   * On Snapshot Create byRequestId, we generate a Sam Group and set it as an auth domain. On
+   * snapshot delete, we need to delete this Sam group. We do not want to delete any other auth
+   * domain groups that may have been added to the snapshot.
    *
    * @param iamService
    * @param snapshotId
@@ -40,10 +42,11 @@ public class DeleteSnapshotDeleteSamGroupStep extends DefaultUndoStep {
     var expectedName = IamService.constructSamGroupName(snapshotId.toString());
     if (Objects.nonNull(authDomains) && authDomains.contains(expectedName)) {
       try {
-        // Only delete the group that we created as a part of snapshot create
         iamService.deleteGroup(expectedName);
       } catch (IamNotFoundException ex) {
-        // if group does not exist, nothing to delete
+        // if group does not exist, nothing to delete)
+      } catch (Exception ex) {
+        logger.error("Error deleting Sam group: {}", expectedName, ex);
       }
     }
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStep.java
@@ -15,6 +15,8 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class DeleteSnapshotPopAndLockDatasetStep implements Step {
@@ -63,9 +65,10 @@ public class DeleteSnapshotPopAndLockDatasetStep implements Step {
     }
 
     try {
-      map.put(
-          SnapshotWorkingMapKeys.SNAPSHOT_AUTH_DOMAIN_GROUPS,
-          snapshotService.getAuthDomains(snapshot.getId(), authenticatedUserRequest));
+      List<String> authDomains =
+          new ArrayList<>(
+              snapshotService.getAuthDomains(snapshot.getId(), authenticatedUserRequest));
+      map.put(SnapshotWorkingMapKeys.SNAPSHOT_AUTH_DOMAIN_GROUPS, authDomains);
     } catch (Exception ex) {
       // Do nothing if we can't retrieve the auth domains
       // No Sam groups will be deleted

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStep.java
@@ -67,7 +67,7 @@ public class DeleteSnapshotPopAndLockDatasetStep implements Step {
     try {
       List<String> authDomains =
           new ArrayList<>(
-              snapshotService.getAuthDomains(snapshot.getId(), authenticatedUserRequest));
+              snapshotService.retrieveAuthDomains(snapshot.getId(), authenticatedUserRequest));
       map.put(SnapshotWorkingMapKeys.SNAPSHOT_AUTH_DOMAIN_GROUPS, authDomains);
     } catch (Exception ex) {
       // Do nothing if we can't retrieve the auth domains

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStep.java
@@ -58,7 +58,17 @@ public class DeleteSnapshotPopAndLockDatasetStep implements Step {
       map.put(SnapshotWorkingMapKeys.DATASET_EXISTS, false);
       map.put(SnapshotWorkingMapKeys.SNAPSHOT_HAS_GOOGLE_PROJECT, false);
       map.put(SnapshotWorkingMapKeys.SNAPSHOT_HAS_AZURE_STORAGE_ACCOUNT, false);
+
       return StepResult.getStepResultSuccess();
+    }
+
+    try {
+      map.put(
+          SnapshotWorkingMapKeys.SNAPSHOT_AUTH_DOMAIN_GROUPS,
+          snapshotService.getAuthDomains(snapshot.getId(), authenticatedUserRequest));
+    } catch (Exception ex) {
+      // Do nothing if we can't retrieve the auth domains
+      // No Sam groups will be deleted
     }
 
     // Now we've confirmed the snapshot exists, let's check on the source dataset

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/SnapshotDeleteFlight.java
@@ -103,6 +103,10 @@ public class SnapshotDeleteFlight extends Flight {
     // deletes the snapshot group, so no ACL cleanup is needed beyond that.
     addStep(new DeleteSnapshotAuthzResource(iamClient, snapshotId, userReq));
 
+    // Now that we no longer have the resources in SAM, we can delete the underlying Sam group
+    // that was created for snapshots byRequestId
+    addStep(new DeleteSnapshotDeleteSamGroupStep(iamClient, snapshotId));
+
     // Primary Data Deletion
     // Note: Must delete primary data before metadata; it relies on being able to retrieve the
     // snapshot object from the metadata to know what to delete.

--- a/src/test/java/bio/terra/integration/SamFixtures.java
+++ b/src/test/java/bio/terra/integration/SamFixtures.java
@@ -1,5 +1,7 @@
 package bio.terra.integration;
 
+import static bio.terra.service.auth.iam.sam.SamIam.convertSAMExToDataRepoEx;
+
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.configuration.TestConfiguration;
@@ -113,6 +115,17 @@ public class SamFixtures {
       return samResourcesApi.getAuthDomainV2(resourceType, resourceId);
     } catch (ApiException e) {
       throw new RuntimeException("Error retrieving Data Access Controls: %s", e);
+    }
+  }
+
+  public String getGroup(TestConfiguration.User user, String groupName) {
+    try {
+      HttpHeaders authedHeader = getHeaders(user);
+      String accessToken = getAccessToken(authedHeader);
+      GroupApi samGroupApi = new GroupApi(getApiClient(accessToken));
+      return samGroupApi.getGroup(groupName);
+    } catch (ApiException e) {
+      throw convertSAMExToDataRepoEx(e);
     }
   }
 

--- a/src/test/java/bio/terra/integration/SamFixtures.java
+++ b/src/test/java/bio/terra/integration/SamFixtures.java
@@ -1,6 +1,6 @@
 package bio.terra.integration;
 
-import static bio.terra.service.auth.iam.sam.SamIam.convertSAMExToDataRepoEx;
+import static bio.terra.service.auth.iam.sam.SamIam.convertSamExToDataRepoEx;
 
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.auth.AuthService;
@@ -125,7 +125,7 @@ public class SamFixtures {
       GroupApi samGroupApi = new GroupApi(getApiClient(accessToken));
       return samGroupApi.getGroup(groupName);
     } catch (ApiException e) {
-      throw convertSAMExToDataRepoEx(e);
+      throw convertSamExToDataRepoEx(e);
     }
   }
 

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -66,12 +66,12 @@ class IamServiceTest {
 
   @Test
   void testRetrieveAuthDomain() throws InterruptedException {
-    when(iamProvider.retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, ID))
+    when(iamProvider.retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, ID))
         .thenReturn(AUTH_DOMAIN);
 
     List<String> result =
-        iamService.retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, ID);
-    verify(iamProvider).retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, ID);
+        iamService.retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, ID);
+    verify(iamProvider).retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, ID);
     assertEquals(AUTH_DOMAIN, result);
   }
 

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -711,7 +711,7 @@ class SamIamTest {
               IamResourceType.DATASNAPSHOT.getSamResourceName(), snapshotId.toString()))
           .thenReturn(authDomain);
       List<String> retrievedAuthDomain =
-          samIam.retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId);
+          samIam.retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId);
       assertThat(retrievedAuthDomain, hasSize(authDomain.size()));
       assertThat(retrievedAuthDomain, containsInAnyOrder(authDomain.toArray()));
     }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1615,4 +1615,12 @@ class SnapshotServiceTest {
       when(snapshotTableDao.retrieveColumns(any())).thenReturn(columns);
     }
   }
+
+  @Test
+  void getAuthDomains() {
+    when(iamService.retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
+        .thenReturn(List.of("group1", "group2"));
+    assertThat(
+        service.getAuthDomains(snapshotId, TEST_USER), containsInAnyOrder("group1", "group2"));
+  }
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -805,7 +805,7 @@ class SnapshotServiceTest {
             mock(InaccessibleWorkspacePolicyModel.class));
     List<String> userGroups = List.of("userGroup1", "userGroup2");
 
-    when(iamService.retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
+    when(iamService.retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
         .thenReturn(userGroups);
     when(rawlsService.resolvePolicyEmails(spm1, TEST_USER))
         .thenReturn(
@@ -1617,10 +1617,10 @@ class SnapshotServiceTest {
   }
 
   @Test
-  void getAuthDomains() {
-    when(iamService.retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
+  void retrieveAuthDomains() {
+    when(iamService.retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
         .thenReturn(List.of("group1", "group2"));
     assertThat(
-        service.getAuthDomains(snapshotId, TEST_USER), containsInAnyOrder("group1", "group2"));
+        service.retrieveAuthDomains(snapshotId, TEST_USER), containsInAnyOrder("group1", "group2"));
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/authDomain/AddSnapshotAuthDomainSetResponseStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/authDomain/AddSnapshotAuthDomainSetResponseStepTest.java
@@ -42,13 +42,13 @@ class AddSnapshotAuthDomainSetResponseStepTest {
   void testDoAndUndoStepSucceeds() {
     AddSnapshotAuthDomainSetResponseStep step =
         new AddSnapshotAuthDomainSetResponseStep(iamService, TEST_USER, SNAPSHOT_ID);
-    when(iamService.retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID))
+    when(iamService.retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID))
         .thenReturn(userGroups);
     when(flightContext.getWorkingMap()).thenReturn(new FlightMap());
 
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
-    verify(iamService).retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID);
+    verify(iamService).retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID);
 
     FlightMap workingMap = flightContext.getWorkingMap();
     assertEquals(

--- a/src/test/java/bio/terra/service/snapshot/flight/authDomain/AddSnapshotAuthDomainStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/authDomain/AddSnapshotAuthDomainStepTest.java
@@ -60,7 +60,7 @@ class AddSnapshotAuthDomainStepTest {
 
   @Test
   void testSnapshotAuthDomainExistsError() throws InterruptedException {
-    when(iamService.retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID))
+    when(iamService.retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID))
         .thenReturn(userGroups);
 
     AddSnapshotAuthDomainStep step =
@@ -74,7 +74,7 @@ class AddSnapshotAuthDomainStepTest {
   void testUserGroupNotFoundError() throws InterruptedException {
     AuthDomainGroupNotFoundException ex =
         new AuthDomainGroupNotFoundException("auth domain not found");
-    when(iamService.retrieveAuthDomain(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID))
+    when(iamService.retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT_ID))
         .thenReturn(List.of());
     doThrow(ex)
         .when(iamService)

--- a/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteSamGroupStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotDeleteSamGroupStepTest.java
@@ -1,0 +1,64 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepStatus;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class DeleteSnapshotDeleteSamGroupStepTest {
+  @Mock IamService iamService;
+  private UUID snapshotId;
+  @Mock private FlightContext flightContext;
+  private DeleteSnapshotDeleteSamGroupStep step;
+
+  @BeforeEach
+  void beforeEach() {
+    snapshotId = UUID.randomUUID();
+    step = new DeleteSnapshotDeleteSamGroupStep(iamService, snapshotId);
+  }
+
+  @Test
+  void doStep() throws InterruptedException {
+    var doNotDeleteGroupName = "group1";
+    var expectedName = IamService.constructSamGroupName(snapshotId.toString());
+
+    var flightMap = new FlightMap();
+    var groups = new ArrayList<>(List.of(doNotDeleteGroupName, expectedName));
+    flightMap.put(SnapshotWorkingMapKeys.SNAPSHOT_AUTH_DOMAIN_GROUPS, groups);
+    when(flightContext.getWorkingMap()).thenReturn(flightMap);
+
+    var result = step.doStep(flightContext);
+    verify(iamService).deleteGroup(expectedName);
+    verify(iamService, never()).deleteGroup(doNotDeleteGroupName);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void doStepNullGroups() throws InterruptedException {
+    var flightMap = new FlightMap();
+    when(flightContext.getWorkingMap()).thenReturn(flightMap);
+    var result = step.doStep(flightContext);
+    verify(iamService, never()).deleteGroup(any());
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStepTest.java
@@ -60,7 +60,7 @@ class DeleteSnapshotPopAndLockDatasetStepTest {
   @Test
   void setAuthDomainGroups() {
     when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
-    when(snapshotService.getAuthDomains(eq(snapshotId), any()))
+    when(snapshotService.retrieveAuthDomains(eq(snapshotId), any()))
         .thenReturn(List.of("group1", "group2"));
     var flightMap = new FlightMap();
     when(flightContext.getWorkingMap()).thenReturn(flightMap);
@@ -76,7 +76,7 @@ class DeleteSnapshotPopAndLockDatasetStepTest {
   @Test
   void noAuthDomainGroups() {
     when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
-    when(snapshotService.getAuthDomains(eq(snapshotId), any())).thenReturn(null);
+    when(snapshotService.retrieveAuthDomains(eq(snapshotId), any())).thenReturn(null);
     var flightMap = new FlightMap();
     when(flightContext.getWorkingMap()).thenReturn(flightMap);
     var result = step.doStep(flightContext);

--- a/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotPopAndLockDatasetStepTest.java
@@ -1,0 +1,90 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.SnapshotSource;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepStatus;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class DeleteSnapshotPopAndLockDatasetStepTest {
+
+  @Mock SnapshotService snapshotService;
+  @Mock DatasetService datasetService;
+  private Snapshot snapshot;
+  private UUID snapshotId;
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private final boolean sharedLock = true;
+  @Mock private FlightContext flightContext;
+  private DeleteSnapshotPopAndLockDatasetStep step;
+
+  @BeforeEach
+  void setUp() {
+    snapshotId = UUID.randomUUID();
+    snapshot =
+        new Snapshot()
+            .id(snapshotId)
+            .snapshotSources(
+                List.of(new SnapshotSource().dataset(new Dataset().id(UUID.randomUUID()))));
+    step =
+        new DeleteSnapshotPopAndLockDatasetStep(
+            snapshotId, snapshotService, datasetService, TEST_USER, sharedLock);
+  }
+
+  @Test
+  void setAuthDomainGroups() {
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    when(snapshotService.getAuthDomains(eq(snapshotId), any()))
+        .thenReturn(List.of("group1", "group2"));
+    var flightMap = new FlightMap();
+    when(flightContext.getWorkingMap()).thenReturn(flightMap);
+    step.doStep(flightContext);
+
+    FlightMap map = flightContext.getWorkingMap();
+    List<String> authDomains =
+        map.get(SnapshotWorkingMapKeys.SNAPSHOT_AUTH_DOMAIN_GROUPS, new TypeReference<>() {});
+    assertThat(
+        "Auth domain list is populated", authDomains, containsInAnyOrder("group1", "group2"));
+  }
+
+  @Test
+  void noAuthDomainGroups() {
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    when(snapshotService.getAuthDomains(eq(snapshotId), any())).thenReturn(null);
+    var flightMap = new FlightMap();
+    when(flightContext.getWorkingMap()).thenReturn(flightMap);
+    var result = step.doStep(flightContext);
+
+    FlightMap map = flightContext.getWorkingMap();
+    List<String> authDomains =
+        map.get(SnapshotWorkingMapKeys.SNAPSHOT_AUTH_DOMAIN_GROUPS, new TypeReference<>() {});
+    assertNull(authDomains);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+}

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -410,7 +410,8 @@ public class BigQueryPdaoTest {
         IamService.constructSamGroupName(String.valueOf(snapshotSummary.getId()));
     verify(samService)
         .patchAuthDomain(any(), any(), eq(snapshotSummary.getId()), eq(List.of(expectedGroupName)));
-    when(samService.retrieveAuthDomain(any(), any(), any())).thenReturn(List.of(expectedGroupName));
+    when(samService.retrieveAuthDomains(any(), any(), any()))
+        .thenReturn(List.of(expectedGroupName));
 
     Snapshot snapshot = snapshotService.retrieve(snapshotSummary.getId());
     assertThat(snapshot.getName(), is(snapshotService.getSnapshotName(requestModel)));


### PR DESCRIPTION
__Jira ticket__:  https://broadworkbench.atlassian.net/browse/DC-1171

## Addresses
We recently made changes to create a Sam group on Snapshot create byRequestId. However, we did not add code to delete the groups on snapshot delete. Since the TDR SA is the owner, we do not have an easy way to manually delete the groups and they are getting automatically created on every integration test run. This PR aims to delete the snapshot-specific sam group on snapshot delete. 

## Summary of changes
- Retrieve list of auth domains before we delete resources in Sam
- Once resources are deleted in Sam, delete only the Sam group that meets two requirements: (1) Matches the naming convention for our snapshot-specific sam group (<snapshotId>-users) and (2) Group that appears in the list of authdomains/Data Access Control groups for the snapshot. 

## Testing Strategy
- Unit tests
- Integration test

