### PR TITLE
[DCJ-653] Add upgrade flight to set Autoclass ARCHIVE on a bucket

### DIFF
--- a/src/main/java/bio/terra/common/ValidationUtils.java
+++ b/src/main/java/bio/terra/common/ValidationUtils.java
@@ -32,6 +32,10 @@ public final class ValidationUtils {
   // more forgiving. Should we enforce this or fix it up, as is done in filesystem.
   private static final String VALID_PATH = "/.*";
 
+  // pattern translated from https://cloud.google.com/storage/docs/buckets#naming
+  private static final Pattern VALID_BUCKET_NAME_REGEX =
+      Pattern.compile("^[a-z0-9][a-z0-9\\-_]{1,61}[a-z0-9]$");
+
   private ValidationUtils() {}
 
   public static <T> boolean hasDuplicates(List<T> list) {
@@ -70,6 +74,17 @@ public final class ValidationUtils {
     } catch (IllegalArgumentException e) {
       return Optional.empty();
     }
+  }
+
+  public static boolean isValidBucketName(String bucketName) {
+    return VALID_BUCKET_NAME_REGEX.matcher(bucketName).matches();
+  }
+
+  public static Optional<String> convertToBucketName(String bucketName) {
+    if (isValidBucketName(bucketName)) {
+      return Optional.of(bucketName);
+    }
+    return Optional.empty();
   }
 
   public static String requireNotBlank(String value, String errorMsg) {

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -22,7 +22,8 @@ public enum JobMapKeys {
   FILE_ID("fileId"),
   ASSET_ID("assetId"),
   TRANSACTION_ID("transactionId"),
-  DELETE_CLOUD_RESOURCES("deleteCloudResources");
+  DELETE_CLOUD_RESOURCES("deleteCloudResources"),
+  BUCKET_NAME("bucketName");
 
   private String keyName;
 

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/BucketAutoclassUpdateFlight.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/BucketAutoclassUpdateFlight.java
@@ -1,0 +1,21 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleBucketService;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import org.springframework.context.ApplicationContext;
+
+public class BucketAutoclassUpdateFlight extends Flight {
+  public BucketAutoclassUpdateFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+    GoogleBucketService googleBucketService = appContext.getBean(GoogleBucketService.class);
+    String bucketName = inputParameters.get(JobMapKeys.BUCKET_NAME.getKeyName(), String.class);
+
+    addStep(new RecordBucketAutoclassStep(googleBucketService, bucketName));
+    addStep(new UpdateBucketAutoclassStep(googleBucketService));
+    addStep(new UpdateDatabaseAutoclassStep(googleBucketService));
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
@@ -34,14 +34,16 @@ public class RecordBucketAutoclassStep implements Step {
     Bucket bucket = googleBucketService.getCloudBucket(bucketName);
     GoogleBucketResource bucketResource = googleBucketService.getBucketMetadata(bucketName);
     Autoclass autoclass = bucket.getAutoclass();
-    if (autoclass.getEnabled() && autoclass.getTerminalStorageClass() == StorageClass.ARCHIVE) {
-      return stepResultFailure("Bucket autoclass already set to ARCHIVE: " + bucketName);
-    }
-    if (autoclass.getEnabled() ^ bucketResource.getAutoclassEnabled()) {
-      return stepResultFailure("Bucket autoclass mismatch in metadata: " + bucketName);
-    }
-    if (autoclass.getEnabled()) {
-      bucketResource = bucketResource.terminalStorageClass(autoclass.getTerminalStorageClass());
+    if (autoclass != null) {
+      if (autoclass.getEnabled() && autoclass.getTerminalStorageClass() == StorageClass.ARCHIVE) {
+        return stepResultFailure("Bucket autoclass already set to ARCHIVE: " + bucketName);
+      }
+      if (autoclass.getEnabled() ^ bucketResource.getAutoclassEnabled()) {
+        return stepResultFailure("Bucket autoclass mismatch in metadata: " + bucketName);
+      }
+      if (autoclass.getEnabled()) {
+        bucketResource = bucketResource.terminalStorageClass(autoclass.getTerminalStorageClass());
+      }
     }
     workingMap.put(FileMapKeys.BUCKET_INFO, bucketResource);
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
@@ -1,0 +1,57 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.exception.GoogleResourceException;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleBucketService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo.Autoclass;
+import com.google.cloud.storage.StorageClass;
+
+public class RecordBucketAutoclassStep implements Step {
+
+  private final GoogleBucketService googleBucketService;
+  private final String bucketName;
+
+  public RecordBucketAutoclassStep(GoogleBucketService googleBucketService, String bucketName) {
+    this.googleBucketService = googleBucketService;
+    this.bucketName = bucketName;
+  }
+
+  private StepResult stepResultFailure(String message) {
+    return new StepResult(
+        StepStatus.STEP_RESULT_FAILURE_FATAL, new GoogleResourceException(message));
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    Bucket bucket = googleBucketService.getCloudBucket(bucketName);
+    GoogleBucketResource bucketResource = googleBucketService.getBucketMetadata(bucketName);
+    if (bucket == null || bucketResource == null) {
+      return stepResultFailure("Bucket not found: " + bucketName);
+    }
+    Autoclass autoclass = bucket.getAutoclass();
+    if (autoclass.getEnabled() && autoclass.getTerminalStorageClass() == StorageClass.ARCHIVE) {
+      return stepResultFailure("Bucket autoclass already set to ARCHIVE: " + bucketName);
+    }
+    if (autoclass.getEnabled() ^ bucketResource.getAutoclassEnabled()) {
+      return stepResultFailure("Bucket autoclass mismatch in metadata: " + bucketName);
+    }
+    if (autoclass.getEnabled()) {
+      bucketResource = bucketResource.terminalStorageClass(autoclass.getTerminalStorageClass());
+    }
+    workingMap.put(FileMapKeys.BUCKET_INFO, bucketResource);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
@@ -33,9 +33,6 @@ public class RecordBucketAutoclassStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     Bucket bucket = googleBucketService.getCloudBucket(bucketName);
     GoogleBucketResource bucketResource = googleBucketService.getBucketMetadata(bucketName);
-    if (bucket == null || bucketResource == null) {
-      return stepResultFailure("Bucket not found: " + bucketName);
-    }
     Autoclass autoclass = bucket.getAutoclass();
     if (autoclass.getEnabled() && autoclass.getTerminalStorageClass() == StorageClass.ARCHIVE) {
       return stepResultFailure("Bucket autoclass already set to ARCHIVE: " + bucketName);

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
@@ -31,8 +31,9 @@ public class RecordBucketAutoclassStep implements Step {
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
-    Bucket bucket = googleBucketService.getCloudBucket(bucketName);
     GoogleBucketResource bucketResource = googleBucketService.getBucketMetadata(bucketName);
+    Bucket bucket = googleBucketService.getCloudBucket(bucketName);
+    bucketResource = bucketResource.storageClass(bucket.getStorageClass());
     Autoclass autoclass = bucket.getAutoclass();
     if (autoclass != null) {
       if (autoclass.getEnabled() && autoclass.getTerminalStorageClass() == StorageClass.ARCHIVE) {

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/UpdateBucketAutoclassStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/UpdateBucketAutoclassStep.java
@@ -1,0 +1,43 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleBucketService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+public class UpdateBucketAutoclassStep implements Step {
+
+  private final GoogleBucketService googleBucketService;
+
+  public UpdateBucketAutoclassStep(GoogleBucketService googleBucketService) {
+    this.googleBucketService = googleBucketService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    GoogleBucketResource bucketResource =
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+
+    googleBucketService.setBucketAutoclassToArchive(bucketResource);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    GoogleBucketResource bucketResource =
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+
+    googleBucketService.setBucketAutoclass(
+        bucketResource,
+        bucketResource.getAutoclassEnabled(),
+        bucketResource.getTerminalStorageClass());
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/UpdateBucketAutoclassStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/UpdateBucketAutoclassStep.java
@@ -36,6 +36,7 @@ public class UpdateBucketAutoclassStep implements Step {
     googleBucketService.setBucketAutoclass(
         bucketResource,
         bucketResource.getAutoclassEnabled(),
+        bucketResource.getStorageClass(),
         bucketResource.getTerminalStorageClass());
 
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/resourcemanagement/flight/UpdateDatabaseAutoclassStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/UpdateDatabaseAutoclassStep.java
@@ -1,0 +1,41 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleBucketService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+public class UpdateDatabaseAutoclassStep implements Step {
+
+  private final GoogleBucketService googleBucketService;
+
+  public UpdateDatabaseAutoclassStep(GoogleBucketService googleBucketService) {
+    this.googleBucketService = googleBucketService;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    GoogleBucketResource bucketResource =
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+
+    googleBucketService.setBucketAutoclassMetadata(bucketResource.getName(), true);
+
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    FlightMap workingMap = context.getWorkingMap();
+    GoogleBucketResource bucketResource =
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+
+    boolean isAutoclassEnabled = bucketResource.getAutoclassEnabled();
+    googleBucketService.setBucketAutoclassMetadata(bucketResource.getName(), isAutoclassEnabled);
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketResource.java
@@ -13,6 +13,7 @@ public class GoogleBucketResource {
   private String name;
   private GoogleRegion region;
   private boolean autoclassEnabled;
+  private String storageClassAsString;
   private String terminalStorageClassAsString;
 
   public GoogleBucketResource() {}
@@ -77,6 +78,28 @@ public class GoogleBucketResource {
 
   public GoogleBucketResource autoclassEnabled(boolean autoclassEnabled) {
     this.autoclassEnabled = autoclassEnabled;
+    return this;
+  }
+
+  // Required to avoid serialization/deserialization issues with Stairway
+  public String getStorageClassAsString() {
+    return storageClassAsString;
+  }
+
+  // Required to avoid serialization/deserialization issues with Stairway
+  public GoogleBucketResource storageClassAsString(String storageClassAsString) {
+    this.storageClassAsString = storageClassAsString;
+    return this;
+  }
+
+  @JsonIgnore
+  public StorageClass getStorageClass() {
+    return storageClassAsString == null ? null : StorageClass.valueOf(storageClassAsString);
+  }
+
+  @JsonIgnore
+  public GoogleBucketResource storageClass(StorageClass storageClass) {
+    this.storageClassAsString = storageClass == null ? null : storageClass.toString();
     return this;
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketResource.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketResource.java
@@ -2,6 +2,7 @@ package bio.terra.service.resourcemanagement.google;
 
 import bio.terra.app.model.GoogleRegion;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.cloud.storage.StorageClass;
 import java.util.UUID;
 
 public class GoogleBucketResource {
@@ -12,6 +13,7 @@ public class GoogleBucketResource {
   private String name;
   private GoogleRegion region;
   private boolean autoclassEnabled;
+  private String terminalStorageClassAsString;
 
   public GoogleBucketResource() {}
 
@@ -75,6 +77,31 @@ public class GoogleBucketResource {
 
   public GoogleBucketResource autoclassEnabled(boolean autoclassEnabled) {
     this.autoclassEnabled = autoclassEnabled;
+    return this;
+  }
+
+  // Required to avoid serialization/deserialization issues with Stairway
+  public String getTerminalStorageClassAsString() {
+    return terminalStorageClassAsString;
+  }
+
+  // Required to avoid serialization/deserialization issues with Stairway
+  public GoogleBucketResource terminalStorageClassAsString(String terminalStorageClassAsString) {
+    this.terminalStorageClassAsString = terminalStorageClassAsString;
+    return this;
+  }
+
+  @JsonIgnore
+  public StorageClass getTerminalStorageClass() {
+    return terminalStorageClassAsString == null
+        ? null
+        : StorageClass.valueOf(terminalStorageClassAsString);
+  }
+
+  @JsonIgnore
+  public GoogleBucketResource terminalStorageClass(StorageClass terminalStorageClass) {
+    this.terminalStorageClassAsString =
+        terminalStorageClass == null ? null : terminalStorageClass.toString();
     return this;
   }
 

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
@@ -466,14 +466,21 @@ public class GoogleBucketService {
    * @return a reference to the bucket as a GCS Bucket object
    */
   public Bucket setBucketAutoclass(
-      GoogleBucketResource bucketResource, boolean enable, StorageClass terminalStorageClass) {
+      GoogleBucketResource bucketResource,
+      boolean enable,
+      StorageClass defaultStorageClass,
+      StorageClass terminalStorageClass) {
     Storage storage = getStorageForBucketResource(bucketResource);
     Bucket bucket = storage.get(bucketResource.getName());
     Autoclass.Builder autoclassBuilder = Autoclass.newBuilder().setEnabled(enable);
     if (enable) {
       autoclassBuilder.setTerminalStorageClass(terminalStorageClass);
     }
-    Bucket bucketUpdate = bucket.toBuilder().setAutoclass(autoclassBuilder.build()).build();
+    Bucket bucketUpdate =
+        bucket.toBuilder()
+            .setStorageClass(defaultStorageClass)
+            .setAutoclass(autoclassBuilder.build())
+            .build();
     return storage.update(bucketUpdate);
   }
 
@@ -484,7 +491,7 @@ public class GoogleBucketService {
    * @return a reference to the bucket as a GCS Bucket object
    */
   public Bucket setBucketAutoclassToArchive(GoogleBucketResource bucketResource) {
-    return setBucketAutoclass(bucketResource, true, StorageClass.ARCHIVE);
+    return setBucketAutoclass(bucketResource, true, StorageClass.STANDARD, StorageClass.ARCHIVE);
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
@@ -505,7 +505,6 @@ public class GoogleBucketService {
    * @param bucketName name of the bucket to retrieve
    * @return a reference to the bucket as a GCS Bucket object, null if not found
    */
-  @VisibleForTesting
   public Bucket getCloudBucket(String bucketName) {
     Storage storage = StorageOptions.getDefaultInstance().getService();
     try {

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleBucketService.java
@@ -488,6 +488,17 @@ public class GoogleBucketService {
   }
 
   /**
+   * Set the autoclass settings for bucket metadata in the bucket_resource table.
+   *
+   * @param bucketName name of the bucket to update
+   * @param enable whether autoclass should be enabled
+   * @return the number of rows updated
+   */
+  public int setBucketAutoclassMetadata(String bucketName, boolean enable) {
+    return resourceDao.updateBucketAutoclassByName(bucketName, enable);
+  }
+
+  /**
    * Fetch an existing bucket cloud resource. Note this method does not check any associated
    * metadata in the bucket_resource table.
    *

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
@@ -431,6 +431,25 @@ public class GoogleResourceDao {
   }
 
   /**
+   * Fetch an existing bucket_resource metadata row using the name. This method expects that there
+   * is exactly one row matching the provided name.
+   *
+   * @param bucketName name of the bucket
+   * @return a reference to the bucket as a POJO GoogleBucketResource
+   * @throws GoogleResourceNotFoundException if no bucket_resource metadata row is found
+   * @throws CorruptMetadataException if multiple buckets have the same name
+   */
+  @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
+  public GoogleBucketResource retrieveBucketByName(String bucketName) {
+    MapSqlParameterSource params = new MapSqlParameterSource().addValue("name", bucketName);
+    GoogleBucketResource bucketResource = retrieveBucketBy(sqlBucketRetrievedByName, params);
+    if (bucketResource == null) {
+      throw new GoogleResourceNotFoundException("Bucket not found for name: " + bucketName);
+    }
+    return bucketResource;
+  }
+
+  /**
    * Fetch an existing bucket_resource metadata row using the id. This method expects that there is
    * exactly one row matching the provided resource id.
    *
@@ -446,6 +465,22 @@ public class GoogleResourceDao {
       throw new GoogleResourceNotFoundException("Bucket not found for id:" + bucketResourceId);
     }
     return bucketResource;
+  }
+
+  /**
+   * Update the autoclass_enabled column in the bucket_resource metadata table for the bucket with
+   * the provided name.
+   *
+   * @param bucketName name of the bucket
+   * @param autoclass new value for the autoclass_enabled column
+   * @return number of rows updated
+   */
+  @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.SERIALIZABLE)
+  public int updateBucketAutoclassByName(String bucketName, boolean autoclass) {
+    String sql = "UPDATE bucket_resource SET autoclass_enabled = :autoclass WHERE name = :name";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("name", bucketName).addValue("autoclass", autoclass);
+    return jdbcTemplate.update(sql, params);
   }
 
   /**

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceDao.java
@@ -444,7 +444,7 @@ public class GoogleResourceDao {
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("name", bucketName);
     GoogleBucketResource bucketResource = retrieveBucketBy(sqlBucketRetrievedByName, params);
     if (bucketResource == null) {
-      throw new GoogleResourceNotFoundException("Bucket not found for name: " + bucketName);
+      throw new GoogleResourceNotFoundException("Bucket resource not found: " + bucketName);
     }
     return bucketResource;
   }

--- a/src/main/java/bio/terra/service/upgrade/UpgradeService.java
+++ b/src/main/java/bio/terra/service/upgrade/UpgradeService.java
@@ -15,6 +15,7 @@ import bio.terra.service.dataset.flight.upgrade.predictableFileIds.ConvertToPred
 import bio.terra.service.job.JobBuilder;
 import bio.terra.service.job.JobMapKeys;
 import bio.terra.service.job.JobService;
+import bio.terra.service.resourcemanagement.flight.BucketAutoclassUpdateFlight;
 import bio.terra.service.upgrade.exception.InvalidCustomNameException;
 import bio.terra.stairway.Flight;
 import com.google.common.base.Preconditions;
@@ -69,7 +70,22 @@ public class UpgradeService {
               datasetId.isPresent(), "Custom argument's single value is not a valid UUID");
 
           return Map.of(JobMapKeys.DATASET_ID.getKeyName(), datasetId.get());
+        }),
+    SET_BUCKET_AUTOCLASS_ARCHIVE(
+        BucketAutoclassUpdateFlight.class,
+        request -> {
+          Preconditions.checkArgument(
+              request.getCustomArgs().size() == 1,
+              "Custom argument must have a single row: a valid bucket name");
+
+          Optional<String> bucketName =
+              ValidationUtils.convertToBucketName(request.getCustomArgs().get(0));
+          Preconditions.checkArgument(
+              bucketName.isPresent(), "Custom argument's single value is not a valid bucket name");
+
+          return Map.of(JobMapKeys.BUCKET_NAME.getKeyName(), bucketName.get());
         });
+
     private final Class<? extends Flight> flightClass;
     private final Function<UpgradeModel, Map<String, Object>> inputParameterSupplier;
 

--- a/src/test/java/bio/terra/common/ValidationUtilsTest.java
+++ b/src/test/java/bio/terra/common/ValidationUtilsTest.java
@@ -59,6 +59,40 @@ class ValidationUtilsTest {
   }
 
   @Test
+  void testIsValidBucketName() {
+    assertThat(ValidationUtils.isValidBucketName("bucket")).isTrue();
+    assertThat(ValidationUtils.isValidBucketName("bucket-1")).isTrue();
+    assertThat(ValidationUtils.isValidBucketName("1-bucket")).isTrue();
+    assertThat(
+            ValidationUtils.isValidBucketName(
+                "bucket-123456789-123456789-123456789-123456789-123456789"))
+        .isTrue();
+    assertThat(ValidationUtils.isValidBucketName("bucket-")).isFalse();
+    assertThat(ValidationUtils.isValidBucketName("-bucket")).isFalse();
+    assertThat(
+            ValidationUtils.isValidBucketName(
+                "bucket-123456789-123456789-123456789-123456789-123456789-123456789-123456789"))
+        .isFalse();
+  }
+
+  @Test
+  void testConvertToBucketName() {
+    assertThat(ValidationUtils.convertToBucketName("bucket")).isPresent();
+    assertThat(ValidationUtils.convertToBucketName("bucket-1")).isPresent();
+    assertThat(ValidationUtils.convertToBucketName("1-bucket")).isPresent();
+    assertThat(
+            ValidationUtils.convertToBucketName(
+                "bucket-123456789-123456789-123456789-123456789-123456789"))
+        .isPresent();
+    assertThat(ValidationUtils.convertToBucketName("bucket-")).isEmpty();
+    assertThat(ValidationUtils.convertToBucketName("-bucket")).isEmpty();
+    assertThat(
+            ValidationUtils.convertToBucketName(
+                "bucket-123456789-123456789-123456789-123456789-123456789-123456789-123456789"))
+        .isEmpty();
+  }
+
+  @Test
   void testValidationOfEmptyBlankAndNullStrings() {
 
     assertThatExceptionOfType(IllegalArgumentException.class)

--- a/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
@@ -321,6 +321,20 @@ public class DatasetBucketDaoTest {
     assertFalse("Correct autoclass setting is returned", retrievedBucket.getAutoclassEnabled());
   }
 
+  @Test(expected = Exception.class)
+  public void testRetrieveBucketByIdException() {
+    UUID bucketId = UUID.randomUUID();
+    // this should fail -> no bucket with this id
+    resourceDao.retrieveBucketById(bucketId);
+  }
+
+  @Test(expected = Exception.class)
+  public void testRetrieveBucketByNameException() {
+    bucketName = "bucketDoesNotExist";
+    // this should fail -> no bucket with this name
+    resourceDao.retrieveBucketByName(bucketName);
+  }
+
   @Test
   public void testGetAndUpdateBucketAutoclassByName() {
     bucketName = "bucket";

--- a/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
@@ -323,7 +323,7 @@ public class DatasetBucketDaoTest {
 
   @Test
   public void testGetAndUpdateBucketAutoclassByName() {
-    String bucketName = "bucketName";
+    bucketName = "bucket";
     GoogleProjectResource resource = dataset.getProjectResource();
     String flightId = UUID.randomUUID().toString();
     GoogleRegion region =

--- a/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetBucketDaoTest.java
@@ -321,6 +321,33 @@ public class DatasetBucketDaoTest {
     assertFalse("Correct autoclass setting is returned", retrievedBucket.getAutoclassEnabled());
   }
 
+  @Test
+  public void testGetAndUpdateBucketAutoclassByName() {
+    String bucketName = "bucketName";
+    GoogleProjectResource resource = dataset.getProjectResource();
+    String flightId = UUID.randomUUID().toString();
+    GoogleRegion region =
+        (GoogleRegion)
+            dataset.getDatasetSummary().getStorageResourceRegion(GoogleCloudResource.BUCKET);
+
+    GoogleBucketResource bucketResource0 =
+        resourceDao.createAndLockBucket(bucketName, resource, region, flightId, false);
+    datasetBucketDao.createDatasetBucketLink(dataset.getId(), bucketResource0.getResourceId());
+
+    GoogleBucketResource bucketResource1 = resourceDao.retrieveBucketByName(bucketName);
+    assertFalse("Autoclass should be disabled", bucketResource1.getAutoclassEnabled());
+    assertEquals(
+        "Autoclass setting should be the same",
+        bucketResource0.getAutoclassEnabled(),
+        bucketResource1.getAutoclassEnabled());
+
+    int rows = resourceDao.updateBucketAutoclassByName(bucketName, true);
+    assertEquals("One row should be updated", 1, rows);
+
+    GoogleBucketResource bucketResource2 = resourceDao.retrieveBucketByName(bucketName);
+    assertTrue("Autoclass should be enabled", bucketResource2.getAutoclassEnabled());
+  }
+
   private UUID createBucketDbEntry(GoogleProjectResource projectResource2) {
     return createBucketDbEntry(projectResource2, true);
   }

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/BucketAutoclassUpdateTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/BucketAutoclassUpdateTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 
 @Tag(Unit.TAG)
-public class BucketAutoclassUpdateTest {
+class BucketAutoclassUpdateTest {
 
   @Test
   void testBucketAutoclassUpdate() {

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/BucketAutoclassUpdateTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/BucketAutoclassUpdateTest.java
@@ -1,0 +1,33 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.Mockito.mock;
+
+import bio.terra.common.FlightTestUtils;
+import bio.terra.common.category.Unit;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightMap;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+
+@Tag(Unit.TAG)
+public class BucketAutoclassUpdateTest {
+
+  @Test
+  void testBucketAutoclassUpdate() {
+    FlightMap inputParameters = new FlightMap();
+    inputParameters.put(JobMapKeys.BUCKET_NAME.getKeyName(), "testBucketName");
+
+    var flight = new BucketAutoclassUpdateFlight(inputParameters, mock(ApplicationContext.class));
+    var steps = FlightTestUtils.getStepNames(flight);
+
+    assertThat(
+        steps,
+        contains(
+            "RecordBucketAutoclassStep",
+            "UpdateBucketAutoclassStep",
+            "UpdateDatabaseAutoclassStep"));
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
@@ -3,12 +3,15 @@ package bio.terra.service.resourcemanagement.flight;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.exception.GoogleResourceException;
 import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
 import bio.terra.service.resourcemanagement.google.GoogleBucketService;
 import bio.terra.stairway.FlightContext;
@@ -66,20 +69,26 @@ class RecordBucketAutoclassStepTest {
 
   @Test
   void testDoStepBucketNotFound() throws InterruptedException {
-    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(null);
+    String errorMessage = "Bucket not found";
+    when(googleBucketService.getCloudBucket(BUCKET_NAME))
+        .thenThrow(new GoogleResourceException(errorMessage));
 
-    StepResult result = step.doStep(flightContext);
-    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    GoogleResourceException thrown =
+        assertThrows(GoogleResourceException.class, () -> step.doStep(flightContext));
+    assertEquals(thrown.getMessage(), errorMessage);
   }
 
   @Test
   void testDoStepBucketResourceNotFound() throws InterruptedException {
     Bucket bucket = mock(Bucket.class);
     when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(bucket);
-    when(googleBucketService.getBucketMetadata(BUCKET_NAME)).thenReturn(null);
+    String errorMessage = "Bucket resource not found";
+    when(googleBucketService.getBucketMetadata(BUCKET_NAME))
+        .thenThrow(new GoogleResourceException(errorMessage));
 
-    StepResult result = step.doStep(flightContext);
-    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    GoogleResourceException thrown =
+        assertThrows(GoogleResourceException.class, () -> step.doStep(flightContext));
+    assertEquals(thrown.getMessage(), errorMessage);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
@@ -27,7 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
-public class RecordBucketAutoclassStepTest {
+class RecordBucketAutoclassStepTest {
   @Mock private GoogleBucketService googleBucketService;
   @Mock private FlightContext flightContext;
   private FlightMap workingMap;

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
@@ -80,8 +80,6 @@ class RecordBucketAutoclassStepTest {
 
   @Test
   void testDoStepBucketResourceNotFound() throws InterruptedException {
-    Bucket bucket = mock(Bucket.class);
-    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(bucket);
     String errorMessage = "Bucket resource not found";
     when(googleBucketService.getBucketMetadata(BUCKET_NAME))
         .thenThrow(new GoogleResourceException(errorMessage));

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
@@ -1,0 +1,156 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleBucketService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo.Autoclass;
+import com.google.cloud.storage.StorageClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+public class RecordBucketAutoclassStepTest {
+  @Mock private GoogleBucketService googleBucketService;
+  @Mock private FlightContext flightContext;
+  private FlightMap workingMap;
+
+  private static final String BUCKET_NAME = "bucket";
+
+  private RecordBucketAutoclassStep step;
+
+  @BeforeEach
+  void setup() {
+    step = new RecordBucketAutoclassStep(googleBucketService, BUCKET_NAME);
+
+    workingMap = new FlightMap();
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void testDoAndUndoStep() throws InterruptedException {
+    Bucket bucket = mock(Bucket.class);
+    GoogleBucketResource bucketResource = new GoogleBucketResource().name(BUCKET_NAME);
+    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(bucket);
+    when(bucket.getAutoclass()).thenReturn(Autoclass.newBuilder().setEnabled(false).build());
+    when(googleBucketService.getBucketMetadata(BUCKET_NAME)).thenReturn(bucketResource);
+
+    StepResult doResult = step.doStep(flightContext);
+    assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(googleBucketService).getCloudBucket(BUCKET_NAME);
+    verify(googleBucketService).getBucketMetadata(BUCKET_NAME);
+    assertThat(
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class),
+        samePropertyValuesAs(bucketResource));
+
+    StepResult undoResult = step.undoStep(flightContext);
+    assertThat(undoResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void testDoStepBucketNotFound() throws InterruptedException {
+    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(null);
+
+    StepResult result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void testDoStepBucketResourceNotFound() throws InterruptedException {
+    Bucket bucket = mock(Bucket.class);
+    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(bucket);
+    when(googleBucketService.getBucketMetadata(BUCKET_NAME)).thenReturn(null);
+
+    StepResult result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void testDoStepBucketAutoclassAlreadySetToNearline() throws InterruptedException {
+    Bucket bucket = mock(Bucket.class);
+    GoogleBucketResource bucketResource =
+        new GoogleBucketResource().name(BUCKET_NAME).autoclassEnabled(true);
+    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(bucket);
+    when(bucket.getAutoclass())
+        .thenReturn(
+            Autoclass.newBuilder()
+                .setEnabled(true)
+                .setTerminalStorageClass(StorageClass.NEARLINE)
+                .build());
+    when(googleBucketService.getBucketMetadata(BUCKET_NAME)).thenReturn(bucketResource);
+
+    StepResult result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    assertThat(
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class),
+        samePropertyValuesAs(bucketResource));
+  }
+
+  @Test
+  void testDoStepBucketAutoclassAlreadySetToArchive() throws InterruptedException {
+    Bucket bucket = mock(Bucket.class);
+    GoogleBucketResource bucketResource =
+        new GoogleBucketResource().name(BUCKET_NAME).autoclassEnabled(true);
+    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(bucket);
+    when(bucket.getAutoclass())
+        .thenReturn(
+            Autoclass.newBuilder()
+                .setEnabled(true)
+                .setTerminalStorageClass(StorageClass.ARCHIVE)
+                .build());
+    when(googleBucketService.getBucketMetadata(BUCKET_NAME)).thenReturn(bucketResource);
+
+    StepResult result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void testDoStepBucketAutoclassMismatchInMetadata1() throws InterruptedException {
+    // The bucket resource has autoclass disabled, but the bucket has autoclass enabled.
+    Bucket bucket = mock(Bucket.class);
+    GoogleBucketResource bucketResource =
+        new GoogleBucketResource().name(BUCKET_NAME).autoclassEnabled(false);
+    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(bucket);
+    when(bucket.getAutoclass())
+        .thenReturn(
+            Autoclass.newBuilder()
+                .setEnabled(true)
+                .setTerminalStorageClass(StorageClass.ARCHIVE)
+                .build());
+    when(googleBucketService.getBucketMetadata(BUCKET_NAME)).thenReturn(bucketResource);
+
+    StepResult result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void testDoStepBucketAutoclassMismatchInMetadata2() throws InterruptedException {
+    // The bucket resource has autoclass enabled, but the bucket has autoclass disabled.
+    Bucket bucket = mock(Bucket.class);
+    GoogleBucketResource bucketResource =
+        new GoogleBucketResource().name(BUCKET_NAME).autoclassEnabled(true);
+    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(bucket);
+    when(bucket.getAutoclass()).thenReturn(Autoclass.newBuilder().setEnabled(false).build());
+    when(googleBucketService.getBucketMetadata(BUCKET_NAME)).thenReturn(bucketResource);
+
+    StepResult result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
@@ -92,6 +92,21 @@ class RecordBucketAutoclassStepTest {
   }
 
   @Test
+  void testDoStepBucketAutoclassIsNull() throws InterruptedException {
+    Bucket bucket = mock(Bucket.class);
+    GoogleBucketResource bucketResource = new GoogleBucketResource().name(BUCKET_NAME);
+    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(bucket);
+    when(googleBucketService.getBucketMetadata(BUCKET_NAME)).thenReturn(bucketResource);
+    when(bucket.getAutoclass()).thenReturn(null);
+
+    StepResult result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    assertThat(
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class),
+        samePropertyValuesAs(bucketResource));
+  }
+
+  @Test
   void testDoStepBucketAutoclassAlreadySetToNearline() throws InterruptedException {
     Bucket bucket = mock(Bucket.class);
     GoogleBucketResource bucketResource =

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/UpdateBucketAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/UpdateBucketAutoclassStepTest.java
@@ -23,7 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
-public class UpdateBucketAutoclassStepTest {
+class UpdateBucketAutoclassStepTest {
   @Mock private GoogleBucketService googleBucketService;
   @Mock private FlightContext flightContext;
 

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/UpdateBucketAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/UpdateBucketAutoclassStepTest.java
@@ -1,0 +1,84 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleBucketService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import com.google.cloud.storage.StorageClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+public class UpdateBucketAutoclassStepTest {
+  @Mock private GoogleBucketService googleBucketService;
+  @Mock private FlightContext flightContext;
+
+  private static final String BUCKET_NAME = "bucket";
+
+  private UpdateBucketAutoclassStep step;
+  private GoogleBucketResource bucketResource;
+  private FlightMap workingMap;
+
+  @BeforeEach
+  void setup() {
+    step = new UpdateBucketAutoclassStep(googleBucketService);
+  }
+
+  void setBucketInfo(boolean autoclassEnabled, StorageClass storageClass) {
+    bucketResource =
+        new GoogleBucketResource()
+            .name(BUCKET_NAME)
+            .autoclassEnabled(autoclassEnabled)
+            .terminalStorageClass(storageClass);
+
+    workingMap = new FlightMap();
+    workingMap.put(FileMapKeys.BUCKET_INFO, bucketResource);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void testDoAndUndoStep() throws InterruptedException {
+    boolean autoclassEnabled = true;
+    StorageClass storageClass = StorageClass.NEARLINE;
+    setBucketInfo(autoclassEnabled, storageClass);
+    GoogleBucketResource bucketResourceGet =
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+
+    step.doStep(flightContext);
+    verify(googleBucketService).setBucketAutoclassToArchive(any());
+    step.undoStep(flightContext);
+    verify(googleBucketService).setBucketAutoclass(any(), eq(autoclassEnabled), eq(storageClass));
+    // Ensure that the bucketResource contents are the same since `any()` is used
+    assertThat(bucketResourceGet, samePropertyValuesAs(bucketResource));
+  }
+
+  @Test
+  void testDoAndUndoStepAutoclassDisabled() throws InterruptedException {
+    boolean autoclassEnabled = false;
+    StorageClass storageClass = null;
+    setBucketInfo(autoclassEnabled, storageClass);
+    GoogleBucketResource bucketResourceGet =
+        workingMap.get(FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+
+    step.doStep(flightContext);
+    verify(googleBucketService).setBucketAutoclassToArchive(any());
+    step.undoStep(flightContext);
+    verify(googleBucketService).setBucketAutoclass(any(), eq(autoclassEnabled), eq(storageClass));
+    // Ensure that the bucketResource contents are the same since `any()` is used
+    assertThat(bucketResourceGet, samePropertyValuesAs(bucketResource));
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/UpdateDatabaseAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/UpdateDatabaseAutoclassStepTest.java
@@ -1,0 +1,54 @@
+package bio.terra.service.resourcemanagement.flight;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleBucketService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+public class UpdateDatabaseAutoclassStepTest {
+  @Mock private GoogleBucketService googleBucketService;
+  @Mock private FlightContext flightContext;
+
+  private static final String BUCKET_NAME = "bucket";
+
+  private UpdateDatabaseAutoclassStep step;
+  private GoogleBucketResource bucketResource;
+  private FlightMap workingMap;
+
+  @BeforeEach
+  void setup() {
+    step = new UpdateDatabaseAutoclassStep(googleBucketService);
+  }
+
+  void setBucketInfo(boolean autoclassEnabled) {
+    bucketResource =
+        new GoogleBucketResource().name(BUCKET_NAME).autoclassEnabled(autoclassEnabled);
+
+    workingMap = new FlightMap();
+    workingMap.put(FileMapKeys.BUCKET_INFO, bucketResource);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void testDoAndUndoStep() throws InterruptedException {
+    boolean autoclass = false;
+    setBucketInfo(autoclass);
+    step.doStep(flightContext);
+    verify(googleBucketService).setBucketAutoclassMetadata(BUCKET_NAME, true);
+    step.undoStep(flightContext);
+    verify(googleBucketService).setBucketAutoclassMetadata(BUCKET_NAME, autoclass);
+  }
+}

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/UpdateDatabaseAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/UpdateDatabaseAutoclassStepTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
-public class UpdateDatabaseAutoclassStepTest {
+class UpdateDatabaseAutoclassStepTest {
   @Mock private GoogleBucketService googleBucketService;
   @Mock private FlightContext flightContext;
 

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleBucketServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleBucketServiceTest.java
@@ -207,4 +207,11 @@ public class GoogleBucketServiceTest {
     assertThat(actual.getAutoclass(), is(autoclassSetting));
     assertThat(actual.getAutoclass().getTerminalStorageClass(), is(storageClass));
   }
+
+  @Test
+  void testSetBucketAutoclassMetadata() {
+    when(googleResourceDao.updateBucketAutoclassByName(BUCKET_NAME, true)).thenReturn(1);
+    int rows = googleBucketService.setBucketAutoclassMetadata(BUCKET_NAME, true);
+    assertThat(rows, is(1));
+  }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleBucketServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleBucketServiceTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.resourcemanagement.google;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -12,9 +13,11 @@ import bio.terra.service.filedata.google.gcs.GcsProjectFactory;
 import com.google.cloud.Policy;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.BucketInfo.Autoclass;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageClass;
 import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,34 +29,182 @@ import org.springframework.core.env.Environment;
 @Tag(Unit.TAG)
 @ExtendWith(MockitoExtension.class)
 public class GoogleBucketServiceTest {
+
+  private static final String BUCKET_NAME = "bucket";
+  private static final String PROJECT_ID = "project";
+
+  @Mock private GoogleResourceDao googleResourceDao;
   @Mock private GcsProjectFactory gcsProjectFactory;
   @Mock private Environment environment;
 
-  @Test
-  void newCloudBucket() {
-    GoogleBucketResource resource =
-        new GoogleBucketResource()
-            .name("bucket")
-            .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
-            .projectResource(new GoogleProjectResource().googleProjectId("project"));
-    when(environment.getActiveProfiles()).thenReturn(new String[] {});
+  private GoogleBucketService googleBucketService;
+
+  @BeforeEach
+  void setUp() {
+    googleBucketService =
+        new GoogleBucketService(googleResourceDao, gcsProjectFactory, null, environment);
+  }
+
+  Storage mockStorageForService() {
     GcsProject gcsProject = mock(GcsProject.class);
-    when(gcsProjectFactory.get("project", true)).thenReturn(gcsProject);
+    when(gcsProjectFactory.get(PROJECT_ID, true)).thenReturn(gcsProject);
     Storage storage = mock(Storage.class);
     when(gcsProject.getStorage()).thenReturn(storage);
+    return storage;
+  }
+
+  @Test
+  void testGetStorageForBucketResource() {
+    GoogleBucketResource bucketResource =
+        new GoogleBucketResource()
+            .name(BUCKET_NAME)
+            .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
+            .projectResource(new GoogleProjectResource().googleProjectId(PROJECT_ID));
+    Storage storage = mockStorageForService();
+    Storage actual = googleBucketService.getStorageForBucketResource(bucketResource);
+    assertThat(actual, is(storage));
+  }
+
+  @Test
+  void testGetBucketMetadata() {
+    GoogleBucketResource expected =
+        new GoogleBucketResource()
+            .name(BUCKET_NAME)
+            .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
+            .projectResource(new GoogleProjectResource().googleProjectId(PROJECT_ID));
+
+    when(googleResourceDao.retrieveBucketByName(BUCKET_NAME)).thenReturn(expected);
+
+    GoogleBucketResource actual = googleBucketService.getBucketMetadata(BUCKET_NAME);
+    assertThat(actual, is(expected));
+  }
+
+  @Test
+  void testNewCloudBucket() {
+    GoogleBucketResource resource =
+        new GoogleBucketResource()
+            .name(BUCKET_NAME)
+            .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
+            .projectResource(new GoogleProjectResource().googleProjectId(PROJECT_ID));
+
+    when(environment.getActiveProfiles()).thenReturn(new String[] {});
     ArgumentCaptor<BucketInfo> bucketInfo = ArgumentCaptor.forClass(BucketInfo.class);
+    Storage storage = mockStorageForService();
     Bucket expected = mock(Bucket.class);
-    when(expected.getName()).thenReturn("bucket");
+    when(expected.getName()).thenReturn(BUCKET_NAME);
     when(storage.create(bucketInfo.capture())).thenReturn(expected);
-    when(storage.getIamPolicy("bucket", Storage.BucketSourceOption.requestedPolicyVersion(3)))
+    when(storage.getIamPolicy(BUCKET_NAME, Storage.BucketSourceOption.requestedPolicyVersion(3)))
         .thenReturn(Policy.newBuilder().build());
 
-    GoogleBucketService service =
-        new GoogleBucketService(null, gcsProjectFactory, null, environment);
     Bucket actual =
-        service.newCloudBucket(resource, Duration.ofDays(10), null, "service account", true);
+        googleBucketService.newCloudBucket(
+            resource, Duration.ofDays(10), null, "service account", true);
     assertThat(actual, is(expected));
     assertThat(
         bucketInfo.getValue().getAutoclass().getTerminalStorageClass(), is(StorageClass.ARCHIVE));
+  }
+
+  @Test
+  void testSetBucketAutoclassEnable() {
+    // Set up the bucket resources
+    boolean enableAutoclass = true;
+    StorageClass storageClass = StorageClass.ARCHIVE;
+    GoogleBucketResource bucketResource =
+        new GoogleBucketResource()
+            .name(BUCKET_NAME)
+            .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
+            .projectResource(new GoogleProjectResource().googleProjectId(PROJECT_ID))
+            .autoclassEnabled(enableAutoclass);
+    Autoclass autoclassSetting =
+        Autoclass.newBuilder()
+            .setEnabled(enableAutoclass)
+            .setTerminalStorageClass(storageClass)
+            .build();
+
+    // Mock the storage and bucket
+    Storage storage = mockStorageForService();
+    Bucket expected = mock(Bucket.class);
+    when(storage.get(BUCKET_NAME)).thenReturn(expected);
+    Bucket.Builder bucketBuilder = mock(Bucket.Builder.class);
+    when(expected.toBuilder()).thenReturn(bucketBuilder);
+    when(bucketBuilder.setAutoclass(autoclassSetting)).thenReturn(bucketBuilder);
+    when(bucketBuilder.build()).thenReturn(expected);
+    when(storage.update(expected)).thenReturn(expected);
+    when(expected.getAutoclass()).thenReturn(autoclassSetting);
+
+    // Check that the bucket has the correct autoclass setting
+    Bucket actual =
+        googleBucketService.setBucketAutoclass(
+            bucketResource, enableAutoclass, StorageClass.ARCHIVE);
+    assertThat(actual, is(expected));
+    assertThat(actual.getAutoclass(), is(autoclassSetting));
+    assertThat(actual.getAutoclass().getTerminalStorageClass(), is(storageClass));
+  }
+
+  @Test
+  void testSetBucketAutoclassDisable() {
+    // Set up the bucket resources
+    boolean enableAutoclass = false;
+    GoogleBucketResource bucketResource =
+        new GoogleBucketResource()
+            .name(BUCKET_NAME)
+            .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
+            .projectResource(new GoogleProjectResource().googleProjectId(PROJECT_ID))
+            .autoclassEnabled(enableAutoclass);
+    Autoclass autoclassSetting = Autoclass.newBuilder().setEnabled(enableAutoclass).build();
+
+    // Mock the storage and bucket
+    Storage storage = mockStorageForService();
+    Bucket expected = mock(Bucket.class);
+    when(storage.get(BUCKET_NAME)).thenReturn(expected);
+    Bucket.Builder bucketBuilder = mock(Bucket.Builder.class);
+    when(expected.toBuilder()).thenReturn(bucketBuilder);
+    when(bucketBuilder.setAutoclass(autoclassSetting)).thenReturn(bucketBuilder);
+    when(bucketBuilder.build()).thenReturn(expected);
+    when(storage.update(expected)).thenReturn(expected);
+    when(expected.getAutoclass()).thenReturn(autoclassSetting);
+
+    // Check that the bucket has no autoclass setting
+    Bucket actual =
+        googleBucketService.setBucketAutoclass(
+            bucketResource, enableAutoclass, StorageClass.ARCHIVE);
+    assertThat(actual, is(expected));
+    assertThat(actual.getAutoclass(), is(autoclassSetting));
+    assertThat(actual.getAutoclass().getTerminalStorageClass(), nullValue());
+  }
+
+  @Test
+  void testSetBucketAutoclassToArchive() {
+    // Set up the bucket resources
+    boolean enableAutoclass = true;
+    StorageClass storageClass = StorageClass.ARCHIVE;
+    GoogleBucketResource bucketResource =
+        new GoogleBucketResource()
+            .name(BUCKET_NAME)
+            .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
+            .projectResource(new GoogleProjectResource().googleProjectId(PROJECT_ID))
+            .autoclassEnabled(enableAutoclass);
+    Autoclass autoclassSetting =
+        Autoclass.newBuilder()
+            .setEnabled(enableAutoclass)
+            .setTerminalStorageClass(storageClass)
+            .build();
+
+    // Mock the storage and bucket
+    Storage storage = mockStorageForService();
+    Bucket expected = mock(Bucket.class);
+    when(storage.get(BUCKET_NAME)).thenReturn(expected);
+    Bucket.Builder bucketBuilder = mock(Bucket.Builder.class);
+    when(expected.toBuilder()).thenReturn(bucketBuilder);
+    when(bucketBuilder.setAutoclass(autoclassSetting)).thenReturn(bucketBuilder);
+    when(bucketBuilder.build()).thenReturn(expected);
+    when(storage.update(expected)).thenReturn(expected);
+    when(expected.getAutoclass()).thenReturn(autoclassSetting);
+
+    // Check that the bucket has the correct autoclass setting
+    Bucket actual = googleBucketService.setBucketAutoclassToArchive(bucketResource);
+    assertThat(actual, is(expected));
+    assertThat(actual.getAutoclass(), is(autoclassSetting));
+    assertThat(actual.getAutoclass().getTerminalStorageClass(), is(storageClass));
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/GoogleBucketServiceTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/GoogleBucketServiceTest.java
@@ -108,17 +108,19 @@ public class GoogleBucketServiceTest {
   void testSetBucketAutoclassEnable() {
     // Set up the bucket resources
     boolean enableAutoclass = true;
-    StorageClass storageClass = StorageClass.ARCHIVE;
+    StorageClass storageClass = StorageClass.STANDARD;
+    StorageClass terminalStorageClass = StorageClass.ARCHIVE;
     GoogleBucketResource bucketResource =
         new GoogleBucketResource()
             .name(BUCKET_NAME)
             .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
             .projectResource(new GoogleProjectResource().googleProjectId(PROJECT_ID))
-            .autoclassEnabled(enableAutoclass);
+            .autoclassEnabled(enableAutoclass)
+            .storageClass(storageClass);
     Autoclass autoclassSetting =
         Autoclass.newBuilder()
             .setEnabled(enableAutoclass)
-            .setTerminalStorageClass(storageClass)
+            .setTerminalStorageClass(terminalStorageClass)
             .build();
 
     // Mock the storage and bucket
@@ -127,6 +129,7 @@ public class GoogleBucketServiceTest {
     when(storage.get(BUCKET_NAME)).thenReturn(expected);
     Bucket.Builder bucketBuilder = mock(Bucket.Builder.class);
     when(expected.toBuilder()).thenReturn(bucketBuilder);
+    when(bucketBuilder.setStorageClass(storageClass)).thenReturn(bucketBuilder);
     when(bucketBuilder.setAutoclass(autoclassSetting)).thenReturn(bucketBuilder);
     when(bucketBuilder.build()).thenReturn(expected);
     when(storage.update(expected)).thenReturn(expected);
@@ -135,22 +138,24 @@ public class GoogleBucketServiceTest {
     // Check that the bucket has the correct autoclass setting
     Bucket actual =
         googleBucketService.setBucketAutoclass(
-            bucketResource, enableAutoclass, StorageClass.ARCHIVE);
+            bucketResource, enableAutoclass, storageClass, terminalStorageClass);
     assertThat(actual, is(expected));
     assertThat(actual.getAutoclass(), is(autoclassSetting));
-    assertThat(actual.getAutoclass().getTerminalStorageClass(), is(storageClass));
+    assertThat(actual.getAutoclass().getTerminalStorageClass(), is(terminalStorageClass));
   }
 
   @Test
   void testSetBucketAutoclassDisable() {
     // Set up the bucket resources
     boolean enableAutoclass = false;
+    StorageClass storageClass = StorageClass.STANDARD;
     GoogleBucketResource bucketResource =
         new GoogleBucketResource()
             .name(BUCKET_NAME)
             .region(GoogleRegion.DEFAULT_GOOGLE_REGION)
             .projectResource(new GoogleProjectResource().googleProjectId(PROJECT_ID))
-            .autoclassEnabled(enableAutoclass);
+            .autoclassEnabled(enableAutoclass)
+            .storageClass(storageClass);
     Autoclass autoclassSetting = Autoclass.newBuilder().setEnabled(enableAutoclass).build();
 
     // Mock the storage and bucket
@@ -159,6 +164,7 @@ public class GoogleBucketServiceTest {
     when(storage.get(BUCKET_NAME)).thenReturn(expected);
     Bucket.Builder bucketBuilder = mock(Bucket.Builder.class);
     when(expected.toBuilder()).thenReturn(bucketBuilder);
+    when(bucketBuilder.setStorageClass(storageClass)).thenReturn(bucketBuilder);
     when(bucketBuilder.setAutoclass(autoclassSetting)).thenReturn(bucketBuilder);
     when(bucketBuilder.build()).thenReturn(expected);
     when(storage.update(expected)).thenReturn(expected);
@@ -167,7 +173,7 @@ public class GoogleBucketServiceTest {
     // Check that the bucket has no autoclass setting
     Bucket actual =
         googleBucketService.setBucketAutoclass(
-            bucketResource, enableAutoclass, StorageClass.ARCHIVE);
+            bucketResource, enableAutoclass, storageClass, StorageClass.ARCHIVE);
     assertThat(actual, is(expected));
     assertThat(actual.getAutoclass(), is(autoclassSetting));
     assertThat(actual.getAutoclass().getTerminalStorageClass(), nullValue());
@@ -177,7 +183,8 @@ public class GoogleBucketServiceTest {
   void testSetBucketAutoclassToArchive() {
     // Set up the bucket resources
     boolean enableAutoclass = true;
-    StorageClass storageClass = StorageClass.ARCHIVE;
+    StorageClass storageClass = StorageClass.STANDARD;
+    StorageClass terminalStorageClass = StorageClass.ARCHIVE;
     GoogleBucketResource bucketResource =
         new GoogleBucketResource()
             .name(BUCKET_NAME)
@@ -187,7 +194,7 @@ public class GoogleBucketServiceTest {
     Autoclass autoclassSetting =
         Autoclass.newBuilder()
             .setEnabled(enableAutoclass)
-            .setTerminalStorageClass(storageClass)
+            .setTerminalStorageClass(terminalStorageClass)
             .build();
 
     // Mock the storage and bucket
@@ -196,6 +203,7 @@ public class GoogleBucketServiceTest {
     when(storage.get(BUCKET_NAME)).thenReturn(expected);
     Bucket.Builder bucketBuilder = mock(Bucket.Builder.class);
     when(expected.toBuilder()).thenReturn(bucketBuilder);
+    when(bucketBuilder.setStorageClass(storageClass)).thenReturn(bucketBuilder);
     when(bucketBuilder.setAutoclass(autoclassSetting)).thenReturn(bucketBuilder);
     when(bucketBuilder.build()).thenReturn(expected);
     when(storage.update(expected)).thenReturn(expected);
@@ -205,7 +213,7 @@ public class GoogleBucketServiceTest {
     Bucket actual = googleBucketService.setBucketAutoclassToArchive(bucketResource);
     assertThat(actual, is(expected));
     assertThat(actual.getAutoclass(), is(autoclassSetting));
-    assertThat(actual.getAutoclass().getTerminalStorageClass(), is(storageClass));
+    assertThat(actual.getAutoclass().getTerminalStorageClass(), is(terminalStorageClass));
   }
 
   @Test


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DCJ-653

## Summary of changes

Runs an upgrade flight which:

- Checks and records the current actual bucket Autoclass state
- Sets the bucket Autoclass state to ARCHIVE, or restores the previous one
- Sets the bucket Autoclass metadata state to true, or restores the previous one

## Testing Strategy

Unit test coverage of all the main components, and manual testing using a local TDR instance against a dev bucket. The upgrade service can be called like this:

```
{
  "upgradeName": "20240911_bucket_upgrade",
  "upgradeType": "custom",
  "customName": "SET_BUCKET_AUTOCLASS_ARCHIVE",
  "customArgs": [
    "mybucketname"
  ]
}
```

Before:

```
$ gcloud storage buckets describe gs://mybucketname --format=json
{
...
  "default_storage_class": "REGIONAL",
...
}
```

After:

```
$ gcloud storage buckets describe gs://mybucketname --format=json
{
...
  "autoclass": {
    "enabled": true,
    "terminalStorageClass": "ARCHIVE",
    "terminalStorageClassUpdateTime": "2024-09-12T00:32:03.001000+00:00",
    "toggleTime": "2024-09-12T00:32:03.001000+00:00"
  },
  "autoclass_enabled_time": "2024-09-12T00:32:03+0000",
  "default_storage_class": "STANDARD",
...
}
```