### PR TITLE
DC-1228 - Handle empty IAM resource in JobTargetResourceModel

### DIFF
--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -303,20 +303,13 @@ public class JobService {
     IamAction iamResourceAction =
         inputParameters.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class);
 
-    JobTargetResourceModel targetResource = new JobTargetResourceModel();
-    if (iamResourceId != null) {
-      targetResource.setId(iamResourceId);
-    }
-    if (iamResourceType != null) {
-      targetResource.setType(iamResourceType.getSamResourceName());
-    }
-    if (iamResourceAction != null) {
-      targetResource.setAction(iamResourceAction.toString());
-    }
-    if (iamResourceId == null && iamResourceAction == null && iamResourceType == null) {
+    if (iamResourceId == null || iamResourceType == null || iamResourceAction == null) {
       return null;
     }
-    return targetResource;
+    return new JobTargetResourceModel()
+        .id(iamResourceId)
+        .type(iamResourceType.getSamResourceName())
+        .action(iamResourceAction.toString());
   }
 
   private JobModel.JobStatusEnum getJobStatus(FlightState flightState) {

--- a/src/main/java/bio/terra/service/job/JobService.java
+++ b/src/main/java/bio/terra/service/job/JobService.java
@@ -303,12 +303,18 @@ public class JobService {
     IamAction iamResourceAction =
         inputParameters.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class);
 
-    JobTargetResourceModel targetResource = new JobTargetResourceModel().id(iamResourceId);
+    JobTargetResourceModel targetResource = new JobTargetResourceModel();
+    if (iamResourceId != null) {
+      targetResource.setId(iamResourceId);
+    }
     if (iamResourceType != null) {
       targetResource.setType(iamResourceType.getSamResourceName());
     }
     if (iamResourceAction != null) {
       targetResource.setAction(iamResourceAction.toString());
+    }
+    if (iamResourceId == null && iamResourceAction == null && iamResourceType == null) {
+      return null;
     }
     return targetResource;
   }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -6717,6 +6717,7 @@ components:
       required:
         - type
         - id
+        - action
       type: object
       description: The IAM resource targeted by a flight
       properties:

--- a/src/test/java/bio/terra/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/service/job/JobServiceTest.java
@@ -304,11 +304,11 @@ class JobServiceTest {
         StairwayException.class, () -> jobService.retrieveJobResult("abcdef", Object.class, null));
   }
 
-  //  @Test
-  //  void testSubmissionAndRetrieval_noParameters() throws InterruptedException {
-  //    JobModel expectedJob = runFlightAndReturnExpectedJobModel(1, false);
-  //    testSingleRetrieval(expectedJob);
-  //  }
+  @Test
+  void testSubmissionAndRetrieval_noParameters() throws InterruptedException {
+    JobModel expectedJob = runFlightAndReturnExpectedJobModel(1, false);
+    testSingleRetrieval(expectedJob);
+  }
 
   private Matcher<JobModel> getJobMatcher(JobModel jobModel) {
     return samePropertyValuesAs(jobModel, "submitted", "completed");
@@ -329,12 +329,13 @@ class JobServiceTest {
   private JobModel runFlightAndReturnExpectedJobModel(int i, boolean shouldAddParameters) {
     String description = makeDescription(i);
     Class<? extends Flight> flightClass = makeFlightClass(i);
-    JobTargetResourceModel targetResource = new JobTargetResourceModel();
+    JobTargetResourceModel targetResource = null;
     if (shouldAddParameters) {
-      targetResource
-          .type(IAM_RESOURCE_TYPE.getSamResourceName())
-          .id(IAM_RESOURCE_ID)
-          .action(IAM_RESOURCE_ACTION.toString());
+      targetResource =
+          new JobTargetResourceModel()
+              .type(IAM_RESOURCE_TYPE.getSamResourceName())
+              .id(IAM_RESOURCE_ID)
+              .action(IAM_RESOURCE_ACTION.toString());
     }
     // Submit a flight with optional input parameters and wait for it to finish.
     String jobId =

--- a/src/test/java/bio/terra/service/job/JobServiceTest.java
+++ b/src/test/java/bio/terra/service/job/JobServiceTest.java
@@ -304,11 +304,11 @@ class JobServiceTest {
         StairwayException.class, () -> jobService.retrieveJobResult("abcdef", Object.class, null));
   }
 
-  @Test
-  void testSubmissionAndRetrieval_noParameters() throws InterruptedException {
-    JobModel expectedJob = runFlightAndReturnExpectedJobModel(1, false);
-    testSingleRetrieval(expectedJob);
-  }
+  //  @Test
+  //  void testSubmissionAndRetrieval_noParameters() throws InterruptedException {
+  //    JobModel expectedJob = runFlightAndReturnExpectedJobModel(1, false);
+  //    testSingleRetrieval(expectedJob);
+  //  }
 
   private Matcher<JobModel> getJobMatcher(JobModel jobModel) {
     return samePropertyValuesAs(jobModel, "submitted", "completed");


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/[ticket_number]

## Addresses
The  setup script is currently broken. It is due to this change to the JobModel - [[DCJ-610] JobModel includes more info on targeted resource by okotsopoulos · Pull Request #1779 · DataBiosphere/jade-data-repo](https://github.com/DataBiosphere/jade-data-repo/pull/1779) . The "type" on the target_iam_resource is null until the resource is created. But, we have "type" as a [required field](https://github.com/DataBiosphere/jade-data-repo/pull/1779/files#diff-c18be1e753bc03f251a6a0e643024b68d3ce256f7e289376fb5afe3844c70b56R6718).


The error on retrieving the job result in the python script: ValueError("Invalid value for `type`, must not be `None`") On directly hitting the create billing profile endpoint, we can see that the type on target_iam_resource is null.

```
{
  "id": "zH9v05hNSe-mpT-9-B8F_A",
  "description": "Create billing profile 'ui_integration_data_2'",
  "job_status": "running",
  "status_code": 202,
  "submitted": "2024-08-20T18:29:37.434125Z",
  "completed": null,
  "class_name": "bio.terra.service.profile.flight.create.ProfileCreateFlight",
  "target_iam_resource": {
    "type": null,
    "id": null,
    "action": null
  }
}
```

## Summary of changes
- If any of the job fields (type, id, or action) are null then return null instead of an empty JobTargetResourceModel
- Make all three job fields required

## Testing Strategy
- Updated unit tests to reflect this change
- Run setup script with this change


[DCJ-610]: https://broadworkbench.atlassian.net/browse/DCJ-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ