### PR TITLE
[DCJ-790]Improve error messaging around locks

### DIFF
--- a/src/main/java/bio/terra/common/LockOperation.java
+++ b/src/main/java/bio/terra/common/LockOperation.java
@@ -1,6 +1,7 @@
 package bio.terra.common;
 
 import bio.terra.model.ResourceLocks;
+import java.util.ArrayList;
 import java.util.List;
 
 /** Actions which could be taken to modify the locks held on a resource (dataset, snapshot). */
@@ -38,13 +39,11 @@ public enum LockOperation {
                 + " Conflicting lock(s): %s. You can remove a lock by using the unlock API endpoint with the ID of the resource (Snapshot or Dataset), the name of the lock, and forceUnlock set to false.";
         if (this == LOCK_EXCLUSIVE) {
           // include any locks that exist both exclusive and shared (but only one will be populated)
-          if (isExclusive(conflictingLocks)) {
-            return List.of(
-                template.formatted(description, conflict, conflictingLocks.getExclusive()));
-          } else if (areShared(conflictingLocks)) {
-            String locks = String.join(", ", conflictingLocks.getShared());
-            return List.of(template.formatted(description, conflict, locks));
-          }
+          List<String> lockList = new ArrayList<>();
+          if (isExclusive(conflictingLocks)) lockList.add(conflictingLocks.getExclusive());
+          if (areShared(conflictingLocks)) lockList.addAll(conflictingLocks.getShared());
+          String locks = String.join(", ", lockList);
+          return List.of(template.formatted(description, conflict, locks));
         } else if (this == LOCK_SHARED) {
           // include only exclusive locks if the lock operation attempted was shared
           return List.of(

--- a/src/main/java/bio/terra/common/LockOperation.java
+++ b/src/main/java/bio/terra/common/LockOperation.java
@@ -1,5 +1,6 @@
 package bio.terra.common;
 
+import bio.terra.model.ResourceLocks;
 import java.util.List;
 
 /** Actions which could be taken to modify the locks held on a resource (dataset, snapshot). */
@@ -27,13 +28,36 @@ public enum LockOperation {
    * @return additional guidance for users investigating a failed lock operation, usually as part of
    *     a failed job / flight.
    */
-  public List<String> getErrorDetails() {
+  public List<String> getErrorDetails(ResourceLocks conflictingLocks) {
     var template =
         "A failure to obtain %s on a resource likely means that it's already %s by another process.";
     if (description != null && conflict != null) {
+      if (conflictingLocks != null && !isEmpty(conflictingLocks)) {
+        template =
+            template
+                + " Conflicting lock(s): %s. You can remove a lock by using the unlock API endpoint with the ID of the resource (Snapshot or Dataset), the name of the lock, and forceUnlock set to false.";
+        if (this == LOCK_EXCLUSIVE) {
+          // include any locks that exist both exclusive and shared (but only one will be populated)
+          if (isExclusive(conflictingLocks)) {
+            return List.of(
+                template.formatted(description, conflict, conflictingLocks.getExclusive()));
+          } else if (areShared(conflictingLocks)) {
+            String locks = String.join(", ", conflictingLocks.getShared());
+            return List.of(template.formatted(description, conflict, locks));
+          }
+        } else if (this == LOCK_SHARED) {
+          // include only exclusive locks if the lock operation attempted was shared
+          return List.of(
+              template.formatted(description, conflict, conflictingLocks.getExclusive()));
+        }
+      }
       return List.of(template.formatted(description, conflict));
     }
     return List.of();
+  }
+
+  public List<String> getErrorDetails() {
+    return getErrorDetails(null);
   }
 
   /**
@@ -42,5 +66,17 @@ public enum LockOperation {
    */
   public boolean lockAttempted() {
     return isLock;
+  }
+
+  private boolean isEmpty(ResourceLocks locks) {
+    return !isExclusive(locks) && !areShared(locks);
+  }
+
+  private boolean isExclusive(ResourceLocks locks) {
+    return locks.getExclusive() != null && !locks.getExclusive().isEmpty();
+  }
+
+  private boolean areShared(ResourceLocks locks) {
+    return locks.getShared() != null && !locks.getShared().isEmpty();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -327,11 +327,11 @@ public class DatasetDao implements TaggableResourceDao {
       if (numRowsUpdated == 0 && lockType.lockAttempted()) {
         // this method checks if the dataset exists
         // if it does not exist, then the method throws a DatasetNotFoundException
-        // we don't need the result (dataset summary) here, just the existence check,
-        // so ignore the return value.
-        retrieveSummaryById(datasetId);
+        // if it does exist, get any locks that exist because this is helpful info for a user
+        DatasetSummary summary = retrieveSummaryById(datasetId);
 
-        throw new DatasetLockException("Failed to lock the dataset", lockType.getErrorDetails());
+        throw new DatasetLockException(
+            "Failed to lock the dataset", lockType.getErrorDetails(summary.getResourceLocks()));
       }
     } catch (DatasetNotFoundException notFound) {
       logger.error(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -163,12 +163,12 @@ public class SnapshotDao implements TaggableResourceDao {
     if (numRowsUpdated == 0) {
       // this method checks if the snapshot exists
       // if it does not exist, then the method throws a SnapshotNotFoundException
-      // we don't need the result (snapshot summary) here, just the existence check, so ignore the
-      // return value.
-      retrieveSummaryById(snapshotId);
+      // if it does exist, get any locks that exist because this is helpful info for a user
+      SnapshotSummary summary = retrieveSummaryById(snapshotId);
 
       throw new SnapshotLockException(
-          "Failed to lock the snapshot", LockOperation.LOCK_EXCLUSIVE.getErrorDetails());
+          "Failed to lock the snapshot",
+          LockOperation.LOCK_EXCLUSIVE.getErrorDetails(summary.getResourceLocks()));
     }
   }
 

--- a/src/test/java/bio/terra/common/LockOperationTest.java
+++ b/src/test/java/bio/terra/common/LockOperationTest.java
@@ -1,0 +1,87 @@
+package bio.terra.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.ResourceLocks;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Unit.TAG)
+class LockOperationTest {
+  ResourceLocks conflictingSharedLocks;
+  ResourceLocks conflictingExclusiveLocks;
+
+  @BeforeEach
+  public void setup() {
+    conflictingSharedLocks = new ResourceLocks().addSharedItem("shared1").addSharedItem("shared2");
+    conflictingExclusiveLocks = new ResourceLocks().exclusive("exclusive");
+  }
+
+  @Test
+  void getErrorDetailsUnlockShared() {
+    assertThat(LockOperation.UNLOCK_SHARED.getErrorDetails(), equalTo(List.of()));
+  }
+
+  @Test
+  void getErrorDetailsUnlockExclusive() {
+    assertThat(LockOperation.UNLOCK_EXCLUSIVE.getErrorDetails(), equalTo(List.of()));
+  }
+
+  @Test
+  void getErrorDetailsUnlockSharedWithLocks() {
+    assertThat(
+        LockOperation.UNLOCK_SHARED.getErrorDetails(conflictingExclusiveLocks), equalTo(List.of()));
+  }
+
+  @Test
+  void getErrorDetailsUnlockExclusiveWithLocks() {
+    assertThat(
+        LockOperation.UNLOCK_EXCLUSIVE.getErrorDetails(conflictingExclusiveLocks),
+        equalTo(List.of()));
+  }
+
+  @Test
+  void getErrorDetailsExclusiveLockNoConflictingLocks() {
+    assertThat(
+        LockOperation.LOCK_EXCLUSIVE.getErrorDetails(),
+        equalTo(
+            List.of(
+                "A failure to obtain an exclusive lock on a resource likely means that it's already locked by another process.")));
+  }
+
+  @Test
+  void getErrorDetailsSharedLockNoConflictingLocks() {
+    assertThat(
+        LockOperation.LOCK_SHARED.getErrorDetails(),
+        equalTo(
+            List.of(
+                "A failure to obtain a shared lock on a resource likely means that it's already exclusively locked by another process.")));
+  }
+
+  @Test
+  void getErrorDetailsExclusiveLockConflictingLocks() {
+    assertThat(
+        LockOperation.LOCK_EXCLUSIVE.getErrorDetails(conflictingExclusiveLocks),
+        equalTo(
+            List.of(
+                "A failure to obtain an exclusive lock on a resource likely means that it's already locked by another process. Conflicting lock(s): exclusive. You can remove a lock by using the unlock API endpoint with the ID of the resource (Snapshot or Dataset), the name of the lock, and forceUnlock set to false.")));
+    assertThat(
+        LockOperation.LOCK_EXCLUSIVE.getErrorDetails(conflictingSharedLocks),
+        equalTo(
+            List.of(
+                "A failure to obtain an exclusive lock on a resource likely means that it's already locked by another process. Conflicting lock(s): shared1, shared2. You can remove a lock by using the unlock API endpoint with the ID of the resource (Snapshot or Dataset), the name of the lock, and forceUnlock set to false.")));
+  }
+
+  @Test
+  void getErrorDetailsSharedLockConflictingLocks() {
+    assertThat(
+        LockOperation.LOCK_SHARED.getErrorDetails(conflictingExclusiveLocks),
+        equalTo(
+            List.of(
+                "A failure to obtain a shared lock on a resource likely means that it's already exclusively locked by another process. Conflicting lock(s): exclusive. You can remove a lock by using the unlock API endpoint with the ID of the resource (Snapshot or Dataset), the name of the lock, and forceUnlock set to false.")));
+  }
+}


### PR DESCRIPTION


__Jira ticket__: https://broadworkbench.atlassian.net/browse/[DCJ-790]

## Addresses
User questions on surrounding failures due to locking and unlocking. Users already have the permissions to solve these kinds of problems on their own; they just need to know how.

## Summary of changes
Updates error messaging for failure to lock snapshots and datasets. Messaging now includes the lock name, and directions on how to unlock a resource. 

## Testing Strategy
Unit tests
<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
