### PR TITLE
[DCJ-650] Expand ResourceLockConflict messages

### DIFF
--- a/src/main/java/bio/terra/service/common/ResourceLockConflict.java
+++ b/src/main/java/bio/terra/service/common/ResourceLockConflict.java
@@ -1,13 +1,14 @@
 package bio.terra.service.common;
 
 import bio.terra.common.exception.ConflictException;
+import java.util.List;
 
 public class ResourceLockConflict extends ConflictException {
   public ResourceLockConflict(String message) {
     super(message);
   }
 
-  public ResourceLockConflict(String message, Throwable cause) {
-    super(message, cause);
+  public ResourceLockConflict(String message, List<String> causes) {
+    super(message, causes);
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/unlock/UnlockDatasetCheckLockNameStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/unlock/UnlockDatasetCheckLockNameStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.dataset.flight.unlock;
 
+import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.common.UnlockResourceCheckLockNameStep;
 import bio.terra.service.dataset.DatasetService;
 import java.util.ArrayList;
@@ -8,18 +9,16 @@ import java.util.UUID;
 
 public class UnlockDatasetCheckLockNameStep extends UnlockResourceCheckLockNameStep {
   private final DatasetService datasetService;
-  private final UUID datasetId;
 
   public UnlockDatasetCheckLockNameStep(
       DatasetService datasetService, UUID datasetId, String lockName) {
-    super(lockName);
+    super(IamResourceType.DATASET, datasetId, lockName);
     this.datasetService = datasetService;
-    this.datasetId = datasetId;
   }
 
   protected List<String> getLocks() {
     var locks = new ArrayList<String>();
-    var lockResource = datasetService.retrieveDatasetSummary(datasetId).getResourceLocks();
+    var lockResource = datasetService.retrieveDatasetSummary(resourceId).getResourceLocks();
     if (lockResource.getExclusive() != null) {
       locks.add(lockResource.getExclusive());
     }
@@ -30,7 +29,7 @@ public class UnlockDatasetCheckLockNameStep extends UnlockResourceCheckLockNameS
   }
 
   protected boolean isSharedLock(String lockName) {
-    var lockResource = datasetService.retrieveDatasetSummary(datasetId).getResourceLocks();
+    var lockResource = datasetService.retrieveDatasetSummary(resourceId).getResourceLocks();
     if (lockResource.getShared() == null) {
       return false;
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/unlock/UnlockSnapshotCheckLockNameStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/unlock/UnlockSnapshotCheckLockNameStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.snapshot.flight.unlock;
 
+import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.common.UnlockResourceCheckLockNameStep;
 import bio.terra.service.snapshot.SnapshotService;
 import java.util.List;
@@ -7,19 +8,17 @@ import java.util.UUID;
 
 public class UnlockSnapshotCheckLockNameStep extends UnlockResourceCheckLockNameStep {
   private final SnapshotService snapshotService;
-  private final UUID snapshotId;
 
   public UnlockSnapshotCheckLockNameStep(
       SnapshotService snapshotService, UUID snapshotId, String lockName) {
-    super(lockName);
+    super(IamResourceType.DATASNAPSHOT, snapshotId, lockName);
     this.snapshotService = snapshotService;
-    this.snapshotId = snapshotId;
   }
 
   protected List<String> getLocks() {
     // Snapshots do not have shared locks, so we just return a list of one exclusive lock
     var exclusiveLock =
-        snapshotService.retrieveSnapshotSummary(snapshotId).getResourceLocks().getExclusive();
+        snapshotService.retrieveSnapshotSummary(resourceId).getResourceLocks().getExclusive();
     if (exclusiveLock != null) {
       return List.of(exclusiveLock);
     } else {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -665,8 +665,8 @@ paths:
       responses:
         200:
           description: >
-            Unlock successful. ResourceLocks object is returned with a "null" value
-            showing that there is no longer an exclusive lock on this resource.
+            Unlock successful. The snapshot's current lock state is returned, which should show no
+            exclusive lock present.
           content:
             application/json:
               schema:
@@ -2084,8 +2084,8 @@ paths:
       responses:
         200:
           description: >
-            Unlock successful. ResourceLocks object is returned with a "null" value
-            if there are no locks on the resource.
+            Unlock successful. The dataset's current lock state is returned, which should no longer
+            include the lock removed.
           content:
             application/json:
               schema:

--- a/src/test/java/bio/terra/service/common/ResourceLockConflictTest.java
+++ b/src/test/java/bio/terra/service/common/ResourceLockConflictTest.java
@@ -1,0 +1,34 @@
+package bio.terra.service.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.exception.ConflictException;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Unit.TAG)
+class ResourceLockConflictTest {
+  private static final String MESSAGE = "exception message";
+  private static final List<String> CAUSES = List.of("cause1", "cause2");
+
+  @Test
+  void resourceLockConflict_message() {
+    ResourceLockConflict exception = new ResourceLockConflict(MESSAGE);
+    assertThat(exception, instanceOf(ConflictException.class));
+    assertThat(exception.getMessage(), equalTo(MESSAGE));
+    assertThat(exception.getCauses(), empty());
+  }
+
+  @Test
+  void resourceLockConflict_messageAndCauses() {
+    ResourceLockConflict exception = new ResourceLockConflict(MESSAGE, CAUSES);
+    assertThat(exception, instanceOf(ConflictException.class));
+    assertThat(exception.getMessage(), equalTo(MESSAGE));
+    assertThat(exception.getCauses(), equalTo(CAUSES));
+  }
+}

--- a/src/test/java/bio/terra/service/common/UnlockResourceCheckLockNameStepTest.java
+++ b/src/test/java/bio/terra/service/common/UnlockResourceCheckLockNameStepTest.java
@@ -2,16 +2,24 @@ package bio.terra.service.common;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,42 +30,78 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
 class UnlockResourceCheckLockNameStepTest {
-  private UnlockResourceCheckLockNameStep step;
+  private static final IamResourceType IAM_RESOURCE_TYPE = IamResourceType.DATASET;
+  private static final UUID RESOURCE_ID = UUID.randomUUID();
+  private static final String LOCK_NAME = "lock-name";
+  private static final String OTHER_LOCK_NAME = "other-lock-name";
+  private static final Boolean IS_SHARED_LOCK = false;
   @Mock private FlightContext flightContext;
+
+  @Test
+  void doStep_success() throws InterruptedException {
+    var workingMap = new FlightMap();
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+
+    UnlockResourceCheckLockNameStep step = new TestStep(List.of(LOCK_NAME, OTHER_LOCK_NAME));
+
+    assertThat(step.doStep(flightContext), equalTo(StepResult.getStepResultSuccess()));
+    assertThat(
+        workingMap.get(DatasetWorkingMapKeys.IS_SHARED_LOCK, Boolean.class),
+        equalTo(IS_SHARED_LOCK));
+  }
+
+  private static Stream<Arguments> doStep_failure() {
+    String noLocksMessage = "Dataset %s is not locked.".formatted(RESOURCE_ID);
+
+    List<String> existingLocksOnResource = List.of(OTHER_LOCK_NAME);
+    String noMatchingLockMessage =
+        """
+            Dataset %s has no lock named '%s'.
+            Do you mean to remove one of these existing locks instead?
+            """
+            .formatted(RESOURCE_ID, LOCK_NAME);
+
+    return Stream.of(
+        arguments(List.of(), new ResourceLockConflict(noLocksMessage)),
+        arguments(
+            existingLocksOnResource,
+            new ResourceLockConflict(noMatchingLockMessage, existingLocksOnResource)));
+  }
 
   @ParameterizedTest
   @MethodSource
-  void doStep(String requestedLockName, List<String> actualLockNames, StepStatus expectedStatus)
+  void doStep_failure(List<String> existingResourceLocks, ResourceLockConflict expectedException)
       throws InterruptedException {
-    // Setup
-    if (expectedStatus.equals(StepStatus.STEP_RESULT_SUCCESS)) {
-      var flightMap = new FlightMap();
-      when(flightContext.getWorkingMap()).thenReturn(flightMap);
-    }
-    step =
-        new UnlockResourceCheckLockNameStep(requestedLockName) {
-          @Override
-          protected List<String> getLocks() {
-            return actualLockNames;
-          }
+    UnlockResourceCheckLockNameStep step = new TestStep(existingResourceLocks);
 
-          @Override
-          protected boolean isSharedLock(String lockName) {
-            return false;
-          }
-        };
+    StepResult stepResult = step.doStep(flightContext);
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
 
-    // Perform Step
-    var stepResult = step.doStep(flightContext);
-
-    // Confirm response is correctly returned
-    assertThat(stepResult.getStepStatus(), equalTo(expectedStatus));
+    Optional<Exception> maybeException = stepResult.getException();
+    assertTrue(maybeException.isPresent());
+    Exception exception = maybeException.get();
+    assertThat(exception, instanceOf(ResourceLockConflict.class));
+    ResourceLockConflict resourceLockConflict = (ResourceLockConflict) exception;
+    assertThat(resourceLockConflict.getMessage(), equalTo(expectedException.getMessage()));
+    assertThat(resourceLockConflict.getCauses(), equalTo(expectedException.getCauses()));
   }
 
-  private static Stream<Arguments> doStep() {
-    return Stream.of(
-        arguments("LockName", List.of("LockName", "OtherLockName"), StepStatus.STEP_RESULT_SUCCESS),
-        arguments("LockName", List.of("OtherLockName"), StepStatus.STEP_RESULT_FAILURE_FATAL),
-        arguments("LockName", List.of(), StepStatus.STEP_RESULT_FAILURE_FATAL));
+  private static class TestStep extends UnlockResourceCheckLockNameStep {
+    private final List<String> actualLocks;
+
+    public TestStep(List<String> actualLockNames) {
+      super(IAM_RESOURCE_TYPE, RESOURCE_ID, LOCK_NAME);
+      this.actualLocks = actualLockNames;
+    }
+
+    @Override
+    protected List<String> getLocks() {
+      return actualLocks;
+    }
+
+    @Override
+    protected boolean isSharedLock(String lockName) {
+      return IS_SHARED_LOCK;
+    }
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/unlock/UnlockSnapshotCheckLockNameStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/unlock/UnlockSnapshotCheckLockNameStepTest.java
@@ -1,21 +1,29 @@
 package bio.terra.service.snapshot.flight.unlock;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
 import bio.terra.model.ResourceLocks;
 import bio.terra.model.SnapshotSummaryModel;
+import bio.terra.service.common.ResourceLockConflict;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -27,53 +35,66 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @Tag(Unit.TAG)
 class UnlockSnapshotCheckLockNameStepTest {
   private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final String LOCK_NAME = "lock-name";
+  private static final String OTHER_LOCK_NAME = "other-lock-name";
+
+  private FlightMap workingMap;
   private UnlockSnapshotCheckLockNameStep step;
+  private SnapshotSummaryModel snapshotSummaryModel;
   @Mock private FlightContext flightContext;
   @Mock private SnapshotService snapshotService;
 
-  @ParameterizedTest
-  @MethodSource
-  void doStep(
-      SnapshotSummaryModel snapshotSummaryModel,
-      String requestedLockName,
-      StepStatus expectedStatus,
-      String exceptionMessage)
-      throws InterruptedException {
-    // Setup
-    step = new UnlockSnapshotCheckLockNameStep(snapshotService, SNAPSHOT_ID, requestedLockName);
-    when(snapshotService.retrieveSnapshotSummary(SNAPSHOT_ID)).thenReturn(snapshotSummaryModel);
-    FlightMap workingMap = new FlightMap();
+  @BeforeEach
+  void beforeEach() {
+    workingMap = new FlightMap();
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
 
-    // Perform Step
-    var stepResult = step.doStep(flightContext);
+    step = new UnlockSnapshotCheckLockNameStep(snapshotService, SNAPSHOT_ID, LOCK_NAME);
 
-    // Confirm response is correctly returned
-    assertThat(stepResult.getStepStatus(), equalTo(expectedStatus));
-    if (exceptionMessage != null) {
-      assertThat(
-          "Expected exception",
-          stepResult.getException().get().getMessage(),
-          containsString(exceptionMessage));
-    }
+    snapshotSummaryModel = new SnapshotSummaryModel();
+    when(snapshotService.retrieveSnapshotSummary(SNAPSHOT_ID)).thenReturn(snapshotSummaryModel);
   }
 
-  private static Stream<Arguments> doStep() {
+  @Test
+  void doStep_success() throws InterruptedException {
+    snapshotSummaryModel.resourceLocks(new ResourceLocks().exclusive(LOCK_NAME));
+
+    assertThat(step.doStep(flightContext), equalTo(StepResult.getStepResultSuccess()));
+    assertThat(workingMap.get(DatasetWorkingMapKeys.IS_SHARED_LOCK, Boolean.class), equalTo(false));
+  }
+
+  private static Stream<Arguments> doStep_failure() {
+    String noLocksMessage = "Datasnapshot %s is not locked.".formatted(SNAPSHOT_ID);
+
+    String noMatchingLockMessage =
+        """
+            Datasnapshot %s has no lock named '%s'.
+            Do you mean to remove one of these existing locks instead?
+            """
+            .formatted(SNAPSHOT_ID, LOCK_NAME);
+
     return Stream.of(
+        arguments(new ResourceLocks(), new ResourceLockConflict(noLocksMessage)),
         arguments(
-            new SnapshotSummaryModel().resourceLocks(new ResourceLocks()),
-            "lockName",
-            StepStatus.STEP_RESULT_FAILURE_FATAL,
-            "Resource is not locked."),
-        arguments(
-            new SnapshotSummaryModel().resourceLocks(new ResourceLocks().exclusive("LockName")),
-            "LockName",
-            StepStatus.STEP_RESULT_SUCCESS,
-            null),
-        arguments(
-            new SnapshotSummaryModel().resourceLocks(new ResourceLocks().exclusive("LockName")),
-            "OtherLockName",
-            StepStatus.STEP_RESULT_FAILURE_FATAL,
-            "Resource not locked by OtherLockName. It is locked by flight(s) LockName."));
+            new ResourceLocks().exclusive(OTHER_LOCK_NAME),
+            new ResourceLockConflict(noMatchingLockMessage, List.of(OTHER_LOCK_NAME))));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void doStep_failure(ResourceLocks existingResourceLocks, ResourceLockConflict expectedException)
+      throws InterruptedException {
+    snapshotSummaryModel.resourceLocks(existingResourceLocks);
+
+    StepResult stepResult = step.doStep(flightContext);
+    assertThat(stepResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+
+    Optional<Exception> maybeException = stepResult.getException();
+    assertTrue(maybeException.isPresent());
+    Exception exception = maybeException.get();
+    assertThat(exception, instanceOf(ResourceLockConflict.class));
+    ResourceLockConflict resourceLockConflict = (ResourceLockConflict) exception;
+    assertThat(resourceLockConflict.getMessage(), equalTo(expectedException.getMessage()));
+    assertThat(resourceLockConflict.getCauses(), equalTo(expectedException.getCauses()));
   }
 }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-650

## Addresses

A GP user tried to [unlock a dataset](https://data.terra.bio/swagger-ui.html#/datasets/unlockDataset) and received the following error in response:

```
{
"message": "Resource not locked by string. It is locked by flight(s) cJI-L254TfqpJqTvXmq6LA.",
"errorDetail": []
}
```

As the TDR Sprint Captain, I had to look at the [API logs](https://cloudlogging.app.goo.gl/ccoAMRBtqyLNFbge7) to realize that they had called the endpoint with the default request body, rather than supplying the name of the lock to remove:

```
{
  "lockName": "string",
  "forceUnlock": false
}
```

## Summary of changes

Expanded `ResourceLockConflict` error messages to better direct our users' next steps (or at least make it easy for Terra Support to help them).  Here's the error message our user would have gotten instead:
```
{
"message": "Dataset 458e1a5f-dfff-41ae-bbc1-93661500a270 has no lock named 'string'.
Do you mean to remove one of these existing locks instead?",
"errorDetail": ["cJI-L254TfqpJqTvXmq6LA"]
}
```

## Testing Strategy

Expanded unit tests.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
