### PR TITLE
[DCJ-571] render-configs.sh RBS secret name differs by environment

### DIFF
--- a/render-configs.sh
+++ b/render-configs.sh
@@ -102,13 +102,13 @@ GOOGLE_SA_CERT=/tmp/jade-dev-account.pem
 if [[ "${RBS_ENV}" == "tools" ]]; then
     BUFFER_CLIENT_SERVICE_ACCOUNT_VAULT_PATH=secret/dsde/terra/kernel/integration/tools/buffer/client-sa
     BUFFER_CLIENT_SERVICE_ACCOUNT_GSM_PROJECT=broad-dsde-qa
-    RBS_GSM_SECRET=buffer-client-sa-b64-integration
+    BUFFER_CLIENT_GSM_SECRET=buffer-client-sa-b64-integration
     RBS_POOLID=datarepo_v1
     RBS_INSTANCEURL=https://buffer.tools.integ.envs.broadinstitute.org
 elif [[ "${RBS_ENV}" == "dev" ]]; then
     BUFFER_CLIENT_SERVICE_ACCOUNT_VAULT_PATH=secret/dsde/terra/kernel/dev/dev/buffer/client-sa
     BUFFER_CLIENT_SERVICE_ACCOUNT_GSM_PROJECT=broad-jade-dev
-    RBS_GSM_SECRET=buffer-client-sa-b64
+    BUFFER_CLIENT_GSM_SECRET=buffer-client-sa-b64
     RBS_POOLID=datarepo_v3
     RBS_INSTANCEURL=https://buffer.dsde-dev.broadinstitute.org
 else
@@ -125,7 +125,7 @@ if $USE_VAULT; then
   vault read -field=key "$BUFFER_CLIENT_SERVICE_ACCOUNT_VAULT_PATH" \
     | base64 -d > "$RBS_CLIENTCREDENTIALFILEPATH"
 else
-  gcloud secrets versions access latest --project $BUFFER_CLIENT_SERVICE_ACCOUNT_GSM_PROJECT --secret $RBS_GSM_SECRET \
+  gcloud secrets versions access latest --project $BUFFER_CLIENT_SERVICE_ACCOUNT_GSM_PROJECT --secret BUFFER_CLIENT_GSM_SECRET \
     | jq -r '.key' | base64 -d > "$RBS_CLIENTCREDENTIALFILEPATH"
 fi
 

--- a/render-configs.sh
+++ b/render-configs.sh
@@ -102,11 +102,13 @@ GOOGLE_SA_CERT=/tmp/jade-dev-account.pem
 if [[ "${RBS_ENV}" == "tools" ]]; then
     BUFFER_CLIENT_SERVICE_ACCOUNT_VAULT_PATH=secret/dsde/terra/kernel/integration/tools/buffer/client-sa
     BUFFER_CLIENT_SERVICE_ACCOUNT_GSM_PROJECT=broad-dsde-qa
+    RBS_GSM_SECRET=buffer-client-sa-b64-integration
     RBS_POOLID=datarepo_v1
     RBS_INSTANCEURL=https://buffer.tools.integ.envs.broadinstitute.org
 elif [[ "${RBS_ENV}" == "dev" ]]; then
     BUFFER_CLIENT_SERVICE_ACCOUNT_VAULT_PATH=secret/dsde/terra/kernel/dev/dev/buffer/client-sa
     BUFFER_CLIENT_SERVICE_ACCOUNT_GSM_PROJECT=broad-jade-dev
+    RBS_GSM_SECRET=buffer-client-sa-b64
     RBS_POOLID=datarepo_v3
     RBS_INSTANCEURL=https://buffer.dsde-dev.broadinstitute.org
 else
@@ -123,7 +125,7 @@ if $USE_VAULT; then
   vault read -field=key "$BUFFER_CLIENT_SERVICE_ACCOUNT_VAULT_PATH" \
     | base64 -d > "$RBS_CLIENTCREDENTIALFILEPATH"
 else
-  gcloud secrets versions access latest --project $BUFFER_CLIENT_SERVICE_ACCOUNT_GSM_PROJECT --secret buffer-client-sa-b64 \
+  gcloud secrets versions access latest --project $BUFFER_CLIENT_SERVICE_ACCOUNT_GSM_PROJECT --secret $RBS_GSM_SECRET \
     | jq -r '.key' | base64 -d > "$RBS_CLIENTCREDENTIALFILEPATH"
 fi
 


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-571

## Addresses

For RBS dev environment, the existing secret name is correct: `buffer-client-sa-b64`
But for RBS tools environment, the desired secret name is `buffer-client-sa-b64-integration`

Previously, the script succeeded successfully (as the GSM secret could still be found and parsed) but caused failures when running TDR locally and trying to create datasets, etc.

## Summary of changes

- Conditionally determine RBS client SA secret name based off of inputted RBS environment

## Testing Strategy

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
