### PR TITLE
DT-937 - Remove nested threadpool

### DIFF
--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -489,13 +489,7 @@ public class TableDirectoryDao {
       List<FireStoreDirectoryEntry> snapshotEntries) {
     String tableName = StorageTableName.SNAPSHOT.toTableName(snapshotId);
     TableClient tableClient = snapshotTableServiceClient.getTableClient(tableName);
-    FutureUtils.waitFor(
-        snapshotEntries.stream()
-            .map(
-                snapshotEntry ->
-                    azureTableThreadpool.submit(
-                        () ->
-                            createEntityForPath(tableClient, snapshotId, tableName, snapshotEntry)))
-            .toList());
+    snapshotEntries.forEach(
+        snapshotEntry -> createEntityForPath(tableClient, snapshotId, tableName, snapshotEntry));
   }
 }

--- a/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
+++ b/src/main/java/bio/terra/service/filedata/azure/tables/TableDirectoryDao.java
@@ -440,7 +440,7 @@ public class TableDirectoryDao {
                 // Store the batch of entries. This will override existing entries,
                 // but that is not the typical case and it is lower cost just overwrite
                 // rather than retrieve to avoid the write.
-                batchStoreDirectoryEntry(snapshotTableServiceClient, snapshotId, snapshotEntries);
+                storeDirectoryEntries(snapshotTableServiceClient, snapshotId, snapshotEntries);
 
                 return null;
               }));
@@ -484,6 +484,23 @@ public class TableDirectoryDao {
   }
 
   void batchStoreDirectoryEntry(
+      TableServiceClient snapshotTableServiceClient,
+      UUID snapshotId,
+      List<FireStoreDirectoryEntry> snapshotEntries) {
+    String tableName = StorageTableName.SNAPSHOT.toTableName(snapshotId);
+    TableClient tableClient = snapshotTableServiceClient.getTableClient(tableName);
+    FutureUtils.waitFor(
+        snapshotEntries.stream()
+            .map(
+                snapshotEntry ->
+                    azureTableThreadpool.submit(
+                        () ->
+                            createEntityForPath(tableClient, snapshotId, tableName, snapshotEntry)))
+            .toList());
+  }
+
+  // Store the directory entries in the snapshot table sequentially, without a thread pool
+  void storeDirectoryEntries(
       TableServiceClient snapshotTableServiceClient,
       UUID snapshotId,
       List<FireStoreDirectoryEntry> snapshotEntries) {

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.EmbeddedDatabaseTest;
@@ -16,6 +17,7 @@ import bio.terra.service.filedata.FileMetadataUtils;
 import bio.terra.service.filedata.google.firestore.FireStoreDirectoryEntry;
 import bio.terra.service.resourcemanagement.azure.AzureAuthService;
 import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.http.rest.Response;
 import com.azure.data.tables.TableClient;
 import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.models.TableEntity;
@@ -44,6 +46,7 @@ import org.springframework.test.context.ActiveProfiles;
 class TableDirectoryDaoTest {
   private static final String FULL_PATH = "/directory/file.json";
   private static final UUID DATASET_ID = UUID.randomUUID();
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
   private static final String PARTITION_KEY = DATASET_ID + " _dr_ directory";
   private static final String ROW_KEY = " _dr_ directory file.json";
   private static final String NONEXISTENT_PATH = "/directory/nonexistent.json";
@@ -173,7 +176,16 @@ class TableDirectoryDaoTest {
     assertThat(response.get(0), equalTo(directoryEntry));
   }
 
-  //  @Test
-  //  void storeDirectoryEntries() {
-  //  }
+  @Test
+  void storeDirectoryEntries() {
+    FireStoreDirectoryEntry entry1 = new FireStoreDirectoryEntry().name("file1").path("path1");
+    FireStoreDirectoryEntry entry2 = new FireStoreDirectoryEntry().name("file2").path("path2");
+    Response<Void> responseMock = mock(Response.class);
+    when(responseMock.getStatusCode()).thenReturn(200);
+    when(tableClient.upsertEntityWithResponse(any(), any(), any(), any())).thenReturn(responseMock);
+
+    dao.storeDirectoryEntries(tableServiceClient, SNAPSHOT_ID, List.of(entry1, entry2));
+
+    Mockito.verify(tableClient, times(2)).upsertEntityWithResponse(any(), any(), any(), any());
+  }
 }

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoTest.java
@@ -2,8 +2,8 @@ package bio.terra.service.filedata.azure.tables;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -25,10 +25,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,15 +35,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
+@Tag(Unit.TAG)
 @EmbeddedDatabaseTest
-public class TableDirectoryDaoTest {
+class TableDirectoryDaoTest {
   private static final String FULL_PATH = "/directory/file.json";
   private static final UUID DATASET_ID = UUID.randomUUID();
   private static final String PARTITION_KEY = DATASET_ID + " _dr_ directory";
@@ -60,8 +57,8 @@ public class TableDirectoryDaoTest {
   @MockBean private TableClient tableClient;
   @Autowired private TableDirectoryDao dao;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     dao = spy(dao);
     when(authService.getTableServiceClient(any(), any(), any())).thenReturn(tableServiceClient);
     when(tableServiceClient.getTableClient(any())).thenReturn(tableClient);
@@ -90,7 +87,7 @@ public class TableDirectoryDaoTest {
   }
 
   @Test
-  public void testRetrieveByPath() {
+  void testRetrieveByPath() {
     when(tableClient.getEntity(PARTITION_KEY, ROW_KEY)).thenReturn(entity);
     FireStoreDirectoryEntry response =
         dao.retrieveByPath(
@@ -98,7 +95,7 @@ public class TableDirectoryDaoTest {
             DATASET_ID,
             StorageTableName.DATASET.toTableName(DATASET_ID),
             FULL_PATH);
-    assertEquals("The same entry is returned", directoryEntry, response);
+    assertThat("The same entry is returned", directoryEntry, equalTo(response));
 
     when(tableClient.getEntity(PARTITION_KEY, NONEXISTENT_ROW_KEY))
         .thenThrow(TableServiceException.class);
@@ -108,11 +105,11 @@ public class TableDirectoryDaoTest {
             DATASET_ID,
             StorageTableName.DATASET.toTableName(DATASET_ID),
             NONEXISTENT_PATH);
-    assertNull("The entry does not exist", nonExistentEntry);
+    assertThat("The entry does not exist", nonExistentEntry, is(nullValue()));
   }
 
   @Test
-  public void testRetrieveByFileId() {
+  void testRetrieveByFileId() {
     PagedIterable<TableEntity> mockPagedIterable = mock(PagedIterable.class);
     Iterator<TableEntity> mockIterator = mock(Iterator.class);
     when(mockIterator.hasNext()).thenReturn(true, false);
@@ -136,7 +133,7 @@ public class TableDirectoryDaoTest {
   }
 
   @Test
-  public void testRetrieveByFileIdNotFound() {
+  void testRetrieveByFileIdNotFound() {
     PagedIterable<TableEntity> mockPagedIterable = mock(PagedIterable.class);
     Iterator<TableEntity> mockIterator = mock(Iterator.class);
     when(mockIterator.hasNext()).thenReturn(false);
@@ -146,11 +143,11 @@ public class TableDirectoryDaoTest {
     FireStoreDirectoryEntry response =
         dao.retrieveById(
             tableServiceClient, StorageTableName.DATASET.toTableName(DATASET_ID), "nonexistentId");
-    assertNull("The entry does not exist", response);
+    assertThat("The entry does not exist", response, is(nullValue()));
   }
 
   @Test
-  public void validateRefIdsFindsMissingRecords() {
+  void validateRefIdsFindsMissingRecords() {
     PagedIterable<TableEntity> mockPagedIterable = mock(PagedIterable.class);
     Iterator<TableEntity> mockIterator = mock(Iterator.class);
     when(mockIterator.hasNext()).thenReturn(false);
@@ -160,19 +157,23 @@ public class TableDirectoryDaoTest {
     String missingId = UUID.randomUUID().toString();
     List<String> refIds = List.of(missingId);
     List<String> response = dao.validateRefIds(tableServiceClient, DATASET_ID, refIds);
-    assertEquals(response.get(0), missingId);
+    assertThat(response.get(0), equalTo(missingId));
   }
 
   @Test
-  public void testEnumerateDirectory() {
+  void testEnumerateDirectory() {
     PagedIterable<TableEntity> mockPagedIterable = mock(PagedIterable.class);
-    Stream<TableEntity> mockStream = List.of(entity).stream();
+    Stream<TableEntity> mockStream = Stream.of(entity);
     when(mockPagedIterable.stream()).thenReturn(mockStream);
     when(tableClient.listEntities(any(), any(), any())).thenReturn(mockPagedIterable);
 
     List<FireStoreDirectoryEntry> response =
         dao.enumerateDirectory(
             tableServiceClient, StorageTableName.DATASET.toTableName(DATASET_ID), FILE_ID);
-    assertEquals(response.get(0), directoryEntry);
+    assertThat(response.get(0), equalTo(directoryEntry));
   }
+
+  //  @Test
+  //  void storeDirectoryEntries() {
+  //  }
 }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-937

## Addresses
We were continuously running into instances where Azure snapshot create flights would get stuck. After adding some logging in previous PRs, we were able to pinpoint the issue. 

For large requests, we are running out of threads in a nested, shared threadpool. The parent call would hand out all of the threads and then the nested call wouldn't have any more threads to hand out. It was stuck forever waiting for a new thread.

```
    List<Future<Void>> futures = new ArrayList<>();
    for (List<String> fileIdsBatch :
        ListUtils.partition(List.copyOf(fileIds), MAX_FILTER_CLAUSES)) {
      futures.add(
          azureTableThreadpool.submit(
              () -> {
                // Do stuff
                /// ... 
                // Then, in batchStoreDirectoryEntry we try to pull from the azureTableTreadpool again, 
                // but all of the threads have already been handed out 
                // So, we just wait forever for more threads to become available 
                batchStoreDirectoryEntry(snapshotTableServiceClient, snapshotId, snapshotEntries);
               
                return null;
              }));
    }
    FutureUtils.waitFor(futures);
```

## Summary of changes
Remove nested thread pool.  Note: I expect that this means we'll see Azure Snapshot Create Jobs take longer. 

## Testing Strategy
- Manually decrease the azure.threading.numTableThreads setting locally and reproduce issue with the bio.terra.service.filedata.azure.tables.TableDaoConnectedTest#testComputeSnapshot connected test.
- With changes, this connected test passes with limited threads and with the normal, higher setting. 