### PR TITLE
[DCJ-511] BoundedAsyncTaskExecutor throttles submissions at saturation

### DIFF
--- a/src/main/java/bio/terra/common/BoundedAsyncTaskExecutor.java
+++ b/src/main/java/bio/terra/common/BoundedAsyncTaskExecutor.java
@@ -1,0 +1,108 @@
+package bio.terra.common;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.task.AsyncTaskExecutor;
+
+public class BoundedAsyncTaskExecutor {
+
+  private static final Logger logger = LoggerFactory.getLogger(BoundedAsyncTaskExecutor.class);
+  private final AsyncTaskExecutor executor;
+  private final Semaphore semaphore;
+
+  /**
+   * A wrapper for an executor which throttles submissions under heavy load, rather than rejecting
+   * tasks.
+   *
+   * <p>Any instances registered as Spring Beans will have their underlying Semaphore instrumented
+   * in Micrometer via {@link bio.terra.service.common.BoundedAsyncTaskExecutorMetricsService}.
+   *
+   * <p>Based on <a href="https://jcip.net/listings/BoundedExecutor.java">"Java Concurrency in
+   * Practice"</a>.
+   */
+  public BoundedAsyncTaskExecutor(AsyncTaskExecutor executor, int permits) {
+    this.executor = executor;
+    this.semaphore = new Semaphore(permits);
+    logger.info("Created BoundedAsyncTaskExecutor with {} available permits", permits);
+  }
+
+  public AsyncTaskExecutor getExecutor() {
+    return this.executor;
+  }
+
+  public Semaphore getSemaphore() {
+    return this.semaphore;
+  }
+
+  /**
+   * Submit a Callable task for execution, receiving a Future representing that task. The Future
+   * will return the Callable's result upon completion.
+   *
+   * <p>If the executor's threads and queue are all occupied, tasks will not be rejected and this
+   * method will block until a permit becomes available in this object's {@link Semaphore}.
+   *
+   * @param task the {@code Callable} to execute (never {@code null})
+   * @return a Future representing pending completion of the task
+   * @throws InterruptedException if the thread was interrupted
+   */
+  public <T> Future<T> submit(Callable<T> task) throws InterruptedException {
+    logger.info("Permits before submission: " + semaphore.availablePermits());
+    semaphore.acquire();
+    logger.info("Permits when Semaphore acquired: " + semaphore.availablePermits());
+    try {
+      return executor.submit(
+          () -> {
+            try {
+              return task.call();
+            } finally {
+              semaphore.release();
+              logger.info("Permits after Semaphore released: " + semaphore.availablePermits());
+            }
+          });
+    } catch (RejectedExecutionException ex) {
+      // Execution should not be rejected when the executor and its queue are fully saturated
+      // (that's the point of the Semaphore), but if execution is rejected for some other reason,
+      // let's release the permit we took out.
+      semaphore.release();
+      throw ex;
+    }
+  }
+
+  /**
+   * Submit a Runnable task for execution, receiving a Future representing that task. The Future
+   * will return a {@code null} result upon completion.
+   *
+   * <p>If the executor's threads and queue are all occupied, tasks will not be rejected and this
+   * method will block until a permit becomes available in this object's {@link Semaphore}.
+   *
+   * @param task the {@code Runnable} to execute (never {@code null})
+   * @return a Future representing pending completion of the task
+   * @throws InterruptedException if the thread was interrupted
+   */
+  public Future<?> submit(Runnable task) throws InterruptedException {
+    logger.info("Permits before submission: " + semaphore.availablePermits());
+    semaphore.acquire();
+    logger.info("Permits after Semaphore acquired: " + semaphore.availablePermits());
+    try {
+      return executor.submit(
+          () -> {
+            try {
+              task.run();
+            } finally {
+              semaphore.release();
+              logger.info("Permits after Semaphore released: " + semaphore.availablePermits());
+            }
+          });
+    } catch (RejectedExecutionException ex) {
+      // Execution should not be rejected when the executor and its queue are fully saturated
+      // (that's the point of the Semaphore), but if execution is rejected for some other reason,
+      // let's release the permit we took out.
+      semaphore.release();
+      throw ex;
+    }
+  }
+}

--- a/src/main/java/bio/terra/service/common/BoundedAsyncTaskExecutorMetricsService.java
+++ b/src/main/java/bio/terra/service/common/BoundedAsyncTaskExecutorMetricsService.java
@@ -1,0 +1,66 @@
+package bio.terra.service.common;
+
+import bio.terra.common.BoundedAsyncTaskExecutor;
+import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import java.util.concurrent.Semaphore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * A service to instrument any {@link BoundedAsyncTaskExecutor}s registered as Spring Beans in
+ * Micrometer.
+ *
+ * <p>While {@link org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor}s are
+ * automatically instrumented by Micrometer via Actuator, our wrapper throttles submissions to these
+ * executors rather than rejecting them at saturation using a {@link Semaphore}.
+ *
+ * <p>We want visibility into:
+ *
+ * <ul>
+ *   <li>The Semaphore's available permits
+ *   <li>The Semaphore's "queue length" (estimated number of threads waiting to acquire a permit)
+ * </ul>
+ */
+@Component
+public class BoundedAsyncTaskExecutorMetricsService {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(BoundedAsyncTaskExecutorMetricsService.class);
+  static final String PREFIX = "datarepo.boundedAsyncTaskExecutor.";
+  /**
+   * A String template for the name of an executor's available permits gauge, expecting a Bean name.
+   */
+  static final String AVAILABLE_PERMITS_TEMPLATE = PREFIX + "%s.availablePermits";
+  /** A String template for the name of an executor's queue length gauge, expecting a Bean name. */
+  static final String QUEUE_LENGTH_TEMPLATE = PREFIX + "%s.queueLength";
+
+  private final ApplicationContext applicationContext;
+  private final MeterRegistry meterRegistry;
+
+  public BoundedAsyncTaskExecutorMetricsService(
+      ApplicationContext applicationContext, MeterRegistry meterRegistry) {
+    this.applicationContext = applicationContext;
+    this.meterRegistry = meterRegistry;
+  }
+
+  @PostConstruct
+  @VisibleForTesting
+  void registerGauges() {
+    applicationContext.getBeansOfType(BoundedAsyncTaskExecutor.class).forEach(this::registerGauges);
+  }
+
+  private void registerGauges(String beanName, BoundedAsyncTaskExecutor boundedAsyncTaskExecutor) {
+    logger.info("Registering Micrometer gauges on {} (available permits, queue length)", beanName);
+    Semaphore semaphore = boundedAsyncTaskExecutor.getSemaphore();
+
+    var availablePermitsName = AVAILABLE_PERMITS_TEMPLATE.formatted(beanName);
+    meterRegistry.gauge(availablePermitsName, semaphore, Semaphore::availablePermits);
+
+    var queueLengthName = QUEUE_LENGTH_TEMPLATE.formatted(beanName);
+    meterRegistry.gauge(queueLengthName, semaphore, Semaphore::getQueueLength);
+  }
+}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-511

## Addresses

TDR and other services use `ThreadPoolTaskExecutor`s to parallelize tasks, which are comprised of a core pool of threads for processing and a queue as a fallback for when those threads are active.  If the queue fills up, tasks submitted to the executor will be rejected with a `RejectedExecutionException`.

Making the queue bigger or even unbounded runs the risk of memory issues if requests come faster than they can be processed.  In some places, TDR tries to batch up its submissions to an executor to avoid overloading it, only proceeding to the next batch when the previous has succeeded.  But this is not as efficient as it could be and doesn’t guard against many separate requests putting load on the same executor.

It would be nice to have a piece of common code which builds in graceful backpressure to our executor.  Java Concurrency in Practice has the following recommendation, though there may be new capabilities native to more recent versions of Java that we can use: https://jcip.net/listings/BoundedExecutor.java

## Summary of changes

## Testing Strategy

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
