### PR TITLE
DT-937: More resilience for upsertEntity into Azure Storage Tables

### DIFF
--- a/src/main/java/bio/terra/common/FutureUtils.java
+++ b/src/main/java/bio/terra/common/FutureUtils.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 public final class FutureUtils {
+  public static final String INTERRUPTED_THREAD_MESSAGE = "Thread was interrupted";
 
   private FutureUtils() {}
 
@@ -65,7 +66,8 @@ public final class FutureUtils {
                     // Cancellation may not be necessary, but it can't hurt:
                     f.cancel(true);
                   } catch (InterruptedException e) {
-                    foundFailure.compareAndSet(null, new ApiException("Thread was interrupted", e));
+                    foundFailure.compareAndSet(
+                        null, new ApiException(INTERRUPTED_THREAD_MESSAGE, e));
                     // Cancellation may not be necessary, but it can't hurt:
                     f.cancel(true);
                   } catch (ExecutionException e) {

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -10,12 +10,15 @@ import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.http.rest.Response;
 import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.models.ListEntitiesOptions;
 import com.azure.data.tables.models.TableEntity;
+import com.azure.data.tables.models.TableEntityUpdateMode;
 import com.azure.data.tables.models.TableServiceException;
 import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -121,13 +124,39 @@ public class TableDirectoryDao {
       String partitionKey = getCollectionPartitionKey(collectionId, testPath);
       String rowKey = encodePathAsAzureRowKey(testPath);
       TableEntity entity = FireStoreDirectoryEntry.toTableEntity(partitionKey, rowKey, dirToCreate);
-      logger.info("Upserting directory entry for {} in table {}", testPath, tableName);
       // For file ingest worker flights,
       // It's possible that another thread is trying to write the same directory entity at the same
       // time upsert rather than create so that it does not fail if it already exists
-      tableClient.upsertEntity(entity);
+      upsertEntityCheckStatus(tableClient, entity, testPath, tableName);
     }
     createEntityForPath(tableClient, collectionId, tableName, createEntry);
+  }
+
+  public void upsertEntityCheckStatus(
+      TableClient tableClient, TableEntity entity, String path, String tableName) {
+    try {
+      Response<Void> response =
+          tableClient.upsertEntityWithResponse(
+              entity, TableEntityUpdateMode.MERGE, Duration.ofSeconds(20), null);
+      if (response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
+        logger.info(
+            "Entity upsert successful with status code: {} for {} in table {}",
+            response.getStatusCode(),
+            path,
+            tableName);
+      } else {
+        throw new FileSystemExecutionException(
+            "Error upserting entity with status code: "
+                + response.getStatusCode()
+                + " for "
+                + path
+                + " in table "
+                + tableName);
+      }
+    } catch (TableServiceException ex) {
+      throw new FileSystemExecutionException(
+          "Error upserting entity for " + path + " in table " + tableName, ex);
+    }
   }
 
   private void createEntityForPath(
@@ -141,8 +170,7 @@ public class TableDirectoryDao {
     String rowKey = encodePathAsAzureRowKey(lookupPath);
     TableEntity createEntryEntity =
         FireStoreDirectoryEntry.toTableEntity(partitionKey, rowKey, createEntry);
-    logger.info("Upserting directory entry for {} in table {}", fullPath, tableName);
-    tableClient.upsertEntity(createEntryEntity);
+    upsertEntityCheckStatus(tableClient, createEntryEntity, fullPath, tableName);
   }
 
   // true - directory entry existed and was deleted; false - directory entry did not exist

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDataStep.java
@@ -1,10 +1,13 @@
 package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.common.FlightUtils;
+import bio.terra.common.FutureUtils;
+import bio.terra.common.exception.ApiException;
 import bio.terra.service.common.CommonMapKeys;
 import bio.terra.service.common.azure.StorageTableName;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
 import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
 import bio.terra.service.resourcemanagement.azure.AzureStorageAuthInfo;
 import bio.terra.service.snapshot.Snapshot;
@@ -12,6 +15,7 @@ import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
 import com.azure.data.tables.TableServiceClient;
 import java.util.Set;
 import java.util.UUID;
@@ -61,13 +65,25 @@ public class CreateSnapshotStorageTableDataStep implements Step {
 
     Set<String> refIds = azureSynapsePdao.getRefIdsForSnapshot(snapshot);
 
-    tableDao.addFilesToSnapshot(
-        datasetTableServiceClient,
-        snapshotTableServiceClient,
-        datasetId,
-        datasetName,
-        snapshot,
-        refIds);
+    try {
+      tableDao.addFilesToSnapshot(
+          datasetTableServiceClient,
+          snapshotTableServiceClient,
+          datasetId,
+          datasetName,
+          snapshot,
+          refIds);
+    } catch (ApiException ex) {
+      // retry step if thread is interrupted
+      if (ex.getMessage().contains(FutureUtils.INTERRUPTED_THREAD_MESSAGE)) {
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+      } else {
+        return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
+      }
+    } catch (FileSystemExecutionException ex) {
+      // retry for case that Azure Table operations fail in transient way
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
+    }
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -380,7 +380,8 @@ public class SnapshotCreateFlight extends Flight {
               snapshotService,
               datasetId,
               datasetName,
-              snapshotId));
+              snapshotId),
+          randomBackoffRetry);
 
       addStep(
           new CreateSnapshotStorageTableDependenciesStep(

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
@@ -4,6 +4,7 @@ import static bio.terra.service.common.azure.StorageTableName.DATASET;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.AzureUtils;
@@ -15,6 +16,7 @@ import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.common.azure.StorageTableName;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.FileMetadataUtils;
+import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.core.http.rest.PagedIterable;
@@ -102,6 +104,28 @@ public class TableDirectoryDaoConnectedTest {
     }
 
     connectedOperations.teardown();
+  }
+
+  @Test
+  public void upsertEntityCheckStatus() {
+    snapshotTableName = StorageTableName.SNAPSHOT.toTableName(snapshotId);
+    tableServiceClient.createTableIfNotExists(snapshotTableName);
+    TableClient tableClient = tableServiceClient.getTableClient(snapshotTableName);
+    tableDirectoryDao.upsertEntityCheckStatus(
+        tableClient, new TableEntity("", ""), "/", snapshotTableName);
+  }
+
+  @Test
+  public void upsertEntityCheckStatusNoTable() {
+    // Upsert the entity
+    snapshotTableName = StorageTableName.SNAPSHOT.toTableName(snapshotId);
+    // "snapshotTableName" should not exist
+    TableClient tableClient = tableServiceClient.getTableClient(snapshotTableName);
+    assertThrows(
+        FileSystemExecutionException.class,
+        () ->
+            tableDirectoryDao.upsertEntityCheckStatus(
+                tableClient, new TableEntity("", ""), "/", snapshotTableName));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -49,7 +48,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class TableDirectoryDaoConnectedTest {
   private static final Logger logger =
       LoggerFactory.getLogger(TableDirectoryDaoConnectedTest.class);

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDataStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotStorageTableDataStepTest.java
@@ -1,0 +1,111 @@
+package bio.terra.service.snapshot.flight.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.FutureUtils;
+import bio.terra.common.category.Unit;
+import bio.terra.common.exception.ApiException;
+import bio.terra.service.common.CommonMapKeys;
+import bio.terra.service.filedata.azure.AzureSynapsePdao;
+import bio.terra.service.filedata.azure.tables.TableDao;
+import bio.terra.service.filedata.exception.FileSystemExecutionException;
+import bio.terra.service.resourcemanagement.azure.AzureAuthService;
+import bio.terra.service.resourcemanagement.azure.AzureStorageAuthInfo;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepStatus;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class CreateSnapshotStorageTableDataStepTest {
+  @Mock private TableDao tableDao;
+  @Mock private AzureAuthService azureAuthService;
+  @Mock private AzureSynapsePdao azureSynapsePdao;
+  @Mock private SnapshotService snapshotService;
+  @Mock private FlightContext flightContext;
+  private FlightMap workingMap;
+  private UUID datasetId;
+  private String datasetName;
+  private UUID snapshotId;
+  private CreateSnapshotStorageTableDataStep step;
+
+  @BeforeEach
+  void setUp() {
+    snapshotId = UUID.randomUUID();
+    datasetId = UUID.randomUUID();
+    datasetName = "datasetName";
+    workingMap = new FlightMap();
+    workingMap.put(
+        CommonMapKeys.DATASET_STORAGE_AUTH_INFO,
+        new AzureStorageAuthInfo(UUID.randomUUID(), "resourceGroup", "storageAccount"));
+    workingMap.put(
+        CommonMapKeys.SNAPSHOT_STORAGE_AUTH_INFO,
+        new AzureStorageAuthInfo(UUID.randomUUID(), "resourceGroup", "storageAccount"));
+    when(flightContext.getInputParameters()).thenReturn(new FlightMap());
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(azureAuthService.getTableServiceClient(any())).thenReturn(null);
+    when(snapshotService.retrieve(any())).thenReturn(new Snapshot().id(snapshotId));
+
+    when(azureSynapsePdao.getRefIdsForSnapshot(any()))
+        .thenReturn(Set.of(UUID.randomUUID().toString()));
+    step =
+        new CreateSnapshotStorageTableDataStep(
+            tableDao,
+            azureAuthService,
+            azureSynapsePdao,
+            snapshotService,
+            datasetId,
+            datasetName,
+            snapshotId);
+  }
+
+  @Test
+  void retryInterruptedThread() throws InterruptedException {
+    doThrow(new ApiException(FutureUtils.INTERRUPTED_THREAD_MESSAGE))
+        .when(tableDao)
+        .addFilesToSnapshot(any(), any(), any(), any(), any(), any());
+    var result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+
+  @Test
+  void fatalApiException() throws InterruptedException {
+    doThrow(new ApiException("other error message"))
+        .when(tableDao)
+        .addFilesToSnapshot(any(), any(), any(), any(), any(), any());
+    var result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+  }
+
+  @Test
+  void retryFileSystemExecutionException() throws InterruptedException {
+    doThrow(new FileSystemExecutionException(""))
+        .when(tableDao)
+        .addFilesToSnapshot(any(), any(), any(), any(), any(), any());
+    var result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+
+  @Test
+  void addFilesToSnapshotSuccess() throws InterruptedException {
+    doNothing().when(tableDao).addFilesToSnapshot(any(), any(), any(), any(), any(), any());
+    var result = step.doStep(flightContext);
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-937

## Addresses
### The Issue
Azure Snapshot Create is _sometimes_ getting stuck on the CreateSnapshotStorageTableDataStep step. It successfully retrieves the snapshot and then we run into the following series of errors from the com.azure.data.tables.TableClient logger:

```
Status code 404, "{"odata.error":{"code":"TableNotFound",
"message":{"lang":"en-US","value":"The table specified does not exist.
RequestId:125c119a-6002-0029-0595-27d9b5000000
Time:2024-10-26T10:58:29.7744892Z"}}}"
```

```
Status code 404, "{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The specified resource does not exist.
RequestId:125c11a9-6002-0029-1195-27d9b5000000
Time:2024-10-26T10:58:29.8874254Z"}}}"
```
Then, we see two logs that it attempted to do an upsertEntity, but we don't know whether it completes (and the above errors suggest that it does not complete).
<img width="997" alt="image-20241028-173223" src="https://github.com/user-attachments/assets/7d6376e8-fa1a-4ec2-ac99-61ee747250b2">
<img width="724" alt="image-20241028-173157" src="https://github.com/user-attachments/assets/9d28c25a-93cd-49b4-8b54-a16e95b2db68">

### Conclusion/Solution
Besides the fact that this is happening in the CreateSnapshotStorageTableDataStep, we don't get a stack trace from the errors. Additionally, we log the "upserting directory entry" in two places. Using some context clues, we can narrow down the location of the issue to the storeTopDirectory() method, which calls upsertEntity in two places. 

I was able to reproduce the "404 TableNotFound" error in the AzureConnected test by skipping the tableServiceClient.createTableIfNotExists() call. So, given the transient errors, we possibly can assume that the storage table is not getting created in time before we try to add entities to the table. So, by more concrete handling the error case and then retrying the step, we should eventually get the step to pass. 

I'm also adding a retry for the case that our threadpool thread is interrupted. This will allow the step to retry rather than having to delete the snapshot and try again. 

## Summary of changes
- Re-enable Azure connected test
- Add method that adds more error handling around upsertEntity
- Add retry on step for interrupted thread (specifically for our specialized thread pool handling) and for transient error with azure table client

## Testing Strategy
- Connected and unit tests to target testing particular code area changed

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
