### PR TITLE
[ID-1364] Log x-transaction-id header from Drshub

### DIFF
--- a/src/main/java/bio/terra/app/usermetrics/BardEventProperties.java
+++ b/src/main/java/bio/terra/app/usermetrics/BardEventProperties.java
@@ -12,4 +12,5 @@ public final class BardEventProperties {
   public static final String DATASET_ID_FIELD_NAME = "datasetId";
   public static final String DATASET_NAME_FIELD_NAME = "datasetName";
   public static final String CLOUD_PLATFORM_FIELD_NAME = "cloudPlatform";
+  public static final String TRANSACTION_ID_FIELD_NAME = "transactionId";
 }

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -67,6 +67,8 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
             Map.of(
                 BardEventProperties.METHOD_FIELD_NAME, method,
                 BardEventProperties.PATH_FIELD_NAME, path));
+    addToPropertiesIfPresentInHeader(
+        request, properties, "x-transaction-id", BardEventProperties.TRANSACTION_ID_FIELD_NAME);
     eventProperties.setAll(properties);
     HashMap<String, Object> bardEventProperties = eventProperties.get();
 
@@ -85,5 +87,26 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
   /** Should we actually ignore sending a tracking event for this path */
   private boolean ignoreEventForPath(String path) {
     return metricsConfig.ignorePaths().stream().anyMatch(p -> FilenameUtils.wildcardMatch(path, p));
+  }
+
+  /**
+   * If a given header is present in the request and has a value, add it to the properties map to be
+   * tracked in Bard
+   *
+   * @param request The request being logged
+   * @param properties The properties map that will be sent to Bard for tracking
+   * @param headerName The name of the header to examine
+   * @param propertyName The name of the map key to use when adding the header value to the
+   *     properties map
+   */
+  private void addToPropertiesIfPresentInHeader(
+      HttpServletRequest request,
+      Map<String, Object> properties,
+      String headerName,
+      String propertyName) {
+    var headerValue = request.getHeader(headerName);
+    if (headerValue != null) {
+      properties.put(propertyName, headerValue);
+    }
   }
 }

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -68,7 +68,7 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
                 BardEventProperties.METHOD_FIELD_NAME, method,
                 BardEventProperties.PATH_FIELD_NAME, path));
     addToPropertiesIfPresentInHeader(
-        request, properties, "x-transaction-id", BardEventProperties.TRANSACTION_ID_FIELD_NAME);
+        request, properties, "X-Transaction-Id", BardEventProperties.TRANSACTION_ID_FIELD_NAME);
     eventProperties.setAll(properties);
     HashMap<String, Object> bardEventProperties = eventProperties.get();
 

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -168,6 +168,33 @@ class UserMetricsInterceptorTest {
   }
 
   @Test
+  void testSendEventWithTransactionIdHeader() throws Exception {
+    String transactionId = UUID.randomUUID().toString();
+    when(request.getHeader("x-transaction-id")).thenReturn(transactionId);
+    mockRequestAuth(request);
+
+    runAndWait();
+
+    verify(bardClient)
+        .logEvent(
+            authCaptor.capture(),
+            eq(
+                new BardEvent(
+                    UserMetricsInterceptor.API_EVENT_NAME,
+                    Map.of(
+                        BardEventProperties.METHOD_FIELD_NAME,
+                        METHOD.toUpperCase(),
+                        BardEventProperties.PATH_FIELD_NAME,
+                        REQUEST_URI,
+                        BardEventProperties.TRANSACTION_ID_FIELD_NAME,
+                        transactionId),
+                    APP_ID,
+                    DNS_NAME)));
+
+    assertThat("token is correct", authCaptor.getValue().getToken(), equalTo(TOKEN));
+  }
+
+  @Test
   void testSendEventNotFiredWithNoBardBasePath() throws Exception {
     when(metricsConfig.bardBasePath()).thenReturn(null);
 

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -106,7 +106,6 @@ class UserMetricsInterceptorTest {
   @Test
   void testSendEvent() throws Exception {
     mockRequestAuth(request);
-
     runAndWait();
 
     verify(bardClient)
@@ -170,7 +169,7 @@ class UserMetricsInterceptorTest {
   @Test
   void testSendEventWithTransactionIdHeader() throws Exception {
     String transactionId = UUID.randomUUID().toString();
-    when(request.getHeader("x-transaction-id")).thenReturn(transactionId);
+    when(request.getHeader("X-Transaction-Id")).thenReturn(transactionId);
     mockRequestAuth(request);
 
     runAndWait();


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/ID-1364

## Addresses
This will allow Bard logs from TDR and Drshub for the same resolve request to be joined in BigQuery.

## Summary of changes
If an "x-transaction-id" header is present on a request, log it to Bard along with the request properties.

## Testing Strategy
Unit testing (will follow up with manual testing once the OIDC proxy is updated to allow this header)

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
