### PR TITLE
DC-1227: Add back env variables needed for bumper action

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -1,11 +1,15 @@
 name: Update devs api image
+env:
+  # This must be defined for the bash redirection
+  GOOGLE_APPLICATION_CREDENTIALS: 'jade-dev-account.json'
+  # This must be defined for the bash redirection
+  GOOGLE_SA_CERT: 'jade-dev-account.pem'
 on:
   workflow_dispatch: {}
   push:
     branches:
       - develop
 jobs:
-
   bump_version:
     runs-on: ubuntu-latest
     outputs:
@@ -71,9 +75,6 @@ jobs:
           java-version: '17'
           cache: 'gradle'
       - name: 'Release Candidate Container Build: Create release candidate images'
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: jade-dev-account.json
-          GOOGLE_SA_CERT: jade-dev-account.pem
         run: |
           # extract service account credentials
           base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1227

## Addresses
After cleanup PR (https://github.com/DataBiosphere/jade-data-repo/pull/1834), dev image update action failed because it needed the env variables. 

## Summary of changes
- Add back top level env variables
- Remove those env variables from step level since now set at top level

## Testing Strategy
I specifically don't want to test the bumper action without actually merging the PR because it gets things in a bad state: the version will bump in some spots but not others. It is possible that this is not as much of a problem now that we have simplified the actions. 

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
