### PR TITLE
[DT-991]Optimize asset_column query to alleviate high CPU/Memory utilization

### DIFF
--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -90,4 +90,5 @@
     <include file="changesets/20240822_load_rename_to_load_lock.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240816_addsamgrouptorequest.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240830_dataset_table_dataset_id_index.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20241127_asset_column_asset_id_index.yaml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20241127_asset_column_asset_id_index.yaml
+++ b/src/main/resources/db/changesets/20241127_asset_column_asset_id_index.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: asset_column_asset_id_index
+      author: rjohanek
+      changes:
+        - createIndex:
+            indexName: asset_column_asset_id_idx
+            tableName: asset_column
+            columns:
+              - column:
+                  name: asset_id


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-991

## Addresses

We have been having memory and CPU utilization errors due to expensive queries. The problematic query is here:  https://github.com/DataBiosphere/jade-data-repo/blob/e77efbb6bc0fecb51514e8836d031008bf4b1bba/src/main/java/bio/terra/service/dataset/AssetDao.java#L146  

Query Insights on GCP Console show that most time is spent on a sequential scan on the asset_id column in the asset_column table.

## Summary of changes
Adds an index to the asset_id column so that a sequential scan is not needed. 

## Testing Strategy
I used postgres to explain the queries and compare before and after the added index. This was tested on dev not prod, so the issue is not seen because of the scale of the data. However, we still see the execution time drop and there is no longer a sequential scan on the asset_id column.

```
EXPLAIN ANALYZE 
SELECT asset_column.id, asset_column.dataset_column_id, dataset_column.table_id                                                                            FROM                                                                                                                                                                                   asset_column                                                                                                                                                                         
INNER JOIN                                                                                                                                                                             dataset_column                                                                                                                                                                       
ON                                                                                                                                                                                     asset_column.dataset_column_id = dataset_column.id                                                                                                                                   WHERE                                                                                                                                                                                  
asset_id = <asset id>                                                                                                                                   
ORDER BY                                                                                                                                                                               dataset_column.ordinal;
```
### Before
 ```
Sort  (cost=1082.07..1082.34 rows=109 width=52) (actual time=1.997..2.004 rows=106 loops=1)
   Sort Key: dataset_column.ordinal
   Sort Method: quicksort  Memory: 39kB
   ->  Nested Loop  (cost=0.29..1078.38 rows=109 width=52) (actual time=0.051..1.883 rows=106 loops=1)
         ->  Seq Scan on asset_column  (cost=0.00..268.86 rows=109 width=32) (actual time=0.012..1.076 rows=106 loops=1)
               Filter: (asset_id = 'f491e9b3-afec-4e54-9ff7-c96efe31c8c5'::uuid)
               Rows Removed by Filter: 11460
         ->  Index Scan using dataset_column_pkey on dataset_column  (cost=0.29..7.43 rows=1 width=36) (actual time=0.007..0.007 rows=1 loops=106)
               Index Cond: (id = asset_column.dataset_column_id)
 Planning Time: 0.720 ms
 Execution Time: 2.160 ms
(11 rows)
```

### Create index
```
CREATE INDEX idx_asset_column_asset_id
ON asset_column(asset_id);
```

### After
```
 Sort  (cost=960.33..960.60 rows=111 width=52) (actual time=0.670..0.682 rows=106 loops=1)
   Sort Key: dataset_column.ordinal
   Sort Method: quicksort  Memory: 39kB
   ->  Nested Loop  (cost=5.44..956.56 rows=111 width=52) (actual time=0.067..0.611 rows=106 loops=1)
         ->  Bitmap Heap Scan on asset_column  (cost=5.15..134.42 rows=111 width=32) (actual time=0.052..0.066 rows=106 loops=1)
               Recheck Cond: (asset_id = 'f491e9b3-afec-4e54-9ff7-c96efe31c8c5'::uuid)
               Heap Blocks: exact=1
               ->  Bitmap Index Scan on idx_asset_column_asset_id  (cost=0.00..5.12 rows=111 width=0) (actual time=0.041..0.041 rows=106 loops=1)
                     Index Cond: (asset_id = 'f491e9b3-afec-4e54-9ff7-c96efe31c8c5'::uuid)
         ->  Index Scan using dataset_column_pkey on dataset_column  (cost=0.29..7.41 rows=1 width=36) (actual time=0.004..0.004 rows=1 loops=106)
               Index Cond: (id = asset_column.dataset_column_id)
 Planning Time: 0.484 ms
 Execution Time: 0.769 ms
(13 rows)
```

## Question
why after adding the index is it 13 rows when before adding the index it said 11?

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
