### PR TITLE
[DC-1150] Add snapshot summary and do a bunch of drive by refactors

### DIFF
--- a/src/main/java/bio/terra/common/DaoUtils.java
+++ b/src/main/java/bio/terra/common/DaoUtils.java
@@ -13,6 +13,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -132,12 +133,14 @@ public final class DaoUtils {
     }
   }
 
-  public static String getInstantString(ResultSet rs, String columnLabel) throws SQLException {
+  public static Instant getInstant(ResultSet rs, String columnLabel) throws SQLException {
     Timestamp timestamp = rs.getTimestamp(columnLabel);
-    if (timestamp != null) {
-      return timestamp.toInstant().toString();
-    }
-    return null;
+    return timestamp != null ? timestamp.toInstant() : null;
+  }
+
+  public static String getInstantString(ResultSet rs, String columnLabel) throws SQLException {
+    Instant instant = getInstant(rs, columnLabel);
+    return instant != null ? instant.toString() : null;
   }
 
   public static class UuidMapper implements RowMapper<UUID> {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -692,7 +692,6 @@ public class SnapshotService {
   }
 
   public SnapshotAccessRequestModel getSnapshotAccessRequestById(UUID accessRequestId) {
-    SnapshotAccessRequestModel model = snapshotRequestDao.getById(accessRequestId);
     return snapshotRequestDao.getById(accessRequestId);
   }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStep.java
@@ -47,7 +47,7 @@ public class CreateSnapshotAddEmailsToSamGroupStep extends DefaultUndoStep {
     String groupName =
         workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_FIRECLOUD_GROUP_NAME, String.class);
     List<String> emailsToAddToGroup =
-        List.of(snapshotRequestDao.getById(snapshotRequestId).getCreatedBy());
+        List.of(snapshotRequestDao.getById(snapshotRequestId).createdBy());
     iamService.overwriteGroupPolicyEmailsIncludeRequestingUser(
         userRequest, groupName, IamRole.MEMBER.toString(), emailsToAddToGroup);
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRequestIdInterface.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRequestIdInterface.java
@@ -29,7 +29,7 @@ public interface CreateSnapshotByRequestIdInterface {
     SnapshotAccessRequestModel accessRequest =
         snapshotService.getSnapshotAccessRequestById(accessRequestId);
 
-    UUID sourceSnapshotId = accessRequest.getSourceSnapshotId();
+    UUID sourceSnapshotId = accessRequest.sourceSnapshotId();
     Snapshot sourceSnapshot = snapshotDao.retrieveSnapshot(sourceSnapshotId);
     Dataset dataset = sourceSnapshot.getSourceDataset();
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRequestIdInterface.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRequestIdInterface.java
@@ -1,13 +1,13 @@
 package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.service.dataset.AssetSpecification;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshotbuilder.SnapshotAccessRequestModel;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
@@ -26,7 +26,7 @@ public interface CreateSnapshotByRequestIdInterface {
       throws InterruptedException {
     UUID accessRequestId =
         snapshotReq.getContents().get(0).getRequestIdSpec().getSnapshotRequestId();
-    SnapshotAccessRequestResponse accessRequest =
+    SnapshotAccessRequestModel accessRequest =
         snapshotService.getSnapshotAccessRequestById(accessRequestId);
 
     UUID sourceSnapshotId = accessRequest.getSourceSnapshotId();

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModel.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModel.java
@@ -17,164 +17,18 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-public class SnapshotAccessRequestModel {
-  private UUID id;
-  private String snapshotName;
-  private String snapshotResearchPurpose;
-  private UUID sourceSnapshotId;
-  private SnapshotBuilderRequest snapshotSpecification;
-  private String createdBy;
-  private Instant createdDate;
-  private Instant statusUpdatedDate;
-  private SnapshotAccessRequestStatus status;
-  private UUID createdSnapshotId;
-  private String flightid;
-
-  public SnapshotAccessRequestModel() {}
-
-  public UUID getId() {
-    return id;
-  }
-
-  public void setId(UUID id) {
-    this.id = id;
-  }
-
-  public SnapshotAccessRequestModel id(UUID id) {
-    this.id = id;
-    return this;
-  }
-
-  public String getSnapshotName() {
-    return snapshotName;
-  }
-
-  public void setSnapshotName(String snapshotName) {
-    this.snapshotName = snapshotName;
-  }
-
-  public SnapshotAccessRequestModel snapshotName(String snapshotName) {
-    this.snapshotName = snapshotName;
-    return this;
-  }
-
-  public String getSnapshotResearchPurpose() {
-    return snapshotResearchPurpose;
-  }
-
-  public void setSnapshotResearchPurpose(String snapshotResearchPurpose) {
-    this.snapshotResearchPurpose = snapshotResearchPurpose;
-  }
-
-  public SnapshotAccessRequestModel snapshotResearchPurpose(String snapshotResearchPurpose) {
-    this.snapshotResearchPurpose = snapshotResearchPurpose;
-    return this;
-  }
-
-  public UUID getSourceSnapshotId() {
-    return sourceSnapshotId;
-  }
-
-  public void setSourceSnapshotId(UUID sourceSnapshotId) {
-    this.sourceSnapshotId = sourceSnapshotId;
-  }
-
-  public SnapshotAccessRequestModel sourceSnapshotId(UUID sourceSnapshotId) {
-    this.sourceSnapshotId = sourceSnapshotId;
-    return this;
-  }
-
-  public SnapshotBuilderRequest getSnapshotSpecification() {
-    return snapshotSpecification;
-  }
-
-  public void setSnapshotSpecification(SnapshotBuilderRequest snapshotSpecification) {
-    this.snapshotSpecification = snapshotSpecification;
-  }
-
-  public SnapshotAccessRequestModel snapshotSpecification(
-      SnapshotBuilderRequest snapshotSpecification) {
-    this.snapshotSpecification = snapshotSpecification;
-    return this;
-  }
-
-  public String getCreatedBy() {
-    return createdBy;
-  }
-
-  public void setCreatedBy(String createdBy) {
-    this.createdBy = createdBy;
-  }
-
-  public SnapshotAccessRequestModel createdBy(String createdBy) {
-    this.createdBy = createdBy;
-    return this;
-  }
-
-  public Instant getCreatedDate() {
-    return createdDate;
-  }
-
-  public void setCreatedDate(Instant createdDate) {
-    this.createdDate = createdDate;
-  }
-
-  public SnapshotAccessRequestModel createdDate(Instant createdDate) {
-    this.createdDate = createdDate;
-    return this;
-  }
-
-  public Instant getStatusUpdatedDate() {
-    return statusUpdatedDate;
-  }
-
-  public void setStatusUpdatedDate(Instant statusUpdatedDate) {
-    this.statusUpdatedDate = statusUpdatedDate;
-  }
-
-  public SnapshotAccessRequestModel statusUpdatedDate(Instant statusUpdatedDate) {
-    this.statusUpdatedDate = statusUpdatedDate;
-    return this;
-  }
-
-  public SnapshotAccessRequestStatus getStatus() {
-    return status;
-  }
-
-  public void setStatus(SnapshotAccessRequestStatus status) {
-    this.status = status;
-  }
-
-  public SnapshotAccessRequestModel status(SnapshotAccessRequestStatus status) {
-    this.status = status;
-    return this;
-  }
-
-  public UUID getCreatedSnapshotId() {
-    return createdSnapshotId;
-  }
-
-  public void setCreatedSnapshotId(UUID createdSnapshotId) {
-    this.createdSnapshotId = createdSnapshotId;
-  }
-
-  public SnapshotAccessRequestModel createdSnapshotId(UUID createdSnapshotId) {
-    this.createdSnapshotId = createdSnapshotId;
-    return this;
-  }
-
-  public String getFlightid() {
-    return flightid;
-  }
-
-  public void setFlightid(String flightid) {
-    this.flightid = flightid;
-  }
-
-  public SnapshotAccessRequestModel flightid(String flightid) {
-    this.flightid = flightid;
-    return this;
-  }
+public record SnapshotAccessRequestModel(
+    UUID id,
+    String snapshotName,
+    String snapshotResearchPurpose,
+    UUID sourceSnapshotId,
+    SnapshotBuilderRequest snapshotSpecification,
+    String createdBy,
+    Instant createdDate,
+    Instant statusUpdatedDate,
+    SnapshotAccessRequestStatus status,
+    UUID createdSnapshotId,
+    String flightid) {
 
   @VisibleForTesting
   static String generateSummaryForCriteria(
@@ -258,7 +112,7 @@ public class SnapshotAccessRequestModel {
     return String.format(
         "Participants included:\n%s\nTables included:%s\n",
         snapshotSpecification.getCohorts().stream()
-            .map(cohort -> this.generateSummaryForCohort(cohort, settings))
+            .map(cohort -> generateSummaryForCohort(cohort, settings))
             .collect(Collectors.joining("\n")),
         snapshotSpecification.getOutputTables().stream()
             .map(SnapshotBuilderOutputTable::getName)

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModel.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModel.java
@@ -109,14 +109,16 @@ public record SnapshotAccessRequestModel(
 
   @VisibleForTesting
   String generateSummaryFromSnapshotSpecification(SnapshotBuilderSettings settings) {
-    return String.format(
-        "Participants included:\n%s\nTables included:%s\n",
-        snapshotSpecification.getCohorts().stream()
-            .map(cohort -> generateSummaryForCohort(cohort, settings))
-            .collect(Collectors.joining("\n")),
-        snapshotSpecification.getOutputTables().stream()
-            .map(SnapshotBuilderOutputTable::getName)
-            .collect(Collectors.joining(", ")));
+    return snapshotSpecification != null
+        ? String.format(
+            "Participants included:\n%s\nTables included:%s\n",
+            snapshotSpecification.getCohorts().stream()
+                .map(cohort -> generateSummaryForCohort(cohort, settings))
+                .collect(Collectors.joining("\n")),
+            snapshotSpecification.getOutputTables().stream()
+                .map(SnapshotBuilderOutputTable::getName)
+                .collect(Collectors.joining(", ")))
+        : "No snapshot specification found";
   }
 
   public SnapshotAccessRequestResponse toApiResponse(SnapshotBuilderSettings settings) {

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModel.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModel.java
@@ -1,0 +1,283 @@
+package bio.terra.service.snapshotbuilder;
+
+import bio.terra.common.exception.InternalServerErrorException;
+import bio.terra.model.SnapshotAccessRequestResponse;
+import bio.terra.model.SnapshotAccessRequestStatus;
+import bio.terra.model.SnapshotBuilderCohort;
+import bio.terra.model.SnapshotBuilderCriteriaGroup;
+import bio.terra.model.SnapshotBuilderDomainCriteria;
+import bio.terra.model.SnapshotBuilderOutputTable;
+import bio.terra.model.SnapshotBuilderProgramDataListCriteria;
+import bio.terra.model.SnapshotBuilderProgramDataRangeCriteria;
+import bio.terra.model.SnapshotBuilderRequest;
+import bio.terra.model.SnapshotBuilderSettings;
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class SnapshotAccessRequestModel {
+  private UUID id;
+  private String snapshotName;
+  private String snapshotResearchPurpose;
+  private UUID sourceSnapshotId;
+  private SnapshotBuilderRequest snapshotSpecification;
+  private String createdBy;
+  private Instant createdDate;
+  private Instant statusUpdatedDate;
+  private SnapshotAccessRequestStatus status;
+  private UUID createdSnapshotId;
+  private String flightid;
+
+  public SnapshotAccessRequestModel() {}
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public SnapshotAccessRequestModel id(UUID id) {
+    this.id = id;
+    return this;
+  }
+
+  public String getSnapshotName() {
+    return snapshotName;
+  }
+
+  public void setSnapshotName(String snapshotName) {
+    this.snapshotName = snapshotName;
+  }
+
+  public SnapshotAccessRequestModel snapshotName(String snapshotName) {
+    this.snapshotName = snapshotName;
+    return this;
+  }
+
+  public String getSnapshotResearchPurpose() {
+    return snapshotResearchPurpose;
+  }
+
+  public void setSnapshotResearchPurpose(String snapshotResearchPurpose) {
+    this.snapshotResearchPurpose = snapshotResearchPurpose;
+  }
+
+  public SnapshotAccessRequestModel snapshotResearchPurpose(String snapshotResearchPurpose) {
+    this.snapshotResearchPurpose = snapshotResearchPurpose;
+    return this;
+  }
+
+  public UUID getSourceSnapshotId() {
+    return sourceSnapshotId;
+  }
+
+  public void setSourceSnapshotId(UUID sourceSnapshotId) {
+    this.sourceSnapshotId = sourceSnapshotId;
+  }
+
+  public SnapshotAccessRequestModel sourceSnapshotId(UUID sourceSnapshotId) {
+    this.sourceSnapshotId = sourceSnapshotId;
+    return this;
+  }
+
+  public SnapshotBuilderRequest getSnapshotSpecification() {
+    return snapshotSpecification;
+  }
+
+  public void setSnapshotSpecification(SnapshotBuilderRequest snapshotSpecification) {
+    this.snapshotSpecification = snapshotSpecification;
+  }
+
+  public SnapshotAccessRequestModel snapshotSpecification(
+      SnapshotBuilderRequest snapshotSpecification) {
+    this.snapshotSpecification = snapshotSpecification;
+    return this;
+  }
+
+  public String getCreatedBy() {
+    return createdBy;
+  }
+
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
+  }
+
+  public SnapshotAccessRequestModel createdBy(String createdBy) {
+    this.createdBy = createdBy;
+    return this;
+  }
+
+  public Instant getCreatedDate() {
+    return createdDate;
+  }
+
+  public void setCreatedDate(Instant createdDate) {
+    this.createdDate = createdDate;
+  }
+
+  public SnapshotAccessRequestModel createdDate(Instant createdDate) {
+    this.createdDate = createdDate;
+    return this;
+  }
+
+  public Instant getStatusUpdatedDate() {
+    return statusUpdatedDate;
+  }
+
+  public void setStatusUpdatedDate(Instant statusUpdatedDate) {
+    this.statusUpdatedDate = statusUpdatedDate;
+  }
+
+  public SnapshotAccessRequestModel statusUpdatedDate(Instant statusUpdatedDate) {
+    this.statusUpdatedDate = statusUpdatedDate;
+    return this;
+  }
+
+  public SnapshotAccessRequestStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(SnapshotAccessRequestStatus status) {
+    this.status = status;
+  }
+
+  public SnapshotAccessRequestModel status(SnapshotAccessRequestStatus status) {
+    this.status = status;
+    return this;
+  }
+
+  public UUID getCreatedSnapshotId() {
+    return createdSnapshotId;
+  }
+
+  public void setCreatedSnapshotId(UUID createdSnapshotId) {
+    this.createdSnapshotId = createdSnapshotId;
+  }
+
+  public SnapshotAccessRequestModel createdSnapshotId(UUID createdSnapshotId) {
+    this.createdSnapshotId = createdSnapshotId;
+    return this;
+  }
+
+  public String getFlightid() {
+    return flightid;
+  }
+
+  public void setFlightid(String flightid) {
+    this.flightid = flightid;
+  }
+
+  public SnapshotAccessRequestModel flightid(String flightid) {
+    this.flightid = flightid;
+    return this;
+  }
+
+  @VisibleForTesting
+  static String generateSummaryForCriteria(
+      SnapshotBuilderProgramDataListCriteria criteria, SnapshotBuilderSettings settings) {
+    return String.format(
+        "The following concepts from %s: %s",
+        settings.getProgramDataOptions().stream()
+            .filter(
+                programDataOption -> Objects.equals(programDataOption.getId(), criteria.getId()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new InternalServerErrorException(
+                        String.format("No value found for criteria ID %d", criteria.getId())))
+            .getName(),
+        criteria.getValues().stream().map(Object::toString).collect(Collectors.joining(", ")));
+  }
+
+  @VisibleForTesting
+  static String generateSummaryForCriteria(
+      SnapshotBuilderProgramDataRangeCriteria criteria, SnapshotBuilderSettings settings) {
+    return String.format(
+        "%s between %d and %d",
+        settings.getProgramDataOptions().stream()
+            .filter(
+                programDataOption -> Objects.equals(programDataOption.getId(), criteria.getId()))
+            .findFirst()
+            .orElseThrow()
+            .getName(),
+        criteria.getLow(),
+        criteria.getHigh());
+  }
+
+  @VisibleForTesting
+  static String generateSummaryForCriteria(
+      SnapshotBuilderDomainCriteria criteria, SnapshotBuilderSettings settings) {
+    return String.format(
+        "%s Concept Id: %s",
+        settings.getDomainOptions().stream()
+            .filter(domainOption -> domainOption.getId().equals(criteria.getId()))
+            .findFirst()
+            .orElseThrow()
+            .getName(),
+        criteria.getConceptId());
+  }
+
+  @VisibleForTesting
+  static String generateSummaryForCriteriaGroup(
+      SnapshotBuilderCriteriaGroup criteriaGroup, SnapshotBuilderSettings settings) {
+    return String.format(
+        "Must %s %s:\n%s",
+        criteriaGroup.isMustMeet() ? "meet" : "not meet",
+        criteriaGroup.isMeetAll() ? "all of" : "any of",
+        criteriaGroup.getCriteria().stream()
+            .map(
+                criteria ->
+                    switch (criteria.getKind()) {
+                      case LIST -> generateSummaryForCriteria(
+                          (SnapshotBuilderProgramDataListCriteria) criteria, settings);
+                      case RANGE -> generateSummaryForCriteria(
+                          (SnapshotBuilderProgramDataRangeCriteria) criteria, settings);
+                      case DOMAIN -> generateSummaryForCriteria(
+                          (SnapshotBuilderDomainCriteria) criteria, settings);
+                    })
+            .collect(Collectors.joining("\n")));
+  }
+
+  @VisibleForTesting
+  static String generateSummaryForCohort(
+      SnapshotBuilderCohort cohort, SnapshotBuilderSettings settings) {
+    return String.format(
+        "Name: %s\nGroups:\n%s",
+        cohort.getName(),
+        cohort.getCriteriaGroups().stream()
+            .map(criteriaGroup -> generateSummaryForCriteriaGroup(criteriaGroup, settings))
+            .collect(Collectors.joining("\n")));
+  }
+
+  @VisibleForTesting
+  String generateSummaryFromSnapshotSpecification(SnapshotBuilderSettings settings) {
+    return String.format(
+        "Participants included:\n%s\nTables included:%s\n",
+        snapshotSpecification.getCohorts().stream()
+            .map(cohort -> this.generateSummaryForCohort(cohort, settings))
+            .collect(Collectors.joining("\n")),
+        snapshotSpecification.getOutputTables().stream()
+            .map(SnapshotBuilderOutputTable::getName)
+            .collect(Collectors.joining(", ")));
+  }
+
+  public SnapshotAccessRequestResponse toApiResponse(SnapshotBuilderSettings settings) {
+    return new SnapshotAccessRequestResponse()
+        .id(id)
+        .flightid(flightid)
+        .sourceSnapshotId(sourceSnapshotId)
+        .snapshotName(snapshotName)
+        .snapshotResearchPurpose(snapshotResearchPurpose)
+        .snapshotSpecification(snapshotSpecification)
+        .createdBy(createdBy)
+        .status(status)
+        .createdDate(createdDate != null ? createdDate.toString() : null)
+        .statusUpdatedDate(statusUpdatedDate != null ? statusUpdatedDate.toString() : null)
+        .createdSnapshotId(createdSnapshotId)
+        .summary(generateSummaryFromSnapshotSpecification(settings));
+  }
+}

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModel.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModel.java
@@ -79,7 +79,7 @@ public record SnapshotAccessRequestModel(
   static String generateSummaryForCriteriaGroup(
       SnapshotBuilderCriteriaGroup criteriaGroup, SnapshotBuilderSettings settings) {
     return String.format(
-        "Must %s %s:\n%s",
+        "Must %s %s:%n%s",
         criteriaGroup.isMustMeet() ? "meet" : "not meet",
         criteriaGroup.isMeetAll() ? "all of" : "any of",
         criteriaGroup.getCriteria().stream()
@@ -100,7 +100,7 @@ public record SnapshotAccessRequestModel(
   static String generateSummaryForCohort(
       SnapshotBuilderCohort cohort, SnapshotBuilderSettings settings) {
     return String.format(
-        "Name: %s\nGroups:\n%s",
+        "Name: %s%nGroups:%n%s",
         cohort.getName(),
         cohort.getCriteriaGroups().stream()
             .map(criteriaGroup -> generateSummaryForCriteriaGroup(criteriaGroup, settings))
@@ -111,7 +111,7 @@ public record SnapshotAccessRequestModel(
   String generateSummaryFromSnapshotSpecification(SnapshotBuilderSettings settings) {
     return snapshotSpecification != null
         ? String.format(
-            "Participants included:\n%s\nTables included:%s\n",
+            "Participants included:%n%s%nTables included:%s%n",
             snapshotSpecification.getCohorts().stream()
                 .map(cohort -> generateSummaryForCohort(cohort, settings))
                 .collect(Collectors.joining("\n")),

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -220,9 +220,7 @@ public class SnapshotBuilderService {
   }
 
   public SnapshotAccessRequestResponse getRequest(UUID id) {
-    SnapshotAccessRequestModel model = snapshotRequestDao.getById(id);
-    return model.toApiResponse(
-        snapshotBuilderSettingsDao.getBySnapshotId(model.sourceSnapshotId()));
+    return convertModelToApiResponse(snapshotRequestDao.getById(id));
   }
 
   public void deleteRequest(AuthenticatedUserRequest user, UUID id) {
@@ -394,13 +392,17 @@ public class SnapshotBuilderService {
   public SnapshotAccessRequestResponse rejectRequest(UUID id) {
     snapshotRequestDao.updateStatus(id, SnapshotAccessRequestStatus.REJECTED);
     SnapshotAccessRequestModel model = snapshotRequestDao.getById(id);
-    return model.toApiResponse(
-        snapshotBuilderSettingsDao.getBySnapshotId(model.sourceSnapshotId()));
+    return convertModelToApiResponse(model);
   }
 
   public SnapshotAccessRequestResponse approveRequest(UUID id) {
     snapshotRequestDao.updateStatus(id, SnapshotAccessRequestStatus.APPROVED);
     SnapshotAccessRequestModel model = snapshotRequestDao.getById(id);
+    return convertModelToApiResponse(model);
+  }
+
+  private SnapshotAccessRequestResponse convertModelToApiResponse(
+      SnapshotAccessRequestModel model) {
     return model.toApiResponse(
         snapshotBuilderSettingsDao.getBySnapshotId(model.sourceSnapshotId()));
   }

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotBuilderService.java
@@ -92,15 +92,14 @@ public class SnapshotBuilderService {
       iamService.createSnapshotBuilderRequestResource(
           userRequest,
           snapshotAccessRequest.getSourceSnapshotId(),
-          snapshotAccessRequestModel.getId());
+          snapshotAccessRequestModel.id());
     } catch (ApiException e) {
-      snapshotRequestDao.delete(snapshotAccessRequestModel.getId());
+      snapshotRequestDao.delete(snapshotAccessRequestModel.id());
       throw e;
     }
 
     return snapshotAccessRequestModel.toApiResponse(
-        snapshotBuilderSettingsDao.getBySnapshotId(
-            snapshotAccessRequestModel.getSourceSnapshotId()));
+        snapshotBuilderSettingsDao.getBySnapshotId(snapshotAccessRequestModel.sourceSnapshotId()));
   }
 
   private <T> List<T> runSnapshotBuilderQuery(
@@ -210,20 +209,20 @@ public class SnapshotBuilderService {
       List<SnapshotAccessRequestModel> models) {
     Map<UUID, SnapshotBuilderSettings> settings =
         models.stream()
-            .map(SnapshotAccessRequestModel::getSourceSnapshotId)
+            .map(SnapshotAccessRequestModel::sourceSnapshotId)
             .distinct()
             .collect(Collectors.toMap(id -> id, snapshotBuilderSettingsDao::getBySnapshotId));
     return new EnumerateSnapshotAccessRequest()
         .items(
             models.stream()
-                .map(model -> model.toApiResponse(settings.get(model.getSourceSnapshotId())))
+                .map(model -> model.toApiResponse(settings.get(model.sourceSnapshotId())))
                 .toList());
   }
 
   public SnapshotAccessRequestResponse getRequest(UUID id) {
     SnapshotAccessRequestModel model = snapshotRequestDao.getById(id);
     return model.toApiResponse(
-        snapshotBuilderSettingsDao.getBySnapshotId(model.getSourceSnapshotId()));
+        snapshotBuilderSettingsDao.getBySnapshotId(model.sourceSnapshotId()));
   }
 
   public void deleteRequest(AuthenticatedUserRequest user, UUID id) {
@@ -325,7 +324,7 @@ public class SnapshotBuilderService {
     SnapshotBuilderSettings settings = snapshotBuilderSettingsDao.getBySnapshotId(snapshot.getId());
     Dataset dataset = snapshot.getSourceDataset();
 
-    List<SnapshotBuilderCohort> cohorts = accessRequest.getSnapshotSpecification().getCohorts();
+    List<SnapshotBuilderCohort> cohorts = accessRequest.snapshotSpecification().getCohorts();
 
     Query sqlQuery =
         queryBuilderFactory.criteriaQueryBuilder(settings).generateRowIdQueryForCohorts(cohorts);
@@ -396,14 +395,14 @@ public class SnapshotBuilderService {
     snapshotRequestDao.updateStatus(id, SnapshotAccessRequestStatus.REJECTED);
     SnapshotAccessRequestModel model = snapshotRequestDao.getById(id);
     return model.toApiResponse(
-        snapshotBuilderSettingsDao.getBySnapshotId(model.getSourceSnapshotId()));
+        snapshotBuilderSettingsDao.getBySnapshotId(model.sourceSnapshotId()));
   }
 
   public SnapshotAccessRequestResponse approveRequest(UUID id) {
     snapshotRequestDao.updateStatus(id, SnapshotAccessRequestStatus.APPROVED);
     SnapshotAccessRequestModel model = snapshotRequestDao.getById(id);
     return model.toApiResponse(
-        snapshotBuilderSettingsDao.getBySnapshotId(model.getSourceSnapshotId()));
+        snapshotBuilderSettingsDao.getBySnapshotId(model.sourceSnapshotId()));
   }
 
   private SnapshotBuilderDomainOption getDomainOption(

--- a/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
+++ b/src/main/java/bio/terra/service/snapshotbuilder/SnapshotRequestDao.java
@@ -46,18 +46,18 @@ public class SnapshotRequestDao {
 
   private class SnapshotAccessRequestModelMapper implements RowMapper<SnapshotAccessRequestModel> {
     public SnapshotAccessRequestModel mapRow(ResultSet rs, int rowNum) throws SQLException {
-      return new SnapshotAccessRequestModel()
-          .id(rs.getObject(ID, UUID.class))
-          .sourceSnapshotId(rs.getObject(SOURCE_SNAPSHOT_ID, UUID.class))
-          .snapshotName(rs.getString(SNAPSHOT_NAME))
-          .snapshotResearchPurpose(rs.getString(SNAPSHOT_RESEARCH_PURPOSE))
-          .snapshotSpecification(mapRequestFromJson(rs.getString(SNAPSHOT_SPECIFICATION)))
-          .createdDate(DaoUtils.getInstant(rs, CREATED_DATE))
-          .statusUpdatedDate(DaoUtils.getInstant(rs, STATUS_UPDATED_DATE))
-          .createdBy(rs.getString(CREATED_BY))
-          .status(SnapshotAccessRequestStatus.valueOf(rs.getString(STATUS)))
-          .flightid(rs.getString(FLIGHT_ID))
-          .createdSnapshotId(rs.getObject(CREATED_SNAPSHOT_ID, UUID.class));
+      return new SnapshotAccessRequestModel(
+          rs.getObject(ID, UUID.class),
+          rs.getString(SNAPSHOT_NAME),
+          rs.getString(SNAPSHOT_RESEARCH_PURPOSE),
+          rs.getObject(SOURCE_SNAPSHOT_ID, UUID.class),
+          mapRequestFromJson(rs.getString(SNAPSHOT_SPECIFICATION)),
+          rs.getString(CREATED_BY),
+          DaoUtils.getInstant(rs, CREATED_DATE),
+          DaoUtils.getInstant(rs, STATUS_UPDATED_DATE),
+          SnapshotAccessRequestStatus.valueOf(rs.getString(STATUS)),
+          rs.getObject(CREATED_SNAPSHOT_ID, UUID.class),
+          rs.getString(FLIGHT_ID));
     }
   }
 

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7517,6 +7517,8 @@ components:
           $ref: '#/components/schemas/ShortIdProperty'
         createdSnapshotId:
           $ref: '#/components/schemas/UniqueIdProperty'
+        summary:
+          type: string
 
 
     SnapshotAccessRequestStatus:

--- a/src/test/java/bio/terra/app/controller/SnapshotAccessRequestApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotAccessRequestApiControllerTest.java
@@ -126,11 +126,12 @@ class SnapshotAccessRequestApiControllerTest {
 
   @Test
   void testGetSnapshotRequest() throws Exception {
-    var expectedResponse = SnapshotBuilderTestData.createSnapshotAccessRequestModel(SNAPSHOT_ID);
-    when(snapshotBuilderService.getRequest(expectedResponse.id()))
-        .thenReturn(expectedResponse.toApiResponse(SnapshotBuilderTestData.SETTINGS));
+    var expectedResponse =
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(SNAPSHOT_ID)
+            .toApiResponse(SnapshotBuilderTestData.SETTINGS);
+    when(snapshotBuilderService.getRequest(expectedResponse.getId())).thenReturn(expectedResponse);
     String actualJson =
-        mvc.perform(get(GET_ENDPOINT, expectedResponse.id()))
+        mvc.perform(get(GET_ENDPOINT, expectedResponse.getId()))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
@@ -142,7 +143,7 @@ class SnapshotAccessRequestApiControllerTest {
         .verifyAuthorization(
             TEST_USER,
             IamResourceType.SNAPSHOT_BUILDER_REQUEST,
-            expectedResponse.id().toString(),
+            expectedResponse.getId().toString(),
             IamAction.GET);
   }
 

--- a/src/test/java/bio/terra/app/controller/SnapshotAccessRequestApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotAccessRequestApiControllerTest.java
@@ -127,10 +127,10 @@ class SnapshotAccessRequestApiControllerTest {
   @Test
   void testGetSnapshotRequest() throws Exception {
     var expectedResponse = SnapshotBuilderTestData.createSnapshotAccessRequestModel(SNAPSHOT_ID);
-    when(snapshotBuilderService.getRequest(expectedResponse.getId()))
+    when(snapshotBuilderService.getRequest(expectedResponse.id()))
         .thenReturn(expectedResponse.toApiResponse(SnapshotBuilderTestData.SETTINGS));
     String actualJson =
-        mvc.perform(get(GET_ENDPOINT, expectedResponse.getId()))
+        mvc.perform(get(GET_ENDPOINT, expectedResponse.id()))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
@@ -142,7 +142,7 @@ class SnapshotAccessRequestApiControllerTest {
         .verifyAuthorization(
             TEST_USER,
             IamResourceType.SNAPSHOT_BUILDER_REQUEST,
-            expectedResponse.getId().toString(),
+            expectedResponse.id().toString(),
             IamAction.GET);
   }
 

--- a/src/test/java/bio/terra/app/controller/SnapshotAccessRequestApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotAccessRequestApiControllerTest.java
@@ -73,7 +73,8 @@ class SnapshotAccessRequestApiControllerTest {
         SnapshotBuilderTestData.createSnapshotAccessRequest(SNAPSHOT_ID);
 
     SnapshotAccessRequestResponse expectedResponse =
-        SnapshotBuilderTestData.createSnapshotAccessRequestResponse(SNAPSHOT_ID);
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(SNAPSHOT_ID)
+            .toApiResponse(SnapshotBuilderTestData.SETTINGS);
     when(snapshotBuilderService.createRequest(any(), eq(request))).thenReturn(expectedResponse);
     String actualJson =
         mvc.perform(
@@ -98,9 +99,11 @@ class SnapshotAccessRequestApiControllerTest {
   @Test
   void testEnumerateSnapshotRequests() throws Exception {
     var expectedResponseItem =
-        SnapshotBuilderTestData.createSnapshotAccessRequestResponse(SNAPSHOT_ID);
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(SNAPSHOT_ID)
+            .toApiResponse(SnapshotBuilderTestData.SETTINGS);
     var secondExpectedResponseItem =
-        SnapshotBuilderTestData.createSnapshotAccessRequestResponse(SNAPSHOT_ID);
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(SNAPSHOT_ID)
+            .toApiResponse(SnapshotBuilderTestData.SETTINGS);
     var expectedResponse = new EnumerateSnapshotAccessRequest();
     Map<UUID, Set<IamRole>> authResponse =
         Map.of(
@@ -123,8 +126,9 @@ class SnapshotAccessRequestApiControllerTest {
 
   @Test
   void testGetSnapshotRequest() throws Exception {
-    var expectedResponse = SnapshotBuilderTestData.createSnapshotAccessRequestResponse(SNAPSHOT_ID);
-    when(snapshotBuilderService.getRequest(expectedResponse.getId())).thenReturn(expectedResponse);
+    var expectedResponse = SnapshotBuilderTestData.createSnapshotAccessRequestModel(SNAPSHOT_ID);
+    when(snapshotBuilderService.getRequest(expectedResponse.getId()))
+        .thenReturn(expectedResponse.toApiResponse(SnapshotBuilderTestData.SETTINGS));
     String actualJson =
         mvc.perform(get(GET_ENDPOINT, expectedResponse.getId()))
             .andExpect(status().isOk())

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -621,9 +621,18 @@ class SnapshotServiceTest {
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
     SnapshotAccessRequestModel accessRequestResponse =
-        new SnapshotAccessRequestModel()
-            .status(SnapshotAccessRequestStatus.APPROVED)
-            .createdBy("email@a.com");
+        new SnapshotAccessRequestModel(
+            null,
+            null,
+            null,
+            null,
+            null,
+            "email@a.com",
+            null,
+            null,
+            SnapshotAccessRequestStatus.APPROVED,
+            null,
+            null);
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
 
     assertDoesNotThrow(() -> service.validateForByRequestIdMode(snapshotRequestContentsModel));
@@ -636,10 +645,18 @@ class SnapshotServiceTest {
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
     SnapshotAccessRequestModel accessRequestResponse =
-        new SnapshotAccessRequestModel()
-            .status(SnapshotAccessRequestStatus.APPROVED)
-            .createdBy("email@a.com")
-            .flightid(flightId);
+        new SnapshotAccessRequestModel(
+            null,
+            null,
+            null,
+            null,
+            null,
+            "email@a.com",
+            null,
+            null,
+            SnapshotAccessRequestStatus.APPROVED,
+            null,
+            flightId);
 
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
     when(jobService.unauthRetrieveJobState(flightId)).thenReturn(FlightStatus.ERROR);
@@ -652,7 +669,18 @@ class SnapshotServiceTest {
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
     SnapshotAccessRequestModel accessRequestResponse =
-        new SnapshotAccessRequestModel().status(SnapshotAccessRequestStatus.SUBMITTED);
+        new SnapshotAccessRequestModel(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SnapshotAccessRequestStatus.SUBMITTED,
+            null,
+            null);
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
 
     assertThrows(
@@ -667,9 +695,18 @@ class SnapshotServiceTest {
         makeByRequestIdContentsModel(snapshotAccessRequestId);
 
     SnapshotAccessRequestModel accessRequestResponse =
-        new SnapshotAccessRequestModel()
-            .status(SnapshotAccessRequestStatus.APPROVED)
-            .createdSnapshotId(UUID.randomUUID());
+        new SnapshotAccessRequestModel(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SnapshotAccessRequestStatus.APPROVED,
+            UUID.randomUUID(),
+            null);
 
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
 
@@ -685,9 +722,18 @@ class SnapshotServiceTest {
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
     SnapshotAccessRequestModel accessRequestResponse =
-        new SnapshotAccessRequestModel()
-            .status(SnapshotAccessRequestStatus.APPROVED)
-            .flightid(flightId);
+        new SnapshotAccessRequestModel(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            SnapshotAccessRequestStatus.APPROVED,
+            null,
+            flightId);
 
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
     // any flight status that isn't error or fatal
@@ -703,9 +749,18 @@ class SnapshotServiceTest {
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
     SnapshotAccessRequestModel accessRequestResponse =
-        new SnapshotAccessRequestModel()
-            .status(SnapshotAccessRequestStatus.APPROVED)
-            .createdBy("notanemail.com");
+        new SnapshotAccessRequestModel(
+            null,
+            null,
+            null,
+            null,
+            null,
+            "notanemail.com",
+            null,
+            null,
+            SnapshotAccessRequestStatus.APPROVED,
+            null,
+            null);
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
     assertThrows(
         ValidationException.class,
@@ -1111,13 +1166,20 @@ class SnapshotServiceTest {
     JobBuilder jobBuilder = mock(JobBuilder.class);
     String jobId = mockJobService(request, jobBuilder);
     SnapshotAccessRequestModel snapshotAccessRequest =
-        new SnapshotAccessRequestModel()
-            .status(SnapshotAccessRequestStatus.APPROVED)
-            .createdBy("email@a.com")
-            .id(snapshotAccessRequestId)
-            .sourceSnapshotId(UUID.randomUUID());
+        new SnapshotAccessRequestModel(
+            snapshotAccessRequestId,
+            null,
+            null,
+            UUID.randomUUID(),
+            null,
+            "email@a.com",
+            null,
+            null,
+            SnapshotAccessRequestStatus.APPROVED,
+            null,
+            null);
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(snapshotAccessRequest);
-    when(snapshotDao.retrieveSnapshot(snapshotAccessRequest.getSourceSnapshotId()))
+    when(snapshotDao.retrieveSnapshot(snapshotAccessRequest.sourceSnapshotId()))
         .thenReturn(
             new Snapshot()
                 .snapshotSources(
@@ -1356,12 +1418,20 @@ class SnapshotServiceTest {
     UUID sourceSnapshotId = UUID.randomUUID();
     when(snapshotRequestDao.getById(snapshotAccessRequestId))
         .thenReturn(
-            new SnapshotAccessRequestModel()
-                .sourceSnapshotId(sourceSnapshotId)
-                .snapshotSpecification(
-                    new SnapshotBuilderRequest()
-                        .addOutputTablesItem(new SnapshotBuilderOutputTable().name("Drug"))
-                        .addOutputTablesItem(new SnapshotBuilderOutputTable().name("Condition"))));
+            new SnapshotAccessRequestModel(
+                null,
+                null,
+                null,
+                sourceSnapshotId,
+                new SnapshotBuilderRequest()
+                    .addOutputTablesItem(new SnapshotBuilderOutputTable().name("Drug"))
+                    .addOutputTablesItem(new SnapshotBuilderOutputTable().name("Condition")),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
     when(settingsDao.getBySnapshotId(sourceSnapshotId))
         .thenReturn(SnapshotBuilderTestData.SETTINGS);
 
@@ -1410,7 +1480,8 @@ class SnapshotServiceTest {
         new SnapshotRequestModel().contents(List.of(contentsModel));
 
     SnapshotAccessRequestModel snapshotAccessRequest =
-        new SnapshotAccessRequestModel().sourceSnapshotId(snapshotId);
+        new SnapshotAccessRequestModel(
+            null, null, null, snapshotId, null, null, null, null, null, null, null);
     Dataset dataset = new Dataset().id(datasetId).name(DATASET_NAME);
     Snapshot snapshot =
         new Snapshot().snapshotSources(List.of(new SnapshotSource().dataset(dataset)));
@@ -1464,7 +1535,9 @@ class SnapshotServiceTest {
         new SnapshotRequestModel().name(name).contents(List.of(contentsModel));
 
     when(snapshotRequestDao.getById(uuid))
-        .thenReturn(new SnapshotAccessRequestModel().snapshotName(" a$%").id(uuid));
+        .thenReturn(
+            new SnapshotAccessRequestModel(
+                uuid, " a$%", null, null, null, null, null, null, null, null, null));
 
     assertThat(service.getSnapshotName(snapshotRequestModel), is(expectedName));
   }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1544,12 +1544,10 @@ class SnapshotServiceTest {
 
   @Test
   void pullTables() {
-    UUID snapshotAccessRequestId = UUID.randomUUID();
     UUID sourceSnapshotId = UUID.randomUUID();
 
     var accessRequestResponse =
         SnapshotBuilderTestData.createSnapshotAccessRequestModel(sourceSnapshotId);
-    accessRequestResponse.id(snapshotAccessRequestId);
     var firstTable =
         service.pullTables(accessRequestResponse, SnapshotBuilderTestData.SETTINGS).get(0);
     assertThat(firstTable.getDatasetTableName(), is("drug_exposure"));
@@ -1566,15 +1564,12 @@ class SnapshotServiceTest {
 
   @Test
   void buildAssetFromSnapshotAccessRequest() {
-    UUID snapshotAccessRequestId = UUID.randomUUID();
-
     Dataset sourceDataset = SnapshotBuilderTestData.DATASET;
     sourceDataset.name("dataset_name");
     sourceDataset.id(datasetId);
     sourceDataset.defaultProfileId(profileId);
     var accessRequestResponse =
         SnapshotBuilderTestData.createSnapshotAccessRequestModel(snapshotId);
-    accessRequestResponse.id(snapshotAccessRequestId);
     when(settingsDao.getBySnapshotId(snapshotId)).thenReturn(SnapshotBuilderTestData.SETTINGS);
 
     var actualAssetSpec =

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -48,7 +48,6 @@ import bio.terra.model.ErrorModel;
 import bio.terra.model.InaccessibleWorkspacePolicyModel;
 import bio.terra.model.PolicyResponse;
 import bio.terra.model.SamPolicyModel;
-import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.model.SnapshotBuilderOutputTable;
 import bio.terra.model.SnapshotBuilderRequest;
@@ -95,6 +94,7 @@ import bio.terra.service.snapshot.flight.authDomain.SnapshotAddDataAccessControl
 import bio.terra.service.snapshot.flight.create.SnapshotCreateFlight;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
 import bio.terra.service.snapshot.flight.duos.SnapshotUpdateDuosDatasetFlight;
+import bio.terra.service.snapshotbuilder.SnapshotAccessRequestModel;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderSettingsDao;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderTestData;
 import bio.terra.service.snapshotbuilder.SnapshotRequestDao;
@@ -620,8 +620,8 @@ class SnapshotServiceTest {
     UUID snapshotAccessRequestId = UUID.randomUUID();
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
-    SnapshotAccessRequestResponse accessRequestResponse =
-        new SnapshotAccessRequestResponse()
+    SnapshotAccessRequestModel accessRequestResponse =
+        new SnapshotAccessRequestModel()
             .status(SnapshotAccessRequestStatus.APPROVED)
             .createdBy("email@a.com");
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
@@ -635,8 +635,8 @@ class SnapshotServiceTest {
     String flightId = "flightId";
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
-    SnapshotAccessRequestResponse accessRequestResponse =
-        new SnapshotAccessRequestResponse()
+    SnapshotAccessRequestModel accessRequestResponse =
+        new SnapshotAccessRequestModel()
             .status(SnapshotAccessRequestStatus.APPROVED)
             .createdBy("email@a.com")
             .flightid(flightId);
@@ -651,8 +651,8 @@ class SnapshotServiceTest {
     UUID snapshotAccessRequestId = UUID.randomUUID();
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
-    SnapshotAccessRequestResponse accessRequestResponse =
-        new SnapshotAccessRequestResponse().status(SnapshotAccessRequestStatus.SUBMITTED);
+    SnapshotAccessRequestModel accessRequestResponse =
+        new SnapshotAccessRequestModel().status(SnapshotAccessRequestStatus.SUBMITTED);
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
 
     assertThrows(
@@ -666,8 +666,8 @@ class SnapshotServiceTest {
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
 
-    SnapshotAccessRequestResponse accessRequestResponse =
-        new SnapshotAccessRequestResponse()
+    SnapshotAccessRequestModel accessRequestResponse =
+        new SnapshotAccessRequestModel()
             .status(SnapshotAccessRequestStatus.APPROVED)
             .createdSnapshotId(UUID.randomUUID());
 
@@ -684,8 +684,8 @@ class SnapshotServiceTest {
     String flightId = "flightId";
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
-    SnapshotAccessRequestResponse accessRequestResponse =
-        new SnapshotAccessRequestResponse()
+    SnapshotAccessRequestModel accessRequestResponse =
+        new SnapshotAccessRequestModel()
             .status(SnapshotAccessRequestStatus.APPROVED)
             .flightid(flightId);
 
@@ -702,8 +702,8 @@ class SnapshotServiceTest {
     UUID snapshotAccessRequestId = UUID.randomUUID();
     SnapshotRequestContentsModel snapshotRequestContentsModel =
         makeByRequestIdContentsModel(snapshotAccessRequestId);
-    SnapshotAccessRequestResponse accessRequestResponse =
-        new SnapshotAccessRequestResponse()
+    SnapshotAccessRequestModel accessRequestResponse =
+        new SnapshotAccessRequestModel()
             .status(SnapshotAccessRequestStatus.APPROVED)
             .createdBy("notanemail.com");
     when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(accessRequestResponse);
@@ -1110,15 +1110,14 @@ class SnapshotServiceTest {
     request.profileId(UUID.randomUUID());
     JobBuilder jobBuilder = mock(JobBuilder.class);
     String jobId = mockJobService(request, jobBuilder);
-    SnapshotAccessRequestResponse snapshotAccessRequestResponse =
-        new SnapshotAccessRequestResponse()
+    SnapshotAccessRequestModel snapshotAccessRequest =
+        new SnapshotAccessRequestModel()
             .status(SnapshotAccessRequestStatus.APPROVED)
             .createdBy("email@a.com")
             .id(snapshotAccessRequestId)
             .sourceSnapshotId(UUID.randomUUID());
-    when(snapshotRequestDao.getById(snapshotAccessRequestId))
-        .thenReturn(snapshotAccessRequestResponse);
-    when(snapshotDao.retrieveSnapshot(snapshotAccessRequestResponse.getSourceSnapshotId()))
+    when(snapshotRequestDao.getById(snapshotAccessRequestId)).thenReturn(snapshotAccessRequest);
+    when(snapshotDao.retrieveSnapshot(snapshotAccessRequest.getSourceSnapshotId()))
         .thenReturn(
             new Snapshot()
                 .snapshotSources(
@@ -1357,7 +1356,7 @@ class SnapshotServiceTest {
     UUID sourceSnapshotId = UUID.randomUUID();
     when(snapshotRequestDao.getById(snapshotAccessRequestId))
         .thenReturn(
-            new SnapshotAccessRequestResponse()
+            new SnapshotAccessRequestModel()
                 .sourceSnapshotId(sourceSnapshotId)
                 .snapshotSpecification(
                     new SnapshotBuilderRequest()
@@ -1410,8 +1409,8 @@ class SnapshotServiceTest {
     SnapshotRequestModel snapshotRequestModel =
         new SnapshotRequestModel().contents(List.of(contentsModel));
 
-    SnapshotAccessRequestResponse snapshotAccessRequest =
-        new SnapshotAccessRequestResponse().sourceSnapshotId(snapshotId);
+    SnapshotAccessRequestModel snapshotAccessRequest =
+        new SnapshotAccessRequestModel().sourceSnapshotId(snapshotId);
     Dataset dataset = new Dataset().id(datasetId).name(DATASET_NAME);
     Snapshot snapshot =
         new Snapshot().snapshotSources(List.of(new SnapshotSource().dataset(dataset)));
@@ -1465,7 +1464,7 @@ class SnapshotServiceTest {
         new SnapshotRequestModel().name(name).contents(List.of(contentsModel));
 
     when(snapshotRequestDao.getById(uuid))
-        .thenReturn(new SnapshotAccessRequestResponse().snapshotName(" a$%").id(uuid));
+        .thenReturn(new SnapshotAccessRequestModel().snapshotName(" a$%").id(uuid));
 
     assertThat(service.getSnapshotName(snapshotRequestModel), is(expectedName));
   }
@@ -1476,7 +1475,7 @@ class SnapshotServiceTest {
     UUID sourceSnapshotId = UUID.randomUUID();
 
     var accessRequestResponse =
-        SnapshotBuilderTestData.createSnapshotAccessRequestResponse(sourceSnapshotId);
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(sourceSnapshotId);
     accessRequestResponse.id(snapshotAccessRequestId);
     var firstTable =
         service.pullTables(accessRequestResponse, SnapshotBuilderTestData.SETTINGS).get(0);
@@ -1501,7 +1500,7 @@ class SnapshotServiceTest {
     sourceDataset.id(datasetId);
     sourceDataset.defaultProfileId(profileId);
     var accessRequestResponse =
-        SnapshotBuilderTestData.createSnapshotAccessRequestResponse(snapshotId);
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(snapshotId);
     accessRequestResponse.id(snapshotAccessRequestId);
     when(settingsDao.getBySnapshotId(snapshotId)).thenReturn(SnapshotBuilderTestData.SETTINGS);
 

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
@@ -7,10 +7,10 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.service.snapshotbuilder.SnapshotAccessRequestModel;
 import bio.terra.service.snapshotbuilder.SnapshotRequestDao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -52,7 +52,7 @@ class CreateSnapshotAddEmailsToSamGroupStepTest {
   void doStep() throws InterruptedException {
     var researcherEmail = "researcher@gmail.com";
     var emailsToAdd = List.of(researcherEmail);
-    var request = new SnapshotAccessRequestResponse().createdBy(researcherEmail);
+    var request = new SnapshotAccessRequestModel().createdBy(researcherEmail);
     when(snapshotRequestDao.getById(snapshotRequestId)).thenReturn(request);
     assertEquals(step.doStep(flightContext), StepResult.getStepResultSuccess());
     verify(iamService)

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotAddEmailsToSamGroupStepTest.java
@@ -52,7 +52,9 @@ class CreateSnapshotAddEmailsToSamGroupStepTest {
   void doStep() throws InterruptedException {
     var researcherEmail = "researcher@gmail.com";
     var emailsToAdd = List.of(researcherEmail);
-    var request = new SnapshotAccessRequestModel().createdBy(researcherEmail);
+    var request =
+        new SnapshotAccessRequestModel(
+            null, null, null, null, null, researcherEmail, null, null, null, null, null);
     when(snapshotRequestDao.getById(snapshotRequestId)).thenReturn(request);
     assertEquals(step.doStep(flightContext), StepResult.getStepResultSuccess());
     verify(iamService)

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRequestIdInterfaceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRequestIdInterfaceTest.java
@@ -9,13 +9,13 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.SnapshotSource;
+import bio.terra.service.snapshotbuilder.SnapshotAccessRequestModel;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderTestData;
 import bio.terra.service.snapshotbuilder.SnapshotRequestDao;
@@ -61,8 +61,8 @@ class CreateSnapshotByRequestIdInterfaceTest {
     Snapshot sourceSnapshot = new Snapshot();
     sourceSnapshot.snapshotSources(List.of(new SnapshotSource().dataset(sourceDataset)));
 
-    SnapshotAccessRequestResponse accessRequestResponse =
-        SnapshotBuilderTestData.createSnapshotAccessRequestResponse(sourceSnapshotId);
+    SnapshotAccessRequestModel accessRequestResponse =
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(sourceSnapshotId);
     accessRequestResponse.id(snapshotAccessRequestId);
 
     SnapshotRequestModel requestModel =

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRequestIdInterfaceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotByRequestIdInterfaceTest.java
@@ -45,7 +45,6 @@ class CreateSnapshotByRequestIdInterfaceTest {
 
   @Test
   void prepareAndCreateSnapshot() throws InterruptedException {
-    UUID snapshotAccessRequestId = UUID.randomUUID();
     UUID sourceSnapshotId = UUID.randomUUID();
     UUID datasetProfileId = UUID.randomUUID();
     UUID datasetId = UUID.randomUUID();
@@ -63,7 +62,7 @@ class CreateSnapshotByRequestIdInterfaceTest {
 
     SnapshotAccessRequestModel accessRequestResponse =
         SnapshotBuilderTestData.createSnapshotAccessRequestModel(sourceSnapshotId);
-    accessRequestResponse.id(snapshotAccessRequestId);
+    UUID snapshotAccessRequestId = accessRequestResponse.id();
 
     SnapshotRequestModel requestModel =
         SnapshotBuilderTestData.createSnapshotRequestByRequestId(snapshotAccessRequestId);

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
@@ -1,0 +1,161 @@
+package bio.terra.service.snapshotbuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.SnapshotAccessRequestResponse;
+import bio.terra.model.SnapshotAccessRequestStatus;
+import bio.terra.model.SnapshotBuilderCohort;
+import bio.terra.model.SnapshotBuilderCriteria;
+import bio.terra.model.SnapshotBuilderCriteriaGroup;
+import bio.terra.model.SnapshotBuilderDomainCriteria;
+import bio.terra.model.SnapshotBuilderProgramDataListCriteria;
+import bio.terra.model.SnapshotBuilderProgramDataRangeCriteria;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Unit.TAG)
+public class SnapshotAccessRequestModelTest {
+  private final String EXPECTED_LIST_SUMMARY_STRING = "The following concepts from Race: 0, 1, 2";
+  private final String EXPECTED_RANGE_SUMMARY_STRING = "Year of birth between 1960 and 1980";
+  private final String EXPECTED_DOMAIN_SUMMARY_STRING = "Condition Concept Id: 401";
+
+  @Test
+  void toApiResponse() {
+    SnapshotAccessRequestModel model = generateSnapshotAccessRequestModel();
+    compareModelAndResponseFields(model, model.toApiResponse(SnapshotBuilderTestData.SETTINGS));
+  }
+
+  @Test
+  void generateSummaryForListCriteria() {
+    SnapshotBuilderProgramDataListCriteria listCriteria = generateListCriteria();
+    assertThat(
+        SnapshotAccessRequestModel.generateSummaryForCriteria(
+            listCriteria, SnapshotBuilderTestData.SETTINGS),
+        is(EXPECTED_LIST_SUMMARY_STRING));
+  }
+
+  @Test
+  void generateSummaryForRangeCriteria() {
+    SnapshotBuilderProgramDataRangeCriteria rangeCriteria = generateRangeCriteria();
+    assertThat(
+        SnapshotAccessRequestModel.generateSummaryForCriteria(
+            rangeCriteria, SnapshotBuilderTestData.SETTINGS),
+        is(EXPECTED_RANGE_SUMMARY_STRING));
+  }
+
+  @Test
+  void generateSummaryForDomainCriteria() {
+    SnapshotBuilderDomainCriteria domainCriteria = generateDomainCriteria();
+    assertThat(
+        SnapshotAccessRequestModel.generateSummaryForCriteria(
+            domainCriteria, SnapshotBuilderTestData.SETTINGS),
+        is(EXPECTED_DOMAIN_SUMMARY_STRING));
+  }
+
+  @Test
+  void generateSummaryForCriteriaGroup() {
+    SnapshotBuilderCriteriaGroup criteriaGroup =
+        new SnapshotBuilderCriteriaGroup()
+            .mustMeet(true)
+            .meetAll(true)
+            .criteria(
+                List.of(generateRangeCriteria(), generateListCriteria(), generateDomainCriteria()));
+    assertThat(
+        SnapshotAccessRequestModel.generateSummaryForCriteriaGroup(
+            criteriaGroup, SnapshotBuilderTestData.SETTINGS),
+        is(
+            String.format(
+                "Must meet all of:\n%s\n%s\n%s",
+                EXPECTED_RANGE_SUMMARY_STRING,
+                EXPECTED_LIST_SUMMARY_STRING,
+                EXPECTED_DOMAIN_SUMMARY_STRING)));
+  }
+
+  @Test
+  void generateSummaryForCohort() {
+    String cohortName = "cohort";
+    String expectedCriteriaGroupString = "Must not meet any of:\n";
+    SnapshotBuilderCohort cohort =
+        new SnapshotBuilderCohort()
+            .name(cohortName)
+            .criteriaGroups(
+                List.of(
+                    new SnapshotBuilderCriteriaGroup().mustMeet(false).meetAll(false),
+                    new SnapshotBuilderCriteriaGroup().mustMeet(false).meetAll(false)));
+    assertThat(
+        SnapshotAccessRequestModel.generateSummaryForCohort(
+            cohort, SnapshotBuilderTestData.SETTINGS),
+        is(
+            String.format(
+                "Name: %s\nGroups:\n%s\n%s",
+                cohortName, expectedCriteriaGroupString, expectedCriteriaGroupString)));
+  }
+
+  private SnapshotBuilderProgramDataRangeCriteria generateRangeCriteria() {
+    SnapshotBuilderProgramDataRangeCriteria rangeCriteria =
+        new SnapshotBuilderProgramDataRangeCriteria();
+    rangeCriteria
+        .low(1960)
+        .high(1980)
+        .id(SnapshotBuilderTestData.YEAR_OF_BIRTH_PROGRAM_DATA_ID)
+        .kind(SnapshotBuilderCriteria.KindEnum.RANGE);
+    return rangeCriteria;
+  }
+
+  private SnapshotBuilderProgramDataListCriteria generateListCriteria() {
+    SnapshotBuilderProgramDataListCriteria listCriteria =
+        new SnapshotBuilderProgramDataListCriteria();
+    listCriteria
+        .values(List.of(0, 1, 2))
+        .id(SnapshotBuilderTestData.RACE_PROGRAM_DATA_ID)
+        .kind(SnapshotBuilderCriteria.KindEnum.LIST);
+    return listCriteria;
+  }
+
+  private SnapshotBuilderDomainCriteria generateDomainCriteria() {
+    SnapshotBuilderDomainCriteria domainCriteria = new SnapshotBuilderDomainCriteria();
+    domainCriteria
+        .conceptId(401)
+        .id(SnapshotBuilderTestData.CONDITION_OCCURRENCE_DOMAIN_ID)
+        .kind(SnapshotBuilderCriteria.KindEnum.DOMAIN);
+    return domainCriteria;
+  }
+
+  private SnapshotAccessRequestModel generateSnapshotAccessRequestModel() {
+    return new SnapshotAccessRequestModel()
+        .id(UUID.randomUUID())
+        .sourceSnapshotId(UUID.randomUUID())
+        .snapshotName("snapshot name")
+        .snapshotResearchPurpose("snapshot research purpose")
+        .snapshotSpecification(SnapshotBuilderTestData.createSnapshotBuilderRequest())
+        .createdDate(Instant.now())
+        .statusUpdatedDate(Instant.now())
+        .createdBy("a@b.com")
+        .status(SnapshotAccessRequestStatus.SUBMITTED)
+        .flightid("flightid")
+        .createdSnapshotId(UUID.randomUUID());
+  }
+
+  private void compareModelAndResponseFields(
+      SnapshotAccessRequestModel model, SnapshotAccessRequestResponse response) {
+    String expectedSummaryString =
+        "Participants included:\nName: cohort\nGroups:\nMust meet all of:\nThe following concepts from Race: \n\nCondition Concept Id: 100\nYear of birth between 1950 and 2000\n\nTables included:Drug, Condition\n";
+
+    assertThat(model.getId(), is(response.getId()));
+    assertThat(model.getSourceSnapshotId(), is(response.getSourceSnapshotId()));
+    assertThat(model.getSnapshotResearchPurpose(), is(response.getSnapshotResearchPurpose()));
+    assertThat(model.getSnapshotSpecification(), is(response.getSnapshotSpecification()));
+    assertThat(model.getCreatedBy(), is(response.getCreatedBy()));
+    assertThat(model.getCreatedDate().toString(), is(response.getCreatedDate()));
+    assertThat(model.getStatusUpdatedDate().toString(), is(response.getStatusUpdatedDate()));
+    assertThat(model.getStatus(), is(response.getStatus()));
+    assertThat(model.getFlightid(), is(response.getFlightid()));
+    assertThat(model.getCreatedSnapshotId(), is(response.getCreatedSnapshotId()));
+    assertThat(response.getSummary(), is(expectedSummaryString));
+  }
+}

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
@@ -144,7 +144,7 @@ public class SnapshotAccessRequestModelTest {
   private void compareModelAndResponseFields(
       SnapshotAccessRequestModel model, SnapshotAccessRequestResponse response) {
     String expectedSummaryString =
-        "Participants included:\nName: cohort\nGroups:\nMust meet all of:\nThe following concepts from Race: \n\nCondition Concept Id: 100\nYear of birth between 1950 and 2000\n\nTables included:Drug, Condition\n";
+        "Participants included:\nName: cohort\nGroups:\nMust meet all of:\nThe following concepts from Race: \nCondition Concept Id: 100\nYear of birth between 1950 and 2000\nTables included:Drug, Condition\n";
 
     assertThat(model.id(), is(response.getId()));
     assertThat(model.sourceSnapshotId(), is(response.getSourceSnapshotId()));

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
@@ -1,6 +1,7 @@
 package bio.terra.service.snapshotbuilder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.Matchers.is;
 
 import bio.terra.common.category.Unit;
@@ -37,7 +38,7 @@ class SnapshotAccessRequestModelTest {
     assertThat(
         SnapshotAccessRequestModel.generateSummaryForCriteria(
             listCriteria, SnapshotBuilderTestData.SETTINGS),
-        is(EXPECTED_LIST_SUMMARY_STRING));
+        equalToCompressingWhiteSpace(EXPECTED_LIST_SUMMARY_STRING));
   }
 
   @Test
@@ -46,7 +47,7 @@ class SnapshotAccessRequestModelTest {
     assertThat(
         SnapshotAccessRequestModel.generateSummaryForCriteria(
             rangeCriteria, SnapshotBuilderTestData.SETTINGS),
-        is(EXPECTED_RANGE_SUMMARY_STRING));
+        equalToCompressingWhiteSpace(EXPECTED_RANGE_SUMMARY_STRING));
   }
 
   @Test
@@ -55,7 +56,7 @@ class SnapshotAccessRequestModelTest {
     assertThat(
         SnapshotAccessRequestModel.generateSummaryForCriteria(
             domainCriteria, SnapshotBuilderTestData.SETTINGS),
-        is(EXPECTED_DOMAIN_SUMMARY_STRING));
+        equalToCompressingWhiteSpace(EXPECTED_DOMAIN_SUMMARY_STRING));
   }
 
   @Test
@@ -69,7 +70,7 @@ class SnapshotAccessRequestModelTest {
     assertThat(
         SnapshotAccessRequestModel.generateSummaryForCriteriaGroup(
             criteriaGroup, SnapshotBuilderTestData.SETTINGS),
-        is(
+        equalToCompressingWhiteSpace(
             String.format(
                 "Must meet all of:\n%s\n%s\n%s",
                 EXPECTED_RANGE_SUMMARY_STRING,
@@ -91,7 +92,7 @@ class SnapshotAccessRequestModelTest {
     assertThat(
         SnapshotAccessRequestModel.generateSummaryForCohort(
             cohort, SnapshotBuilderTestData.SETTINGS),
-        is(
+        equalToCompressingWhiteSpace(
             String.format(
                 "Name: %s\nGroups:\n%s\n%s",
                 cohortName, expectedCriteriaGroupString, expectedCriteriaGroupString)));
@@ -157,6 +158,6 @@ class SnapshotAccessRequestModelTest {
     assertThat(model.status(), is(response.getStatus()));
     assertThat(model.flightid(), is(response.getFlightid()));
     assertThat(model.createdSnapshotId(), is(response.getCreatedSnapshotId()));
-    assertThat(response.getSummary(), is(expectedSummaryString));
+    assertThat(response.getSummary(), equalToCompressingWhiteSpace(expectedSummaryString));
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
@@ -19,10 +19,11 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag(Unit.TAG)
-public class SnapshotAccessRequestModelTest {
-  private final String EXPECTED_LIST_SUMMARY_STRING = "The following concepts from Race: 0, 1, 2";
-  private final String EXPECTED_RANGE_SUMMARY_STRING = "Year of birth between 1960 and 1980";
-  private final String EXPECTED_DOMAIN_SUMMARY_STRING = "Condition Concept Id: 401";
+class SnapshotAccessRequestModelTest {
+  private static final String EXPECTED_LIST_SUMMARY_STRING =
+      "The following concepts from Race: 0, 1, 2";
+  private static final String EXPECTED_RANGE_SUMMARY_STRING = "Year of birth between 1960 and 1980";
+  private static final String EXPECTED_DOMAIN_SUMMARY_STRING = "Condition Concept Id: 401";
 
   @Test
   void toApiResponse() {

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
@@ -127,18 +127,18 @@ public class SnapshotAccessRequestModelTest {
   }
 
   private SnapshotAccessRequestModel generateSnapshotAccessRequestModel() {
-    return new SnapshotAccessRequestModel()
-        .id(UUID.randomUUID())
-        .sourceSnapshotId(UUID.randomUUID())
-        .snapshotName("snapshot name")
-        .snapshotResearchPurpose("snapshot research purpose")
-        .snapshotSpecification(SnapshotBuilderTestData.createSnapshotBuilderRequest())
-        .createdDate(Instant.now())
-        .statusUpdatedDate(Instant.now())
-        .createdBy("a@b.com")
-        .status(SnapshotAccessRequestStatus.SUBMITTED)
-        .flightid("flightid")
-        .createdSnapshotId(UUID.randomUUID());
+    return new SnapshotAccessRequestModel(
+        UUID.randomUUID(),
+        "snapshot name",
+        "snapshot research purpose",
+        UUID.randomUUID(),
+        SnapshotBuilderTestData.createSnapshotBuilderRequest(),
+        "a@b.com",
+        Instant.now(),
+        Instant.now(),
+        SnapshotAccessRequestStatus.SUBMITTED,
+        UUID.randomUUID(),
+        "flightid");
   }
 
   private void compareModelAndResponseFields(
@@ -146,16 +146,16 @@ public class SnapshotAccessRequestModelTest {
     String expectedSummaryString =
         "Participants included:\nName: cohort\nGroups:\nMust meet all of:\nThe following concepts from Race: \n\nCondition Concept Id: 100\nYear of birth between 1950 and 2000\n\nTables included:Drug, Condition\n";
 
-    assertThat(model.getId(), is(response.getId()));
-    assertThat(model.getSourceSnapshotId(), is(response.getSourceSnapshotId()));
-    assertThat(model.getSnapshotResearchPurpose(), is(response.getSnapshotResearchPurpose()));
-    assertThat(model.getSnapshotSpecification(), is(response.getSnapshotSpecification()));
-    assertThat(model.getCreatedBy(), is(response.getCreatedBy()));
-    assertThat(model.getCreatedDate().toString(), is(response.getCreatedDate()));
-    assertThat(model.getStatusUpdatedDate().toString(), is(response.getStatusUpdatedDate()));
-    assertThat(model.getStatus(), is(response.getStatus()));
-    assertThat(model.getFlightid(), is(response.getFlightid()));
-    assertThat(model.getCreatedSnapshotId(), is(response.getCreatedSnapshotId()));
+    assertThat(model.id(), is(response.getId()));
+    assertThat(model.sourceSnapshotId(), is(response.getSourceSnapshotId()));
+    assertThat(model.snapshotResearchPurpose(), is(response.getSnapshotResearchPurpose()));
+    assertThat(model.snapshotSpecification(), is(response.getSnapshotSpecification()));
+    assertThat(model.createdBy(), is(response.getCreatedBy()));
+    assertThat(model.createdDate().toString(), is(response.getCreatedDate()));
+    assertThat(model.statusUpdatedDate().toString(), is(response.getStatusUpdatedDate()));
+    assertThat(model.status(), is(response.getStatus()));
+    assertThat(model.flightid(), is(response.getFlightid()));
+    assertThat(model.createdSnapshotId(), is(response.getCreatedSnapshotId()));
     assertThat(response.getSummary(), is(expectedSummaryString));
   }
 }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotAccessRequestModelTest.java
@@ -72,7 +72,7 @@ class SnapshotAccessRequestModelTest {
             criteriaGroup, SnapshotBuilderTestData.SETTINGS),
         equalToCompressingWhiteSpace(
             String.format(
-                "Must meet all of:\n%s\n%s\n%s",
+                "Must meet all of:%n%s%n%s%n%s",
                 EXPECTED_RANGE_SUMMARY_STRING,
                 EXPECTED_LIST_SUMMARY_STRING,
                 EXPECTED_DOMAIN_SUMMARY_STRING)));
@@ -94,7 +94,7 @@ class SnapshotAccessRequestModelTest {
             cohort, SnapshotBuilderTestData.SETTINGS),
         equalToCompressingWhiteSpace(
             String.format(
-                "Name: %s\nGroups:\n%s\n%s",
+                "Name: %s%nGroups:%n%s%n%s",
                 cohortName, expectedCriteriaGroupString, expectedCriteriaGroupString)));
   }
 

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -108,11 +108,13 @@ class SnapshotBuilderServiceTest {
   @Test
   void createRequest() {
     UUID snapshotId = UUID.randomUUID();
-    SnapshotAccessRequestModel model = new SnapshotAccessRequestModel();
+    SnapshotAccessRequestModel model =
+        new SnapshotAccessRequestModel(
+            null, null, null, null, null, null, null, null, null, null, null);
     when(snapshotRequestDao.create(
             SnapshotBuilderTestData.createSnapshotAccessRequest(snapshotId), TEST_USER.getEmail()))
         .thenReturn(model);
-    when(snapshotBuilderSettingsDao.getBySnapshotId(model.getSourceSnapshotId()))
+    when(snapshotBuilderSettingsDao.getBySnapshotId(model.sourceSnapshotId()))
         .thenReturn(SnapshotBuilderTestData.SETTINGS);
     when(iamService.createSnapshotBuilderRequestResource(eq(TEST_USER), any(), any()))
         .thenReturn(Map.of(IamRole.OWNER, List.of(TEST_USER.getEmail())));
@@ -127,7 +129,9 @@ class SnapshotBuilderServiceTest {
   void createRequestRollsBackIfSamFails() {
     UUID snapshotId = UUID.randomUUID();
     UUID snapshotRequestId = UUID.randomUUID();
-    SnapshotAccessRequestModel model = new SnapshotAccessRequestModel().id(snapshotRequestId);
+    SnapshotAccessRequestModel model =
+        new SnapshotAccessRequestModel(
+            snapshotRequestId, null, null, null, null, null, null, null, null, null, null);
     SnapshotAccessRequest request = SnapshotBuilderTestData.createSnapshotAccessRequest(snapshotId);
     when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
         .thenReturn(SnapshotBuilderTestData.SETTINGS);
@@ -145,7 +149,7 @@ class SnapshotBuilderServiceTest {
     SnapshotAccessRequestModel responseItem =
         SnapshotBuilderTestData.createSnapshotAccessRequestModel(UUID.randomUUID());
     List<SnapshotAccessRequestModel> response = List.of(responseItem);
-    when(snapshotRequestDao.enumerate(Set.of(responseItem.getId()))).thenReturn(response);
+    when(snapshotRequestDao.enumerate(Set.of(responseItem.id()))).thenReturn(response);
     when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
         .thenReturn(SnapshotBuilderTestData.SETTINGS);
     EnumerateSnapshotAccessRequest expected =
@@ -154,7 +158,7 @@ class SnapshotBuilderServiceTest {
 
     assertThat(
         "EnumerateByDatasetId returns the expected response",
-        snapshotBuilderService.enumerateRequests(Set.of(responseItem.getId())),
+        snapshotBuilderService.enumerateRequests(Set.of(responseItem.id())),
         equalTo(expected));
   }
 
@@ -366,7 +370,7 @@ class SnapshotBuilderServiceTest {
     when(queryBuilderFactory.criteriaQueryBuilder(SnapshotBuilderTestData.SETTINGS))
         .thenReturn(criteriaQueryBuilderMock);
     when(criteriaQueryBuilderMock.generateRowIdQueryForCohorts(
-            snapshotAccessRequestModel.getSnapshotSpecification().getCohorts()))
+            snapshotAccessRequestModel.snapshotSpecification().getCohorts()))
         .thenReturn(query);
     var contextArgument = ArgumentCaptor.forClass(SqlRenderContext.class);
     when(query.renderSQL(contextArgument.capture())).thenReturn("sql");
@@ -432,7 +436,9 @@ class SnapshotBuilderServiceTest {
   @Test
   void testRejectRequest() {
     UUID id = UUID.randomUUID();
-    var response = new SnapshotAccessRequestModel();
+    var response =
+        new SnapshotAccessRequestModel(
+            null, null, null, null, null, null, null, null, null, null, null);
     when(snapshotRequestDao.getById(id)).thenReturn(response);
     when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
         .thenReturn(SnapshotBuilderTestData.SETTINGS);
@@ -445,7 +451,9 @@ class SnapshotBuilderServiceTest {
   @Test
   void testApproveRequest() {
     UUID id = UUID.randomUUID();
-    var response = new SnapshotAccessRequestModel();
+    var response =
+        new SnapshotAccessRequestModel(
+            id, null, null, null, null, null, null, null, null, null, null);
     when(snapshotRequestDao.getById(id)).thenReturn(response);
     when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
         .thenReturn(SnapshotBuilderTestData.SETTINGS);
@@ -458,7 +466,9 @@ class SnapshotBuilderServiceTest {
   @Test
   void testGetRequest() {
     UUID id = UUID.randomUUID();
-    SnapshotAccessRequestModel daoResponse = new SnapshotAccessRequestModel().id(id);
+    SnapshotAccessRequestModel daoResponse =
+        new SnapshotAccessRequestModel(
+            id, null, null, null, null, null, null, null, null, null, null);
     when(snapshotRequestDao.getById(id)).thenReturn(daoResponse);
     when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
         .thenReturn(SnapshotBuilderTestData.SETTINGS);
@@ -478,7 +488,10 @@ class SnapshotBuilderServiceTest {
   @Test
   void testEnumerateRequestsBySnapshot() {
     UUID id = UUID.randomUUID();
-    List<SnapshotAccessRequestModel> daoResponse = List.of(new SnapshotAccessRequestModel());
+    List<SnapshotAccessRequestModel> daoResponse =
+        List.of(
+            new SnapshotAccessRequestModel(
+                null, null, null, null, null, null, null, null, null, null, null));
     when(snapshotRequestDao.enumerateBySnapshot(id)).thenReturn(daoResponse);
     when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
         .thenReturn(SnapshotBuilderTestData.SETTINGS);

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -133,8 +133,6 @@ class SnapshotBuilderServiceTest {
         new SnapshotAccessRequestModel(
             snapshotRequestId, null, null, null, null, null, null, null, null, null, null);
     SnapshotAccessRequest request = SnapshotBuilderTestData.createSnapshotAccessRequest(snapshotId);
-    when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
-        .thenReturn(SnapshotBuilderTestData.SETTINGS);
     when(snapshotRequestDao.create(request, TEST_USER.getEmail())).thenReturn(model);
     when(iamService.createSnapshotBuilderRequestResource(eq(TEST_USER), any(), any()))
         .thenThrow(new ApiException("Error"));

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderServiceTest.java
@@ -25,7 +25,6 @@ import bio.terra.grammar.google.BigQueryVisitor;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.EnumerateSnapshotAccessRequest;
 import bio.terra.model.SnapshotAccessRequest;
-import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.model.SnapshotBuilderCohort;
 import bio.terra.model.SnapshotBuilderConcept;
@@ -109,27 +108,30 @@ class SnapshotBuilderServiceTest {
   @Test
   void createRequest() {
     UUID snapshotId = UUID.randomUUID();
-    SnapshotAccessRequestResponse response = new SnapshotAccessRequestResponse();
+    SnapshotAccessRequestModel model = new SnapshotAccessRequestModel();
     when(snapshotRequestDao.create(
             SnapshotBuilderTestData.createSnapshotAccessRequest(snapshotId), TEST_USER.getEmail()))
-        .thenReturn(response);
+        .thenReturn(model);
+    when(snapshotBuilderSettingsDao.getBySnapshotId(model.getSourceSnapshotId()))
+        .thenReturn(SnapshotBuilderTestData.SETTINGS);
     when(iamService.createSnapshotBuilderRequestResource(eq(TEST_USER), any(), any()))
         .thenReturn(Map.of(IamRole.OWNER, List.of(TEST_USER.getEmail())));
     assertThat(
         "createSnapshotRequest returns the expected response",
         snapshotBuilderService.createRequest(
             TEST_USER, SnapshotBuilderTestData.createSnapshotAccessRequest(snapshotId)),
-        equalTo(response));
+        equalTo(model.toApiResponse(SnapshotBuilderTestData.SETTINGS)));
   }
 
   @Test
   void createRequestRollsBackIfSamFails() {
     UUID snapshotId = UUID.randomUUID();
     UUID snapshotRequestId = UUID.randomUUID();
-    SnapshotAccessRequestResponse response =
-        new SnapshotAccessRequestResponse().id(snapshotRequestId);
+    SnapshotAccessRequestModel model = new SnapshotAccessRequestModel().id(snapshotRequestId);
     SnapshotAccessRequest request = SnapshotBuilderTestData.createSnapshotAccessRequest(snapshotId);
-    when(snapshotRequestDao.create(request, TEST_USER.getEmail())).thenReturn(response);
+    when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
+        .thenReturn(SnapshotBuilderTestData.SETTINGS);
+    when(snapshotRequestDao.create(request, TEST_USER.getEmail())).thenReturn(model);
     when(iamService.createSnapshotBuilderRequestResource(eq(TEST_USER), any(), any()))
         .thenThrow(new ApiException("Error"));
     doNothing().when(snapshotRequestDao).delete(snapshotRequestId);
@@ -140,13 +142,15 @@ class SnapshotBuilderServiceTest {
 
   @Test
   void enumerateRequests() {
-    SnapshotAccessRequestResponse responseItem =
-        SnapshotBuilderTestData.createSnapshotAccessRequestResponse(UUID.randomUUID());
-    List<SnapshotAccessRequestResponse> response = List.of(responseItem);
+    SnapshotAccessRequestModel responseItem =
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(UUID.randomUUID());
+    List<SnapshotAccessRequestModel> response = List.of(responseItem);
     when(snapshotRequestDao.enumerate(Set.of(responseItem.getId()))).thenReturn(response);
-
+    when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
+        .thenReturn(SnapshotBuilderTestData.SETTINGS);
     EnumerateSnapshotAccessRequest expected =
-        new EnumerateSnapshotAccessRequest().addItemsItem(responseItem);
+        new EnumerateSnapshotAccessRequest()
+            .addItemsItem(responseItem.toApiResponse(SnapshotBuilderTestData.SETTINGS));
 
     assertThat(
         "EnumerateByDatasetId returns the expected response",
@@ -346,8 +350,8 @@ class SnapshotBuilderServiceTest {
   @Test
   void generateRowIdQuery() {
     UUID snapshotId = UUID.randomUUID();
-    SnapshotAccessRequestResponse accessRequest =
-        SnapshotBuilderTestData.createSnapshotAccessRequestResponse(snapshotId);
+    SnapshotAccessRequestModel snapshotAccessRequestModel =
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(snapshotId);
 
     Dataset dataset = makeDataset(CloudPlatform.GCP);
     Snapshot snapshot =
@@ -362,13 +366,14 @@ class SnapshotBuilderServiceTest {
     when(queryBuilderFactory.criteriaQueryBuilder(SnapshotBuilderTestData.SETTINGS))
         .thenReturn(criteriaQueryBuilderMock);
     when(criteriaQueryBuilderMock.generateRowIdQueryForCohorts(
-            accessRequest.getSnapshotSpecification().getCohorts()))
+            snapshotAccessRequestModel.getSnapshotSpecification().getCohorts()))
         .thenReturn(query);
     var contextArgument = ArgumentCaptor.forClass(SqlRenderContext.class);
     when(query.renderSQL(contextArgument.capture())).thenReturn("sql");
 
     assertEquals(
-        "sql", snapshotBuilderService.generateRowIdQuery(accessRequest, snapshot, TEST_USER));
+        "sql",
+        snapshotBuilderService.generateRowIdQuery(snapshotAccessRequestModel, snapshot, TEST_USER));
     assertThat(
         contextArgument.getValue().getPlatform().getCloudPlatform(),
         is(dataset.getCloudPlatform()));
@@ -427,27 +432,39 @@ class SnapshotBuilderServiceTest {
   @Test
   void testRejectRequest() {
     UUID id = UUID.randomUUID();
-    var response = new SnapshotAccessRequestResponse();
+    var response = new SnapshotAccessRequestModel();
     when(snapshotRequestDao.getById(id)).thenReturn(response);
-    assertThat(snapshotBuilderService.rejectRequest(id), is(response));
+    when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
+        .thenReturn(SnapshotBuilderTestData.SETTINGS);
+    assertThat(
+        snapshotBuilderService.rejectRequest(id),
+        is(response.toApiResponse(SnapshotBuilderTestData.SETTINGS)));
     verify(snapshotRequestDao).updateStatus(id, SnapshotAccessRequestStatus.REJECTED);
   }
 
   @Test
   void testApproveRequest() {
     UUID id = UUID.randomUUID();
-    var response = new SnapshotAccessRequestResponse();
+    var response = new SnapshotAccessRequestModel();
     when(snapshotRequestDao.getById(id)).thenReturn(response);
-    assertThat(snapshotBuilderService.approveRequest(id), is(response));
+    when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
+        .thenReturn(SnapshotBuilderTestData.SETTINGS);
+    assertThat(
+        snapshotBuilderService.approveRequest(id),
+        is(response.toApiResponse(SnapshotBuilderTestData.SETTINGS)));
     verify(snapshotRequestDao).updateStatus(id, SnapshotAccessRequestStatus.APPROVED);
   }
 
   @Test
   void testGetRequest() {
     UUID id = UUID.randomUUID();
-    SnapshotAccessRequestResponse daoResponse = new SnapshotAccessRequestResponse().id(id);
+    SnapshotAccessRequestModel daoResponse = new SnapshotAccessRequestModel().id(id);
     when(snapshotRequestDao.getById(id)).thenReturn(daoResponse);
-    assertThat(snapshotBuilderService.getRequest(id), is(daoResponse));
+    when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
+        .thenReturn(SnapshotBuilderTestData.SETTINGS);
+    assertThat(
+        snapshotBuilderService.getRequest(id),
+        is(daoResponse.toApiResponse(SnapshotBuilderTestData.SETTINGS)));
   }
 
   @Test
@@ -461,11 +478,18 @@ class SnapshotBuilderServiceTest {
   @Test
   void testEnumerateRequestsBySnapshot() {
     UUID id = UUID.randomUUID();
-    List<SnapshotAccessRequestResponse> daoResponse = List.of(new SnapshotAccessRequestResponse());
+    List<SnapshotAccessRequestModel> daoResponse = List.of(new SnapshotAccessRequestModel());
     when(snapshotRequestDao.enumerateBySnapshot(id)).thenReturn(daoResponse);
+    when(snapshotBuilderSettingsDao.getBySnapshotId(any()))
+        .thenReturn(SnapshotBuilderTestData.SETTINGS);
     assertThat(
         snapshotBuilderService.enumerateRequestsBySnapshot(id),
-        is(new EnumerateSnapshotAccessRequest().items(daoResponse)));
+        is(
+            new EnumerateSnapshotAccessRequest()
+                .items(
+                    daoResponse.stream()
+                        .map(model -> model.toApiResponse(SnapshotBuilderTestData.SETTINGS))
+                        .toList())));
   }
 
   static SnapshotBuilderConcept concept(String name, int id, boolean hasChildren) {

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -4,7 +4,6 @@ import bio.terra.common.Column;
 import bio.terra.common.Relationship;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.SnapshotAccessRequest;
-import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.model.SnapshotBuilderCohort;
 import bio.terra.model.SnapshotBuilderConcept;
@@ -37,6 +36,7 @@ import bio.terra.service.snapshotbuilder.utils.constants.ConditionOccurrence;
 import bio.terra.service.snapshotbuilder.utils.constants.DrugExposure;
 import bio.terra.service.snapshotbuilder.utils.constants.Observation;
 import bio.terra.service.snapshotbuilder.utils.constants.ProcedureOccurrence;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -386,7 +386,7 @@ public class SnapshotBuilderTestData {
                 .mustMeet(true)
                 .addCriteriaItem(
                     new SnapshotBuilderProgramDataListCriteria()
-                        .id(0)
+                        .id(RACE_PROGRAM_DATA_ID)
                         .kind(SnapshotBuilderCriteria.KindEnum.LIST))
                 .addCriteriaItem(
                     new SnapshotBuilderDomainCriteria()
@@ -397,7 +397,7 @@ public class SnapshotBuilderTestData {
                     new SnapshotBuilderProgramDataRangeCriteria()
                         .low(1950)
                         .high(2000)
-                        .id(1)
+                        .id(YEAR_OF_BIRTH_PROGRAM_DATA_ID)
                         .kind(SnapshotBuilderCriteria.KindEnum.RANGE)));
   }
 
@@ -416,15 +416,15 @@ public class SnapshotBuilderTestData {
         .snapshotBuilderRequest(createSnapshotBuilderRequest());
   }
 
-  public static SnapshotAccessRequestResponse createSnapshotAccessRequestResponse(UUID snapshotId) {
+  public static SnapshotAccessRequestModel createSnapshotAccessRequestModel(UUID snapshotId) {
     SnapshotAccessRequest request = createSnapshotAccessRequest(snapshotId);
-    return new SnapshotAccessRequestResponse()
+    return new SnapshotAccessRequestModel()
         .id(UUID.randomUUID())
         .sourceSnapshotId(request.getSourceSnapshotId())
         .snapshotName(request.getName())
         .snapshotResearchPurpose(request.getResearchPurposeStatement())
         .snapshotSpecification(request.getSnapshotBuilderRequest())
-        .createdDate("date")
+        .createdDate(Instant.now())
         .createdBy("user@gmail.com")
         .status(SnapshotAccessRequestStatus.SUBMITTED);
   }

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotBuilderTestData.java
@@ -418,15 +418,18 @@ public class SnapshotBuilderTestData {
 
   public static SnapshotAccessRequestModel createSnapshotAccessRequestModel(UUID snapshotId) {
     SnapshotAccessRequest request = createSnapshotAccessRequest(snapshotId);
-    return new SnapshotAccessRequestModel()
-        .id(UUID.randomUUID())
-        .sourceSnapshotId(request.getSourceSnapshotId())
-        .snapshotName(request.getName())
-        .snapshotResearchPurpose(request.getResearchPurposeStatement())
-        .snapshotSpecification(request.getSnapshotBuilderRequest())
-        .createdDate(Instant.now())
-        .createdBy("user@gmail.com")
-        .status(SnapshotAccessRequestStatus.SUBMITTED);
+    return new SnapshotAccessRequestModel(
+        UUID.randomUUID(),
+        request.getName(),
+        request.getResearchPurposeStatement(),
+        request.getSourceSnapshotId(),
+        request.getSnapshotBuilderRequest(),
+        "user@gmail.com",
+        Instant.now(),
+        null,
+        SnapshotAccessRequestStatus.SUBMITTED,
+        null,
+        null);
   }
 
   public static SnapshotRequestModel createSnapshotRequestByRequestId(

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
@@ -15,6 +15,7 @@ import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.fixtures.DaoOperations;
+import bio.terra.model.SnapshotAccessRequest;
 import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.Snapshot;
@@ -61,8 +62,7 @@ class SnapshotRequestDaoTest {
     return snapshotRequestDao.create(snapshotAccessRequest, EMAIL);
   }
 
-  private SnapshotAccessRequestModel createRequest(
-      bio.terra.model.SnapshotAccessRequest snapshotAccessRequest) {
+  private SnapshotAccessRequestModel createRequest(SnapshotAccessRequest snapshotAccessRequest) {
     return snapshotRequestDao.create(snapshotAccessRequest, EMAIL);
   }
 
@@ -78,16 +78,16 @@ class SnapshotRequestDaoTest {
         response,
         samePropertyValuesAs(
             expected, "id", "createdDate", "datasetId", "flightid", "createdSnapshotId"));
-    assertNotNull(response.getId(), "Snapshot Access Request Response should have an id");
+    assertNotNull(response.id(), "Snapshot Access Request Response should have an id");
     assertNotNull(
-        response.getCreatedDate(),
+        response.createdDate(),
         "Snapshot Access Request Response should have a create date timestamp");
   }
 
   @Test
   void getById() {
     SnapshotAccessRequestModel response = createRequest();
-    SnapshotAccessRequestModel retrieved = snapshotRequestDao.getById(response.getId());
+    SnapshotAccessRequestModel retrieved = snapshotRequestDao.getById(response.id());
     verifyResponseContents(retrieved);
   }
 
@@ -102,7 +102,7 @@ class SnapshotRequestDaoTest {
     SnapshotAccessRequestModel response1 = createRequest();
     assertThat(
         "Snapshot Access Request should be the same as the example",
-        snapshotRequestDao.enumerate(Set.of(response.getId(), response1.getId())),
+        snapshotRequestDao.enumerate(Set.of(response.id(), response1.id())),
         contains(response, response1));
   }
 
@@ -110,10 +110,10 @@ class SnapshotRequestDaoTest {
   void enumerateIgnoresDeletedRequests() {
     SnapshotAccessRequestModel response = createRequest();
     SnapshotAccessRequestModel response1 = createRequest();
-    snapshotRequestDao.updateStatus(response1.getId(), SnapshotAccessRequestStatus.DELETED);
+    snapshotRequestDao.updateStatus(response1.id(), SnapshotAccessRequestStatus.DELETED);
     assertThat(
         "Snapshot Access Request should be the same as the example",
-        snapshotRequestDao.enumerate(Set.of(response.getId(), response1.getId())),
+        snapshotRequestDao.enumerate(Set.of(response.id(), response1.id())),
         contains(response));
   }
 
@@ -126,6 +126,7 @@ class SnapshotRequestDaoTest {
     assertThat(
         "Snapshot Access Request should be the same as the example",
         snapshotRequestDao.enumerateBySnapshot(sourceSnapshot.getId()),
+        //        contains(hasProperty("id", equalTo(response.getId()))));
         contains(response));
   }
 
@@ -135,7 +136,7 @@ class SnapshotRequestDaoTest {
         daoOperations.createAndIngestSnapshot(dataset, DaoOperations.SNAPSHOT_MINIMAL);
     SnapshotAccessRequestModel response = createRequest();
     createRequest(SnapshotBuilderTestData.createSnapshotAccessRequest(secondSnapshot.getId()));
-    snapshotRequestDao.updateStatus(response.getId(), SnapshotAccessRequestStatus.DELETED);
+    snapshotRequestDao.updateStatus(response.id(), SnapshotAccessRequestStatus.DELETED);
     assertThat(
         "Snapshot Access Request should be the same as the example",
         snapshotRequestDao.enumerateBySnapshot(sourceSnapshot.getId()).size(),
@@ -158,12 +159,12 @@ class SnapshotRequestDaoTest {
     SnapshotAccessRequestModel response1 = snapshotRequestDao.create(snapshotAccessRequest, EMAIL);
 
     assertNotEquals(
-        response1.getId(),
-        response.getId(),
+        response1.id(),
+        response.id(),
         "Snapshot Access Request Response should have unique request id");
     assertNotEquals(
-        response1.getCreatedDate(),
-        response.getCreatedDate(),
+        response1.createdDate(),
+        response.createdDate(),
         "Snapshot Access Request Response should have unique create date timestamp");
   }
 
@@ -179,16 +180,16 @@ class SnapshotRequestDaoTest {
   @Test
   void updateStatus() {
     SnapshotAccessRequestModel response = createRequest();
-    assertNull(response.getStatusUpdatedDate(), "Status was never updated.");
+    assertNull(response.statusUpdatedDate(), "Status was never updated.");
     verifyResponseContents(response);
-    snapshotRequestDao.updateStatus(response.getId(), SnapshotAccessRequestStatus.APPROVED);
-    SnapshotAccessRequestModel updatedResponse = snapshotRequestDao.getById(response.getId());
+    snapshotRequestDao.updateStatus(response.id(), SnapshotAccessRequestStatus.APPROVED);
+    SnapshotAccessRequestModel updatedResponse = snapshotRequestDao.getById(response.id());
     assertThat(
         "Updated Snapshot Access Request Response should have approved status",
-        updatedResponse.getStatus(),
+        updatedResponse.status(),
         equalTo(SnapshotAccessRequestStatus.APPROVED));
     assertNotNull(
-        updatedResponse.getStatusUpdatedDate(),
+        updatedResponse.statusUpdatedDate(),
         "Updated Snapshot Access Request Response should have a status update date");
   }
 
@@ -205,14 +206,14 @@ class SnapshotRequestDaoTest {
   void updateFlightId() {
     SnapshotAccessRequestModel response = createRequest();
     verifyResponseContents(response);
-    snapshotRequestDao.updateFlightId(response.getId(), FLIGHT_ID);
-    SnapshotAccessRequestModel updatedResponse = snapshotRequestDao.getById(response.getId());
+    snapshotRequestDao.updateFlightId(response.id(), FLIGHT_ID);
+    SnapshotAccessRequestModel updatedResponse = snapshotRequestDao.getById(response.id());
 
     // only the flightId is updated
     verifyResponseContents(updatedResponse);
     assertThat(
         "Updated Snapshot Access Request Response should have flight id",
-        updatedResponse.getFlightid(),
+        updatedResponse.flightid(),
         equalTo(FLIGHT_ID));
   }
 
@@ -227,14 +228,14 @@ class SnapshotRequestDaoTest {
   void updateCreatedSnapshotId() {
     SnapshotAccessRequestModel response = createRequest();
     verifyResponseContents(response);
-    snapshotRequestDao.updateCreatedSnapshotId(response.getId(), createdSnapshot.getId());
-    SnapshotAccessRequestModel updatedResponse = snapshotRequestDao.getById(response.getId());
+    snapshotRequestDao.updateCreatedSnapshotId(response.id(), createdSnapshot.getId());
+    SnapshotAccessRequestModel updatedResponse = snapshotRequestDao.getById(response.id());
 
     // only the createdSnapshotId is updated
     verifyResponseContents(updatedResponse);
     assertThat(
         "Updated Snapshot Access Request Response should have created snapshot id",
-        updatedResponse.getCreatedSnapshotId(),
+        updatedResponse.createdSnapshotId(),
         equalTo(createdSnapshot.getId()));
   }
 
@@ -259,12 +260,12 @@ class SnapshotRequestDaoTest {
     SnapshotAccessRequestModel response = createRequest();
     assertThat(
         "We can retrieve the snapshot request",
-        snapshotRequestDao.getById(response.getId()),
+        snapshotRequestDao.getById(response.id()),
         equalTo(response));
     // delete the source snapshot
     // This should also delete the snapshot request
     daoOperations.deleteSnapshot(sourceSnapshot.getId());
-    assertThrows(NotFoundException.class, () -> snapshotRequestDao.getById(response.getId()));
+    assertThrows(NotFoundException.class, () -> snapshotRequestDao.getById(response.id()));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
@@ -15,8 +15,6 @@ import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.fixtures.DaoOperations;
-import bio.terra.model.SnapshotAccessRequest;
-import bio.terra.model.SnapshotAccessRequestResponse;
 import bio.terra.model.SnapshotAccessRequestStatus;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.Snapshot;
@@ -44,7 +42,7 @@ class SnapshotRequestDaoTest {
   private Dataset dataset;
   private Snapshot sourceSnapshot;
   private Snapshot createdSnapshot;
-  private SnapshotAccessRequest snapshotAccessRequest;
+  private bio.terra.model.SnapshotAccessRequest snapshotAccessRequest;
 
   private static final String EMAIL = "user@gmail.com";
   private static final String FLIGHT_ID = "flight_id";
@@ -59,17 +57,18 @@ class SnapshotRequestDaoTest {
         SnapshotBuilderTestData.createSnapshotAccessRequest(sourceSnapshot.getId());
   }
 
-  private SnapshotAccessRequestResponse createRequest() {
+  private SnapshotAccessRequestModel createRequest() {
     return snapshotRequestDao.create(snapshotAccessRequest, EMAIL);
   }
 
-  private SnapshotAccessRequestResponse createRequest(SnapshotAccessRequest snapshotAccessRequest) {
+  private SnapshotAccessRequestModel createRequest(
+      bio.terra.model.SnapshotAccessRequest snapshotAccessRequest) {
     return snapshotRequestDao.create(snapshotAccessRequest, EMAIL);
   }
 
-  private void verifyResponseContents(SnapshotAccessRequestResponse response) {
-    SnapshotAccessRequestResponse expected =
-        SnapshotBuilderTestData.createSnapshotAccessRequestResponse(sourceSnapshot.getId());
+  private void verifyResponseContents(SnapshotAccessRequestModel response) {
+    SnapshotAccessRequestModel expected =
+        SnapshotBuilderTestData.createSnapshotAccessRequestModel(sourceSnapshot.getId());
     expected.sourceSnapshotId(sourceSnapshot.getId());
 
     expected.createdBy(EMAIL);
@@ -87,8 +86,8 @@ class SnapshotRequestDaoTest {
 
   @Test
   void getById() {
-    SnapshotAccessRequestResponse response = createRequest();
-    SnapshotAccessRequestResponse retrieved = snapshotRequestDao.getById(response.getId());
+    SnapshotAccessRequestModel response = createRequest();
+    SnapshotAccessRequestModel retrieved = snapshotRequestDao.getById(response.getId());
     verifyResponseContents(retrieved);
   }
 
@@ -99,8 +98,8 @@ class SnapshotRequestDaoTest {
 
   @Test
   void enumerate() {
-    SnapshotAccessRequestResponse response = createRequest();
-    SnapshotAccessRequestResponse response1 = createRequest();
+    SnapshotAccessRequestModel response = createRequest();
+    SnapshotAccessRequestModel response1 = createRequest();
     assertThat(
         "Snapshot Access Request should be the same as the example",
         snapshotRequestDao.enumerate(Set.of(response.getId(), response1.getId())),
@@ -109,8 +108,8 @@ class SnapshotRequestDaoTest {
 
   @Test
   void enumerateIgnoresDeletedRequests() {
-    SnapshotAccessRequestResponse response = createRequest();
-    SnapshotAccessRequestResponse response1 = createRequest();
+    SnapshotAccessRequestModel response = createRequest();
+    SnapshotAccessRequestModel response1 = createRequest();
     snapshotRequestDao.updateStatus(response1.getId(), SnapshotAccessRequestStatus.DELETED);
     assertThat(
         "Snapshot Access Request should be the same as the example",
@@ -122,7 +121,7 @@ class SnapshotRequestDaoTest {
   void enumerateBySnapshotId() throws IOException {
     Snapshot secondSnapshot =
         daoOperations.createAndIngestSnapshot(dataset, DaoOperations.SNAPSHOT_MINIMAL);
-    SnapshotAccessRequestResponse response = createRequest();
+    SnapshotAccessRequestModel response = createRequest();
     createRequest(SnapshotBuilderTestData.createSnapshotAccessRequest(secondSnapshot.getId()));
     assertThat(
         "Snapshot Access Request should be the same as the example",
@@ -134,7 +133,7 @@ class SnapshotRequestDaoTest {
   void enumerateBySnapshotIdExcludesDeletedRequests() throws IOException {
     Snapshot secondSnapshot =
         daoOperations.createAndIngestSnapshot(dataset, DaoOperations.SNAPSHOT_MINIMAL);
-    SnapshotAccessRequestResponse response = createRequest();
+    SnapshotAccessRequestModel response = createRequest();
     createRequest(SnapshotBuilderTestData.createSnapshotAccessRequest(secondSnapshot.getId()));
     snapshotRequestDao.updateStatus(response.getId(), SnapshotAccessRequestStatus.DELETED);
     assertThat(
@@ -153,11 +152,10 @@ class SnapshotRequestDaoTest {
 
   @Test
   void create() {
-    SnapshotAccessRequestResponse response = createRequest();
+    SnapshotAccessRequestModel response = createRequest();
     verifyResponseContents(response);
 
-    SnapshotAccessRequestResponse response1 =
-        snapshotRequestDao.create(snapshotAccessRequest, EMAIL);
+    SnapshotAccessRequestModel response1 = snapshotRequestDao.create(snapshotAccessRequest, EMAIL);
 
     assertNotEquals(
         response1.getId(),
@@ -180,11 +178,11 @@ class SnapshotRequestDaoTest {
 
   @Test
   void updateStatus() {
-    SnapshotAccessRequestResponse response = createRequest();
+    SnapshotAccessRequestModel response = createRequest();
     assertNull(response.getStatusUpdatedDate(), "Status was never updated.");
     verifyResponseContents(response);
     snapshotRequestDao.updateStatus(response.getId(), SnapshotAccessRequestStatus.APPROVED);
-    SnapshotAccessRequestResponse updatedResponse = snapshotRequestDao.getById(response.getId());
+    SnapshotAccessRequestModel updatedResponse = snapshotRequestDao.getById(response.getId());
     assertThat(
         "Updated Snapshot Access Request Response should have approved status",
         updatedResponse.getStatus(),
@@ -205,10 +203,10 @@ class SnapshotRequestDaoTest {
 
   @Test
   void updateFlightId() {
-    SnapshotAccessRequestResponse response = createRequest();
+    SnapshotAccessRequestModel response = createRequest();
     verifyResponseContents(response);
     snapshotRequestDao.updateFlightId(response.getId(), FLIGHT_ID);
-    SnapshotAccessRequestResponse updatedResponse = snapshotRequestDao.getById(response.getId());
+    SnapshotAccessRequestModel updatedResponse = snapshotRequestDao.getById(response.getId());
 
     // only the flightId is updated
     verifyResponseContents(updatedResponse);
@@ -227,10 +225,10 @@ class SnapshotRequestDaoTest {
 
   @Test
   void updateCreatedSnapshotId() {
-    SnapshotAccessRequestResponse response = createRequest();
+    SnapshotAccessRequestModel response = createRequest();
     verifyResponseContents(response);
     snapshotRequestDao.updateCreatedSnapshotId(response.getId(), createdSnapshot.getId());
-    SnapshotAccessRequestResponse updatedResponse = snapshotRequestDao.getById(response.getId());
+    SnapshotAccessRequestModel updatedResponse = snapshotRequestDao.getById(response.getId());
 
     // only the createdSnapshotId is updated
     verifyResponseContents(updatedResponse);
@@ -258,7 +256,7 @@ class SnapshotRequestDaoTest {
 
   @Test
   void deleteSourceSnapshot() {
-    SnapshotAccessRequestResponse response = createRequest();
+    SnapshotAccessRequestModel response = createRequest();
     assertThat(
         "We can retrieve the snapshot request",
         snapshotRequestDao.getById(response.getId()),

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
@@ -69,15 +69,12 @@ class SnapshotRequestDaoTest {
   private void verifyResponseContents(SnapshotAccessRequestModel response) {
     SnapshotAccessRequestModel expected =
         SnapshotBuilderTestData.createSnapshotAccessRequestModel(sourceSnapshot.getId());
-    expected.sourceSnapshotId(sourceSnapshot.getId());
 
-    expected.createdBy(EMAIL);
-    expected.status(SnapshotAccessRequestStatus.SUBMITTED);
     assertThat(
         "Given response is the same as expected.",
         response,
         samePropertyValuesAs(
-            expected, "id", "createdDate", "datasetId", "flightid", "createdSnapshotId"));
+            expected, "id", "createdDate", "flightid", "createdSnapshotId"));
     assertNotNull(response.id(), "Snapshot Access Request Response should have an id");
     assertNotNull(
         response.createdDate(),

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
@@ -122,7 +122,6 @@ class SnapshotRequestDaoTest {
     assertThat(
         "Snapshot Access Request should be the same as the example",
         snapshotRequestDao.enumerateBySnapshot(sourceSnapshot.getId()),
-        //        contains(hasProperty("id", equalTo(response.getId()))));
         contains(response));
   }
 
@@ -254,14 +253,15 @@ class SnapshotRequestDaoTest {
   @Test
   void deleteSourceSnapshot() {
     SnapshotAccessRequestModel response = createRequest();
+    UUID responseId = response.id();
     assertThat(
         "We can retrieve the snapshot request",
-        snapshotRequestDao.getById(response.id()),
+        snapshotRequestDao.getById(responseId),
         equalTo(response));
     // delete the source snapshot
     // This should also delete the snapshot request
     daoOperations.deleteSnapshot(sourceSnapshot.getId());
-    assertThrows(NotFoundException.class, () -> snapshotRequestDao.getById(response.id()));
+    assertThrows(NotFoundException.class, () -> snapshotRequestDao.getById(responseId));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshotbuilder/SnapshotRequestDaoTest.java
@@ -73,8 +73,7 @@ class SnapshotRequestDaoTest {
     assertThat(
         "Given response is the same as expected.",
         response,
-        samePropertyValuesAs(
-            expected, "id", "createdDate", "flightid", "createdSnapshotId"));
+        samePropertyValuesAs(expected, "id", "createdDate", "flightid", "createdSnapshotId"));
     assertNotNull(response.id(), "Snapshot Access Request Response should have an id");
     assertNotNull(
         response.createdDate(),

--- a/tools/setupResourceScripts/README.md
+++ b/tools/setupResourceScripts/README.md
@@ -5,7 +5,7 @@ The `setup_tdr_resources.py` script can be used to easily create datasets and sn
     * `python3 -m venv c:/path/to/myenv`
     * `source c:/path/to/myenv/bin/activate`
 2. `cd jade-data-repo/tools/setupResourceScripts`
-3. `pip3 install -r requirements.txt`
+3. `pip3 install -r requirements.txt --upgrade`
 4. `gcloud auth login <user>`
 5. `python3 setup_tdr_resources.py --help to see all flags used.`
 

--- a/tools/setupResourceScripts/requirements.txt
+++ b/tools/setupResourceScripts/requirements.txt
@@ -1,2 +1,3 @@
-data-repo-client>=2.62.0
+data-repo-client>=2.114.0
 google-cloud-bigquery
+protobuf==3.20.1

--- a/tools/setupResourceScripts/setup_tdr_resources.py
+++ b/tools/setupResourceScripts/setup_tdr_resources.py
@@ -1,3 +1,8 @@
+import argparse
+import json
+import os
+import subprocess
+import time
 import uuid
 
 from data_repo_client import (
@@ -9,12 +14,6 @@ from data_repo_client import (
     JobsApi,
     SnapshotAccessRequestApi,
 )
-import argparse
-import subprocess
-import json
-import os
-import subprocess
-import time
 
 
 class Clients:


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/dc-1150

## Addresses
This adds a summary to the `SnapshotAccessRequestResponse` object that is generated as needed.

## Summary of changes

- Add an intermediary model to represent what is stored in the DB and lazily generate the response
- Fixes setup_tdr_resources script
- Generates text summary from the snapshot specification

## Future Improvements
- We still have a number of openAPI generated values that are fields in `SnapshotAccessRequestModel` - these could probably get their own classes.

## Testing Strategy

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
