### PR TITLE
DC-1227: Further cleanup of dev image update GHA

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -22,15 +22,14 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: "Bump the tag to a new version"
         id: bumperstep
-        run: echo "tag=2.160.0" >> "$GITHUB_OUTPUT"
-#        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-#        with:
-#          actions_subcommand: 'bumper'
-#          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-#          version_file_path: build.gradle
-#          version_variable_name: version
-#          # Sets the author of the version bump commit to broadbot. This is used in our skip job logic.
-#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
+        with:
+          actions_subcommand: 'bumper'
+          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
+          version_file_path: build.gradle
+          version_variable_name: version
+          # Sets the author of the version bump commit to broadbot. This is used in our skip job logic.
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 
   build_client_and_publish:
     runs-on: ubuntu-latest
@@ -85,45 +84,45 @@ jobs:
           # Build, tag and push the image
           ./gradlew jib
 
-#  cherry_pick_image_to_production_gcr:
-#    needs: [bump_version, build_container_and_publish]
-#    uses: ./.github/workflows/cherry-pick-image.yaml
-#    secrets: inherit
-#    with:
-#      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
-#      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
-#      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
-#
-#  report-to-sherlock:
-#    name: Report App Version to DevOps
-#    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-#    needs: [bump_version, cherry_pick_image_to_production_gcr]
-#    with:
-#      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
-#      chart-name: datarepo
-#    permissions:
-#      contents: read
-#      id-token: write
-#
-#  set-app-version-in-dev:
-#    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-#    needs:
-#      - bump_version
-#      - report-to-sherlock
-#    with:
-#      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
-#      chart-name: datarepo
-#      environment-name: dev
-#    secrets:
-#      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
-#    permissions:
-#      id-token: write
-#
-#  helm_tag_bumper:
-#    needs:
-#      - build_container_and_publish
-#      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
-#      # too, and we don't want to be deploying to datarepo-dev twice simultaneously
-#      - set-app-version-in-dev
-#    uses: ./.github/workflows/helmtagbumper.yaml
-#    secrets: inherit
+  cherry_pick_image_to_production_gcr:
+    needs: [bump_version, build_container_and_publish]
+    uses: ./.github/workflows/cherry-pick-image.yaml
+    secrets: inherit
+    with:
+      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
+      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
+      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
+
+  report-to-sherlock:
+    name: Report App Version to DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: [bump_version, cherry_pick_image_to_production_gcr]
+    with:
+      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
+      chart-name: datarepo
+    permissions:
+      contents: read
+      id-token: write
+
+  set-app-version-in-dev:
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs:
+      - bump_version
+      - report-to-sherlock
+    with:
+      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
+      chart-name: datarepo
+      environment-name: dev
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: write
+
+  helm_tag_bumper:
+    needs:
+      - build_container_and_publish
+      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
+      # too, and we don't want to be deploying to datarepo-dev twice simultaneously
+      - set-app-version-in-dev
+    uses: ./.github/workflows/helmtagbumper.yaml
+    secrets: inherit

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -37,10 +37,10 @@ jobs:
     needs:
         - bump_version
     steps:
-      - name: Checkout Develop branch of jade-data-repo
+      - name: Checkout tagged branch of jade-data-repo
         uses: actions/checkout@v3
         with:
-          ref: develop
+          ref: ${{ needs.bump_version.outputs.api_image_tag }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -1,24 +1,9 @@
 name: Update devs api image
-env:
-  # This must be defined for the bash redirection
-  GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
-  # This must be defined for the bash redirection
-  GOOGLE_SA_CERT: 'jade-dev-account.pem'
 on:
   workflow_dispatch: {}
   push:
     branches:
       - develop
-    paths:
-      - '!*'
-      - 'src/**'
-      - 'gradle/**'
-      - 'gradle**'
-      - '**.gradle'
-      - 'Dockerfile'
-      - 'datarepo-clienttests/**'
-      - '.github/workflows/dev-image-update.yaml'
-      - '.swagger-codegen-ignore'
 jobs:
 
   bump_version:
@@ -55,7 +40,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: develop
-          token: ${{ secrets.BROADBOT_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -80,7 +64,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.bump_version.outputs.api_image_tag }}
-          token: ${{ secrets.BROADBOT_TOKEN }}
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -22,14 +22,15 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: "Bump the tag to a new version"
         id: bumperstep
-        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
-        with:
-          actions_subcommand: 'bumper'
-          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
-          version_file_path: build.gradle
-          version_variable_name: version
-          # Sets the author of the version bump commit to broadbot. This is used in our skip job logic.
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+        run: echo "tag=2.160.0" >> "$GITHUB_OUTPUT"
+#        uses: broadinstitute/datarepo-actions/actions/main@0.74.0
+#        with:
+#          actions_subcommand: 'bumper'
+#          sa_b64_credentials: ${{ secrets.SA_B64_CREDENTIALS }}
+#          version_file_path: build.gradle
+#          version_variable_name: version
+#          # Sets the author of the version bump commit to broadbot. This is used in our skip job logic.
+#          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
 
   build_client_and_publish:
     runs-on: ubuntu-latest
@@ -84,45 +85,45 @@ jobs:
           # Build, tag and push the image
           ./gradlew jib
 
-  cherry_pick_image_to_production_gcr:
-    needs: [bump_version, build_container_and_publish]
-    uses: ./.github/workflows/cherry-pick-image.yaml
-    secrets: inherit
-    with:
-      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
-      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
-      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
-
-  report-to-sherlock:
-    name: Report App Version to DevOps
-    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: [bump_version, cherry_pick_image_to_production_gcr]
-    with:
-      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
-      chart-name: datarepo
-    permissions:
-      contents: read
-      id-token: write
-
-  set-app-version-in-dev:
-    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs:
-      - bump_version
-      - report-to-sherlock
-    with:
-      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
-      chart-name: datarepo
-      environment-name: dev
-    secrets:
-      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
-    permissions:
-      id-token: write
-
-  helm_tag_bumper:
-    needs:
-      - build_container_and_publish
-      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
-      # too, and we don't want to be deploying to datarepo-dev twice simultaneously
-      - set-app-version-in-dev
-    uses: ./.github/workflows/helmtagbumper.yaml
-    secrets: inherit
+#  cherry_pick_image_to_production_gcr:
+#    needs: [bump_version, build_container_and_publish]
+#    uses: ./.github/workflows/cherry-pick-image.yaml
+#    secrets: inherit
+#    with:
+#      gcr_tag: ${{ needs.bump_version.outputs.api_image_tag }}
+#      source_gcr_url: 'gcr.io/broad-jade-dev/jade-data-repo'
+#      target_gcr_url: 'gcr.io/datarepo-public-gcr/jade-data-repo'
+#
+#  report-to-sherlock:
+#    name: Report App Version to DevOps
+#    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+#    needs: [bump_version, cherry_pick_image_to_production_gcr]
+#    with:
+#      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
+#      chart-name: datarepo
+#    permissions:
+#      contents: read
+#      id-token: write
+#
+#  set-app-version-in-dev:
+#    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+#    needs:
+#      - bump_version
+#      - report-to-sherlock
+#    with:
+#      new-version: ${{ needs.bump_version.outputs.api_image_tag }}
+#      chart-name: datarepo
+#      environment-name: dev
+#    secrets:
+#      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+#    permissions:
+#      id-token: write
+#
+#  helm_tag_bumper:
+#    needs:
+#      - build_container_and_publish
+#      # We block bumping the tag in datarepo-helm because that will cause a deployment to datarepo-dev
+#      # too, and we don't want to be deploying to datarepo-dev twice simultaneously
+#      - set-app-version-in-dev
+#    uses: ./.github/workflows/helmtagbumper.yaml
+#    secrets: inherit


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1227

## Addresses
Addresses clean up suggestions from previous PR: https://github.com/DataBiosphere/jade-data-repo/pull/1826
I wanted to limit the number of changes in the original PR, making it easier the test the bigger change.

## Summary of changes
- Remove env section since defining it later in the particular step used
- Remove file and directory exclusions - This isn't strictly necessary, but a simplification: Always deploy a version of tdr on merge code.
- Remove references to BROADBOT_TOKEN where not needed
- Check out the tagged version of the code instead of develop before deploying the client to artifactory. 

## Testing Strategy
Test run (hard coding the bumped version and commenting out any action not touched by changes) - https://github.com/DataBiosphere/jade-data-repo/actions/runs/11297765241

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
