### PR TITLE
[DC-1120] Update all rows from snapshot builder request table to valid spec

### DIFF
--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -84,4 +84,5 @@
     <include file="changesets/20240521_dropsettingsdatasetidaddconstraint.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240522_addjobidandcreatedsnapshotidtorequest.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240604_renameupdateddateonrequest.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20240722_clearsnapshotbuilderrequests.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -84,5 +84,5 @@
     <include file="changesets/20240521_dropsettingsdatasetidaddconstraint.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240522_addjobidandcreatedsnapshotidtorequest.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240604_renameupdateddateonrequest.yaml" relativeToChangelogFile="true" />
-    <include file="changesets/20240722_clearsnapshotbuilderrequests.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20240723_updatesnapshotbuilderrequestspecifications.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20240722_clearsnapshotbuilderrequests.yaml
+++ b/src/main/resources/db/changesets/20240722_clearsnapshotbuilderrequests.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: clear_snapshot_builder_requests
+      author: srubenstein
+      # Delete all rows from the snapshot_request
+      # table due to breaking change to json structure
+      changes:
+        - delete:
+            tableName: snapshot_request

--- a/src/main/resources/db/changesets/20240723_updatesnapshotbuilderrequestspecifications.yaml
+++ b/src/main/resources/db/changesets/20240723_updatesnapshotbuilderrequestspecifications.yaml
@@ -5,5 +5,9 @@ databaseChangeLog:
       # Delete all rows from the snapshot_request
       # table due to breaking change to json structure
       changes:
-        - delete:
+        - update:
             tableName: snapshot_request
+            columns:
+              - column:
+                  name: snapshot_specification
+                  value: "{\"cohorts\": [{\"name\": \"test\",\"criteriaGroups\": []}],\"outputTables\": [{\"name\": \"Drug\",\"columns\": []}]}"

--- a/src/main/resources/db/changesets/20240723_updatesnapshotbuilderrequestspecifications.yaml
+++ b/src/main/resources/db/changesets/20240723_updatesnapshotbuilderrequestspecifications.yaml
@@ -10,4 +10,4 @@ databaseChangeLog:
             columns:
               - column:
                   name: snapshot_specification
-                  value: "{\"cohorts\": [{\"name\": \"test\",\"criteriaGroups\": []}],\"outputTables\": [{\"name\": \"Drug\",\"columns\": []}]}"
+                  value: "{\"cohorts\": [{}], \"outputTables\": [{\"name\": \"Drug\"}]}"


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/dc-1120

## Addresses
With the change to settings and snapshot builder requests, old snapshot builder requests are now invalid. Because they are stored as json blobs, there is no clean way to update/migrate them, so we are just blowing them away. We are not deleting them because we don't want to orphan the Sam resources

## Summary of changes
Update all rows from the snapshot request table.

## Testing Strategy
Tested locally by populating my db and then running `bootRun`, then running `enumerateSnapshotAccessRequests` locally.
<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
