### PR TITLE
[DCJ-742] Update codeowners for data team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # These owners will be the default owners for everything in the repo.
-*       @DataBiosphere/data-custodian-journeys @DataBiosphere/data-explorer-eng
+*       @DataBiosphere/dsp-data-team-eng
 
 # Order is important. The last matching pattern has the most precedence.
 # Example: if a pull request only touches files in a `/snapshotbuilder` directory


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-742

### Summary

Updates the CODEOWNERS with the new data team.