### PR TITLE
[DCJ-603] Double Gradle build VM's max heap size 512m -> 1g

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,8 @@ dbDatarepoChangesetFile=src/main/resources/db/changelog.xml
 dbStairwayUri=jdbc:postgresql://127.0.0.1:5432/stairway
 dbStairwayUsername=drmanager
 dbStairwayPassword=drpasswd
+# Increasing max heap size from default of 512m:
+# https://docs.gradle.org/current/userguide/config_gradle.html#sec:configuring_jvm_memory
+org.gradle.jvmargs=-Xms512m -Xmx1g "-XX:MaxMetaspaceSize=384m"
 org.gradle.parallel = true
 org.gradle.workers.max = 8


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-603

## Addresses

We are seeing sporadic Gradle check failures in CI with the following cause:

```
Execution failed for task ':sonar'.
> Java heap space
```

The build VM defaults to the following JVM args:
```
-Xmx512m "-XX:MaxMetaspaceSize=384m"
```

## Summary of changes

This commit follows guidance set in Gradle documentation to double the Gradle build VM's max heap size: https://docs.gradle.org/current/userguide/config_gradle.html#sec:configuring_jvm_memory

## Testing Strategy

I examined this PR's build scan performance against the performance of a failed run.  I confirmed that our PR run correctly reflects the new max heap size.

Failed run: https://github.com/DataBiosphere/jade-data-repo/actions/runs/10357286296/job/28668988273?pr=1771
Failed run's scan: https://scans.gradle.com/s/nyg2cy6mgm7qg/performance/build
<img width="1263" alt="Screenshot 2024-08-13 at 9 47 34 AM" src="https://github.com/user-attachments/assets/c1a6e85e-4b09-47ae-919a-9c4d28f30e16">

PR run: https://github.com/DataBiosphere/jade-data-repo/actions/runs/10362632175/job/28684936995?pr=1777
PR run's scan: https://scans.gradle.com/s/nutis7gkvmmio/performance/build
<img width="1210" alt="Screenshot 2024-08-13 at 9 48 56 AM" src="https://github.com/user-attachments/assets/a3c70755-b332-4de0-b056-ddca068d1d19">

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
