### PR TITLE
DCJ-751: Reenable retry for test runs in GHA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ subprojects.each { s ->
     }
 }
 
-boolean isCiServer = System.getenv().containsKey("CI")
+boolean isCiServer = System.getenv().containsKey("GITHUB_ACTIONS")
 
 java {
     sourceCompatibility = 17


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-751

## Addresses
We've noticed increasing failures for our integration test runs on TDR. We previously had retries enabled so that flakiness in a single test could automatically be re-run rather than needing to re-run the whole test suite. We've had this feature enabled for years. 

On switching over to running tests natively in Github Actions (GHA), our isCIServer flag was no longer getting set. From [stackoverflow](https://stackoverflow.com/questions/60006265/whats-the-purpose-of-the-environment-variable-ci-set-to-true-within-a-github-wo#:~:text=GitHub%20Actions%20itself%2C%20does%20not,not%20intended%20for%20CI%20only.), it does not appear that GHAs set the CI environment variable. Instead, they use their own `GITHUB_ACTIONS` env variable. This was tested and confirmed to enabled retries with this GHA test run ([GHA](https://github.com/DataBiosphere/jade-data-repo/actions/runs/11345521754), [Gradle Scan](https://scans.gradle.com/s/vs2pvtgswtkzc)) 

## Summary of changes
- Switch gradle.build from looking at `CI` env variable to `GITHUB_ACTIONS` variable. 

## Testing Strategy
This change was tested and confirmed to enabled retries with this GHA test run ([GHA](https://github.com/DataBiosphere/jade-data-repo/actions/runs/11345521754), [Gradle Scan](https://scans.gradle.com/s/vs2pvtgswtkzc)) 

<img width="781" alt="image" src="https://github.com/user-attachments/assets/3f5166d1-0576-4a2d-824a-694689c21418">

## Future Improvements
It would be worth looking into why these tests are flaky.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
