### PR TITLE
DC-958: Catch and log google pubsub errors for now.

### DIFF
--- a/src/main/java/bio/terra/service/notification/NotificationService.java
+++ b/src/main/java/bio/terra/service/notification/NotificationService.java
@@ -2,6 +2,7 @@ package bio.terra.service.notification;
 
 import bio.terra.app.configuration.NotificationConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.gax.rpc.ApiException;
 import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
@@ -33,7 +34,7 @@ public class NotificationService {
     try {
       pubSubService.createTopic(
           notificationConfiguration.projectId(), notificationConfiguration.topicId());
-    } catch (IOException e) {
+    } catch (IOException | ApiException e) {
       logger.warn("Error creating notification topic", e);
     }
   }
@@ -47,7 +48,7 @@ public class NotificationService {
           objectMapper.writeValueAsString(
               new SnapshotReadyNotification(
                   subjectId, snapshotExportLink, snapshotName, snapshotSummary)));
-    } catch (IOException e) {
+    } catch (IOException | ApiException e) {
       logger.warn("Error sending notification", e);
     }
   }

--- a/src/main/java/bio/terra/service/notification/PubSubService.java
+++ b/src/main/java/bio/terra/service/notification/PubSubService.java
@@ -1,5 +1,6 @@
 package bio.terra.service.notification;
 
+import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.protobuf.ByteString;
@@ -15,7 +16,7 @@ import org.springframework.stereotype.Service;
 public class PubSubService {
   private static final Logger logger = LoggerFactory.getLogger(PubSubService.class);
 
-  public void createTopic(String projectId, String topicId) throws IOException {
+  public void createTopic(String projectId, String topicId) throws IOException, ApiException {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
       TopicName topicName = TopicName.of(projectId, topicId);
       if (topicAdminClient.getTopic(topicName) == null) {
@@ -25,7 +26,7 @@ public class PubSubService {
     }
   }
 
-  public void publishMessage(String projectId, String topicId, String message) throws IOException {
+  public void publishMessage(String projectId, String topicId, String message) throws IOException, ApiException {
     TopicName topicName = TopicName.of(projectId, topicId);
     var publisher = Publisher.newBuilder(topicName).build();
     publisher.publish(PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8(message)).build());

--- a/src/main/java/bio/terra/service/notification/PubSubService.java
+++ b/src/main/java/bio/terra/service/notification/PubSubService.java
@@ -26,7 +26,8 @@ public class PubSubService {
     }
   }
 
-  public void publishMessage(String projectId, String topicId, String message) throws IOException, ApiException {
+  public void publishMessage(String projectId, String topicId, String message)
+      throws IOException, ApiException {
     TopicName topicName = TopicName.of(projectId, topicId);
     var publisher = Publisher.newBuilder(topicName).build();
     publisher.publish(PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8(message)).build());


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-958

## Addresses

If pubsub permissions aren't set up correctly, failing to initialize the notification pubsub topic can cause TDR to fail to start up.

## Summary of changes

Until we have notifications enabled in all environments, catch exceptions and log them instead of throwing.

See https://javadoc.io/doc/com.google.cloud/google-cloud-pubsub/latest/com/google/cloud/pubsub/v1/TopicAdminClient.html#createTopic(com.google.pubsub.v1.ProjectTopicName) for documentation on APIs throwing `com.google.api.gax.rpc.ApiException`

## Testing Strategy

Tested locally by changing `application.properties`:
```
notification.projectId=invalid
```

When running, the error on startup is logged but TDR continues to start up:

```
2024-08-21 09:35:15,189 INFO  [main] b.t.s.f.azure.AzureSynapsePdao: Skipping Synapse database initialization
2024-08-21 09:35:16,768 WARN  [main] b.t.s.n.NotificationService: Error creating notification topic
com.google.api.gax.rpc.NotFoundException: io.grpc.StatusRuntimeException: NOT_FOUND: Resource not found (resource=workbench-notifications-dev).
[...]
2024-08-21 09:35:18,398 INFO  [main] o.a.coyote.http11.Http11NioProtocol: Starting ProtocolHandler ["http-nio-8080"]
2024-08-21 09:35:18,437 INFO  [main] bio.terra.Main: Started Main in 9.258 seconds (process running for 10.045)
```