### PR TITLE
DC-1227: No longer report version bump to datarepo-helm-definitions; Only build one docker image

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -28,48 +28,51 @@ jobs:
     # Skip entire workflow if commit is authored by broadbot
     # broadbot is only used for automated commits, like version bumps
     # We don't want to trigger a version bump/deploy to dev for those
-    if: ${{ !contains( github.event.sender.login, 'broadbot') }}
+#    if: ${{ !contains( github.event.sender.login, 'broadbot') }}
     steps:
-      - name: Checkout Develop branch of jade-data-repo
-        uses: actions/checkout@v3
-        with:
-          ref: develop
-          token: ${{ secrets.BROADBOT_TOKEN }}
-      - name: "Bump the tag to a new version"
+#      - name: Checkout Develop branch of jade-data-repo
+#        uses: actions/checkout@v3
+#        with:
+#          ref: develop
+#          token: ${{ secrets.BROADBOT_TOKEN }}
+#      - name: "Bump the tag to a new version"
+#        id: bumperstep
+#        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
+#        with:
+#          actions_subcommand: 'bumper'
+#          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
+#          version_file_path: build.gradle
+#          version_variable_name: version
+#          # Sets the author of the version bump commit to broadbot. This is used in our skip job logic.
+#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+      - name: 'manually set ouput'
         id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        with:
-          actions_subcommand: 'bumper'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-          version_file_path: build.gradle
-          version_variable_name: version
-          # Sets the author of the version bump commit to broadbot. This is used in our skip job logic.
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+        run: echo "tag=2.159.0" >> "$GITHUB_OUTPUT"
 
-  build_client_and_publish:
-    runs-on: ubuntu-latest
-    needs:
-        - bump_version
-    steps:
-      - name: Checkout Develop branch of jade-data-repo
-        uses: actions/checkout@v3
-        with:
-          ref: develop
-          token: ${{ secrets.BROADBOT_TOKEN }}
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-      - name: "Publish to Artifactory"
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: ':datarepo-client:artifactoryPublish'
-        env:
-          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ENABLE_SUBPROJECT_TASKS: true
+#  build_client_and_publish:
+#    runs-on: ubuntu-latest
+#    needs:
+#        - bump_version
+#    steps:
+#      - name: Checkout Develop branch of jade-data-repo
+#        uses: actions/checkout@v3
+#        with:
+#          ref: develop
+#          token: ${{ secrets.BROADBOT_TOKEN }}
+#      - name: Set up JDK
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#          cache: 'gradle'
+#      - name: "Publish to Artifactory"
+#        uses: gradle/gradle-build-action@v2
+#        with:
+#          arguments: ':datarepo-client:artifactoryPublish'
+#        env:
+#          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+#          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+#          ENABLE_SUBPROJECT_TASKS: true
 
   build_container_and_publish:
     runs-on: ubuntu-latest
@@ -93,45 +96,46 @@ jobs:
           alpharelease: ${{ needs.bump_version.outputs.api_image_tag }} # creates gcr build with semver tag
           gcr_google_project: 'broad-jade-dev'
 
-  cherry_pick_image_to_production_gcr:
-    needs: [bump_version, build_container_and_publish]
-    uses: ./.github/workflows/cherry-pick-image.yaml
-    secrets: inherit
-    with:
-      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
-      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
-      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
 
-  report-to-sherlock:
-    name: Report App Version to DevOps
-    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: [bump_version, cherry_pick_image_to_production_gcr]
-    with:
-      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
-      chart-name: datarepo
-    permissions:
-      contents: read
-      id-token: write
-
-  set-app-version-in-dev:
-    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs:
-      - bump_version
-      - report-to-sherlock
-    with:
-      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
-      chart-name: datarepo
-      environment-name: dev
-    secrets:
-      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
-    permissions:
-      id-token: write
-
-  helm_tag_bumper:
-    needs:
-      - build_container_and_publish
-      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
-      # too, and we don't want to be deploying to datarepo-dev twice simultaneously
-      - set-app-version-in-dev
-    uses: ./.github/workflows/helmtagbumper.yaml
-    secrets: inherit
+#  cherry_pick_image_to_production_gcr:
+#    needs: [bump_version, build_container_and_publish]
+#    uses: ./.github/workflows/cherry-pick-image.yaml
+#    secrets: inherit
+#    with:
+#      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
+#      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
+#      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
+#
+#  report-to-sherlock:
+#    name: Report App Version to DevOps
+#    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+#    needs: [bump_version, cherry_pick_image_to_production_gcr]
+#    with:
+#      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
+#      chart-name: datarepo
+#    permissions:
+#      contents: read
+#      id-token: write
+#
+#  set-app-version-in-dev:
+#    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+#    needs:
+#      - bump_version
+#      - report-to-sherlock
+#    with:
+#      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
+#      chart-name: datarepo
+#      environment-name: dev
+#    secrets:
+#      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+#    permissions:
+#      id-token: write
+#
+#  helm_tag_bumper:
+#    needs:
+#      - build_container_and_publish
+#      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
+#      # too, and we don't want to be deploying to datarepo-dev twice simultaneously
+#      - set-app-version-in-dev
+#    uses: ./.github/workflows/helmtagbumper.yaml
+#    secrets: inherit

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -76,11 +76,15 @@ jobs:
     needs:
       - bump_version
     steps:
-      - name: Checkout Develop branch of jade-data-repo
-        uses: actions/checkout@v3
+      - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
+        uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
         with:
-          ref: develop
-          token: ${{ secrets.BROADBOT_TOKEN }}
+          timeout_minutes: 1
+          polling_interval_seconds: 5
+          max_attempts: 5
+          command: |
+            git fetch --all --tags
+            git checkout ${{ needs.bump_version.outputs.api_image_tag }}
       - name: 'Release Candidate Container Build: Create release candidate images'
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -81,22 +81,10 @@ jobs:
         with:
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
-      - name: 'Checkout datarepo-helm-definitions repo'
-        uses: actions/checkout@v3
-        with:
-          repository: 'broadinstitute/datarepo-helm-definitions'
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          path: datarepo-helm-definitions
       - name: "Build new delevop docker image"
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:
           actions_subcommand: 'gradlebuild'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-      - name: "Update Version in helm for Dev Env"
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        with:
-          actions_subcommand: 'deploytagupdate'
-          helm_env_prefix: dev
           sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
       - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
         uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -81,27 +81,6 @@ jobs:
         with:
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
-      - name: "Build new delevop docker image"
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        with:
-          actions_subcommand: 'gradlebuild'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-      - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
-        uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
-        with:
-          timeout_minutes: 1
-          polling_interval_seconds: 5
-          max_attempts: 5
-          command: |
-            git fetch --all --tags
-            git checkout ${{ needs.bump_version.outputs.api_image_tag }}
-      - name: 'Release Candidate Container Build: Checkout DataBiosphere/jade-data-repo-ui repo'
-        uses: actions/checkout@v3
-        with:
-          repository: 'DataBiosphere/jade-data-repo-ui'
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          path: jade-data-repo-ui
-          ref: develop
       - name: 'Release Candidate Container Build: Create release candidate images'
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -84,6 +84,12 @@ jobs:
         with:
           ref: ${{ needs.bump_version.outputs.api_image_tag }}
           token: ${{ secrets.BROADBOT_TOKEN }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
       - name: 'Release Candidate Container Build: Create release candidate images'
         env:
           GOOGLE_APPLICATION_CREDENTIALS: jade-dev-account.json

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -85,12 +85,18 @@ jobs:
           ref: ${{ needs.bump_version.outputs.api_image_tag }}
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Release Candidate Container Build: Create release candidate images'
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        with:
-          actions_subcommand: 'alpharelease'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-          alpharelease: ${{ needs.bump_version.outputs.api_image_tag }} # creates gcr build with semver tag
-          gcr_google_project: 'broad-jade-dev'
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: jade-dev-account.json
+          GOOGLE_SA_CERT: jade-dev-account.pem
+        run: |
+          # extract service account credentials
+          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          jq -r .private_key ${GOOGLE_APPLICATION_CREDENTIALS} > ${GOOGLE_SA_CERT}
+          chmod 644 ${GOOGLE_SA_CERT}
+          # Set tag to semver version
+          export GCR_TAG=${{ needs.bump_version.outputs.api_image_tag }}
+          # Build, tag and push the image
+          ./gradlew jib
 
 
 #  cherry_pick_image_to_production_gcr:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -28,51 +28,48 @@ jobs:
     # Skip entire workflow if commit is authored by broadbot
     # broadbot is only used for automated commits, like version bumps
     # We don't want to trigger a version bump/deploy to dev for those
-#    if: ${{ !contains( github.event.sender.login, 'broadbot') }}
+    if: ${{ !contains( github.event.sender.login, 'broadbot') }}
     steps:
-#      - name: Checkout Develop branch of jade-data-repo
-#        uses: actions/checkout@v3
-#        with:
-#          ref: develop
-#          token: ${{ secrets.BROADBOT_TOKEN }}
-#      - name: "Bump the tag to a new version"
-#        id: bumperstep
-#        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-#        with:
-#          actions_subcommand: 'bumper'
-#          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-#          version_file_path: build.gradle
-#          version_variable_name: version
-#          # Sets the author of the version bump commit to broadbot. This is used in our skip job logic.
-#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-      - name: 'manually set ouput'
+      - name: Checkout Develop branch of jade-data-repo
+        uses: actions/checkout@v3
+        with:
+          ref: develop
+          token: ${{ secrets.BROADBOT_TOKEN }}
+      - name: "Bump the tag to a new version"
         id: bumperstep
-        run: echo "tag=2.159.0" >> "$GITHUB_OUTPUT"
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
+        with:
+          actions_subcommand: 'bumper'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
+          version_file_path: build.gradle
+          version_variable_name: version
+          # Sets the author of the version bump commit to broadbot. This is used in our skip job logic.
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 
-#  build_client_and_publish:
-#    runs-on: ubuntu-latest
-#    needs:
-#        - bump_version
-#    steps:
-#      - name: Checkout Develop branch of jade-data-repo
-#        uses: actions/checkout@v3
-#        with:
-#          ref: develop
-#          token: ${{ secrets.BROADBOT_TOKEN }}
-#      - name: Set up JDK
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '17'
-#          distribution: 'temurin'
-#          cache: 'gradle'
-#      - name: "Publish to Artifactory"
-#        uses: gradle/gradle-build-action@v2
-#        with:
-#          arguments: ':datarepo-client:artifactoryPublish'
-#        env:
-#          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
-#          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-#          ENABLE_SUBPROJECT_TASKS: true
+  build_client_and_publish:
+    runs-on: ubuntu-latest
+    needs:
+        - bump_version
+    steps:
+      - name: Checkout Develop branch of jade-data-repo
+        uses: actions/checkout@v3
+        with:
+          ref: develop
+          token: ${{ secrets.BROADBOT_TOKEN }}
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: "Publish to Artifactory"
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ':datarepo-client:artifactoryPublish'
+        env:
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ENABLE_SUBPROJECT_TASKS: true
 
   build_container_and_publish:
     runs-on: ubuntu-latest
@@ -104,46 +101,45 @@ jobs:
           # Build, tag and push the image
           ./gradlew jib
 
+  cherry_pick_image_to_production_gcr:
+    needs: [bump_version, build_container_and_publish]
+    uses: ./.github/workflows/cherry-pick-image.yaml
+    secrets: inherit
+    with:
+      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
+      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
+      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
 
-#  cherry_pick_image_to_production_gcr:
-#    needs: [bump_version, build_container_and_publish]
-#    uses: ./.github/workflows/cherry-pick-image.yaml
-#    secrets: inherit
-#    with:
-#      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
-#      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
-#      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
-#
-#  report-to-sherlock:
-#    name: Report App Version to DevOps
-#    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-#    needs: [bump_version, cherry_pick_image_to_production_gcr]
-#    with:
-#      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
-#      chart-name: datarepo
-#    permissions:
-#      contents: read
-#      id-token: write
-#
-#  set-app-version-in-dev:
-#    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-#    needs:
-#      - bump_version
-#      - report-to-sherlock
-#    with:
-#      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
-#      chart-name: datarepo
-#      environment-name: dev
-#    secrets:
-#      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
-#    permissions:
-#      id-token: write
-#
-#  helm_tag_bumper:
-#    needs:
-#      - build_container_and_publish
-#      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
-#      # too, and we don't want to be deploying to datarepo-dev twice simultaneously
-#      - set-app-version-in-dev
-#    uses: ./.github/workflows/helmtagbumper.yaml
-#    secrets: inherit
+  report-to-sherlock:
+    name: Report App Version to DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: [bump_version, cherry_pick_image_to_production_gcr]
+    with:
+      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
+      chart-name: datarepo
+    permissions:
+      contents: read
+      id-token: write
+
+  set-app-version-in-dev:
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs:
+      - bump_version
+      - report-to-sherlock
+    with:
+      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
+      chart-name: datarepo
+      environment-name: dev
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: write
+
+  helm_tag_bumper:
+    needs:
+      - build_container_and_publish
+      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
+      # too, and we don't want to be deploying to datarepo-dev twice simultaneously
+      - set-app-version-in-dev
+    uses: ./.github/workflows/helmtagbumper.yaml
+    secrets: inherit

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -79,15 +79,11 @@ jobs:
     needs:
       - bump_version
     steps:
-      - name: 'Release Candidate Container Build: Checkout tag for DataBiosphere/jade-data-repo'
-        uses: broadinstitute/retry@v2.8.3 #forked from nick-fields/retry
+      - name: Checkout tagged branch of jade-data-repo
+        uses: actions/checkout@v3
         with:
-          timeout_minutes: 1
-          polling_interval_seconds: 5
-          max_attempts: 5
-          command: |
-            git fetch --all --tags
-            git checkout ${{ needs.bump_version.outputs.api_image_tag }}
+          ref: ${{ needs.bump_version.outputs.api_image_tag }}
+          token: ${{ secrets.BROADBOT_TOKEN }}
       - name: 'Release Candidate Container Build: Create release candidate images'
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
         with:


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1227

## Addresses
As part of cleaning up datarepo-helm-definitions, we no longer need to report the latest dev version to this repo. This is instead reported to terra-helmfile by sherlock.

We also were building the docker image twice. I think we only ever need the semver tagged docker image.
<img width="835" alt="image" src="https://github.com/user-attachments/assets/49f0c2dc-5207-4ea3-bdca-7e728c77401e">


## Summary of changes
- remove GHA steps that report dev version to datarepo-helm-definitions
- Remove second build of docker container
- Remove reliance on datarepo-actions by moving the jib call to this workflow.

## Testing Strategy
Example run with a manually set version bump: https://github.com/DataBiosphere/jade-data-repo/actions/runs/11131919078
We won't see the whole thing run until merged.
