### PR TITLE
[DCJ-511] azureTableThreadpool blocks when saturated

### DIFF
--- a/src/main/java/bio/terra/common/BlockingRejectedExecutionHandler.java
+++ b/src/main/java/bio/terra/common/BlockingRejectedExecutionHandler.java
@@ -14,13 +14,13 @@ import java.util.concurrent.ThreadPoolExecutor;
  */
 public class BlockingRejectedExecutionHandler implements RejectedExecutionHandler {
   @VisibleForTesting
-  static String interruptedExceptionMessage(Runnable r, ThreadPoolExecutor executor) {
-    return "Task %s interrupted while waiting to be added to queue: %s".formatted(r, executor);
+  static String interruptedExceptionMessage(ThreadPoolExecutor executor) {
+    return "Task interrupted while waiting to be added to queue: %s".formatted(executor);
   }
 
   @VisibleForTesting
-  static String executorShutdownMessage(Runnable r, ThreadPoolExecutor executor) {
-    return "%s is shutting down and cannot accept task %s".formatted(executor, r);
+  static String executorShutdownMessage(ThreadPoolExecutor executor) {
+    return "%s is shutting down and cannot accept task".formatted(executor);
   }
 
   /**
@@ -46,10 +46,10 @@ public class BlockingRejectedExecutionHandler implements RejectedExecutionHandle
         executor.getQueue().put(r);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw new RejectedExecutionException(interruptedExceptionMessage(r, executor), e);
+        throw new RejectedExecutionException(interruptedExceptionMessage(executor), e);
       }
     } else {
-      throw new RejectedExecutionException(executorShutdownMessage(r, executor));
+      throw new RejectedExecutionException(executorShutdownMessage(executor));
     }
   }
 }

--- a/src/main/java/bio/terra/common/BlockingRejectedExecutionHandler.java
+++ b/src/main/java/bio/terra/common/BlockingRejectedExecutionHandler.java
@@ -1,0 +1,55 @@
+package bio.terra.common;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * An implementation of {@link RejectedExecutionHandler}.
+ *
+ * <p>If a {@link ThreadPoolExecutor} can't accept a task due to saturation of its threadpool and
+ * queue, this handler blocks when waiting for a spot to become available in the queue rather than
+ * rejecting the task.
+ */
+public class BlockingRejectedExecutionHandler implements RejectedExecutionHandler {
+  @VisibleForTesting
+  static String interruptedExceptionMessage(Runnable r, ThreadPoolExecutor executor) {
+    return "Task %s interrupted while waiting to be added to queue: %s".formatted(r, executor);
+  }
+
+  @VisibleForTesting
+  static String executorShutdownMessage(Runnable r, ThreadPoolExecutor executor) {
+    return "%s is shutting down and cannot accept task %s".formatted(executor, r);
+  }
+
+  /**
+   * Method that may be invoked by a {@link ThreadPoolExecutor} when {@link
+   * ThreadPoolExecutor#execute execute} cannot accept a task.
+   *
+   * <p>If the reason for invocation is that the Executor is saturated (no more threads or queue
+   * slots available), then the runnable will be added to the queue, blocking until space is
+   * available.
+   *
+   * <p>If the Executor has been shut down or the thread is interrupted, the method will throw a
+   * {@link RejectedExecutionException}, which will be propagated to the caller of {@code execute}.
+   *
+   * @param r the runnable task requested to be executed
+   * @param executor the executor attempting to execute this task
+   * @throws RejectedExecutionException if there is no remedy
+   */
+  @Override
+  public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+    if (!executor.isShutdown()) {
+      try {
+        // Block until space becomes available in the queue
+        executor.getQueue().put(r);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RejectedExecutionException(interruptedExceptionMessage(r, executor), e);
+      }
+    } else {
+      throw new RejectedExecutionException(executorShutdownMessage(r, executor));
+    }
+  }
+}

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDependencyDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDependencyDao.java
@@ -4,6 +4,7 @@ import bio.terra.common.FutureUtils;
 import bio.terra.service.common.azure.StorageTableName;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.google.firestore.FireStoreDependency;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
@@ -35,7 +36,8 @@ public class TableDependencyDao {
 
   @Autowired
   public TableDependencyDao(
-      @Qualifier("azureTableThreadpool") AsyncTaskExecutor azureTableThreadpool) {
+      @Qualifier(AzureResourceConfiguration.TABLE_THREADPOOL_NAME)
+          AsyncTaskExecutor azureTableThreadpool) {
     this.azureTableThreadpool = azureTableThreadpool;
   }
 

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -8,6 +8,7 @@ import bio.terra.service.filedata.FileMetadataUtils;
 import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
@@ -73,7 +74,8 @@ public class TableDirectoryDao {
 
   public TableDirectoryDao(
       ConfigurationService configurationService,
-      @Qualifier("azureTableThreadpool") AsyncTaskExecutor azureTableThreadpool) {
+      @Qualifier(AzureResourceConfiguration.TABLE_THREADPOOL_NAME)
+          AsyncTaskExecutor azureTableThreadpool) {
     this.configurationService = configurationService;
     this.azureTableThreadpool = azureTableThreadpool;
   }

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableFileDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableFileDao.java
@@ -9,6 +9,7 @@ import bio.terra.service.filedata.google.firestore.ApiFutureGenerator;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import bio.terra.service.filedata.google.firestore.FireStoreFile;
 import bio.terra.service.filedata.google.firestore.InterruptibleConsumer;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
@@ -39,7 +40,9 @@ public class TableFileDao {
   private final AsyncTaskExecutor azureTableThreadpool;
   private static final String PARTITION_KEY = "partitionKey";
 
-  TableFileDao(@Qualifier("azureTableThreadpool") AsyncTaskExecutor azureTableThreadpool) {
+  TableFileDao(
+      @Qualifier(AzureResourceConfiguration.TABLE_THREADPOOL_NAME)
+          AsyncTaskExecutor azureTableThreadpool) {
     this.azureTableThreadpool = azureTableThreadpool;
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/azure/AzureResourceConfiguration.java
@@ -166,7 +166,13 @@ public record AzureResourceConfiguration(
 
   public record Threading(int numTableThreads, int maxQueueSize, boolean blockWhenSaturated) {}
 
-  @Bean("azureTableThreadpool")
+  /**
+   * The name of a {@link AsyncTaskExecutor} Spring Bean which executes tasks related to Azure
+   * Storage Tables.
+   */
+  public static final String TABLE_THREADPOOL_NAME = "azureTableThreadpool";
+
+  @Bean(TABLE_THREADPOOL_NAME)
   public AsyncTaskExecutor azureTableThreadpool() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(threading().numTableThreads());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -133,6 +133,7 @@ azure.synapse.connectRetryCount=20
 # Number of concurrent operations on Azure storage tables.  Note operations can be batches of operations.
 azure.threading.numTableThreads=1000
 azure.threading.maxQueueSize=10000
+azure.threading.blockWhenSaturated=true
 azure.apiVersion=2021-07-01
 azure.maxRetries=3
 azure.retryTimeoutSeconds=3600

--- a/src/test/java/bio/terra/app/configuration/AzureResourceConfigurationTest.java
+++ b/src/test/java/bio/terra/app/configuration/AzureResourceConfigurationTest.java
@@ -4,11 +4,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
+import bio.terra.common.BlockingRejectedExecutionHandler;
 import bio.terra.common.category.Unit;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration.Threading;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -17,9 +21,10 @@ public class AzureResourceConfigurationTest {
   private static final int NUM_TABLE_THREADS = 3;
   private static final int MAX_QUEUE_SIZE = 5;
 
-  @Test
-  void azureTableThreadPool() {
-    Threading threading = new Threading(NUM_TABLE_THREADS, MAX_QUEUE_SIZE);
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void azureTableThreadPool(boolean blockWhenSaturated) {
+    Threading threading = new Threading(NUM_TABLE_THREADS, MAX_QUEUE_SIZE, blockWhenSaturated);
     AzureResourceConfiguration config =
         new AzureResourceConfiguration(null, null, 0, 0, null, null, threading);
     AsyncTaskExecutor genericExecutor = config.azureTableThreadpool();
@@ -29,5 +34,12 @@ public class AzureResourceConfigurationTest {
     assertThat(azureTableThreadPool.getMaxPoolSize(), equalTo(NUM_TABLE_THREADS));
     assertThat(azureTableThreadPool.getKeepAliveSeconds(), equalTo(0));
     assertThat(azureTableThreadPool.getQueueCapacity(), equalTo(MAX_QUEUE_SIZE));
+    RejectedExecutionHandler rejectedExecutionHandler =
+        azureTableThreadPool.getThreadPoolExecutor().getRejectedExecutionHandler();
+    if (blockWhenSaturated) {
+      assertThat(rejectedExecutionHandler, instanceOf(BlockingRejectedExecutionHandler.class));
+    } else {
+      assertThat(rejectedExecutionHandler, instanceOf(ThreadPoolExecutor.AbortPolicy.class));
+    }
   }
 }

--- a/src/test/java/bio/terra/common/BlockingRejectedExecutionHandlerTest.java
+++ b/src/test/java/bio/terra/common/BlockingRejectedExecutionHandlerTest.java
@@ -44,7 +44,7 @@ class BlockingRejectedExecutionHandlerTest {
     RejectedExecutionException exception =
         assertThrows(
             RejectedExecutionException.class, () -> handler.rejectedExecution(r, executor));
-    String expectedMessage = BlockingRejectedExecutionHandler.executorShutdownMessage(r, executor);
+    String expectedMessage = BlockingRejectedExecutionHandler.executorShutdownMessage(executor);
     assertThat(exception.getMessage(), equalTo(expectedMessage));
     assertThat(exception.getCause(), nullValue());
   }
@@ -58,8 +58,7 @@ class BlockingRejectedExecutionHandlerTest {
     RejectedExecutionException exception =
         assertThrows(
             RejectedExecutionException.class, () -> handler.rejectedExecution(r, executor));
-    String expectedMessage =
-        BlockingRejectedExecutionHandler.interruptedExceptionMessage(r, executor);
+    String expectedMessage = BlockingRejectedExecutionHandler.interruptedExceptionMessage(executor);
     assertThat(exception.getMessage(), equalTo(expectedMessage));
     assertThat(exception.getCause(), instanceOf(InterruptedException.class));
     assertTrue(Thread.interrupted());

--- a/src/test/java/bio/terra/common/BlockingRejectedExecutionHandlerTest.java
+++ b/src/test/java/bio/terra/common/BlockingRejectedExecutionHandlerTest.java
@@ -1,0 +1,67 @@
+package bio.terra.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class BlockingRejectedExecutionHandlerTest {
+  @Mock private Runnable r;
+  @Mock private ThreadPoolExecutor executor;
+  @Mock private BlockingQueue<Runnable> queue;
+  private final BlockingRejectedExecutionHandler handler = new BlockingRejectedExecutionHandler();
+
+  @Test
+  void rejectedExecution() throws InterruptedException {
+    when(executor.isShutdown()).thenReturn(false);
+    when(executor.getQueue()).thenReturn(queue);
+
+    handler.rejectedExecution(r, executor);
+    verify(queue).put(r);
+  }
+
+  @Test
+  void rejectedExecution_executorShutdown() {
+    when(executor.isShutdown()).thenReturn(true);
+
+    RejectedExecutionException exception =
+        assertThrows(
+            RejectedExecutionException.class, () -> handler.rejectedExecution(r, executor));
+    String expectedMessage = BlockingRejectedExecutionHandler.executorShutdownMessage(r, executor);
+    assertThat(exception.getMessage(), equalTo(expectedMessage));
+    assertThat(exception.getCause(), nullValue());
+  }
+
+  @Test
+  void rejectedExecution_InterruptedException() throws InterruptedException {
+    when(executor.isShutdown()).thenReturn(false);
+    when(executor.getQueue()).thenReturn(queue);
+    doThrow(InterruptedException.class).when(queue).put(r);
+
+    RejectedExecutionException exception =
+        assertThrows(
+            RejectedExecutionException.class, () -> handler.rejectedExecution(r, executor));
+    String expectedMessage =
+        BlockingRejectedExecutionHandler.interruptedExceptionMessage(r, executor);
+    assertThat(exception.getMessage(), equalTo(expectedMessage));
+    assertThat(exception.getCause(), instanceOf(InterruptedException.class));
+    assertTrue(Thread.interrupted());
+  }
+}

--- a/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/blobstore/AzureBlobStorePdaoTest.java
@@ -126,7 +126,7 @@ public class AzureBlobStorePdaoTest {
   @MockBean private GcsProjectFactory gcsProjectFactory;
   @MockBean private AzureBlobService azureBlobService;
 
-  @MockBean(name = "azureTableThreadpool")
+  @MockBean(name = AzureResourceConfiguration.TABLE_THREADPOOL_NAME)
   private AsyncTaskExecutor asyncTaskExecutor;
 
   @Autowired private AzureBlobStorePdao dao;


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-511

## Addresses

TDR and other services use [ThreadPoolTaskExecutor](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/concurrent/ThreadPoolTaskExecutor.html)s to parallelize tasks, which are comprised of a core pool of threads for processing and a queue as a fallback for when those threads are active. If the queue fills up, tasks submitted to the executor will be rejected with a [RejectedExecutionException](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/RejectedExecutionException.html).

Making the queue bigger or even unbounded runs the risk of memory issues if requests come faster than they can be processed. In some places, TDR tries to batch up its submissions to an executor to avoid overloading it, only proceeding to the next batch when the previous has succeeded. But this does not make the most efficient use of the executor's capacity, nor does it guard against the scenario where many separate requests are submitting tasks the same executor.

Our driver problem here is that Nate's Azure ingests with 10s of thousands of file references are still encountering intermittent failures due to threadpool saturation, despite increasing the queue size to 10,000.

## Summary of changes

- Introduce new `BlockingRejectedExecutionHandler` to override executor behavior.  If an executor cannot accept a task due to saturation of its threadpool and queue, this handler blocks when waiting for a spot to become available in the queue rather than rejecting the task.
- Set `azureTableThreadpool`'s rejected execution handler to a new instance of `BlockingRejectedExecutionHandler` if the threadpool is configured to block when saturated.
- Set application property `azure.threading.blockWhenSaturated=true` -- can be overridden at the environment level by setting environment variable `AZURE_THREADING_BLOCKWHENSATURATED`.

## Testing Strategy

- Expanded unit testing.

## Future Opportunities

- Evaluate TDR's other existing `ThreadPoolTaskExecutor`s to see if blocking handling is a good fit for them, and wire them in if so.
- Convert TDR's older `ThreadPoolExecutor`s to `ThreadPoolTaskExecutor`s for automatic threadpool and queue instrumentation via Micrometer / Actuator, then evaluate for blocking handling.
- In places where TDR presently batches submissions to a threadpool to avoid saturation, refactor out in favor of blocking handling.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
