### PR TITLE
[DCJ-616] Unbreak the test action due to datarepo-helm action running

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -208,5 +208,3 @@ jobs:
       notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
     permissions:
       id-token: write
-  deploy_test_integration:
-    steps: {}


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DCJ-616

## Summary

In TDR, Changes were recently made to the action which runs on PRs:

- https://github.com/DataBiosphere/jade-data-repo/pull/1781 
- https://github.com/DataBiosphere/jade-data-repo/pull/1794

The workflow in https://github.com/broadinstitute/datarepo-helm/pull/276 tries to (unsuccessfully) modify the action, breaking it in the process:

https://github.com/DataBiosphere/jade-data-repo/commit/31b4714b0032fcc4c982e64709c68ce45e576fa6

Links to failed builds:

https://github.com/DataBiosphere/jade-data-repo/actions/runs/10708679629 https://github.com/DataBiosphere/jade-data-repo/actions/runs/10708678706 https://github.com/DataBiosphere/jade-data-repo/actions/runs/10708668823

It adds this little chunk at the bottom of the action which breaks it.