### PR TITLE
[DCJ-640] Update integration tests in GitHub Action to latest standards

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -144,7 +144,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: api-logs
+          name: integration-test-api-logs
           path: local-api-output.log
           retention-days: 7
   git_hash:
@@ -162,6 +162,7 @@ jobs:
           echo "GIT_HASH=${GIT_HASH}" >> $GITHUB_OUTPUT
           echo "Latest git hash in branch is ${GIT_HASH}"
   report-to-sherlock:
+    # only runs on pull requests and reports the appVersion even if tests fail
     if: github.event_name == 'pull_request'
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: git_hash
@@ -174,6 +175,7 @@ jobs:
   report-workflow:
     if: github.ref == 'refs/heads/develop'
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    # dependency is not required but makes the action run page more readable
     needs: git_hash
     with:
       relates-to-chart-releases: 'datarepo-dev'

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -179,3 +179,37 @@ jobs:
           name: api-logs
           path: local-api-output.log
           retention-days: 7
+  git_hash:
+    name: Extract git hash
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.config.outputs.GIT_HASH }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get the latest git hash
+        id: config
+        run: |
+          GIT_HASH=$(git rev-parse --short HEAD)
+          echo "GIT_HASH=${GIT_HASH}" >> $GITHUB_OUTPUT
+          echo "Latest git hash in branch is ${GIT_HASH}"
+  report-to-sherlock:
+    if: github.event_name == 'pull_request'
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: git_hash
+    with:
+      new-version: ${{ needs.git_hash.outputs.version }}
+      chart-name: 'datarepo'
+    permissions:
+      contents: read
+      id-token: write
+  report-workflow:
+    if: github.ref == 'refs/heads/develop'
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    needs: git_hash
+    with:
+      relates-to-chart-releases: 'datarepo-dev'
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+    permissions:
+      id-token: write

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -138,6 +138,9 @@ jobs:
           AZURE_CREDENTIALS_APPLICATIONID: 0e29ec36-04e8-44d5-ae7c-50dc15135571
           AZURE_CREDENTIALS_HOMETENANTID: fad90753-2022-4456-9b0a-c7e5b934e408
           AZURE_CREDENTIALS_SECRET: ${{ secrets.AZURE_CREDENTIALS_SECRET }}
+          AZURE_SYNAPSE_SQLADMINUSER: ${{ secrets.AZURE_SYNAPSE_SQLADMINUSER }}
+          AZURE_SYNAPSE_SQLADMINPASSWORD: ${{ secrets.AZURE_SYNAPSE_SQLADMINPASSWORD }}
+          AZURE_SYNAPSE_WORKSPACENAME: tdr-snps-int-east-us-ondemand.sql.azuresynapse.net
           # required for integration tests
           GOOGLE_APPLICATION_CREDENTIALS: jade-dev-account.json
           GOOGLE_SA_CERT: jade-dev-account.pem
@@ -147,6 +150,8 @@ jobs:
           PGPASSWORD: postgres
           # required for integration tests
           RBS_CLIENT_CREDENTIAL_FILE_PATH: rbs-tools-sa.json
+          RBS_INSTANCEURL: https://buffer.tools.integ.envs.broadinstitute.org
+          RBS_POOLID: datarepo_v1
           # output plain logs instead of json
           TDR_LOG_APPENDER: 'Console-Standard'
         run: |

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -26,15 +26,17 @@ jobs:
           cache: 'gradle'
       - name: Run unit tests
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
+          # required for unit tests
+          GOOGLE_APPLICATION_CREDENTIALS: jade-dev-account.json
+          # required for sonarqube reports
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # output plain logs instead of json
           TDR_LOG_APPENDER: 'Console-Standard'
         run: |
           # extract service account credentials
           base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
           # assemble code, run unit tests, and generate scan
-          ./gradlew assemble
-          ./gradlew check --scan jacocoTestReport sonar
+          ./gradlew --scan assemble check jacocoTestReport sonar
   test_connected:
     name: Connected tests
     runs-on: ubuntu-latest
@@ -74,14 +76,43 @@ jobs:
           base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
           base64 --decode <<< ${{ secrets.B64_RBS_APPLICATION_CREDENTIALS }} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
           # assemble code and run connected tests
-          ./gradlew assemble
-          ./gradlew testConnected --scan
+          ./gradlew --scan assemble testConnected
+  test_smoke:
+    name: Smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+      - name: Run Test Runner smoke tests
+        env:
+          # required for smoke tests
+          GOOGLE_APPLICATION_CREDENTIALS: jade-dev-account.json
+          TEST_RUNNER_SA_KEY_DIRECTORY_PATH: '..'
+          # output plain logs instead of json
+          TDR_LOG_APPENDER: 'Console-Standard'
+        run: |
+          # extract service account credentials
+          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          # build the datarepo-client subproject
+          ENABLE_SUBPROJECT_TASKS=1 ./gradlew :datarepo-client:clean :datarepo-client:assemble
+          # find the datarepo-client jar from the clienttests subproject
+          # the odd capitalization of the environment variable is required
+          cd datarepo-clienttests
+          export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
+          # assemble code and run smoke tests
+          sed -i 's/"skipKubernetes": false/"skipKubernetes": true/' src/main/resources/servers/integration-6.json
+          ./gradlew spotlessCheck spotbugsMain runTest --args="suites/PRSmokeTests.json /tmp/TestRunnerResults"
   test_integration:
     name: Integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 300
-    outputs:
-      api_image_tag: ${{ steps.configuration.outputs.git_hash }}
     services:
       postgres:
         image: postgres:11
@@ -92,13 +123,6 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-    env:
-      # this must be defined for the bash redirection
-      GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
-      # this must be defined for the bash redirection
-      GOOGLE_SA_CERT: 'jade-dev-account.pem'
-      # required for locking and deployment to integration namespace
-      K8_CLUSTER: 'integration-master'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -108,103 +132,45 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
-      - name: Whitelist Runner IP
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        with:
-          actions_subcommand: 'gcp_whitelist'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-      - name: Check for an available namespace to deploy API to and set state lock
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        with:
-          actions_subcommand: 'k8_checknamespace'
-          k8_namespaces: 'integration-1,integration-2,integration-3,integration-6'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-      - name: Build docker container via Gradle
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        env:
-          # unset the GitHub Action default JAVA_HOME to build with JDK 17
-          JAVA_HOME:
-        with:
-          actions_subcommand: 'gradlebuild' # creates gcr build with git_hash tag
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-      - name: Deploy to cluster with Helm
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        with:
-          actions_subcommand: 'helmdeploy'
-          helm_create_secret_manager_secret_version: 0.0.8
-          helm_datarepo_api_chart_version: 0.0.753
-          helm_datarepo_ui_chart_version: 0.0.365
-          helm_gcloud_sqlproxy_chart_version: 0.19.13
-          helm_oidc_proxy_chart_version: 0.0.44
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-      - name: Fetch gitHash for deployed integration version
-        id: configuration
-        run: |
-          git_hash=$(git rev-parse --short HEAD)
-          echo "git_hash=${git_hash}" >> $GITHUB_OUTPUT
-          echo "Latest git hash for this branch: $git_hash"
-      - name: Wait for deployment to come back online
-        uses: broadinstitute/datarepo-actions/actions/wait-for-deployment@0.74.0
-        timeout-minutes: 20
-        env:
-          DESIRED_GITHASH: ${{ steps.configuration.outputs.git_hash }}
-          DEPLOYMENT_TYPE: 'api'
-      - name: Run test runner smoke tests via Gradle
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        env:
-          # unset the GitHub Action default JAVA_HOME to run with JDK 17
-          JAVA_HOME:
-          # output plain logs instead of json
-          TDR_LOG_APPENDER: 'Console-Standard'
-        with:
-          actions_subcommand: 'gradletestrunnersmoketest'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-      - name: Run integration tests via Gradle
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
+      - name: Run integration tests
         env:
           # required for azure tests
           AZURE_CREDENTIALS_APPLICATIONID: 0e29ec36-04e8-44d5-ae7c-50dc15135571
           AZURE_CREDENTIALS_HOMETENANTID: fad90753-2022-4456-9b0a-c7e5b934e408
           AZURE_CREDENTIALS_SECRET: ${{ secrets.AZURE_CREDENTIALS_SECRET }}
-          # unset the GitHub Action default JAVA_HOME to run with JDK 17
-          JAVA_HOME:
+          # required for integration tests
+          GOOGLE_APPLICATION_CREDENTIALS: jade-dev-account.json
+          GOOGLE_SA_CERT: jade-dev-account.pem
+          IT_JADE_API_URL: http://localhost:8080
+          # postgres connection details
+          PGHOST: 127.0.0.1
+          PGPASSWORD: postgres
+          # required for integration tests
+          RBS_CLIENT_CREDENTIAL_FILE_PATH: rbs-tools-sa.json
           # output plain logs instead of json
           TDR_LOG_APPENDER: 'Console-Standard'
-        with:
-          actions_subcommand: 'gradleinttest'
-          pgport: ${{ job.services.postgres.ports[5432] }}
-          test_to_run: 'testIntegration'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-      - name: Clean state lock from used Namespace on API deploy
+        run: |
+          # wait for postgres to be ready
+          pg_isready -h ${PGHOST} -t 30
+          # create the datarepo and stairway databases
+          psql -U postgres -f ./db/create-data-repo-db
+          # extract service account credentials
+          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          jq -r .private_key ${GOOGLE_APPLICATION_CREDENTIALS} > ${GOOGLE_SA_CERT}
+          chmod 644 ${GOOGLE_SA_CERT}
+          base64 --decode <<< ${{ secrets.B64_RBS_APPLICATION_CREDENTIALS }} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
+          # build code and run local api
+          ./gradlew bootJar
+          export DATA_REPO_JAR=$(find . -type f -name jade-data-repo-*-SNAPSHOT.jar)
+          java -jar ${DATA_REPO_JAR} > local-api-output.log &
+          # wait until api is ready
+          timeout 30 bash -c 'until curl -s ${IT_JADE_API_URL}/status; do sleep 1; done'
+          # run integration tests
+          ./gradlew --scan testIntegration
+      - name: Upload API logs
         if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
+        uses: actions/upload-artifact@v4
         with:
-          actions_subcommand: 'k8_checknamespace_clean'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-      - name: Clean whitelisted Runner IP
-        if: always()
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        with:
-          actions_subcommand: 'gcp_whitelist_clean'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-  report-to-sherlock:
-    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: test_integration
-    # Always attempt to run if pull_request, as we want to report the appVersion even if the tests fail.
-    # never run on cron or other runs as we don't want extranaeous build reporting.
-    if: github.event_name == 'pull_request'
-    with:
-      new-version: ${{ needs.test_integration.outputs.api_image_tag }}
-      chart-name: 'datarepo'
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-  report-workflow:
-    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
-    if: ${{ github.ref == 'refs/heads/develop' }}
-    with:
-      relates-to-chart-releases: 'datarepo-dev'
-      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
-      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
-    permissions:
-      id-token: write
+          name: api-logs
+          path: local-api-output.log
+          retention-days: 7

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -77,38 +77,6 @@ jobs:
           base64 --decode <<< ${{ secrets.B64_RBS_APPLICATION_CREDENTIALS }} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
           # assemble code and run connected tests
           ./gradlew --scan assemble testConnected
-  test_smoke:
-    name: Smoke tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-      - name: Run Test Runner smoke tests
-        env:
-          # required for smoke tests
-          GOOGLE_APPLICATION_CREDENTIALS: jade-dev-account.json
-          TEST_RUNNER_SA_KEY_DIRECTORY_PATH: '..'
-          # output plain logs instead of json
-          TDR_LOG_APPENDER: 'Console-Standard'
-        run: |
-          # extract service account credentials
-          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
-          # build the datarepo-client subproject
-          ENABLE_SUBPROJECT_TASKS=1 ./gradlew :datarepo-client:clean :datarepo-client:assemble
-          # find the datarepo-client jar from the clienttests subproject
-          # the odd capitalization of the environment variable is required
-          cd datarepo-clienttests
-          export ORG_GRADLE_PROJECT_datarepoclientjar=$(find .. -type f -name "datarepo-client*.jar")
-          # assemble code and run smoke tests
-          sed -i 's/"skipKubernetes": false/"skipKubernetes": true/' src/main/resources/servers/integration-6.json
-          ./gradlew spotlessCheck spotbugsMain runTest --args="suites/PRSmokeTests.json /tmp/TestRunnerResults"
   test_integration:
     name: Integration tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DCJ-640

## Summary of changes

Removes use of `datarepo-actions` in integrations tests.

## Testing Strategy

Tested in branch, can also be tested manually with `workflow_dispatch`

Latest run (all green): https://github.com/DataBiosphere/jade-data-repo/actions/runs/10634337497
