### PR TITLE
[DCJ-653] Restore test and null check for bucket

### DIFF
--- a/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStep.java
@@ -33,6 +33,9 @@ public class RecordBucketAutoclassStep implements Step {
     FlightMap workingMap = context.getWorkingMap();
     GoogleBucketResource bucketResource = googleBucketService.getBucketMetadata(bucketName);
     Bucket bucket = googleBucketService.getCloudBucket(bucketName);
+    if (bucket == null) {
+      return stepResultFailure("Bucket not found: " + bucketName);
+    }
     bucketResource.setStorageClass(bucket.getStorageClass());
     Autoclass autoclass = bucket.getAutoclass();
     if (autoclass != null) {

--- a/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/flight/RecordBucketAutoclassStepTest.java
@@ -68,7 +68,15 @@ class RecordBucketAutoclassStepTest {
   }
 
   @Test
-  void testDoStepBucketNotFound() {
+  void testDoStepBucketNotFoundNull() throws InterruptedException {
+    when(googleBucketService.getCloudBucket(BUCKET_NAME)).thenReturn(null);
+
+    StepResult result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void testDoStepBucketNotFoundThrow() {
     String errorMessage = "Bucket not found";
     when(googleBucketService.getCloudBucket(BUCKET_NAME))
         .thenThrow(new GoogleResourceException(errorMessage));


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DCJ-653

## Summary of changes

It is possible for the bucket to return `null` after all in addition to throwing an exception. This was removed during a cleanup of tests in #1809 and is a follow up to #1812 .

This doesn't make a substantive change in the running of the Autoclass flight, except to catch an error earlier instead of failing on the `setStorageClass` line.

## Testing Strategy

This issue was detected by running the code on over 800 buckets in dev. I also restored the `null` check unit test.