### PR TITLE
[DCJ-3] Fix Dependabot target branch: main -> develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
       interval: "weekly"
       time: "06:00"
       timezone: "America/New_York"
-    target-branch: "main"
+    target-branch: "develop"
     labels:
       - "dependency"
       - "gradle"


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-3

## Addresses

Follow-on from https://github.com/DataBiosphere/jade-data-repo/pull/1761 where I copypasta'd the incorrect target branch name from another repo's Dependabot configuration.

Thanks @pshapiro4broad for catching this.

## Summary of changes

- Fix Dependabot target branch: this repository uses `develop` as its destination branch, not `main`.

## Testing Strategy

N/A

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
