### PR TITLE
[DCJ-647] Optimize dataset_relationship retrieval

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetRelationshipDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRelationshipDao.java
@@ -28,7 +28,14 @@ public class DatasetRelationshipDao {
     this.jdbcTemplate = jdbcTemplate;
   }
 
-  // part of a transaction propagated from DatasetDao
+  /**
+   * When creating new relationships, callers should note that relationships are assumed to exist
+   * only between tables in the same dataset. The query powering relationship retrieval relies on
+   * this assumption -- see {@link #retrieve(Dataset)}.
+   *
+   * @param relationships Dataset relationships to create in {@code dataset_relationship} table.
+   *     Each relationship is assumed to only exist between tables in the same dataset.
+   */
   public void createDatasetRelationships(List<Relationship> relationships) {
     for (Relationship rel : relationships) {
       create(rel);
@@ -54,6 +61,16 @@ public class DatasetRelationshipDao {
     relationship.id(relationshipId);
   }
 
+  /**
+   * Enrich the supplied dataset with its associated relationships.
+   *
+   * <p>Callers should note that relationships are assumed to exist only between tables in the same
+   * dataset. The query powering this method relies on this assumption.
+   *
+   * @param dataset Dataset whose relationships will be populated from the {@code
+   *     dataset_relationship} table. Each relationship is assumed to only exist between tables in
+   *     the same dataset.
+   */
   public void retrieve(Dataset dataset) {
     List<Relationship> relationships = retrieveDatasetRelationships(dataset);
     dataset.relationships(relationships);

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -89,4 +89,5 @@
     <include file="changesets/20240816_load_datasetid.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240822_load_rename_to_load_lock.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240816_addsamgrouptorequest.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20240830_dataset_table_dataset_id_index.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20240830_dataset_table_dataset_id_index.yaml
+++ b/src/main/resources/db/changesets/20240830_dataset_table_dataset_id_index.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: dataset_table_dataset_id_index
+      author: okotsopo
+      remarks: |
+        When retrieving dataset or snapshot relationships, we query dataset_table.
+      changes:
+        - createIndex:
+            indexName: dataset_table_dataset_id_idx
+            tableName: dataset_table
+            columns:
+              - column:
+                  name: dataset_id


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-647

## Addresses

In a recent PR, we reduced the number of calls that we make to retrieve `dataset_relationship`s when facilitating dataset ingests: https://github.com/DataBiosphere/jade-data-repo/pull/1754

As I was looking at Query Insights, I noticed that `dataset_relationship` retrieval for large schemas was still frequently represented among the queries most responsible for CPU utilization.

Previously, `dataset_relationship` retrieval performance degraded as the dataset's schema grew, specifically its total column count across its tables.  The backbone of the old query was a costly `WHERE… IN (<dataset's columns>) OR … IN (<dataset's columns>)` clause.

## Summary of changes

The new query joins `dataset_relationship` with `dataset_table` with a filter on `dataset_id`.  We also eliminated an additional join under the principle that relationships can only exist between tables in the same dataset.

As we now query `dataset_table` with a filter on `dataset_id`, I've added an index to avoid a full sequential scan of that table during relationship construction.

## Testing Strategy

Connected directly to `datarepo` production database with a RO connection.  Compared query plans for `dataset_relationship` retrieval from the eMERGE production dataset (UUID `9c259486-2ee8-4e1e-8d87-1741b1432194`), which has a large schema (204 columns across 9 tables) and has been receiving many ingests lately.

Old query (**cost = 13253.04**):
```
EXPLAIN ANALYZE
  SELECT id, name, from_table, from_column, to_table, to_column
  FROM dataset_relationship
  WHERE from_column IN
    ('<column1>', '<column2>', … , '<column204>')
  OR to_column IN
    ('<column1>', '<column2>', … , '<column204>');

Seq Scan on dataset_relationship  (cost=0.00..13253.04 rows=726 width=131) (actual time=2.992..48.119 rows=4 loops=1)
"  Filter: ((from_column = ANY ('{<column1>,<column2>,…,<column204>}'::uuid[])) OR (to_column = ANY ('{<column1>,<column2>,…,<column204>}'::uuid[])))"
  Rows Removed by Filter: 23505
Planning Time: 1.632 ms
Execution Time: 48.156 ms
```

New query without index (**cost = 4210.69**):
```
EXPLAIN ANALYZE
    SELECT r.id, r.name, r.from_table, r.from_column, r.to_table, r.to_column
    FROM dataset_relationship AS r
        JOIN dataset_table AS dt ON (r.from_table = dt.id)
    WHERE dt.dataset_id = '9c259486-2ee8-4e1e-8d87-1741b1432194';

Hash Join  (cost=3351.30..4210.69 rows=5 width=131) (actual time=9.057..14.461 rows=4 loops=1)
  Hash Cond: (r.from_table = dt.id)
  ->  Seq Scan on dataset_relationship r  (cost=0.00..795.27 rows=24427 width=131) (actual time=0.013..3.964 rows=23509 loops=1)
  ->  Hash  (cost=3351.18..3351.18 rows=10 width=16) (actual time=8.761..8.762 rows=9 loops=1)
        Buckets: 1024  Batches: 1  Memory Usage: 9kB
        ->  Seq Scan on dataset_table dt  (cost=0.00..3351.18 rows=10 width=16) (actual time=1.451..8.742 rows=9 loops=1)
              Filter: (dataset_id = '9c259486-2ee8-4e1e-8d87-1741b1432194'::uuid)
              Rows Removed by Filter: 47192
Planning Time: 0.837 ms
Execution Time: 14.517 ms
```

So, a roughly **70% reduction in query cost** even before you take the new index on `dataset_table` into the account, which should avoid a sequential scan on that table (it's the most costly part of the new query).

## Future Opportunity

Share code with `SnapshotRelationshipDao` so that retrieving snapshot relationships benefits from the same optimization.  I did not want to dilute reviewers' attention away from the core query change, which is why I haven't included that refactor in this PR.

This PR could be an incremental step towards a larger refactor to construct datasets and snapshots via joins rather than multiple separate queries -- let's discuss!

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
