### PR TITLE
DT-956: Re-enable Azure tests

### DIFF
--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -126,7 +126,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -145,7 +144,6 @@ import org.springframework.util.ResourceUtils;
 @ActiveProfiles({"google", "integrationtest"})
 @AutoConfigureMockMvc
 @Category(Integration.class)
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class AzureIntegrationTest extends UsersBase {
   private static final Logger logger = LoggerFactory.getLogger(AzureIntegrationTest.class);
 

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -46,7 +46,6 @@ import java.util.stream.Stream;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -66,7 +65,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class AzureIngestFileConnectedTest {
   private static final Logger logger = LoggerFactory.getLogger(AzureIngestFileConnectedTest.class);
 

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -46,7 +46,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -63,7 +62,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class AzureSynapsePdaoConnectedTest {
   private String randomFlightId;
   private BlobUrlParts snapshotSignUrlBlob;

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
@@ -48,7 +48,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -67,7 +66,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class AzureSynapsePdaoSnapshotConnectedTest {
   private static Logger logger = LoggerFactory.getLogger(AzureSynapsePdaoConnectedTest.class);
 

--- a/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,7 +44,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class LoadHistoryStorageTableConnectedTest {
   private UUID datasetId;
   private TableServiceClient serviceClient;

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDaoConnectedTest.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,7 +49,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class TableDaoConnectedTest {
   private final Logger logger = LoggerFactory.getLogger(TableDaoConnectedTest.class);
   @Autowired private ConnectedTestConfiguration connectedTestConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyConnectedTest.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -34,7 +33,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class TableDependencyConnectedTest {
 
   @Autowired private ConnectedTestConfiguration connectedTestConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -49,7 +48,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class TableDirectoryDaoConnectedTest {
   private static final Logger logger =
       LoggerFactory.getLogger(TableDirectoryDaoConnectedTest.class);

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
@@ -16,7 +16,6 @@ import com.azure.data.tables.TableServiceClientBuilder;
 import com.azure.data.tables.models.TableEntity;
 import java.util.UUID;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -32,7 +31,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class TableFileConnectedTest {
 
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsTest.java
@@ -17,7 +17,6 @@ import com.azure.data.tables.models.TableEntity;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -36,7 +35,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class TableServiceClientUtilsTest {
   private static final Logger logger = LoggerFactory.getLogger(TableServiceClientUtilsTest.class);
   private TableServiceClient tableServiceClient;

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -17,7 +17,6 @@ import com.azure.storage.common.policy.RequestRetryOptions;
 import com.azure.storage.common.policy.RetryPolicyType;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -41,7 +40,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class BlobContainerClientFactoryTest {
 
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -47,7 +46,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class BlobContainerCopierTest {
 
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -44,7 +43,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class BlobCrlTest {
 
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
@@ -25,7 +25,6 @@ import java.util.Locale;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -41,7 +40,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-@Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
 public class SasUrlFactoriesTest {
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;
 

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -83,7 +82,6 @@ public class ProfileConnectedTest {
   }
 
   @Test
-  @Ignore("DCJ-826: Temporarily disabled due to missing Azure resources")
   public void testAzureBillingProfile() throws Exception {
     if (!ValidationUtils.isValidEmail(applicationConfiguration.getUserEmail())) {
       logger.info("Skipping test since default user was not set");


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-956

## Addresses
We previously had disabled azure tests because they were all failing. 

As a part of https://github.com/DataBiosphere/jade-data-repo/pull/1845, I found that my connected test passed locally. This led me to find out an issue with our github action secrets - https://github.com/broadinstitute/terraform-ap-deployments/pull/1747. 
Fixing this secret issue fixed our tests.

## Summary of changes
This reverts commit ae0ee4737fd5517a8ceaf8e4dc0b9f86c20a011d.
-re-enable tests

## Testing Strategy
- tests!

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
