### PR TITLE
[DR-3476] Include additional fields in DRS getAccessURL Bard logs

### DIFF
--- a/src/main/java/bio/terra/app/usermetrics/BardEventProperties.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardEventProperties.java
@@ -6,5 +6,10 @@ public final class BardEventProperties {
   public static final String BILLING_PROFILE_ID_FIELD_NAME = "billingProfileId";
   public static final String METHOD_FIELD_NAME = "method";
   public static final String PATH_FIELD_NAME = "path";
+  public static final String SNAPSHOT_ID_FIELD_NAME = "snapshotId";
   public static final String SNAPSHOT_NAME_FIELD_NAME = "snapshotName";
+
+  public static final String DATASET_ID_FIELD_NAME = "datasetId";
+  public static final String DATASET_NAME_FIELD_NAME = "datasetName";
+  public static final String CLOUD_PLATFORM_FIELD_NAME = "cloudPlatform";
 }

--- a/src/main/java/bio/terra/app/usermetrics/BardEventProperties.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardEventProperties.java
@@ -6,4 +6,5 @@ public final class BardEventProperties {
   public static final String BILLING_PROFILE_ID_FIELD_NAME = "billingProfileId";
   public static final String METHOD_FIELD_NAME = "method";
   public static final String PATH_FIELD_NAME = "path";
+  public static final String SNAPSHOT_NAME_FIELD_NAME = "snapshotName";
 }

--- a/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
@@ -1,6 +1,7 @@
 package bio.terra.app.usermetrics;
 
 import java.util.HashMap;
+import org.apache.arrow.util.VisibleForTesting;
 import org.springframework.stereotype.Component;
 
 /**
@@ -44,5 +45,10 @@ public class UserLoggingMetrics {
     HashMap<String, Object> properties = metrics.get();
     properties.putAll(value);
     metrics.set(properties);
+  }
+
+  @VisibleForTesting
+  public void reset() {
+    metrics.get().clear();
   }
 }

--- a/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
@@ -1,7 +1,6 @@
 package bio.terra.app.usermetrics;
 
 import java.util.HashMap;
-import org.apache.arrow.util.VisibleForTesting;
 import org.springframework.stereotype.Component;
 
 /**
@@ -45,10 +44,5 @@ public class UserLoggingMetrics {
     HashMap<String, Object> properties = metrics.get();
     properties.putAll(value);
     metrics.set(properties);
-  }
-
-  @VisibleForTesting
-  public void reset() {
-    metrics.get().clear();
   }
 }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -491,16 +491,7 @@ public class DrsService {
 
     BillingProfileModel billingProfileModel = cachedSnapshot.datasetBillingProfileModel;
 
-    loggingMetrics.set(BardEventProperties.DATASET_ID_FIELD_NAME, cachedSnapshot.getDatasetId());
-    loggingMetrics.set(
-        BardEventProperties.DATASET_NAME_FIELD_NAME, cachedSnapshot.getDatasetName());
-    loggingMetrics.set(BardEventProperties.SNAPSHOT_ID_FIELD_NAME, snapshotId);
-    loggingMetrics.set(BardEventProperties.SNAPSHOT_NAME_FIELD_NAME, cachedSnapshot.getName());
-    loggingMetrics.set(
-        BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME,
-        cachedSnapshot.getSnapshotBillingProfileId());
-    loggingMetrics.set(
-        BardEventProperties.CLOUD_PLATFORM_FIELD_NAME, cachedSnapshot.getCloudPlatform());
+    logAdditionalProperties(cachedSnapshot);
 
     assertAccessMethodMatchingAccessId(accessId, drsObject);
 
@@ -524,6 +515,24 @@ public class DrsService {
     } else {
       throw new FeatureNotImplementedException("Cloud platform not implemented");
     }
+  }
+
+  /**
+   * Include additional properties in the event log sent to Bard
+   *
+   * @param cachedSnapshot
+   */
+  private void logAdditionalProperties(SnapshotCacheResult cachedSnapshot) {
+    loggingMetrics.set(BardEventProperties.DATASET_ID_FIELD_NAME, cachedSnapshot.getDatasetId());
+    loggingMetrics.set(
+        BardEventProperties.DATASET_NAME_FIELD_NAME, cachedSnapshot.getDatasetName());
+    loggingMetrics.set(BardEventProperties.SNAPSHOT_ID_FIELD_NAME, cachedSnapshot.getId());
+    loggingMetrics.set(BardEventProperties.SNAPSHOT_NAME_FIELD_NAME, cachedSnapshot.getName());
+    loggingMetrics.set(
+        BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME,
+        cachedSnapshot.getSnapshotBillingProfileId());
+    loggingMetrics.set(
+        BardEventProperties.CLOUD_PLATFORM_FIELD_NAME, cachedSnapshot.getCloudPlatform());
   }
 
   @VisibleForTesting

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -491,10 +491,16 @@ public class DrsService {
 
     BillingProfileModel billingProfileModel = cachedSnapshot.datasetBillingProfileModel;
 
+    loggingMetrics.set(BardEventProperties.DATASET_ID_FIELD_NAME, cachedSnapshot.getDatasetId());
+    loggingMetrics.set(
+        BardEventProperties.DATASET_NAME_FIELD_NAME, cachedSnapshot.getDatasetName());
+    loggingMetrics.set(BardEventProperties.SNAPSHOT_ID_FIELD_NAME, snapshotId);
     loggingMetrics.set(BardEventProperties.SNAPSHOT_NAME_FIELD_NAME, cachedSnapshot.getName());
     loggingMetrics.set(
         BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME,
         cachedSnapshot.getSnapshotBillingProfileId());
+    loggingMetrics.set(
+        BardEventProperties.CLOUD_PLATFORM_FIELD_NAME, cachedSnapshot.getCloudPlatform());
 
     assertAccessMethodMatchingAccessId(accessId, drsObject);
 
@@ -1002,6 +1008,8 @@ public class DrsService {
     private final CloudPlatform cloudPlatform;
     private final String googleProjectId;
     private final String datasetProjectId;
+    private final UUID datasetId;
+    private final String datasetName;
     private final boolean globalFileIds;
 
     public SnapshotCacheResult(Snapshot snapshot) {
@@ -1025,6 +1033,8 @@ public class DrsService {
       } else {
         this.datasetProjectId = null;
       }
+      this.datasetId = snapshot.getSourceDataset().getId();
+      this.datasetName = snapshot.getSourceDataset().getName();
     }
 
     public UUID getId() {
@@ -1035,8 +1045,20 @@ public class DrsService {
       return this.name;
     }
 
+    public UUID getDatasetId() {
+      return this.datasetId;
+    }
+
+    public String getDatasetName() {
+      return this.datasetName;
+    }
+
     public UUID getSnapshotBillingProfileId() {
       return snapshotBillingProfileId;
+    }
+
+    public CloudPlatform getCloudPlatform() {
+      return this.cloudPlatform;
     }
   }
 }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -8,6 +8,8 @@ import bio.terra.app.configuration.EcmConfiguration;
 import bio.terra.app.controller.exception.TooManyRequestsException;
 import bio.terra.app.logging.PerformanceLogger;
 import bio.terra.app.model.GoogleRegion;
+import bio.terra.app.usermetrics.BardEventProperties;
+import bio.terra.app.usermetrics.UserLoggingMetrics;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.FutureUtils;
 import bio.terra.common.exception.FeatureNotImplementedException;
@@ -111,6 +113,7 @@ public class DrsService {
   private final DrsDao drsDao;
   private final DrsMetricsService drsMetricsService;
   private final AsyncTaskExecutor executor;
+  private final UserLoggingMetrics loggingMetrics;
 
   private final Map<UUID, SnapshotProject> snapshotProjectsCache =
       Collections.synchronizedMap(new PassiveExpiringMap<>(15, TimeUnit.MINUTES));
@@ -133,7 +136,8 @@ public class DrsService {
       EcmConfiguration ecmConfiguration,
       DrsDao drsDao,
       DrsMetricsService drsMetricsService,
-      @Qualifier("drsResolutionThreadpool") AsyncTaskExecutor executor) {
+      @Qualifier("drsResolutionThreadpool") AsyncTaskExecutor executor,
+      UserLoggingMetrics loggingMetrics) {
     this.snapshotService = snapshotService;
     this.fileService = fileService;
     this.drsIdService = drsIdService;
@@ -148,6 +152,7 @@ public class DrsService {
     this.drsDao = drsDao;
     this.drsMetricsService = drsMetricsService;
     this.executor = executor;
+    this.loggingMetrics = loggingMetrics;
   }
 
   private class DrsRequestResource implements AutoCloseable {
@@ -485,6 +490,11 @@ public class DrsService {
     SnapshotCacheResult cachedSnapshot = getSnapshot(snapshotId);
 
     BillingProfileModel billingProfileModel = cachedSnapshot.datasetBillingProfileModel;
+
+    loggingMetrics.set(BardEventProperties.SNAPSHOT_NAME_FIELD_NAME, cachedSnapshot.getName());
+    loggingMetrics.set(
+        BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME,
+        cachedSnapshot.getSnapshotBillingProfileId());
 
     assertAccessMethodMatchingAccessId(accessId, drsObject);
 
@@ -985,6 +995,7 @@ public class DrsService {
   @VisibleForTesting
   static class SnapshotCacheResult {
     private final UUID id;
+    private final String name;
     private final boolean isSelfHosted;
     private final BillingProfileModel datasetBillingProfileModel;
     private final UUID snapshotBillingProfileId;
@@ -995,6 +1006,7 @@ public class DrsService {
 
     public SnapshotCacheResult(Snapshot snapshot) {
       this.id = snapshot.getId();
+      this.name = snapshot.getName();
       this.isSelfHosted = snapshot.isSelfHosted();
       this.globalFileIds = snapshot.hasGlobalFileIds();
       this.datasetBillingProfileModel =
@@ -1017,6 +1029,10 @@ public class DrsService {
 
     public UUID getId() {
       return this.id;
+    }
+
+    public String getName() {
+      return this.name;
     }
 
     public UUID getSnapshotBillingProfileId() {

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -70,7 +70,7 @@ class UserMetricsInterceptorTest {
 
   @BeforeEach
   void setUp() {
-    eventProperties.reset();
+    eventProperties.get().clear();
     when(metricsConfig.ignorePaths()).thenReturn(List.of());
     when(metricsConfig.appId()).thenReturn(APP_ID);
     when(metricsConfig.bardBasePath()).thenReturn(BARD_BASE_PATH);

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -125,9 +125,11 @@ class UserMetricsInterceptorTest {
   }
 
   @Test
-  void testSendEventWithBillingProfileId() throws Exception {
+  void testSendEventWithAdditionalProperties() throws Exception {
+    String snapshotName = "snapshotName";
     String billingProfileId = UUID.randomUUID().toString();
     eventProperties.set(BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId);
+    eventProperties.set(BardEventProperties.SNAPSHOT_NAME_FIELD_NAME, snapshotName);
 
     mockRequestAuth(request);
 
@@ -142,7 +144,8 @@ class UserMetricsInterceptorTest {
                     Map.of(
                         BardEventProperties.METHOD_FIELD_NAME, METHOD.toUpperCase(),
                         BardEventProperties.PATH_FIELD_NAME, REQUEST_URI,
-                        BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId),
+                        BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId,
+                        BardEventProperties.SNAPSHOT_NAME_FIELD_NAME, snapshotName),
                     APP_ID,
                     DNS_NAME)));
 

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -15,6 +15,7 @@ import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import bio.terra.model.CloudPlatform;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -69,6 +70,7 @@ class UserMetricsInterceptorTest {
 
   @BeforeEach
   void setUp() {
+    eventProperties.reset();
     when(metricsConfig.ignorePaths()).thenReturn(List.of());
     when(metricsConfig.appId()).thenReturn(APP_ID);
     when(metricsConfig.bardBasePath()).thenReturn(BARD_BASE_PATH);
@@ -126,10 +128,19 @@ class UserMetricsInterceptorTest {
 
   @Test
   void testSendEventWithAdditionalProperties() throws Exception {
+    UUID datasetId = UUID.randomUUID();
+    String datasetName = "datasetName";
+    UUID snapshotId = UUID.randomUUID();
     String snapshotName = "snapshotName";
     String billingProfileId = UUID.randomUUID().toString();
-    eventProperties.set(BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId);
+    CloudPlatform cloudPlatform = CloudPlatform.GCP;
+
+    eventProperties.set(BardEventProperties.DATASET_ID_FIELD_NAME, datasetId);
+    eventProperties.set(BardEventProperties.DATASET_NAME_FIELD_NAME, datasetName);
+    eventProperties.set(BardEventProperties.SNAPSHOT_ID_FIELD_NAME, snapshotId);
     eventProperties.set(BardEventProperties.SNAPSHOT_NAME_FIELD_NAME, snapshotName);
+    eventProperties.set(BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId);
+    eventProperties.set(BardEventProperties.CLOUD_PLATFORM_FIELD_NAME, cloudPlatform);
 
     mockRequestAuth(request);
 
@@ -144,8 +155,12 @@ class UserMetricsInterceptorTest {
                     Map.of(
                         BardEventProperties.METHOD_FIELD_NAME, METHOD.toUpperCase(),
                         BardEventProperties.PATH_FIELD_NAME, REQUEST_URI,
+                        BardEventProperties.DATASET_ID_FIELD_NAME, datasetId,
+                        BardEventProperties.DATASET_NAME_FIELD_NAME, datasetName,
+                        BardEventProperties.SNAPSHOT_ID_FIELD_NAME, snapshotId,
+                        BardEventProperties.SNAPSHOT_NAME_FIELD_NAME, snapshotName,
                         BardEventProperties.BILLING_PROFILE_ID_FIELD_NAME, billingProfileId,
-                        BardEventProperties.SNAPSHOT_NAME_FIELD_NAME, snapshotName),
+                        BardEventProperties.CLOUD_PLATFORM_FIELD_NAME, cloudPlatform),
                     APP_ID,
                     DNS_NAME)));
 

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -31,6 +31,7 @@ import bio.terra.app.logging.PerformanceLogger;
 import bio.terra.app.model.AzureRegion;
 import bio.terra.app.model.CloudRegion;
 import bio.terra.app.model.GoogleRegion;
+import bio.terra.app.usermetrics.UserLoggingMetrics;
 import bio.terra.common.TestUtils;
 import bio.terra.common.UriUtils;
 import bio.terra.common.category.Unit;
@@ -137,6 +138,7 @@ class DrsServiceTest {
   @Mock private DrsDao drsDao;
   @Mock private ApplicationConfiguration appConfig;
   @Mock private DrsMetricsService drsMetricsService;
+  @Mock private UserLoggingMetrics loggingMetrics;
 
   private DrsIdService drsIdService;
   private DrsService drsService;
@@ -176,7 +178,8 @@ class DrsServiceTest {
                 ecmConfiguration,
                 drsDao,
                 drsMetricsService,
-                new SimpleAsyncTaskExecutor()));
+                new SimpleAsyncTaskExecutor(),
+                loggingMetrics));
     when(jobService.getActivePodCount()).thenReturn(1);
     when(drsConfiguration.maxDrsLookups()).thenReturn(1);
 


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DR-3476

## Addresses
Key stakeholders such as the NIH want to know the usage patterns of the data that they are storing. Adding the snapshot name is more informative than using just the snapshot ids. This along with the addition of the billing profile id, dataset id and dataset name allows us to answer questions like, "What are the top X datasets and/or snapshots (of billing profile Y) that users are requesting data from?"

## Summary of changes
Add the following fields to the DRS Bard log for getAccessURL (Note these are already available in the snapshot object that gets retrieved from the database, but these fields were not included in the cached snapshot object):
- snapshot id
- snapshot name
- dataset id
- dataset name
- billing profile id
- cloud platform

## Testing Strategy
Local testing:
- Enabled logging to Bard by setting `usermetrics.bardBasePath=https://terra-bard-dev.appspot.com` in `application.properties`
- Ran the TDR server locally in debug mode with a breakpoint in UserMetricsInterceptor (where the call to Bard is made)
- Ran the `drsHacky` test to hit the breakpoint
- Verified that the additional properties get included in the request to get an access url

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
