### PR TITLE
[DC-1147]Remove snapshot builder settings from datasets API

### DIFF
--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -5061,8 +5061,6 @@ components:
             $ref: '#/components/schemas/Tag'
         resourceLocks:
           $ref: '#/components/schemas/ResourceLocks'
-        snapshotBuilderSettings:
-          $ref: '#/components/schemas/SnapshotBuilderSettings'
       description: >
         Complete definition of a dataset.
     DatasetSummaryModel:
@@ -5226,7 +5224,7 @@ components:
       type: string
       description: >
         Type of information to include in the response
-      enum: [ NONE, SCHEMA, ACCESS_INFORMATION, PROFILE, PROPERTIES, DATA_PROJECT, STORAGE, SNAPSHOT_BUILDER_SETTINGS ]
+      enum: [ NONE, SCHEMA, ACCESS_INFORMATION, PROFILE, PROPERTIES, DATA_PROJECT, STORAGE ]
     EnumerateDatasetModel:
       type: object
       properties:

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -20,7 +20,6 @@ import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestAccessIncludeModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSpecificationModel;
-import bio.terra.model.SnapshotBuilderSettings;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
 import bio.terra.service.resourcemanagement.MetadataDataAccessUtils;
@@ -153,7 +152,6 @@ class DatasetJsonConversionTest {
                                 .rootTable(DATASET_TABLE_NAME)
                                 .rootColumn(DATASET_COLUMN_NAME)
                                 .follow(Collections.emptyList()))))
-            .snapshotBuilderSettings(new SnapshotBuilderSettings())
             .dataProject(DATASET_DATA_PROJECT);
   }
 
@@ -167,7 +165,7 @@ class DatasetJsonConversionTest {
                 DatasetRequestAccessIncludeModel.PROFILE,
                 DatasetRequestAccessIncludeModel.DATA_PROJECT),
             testUser),
-        equalTo(datasetModel.snapshotBuilderSettings(null)));
+        equalTo(datasetModel));
   }
 
   @Test
@@ -178,12 +176,7 @@ class DatasetJsonConversionTest {
             List.of(
                 DatasetRequestAccessIncludeModel.NONE, DatasetRequestAccessIncludeModel.PROFILE),
             testUser),
-        equalTo(
-            datasetModel
-                .dataProject(null)
-                .defaultProfileId(null)
-                .schema(null)
-                .snapshotBuilderSettings(null)));
+        equalTo(datasetModel.dataProject(null).defaultProfileId(null).schema(null)));
   }
 
   @Test
@@ -197,7 +190,6 @@ class DatasetJsonConversionTest {
                 .dataProject(null)
                 .defaultProfileId(null)
                 .schema(null)
-                .snapshotBuilderSettings(null)
                 .accessInformation(
                     new AccessInfoModel()
                         .bigQuery(


### PR DESCRIPTION

__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1147

## Summary of changes
In the openapi yaml file, removed snapshotBuilderSettings from DatasetModel and removed SNAPSHOT_BUILDER_SETTINGS from DatasetRequestAccessIncludeModel
## Testing Strategy
Didn't write any new tests, modified some tests in DatasetJsonConversionTest.java that used snapshotBuilderSettings
<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
