### PR TITLE
[DCJ-3] Enable Dependabot for Gradle updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  # Enable version updates for Gradle
+  - package-ecosystem: "gradle"
+    directory: "/"
+    # See workflows/int-and-connected-test-run.yml for the current list of k8s namespaces available
+    # for integration testing.
+    # Presently, there are only 4, and these tests often take 2 hours to run.
+    # Keeping the open PR limit low at 4 so that concurrent Dependabot PR integration test runs all
+    # stand a chance at success rather than some being likely to time out waiting for an available
+    # namespace.
+    open-pull-requests-limit: 4
+    groups:
+      # We group minor and patch updates together because they are less likely to break things.
+      # Major updates will be PR-ed individually: they are more likely to need developer
+      # intervention.
+      minor-patch-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "spotless-plugin-gradle" # likely to require reformatting of code
+        update-types:
+          - "minor"
+          - "patch"
+    schedule:
+      interval: "weekly"
+      time: "06:00"
+      timezone: "America/New_York"
+    target-branch: "main"
+    labels:
+      - "dependency"
+      - "gradle"
+    commit-message:
+      prefix: "[DCJ-400-gradle]"
+    ignore:
+      # Google API dependencies use a version format that Dependabot wrongly interprets as semver.
+      - dependency-name: "com.google.apis:*"
+      # From 20.0.0 onward, k8s client publishes versions with and without '-legacy' suffix.
+      # We use the non-legacy client: the legacy client is not compatible with our code.
+      # Dependabot doesn't have an option for ignoring versions conforming to a naming convention
+      # (outside of semver major, minor, and patch designations) and will attempt to update
+      # to the latest published version.
+      - dependency-name: "io.kubernetes:client-java"


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-3

## Addresses

Presently, we update dependencies in TDR on a "just in time" basis:
- As needed for development
- To upgrade past an end-of-life version
- When required to pull in a security patch

But these dependency jumps can often be quite large and make for difficult upgrade experiences.

The standard throughout DSP has been to use Dependabot to automate dependency upgrades (which has also shown the benefit of mitigating security vulnerabilities before they're flagged without additional out-of-band-effort).  Now that all of the repository secrets used in PR workflows are managed by Terraform and exposed to Dependabot (see https://github.com/broadinstitute/terraform-ap-deployments/pull/1668) we can enable Dependabot in this repository as well.

## Summary of changes

- Use Dependabot to automate dependency upgrades in this repository, with past experience working on [WSM](https://github.com/DataBiosphere/terra-workspace-manager/blob/main/.github/dependabot.yml) as a guide
- Minor and patch upgrades will be grouped together, major upgrades will be PRed individually as they are more likely to contain breaking changes

## Testing Strategy

None: we will iterate on this workflow if needed.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
