### PR TITLE
DC-1261- Re-enable and update Firestore connected tests

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -74,7 +74,7 @@ jobs:
           base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
           base64 --decode <<< ${{ secrets.B64_RBS_APPLICATION_CREDENTIALS }} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
           # run connected tests
-          ./gradlew --scan -w testConnected
+          ./gradlew --scan --warn testConnected
   test_integration:
     name: Integration tests
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
           # wait until api is ready
           timeout 30 bash -c 'until curl -s ${IT_JADE_API_URL}/status; do sleep 1; done'
           # run integration tests
-          ./gradlew --scan -w testIntegration
+          ./gradlew --scan --warn testIntegration
       - name: Upload API logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -73,8 +73,8 @@ jobs:
           # extract service account credentials
           base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
           base64 --decode <<< ${{ secrets.B64_RBS_APPLICATION_CREDENTIALS }} > ${RBS_CLIENT_CREDENTIAL_FILE_PATH}
-          # assemble code and run connected tests
-          ./gradlew assemble -w testConnected --scan
+          # run connected tests
+          ./gradlew --scan -w testConnected
   test_integration:
     name: Integration tests
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
           # wait until api is ready
           timeout 30 bash -c 'until curl -s ${IT_JADE_API_URL}/status; do sleep 1; done'
           # run integration tests
-          ./gradlew -w testIntegration --scan
+          ./gradlew --scan -w testIntegration
       - name: Upload API logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/src/main/java/bio/terra/service/configuration/ConfigEnum.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigEnum.java
@@ -53,8 +53,6 @@ public enum ConfigEnum {
   SNAPSHOT_GRANT_ACCESS_FAULT,
   SNAPSHOT_GRANT_FILE_ACCESS_FAULT,
 
-  FIRESTORE_RETRIEVE_FAULT,
-
   CRITICAL_SYSTEM_FAULT,
 
   // Faults to test the fault system

--- a/src/main/java/bio/terra/service/configuration/ConfigurationService.java
+++ b/src/main/java/bio/terra/service/configuration/ConfigurationService.java
@@ -13,7 +13,6 @@ import static bio.terra.service.configuration.ConfigEnum.FILE_INGEST_UNLOCK_FATA
 import static bio.terra.service.configuration.ConfigEnum.FILE_INGEST_UNLOCK_RETRY_FAULT;
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_QUERY_BATCH_SIZE;
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_RETRIES;
-import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_RETRIEVE_FAULT;
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_SNAPSHOT_BATCH_SIZE;
 import static bio.terra.service.configuration.ConfigEnum.FIRESTORE_VALIDATE_BATCH_SIZE;
 import static bio.terra.service.configuration.ConfigEnum.LOAD_BULK_ARRAY_FILES_MAX;
@@ -254,8 +253,5 @@ public class ConfigurationService {
         SNAPSHOT_GRANT_ACCESS_FAULT, 0, 3, 100, ConfigFaultCountedModel.RateStyleEnum.FIXED);
     addFaultCounted(
         SNAPSHOT_GRANT_FILE_ACCESS_FAULT, 0, 3, 100, ConfigFaultCountedModel.RateStyleEnum.FIXED);
-
-    addFaultCounted(
-        FIRESTORE_RETRIEVE_FAULT, 0, 11, 100, ConfigFaultCountedModel.RateStyleEnum.FIXED);
   }
 }

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
@@ -1,6 +1,5 @@
 package bio.terra.service.filedata.google.firestore;
 
-import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.exception.FileAlreadyExistsException;
 import bio.terra.service.filedata.exception.FileSystemCorruptException;
@@ -14,8 +13,6 @@ import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.Transaction;
 import com.google.cloud.firestore.WriteResult;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreFileDao.java
@@ -159,11 +159,6 @@ class FireStoreFileDao {
         xn -> {
           DocumentSnapshot docSnap = lookupByFileId(firestore, collectionId, fileId, xn);
 
-          // Fault insertion to test retry
-          if (configurationService.testInsertFault(ConfigEnum.FIRESTORE_RETRIEVE_FAULT)) {
-            throw new StatusRuntimeException(Status.fromCodeValue(500));
-          }
-
           return Optional.ofNullable(docSnap)
               .map(d -> docSnap.toObject(FireStoreFile.class))
               .orElse(null);

--- a/src/test/java/bio/terra/common/category/Connected.java
+++ b/src/test/java/bio/terra/common/category/Connected.java
@@ -4,4 +4,6 @@ package bio.terra.common.category;
  * Connected test category. Tests in this category require credentials allowing access to a GCP
  * project for operating BigQuery and GCS bucket.
  */
-public interface Connected {}
+public interface Connected {
+  String TAG = "bio.terra.common.category.Connected";
+}

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -13,7 +13,6 @@ import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
-import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
@@ -34,8 +33,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -50,20 +47,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 @Category(Connected.class)
 @EmbeddedDatabaseTest
 public class FireStoreDaoTest {
-  private final Logger logger = LoggerFactory.getLogger(FireStoreDaoTest.class);
-
   @Autowired private FireStoreDirectoryDao directoryDao;
-
   @Autowired private FireStoreFileDao fileDao;
-
   @Autowired private FireStoreDao dao;
-
   @Autowired private FireStoreUtils fireStoreUtils;
-
   @Autowired private FireStoreDependencyDao fireStoreDependencyDao;
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private ConnectedTestConfiguration testConfig;
-  @Autowired private JsonLoader jsonLoader;
   @MockBean private IamProviderInterface samService;
   @Autowired private ConfigurationService configService;
 

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -157,7 +156,7 @@ class FireStoreDirectoryDaoTest {
 
     // Test all valid file references
     List<String> fileRefs =
-        fileObjects.stream().map(FireStoreDirectoryEntry::getFileId).collect(Collectors.toList());
+        fileObjects.stream().map(FireStoreDirectoryEntry::getFileId).toList();
     List<String> mismatches = directoryDao.validateRefIds(firestore, collectionId, fileRefs);
     assertThat("No invalid file refs", mismatches.size(), equalTo(0));
 
@@ -184,7 +183,7 @@ class FireStoreDirectoryDaoTest {
     assertThat("Correct number of object returned", enumList.size(), equalTo(3));
     List<String> expectedNames = Arrays.asList("A1", "A2", "bdir");
     List<String> enumNames =
-        enumList.stream().map(FireStoreDirectoryEntry::getName).collect(Collectors.toList());
+        enumList.stream().map(FireStoreDirectoryEntry::getName).toList();
 
     StringListCompare enumCompare = new StringListCompare(expectedNames, enumNames);
     assertThat("Enum names match", enumCompare.compare());

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
@@ -155,10 +155,9 @@ class FireStoreDirectoryDaoTest {
     }
 
     // Test all valid file references
-    List<String> fileRefs =
-        fileObjects.stream().map(FireStoreDirectoryEntry::getFileId).toList();
+    List<String> fileRefs = fileObjects.stream().map(FireStoreDirectoryEntry::getFileId).toList();
     List<String> mismatches = directoryDao.validateRefIds(firestore, collectionId, fileRefs);
-    assertThat("No invalid file refs", mismatches.size(), equalTo(0));
+    assertThat("No invalid file refs", mismatches, empty());
 
     List<String> badids = Arrays.asList("badid1", "badid2");
 
@@ -182,8 +181,7 @@ class FireStoreDirectoryDaoTest {
         directoryDao.enumerateDirectory(firestore, collectionId, "/adir");
     assertThat("Correct number of object returned", enumList.size(), equalTo(3));
     List<String> expectedNames = Arrays.asList("A1", "A2", "bdir");
-    List<String> enumNames =
-        enumList.stream().map(FireStoreDirectoryEntry::getName).toList();
+    List<String> enumNames = enumList.stream().map(FireStoreDirectoryEntry::getName).toList();
 
     StringListCompare enumCompare = new StringListCompare(expectedNames, enumNames);
     assertThat("Enum names match", enumCompare.compare());
@@ -270,7 +268,7 @@ class FireStoreDirectoryDaoTest {
 
     Map<UUID, UUID> initialConflicts =
         directoryDao.upsertDirectoryEntries(firestore, collectionId, initialFileObjects);
-    assertThat("the correct number were inserted", initialConflicts.entrySet(), hasSize(0));
+    assertThat("the correct number were inserted", initialConflicts.entrySet(), empty());
 
     // Insert a subset of objects (only the B3 directory should be new) using the same load tag
     List<FireStoreDirectoryEntry> nextFileObjects =

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -155,7 +156,8 @@ class FireStoreDirectoryDaoTest {
     }
 
     // Test all valid file references
-    List<String> fileRefs = fileObjects.stream().map(FireStoreDirectoryEntry::getFileId).toList();
+    List<String> fileRefs =
+        fileObjects.stream().map(FireStoreDirectoryEntry::getFileId).collect(Collectors.toList());
     List<String> mismatches = directoryDao.validateRefIds(firestore, collectionId, fileRefs);
     assertThat("No invalid file refs", mismatches, empty());
 

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDirectoryDaoTest.java
@@ -17,10 +17,8 @@ import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
-import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.StringListCompare;
 import bio.terra.model.BillingProfileModel;
-import bio.terra.model.DatasetSummaryModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
@@ -36,7 +34,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -52,7 +49,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
-@Ignore
 @EmbeddedDatabaseTest
 public class FireStoreDirectoryDaoTest {
 
@@ -62,11 +58,9 @@ public class FireStoreDirectoryDaoTest {
 
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private ConnectedTestConfiguration testConfig;
-  @Autowired private JsonLoader jsonLoader;
   @MockBean private IamProviderInterface samService;
   @Autowired private ConfigurationService configService;
 
-  private DatasetSummaryModel summaryModel;
   private String datasetId;
   private String collectionId;
   private Firestore firestore;
@@ -79,7 +73,7 @@ public class FireStoreDirectoryDaoTest {
     // Create dataset so that we have a firestore instance to test with
     BillingProfileModel billingProfile =
         connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
-    summaryModel = connectedOperations.createDataset(billingProfile, "dataset-minimal.json");
+    var summaryModel = connectedOperations.createDataset(billingProfile, "dataset-minimal.json");
 
     datasetId = summaryModel.getId().toString();
     collectionId = "directoryDaoTest_" + datasetId;

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
@@ -2,6 +2,7 @@ package bio.terra.service.filedata.google.firestore;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -81,7 +82,7 @@ class FireStoreFileDaoTest {
     assertThat(
         "Cleanup from previous test successful",
         fileDao.enumerateAllWithEmptyField(firestore, datasetId, "fileId"),
-        hasSize(0));
+        empty());
     directoryEntries = null;
     files = null;
     objects = null;

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
@@ -4,155 +4,92 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
-import bio.terra.common.TestUtils;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
-import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.model.BillingProfileModel;
-import bio.terra.model.ConfigFaultCountedModel;
-import bio.terra.model.ConfigFaultModel;
-import bio.terra.model.ConfigGroupModel;
-import bio.terra.model.ConfigModel;
-import bio.terra.model.DatasetSummaryModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
-import bio.terra.service.configuration.ConfigEnum;
-import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.exception.FileAlreadyExistsException;
 import bio.terra.service.filedata.exception.FileSystemCorruptException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import com.google.cloud.firestore.Firestore;
-import io.grpc.StatusRuntimeException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "connectedtest"})
-@Category(Connected.class)
-@Ignore
+@Tag(Connected.TAG)
 @EmbeddedDatabaseTest
-public class FireStoreFileDaoTest {
-  private final Logger logger = LoggerFactory.getLogger(FireStoreFileDaoTest.class);
+class FireStoreFileDaoTest {
   private final Long FILE_SIZE = 42L;
   private final Long CHANGED_FILE_SIZE = 22L;
 
   @Autowired private FireStoreFileDao fileDao;
-
   @Autowired private FireStoreUtils fireStoreUtils;
-
-  @Autowired private ConfigurationService configurationService;
-
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private ConnectedTestConfiguration testConfig;
-  @Autowired private JsonLoader jsonLoader;
   @MockBean private IamProviderInterface samService;
-  @Autowired private ConfigurationService configService;
-
-  private DatasetSummaryModel summaryModel;
   private String datasetId;
   private Firestore firestore;
-  private String collectionId;
+  private List<FireStoreDirectoryEntry> directoryEntries;
+  private List<FireStoreFile> files;
+  private List<String> objects;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     connectedOperations.stubOutSamCalls(samService);
-    configService.reset();
 
     // Create dataset so that we have a firestore instance to test with
     BillingProfileModel billingProfile =
         connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
-    summaryModel = connectedOperations.createDataset(billingProfile, "dataset-minimal.json");
+    var summaryModel = connectedOperations.createDataset(billingProfile, "dataset-minimal.json");
     datasetId = summaryModel.getId().toString();
 
-    collectionId = String.format("%s-files", datasetId);
     firestore = TestFirestoreProvider.getFirestore(summaryModel.getDataProject());
-  }
 
-  @After
-  public void cleanup() throws Exception {
-    configurationService.reset();
-    connectedOperations.teardown();
-  }
-
-  @Test
-  public void createDeleteFileTest() throws Exception {
-    FireStoreFile file1 = makeFile();
-    FireStoreFile file2 = makeFile();
-    String objectId1 = file1.getFileId();
-
-    FireStoreFile existCheck = fileDao.retrieveFileMetadata(firestore, datasetId, objectId1);
-    assertNull("Object id does not exists", existCheck);
-    fileDao.upsertFileMetadata(firestore, datasetId, file1);
-    existCheck = fileDao.retrieveFileMetadata(firestore, datasetId, objectId1);
-    assertNotNull("Object id exists", existCheck);
-    assertThat("Correct size", existCheck.getSize(), equalTo(FILE_SIZE));
-
-    file1.size(CHANGED_FILE_SIZE);
-    fileDao.upsertFileMetadata(firestore, datasetId, file1);
-    existCheck = fileDao.retrieveFileMetadata(firestore, datasetId, objectId1);
-    assertNotNull("Object id exists", existCheck);
-    assertThat("Correct size", existCheck.getSize(), equalTo(CHANGED_FILE_SIZE));
-
-    file2.checksumMd5("foo");
-    fileDao.upsertFileMetadata(firestore, datasetId, file2);
-    List<FireStoreFile> filesWithNullMd5Field =
-        fileDao.enumerateAllWithEmptyField(firestore, datasetId, "checksumMd5");
-    assertThat("only one file has no md5", filesWithNullMd5Field, hasSize(1));
-    assertThat(
-        "file1's id has a null md5", filesWithNullMd5Field.get(0).getFileId(), equalTo(objectId1));
-
-    boolean fileExisted = fileDao.deleteFileMetadata(firestore, datasetId, objectId1);
-    assertTrue("File existed before delete", fileExisted);
-    existCheck = fileDao.retrieveFileMetadata(firestore, datasetId, objectId1);
-    assertNull("Object id does not exists", existCheck);
-
-    fileExisted = fileDao.deleteFileMetadata(firestore, datasetId, objectId1);
-    assertFalse("File doesn't exist after delete", fileExisted);
-  }
-
-  @Test
-  public void deleteAllFilesTest() throws Exception {
-    // Make some files
-    List<FireStoreFile> fileList = IntStream.range(0, 5).boxed().map(i -> makeFile()).toList();
-    fileDao.upsertFileMetadata(firestore, datasetId, fileList);
-
-    List<String> fileIds = fileList.stream().map(FireStoreFile::getFileId).toList();
-
-    for (String fileId : fileIds) {
-      FireStoreFile existCheck = fileDao.retrieveFileMetadata(firestore, datasetId, fileId);
-      assertNotNull("File entry was created", existCheck);
+    // seed firestore with a collection of directory and file entries
+    directoryEntries =
+        IntStream.range(0, 5)
+            .mapToObj(i -> new FireStoreDirectoryEntry().fileId(UUID.randomUUID().toString()))
+            .toList();
+    files =
+        directoryEntries.stream()
+            .map(FireStoreDirectoryEntry::getFileId)
+            .map(this::makeFile)
+            .toList();
+    for (FireStoreFile file : files) {
+      fileDao.upsertFileMetadata(firestore, datasetId, file);
     }
+    objects = files.stream().map(FireStoreFile::getFileId).toList();
+  }
 
+  @AfterEach
+  public void cleanup() throws Exception {
+    // delete remaining files from firestore, or else database delete will fail
+    // and confirm delete all works as expected
     List<String> deleteIds = new ArrayList<>();
-
-    // Delete the files; our function collects the deleted object ids in a list
     fileDao.deleteFilesFromDataset(
         firestore,
         datasetId,
@@ -161,70 +98,81 @@ public class FireStoreFileDaoTest {
             deleteIds.add(fsf.getFileId());
           }
         });
-
     assertThat(
         "Deleted id list matched created id list",
         deleteIds,
-        containsInAnyOrder(fileIds.toArray(new String[0])));
-
-    for (String fileId : fileIds) {
+        containsInAnyOrder(objects.toArray(new String[0])));
+    for (String fileId : objects) {
       FireStoreFile existCheck = fileDao.retrieveFileMetadata(firestore, datasetId, fileId);
-      assertNull("File entry was deleted", existCheck);
+      assertThat("File entry was deleted", existCheck, is(nullValue()));
     }
+
+    connectedOperations.teardown();
   }
 
   @Test
-  public void createFileWithConflictingLoadTagsTest() throws Exception {
-    FireStoreFile file1 = makeFile();
-    String objectId1 = file1.getFileId();
-
-    FireStoreFile existCheck = fileDao.retrieveFileMetadata(firestore, datasetId, objectId1);
-    assertNull("Object id does not exists", existCheck);
-    fileDao.upsertFileMetadata(firestore, datasetId, file1.loadTag("lt1"));
-    Throwable cause =
-        assertThrows(
-                "upsert fails with load tag conflict (and try the list uploader)",
-                FileSystemExecutionException.class,
-                () ->
-                    fileDao.upsertFileMetadata(firestore, datasetId, List.of(file1.loadTag("lt2"))))
-            .getCause();
-    assertThat(
-        "Correct cause triggered the error",
-        cause.getCause(),
-        isA(FileAlreadyExistsException.class));
-  }
-
-  @Test
-  public void testBatchRetrieveFileMetadata() throws InterruptedException {
-    List<FireStoreDirectoryEntry> directoryEntries =
-        IntStream.range(0, 5)
-            .mapToObj(i -> new FireStoreDirectoryEntry().fileId(UUID.randomUUID().toString()))
-            .toList();
-    List<FireStoreFile> files =
-        directoryEntries.stream()
-            .map(FireStoreDirectoryEntry::getFileId)
-            .map(this::makeFile)
-            .toList();
-    for (FireStoreFile file : files) {
-      fileDao.upsertFileMetadata(firestore, datasetId, file);
+  void createDeleteFileTest() throws Exception {
+    // ====== test retrieving file metadata firestore entries ======
+    for (String obj : objects) {
+      assertThat(
+          "All files were added to firestore and that the correct file size is returned",
+          fileDao.retrieveFileMetadata(firestore, datasetId, obj).getSize(),
+          equalTo(FILE_SIZE));
     }
+
+    // batch retrieve
     List<FireStoreFile> retrievedFiles =
         fileDao.batchRetrieveFileMetadata(firestore, datasetId, directoryEntries);
     assertEquals(files, retrievedFiles);
-  }
 
-  @Test
-  public void testBatchRetrieveNonExistentFileMetadata() {
+    // can't retrieve non-existent file
     FireStoreDirectoryEntry directoryEntry =
         new FireStoreDirectoryEntry().fileId(UUID.randomUUID().toString());
     assertThrows(
         FileSystemCorruptException.class,
         () -> fileDao.batchRetrieveFileMetadata(firestore, datasetId, List.of(directoryEntry)));
-  }
 
-  private FireStoreFile makeFile() {
-    String fileId = UUID.randomUUID().toString();
-    return makeFile(fileId);
+    // ====== test updating file metadata firestore entries ======
+    // update file size field
+    var file0 = files.get(0).size(CHANGED_FILE_SIZE);
+    fileDao.upsertFileMetadata(firestore, datasetId, file0);
+    assertThat(
+        "Returned updated file size for file0",
+        fileDao.retrieveFileMetadata(firestore, datasetId, file0.getFileId()).getSize(),
+        equalTo(CHANGED_FILE_SIZE));
+
+    // test enumerateAllWithEmptyField
+    var file1 = files.get(1).checksumMd5("md5");
+    fileDao.upsertFileMetadata(firestore, datasetId, file1);
+    List<FireStoreFile> filesWithNullMd5Field =
+        fileDao.enumerateAllWithEmptyField(firestore, datasetId, "checksumMd5");
+    assertThat(
+        "All but one file has empty field", filesWithNullMd5Field, hasSize(files.size() - 1));
+
+    // conflicting load tags
+    var file2 = files.get(2); // By default it should have loadTag = "loadTag"
+    fileDao.upsertFileMetadata(firestore, datasetId, file2);
+    Throwable cause =
+        assertThrows(
+                "upsert fails with load tag conflict (and try the list uploader)",
+                FileSystemExecutionException.class,
+                () ->
+                    fileDao.upsertFileMetadata(firestore, datasetId, List.of(file2.loadTag("lt2"))))
+            .getCause();
+    assertThat(
+        "Correct cause triggered the error",
+        cause.getCause(),
+        isA(FileAlreadyExistsException.class));
+
+    // ====== test deleting file metadata firestore entries ======
+    // delete single file
+    assertThat("File existed", fileDao.deleteFileMetadata(firestore, datasetId, file0.getFileId()));
+    assertThat(
+        "File entry was deleted",
+        fileDao.retrieveFileMetadata(firestore, datasetId, file0.getFileId()),
+        is(nullValue()));
+    // remove first file from list so that we can test batch delete in the cleanup method
+    objects = objects.stream().filter(obj -> !obj.equals(file0.getFileId())).toList();
   }
 
   private FireStoreFile makeFile(String fileId) {
@@ -234,6 +182,7 @@ public class FireStoreFileDaoTest {
         .description("file")
         .bucketResourceId("BostonBucket")
         .gspath("gs://server.example.com/" + fileId)
+        .loadTag("loadTag")
         .size(FILE_SIZE);
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
@@ -24,10 +24,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -39,6 +42,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles({"google", "connectedtest"})
 @Tag(Connected.TAG)
 @EmbeddedDatabaseTest
@@ -57,7 +61,7 @@ class FireStoreFileDaoTest {
   private List<FireStoreFile> files;
   private List<String> objects;
 
-  @BeforeEach
+  @BeforeAll
   public void setup() throws Exception {
     connectedOperations.stubOutSamCalls(samService);
 
@@ -68,6 +72,19 @@ class FireStoreFileDaoTest {
     datasetId = summaryModel.getId().toString();
 
     firestore = TestFirestoreProvider.getFirestore(summaryModel.getDataProject());
+  }
+
+  @BeforeEach
+  public void seedDirectoryEntries() throws InterruptedException {
+    // Make sure there aren't any lingering entries from other tests - directory is empty
+    fileDao.deleteFilesFromDataset(firestore, datasetId, fsf -> {});
+    assertThat(
+        "Cleanup from previous test successful",
+        fileDao.enumerateAllWithEmptyField(firestore, datasetId, "fileId"),
+        hasSize(0));
+    directoryEntries = null;
+    files = null;
+    objects = null;
 
     // seed firestore with a collection of directory and file entries
     directoryEntries =
@@ -86,9 +103,92 @@ class FireStoreFileDaoTest {
   }
 
   @AfterEach
+  public void cleanupAfterEachTest() throws Exception {
+    if (datasetId != null) {
+      fileDao.deleteFilesFromDataset(firestore, datasetId, fsf -> {});
+    }
+  }
+
+  @AfterAll
   public void cleanup() throws Exception {
-    // delete remaining files from firestore, or else database delete will fail
-    // and confirm delete all works as expected
+    connectedOperations.stubOutSamCalls(samService);
+    connectedOperations.teardown();
+  }
+
+  @Test
+  void testRetrieveFileMetadata() throws Exception {
+    for (String obj : objects) {
+      assertThat(
+          "All files were added to firestore and that the correct file size is returned",
+          fileDao.retrieveFileMetadata(firestore, datasetId, obj).getSize(),
+          equalTo(FILE_SIZE));
+    }
+
+    // batch retrieve
+    List<FireStoreFile> retrievedFiles =
+        fileDao.batchRetrieveFileMetadata(firestore, datasetId, directoryEntries);
+    assertEquals(files, retrievedFiles);
+  }
+
+  @Test
+  void testRetrieveNonExistentFileMetadata() throws Exception {
+    FireStoreDirectoryEntry directoryEntry =
+        new FireStoreDirectoryEntry().fileId(UUID.randomUUID().toString());
+    assertThrows(
+        FileSystemCorruptException.class,
+        () -> fileDao.batchRetrieveFileMetadata(firestore, datasetId, List.of(directoryEntry)));
+  }
+
+  @Test
+  void testUpdateFileMetadata() throws Exception {
+    // update file size field
+    var file0 = files.get(0).size(CHANGED_FILE_SIZE);
+    fileDao.upsertFileMetadata(firestore, datasetId, file0);
+    assertThat(
+        "Returned updated file size for file0",
+        fileDao.retrieveFileMetadata(firestore, datasetId, file0.getFileId()).getSize(),
+        equalTo(CHANGED_FILE_SIZE));
+  }
+
+  @Test
+  void testEnumerateAllWithEmptyField() throws Exception {
+    var file1 = files.get(1).checksumMd5("md5");
+    fileDao.upsertFileMetadata(firestore, datasetId, file1);
+    List<FireStoreFile> filesWithNullMd5Field =
+        fileDao.enumerateAllWithEmptyField(firestore, datasetId, "checksumMd5");
+    assertThat(
+        "All but one file has empty field", filesWithNullMd5Field, hasSize(files.size() - 1));
+  }
+
+  @Test
+  void testConflictingLoadTags() throws Exception {
+    var file2 = files.get(2); // By default it should have loadTag = "loadTag"
+    fileDao.upsertFileMetadata(firestore, datasetId, file2);
+    Throwable cause =
+        assertThrows(
+                "upsert fails with load tag conflict (and try the list uploader)",
+                FileSystemExecutionException.class,
+                () ->
+                    fileDao.upsertFileMetadata(firestore, datasetId, List.of(file2.loadTag("lt2"))))
+            .getCause();
+    assertThat(
+        "Correct cause triggered the error",
+        cause.getCause(),
+        isA(FileAlreadyExistsException.class));
+  }
+
+  @Test
+  void testDeleteSingleFileMetadata() throws Exception {
+    var file0 = files.get(0);
+    assertThat("File existed", fileDao.deleteFileMetadata(firestore, datasetId, file0.getFileId()));
+    assertThat(
+        "File entry was deleted",
+        fileDao.retrieveFileMetadata(firestore, datasetId, file0.getFileId()),
+        is(nullValue()));
+  }
+
+  @Test
+  void testDeleteAllFileMetadataEntries() throws InterruptedException {
     List<String> deleteIds = new ArrayList<>();
     fileDao.deleteFilesFromDataset(
         firestore,
@@ -106,73 +206,6 @@ class FireStoreFileDaoTest {
       FireStoreFile existCheck = fileDao.retrieveFileMetadata(firestore, datasetId, fileId);
       assertThat("File entry was deleted", existCheck, is(nullValue()));
     }
-
-    connectedOperations.teardown();
-  }
-
-  @Test
-  void createDeleteFileTest() throws Exception {
-    // ====== test retrieving file metadata firestore entries ======
-    for (String obj : objects) {
-      assertThat(
-          "All files were added to firestore and that the correct file size is returned",
-          fileDao.retrieveFileMetadata(firestore, datasetId, obj).getSize(),
-          equalTo(FILE_SIZE));
-    }
-
-    // batch retrieve
-    List<FireStoreFile> retrievedFiles =
-        fileDao.batchRetrieveFileMetadata(firestore, datasetId, directoryEntries);
-    assertEquals(files, retrievedFiles);
-
-    // can't retrieve non-existent file
-    FireStoreDirectoryEntry directoryEntry =
-        new FireStoreDirectoryEntry().fileId(UUID.randomUUID().toString());
-    assertThrows(
-        FileSystemCorruptException.class,
-        () -> fileDao.batchRetrieveFileMetadata(firestore, datasetId, List.of(directoryEntry)));
-
-    // ====== test updating file metadata firestore entries ======
-    // update file size field
-    var file0 = files.get(0).size(CHANGED_FILE_SIZE);
-    fileDao.upsertFileMetadata(firestore, datasetId, file0);
-    assertThat(
-        "Returned updated file size for file0",
-        fileDao.retrieveFileMetadata(firestore, datasetId, file0.getFileId()).getSize(),
-        equalTo(CHANGED_FILE_SIZE));
-
-    // test enumerateAllWithEmptyField
-    var file1 = files.get(1).checksumMd5("md5");
-    fileDao.upsertFileMetadata(firestore, datasetId, file1);
-    List<FireStoreFile> filesWithNullMd5Field =
-        fileDao.enumerateAllWithEmptyField(firestore, datasetId, "checksumMd5");
-    assertThat(
-        "All but one file has empty field", filesWithNullMd5Field, hasSize(files.size() - 1));
-
-    // conflicting load tags
-    var file2 = files.get(2); // By default it should have loadTag = "loadTag"
-    fileDao.upsertFileMetadata(firestore, datasetId, file2);
-    Throwable cause =
-        assertThrows(
-                "upsert fails with load tag conflict (and try the list uploader)",
-                FileSystemExecutionException.class,
-                () ->
-                    fileDao.upsertFileMetadata(firestore, datasetId, List.of(file2.loadTag("lt2"))))
-            .getCause();
-    assertThat(
-        "Correct cause triggered the error",
-        cause.getCause(),
-        isA(FileAlreadyExistsException.class));
-
-    // ====== test deleting file metadata firestore entries ======
-    // delete single file
-    assertThat("File existed", fileDao.deleteFileMetadata(firestore, datasetId, file0.getFileId()));
-    assertThat(
-        "File entry was deleted",
-        fileDao.retrieveFileMetadata(firestore, datasetId, file0.getFileId()),
-        is(nullValue()));
-    // remove first file from list so that we can test batch delete in the cleanup method
-    objects = objects.stream().filter(obj -> !obj.equals(file0.getFileId())).toList();
   }
 
   private FireStoreFile makeFile(String fileId) {

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreFileDaoTest.java
@@ -173,53 +173,6 @@ public class FireStoreFileDaoTest {
     }
   }
 
-  // Default settings of the thought should result in a retry failure
-  @Test(expected = StatusRuntimeException.class)
-  public void faultRetrieveRetryFail() throws Exception {
-    configurationService.setFault(ConfigEnum.FIRESTORE_RETRIEVE_FAULT.name(), true);
-
-    TestUtils.setConfigParameterValue(
-        configurationService, ConfigEnum.FIRESTORE_RETRIES, "1", "setRetryParameter");
-
-    FireStoreFile file1 = makeFile();
-    String objectId = file1.getFileId();
-
-    fileDao.upsertFileMetadata(firestore, datasetId, file1);
-    fileDao.retrieveFileMetadata(firestore, datasetId, objectId);
-  }
-
-  @Test()
-  public void faultRetrieveRetrySuccess() throws Exception {
-    ConfigFaultCountedModel countedModel =
-        new ConfigFaultCountedModel()
-            .skipFor(0)
-            .insert(3)
-            .rate(100)
-            .rateStyle(ConfigFaultCountedModel.RateStyleEnum.FIXED);
-
-    ConfigFaultModel configFaultModel =
-        new ConfigFaultModel()
-            .enabled(true)
-            .faultType(ConfigFaultModel.FaultTypeEnum.COUNTED)
-            .counted(countedModel);
-
-    ConfigModel configModel =
-        new ConfigModel()
-            .name(ConfigEnum.FIRESTORE_RETRIEVE_FAULT.name())
-            .configType(ConfigModel.ConfigTypeEnum.FAULT)
-            .fault(configFaultModel);
-
-    ConfigGroupModel configGroupModel =
-        new ConfigGroupModel().label("faultRetrieveRetrySuccess").addGroupItem(configModel);
-    configurationService.setConfig(configGroupModel);
-
-    FireStoreFile file1 = makeFile();
-    String objectId = file1.getFileId();
-
-    fileDao.upsertFileMetadata(firestore, datasetId, file1);
-    fileDao.retrieveFileMetadata(firestore, datasetId, objectId);
-  }
-
   @Test
   public void createFileWithConflictingLoadTagsTest() throws Exception {
     FireStoreFile file1 = makeFile();

--- a/src/test/java/bio/terra/service/filedata/google/firestore/TestFirestoreProvider.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/TestFirestoreProvider.java
@@ -7,9 +7,9 @@ public final class TestFirestoreProvider {
 
   private TestFirestoreProvider() {}
 
-  public static Firestore getFirestore() {
+  public static Firestore getFirestore(String googleProjectId) {
     return FirestoreOptions.getDefaultInstance().toBuilder()
-        .setProjectId(System.getenv("GOOGLE_CLOUD_DATA_PROJECT"))
+        .setProjectId(googleProjectId)
         .build()
         .getService();
   }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1261

## Addresses
We recently have undergone a cost savings effort to remove unused google projects. It turns out our Firestore connected tests still relied on the broad-jade-integration-data project. We still want to delete this project, so this change aims to remove our reliance on this project. 

## Summary of changes
- Remove `@Ignore` tags on the three firestore connected tests (Added to temporarily unblock test runs - https://github.com/DataBiosphere/jade-data-repo/pull/1816) 
- Instead of relying on a pre-existing google project, we instead will create a new dataset that contains a google project with firestore enabled. 
- Update the three tests to use Junit5
- Remove test that relied on inserted faults to test retries in firestore. We are moving away from that pattern
- Performance: Creating a dataset for each test would be a hit to performance. So, I set these tests up to use Junit's`@BeforeAll`, and `@AfterAll` tags. This enables us to create one dataset/firestore instance per test class rather than per test. 

## Testing Strategy
- Updated existing tests
