### PR TITLE
[DCJ-610] JobModel includes more info on targeted resource

### DIFF
--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -264,6 +264,12 @@ public class JobService {
   public JobModel mapFlightStateToJobModel(FlightState flightState) {
     FlightMap inputParameters = flightState.getInputParameters();
     String description = inputParameters.get(JobMapKeys.DESCRIPTION.getKeyName(), String.class);
+    IamResourceType iamResourceType =
+        inputParameters.get(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.class);
+    String iamResourceId =
+        inputParameters.get(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), String.class);
+    IamAction iamResourceAction =
+        inputParameters.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class);
     String submittedDate = flightState.getSubmitted().toString();
     JobModel.JobStatusEnum jobStatus = getJobStatus(flightState);
 
@@ -282,14 +288,23 @@ public class JobService {
       completedDate = flightState.getCompleted().get().toString();
     }
 
-    return new JobModel()
-        .id(flightState.getFlightId())
-        .className(flightState.getClassName())
-        .description(description)
-        .jobStatus(jobStatus)
-        .statusCode(statusCode.value())
-        .submitted(submittedDate)
-        .completed(completedDate);
+    var jobModel =
+        new JobModel()
+            .id(flightState.getFlightId())
+            .className(flightState.getClassName())
+            .description(description)
+            .jobStatus(jobStatus)
+            .statusCode(statusCode.value())
+            .submitted(submittedDate)
+            .completed(completedDate)
+            .iamResourceId(iamResourceId);
+    if (iamResourceType != null) {
+      jobModel.iamResourceType(iamResourceType.getSamResourceName());
+    }
+    if (iamResourceAction != null) {
+      jobModel.iamResourceAction(iamResourceAction.toString());
+    }
+    return jobModel;
   }
 
   private JobModel.JobStatusEnum getJobStatus(FlightState flightState) {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -6709,6 +6709,17 @@ components:
         class_name:
           type: string
           description: Class name of the flight
+        iam_resource_type:
+          type: string
+          description: Type of the flight's target resource
+        iam_resource_id:
+          type: string
+          description: Unique identifier for the flight's target resource
+        iam_resource_action:
+          type: string
+          description: >
+            The Sam action which a caller must hold on the flight's target resource in order to
+            retrieve information about this flight
       description: >
         Status of job
     ErrorModel:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -6709,19 +6709,28 @@ components:
         class_name:
           type: string
           description: Class name of the flight
-        iam_resource_type:
+        target_iam_resource:
+          $ref: '#/components/schemas/JobTargetResourceModel'
+      description: >
+        Status of job
+    JobTargetResourceModel:
+      required:
+        - type
+        - id
+      type: object
+      description: The IAM resource targeted by a flight
+      properties:
+        type:
           type: string
           description: Type of the flight's target resource
-        iam_resource_id:
+        id:
           type: string
           description: Unique identifier for the flight's target resource
-        iam_resource_action:
+        action:
           type: string
           description: >
             The Sam action which a caller must hold on the flight's target resource in order to
             retrieve information about this flight
-      description: >
-        Status of job
     ErrorModel:
       required:
         - message


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-610

## Addresses

When debugging flights on behalf of users, it's not always clear from a flight's description or log spelunking what resource is being targeted.  We do not want to have to connect directly to the database to confirm, and would like to avoid needless back-and-forth with users.

## Summary of changes

Expand `JobModel` response body to include more information on the resource targeted by the flight: `targetIamResource` with fields `type`, `id`, and `action`.

We already pass this information as flight inputs for the majority of our flights, to enable Sam-based permission checks when retrieving information on flights.

When this change is merged in, we'll benefit from this change for flights that have already run, since we have several years of history where we pass in these input parameters.

## Testing Strategy

Expanded unit tests.

Locally, added additional print statements to unit tests for a visual into what the beefed-up `JobModel`s will look like:
```
class JobModel {
    id: fgK5VbjTTkCXv9F633zCnA
    description: flight2
    jobStatus: succeeded
    statusCode: 418
    submitted: null
    completed: null
    className: bio.terra.service.job.JobServiceTestFlight
    targetIamResource: class JobTargetResourceModel {
        type: dataset
        id: 6a430aa8-a84d-4ac3-8ed3-19ca7cc17c57
        action: share_policy::reader
    }
}
```

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
