### PR TITLE
[DCJ-400-gradle] Upgrade io.swagger.codegen.v3 deps 3.0.61 -> 3.0.62

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,14 @@ updates:
           - "*"
         exclude-patterns:
           - "com.diffplug.spotless" # likely to require reformatting of code
+          - "io.swagger.codegen.v3" # patch upgrades have lately included breaking changes
         update-types:
           - "minor"
           - "patch"
+      # We want Swagger codegen dep versions to stay in sync with each other, and be PRed together.
+      io.swagger.codegen.v3:
+        patterns:
+          - "io.swagger.codegen.v3"
     schedule:
       interval: "weekly"
       time: "06:00"

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('io.swagger.codegen.v3:swagger-codegen:3.0.61')
+        classpath('io.swagger.codegen.v3:swagger-codegen:3.0.62')
         // Required for gradle liquibase plugin
         classpath ('org.liquibase:liquibase-core:4.29.1')
     }
@@ -63,7 +63,7 @@ allprojects {
         }
         dependencies {
             dependency 'io.swagger.core.v3:swagger-annotations:2.2.23'
-            dependency 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.61'
+            dependency 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.62'
         }
     }
 }
@@ -313,8 +313,8 @@ swaggerSources {
                     "useTags=true," +
                     "dateLibrary=java8," +
                     "jakarta=true," +
-                    // https://github.com/swagger-api/swagger-codegen-generators/issues/1295#issuecomment-2203238201
-                    "useNullableForNotNull=false"
+                    // https://github.com/swagger-api/swagger-codegen-generators/pull/1308
+                    "validationMode=legacy"
             ]
         }
     }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-400

## Addresses

This patch upgrade without changing configuration caused compilation of Swagger generated code to fail with the following errors:

```
/github/workspace/build/generated-src/swagger/src/main/java/bio/terra/model/ResourcePolicyModel.java:10: error: package io.swagger.configuration does not exist
import io.swagger.configuration.NotUndefined;
                               ^
/github/workspace/build/generated-src/swagger/src/main/java/bio/terra/model/ResourcePolicyModel.java:21: error: cannot find symbol
@NotUndefined
 ^
```

This was introduced in https://github.com/swagger-api/swagger-codegen-generators/pull/1308

## Summary of changes

- Upgrade `io.swagger.codegen.v3:swagger-codegen` and `io.swagger.codegen.v3:swagger-codegen-cli` from 3.0.61 -> 3.0.62
- For the time being, set `validationMode=legacy` along with these patch upgrades to mitigate another likely bug in swagger-codegen-generators.
- Because `io.swagger.codegen.v3` patch upgrades have lately included breaking changes, exclude them from our grouped minor and patch upgrade Dependabot PRs.  Any available upgrades will be PRed separately. 

## Testing Strategy

CI build and tests should pass.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
