### PR TITLE
DC-1203 - Unpin Protobuf Version

### DIFF
--- a/tools/setupResourceScripts/requirements.txt
+++ b/tools/setupResourceScripts/requirements.txt
@@ -1,3 +1,3 @@
 data-repo-client>=2.114.0
 google-cloud-bigquery
-protobuf==3.20.2
+protobuf


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1203

## Addresses

Where possible, we should unpin versions so that we don’t need to manage dependabot upgrades for our tools scripts. 

## Summary of changes

Unpin the version for protobuf, a resource used in our setup script.

## Testing Strategy
- run `pip3 install -r requirements.txt --upgrade` to install the latest version of protobuf, now that the pin is no loner there
- run the setup script `python3 setup_tdr_resources.py --host=http://localhost:8080 --datasets='datarepo_datasets.json'`
- Note: I ran into an issue with running the set up script. It is detailed in [this ticket. ](https://broadworkbench.atlassian.net/browse/DC-1228). I made a local change to workaround this issue for testing this change. 
- ✅ Script successfully ran
