### PR TITLE
DT-972: Only delete file on undo when data isn't self hosted.

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStep.java
@@ -80,15 +80,18 @@ public class IngestFilePrimaryDataStep implements Step {
 
   @Override
   public StepResult undoStep(FlightContext context) {
-    FlightMap inputParameters = context.getInputParameters();
-    FileLoadModel fileLoadModel =
-        inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
-    FlightMap workingMap = context.getWorkingMap();
-    String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
-    GoogleBucketResource bucketResource =
-        FlightUtils.getContextValue(context, FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
-    String fileName = getLastNameFromPath(fileLoadModel.getSourcePath());
-    gcsPdao.deleteFileById(dataset, fileId, fileName, bucketResource);
+    // If the dataset is self-hosted, don't try to delete the file on Undo.
+    if (!dataset.isSelfHosted()) {
+      FlightMap inputParameters = context.getInputParameters();
+      FileLoadModel fileLoadModel =
+          inputParameters.get(JobMapKeys.REQUEST.getKeyName(), FileLoadModel.class);
+      FlightMap workingMap = context.getWorkingMap();
+      String fileId = workingMap.get(FileMapKeys.FILE_ID, String.class);
+      GoogleBucketResource bucketResource =
+          FlightUtils.getContextValue(context, FileMapKeys.BUCKET_INFO, GoogleBucketResource.class);
+      String fileName = getLastNameFromPath(fileLoadModel.getSourcePath());
+      gcsPdao.deleteFileById(dataset, fileId, fileName, bucketResource);
+    }
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestFilePrimaryDataStepTest.java
@@ -2,11 +2,14 @@ package bio.terra.service.filedata.flight.ingest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
@@ -108,6 +111,16 @@ class IngestFilePrimaryDataStepTest {
     verify(gcsPdao, times(3)).linkSelfHostedFile(any(), any(), any());
     assertThat(
         "Retried step succeeds", result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+  }
+
+  @Test
+  void undoStepSelfHostedSkipDelete() {
+    // Dataset is self-hosted.
+    when(dataset.isSelfHosted()).thenReturn(true);
+    // Remove unused mocks to avoid strict stubbing errors.
+    reset(flightContext);
+    assertThat(step.undoStep(flightContext), is(StepResult.getStepResultSuccess()));
+    verifyNoInteractions(gcsPdao);
   }
 
   @Test


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-972

## Addresses

If an ingest flight fails for a self-hosted dataset, and some files have been ingested, TDR will try to delete the self-hosted files if the flight fails. This is incorrect as TDR doesn't own these files, and will cause flight to fail with a DISMAL error. 

## Summary of changes

Only delete files on undo if the dataset isn't self-hosted.

## Testing Strategy

Unit test