### PR TITLE
[DCJ-400] Minor and patch dependency updates, inc. Spring Boot 3.2.4 -> 3.3.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "spotless-plugin-gradle" # likely to require reformatting of code
+          - "com.diffplug.spotless" # likely to require reformatting of code
         update-types:
           - "minor"
           - "patch"

--- a/build.gradle
+++ b/build.gradle
@@ -238,7 +238,7 @@ dependencies {
     implementation('io.sentry:sentry-logback')
 
     // OpenTelemetry @WithSpan annotations:
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.6.0'
 
     testImplementation 'org.apache.parquet:parquet-common:1.12.0'
     testImplementation 'org.apache.parquet:parquet-hadoop:1.12.0'

--- a/build.gradle
+++ b/build.gradle
@@ -253,8 +253,8 @@ dependencies {
         exclude group: 'org.slf4j', module: 'slf4j-reload4j'
     }
 
-    testImplementation 'au.com.dius.pact.provider:junit5:4.3.19'
-    testImplementation 'au.com.dius.pact.provider:junit5spring:4.3.19'
+    testImplementation 'au.com.dius.pact.provider:junit5:4.6.12'
+    testImplementation 'au.com.dius.pact.provider:junit5spring:4.6.12'
 
     antlr 'org.antlr:antlr4:4.13.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ dependencies {
     swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli'
 
     implementation 'org.springframework:spring-jdbc'
-    implementation 'org.antlr:ST4:4.3'                          // String templating
+    implementation 'org.antlr:ST4:4.3.4' // String templating
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api'
@@ -265,7 +265,7 @@ dependencies {
     testImplementation 'au.com.dius.pact.provider:junit5:4.3.19'
     testImplementation 'au.com.dius.pact.provider:junit5spring:4.3.19'
 
-    antlr 'org.antlr:antlr4:4.8'
+    antlr 'org.antlr:antlr4:4.13.2'
 
     // Need groovy on the class path for the logback config. Could use XML and skip this dependency,
     // but the groovy config is... well... groovy.

--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,7 @@ dependencies {
 
     implementation 'bio.terra:terra-common-lib:1.1.17-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
-    implementation 'bio.terra:terra-policy-client:1.0.11-SNAPSHOT'
+    implementation 'bio.terra:terra-policy-client:1.0.15-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'
     implementation 'bio.terra:externalcreds-client-resttemplate:1.3.0-SNAPSHOT'
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.1'
     id 'com.dorongold.task-tree' version '2.1.0'
     // enables release info in sentry events
-    id 'com.gorylenko.gradle-git-properties' version '2.4.1'
+    id 'com.gorylenko.gradle-git-properties' version '2.4.2'
     id 'org.sonarqube' version '4.2.1.3168'
     id 'com.srcclr.gradle' version '3.1.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -260,12 +260,12 @@ dependencies {
 
     liquibaseRuntime 'org.liquibase:liquibase-core'
     liquibaseRuntime 'org.postgresql:postgresql'
-    liquibaseRuntime 'info.picocli:picocli:4.7.5'
+    liquibaseRuntime 'info.picocli:picocli:4.7.6'
 
     testImplementation 'org.junit.vintage:junit-vintage-engine'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'io.zonky.test:embedded-database-spring-test:2.5.0'
-    testImplementation 'io.zonky.test:embedded-postgres:2.0.6'
+    testImplementation 'io.zonky.test:embedded-database-spring-test:2.5.1'
+    testImplementation 'io.zonky.test:embedded-postgres:2.0.7'
     implementation enforcedPlatform('io.zonky.test.postgres:embedded-postgres-binaries-bom:12.8.0')
 
     generatedCompile 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,10 @@ plugins {
     id 'org.gradle.test-retry' version '1.5.8'
     id 'antlr'
     id 'org.hidetake.swagger.generator' version '2.19.2'
-    id 'org.springframework.boot' version '3.2.4'
+    id 'org.springframework.boot' version '3.3.2'
     id 'idea'
     id 'java'
-    id 'io.spring.dependency-management' version '1.1.4'
+    id 'io.spring.dependency-management' version '1.1.6'
     id 'jacoco'
     id 'com.diffplug.spotless' version '6.7.1'
     id 'com.dorongold.task-tree' version '2.1.0'
@@ -160,12 +160,6 @@ configurations {
     runtimeClasspath
 }
 
-// Spring Boot 3.2.4 pulls in opentelemetry-bom 1.31.0.
-// It must have version >= 1.34.1 for compatibility with terra-common-lib 1.1.10:
-ext['opentelemetry.version'] = '1.36.0'
-// Spring Boot 3.2.4 pulls in io.netty:netty-bom 4.1.107.Final which is impacted by CVE-2024-29025.
-ext['netty.version'] = '4.1.108.Final'
-
 dependencies {
     implementation 'com.google.apis:google-api-services-serviceusage:v1-rev20230215-2.0.0'
     implementation 'com.google.apis:google-api-services-appengine:v1-rev20230206-2.0.0'
@@ -188,7 +182,7 @@ dependencies {
     implementation 'org.apache.directory.studio:org.apache.commons.io:2.4'
     implementation 'org.apache.httpcomponents.client5:httpclient5'
 
-    implementation 'org.liquibase:liquibase-core:4.26.0'
+    implementation 'org.liquibase:liquibase-core'
 
     implementation 'org.codehaus.janino:janino'           // Provides if/else xml parsing for logback config
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -222,9 +216,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.3'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.3'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
+    implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // Azure related dependencies
     implementation 'com.azure:azure-identity:1.11.1'

--- a/build.gradle
+++ b/build.gradle
@@ -203,8 +203,8 @@ dependencies {
     implementation 'com.microsoft.sqlserver:mssql-jdbc:11.2.3.jre17'
 
     // For distributed locking of Spring @Scheduled tasks across multiple instances
-    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.2.0'
-    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.14.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.14.0'
 
     implementation 'bio.terra:terra-common-lib:1.1.17-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'

--- a/build.gradle
+++ b/build.gradle
@@ -225,13 +225,13 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // Azure related dependencies
-    implementation 'com.azure:azure-identity:1.11.1'
-    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.34.0'
+    implementation 'com.azure:azure-identity:1.13.2'
+    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.41.0'
     implementation 'com.azure.resourcemanager:azure-resourcemanager-loganalytics:1.0.0'
     implementation 'com.azure.resourcemanager:azure-resourcemanager-securityinsights:1.0.0-beta.4'
-    implementation 'com.azure:azure-storage-common:12.24.1'
-    implementation 'com.azure:azure-storage-file-datalake:12.18.1'
-    implementation 'com.azure:azure-data-tables:12.3.18'
+    implementation 'com.azure:azure-storage-common:12.26.0'
+    implementation 'com.azure:azure-storage-file-datalake:12.20.0'
+    implementation 'com.azure:azure-data-tables:12.4.3'
 
     implementation platform('io.sentry:sentry-bom:7.13.0') //import bom
     implementation('io.sentry:sentry-spring-boot-starter')

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 plugins {
     id 'com.google.cloud.tools.jib' version '3.4.3'
     id 'org.liquibase.gradle' version '2.2.1'
-    id 'org.gradle.test-retry' version '1.5.8'
+    id 'org.gradle.test-retry' version '1.5.10'
     id 'antlr'
     id 'org.hidetake.swagger.generator' version '2.19.2'
     id 'org.springframework.boot' version '3.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ dependencies {
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
     implementation 'bio.terra:terra-policy-client:1.0.15-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'
-    implementation 'bio.terra:externalcreds-client-resttemplate:1.3.0-SNAPSHOT'
+    implementation 'bio.terra:externalcreds-client-resttemplate:1.45.0-SNAPSHOT'
 
     implementation 'org.glassfish.jersey.inject:jersey-hk2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
     implementation 'com.azure:azure-data-tables:12.4.3'
 
     implementation platform('io.sentry:sentry-bom:7.13.0') //import bom
-    implementation('io.sentry:sentry-spring-boot-starter')
+    implementation('io.sentry:sentry-spring-boot-starter-jakarta')
     implementation('io.sentry:sentry-logback')
 
     // OpenTelemetry @WithSpan annotations:

--- a/build.gradle
+++ b/build.gradle
@@ -245,23 +245,12 @@ dependencies {
     testImplementation 'org.apache.parquet:parquet-hadoop-bundle:1.14.1'
     testImplementation 'org.apache.parquet:parquet-encoding:1.14.1'
     testImplementation 'org.apache.parquet:parquet-column:1.14.1'
-    testImplementation ('org.apache.hadoop:hadoop-common:3.3.1')  {
+    testImplementation ('org.apache.hadoop:hadoop-common:3.4.0')  {
         exclude group: 'com.sun.jersey', module: 'jersey-core'
         exclude group: 'com.sun.jersey', module: 'jersey-servlet'
         exclude group: 'com.sun.jersey', module: 'jersey-json'
         exclude group: 'com.sun.jersey', module: 'jersey-server'
-    }
-    testImplementation ('org.apache.hadoop:hadoop-azure:3.3.1') {
-        exclude group: 'com.sun.jersey', module: 'jersey-core'
-        exclude group: 'com.sun.jersey', module: 'jersey-servlet'
-        exclude group: 'com.sun.jersey', module: 'jersey-json'
-        exclude group: 'com.sun.jersey', module: 'jersey-server'
-    }
-    testImplementation('org.apache.hadoop:hadoop-mapreduce-client-core:3.3.1') {
-        exclude group: 'com.sun.jersey', module: 'jersey-core'
-        exclude group: 'com.sun.jersey', module: 'jersey-servlet'
-        exclude group: 'com.sun.jersey', module: 'jersey-json'
-        exclude group: 'com.sun.jersey', module: 'jersey-server'
+        exclude group: 'org.slf4j', module: 'slf4j-reload4j'
     }
 
     testImplementation 'au.com.dius.pact.provider:junit5:4.3.19'

--- a/build.gradle
+++ b/build.gradle
@@ -252,6 +252,13 @@ dependencies {
         exclude group: 'com.sun.jersey', module: 'jersey-server'
         exclude group: 'org.slf4j', module: 'slf4j-reload4j'
     }
+    testImplementation('org.apache.hadoop:hadoop-mapreduce-client-core:3.4.0') {
+        exclude group: 'com.sun.jersey', module: 'jersey-core'
+        exclude group: 'com.sun.jersey', module: 'jersey-servlet'
+        exclude group: 'com.sun.jersey', module: 'jersey-json'
+        exclude group: 'com.sun.jersey', module: 'jersey-server'
+        exclude group: 'org.slf4j', module: 'slf4j-reload4j'
+    }
 
     testImplementation 'au.com.dius.pact.provider:junit5:4.6.12'
     testImplementation 'au.com.dius.pact.provider:junit5spring:4.6.12'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.google.cloud.tools.jib' version '3.2.0'
+    id 'com.google.cloud.tools.jib' version '3.4.2'
     id 'org.liquibase.gradle' version '2.2.1'
     id 'org.gradle.test-retry' version '1.5.8'
     id 'antlr'
@@ -176,6 +176,8 @@ dependencies {
     implementation 'com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0'
     implementation 'com.google.http-client:google-http-client'
 
+    implementation 'org.apache.commons:commons-compress:1.26.2' // For srcclr, jib plugin conflict
+    // More info: https://discuss.gradle.org/t/plugin-dependency-conflict-with-jib-and-srcclr/42355
     implementation 'org.apache.commons:commons-dbcp2' // For database connection support
     implementation 'org.apache.commons:commons-lang3'
     implementation 'org.apache.commons:commons-collections4'

--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ dependencies {
     implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-2.0.0'
     implementation 'com.google.apis:google-api-services-iam:v1-rev20230209-2.0.0'
 
-    implementation platform('com.google.cloud:libraries-bom:26.30.0')
+    implementation platform('com.google.cloud:libraries-bom:26.43.0')
     implementation 'com.google.cloud:google-cloud-billing'
     implementation 'com.google.cloud:google-cloud-resourcemanager'
     implementation 'com.google.cloud:google-cloud-bigquery'

--- a/build.gradle
+++ b/build.gradle
@@ -258,10 +258,6 @@ dependencies {
 
     antlr 'org.antlr:antlr4:4.13.2'
 
-    // Need groovy on the class path for the logback config. Could use XML and skip this dependency,
-    // but the groovy config is... well... groovy.
-    runtimeOnly 'org.codehaus.groovy:groovy:3.0.7'
-
     liquibaseRuntime 'org.liquibase:liquibase-core'
     liquibaseRuntime 'org.postgresql:postgresql'
     liquibaseRuntime 'info.picocli:picocli:4.7.5'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.google.cloud.tools.jib' version '3.4.2'
+    id 'com.google.cloud.tools.jib' version '3.4.3'
     id 'org.liquibase.gradle' version '2.2.1'
     id 'org.gradle.test-retry' version '1.5.8'
     id 'antlr'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     dependencies {
         classpath('io.swagger.codegen.v3:swagger-codegen:3.0.52')
         // Required for gradle liquibase plugin
-        classpath ('org.liquibase:liquibase-core:4.27.0')
+        classpath ('org.liquibase:liquibase-core:4.29.1')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -240,11 +240,11 @@ dependencies {
     // OpenTelemetry @WithSpan annotations:
     implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.6.0'
 
-    testImplementation 'org.apache.parquet:parquet-common:1.12.0'
-    testImplementation 'org.apache.parquet:parquet-hadoop:1.12.0'
-    testImplementation 'org.apache.parquet:parquet-hadoop-bundle:1.12.0'
-    testImplementation 'org.apache.parquet:parquet-encoding:1.12.0'
-    testImplementation 'org.apache.parquet:parquet-column:1.12.0'
+    testImplementation 'org.apache.parquet:parquet-common:1.14.1'
+    testImplementation 'org.apache.parquet:parquet-hadoop:1.14.1'
+    testImplementation 'org.apache.parquet:parquet-hadoop-bundle:1.14.1'
+    testImplementation 'org.apache.parquet:parquet-encoding:1.14.1'
+    testImplementation 'org.apache.parquet:parquet-column:1.14.1'
     testImplementation ('org.apache.hadoop:hadoop-common:3.3.1')  {
         exclude group: 'com.sun.jersey', module: 'jersey-core'
         exclude group: 'com.sun.jersey', module: 'jersey-servlet'

--- a/src/main/java/bio/terra/service/auth/ras/EcmService.java
+++ b/src/main/java/bio/terra/service/auth/ras/EcmService.java
@@ -5,6 +5,7 @@ import bio.terra.app.configuration.EcmConfiguration;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.externalcreds.api.PassportApi;
 import bio.terra.externalcreds.client.ApiClient;
+import bio.terra.externalcreds.model.PassportProvider;
 import bio.terra.externalcreds.model.RASv1Dot1VisaCriterion;
 import bio.terra.externalcreds.model.ValidatePassportRequest;
 import bio.terra.externalcreds.model.ValidatePassportResult;
@@ -37,7 +38,6 @@ public class EcmService {
   private final ObjectMapper objectMapper;
   private final OidcApiService oidcApiService;
 
-  private static final String RAS_PROVIDER = "ras";
   @VisibleForTesting public static final String GA4GH_PASSPORT_V1_CLAIM = "ga4gh_passport_v1";
   private static final String RAS_DBGAP_PERMISSIONS_CLAIM = "ras_dbgap_permissions";
   private static final String RAS_CRITERIA_TYPE = "RASv1Dot1VisaCriterion";
@@ -98,7 +98,7 @@ public class EcmService {
    */
   public String getRasProviderPassport(AuthenticatedUserRequest userReq) {
     try {
-      return oidcApiService.getOidcApi(userReq).getProviderPassport(RAS_PROVIDER);
+      return oidcApiService.getOidcApi(userReq).getProviderPassport(PassportProvider.RAS);
     } catch (HttpClientErrorException ex) {
       if (ex.getStatusCode() == HttpStatus.NOT_FOUND) {
         return null;

--- a/src/main/java/bio/terra/service/policy/PolicyService.java
+++ b/src/main/java/bio/terra/service/policy/PolicyService.java
@@ -62,7 +62,7 @@ public class PolicyService {
   public TpsPaoGetResult getPao(UUID resourceId) {
     TpsApi tpsApi = policyApiService.getPolicyApi();
     try {
-      return tpsApi.getPao(resourceId);
+      return tpsApi.getPao(resourceId, false);
     } catch (ApiException e) {
       throw convertApiException(e);
     }

--- a/src/test/java/bio/terra/common/BQTestUtils.java
+++ b/src/test/java/bio/terra/common/BQTestUtils.java
@@ -66,8 +66,11 @@ public final class BQTestUtils {
 
   private static Answer<TableResult> mockAnswer(Schema schema, List<Map<String, String>> results) {
     return a ->
-        new TableResult(
-            schema, results.size(), new PageImpl<>(null, null, convertValues(results, schema)));
+        TableResult.newBuilder()
+            .setSchema(schema)
+            .setTotalRows((long) results.size())
+            .setPageNoSchema(new PageImpl<>(null, null, convertValues(results, schema)))
+            .build();
   }
 
   private static List<FieldValueList> convertValues(

--- a/src/test/java/bio/terra/service/auth/iam/ras/EcmServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/ras/EcmServiceTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +12,7 @@ import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.externalcreds.api.OidcApi;
+import bio.terra.externalcreds.model.PassportProvider;
 import bio.terra.service.auth.ras.EcmService;
 import bio.terra.service.auth.ras.OidcApiService;
 import bio.terra.service.auth.ras.RasDbgapPermissions;
@@ -56,7 +56,7 @@ class EcmServiceTest {
     String passport = "passportJwt";
     HttpClientErrorException shouldCatch = new HttpClientErrorException(HttpStatus.NOT_FOUND);
     HttpClientErrorException shouldThrow = new HttpClientErrorException(HttpStatus.UNAUTHORIZED);
-    when(oidcApi.getProviderPassport(any()))
+    when(oidcApi.getProviderPassport(PassportProvider.RAS))
         .thenReturn(passport)
         .thenThrow(shouldCatch)
         .thenThrow(shouldThrow);
@@ -75,7 +75,7 @@ class EcmServiceTest {
 
   @Test
   void testGetRasDbgapPermissionsNoPassport() throws Exception {
-    when(oidcApi.getProviderPassport(any()))
+    when(oidcApi.getProviderPassport(PassportProvider.RAS))
         .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
     assertThat(
         "No RAS dbGaP permissions when a user doesn't have a passport",
@@ -85,7 +85,7 @@ class EcmServiceTest {
 
   @Test
   void testGetRasDbgapPermissionsNoVisaClaim() throws Exception {
-    when(oidcApi.getProviderPassport(any())).thenReturn(toJwtToken("{}"));
+    when(oidcApi.getProviderPassport(PassportProvider.RAS)).thenReturn(toJwtToken("{}"));
     assertThat(
         "No RAS dbGaP permissions when a user's passport has no visa claim'",
         ecmService.getRasDbgapPermissions(TEST_USER),
@@ -94,7 +94,7 @@ class EcmServiceTest {
 
   @Test
   void testGetRasDbgapPermissionsNoVisas() throws Exception {
-    when(oidcApi.getProviderPassport(any())).thenReturn(toPassportJwt(null));
+    when(oidcApi.getProviderPassport(PassportProvider.RAS)).thenReturn(toPassportJwt(null));
     assertThat(
         "No RAS dbGaP permissions when a user's passport has no visas",
         ecmService.getRasDbgapPermissions(TEST_USER),
@@ -110,7 +110,7 @@ class EcmServiceTest {
         "ras_dbgap_permissions": "should throw InvalidDefinitionException"
       }
       """;
-    when(oidcApi.getProviderPassport(any())).thenReturn(toPassportJwt(invalidVisa));
+    when(oidcApi.getProviderPassport(PassportProvider.RAS)).thenReturn(toPassportJwt(invalidVisa));
 
     assertThat(
         "No RAS dbGaP permissions when a user's passport has invalid visas",
@@ -143,7 +143,7 @@ class EcmServiceTest {
         ]
       }
       """;
-    when(oidcApi.getProviderPassport(any())).thenReturn(toPassportJwt(validVisa));
+    when(oidcApi.getProviderPassport(PassportProvider.RAS)).thenReturn(toPassportJwt(validVisa));
 
     assertThat(
         "Passport visa permissions are successfully decoded and unknown properties ignored",

--- a/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
+++ b/src/test/java/bio/terra/service/policy/PolicyServiceTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.policy;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -19,6 +20,7 @@ import bio.terra.policy.client.ApiException;
 import bio.terra.policy.model.TpsComponent;
 import bio.terra.policy.model.TpsObjectType;
 import bio.terra.policy.model.TpsPaoCreateRequest;
+import bio.terra.policy.model.TpsPaoGetResult;
 import bio.terra.policy.model.TpsPaoUpdateRequest;
 import bio.terra.policy.model.TpsPolicyInput;
 import bio.terra.policy.model.TpsPolicyInputs;
@@ -209,7 +211,8 @@ class PolicyServiceTest {
   @Test
   void getPao() throws ApiException {
     mockPolicyApi();
-    policyService.getPao(snapshotId);
-    verify(tpsApi).getPao(snapshotId);
+    var expected = new TpsPaoGetResult().objectId(snapshotId);
+    when(tpsApi.getPao(snapshotId, false)).thenReturn(expected);
+    assertThat(policyService.getPao(snapshotId), equalTo(expected));
   }
 }

--- a/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
@@ -1061,7 +1061,8 @@ class BigQueryPdaoUnitTest {
 
     Page<FieldValueList> page = mockPage(listOfFieldValueList);
 
-    TableResult table = new TableResult(schema, 10, page);
+    TableResult table =
+        TableResult.newBuilder().setSchema(schema).setTotalRows(10L).setPageNoSchema(page).build();
 
     List<BigQueryDataResultModel> result = BigQueryPdao.aggregateTableData(table);
 
@@ -1091,7 +1092,8 @@ class BigQueryPdaoUnitTest {
                             "2"))))); // For some reason, it wants the numeric value passed in as a
     // string
 
-    TableResult table = new TableResult(schema, 10, page);
+    TableResult table =
+        TableResult.newBuilder().setSchema(schema).setTotalRows(10L).setPageNoSchema(page).build();
 
     List<ColumnStatisticsTextValue> result =
         BigQueryPdao.aggregateTextColumnStats(table, columnName);


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-400

## Addresses

Minor and patch dependency updates, which should take care of most of the updates proposed in https://github.com/DataBiosphere/jade-data-repo/pull/1763 (TDR's first grouped Dependabot PR) and triangulate on remaining troublesome ones.

I broke up my changes into logical commits for easier review.

## Summary of changes

| Package | From | To |
| --- | --- | --- |
| [com.google.cloud:libraries-bom](https://github.com/googleapis/java-cloud-bom) | `26.30.0` | `26.43.0` |
| [org.liquibase:liquibase-core](https://github.com/liquibase/liquibase) | `4.26.0` | `4.29.1` |
| [org.antlr:ST4](https://github.com/antlr/stringtemplate4) | `4.3` | `4.3.4` |
| net.javacrumbs.shedlock:shedlock-provider-jdbc-template | `5.2.0` | `5.14.0` |
| [net.javacrumbs.shedlock:shedlock-spring](https://github.com/lukas-krecan/ShedLock) | `5.2.0` | `5.14.0` |
| bio.terra:terra-policy-client | `1.0.11-SNAPSHOT` | `1.0.15-SNAPSHOT` |
| bio.terra:externalcreds-client-resttemplate | `1.3.0-SNAPSHOT` | `1.45.0-SNAPSHOT` |
| [com.fasterxml.jackson.core:jackson-core](https://github.com/FasterXML/jackson-core) | `2.15.3` | [2.17.2](https://github.com/spring-projects/spring-boot/blob/a4c428a328d969fb963074f25981f5fc30b34bfd/gradle.properties#L12) (now versioned by Spring dependency manager) |
| [com.fasterxml.jackson.core:jackson-annotations](https://github.com/FasterXML/jackson) | `2.15.3` | [2.17.2](https://github.com/spring-projects/spring-boot/blob/a4c428a328d969fb963074f25981f5fc30b34bfd/gradle.properties#L12) (now versioned by Spring dependency manager) |
| [com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson) | `2.15.3` | [2.17.2](https://github.com/spring-projects/spring-boot/blob/a4c428a328d969fb963074f25981f5fc30b34bfd/gradle.properties#L12) (now versioned by Spring dependency manager) |
| [com.azure:azure-identity](https://github.com/Azure/azure-sdk-for-java) | `1.11.1` | `1.13.2` |
| [com.azure.resourcemanager:azure-resourcemanager](https://github.com/Azure/azure-sdk-for-java) | `2.34.0` | `2.41.0` |
| [com.azure:azure-storage-common](https://github.com/Azure/azure-sdk-for-java) | `12.24.1` | `12.26.0` |
| [com.azure:azure-storage-file-datalake](https://github.com/Azure/azure-sdk-for-java) | `12.18.1` | `12.20.0` |
| [com.azure:azure-data-tables](https://github.com/Azure/azure-sdk-for-java) | `12.3.18` | `12.4.3` |
| [io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations](https://github.com/open-telemetry/opentelemetry-java-instrumentation) | `2.2.0` | `2.6.0` |
| [org.apache.parquet:parquet-common](https://github.com/apache/parquet-mr) | `1.12.0` | `1.14.1` |
| [org.apache.parquet:parquet-hadoop](https://github.com/apache/parquet-mr) | `1.12.0` | `1.14.1` |
| [org.apache.parquet:parquet-hadoop-bundle](https://github.com/apache/parquet-mr) | `1.12.0` | `1.14.1` |
| [org.apache.parquet:parquet-encoding](https://github.com/apache/parquet-mr) | `1.12.0` | `1.14.1` |
| [org.apache.parquet:parquet-column](https://github.com/apache/parquet-mr) | `1.12.0` | `1.14.1` |
| org.apache.hadoop:hadoop-common | `3.3.1` | `3.4.0` |
| org.apache.hadoop:hadoop-azure | `3.3.1` | Removed (unused) |
| org.apache.hadoop:hadoop-mapreduce-client-core | `3.3.1` | `3.4.0` |
| [au.com.dius.pact.provider:junit5](https://github.com/pact-foundation/pact-jvm) | `4.3.19` | `4.6.12` |
| [au.com.dius.pact.provider:junit5spring](https://github.com/pact-foundation/pact-jvm) | `4.3.19` | `4.6.12` |
| [org.antlr:antlr4](https://github.com/antlr/antlr4) | `4.8` | `4.13.2` |
| [org.codehaus.groovy:groovy](https://github.com/apache/groovy) | `3.0.7` | Removed (unused) |
| [info.picocli:picocli](https://github.com/remkop/picocli) | `4.7.5` | `4.7.6` |
| [io.zonky.test:embedded-database-spring-test](https://github.com/zonkyio/embedded-database-spring-test) | `2.5.0` | `2.5.1` |
| [io.zonky.test:embedded-postgres](https://github.com/zonkyio/embedded-postgres) | `2.0.6` | `2.0.7` |
| com.google.cloud.tools.jib | `3.2.0` | `3.4.3` |
| org.gradle.test-retry | `1.5.8` | `1.5.10` |
| [org.springframework.boot](https://github.com/spring-projects/spring-boot) | `3.2.4` | `3.3.2` |
| [io.spring.dependency-management](https://github.com/spring-gradle-plugins/dependency-management-plugin) | `1.1.4` | `1.1.6` |
| com.gorylenko.gradle-git-properties | `2.4.1` | `2.4.2` |

## Testing Strategy

- Expanded unit tests to cover modified code.
- Ran a Static Code Analysis off of this feature branch to confirm that no vulnerabilities were introduced or reintroduced: https://github.com/broadinstitute/dsp-appsec-sourceclear-github-actions/actions/runs/10292414130/job/28486770708

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
