### PR TITLE
[DC-1170] Add code for get and delete requests

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotAccessRequestApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotAccessRequestApiController.java
@@ -63,6 +63,23 @@ public class SnapshotAccessRequestApiController implements SnapshotAccessRequest
   }
 
   @Override
+  public ResponseEntity<SnapshotAccessRequestResponse> getSnapshotAccessRequest(UUID id) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    iamService.verifyAuthorization(
+        userRequest, IamResourceType.SNAPSHOT_BUILDER_REQUEST, id.toString(), IamAction.GET);
+    return ResponseEntity.ok(snapshotBuilderService.getRequest(id));
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteSnapshotAccessRequest(UUID id) {
+    AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
+    iamService.verifyAuthorization(
+        userRequest, IamResourceType.SNAPSHOT_BUILDER_REQUEST, id.toString(), IamAction.DELETE);
+    snapshotBuilderService.deleteRequest(userRequest, id);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
   public ResponseEntity<SnapshotAccessRequestResponse> rejectSnapshotAccessRequest(UUID id) {
     AuthenticatedUserRequest userRequest = getAuthenticatedInfo();
     iamService.verifyAuthorization(

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -143,6 +143,9 @@ public interface IamProviderInterface {
       AuthenticatedUserRequest userReq, UUID snapshotId, UUID snapshotBuilderRequestId)
       throws InterruptedException;
 
+  void deleteSnapshotBuilderRequestResource(
+      AuthenticatedUserRequest userReq, UUID snapshotBuilderRequestId) throws InterruptedException;
+
   // -- billing profile resource support --
 
   /**

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -306,6 +306,10 @@ public class IamService {
                 userReq, snapshotId, snapshotBuilderRequestId));
   }
 
+  public void deleteSnapshotBuilderRequest(AuthenticatedUserRequest userReq, UUID requestId) {
+    callProvider(() -> iamProvider.deleteSnapshotBuilderRequestResource(userReq, requestId));
+  }
+
   /**
    * @param request snapshot creation request
    * @return user-defined snapshot policy object, supplemented with readers from deprecated input

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -333,6 +333,13 @@ public class SamIam implements IamProviderInterface {
     return initialRoles;
   }
 
+  @Override
+  public void deleteSnapshotBuilderRequestResource(
+      AuthenticatedUserRequest userReq, UUID snapshotBuilderRequestId) throws InterruptedException {
+    deleteResource(
+        userReq, IamResourceType.SNAPSHOT_BUILDER_REQUEST, snapshotBuilderRequestId.toString());
+  }
+
   private void createSnapshotBuilderRequestResourceInner(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
@@ -34,20 +34,22 @@ public class DeleteOutstandingSnapshotAccessRequestsStep implements Step {
     try {
       EnumerateSnapshotAccessRequest requestResponseList =
           snapshotBuilderService.enumerateRequestsBySnapshot(snapshotId);
-      requestResponseList.getItems().stream()
-          .filter(
-              snapshotAccessRequestResponse ->
-                  SnapshotAccessRequestStatus.DELETED.equals(
-                      snapshotAccessRequestResponse.getStatus()))
-          .forEach(
-              snapshotAccessRequestResponse ->
-                  snapshotBuilderService.deleteRequest(
-                      userReq, snapshotAccessRequestResponse.getId()));
+      if (requestResponseList != null) {
+        requestResponseList.getItems().stream()
+            .filter(
+                snapshotAccessRequestResponse ->
+                    !SnapshotAccessRequestStatus.DELETED.equals(
+                        snapshotAccessRequestResponse.getStatus()))
+            .forEach(
+                snapshotAccessRequestResponse ->
+                    snapshotBuilderService.deleteRequest(
+                        userReq, snapshotAccessRequestResponse.getId()));
+      }
     } catch (NotFoundException e) {
       // Do nothing, if there are no requests we are good.
       return StepResult.getStepResultSuccess();
     }
-    return null;
+    return StepResult.getStepResultSuccess();
   }
 
   @Override

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
@@ -50,7 +50,7 @@ public class DeleteOutstandingSnapshotAccessRequestsStep implements Step {
     // can't undo delete
     logger.warn(
         String.format(
-            "Trying to undo delete resource for snapshot access requests on snapshot %s",
+            "Cannot undo delete resource for snapshot access requests on snapshot %s",
             snapshotId));
     return null;
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
@@ -30,18 +30,20 @@ public class DeleteOutstandingSnapshotAccessRequestsStep implements Step {
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
-    try {
-      EnumerateSnapshotAccessRequest requestResponseList =
-          snapshotBuilderService.enumerateRequestsBySnapshot(snapshotId);
-      requestResponseList
-          .getItems()
-          .forEach(
-              snapshotAccessRequestResponse ->
-                  snapshotBuilderService.deleteRequest(
-                      userReq, snapshotAccessRequestResponse.getId()));
-    } catch (NotFoundException e) {
-      // Do nothing, if there are no requests we are good.
-    }
+    EnumerateSnapshotAccessRequest requestResponseList =
+        snapshotBuilderService.enumerateRequestsBySnapshot(snapshotId);
+    requestResponseList
+        .getItems()
+        .forEach(
+            snapshotAccessRequestResponse -> {
+              try {
+                snapshotBuilderService.deleteRequest(
+                    userReq, snapshotAccessRequestResponse.getId());
+              } catch (NotFoundException ignored) {
+                // Do nothing and proceed with the expectation it is deleted
+              }
+            });
+
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
@@ -1,0 +1,62 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import bio.terra.common.exception.NotFoundException;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.EnumerateSnapshotAccessRequest;
+import bio.terra.model.SnapshotAccessRequestStatus;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteOutstandingSnapshotAccessRequestsStep implements Step {
+  private static final Logger logger =
+      LoggerFactory.getLogger(DeleteOutstandingSnapshotAccessRequestsStep.class);
+  private final SnapshotBuilderService snapshotBuilderService;
+  private final UUID snapshotId;
+  private final AuthenticatedUserRequest userReq;
+
+  public DeleteOutstandingSnapshotAccessRequestsStep(
+      AuthenticatedUserRequest userReq,
+      UUID snapshotId,
+      SnapshotBuilderService snapshotBuilderService) {
+    this.snapshotId = snapshotId;
+    this.userReq = userReq;
+    this.snapshotBuilderService = snapshotBuilderService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    try {
+      EnumerateSnapshotAccessRequest requestResponseList =
+          snapshotBuilderService.enumerateRequestsBySnapshot(snapshotId);
+      requestResponseList.getItems().stream()
+          .filter(
+              snapshotAccessRequestResponse ->
+                  SnapshotAccessRequestStatus.DELETED.equals(
+                      snapshotAccessRequestResponse.getStatus()))
+          .forEach(
+              snapshotAccessRequestResponse ->
+                  snapshotBuilderService.deleteRequest(
+                      userReq, snapshotAccessRequestResponse.getId()));
+    } catch (NotFoundException e) {
+      // Do nothing, if there are no requests we are good.
+      return StepResult.getStepResultSuccess();
+    }
+    return null;
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    // can't undo delete
+    logger.warn(
+        String.format(
+            "Trying to undo delete resource for snapshot access requests on snapshot %s",
+            snapshotId.toString()));
+    return null;
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
@@ -53,6 +53,6 @@ public class DeleteOutstandingSnapshotAccessRequestsStep implements Step {
     logger.warn(
         String.format(
             "Cannot undo delete resource for snapshot access requests on snapshot %s", snapshotId));
-    return null;
+    return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
@@ -3,7 +3,6 @@ package bio.terra.service.snapshot.flight.delete;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.EnumerateSnapshotAccessRequest;
-import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
@@ -34,11 +33,8 @@ public class DeleteOutstandingSnapshotAccessRequestsStep implements Step {
     try {
       EnumerateSnapshotAccessRequest requestResponseList =
           snapshotBuilderService.enumerateRequestsBySnapshot(snapshotId);
-      requestResponseList.getItems().stream()
-          .filter(
-              snapshotAccessRequestResponse ->
-                  !SnapshotAccessRequestStatus.DELETED.equals(
-                      snapshotAccessRequestResponse.getStatus()))
+      requestResponseList
+          .getItems()
           .forEach(
               snapshotAccessRequestResponse ->
                   snapshotBuilderService.deleteRequest(

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
@@ -50,8 +50,7 @@ public class DeleteOutstandingSnapshotAccessRequestsStep implements Step {
     // can't undo delete
     logger.warn(
         String.format(
-            "Cannot undo delete resource for snapshot access requests on snapshot %s",
-            snapshotId));
+            "Cannot undo delete resource for snapshot access requests on snapshot %s", snapshotId));
     return null;
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStep.java
@@ -34,20 +34,17 @@ public class DeleteOutstandingSnapshotAccessRequestsStep implements Step {
     try {
       EnumerateSnapshotAccessRequest requestResponseList =
           snapshotBuilderService.enumerateRequestsBySnapshot(snapshotId);
-      if (requestResponseList != null) {
-        requestResponseList.getItems().stream()
-            .filter(
-                snapshotAccessRequestResponse ->
-                    !SnapshotAccessRequestStatus.DELETED.equals(
-                        snapshotAccessRequestResponse.getStatus()))
-            .forEach(
-                snapshotAccessRequestResponse ->
-                    snapshotBuilderService.deleteRequest(
-                        userReq, snapshotAccessRequestResponse.getId()));
-      }
+      requestResponseList.getItems().stream()
+          .filter(
+              snapshotAccessRequestResponse ->
+                  !SnapshotAccessRequestStatus.DELETED.equals(
+                      snapshotAccessRequestResponse.getStatus()))
+          .forEach(
+              snapshotAccessRequestResponse ->
+                  snapshotBuilderService.deleteRequest(
+                      userReq, snapshotAccessRequestResponse.getId()));
     } catch (NotFoundException e) {
       // Do nothing, if there are no requests we are good.
-      return StepResult.getStepResultSuccess();
     }
     return StepResult.getStepResultSuccess();
   }
@@ -58,7 +55,7 @@ public class DeleteOutstandingSnapshotAccessRequestsStep implements Step {
     logger.warn(
         String.format(
             "Trying to undo delete resource for snapshot access requests on snapshot %s",
-            snapshotId.toString()));
+            snapshotId));
     return null;
   }
 }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -197,6 +197,20 @@ public class SnapshotBuilderService {
         .items(snapshotRequestDao.enumerate(authorizedResources));
   }
 
+  public EnumerateSnapshotAccessRequest enumerateRequestsBySnapshot(UUID snapshotId) {
+    return new EnumerateSnapshotAccessRequest()
+        .items(snapshotRequestDao.enumerateBySnapshot(snapshotId));
+  }
+
+  public SnapshotAccessRequestResponse getRequest(UUID id) {
+    return snapshotRequestDao.getById(id);
+  }
+
+  public void deleteRequest(AuthenticatedUserRequest user, UUID id) {
+    iamService.deleteSnapshotBuilderRequest(user, id);
+    snapshotRequestDao.updateStatus(id, SnapshotAccessRequestStatus.DELETED);
+  }
+
   public SnapshotBuilderConceptsResponse enumerateConcepts(
       UUID snapshotId, int domainId, String filterText, AuthenticatedUserRequest userRequest) {
     Snapshot snapshot = snapshotService.retrieve(snapshotId);

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -115,11 +115,9 @@ public class SnapshotRequestDao {
 
   @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
   public List<SnapshotAccessRequestResponse> enumerateBySnapshot(UUID snapshotId) {
-    String sql =
-        String.format(
-            "SELECT * FROM snapshot_request WHERE %s = (:source_snapshot_id)", SOURCE_SNAPSHOT_ID);
+    String sql = "SELECT * FROM snapshot_request WHERE source_snapshot_id = :source_snapshot_id";
     MapSqlParameterSource params =
-        new MapSqlParameterSource().addValue(SOURCE_SNAPSHOT_ID, snapshotId.toString());
+        new MapSqlParameterSource().addValue(SOURCE_SNAPSHOT_ID, snapshotId);
     try {
       return jdbcTemplate.query(sql, params, responseMapper);
     } catch (EmptyResultDataAccessException ex) {

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -112,7 +112,7 @@ public class SnapshotRequestDao {
     try {
       return jdbcTemplate.query(sql, params, responseMapper);
     } catch (EmptyResultDataAccessException ex) {
-      throw new NotFoundException("No snapshot requests found for user", ex);
+      return List.of();
     }
   }
 
@@ -127,7 +127,7 @@ public class SnapshotRequestDao {
     try {
       return jdbcTemplate.query(sql, params, responseMapper);
     } catch (EmptyResultDataAccessException ex) {
-      throw new NotFoundException("No snapshot requests found for snapshot", ex);
+      return List.of();
     }
   }
 

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -113,6 +113,20 @@ public class SnapshotRequestDao {
     }
   }
 
+  @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
+  public List<SnapshotAccessRequestResponse> enumerateBySnapshot(UUID snapshotId) {
+    String sql =
+        String.format(
+            "SELECT * FROM snapshot_request WHERE %s = (:source_snapshot_id)", SOURCE_SNAPSHOT_ID);
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue(SOURCE_SNAPSHOT_ID, snapshotId.toString());
+    try {
+      return jdbcTemplate.query(sql, params, responseMapper);
+    } catch (EmptyResultDataAccessException ex) {
+      throw new NotFoundException("No snapshot requests found for snapshot", ex);
+    }
+  }
+
   /**
    * Create a new Snapshot Access Request for the given snapshot id.
    *

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -100,12 +100,15 @@ public class SnapshotRequestDao {
    */
   @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
   public List<SnapshotAccessRequestResponse> enumerate(Collection<UUID> authorizedResources) {
-    String sql = "SELECT * FROM snapshot_request WHERE id IN (:authorized_resources)";
+    String sql =
+        "SELECT * FROM snapshot_request WHERE id IN (:authorized_resources) AND status != :status";
     if (authorizedResources.isEmpty()) {
       return List.of();
     }
     MapSqlParameterSource params =
-        new MapSqlParameterSource().addValue(AUTHORIZED_RESOURCES, authorizedResources);
+        new MapSqlParameterSource()
+            .addValue(AUTHORIZED_RESOURCES, authorizedResources)
+            .addValue(STATUS, SnapshotAccessRequestStatus.DELETED.toString());
     try {
       return jdbcTemplate.query(sql, params, responseMapper);
     } catch (EmptyResultDataAccessException ex) {
@@ -115,9 +118,12 @@ public class SnapshotRequestDao {
 
   @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
   public List<SnapshotAccessRequestResponse> enumerateBySnapshot(UUID snapshotId) {
-    String sql = "SELECT * FROM snapshot_request WHERE source_snapshot_id = :source_snapshot_id";
+    String sql =
+        "SELECT * FROM snapshot_request WHERE source_snapshot_id = :source_snapshot_id AND status != :status";
     MapSqlParameterSource params =
-        new MapSqlParameterSource().addValue(SOURCE_SNAPSHOT_ID, snapshotId);
+        new MapSqlParameterSource()
+            .addValue(SOURCE_SNAPSHOT_ID, snapshotId)
+            .addValue(STATUS, SnapshotAccessRequestStatus.DELETED.toString());
     try {
       return jdbcTemplate.query(sql, params, responseMapper);
     } catch (EmptyResultDataAccessException ex) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3071,6 +3071,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SnapshotAccessRequestResponse'
+        404:
+          description: The request cannot be found or you do not have access
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
         default:
           description: Unexpected error
           content:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3071,26 +3071,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SnapshotAccessRequestResponse'
-        401:
-          description: Unauthorized - snapshot request does not exist or missing permissions to view.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        403:
-          description: Unauthorized - missing permissions to view snapshot request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        404:
-          description: No snapshot request found that meets the request parameters.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        500:
-          description: An unexpected error occurred.
+        default:
+          description: Unexpected error
           content:
             application/json:
               schema:
@@ -3105,26 +3087,8 @@ paths:
       responses:
         204:
           description: The request has been deleted
-        401:
-          description: Unauthorized - snapshot request does not exist or missing permissions to view.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        403:
-          description: Unauthorized - missing permissions to view snapshot request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        404:
-          description: No snapshot request found that meets the request parameters.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-        500:
-          description: An unexpected error occurred.
+        default:
+          description: Unexpected error
           content:
             application/json:
               schema:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3056,6 +3056,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+  /api/repository/v1/snapshotAccessRequests/{id}:
+    get:
+      tags:
+        - SnapshotAccessRequest
+      description: Get a snapshot access request you have access to read
+      operationId: getSnapshotAccessRequest
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: The request fetched
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SnapshotAccessRequestResponse'
+        401:
+          description: Unauthorized - snapshot request does not exist or missing permissions to view.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: Unauthorized - missing permissions to view snapshot request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: No snapshot request found that meets the request parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+    delete:
+      tags:
+        - SnapshotAccessRequest
+      description: Delete a snapshot access request you have access to delete
+      operationId: deleteSnapshotAccessRequest
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        204:
+          description: The request has been deleted
+        401:
+          description: Unauthorized - snapshot request does not exist or missing permissions to view.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: Unauthorized - missing permissions to view snapshot request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: No snapshot request found that meets the request parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
   /api/repository/v1/snapshotAccessRequests/{id}/reject:
     put:
       tags:
@@ -7478,7 +7551,7 @@ components:
 
     SnapshotAccessRequestStatus:
       type: string
-      enum: [ SUBMITTED, APPROVED, REJECTED ]
+      enum: [ SUBMITTED, APPROVED, REJECTED, DELETED ]
 
     SnapshotBuilderCountRequest:
       type: object

--- a/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStepTest.java
@@ -1,0 +1,70 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.EnumerateSnapshotAccessRequest;
+import bio.terra.model.SnapshotAccessRequestResponse;
+import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepStatus;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+public class DeleteOutstandingSnapshotAccessRequestsStepTest {
+  @Mock SnapshotBuilderService snapshotBuilderService;
+  private UUID snapshotId;
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  @Mock private FlightContext flightContext;
+  private DeleteOutstandingSnapshotAccessRequestsStep step;
+
+  @BeforeEach
+  void beforeEach() {
+    snapshotId = UUID.randomUUID();
+    step =
+        new DeleteOutstandingSnapshotAccessRequestsStep(
+            TEST_USER, snapshotId, snapshotBuilderService);
+  }
+
+  @Test
+  void doStep() throws InterruptedException {
+    UUID firstRequestId = UUID.randomUUID();
+    UUID secondRequestId = UUID.randomUUID();
+    when(snapshotBuilderService.enumerateRequestsBySnapshot(snapshotId))
+        .thenReturn(
+            new EnumerateSnapshotAccessRequest()
+                .items(
+                    List.of(
+                        new SnapshotAccessRequestResponse().id(firstRequestId),
+                        new SnapshotAccessRequestResponse().id(secondRequestId))));
+    var result = step.doStep(flightContext);
+    verify(snapshotBuilderService).deleteRequest(TEST_USER, firstRequestId);
+    verify(snapshotBuilderService).deleteRequest(TEST_USER, secondRequestId);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void doStepNoRequests() throws InterruptedException {
+    when(snapshotBuilderService.enumerateRequestsBySnapshot(snapshotId))
+        .thenReturn(new EnumerateSnapshotAccessRequest().items(List.of()));
+    var result = step.doStep(flightContext);
+    verify(snapshotBuilderService, never()).deleteRequest(any(), any());
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStepTest.java
@@ -26,7 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
-public class DeleteOutstandingSnapshotAccessRequestsStepTest {
+class DeleteOutstandingSnapshotAccessRequestsStepTest {
   @Mock SnapshotBuilderService snapshotBuilderService;
   private UUID snapshotId;
   private static final AuthenticatedUserRequest TEST_USER =

--- a/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteOutstandingSnapshotAccessRequestsStepTest.java
@@ -13,7 +13,6 @@ import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.EnumerateSnapshotAccessRequest;
 import bio.terra.model.SnapshotAccessRequestResponse;
-import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import bio.terra.stairway.StepStatus;
 import java.util.List;
@@ -46,17 +45,13 @@ class DeleteOutstandingSnapshotAccessRequestsStepTest {
   void doStep() throws InterruptedException {
     UUID firstRequestId = UUID.randomUUID();
     UUID secondRequestId = UUID.randomUUID();
-    UUID thirdRequestId = UUID.randomUUID();
     when(snapshotBuilderService.enumerateRequestsBySnapshot(snapshotId))
         .thenReturn(
             new EnumerateSnapshotAccessRequest()
                 .items(
                     List.of(
                         new SnapshotAccessRequestResponse().id(firstRequestId),
-                        new SnapshotAccessRequestResponse().id(secondRequestId),
-                        new SnapshotAccessRequestResponse()
-                            .id(thirdRequestId)
-                            .status(SnapshotAccessRequestStatus.DELETED))));
+                        new SnapshotAccessRequestResponse().id(secondRequestId))));
     var result = step.doStep(null);
     verify(snapshotBuilderService).deleteRequest(TEST_USER, firstRequestId);
     verify(snapshotBuilderService).deleteRequest(TEST_USER, secondRequestId);

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -442,6 +442,32 @@ class SnapshotBuilderServiceTest {
     verify(snapshotRequestDao).updateStatus(id, SnapshotAccessRequestStatus.APPROVED);
   }
 
+  @Test
+  void testGetRequest() {
+    UUID id = UUID.randomUUID();
+    SnapshotAccessRequestResponse daoResponse = new SnapshotAccessRequestResponse().id(id);
+    when(snapshotRequestDao.getById(id)).thenReturn(daoResponse);
+    assertThat(snapshotBuilderService.getRequest(id), is(daoResponse));
+  }
+
+  @Test
+  void testDeleteRequest() {
+    UUID id = UUID.randomUUID();
+    snapshotBuilderService.deleteRequest(TEST_USER, id);
+    verify(snapshotRequestDao).updateStatus(id, SnapshotAccessRequestStatus.DELETED);
+    verify(iamService).deleteSnapshotBuilderRequest(TEST_USER, id);
+  }
+
+  @Test
+  void testEnumerateRequestsBySnapshot() {
+    UUID id = UUID.randomUUID();
+    List<SnapshotAccessRequestResponse> daoResponse = List.of(new SnapshotAccessRequestResponse());
+    when(snapshotRequestDao.enumerateBySnapshot(id)).thenReturn(daoResponse);
+    assertThat(
+        snapshotBuilderService.enumerateRequestsBySnapshot(id),
+        is(new EnumerateSnapshotAccessRequest().items(daoResponse)));
+  }
+
   static SnapshotBuilderConcept concept(String name, int id, boolean hasChildren) {
     return new SnapshotBuilderConcept()
         .name(name)

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
@@ -40,6 +40,7 @@ class SnapshotRequestDaoTest {
   @Autowired private DaoOperations daoOperations;
   @Autowired private SnapshotRequestDao snapshotRequestDao;
 
+  private Dataset dataset;
   private Snapshot sourceSnapshot;
   private Snapshot createdSnapshot;
   private SnapshotAccessRequest snapshotAccessRequest;
@@ -49,7 +50,7 @@ class SnapshotRequestDaoTest {
 
   @BeforeEach
   void beforeEach() throws IOException {
-    Dataset dataset = daoOperations.createDataset(DaoOperations.DATASET_MINIMAL);
+    dataset = daoOperations.createDataset(DaoOperations.DATASET_MINIMAL);
     sourceSnapshot = daoOperations.createAndIngestSnapshot(dataset, DaoOperations.SNAPSHOT_MINIMAL);
     createdSnapshot =
         daoOperations.createAndIngestSnapshot(dataset, DaoOperations.SNAPSHOT_MINIMAL);
@@ -58,6 +59,10 @@ class SnapshotRequestDaoTest {
   }
 
   private SnapshotAccessRequestResponse createRequest() {
+    return snapshotRequestDao.create(snapshotAccessRequest, EMAIL);
+  }
+
+  private SnapshotAccessRequestResponse createRequest(SnapshotAccessRequest snapshotAccessRequest) {
     return snapshotRequestDao.create(snapshotAccessRequest, EMAIL);
   }
 
@@ -99,6 +104,19 @@ class SnapshotRequestDaoTest {
         "Snapshot Access Request should be the same as the example",
         snapshotRequestDao.enumerate(Set.of(response.getId(), response1.getId())),
         contains(response, response1));
+  }
+
+  @Test
+  void enumerateBySnapshotId() throws IOException {
+    Snapshot secondSnapshot =
+        daoOperations.createAndIngestSnapshot(dataset, DaoOperations.SNAPSHOT_MINIMAL);
+    SnapshotAccessRequestResponse response = createRequest();
+    SnapshotAccessRequestResponse response1 =
+        createRequest(SnapshotBuilderTestData.createSnapshotAccessRequest(secondSnapshot.getId()));
+    assertThat(
+        "Snapshot Access Request should be the same as the example",
+        snapshotRequestDao.enumerateBySnapshot(sourceSnapshot.getId()),
+        contains(response));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
@@ -111,8 +111,7 @@ class SnapshotRequestDaoTest {
     Snapshot secondSnapshot =
         daoOperations.createAndIngestSnapshot(dataset, DaoOperations.SNAPSHOT_MINIMAL);
     SnapshotAccessRequestResponse response = createRequest();
-    SnapshotAccessRequestResponse response1 =
-        createRequest(SnapshotBuilderTestData.createSnapshotAccessRequest(secondSnapshot.getId()));
+    createRequest(SnapshotBuilderTestData.createSnapshotAccessRequest(secondSnapshot.getId()));
     assertThat(
         "Snapshot Access Request should be the same as the example",
         snapshotRequestDao.enumerateBySnapshot(sourceSnapshot.getId()),


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/dc-1170

## Addresses
1. Adds GET and DELETE for snapshot access request to help make snapshot access requests more usable.
2. Adds a step to the Snapshot delete flight to check for outstanding requests and delete them, so that requests don't block deletion of the Sam Snapshot resource.

## Summary of changes

## Testing Strategy

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
