### PR TITLE
[DCJ-400] Ignore spotless 6.25.0 upgrade in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,7 @@
 
 # DR-1850: Replace checkstyle with spotless
 c6a70ff75f408fcb8dc36cda777e91b7a27be535
+
+# DCJ-400: Upgrade com.diffplug.spotless 6.7.1 -> 6.25.0
+# https://github.com/DataBiosphere/jade-data-repo/pull/1771
+99e385bd48fc7ab62b83d21f18682fcbb7147fa7

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,9 @@ plugins {
     id 'java'
     id 'io.spring.dependency-management' version '1.1.6'
     id 'jacoco'
-    id 'com.diffplug.spotless' version '6.25.0'
+    // After merging a spotless version update which requires a large-scale code reformat, add the
+    // commit hash to .git-blame-ignore-revs to avoid cluttering git blame.
+    id 'com.diffplug.spotless' version '6.25.0'  // SEE ABOVE.
     id 'com.dorongold.task-tree' version '4.0.0'
     // enables release info in sentry events
     id 'com.gorylenko.gradle-git-properties' version '2.4.2'


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-400

## Addresses

This PR is a follow-on from our upgrade of Spotless from 6.7.1 -> 6.25.0: https://github.com/DataBiosphere/jade-data-repo/pull/1771#pullrequestreview-2235884316

## Summary of changes

Under the assumption that most developers using `git blame` are doing so to track the history of interesting code changes rather than whitespace changes, added the Spotless upgrade commit to our git blame ignore list.

Documented this after-upgrade recommendation in `build.gradle` - Dependabot will try to upgrade Spotless for us in standalone PRs, and developer intervention to reformat will likely be needed.

## Testing Strategy

N/A

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
