### PR TITLE
[DCJ-653] Set terminal storage class of Autoclass buckets to ARCHIVE

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
@@ -18,6 +18,7 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.BucketInfo.Autoclass;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
@@ -381,7 +382,11 @@ public class GoogleBucketService {
     BucketInfo bucketInfo =
         BucketInfo.newBuilder(bucketName)
             // .setRequesterPays()
-            .setAutoclass(Autoclass.newBuilder().setEnabled(enableAutoclass).build())
+            .setAutoclass(
+                Autoclass.newBuilder()
+                    .setEnabled(enableAutoclass)
+                    .setTerminalStorageClass(StorageClass.ARCHIVE)
+                    .build())
             .setLocation(region.toString())
             .setVersioningEnabled(doVersioning)
             .setLifecycleRules(lifecycleRules)

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -48,17 +47,17 @@ public class GoogleBucketService {
   private final GoogleResourceDao resourceDao;
   private final GcsProjectFactory gcsProjectFactory;
   private final ConfigurationService configService;
+  private final Environment env;
 
-  @Autowired private Environment env;
-
-  @Autowired
   public GoogleBucketService(
       GoogleResourceDao resourceDao,
       GcsProjectFactory gcsProjectFactory,
-      ConfigurationService configService) {
+      ConfigurationService configService,
+      Environment env) {
     this.resourceDao = resourceDao;
     this.gcsProjectFactory = gcsProjectFactory;
     this.configService = configService;
+    this.env = env;
   }
 
   /**
@@ -350,12 +349,13 @@ public class GoogleBucketService {
    *     with the dataset that this bucket will be associated with
    * @return a reference to the bucket as a GCS Bucket object
    */
-  private Bucket newCloudBucket(
+  @VisibleForTesting
+  protected Bucket newCloudBucket(
       GoogleBucketResource bucketResource,
       Duration daysToLive,
-      Callable<List<String>> getReaderGroups,
+      Callable<? extends List<String>> getReaderGroups,
       String dedicatedServiceAccount,
-      Boolean enableAutoclass) {
+      boolean enableAutoclass) {
     final List<String> readerGroups;
     try {
       if (getReaderGroups != null) {

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleBucketServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleBucketServiceTest.java
@@ -1,0 +1,59 @@
+package bio.terra.service.resourcemanagement.google;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.app.model.GoogleRegion;
+import bio.terra.common.category.Unit;
+import bio.terra.service.filedata.google.gcs.GcsProject;
+import bio.terra.service.filedata.google.gcs.GcsProjectFactory;
+import com.google.cloud.Policy;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
+import java.time.Duration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+@Tag(Unit.TAG)
+@ExtendWith(MockitoExtension.class)
+public class GoogleBucketServiceTest {
+  @Mock private GcsProjectFactory gcsProjectFactory;
+  @Mock private Environment environment;
+
+  @Test
+  void newCloudBucket() {
+    GoogleBucketResource resource =
+        new GoogleBucketResource()
+            .name("bucket")
+            .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
+            .projectResource(new GoogleProjectResource().googleProjectId("project"));
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+    GcsProject gcsProject = mock(GcsProject.class);
+    when(gcsProjectFactory.get("project", true)).thenReturn(gcsProject);
+    Storage storage = mock(Storage.class);
+    when(gcsProject.getStorage()).thenReturn(storage);
+    ArgumentCaptor<BucketInfo> bucketInfo = ArgumentCaptor.forClass(BucketInfo.class);
+    Bucket expected = mock(Bucket.class);
+    when(expected.getName()).thenReturn("bucket");
+    when(storage.create(bucketInfo.capture())).thenReturn(expected);
+    when(storage.getIamPolicy("bucket", Storage.BucketSourceOption.requestedPolicyVersion(3)))
+        .thenReturn(Policy.newBuilder().build());
+
+    GoogleBucketService service =
+        new GoogleBucketService(null, gcsProjectFactory, null, environment);
+    Bucket actual =
+        service.newCloudBucket(resource, Duration.ofDays(10), null, "service account", true);
+    assertThat(actual, is(expected));
+    assertThat(
+        bucketInfo.getValue().getAutoclass().getTerminalStorageClass(), is(StorageClass.ARCHIVE));
+  }
+}


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DCJ-653

## Summary of changes

Per discussion with the team today, this is a quick win to set Autoclass on new buckets to terminate at `ARCHIVE`. In October of 2023, Google changed the termination class for Autoclass from `ARCHIVE` to `NEARLINE`.

Per a previous analysis done by @snf2ye , `ARCHIVE` is the most cost effective storage tier and should be the default for rarely accessed data:

* https://github.com/DataBiosphere/jade-data-repo/pull/1413
* https://docs.google.com/document/d/1j7M6cMHgrC0V6gITxdIBSPgDjwXcyUjuG9n83mrr7nk/edit#heading=h.20px7xcotqwc

It also matches the expected behavior of setting items to Autoclass per the original design approach.

## Testing Strategy

Open to suggestions

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
