### PR TITLE
DT-937: Add more logging and error handling

### DIFF
--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -329,6 +329,7 @@ public class TableDirectoryDao {
     try {
       return tableClient.getEntity(partitionKey, rowKey);
     } catch (TableServiceException ex) {
+      logger.info("lookupByFilePath operation failed", ex);
       return null;
     }
   }
@@ -381,6 +382,7 @@ public class TableDirectoryDao {
     List<Future<Void>> futures = new ArrayList<>();
     for (List<String> fileIdsBatch :
         ListUtils.partition(List.copyOf(fileIds), MAX_FILTER_CLAUSES)) {
+      logger.info("Processing batch of {} fileIds", fileIdsBatch.size());
       futures.add(
           azureTableThreadpool.submit(
               () -> {
@@ -408,12 +410,18 @@ public class TableDirectoryDao {
                 // Find directory paths that need to be created; plus add to the cache
                 Set<String> newPaths =
                     FileMetadataUtils.findNewDirectoryPaths(directoryEntries, pathMap);
+                logger.info(
+                    "Out of {} directory entries, found {} new paths to create",
+                    directoryEntries.size(),
+                    newPaths.size());
                 List<FireStoreDirectoryEntry> datasetDirectoryEntries =
                     batchRetrieveByPath(
                         datasetTableServiceClient,
                         datasetId,
                         StorageTableName.DATASET.toTableName(datasetId),
                         newPaths);
+                logger.info(
+                    "Retrieved {} dataset directory entries", datasetDirectoryEntries.size());
 
                 // Create snapshot file system entries
                 List<FireStoreDirectoryEntry> snapshotEntries = new ArrayList<>();
@@ -428,6 +436,7 @@ public class TableDirectoryDao {
                     snapshotEntries.add(datasetEntry.copyEntryUnderNewPath(datasetDirName));
                   }
                 }
+                logger.info("Snapshot entries to store: {}", snapshotEntries.size());
                 // Store the batch of entries. This will override existing entries,
                 // but that is not the typical case and it is lower cost just overwrite
                 // rather than retrieve to avoid the write.

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtils.java
@@ -1,20 +1,24 @@
 package bio.terra.service.filedata.azure.tables;
 
 import bio.terra.service.common.azure.StorageTableName;
+import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.models.ListEntitiesOptions;
 import com.azure.data.tables.models.ListTablesOptions;
 import com.azure.data.tables.models.TableEntity;
-import com.azure.data.tables.models.TableItem;
+import com.azure.data.tables.models.TableServiceException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TableServiceClientUtils {
+  private static final Logger logger = LoggerFactory.getLogger(TableServiceClientUtils.class);
 
   public static boolean tableHasEntries(
       TableServiceClient tableServiceClient, String tableName, ListEntitiesOptions options) {
@@ -24,9 +28,14 @@ public class TableServiceClientUtils {
     if (tableExists(tableServiceClient, tableName)) {
       TableClient tableClient = tableServiceClient.getTableClient(tableName);
       options.setTop(1);
-      PagedIterable<TableEntity> tableEntities = tableClient.listEntities(options, null, null);
-      if (tableEntities.iterator().hasNext()) {
-        return true;
+      try {
+        PagedIterable<TableEntity> tableEntities = tableClient.listEntities(options, null, null);
+        if (tableEntities.iterator().hasNext()) {
+          return true;
+        }
+      } catch (TableServiceException ex) {
+        logger.error("Error listing entities in table {}", tableName, ex);
+        return false;
       }
     }
     return false;
@@ -40,9 +49,14 @@ public class TableServiceClientUtils {
   public static boolean tableExists(TableServiceClient tableServiceClient, String tableName) {
     ListTablesOptions options =
         new ListTablesOptions().setFilter(String.format("TableName eq '%s'", tableName));
-    PagedIterable<TableItem> retrievedTableItems =
-        tableServiceClient.listTables(options, null, null);
-    return retrievedTableItems.iterator().hasNext();
+    try {
+      var result = tableServiceClient.listTables(options, null, null);
+      logger.info("Table {} exists", tableName);
+      return result.iterator().hasNext();
+    } catch (TableServiceException ex) {
+      logger.error("Error listing tables with table name filter " + tableName, ex);
+      return false;
+    }
   }
 
   public static List<TableEntity> filterTable(
@@ -50,8 +64,17 @@ public class TableServiceClientUtils {
     TableClient tableClient = tableServiceClient.getTableClient(tableName);
     ListEntitiesOptions options = new ListEntitiesOptions().setFilter(filter);
     if (TableServiceClientUtils.tableHasEntries(tableServiceClient, tableName, options)) {
-      return tableClient.listEntities(options, null, null).stream().collect(Collectors.toList());
+      try {
+        var result = tableClient.listEntities(options, null, null).stream().toList();
+        logger.info("Found {} entities in table {}", result.size(), tableName);
+        return result;
+      } catch (TableServiceException ex) {
+        throw new FileSystemExecutionException(
+            String.format("Error listing entities from table %s with filter %s", tableName, filter),
+            ex);
+      }
     }
+    logger.info("No entities found in table {} with filter {}", tableName, filter);
     return Collections.emptyList();
   }
 
@@ -82,12 +105,20 @@ public class TableServiceClientUtils {
     options.setTop(2);
     if (tableHasEntries(tableServiceClient, tableName, options)) {
       TableClient tableClient = tableServiceClient.getTableClient(tableName);
-      PagedIterable<TableEntity> entities = tableClient.listEntities(options, null, null);
-      Iterator<TableEntity> iter = entities.iterator();
-      // Since hasHasEntries = true, we expect there to be at least one entry
-      iter.next();
-      // Test for exactly one entry - the next hasNext() should return false
-      return !iter.hasNext();
+      try {
+        PagedIterable<TableEntity> entities = tableClient.listEntities(options, null, null);
+        Iterator<TableEntity> iter = entities.iterator();
+        // Since hasHasEntries = true, we expect there to be at least one entry
+        iter.next();
+        // Test for exactly one entry - the next hasNext() should return false
+        return !iter.hasNext();
+      } catch (TableServiceException ex) {
+        logger.error(
+            String.format(
+                "Error listing entities from table %s with filter %s",
+                tableName, options.getFilter()),
+            ex);
+      }
     }
     return false;
   }

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsConnectedTest.java
@@ -1,6 +1,8 @@
 package bio.terra.service.filedata.azure.tables;
 
+import static bio.terra.service.filedata.google.firestore.FireStoreFile.FILE_ID_FIELD_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.AzureUtils;
@@ -14,6 +16,7 @@ import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.TableServiceClientBuilder;
 import com.azure.data.tables.models.TableEntity;
+import java.util.List;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
@@ -35,8 +38,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
-public class TableServiceClientUtilsTest {
-  private static final Logger logger = LoggerFactory.getLogger(TableServiceClientUtilsTest.class);
+public class TableServiceClientUtilsConnectedTest {
+  private static final Logger logger =
+      LoggerFactory.getLogger(TableServiceClientUtilsConnectedTest.class);
   private TableServiceClient tableServiceClient;
   private String tableName;
 
@@ -93,7 +97,9 @@ public class TableServiceClientUtilsTest {
     assertThat("table should have zero entries", !tableZeroEntry);
 
     // add an entry to the table
-    tableClient.createEntity(new TableEntity("test1", UUID.randomUUID().toString()));
+    tableClient.createEntity(
+        new TableEntity("test1", UUID.randomUUID().toString())
+            .addProperty(FILE_ID_FIELD_NAME, "test1"));
     boolean tableHasEntries =
         TableServiceClientUtils.tableHasEntries(tableServiceClient, tableName);
     assertThat("table should have one entry", tableHasEntries);
@@ -103,10 +109,18 @@ public class TableServiceClientUtilsTest {
     assertThat("table should have one entry", tableOneEntry);
 
     // add a second entry to the table
-    tableClient.createEntity(new TableEntity("test2", UUID.randomUUID().toString()));
+    tableClient.createEntity(
+        new TableEntity("test2", UUID.randomUUID().toString())
+            .addProperty(FILE_ID_FIELD_NAME, "test2"));
     boolean tableTwoEntry =
         TableServiceClientUtils.tableHasSingleEntry(tableServiceClient, tableName, null);
     assertThat("table should have two entries", !tableTwoEntry);
+
+    // filter to one entry
+    String filter = "fileId eq 'test1'";
+    List<TableEntity> entities =
+        TableServiceClientUtils.filterTable(tableServiceClient, tableName, filter);
+    assertThat("table should have one entry", entities, hasSize(1));
 
     tableClient.deleteTable();
     boolean tableExistsAfterDelete =

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsTest.java
@@ -20,39 +20,27 @@ import com.azure.data.tables.models.TableItem;
 import com.azure.data.tables.models.TableServiceException;
 import java.util.Iterator;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+@ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
 class TableServiceClientUtilsTest {
 
   @Mock TableServiceClient tableServiceClient;
   @Mock TableClient tableClient;
 
-  @BeforeEach
-  void setUp() {
-    // mock table exists check
-    mockTableExists(true);
-
-    // get table client
-    when(tableServiceClient.getTableClient(any())).thenReturn(tableClient);
-  }
-
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void tableHasEntries(boolean hasEntries) {
+    when(tableServiceClient.getTableClient(any())).thenReturn(tableClient);
+    mockTableExists(true);
     mockTableHasEntries(hasEntries);
 
     assertThat(
@@ -62,6 +50,8 @@ class TableServiceClientUtilsTest {
 
   @Test
   void tableHasEntriesCatchThrownException() {
+    when(tableServiceClient.getTableClient(any())).thenReturn(tableClient);
+    mockTableExists(true);
     when(tableClient.listEntities(any(), any(), any()))
         .thenThrow(new TableServiceException("error", mock(HttpResponse.class)));
 
@@ -88,17 +78,22 @@ class TableServiceClientUtilsTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void filterTable(boolean hasEntries) {
-    mockTableHasEntries(true);
+    when(tableServiceClient.getTableClient(any())).thenReturn(tableClient);
+    mockTableExists(true);
+    // mock tableHasEntries
+    PagedIterable<TableEntity> hasEntriesMockPagedIterable = mock(PagedIterable.class);
+    when(tableClient.listEntities(any(), any(), any())).thenReturn(hasEntriesMockPagedIterable);
 
     // Mock listing entities with filter
     var filter = "exampleParameter eq '1'";
     TableEntity fireStoreDependencyEntity = new TableEntity("partitionKey", "rowKey");
     PagedIterable<TableEntity> mockPagedIterable2 = mock(PagedIterable.class);
-    Iterator<TableEntity> mockIterator2 = mock(Iterator.class);
-    when(mockIterator2.hasNext()).thenReturn(hasEntries, false);
-    when(mockIterator2.next()).thenReturn(fireStoreDependencyEntity);
-    when(mockPagedIterable2.iterator()).thenReturn(mockIterator2);
-    when(mockPagedIterable2.stream()).thenReturn(Stream.of(fireStoreDependencyEntity));
+    Iterator<TableEntity> mockIterator = mock(Iterator.class);
+    when(mockIterator.hasNext()).thenReturn(hasEntries, false);
+    when(mockPagedIterable2.iterator()).thenReturn(mockIterator);
+    if (hasEntries) {
+      when(mockPagedIterable2.stream()).thenReturn(Stream.of(fireStoreDependencyEntity));
+    }
     // only match for listing entities with filter
     ArgumentMatcher<ListEntitiesOptions> matcher =
         options -> options.getFilter() != null && options.getFilter().contains(filter);
@@ -111,7 +106,11 @@ class TableServiceClientUtilsTest {
 
   @Test
   void filterTableCatchThrownException() {
-    mockTableHasEntries(true);
+    when(tableServiceClient.getTableClient(any())).thenReturn(tableClient);
+    mockTableExists(true);
+    // mock tableHasEntries
+    PagedIterable<TableEntity> hasEntriesMockPagedIterable = mock(PagedIterable.class);
+    when(tableClient.listEntities(any(), any(), any())).thenReturn(hasEntriesMockPagedIterable);
 
     var filter = "exampleParameter eq '1'";
     // only match for listing entities with filter

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsTest.java
@@ -1,0 +1,142 @@
+package bio.terra.service.filedata.azure.tables;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.data.tables.TableClient;
+import com.azure.data.tables.TableServiceClient;
+import com.azure.data.tables.models.ListEntitiesOptions;
+import com.azure.data.tables.models.TableEntity;
+import com.azure.data.tables.models.TableItem;
+import com.azure.data.tables.models.TableServiceException;
+import java.util.Iterator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Tag(Unit.TAG)
+class TableServiceClientUtilsTest {
+
+  @Mock TableServiceClient tableServiceClient;
+  @Mock TableClient tableClient;
+
+  @BeforeEach
+  void setUp() {
+    // mock table exists check
+    mockTableExists(true);
+
+    // get table client
+    when(tableServiceClient.getTableClient(any())).thenReturn(tableClient);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void tableHasEntries(boolean hasEntries) {
+    mockTableHasEntries(hasEntries);
+
+    assertThat(
+        TableServiceClientUtils.tableHasEntries(tableServiceClient, "tableName", null),
+        equalTo(hasEntries));
+  }
+
+  @Test
+  void tableHasEntriesCatchThrownException() {
+    when(tableClient.listEntities(any(), any(), any()))
+        .thenThrow(new TableServiceException("error", mock(HttpResponse.class)));
+
+    assertFalse(TableServiceClientUtils.tableHasEntries(tableServiceClient, "tableName", null));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void tableExists(boolean tableExists) {
+    mockTableExists(tableExists);
+
+    assertThat(
+        TableServiceClientUtils.tableExists(tableServiceClient, "tableName"), equalTo(tableExists));
+  }
+
+  @Test
+  void tableExistsCatchThrownException() {
+    when(tableServiceClient.listTables(any(), any(), any()))
+        .thenThrow(new TableServiceException("error", mock(HttpResponse.class)));
+
+    assertFalse(TableServiceClientUtils.tableExists(tableServiceClient, "tableName"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void filterTable(boolean hasEntries) {
+    mockTableHasEntries(true);
+
+    // Mock listing entities with filter
+    var filter = "exampleParameter eq '1'";
+    TableEntity fireStoreDependencyEntity = new TableEntity("partitionKey", "rowKey");
+    PagedIterable<TableEntity> mockPagedIterable2 = mock(PagedIterable.class);
+    Iterator<TableEntity> mockIterator2 = mock(Iterator.class);
+    when(mockIterator2.hasNext()).thenReturn(hasEntries, false);
+    when(mockIterator2.next()).thenReturn(fireStoreDependencyEntity);
+    when(mockPagedIterable2.iterator()).thenReturn(mockIterator2);
+    when(mockPagedIterable2.stream()).thenReturn(Stream.of(fireStoreDependencyEntity));
+    // only match for listing entities with filter
+    ArgumentMatcher<ListEntitiesOptions> matcher =
+        options -> options.getFilter() != null && options.getFilter().contains(filter);
+    when(tableClient.listEntities(argThat(matcher), any(), any())).thenReturn(mockPagedIterable2);
+
+    assertThat(
+        TableServiceClientUtils.filterTable(tableServiceClient, "tableName", filter),
+        hasSize(hasEntries ? 1 : 0));
+  }
+
+  @Test
+  void filterTableCatchThrownException() {
+    mockTableHasEntries(true);
+
+    var filter = "exampleParameter eq '1'";
+    // only match for listing entities with filter
+    ArgumentMatcher<ListEntitiesOptions> matcher =
+        options -> options.getFilter() != null && options.getFilter().contains(filter);
+    when(tableClient.listEntities(argThat(matcher), any(), any()))
+        .thenThrow(new TableServiceException("error", mock(HttpResponse.class)));
+
+    assertThat(
+        TableServiceClientUtils.filterTable(tableServiceClient, "tableName", filter), hasSize(0));
+  }
+
+  private void mockTableExists(boolean shouldExist) {
+    PagedIterable<TableItem> mockPagedIterable = mock(PagedIterable.class);
+    Iterator<TableItem> mockIterator = mock(Iterator.class);
+    when(mockIterator.hasNext()).thenReturn(shouldExist);
+    when(mockPagedIterable.iterator()).thenReturn(mockIterator);
+    when(tableServiceClient.listTables(any(), any(), any())).thenReturn(mockPagedIterable);
+  }
+
+  private void mockTableHasEntries(boolean shouldHaveEntries) {
+    PagedIterable<TableEntity> mockPagedIterable = mock(PagedIterable.class);
+    Iterator<TableEntity> mockIterator = mock(Iterator.class);
+    when(mockIterator.hasNext()).thenReturn(shouldHaveEntries);
+    when(mockPagedIterable.iterator()).thenReturn(mockIterator);
+    when(tableClient.listEntities(any(), any(), any())).thenReturn(mockPagedIterable);
+  }
+}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-937

## Addresses
The changes in https://github.com/DataBiosphere/jade-data-repo/pull/1845 did not correctly pinpoint the place where the error is occurring. 

After merging the previous PR, the failing flight was retried and we again ran into the same uncaught set of errors. I had hoped that the error handling I added would have caught the error and provide a stack trace. 

<img width="895" alt="image" src="https://github.com/user-attachments/assets/412fe483-887e-4231-8d4d-b204cc92e334">

In the previous iteration, I made an educated guess that the upsertEntity call was not successful and focused there. I updated the logs as a part of that change and this shows that the upsert was indeed successful. So, the problem must be elsewhere in the step.

The error we're running into is directly from the azure table client and does not provide a stack trace. This makes it hard to pinpoint exactly what is going wrong. So, this PR aims to add logging and more error handling so that we can pinpoint the issue. It is possible that the error handling will help, but it is very likely that we will need another change. I haven't been able to reproduce this issue locally to test. 

## Summary of changes
- Add error handling around calls in azure table client service that are referenced in the CreateSnapshotStorageTableDataStep
- Add logs so that we can narrow down the problematic area

## Testing Strategy
- There are existing connected and integration tests that test this code
