### PR TITLE
[DCJ-575] Dataset obtained for ingest flight needn't have relationships or assets

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -483,6 +483,11 @@ public class DatasetDao implements TaggableResourceDao {
     return rowsAffected > 0;
   }
 
+  public Dataset retrieve(UUID id, boolean retrieveRelationship, boolean retrieveAsset) {
+    DatasetSummary summary = retrieveSummaryById(id);
+    return retrieveWorker(summary, retrieveRelationship, retrieveAsset);
+  }
+
   public Dataset retrieve(UUID id) {
     DatasetSummary summary = retrieveSummaryById(id);
     return retrieveWorker(summary);
@@ -494,14 +499,23 @@ public class DatasetDao implements TaggableResourceDao {
   }
 
   private Dataset retrieveWorker(DatasetSummary summary) {
+    return retrieveWorker(summary, true, true);
+  }
+
+  private Dataset retrieveWorker(
+      DatasetSummary summary, boolean retrieveRelationship, boolean retrieveAsset) {
     Dataset dataset = null;
     try {
       if (summary != null) {
         summary.storage(storageResourceDao.getStorageResourcesByDatasetId(summary.getId()));
         dataset = new Dataset(summary);
         dataset.tables(tableDao.retrieveTables(dataset.getId()));
-        relationshipDao.retrieve(dataset);
-        assetDao.retrieve(dataset);
+        if (retrieveRelationship) {
+          relationshipDao.retrieve(dataset);
+        }
+        if (retrieveAsset) {
+          assetDao.retrieve(dataset);
+        }
         // Retrieve the project and application deployment resource associated with the dataset
         // This is a bit sketchy filling in the object via a dao in another package.
         // It seemed like the cleanest thing to me at the time.

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -511,9 +511,11 @@ public class DatasetDao implements TaggableResourceDao {
         dataset = new Dataset(summary);
         dataset.tables(tableDao.retrieveTables(dataset.getId()));
         if (retrieveRelationship) {
+          // This query is costly and should only be run when necessary.
           relationshipDao.retrieve(dataset);
         }
         if (retrieveAsset) {
+          // This query is costly and should only be run when necessary.
           assetDao.retrieve(dataset);
         }
         // Retrieve the project and application deployment resource associated with the dataset

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -183,6 +183,17 @@ public class DatasetService {
   }
 
   /**
+   * Fetch existing Dataset object populated only as necessary to facilitate data ingestion (i.e.
+   * without relationships or assets which are constructed via costly database calls).
+   *
+   * @param id in UUID format
+   * @return a Dataset object
+   */
+  public Dataset retrieveForIngest(UUID id) {
+    return datasetDao.retrieve(id, false, false);
+  }
+
+  /**
    * Fetch existing Dataset object using the name.
    *
    * @param name

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -63,6 +63,11 @@ public final class IngestUtils {
 
   private IngestUtils() {}
 
+  /**
+   * @param context with dataset ID provided as an input parameter.
+   * @return the existing Dataset object populated only as necessary to facilitate data ingestion
+   *     (i.e. without relationships or assets which are constructed via costly database calls).
+   */
   public static Dataset getDataset(FlightContext context, DatasetService datasetService) {
     FlightMap inputParameters = context.getInputParameters();
     UUID datasetId =

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestUtils.java
@@ -67,7 +67,7 @@ public final class IngestUtils {
     FlightMap inputParameters = context.getInputParameters();
     UUID datasetId =
         UUID.fromString(inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), String.class));
-    return datasetService.retrieve(datasetId);
+    return datasetService.retrieveForIngest(datasetId);
   }
 
   public static IngestRequestModel getIngestRequestModel(FlightContext context) {

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestCreateParquetFilesStepTest.java
@@ -96,7 +96,7 @@ class IngestCreateParquetFilesStepTest {
     when(flightContext.getWorkingMap()).thenReturn(flightMap);
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     when(flightContext.getFlightId()).thenReturn(FLIGHT_ID);
-    when(datasetService.retrieve(DATASET_ID)).thenReturn(dataset);
+    when(datasetService.retrieveForIngest(DATASET_ID)).thenReturn(dataset);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestUtilsTest.java
@@ -7,26 +7,48 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestRequestModel.FormatEnum;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.exception.InvalidBlobURLException;
 import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.ShortUUID;
 import com.azure.storage.blob.BlobUrlParts;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
 class IngestUtilsTest {
+  private static final UUID DATASET_ID = UUID.randomUUID();
+  private static final Dataset DATASET = new Dataset().id(DATASET_ID);
+  @Mock private FlightContext context;
+  @Mock private DatasetService datasetService;
+
+  @Test
+  void getDataset() {
+    FlightMap inputParameters = new FlightMap();
+    inputParameters.put(JobMapKeys.DATASET_ID.getKeyName(), DATASET_ID.toString());
+    when(context.getInputParameters()).thenReturn(inputParameters);
+    when(datasetService.retrieveForIngest(DATASET_ID)).thenReturn(DATASET);
+    assertThat(IngestUtils.getDataset(context, datasetService), equalTo(DATASET));
+  }
 
   @ParameterizedTest
   @EnumSource(names = {"CSV", "ARRAY", "JSON"})

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestValidateScratchTableFilerefsStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestValidateScratchTableFilerefsStepTest.java
@@ -91,7 +91,7 @@ class IngestValidateScratchTableFilerefsStepTest {
   private void mockDatasetWithColumns(Column... columns) {
     DatasetTable table = new DatasetTable().name(TABLE_NAME).columns(Arrays.asList(columns));
     Dataset dataset = new Dataset().id(DATASET_ID).tables(List.of(table));
-    when(datasetService.retrieve(DATASET_ID)).thenReturn(dataset);
+    when(datasetService.retrieveForIngest(DATASET_ID)).thenReturn(dataset);
   }
 
   /**


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-575

## Addresses

By a long shot, the highest drivers of database load during this Prod incident were queries to construct dataset assets and relationships, called as part of constructing full dataset objects from the DB.  We deduced that the high number of calls happened while facilitating a high number (300+) of concurrent ingest flights.  The size of the ingests had no bearing on this load.

Dataset assets and relationships are not needed to facilitate ingestion, so that load on the database is unnecessary even before you consider whether the queries themselves could be optimized.

As we continue to see DB CPU utilization spikes up to 100% despite doubling our Prod DB's available CPU, we want to pursue an attainable optimization ASAP.  Further iteration may be explored later, but my priority with this PR is to get us more breathing room to prioritize such work thoughtfully.

## Summary of changes

`IngestUtils.getDataset(FlightContext, DatasetService)` still constructs the latest version of the Dataset from the DB, but now avoids the costly DB calls to construct relationships and assets.

## Testing Strategy

Expanded unit tests.

Examined Query Insights for integration test runs (which exercise ingestion, though not at high levels of concurrency) and observed reduced DB CPU utilization attributed to relationship and asset construction.

Integration tests off of this PR:
<img width="1488" alt="Screenshot 2024-08-01 at 3 21 35 PM" src="https://github.com/user-attachments/assets/ce5491bb-e6b2-4ca8-9112-1f6e2b133e1c">

Integration tests off of `develop` branch (control):
<img width="1481" alt="Screenshot 2024-08-01 at 3 19 58 PM" src="https://github.com/user-attachments/assets/ee921020-572e-424a-8e85-f13cb0dd5c55">

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
