### PR TITLE
DC-1259: Enable listFiles to work for Azure; Add try/catch to avoid issue in future

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -74,7 +74,7 @@ jobs:
           base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
           base64 --decode <<< ${{ secrets.B64_RBS_APPLICATION_CREDENTIALS }} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
           # assemble code and run connected tests
-          ./gradlew --scan assemble testConnected
+          ./gradlew assemble -w testConnected --scan
   test_integration:
     name: Integration tests
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
           # wait until api is ready
           timeout 30 bash -c 'until curl -s ${IT_JADE_API_URL}/status; do sleep 1; done'
           # run integration tests
-          ./gradlew --scan testIntegration
+          ./gradlew -w testIntegration --scan
       - name: Upload API logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
+++ b/src/main/java/bio/terra/service/filedata/FileMetadataUtils.java
@@ -201,7 +201,8 @@ public class FileMetadataUtils {
       String collectionId,
       boolean enforceMatchingDirectoryEntries) {
     if (enforceMatchingDirectoryEntries && (directoryEntries.size() != files.size())) {
-      throw new FileSystemExecutionException("List sizes should be identical");
+      throw new FileSystemExecutionException(
+          "Unexpected discrepancy in retrieving file metadata. When enforceMatchingDirectoryEntries is enabled, the number of directory entries should match the number of files.");
     }
 
     Map<String, FireStoreDirectoryEntry> fileIdDirectoryMap =
@@ -214,7 +215,7 @@ public class FileMetadataUtils {
               FireStoreDirectoryEntry entry = fileIdDirectoryMap.get(file.getFileId());
               if (entry == null) {
                 throw new FileSystemExecutionException(
-                    "There should be a matching directory entry for every file.");
+                    "Unexpected discrepancy in retrieving file metadata. There should be a matching directory entry for every file.");
               }
               return new FileModel()
                   .fileId(entry.getFileId())

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFileAzurePrimaryDataStep.java
@@ -100,8 +100,9 @@ public class IngestFileAzurePrimaryDataStep implements Step {
             CommonMapKeys.DATASET_STORAGE_ACCOUNT_RESOURCE,
             AzureStorageAccountResource.class);
     String fileName = getLastNameFromPath(fileLoadModel.getSourcePath());
-    if (!azureBlobStorePdao.deleteDataFileById(
-        fileId, fileName, storageAccountResource, userRequest)) {
+    try {
+      azureBlobStorePdao.deleteDataFileById(fileId, fileName, storageAccountResource, userRequest);
+    } catch (Exception ex) {
       logger.warn(
           "File {} {} in storage account {} was not deleted.  It could ne non-existent",
           fileId,

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -436,7 +436,8 @@ public class FireStoreDao {
     List<FireStoreFile> files =
         fileDao.batchRetrieveFileMetadata(
             datasetFirestore, dataset.getId().toString(), directoryEntries);
-    return FileMetadataUtils.toFileModel(directoryEntries, files, container.getId().toString());
+    return FileMetadataUtils.toFileModel(
+        directoryEntries, files, container.getId().toString(), true);
   }
 
   /**

--- a/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/FileMetadataUtilsTest.java
@@ -253,6 +253,20 @@ class FileMetadataUtilsTest {
   }
 
   @Test
+  void testMissingDirectoryEntry() {
+    UUID fileId1 = UUID.randomUUID();
+    UUID fileId2 = UUID.randomUUID();
+    FireStoreDirectoryEntry entry1 = mockFileRefDirectoryEntry(fileId1);
+    FireStoreFile file1 = mockFileRefFireStoreFile(fileId1);
+    FireStoreFile file2 = mockFileRefFireStoreFile(fileId2);
+    assertThrows(
+        FileSystemExecutionException.class,
+        () ->
+            FileMetadataUtils.toFileModel(
+                List.of(entry1), List.of(file1, file2), UUID.randomUUID().toString(), false));
+  }
+
+  @Test
   void testIgnoreMismatchedSize() {
     UUID fileId1 = UUID.randomUUID();
     UUID fileId2 = UUID.randomUUID();


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1259

## Addresses
Users have reported issues with the listFiles endpoint on Azure. This PR addresses the root issue (commit 1) and a "fix" that enable the listFiles endpoint to work for datasets that have already encountered this issue (commit 2). 

The reported issue: listFiles does not reliably work. 
User reported that they saw errors when they used the offset/limit options to retrieve files beyond what exists. 

For example - If there are 25 files:
✅  list files, offset: 0, limit:25
❌  list files, offset: 0, limit:26
- Fails with the following error:` 404 The specified resource does not exist`
- We found logs with: `Error retrieving file metadata for file: <nonexistent fileId>`
- This corresponded to an error from:
         - `TableFileDao.retrieveFileMetadata()`
         - Called by `TableFileDao.batchRetrieveFileMetadata`
         - Which is called based on a list of directory entries retrieved by `directoryDao.enumerateFileRefEntries`.

Conclusion: This dataset erroneously has directory entires listing fileIds that do not exist in the dataset. 

How did this happen? The user reported that there were failed file ingests on this dataset. So, possibly these are fileIds left over from failed ingests.

**Failure on Ingest**

Took some tracking down, but found one of the failed FileIngestWorkerFlights for the user’s case - Flight Id: nzrj0brYRDKgrM5y2XG6jQ (the logs reference datarepo34f9c0d53a784e7d85b52089280ff87adataset, which includes the dataset id, and other clues such as the file names).

“DO” step of IngestFileAzurePrimaryDataStep failed with Interrupted exception on attempting to copy file 
<img width="1072" alt="image-20240916-183857" src="https://github.com/user-attachments/assets/aecccfd5-f0ff-46fe-b502-d73d707cc533">


“UNDO” step of IngestFileAzurePrimaryDataStep dismally failed when attempting to delete the file 
<img width="914" alt="image-20240916-184102" src="https://github.com/user-attachments/assets/331a181e-b4ac-4cf9-b8d4-45092a506a16">

Dismal Failure:
<img width="964" alt="image-20240916-184130" src="https://github.com/user-attachments/assets/5dd0bda5-6139-43dd-9ced-075d53253335">


## Summary of changes
- Make "undo" step of IngestFileAzurePrimaryDataStep try/catch on deleting the file, so that we do not dismally fail on undo. This should enable the cleanup to remove the other file metadata entries
- Ignore case where directory entries do not have matching file entry so that listFiles endpoint should still work even if the dataset has run into this error case. 

## Testing Strategy
- Unit tests
- Hard to reproduce exact issue - we should see whether it fixes the issue for our users
