### PR TITLE
[DT-985] Validator doesn't recognize "schema" field when Updating Schema and serves misleading error message

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -1,28 +1,18 @@
 package bio.terra.service.dataset;
 
 import bio.terra.common.CloudPlatformWrapper;
-import bio.terra.common.PdaoConstant;
 import bio.terra.common.ValidationUtils;
 import bio.terra.model.AssetModel;
 import bio.terra.model.AssetTableModel;
-import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSpecificationModel;
-import bio.terra.model.DatePartitionOptionsModel;
-import bio.terra.model.IntPartitionOptionsModel;
 import bio.terra.model.RelationshipModel;
-import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -40,78 +30,9 @@ import org.springframework.validation.Validator;
 @Component
 public class DatasetRequestValidator implements Validator {
 
-  private static String PRIMARY_KEY = "PrimaryKey";
-  private static String FOREIGN_KEY = "ForeignKey";
-
   @Override
   public boolean supports(Class<?> clazz) {
     return true;
-  }
-
-  public static class SchemaValidationContext {
-
-    enum Operation {
-      CREATE("schema"),
-      UPDATE("changes");
-
-      private final String fieldName;
-
-      Operation(String fieldName) {
-        this.fieldName = fieldName;
-      }
-    }
-
-    private HashMap<String, HashSet<String>> tableColumnMap;
-    private HashMap<String, HashSet<String>> tableArrayColumns;
-    private HashSet<String> relationshipNameSet;
-    private Operation operation;
-
-    SchemaValidationContext(Operation op) {
-      tableColumnMap = new HashMap<>();
-      tableArrayColumns = new HashMap<>();
-      relationshipNameSet = new HashSet<>();
-      operation = op;
-    }
-
-    String getFieldName() {
-      return operation.fieldName;
-    }
-
-    void addTable(String tableName, List<ColumnModel> columns) {
-      HashSet<String> colNames = new HashSet<>();
-      HashSet<String> arrayCols = new HashSet<>();
-
-      for (ColumnModel col : columns) {
-        colNames.add(col.getName());
-        if (col.isArrayOf()) {
-          arrayCols.add(col.getName());
-        }
-      }
-
-      tableColumnMap.put(tableName, colNames);
-      tableArrayColumns.put(tableName, arrayCols);
-    }
-
-    void addRelationship(String relationshipName) {
-      relationshipNameSet.add(relationshipName);
-    }
-
-    boolean isValidTable(String tableName) {
-      return tableColumnMap.containsKey(tableName);
-    }
-
-    boolean isValidTableColumn(String tableName, String columnName) {
-      return isValidTable(tableName) && tableColumnMap.get(tableName).contains(columnName);
-    }
-
-    boolean isArrayColumn(String tableName, String columnName) {
-      return isValidTableColumn(tableName, columnName)
-          && tableArrayColumns.get(tableName).contains(columnName);
-    }
-
-    boolean isValidRelationship(String relationshipName) {
-      return relationshipNameSet.contains(relationshipName);
-    }
   }
 
   private void validateDatasetName(String datasetName, Errors errors) {
@@ -119,244 +40,6 @@ public class DatasetRequestValidator implements Validator {
     // versions of Swagger codegen now auto-generate an equivalent check.
     if (datasetName == null) {
       errors.rejectValue("name", "DatasetNameMissing");
-    }
-  }
-
-  private void validateDatePartitionOptions(
-      DatePartitionOptionsModel options,
-      List<ColumnModel> columns,
-      Errors errors,
-      SchemaValidationContext context) {
-    String targetColumn = options.getColumn();
-
-    if (targetColumn == null) {
-      errors.rejectValue(context.getFieldName(), "MissingDatePartitionColumnName");
-    } else if (!targetColumn.equals(PdaoConstant.PDAO_INGEST_DATE_COLUMN_ALIAS)) {
-      Optional<ColumnModel> matchingColumn =
-          columns.stream().filter(c -> targetColumn.equals(c.getName())).findFirst();
-
-      if (matchingColumn.isPresent()) {
-        TableDataType colType = matchingColumn.get().getDatatype();
-
-        if (colType != TableDataType.DATE && colType != TableDataType.TIMESTAMP) {
-          errors.rejectValue(
-              context.getFieldName(),
-              "InvalidDatePartitionColumnType",
-              "partitionColumn in datePartitionOptions must refer to a DATE or TIMESTAMP column");
-        }
-      } else {
-        errors.rejectValue(
-            context.getFieldName(),
-            "InvalidDatePartitionColumnName",
-            "No such column: " + targetColumn);
-      }
-    }
-  }
-
-  private void validateIntPartitionOptions(
-      IntPartitionOptionsModel options,
-      List<ColumnModel> columns,
-      Errors errors,
-      SchemaValidationContext context) {
-    String targetColumn = options.getColumn();
-
-    if (targetColumn == null) {
-      errors.rejectValue(context.getFieldName(), "MissingIntPartitionColumnName");
-    } else {
-      Optional<ColumnModel> matchingColumn =
-          columns.stream().filter(c -> targetColumn.equals(c.getName())).findFirst();
-
-      if (matchingColumn.isPresent()) {
-        TableDataType colType = matchingColumn.get().getDatatype();
-
-        if (colType != TableDataType.INTEGER && colType != TableDataType.INT64) {
-          errors.rejectValue(
-              context.getFieldName(),
-              "InvalidIntPartitionColumnType",
-              "partitionColumn in intPartitionOptions must refer to an INTEGER or INT64 column");
-        }
-      } else {
-        errors.rejectValue(
-            context.getFieldName(),
-            "InvalidIntPartitionColumnName",
-            "No such column: " + targetColumn);
-      }
-    }
-
-    Long min = options.getMin();
-    Long max = options.getMax();
-    Long interval = options.getInterval();
-
-    if (min == null || max == null || interval == null) {
-      errors.rejectValue(
-          context.getFieldName(),
-          "MissingIntPartitionOptions",
-          "intPartitionOptions must specify min, max, and interval");
-    } else {
-      if (max <= min) {
-        errors.rejectValue(
-            context.getFieldName(),
-            "InvalidIntPartitionRange",
-            "Max partition value must be larger than min partition value");
-      }
-      if (interval <= 0) {
-        errors.rejectValue(
-            context.getFieldName(),
-            "InvalidIntPartitionInterval",
-            "Partition interval must be >= 1");
-      }
-      if (max > min && interval > 0 && (max - min) / interval > 4000L) {
-        errors.rejectValue(
-            context.getFieldName(),
-            "TooManyIntPartitions",
-            "Cannot configure more than 4K partitions through min, max, and interval");
-      }
-    }
-  }
-
-  public void validateTable(TableModel table, Errors errors, SchemaValidationContext context) {
-    String tableName = table.getName();
-    List<ColumnModel> columns = table.getColumns();
-    List<String> primaryKeyList = table.getPrimaryKey();
-    List<String> columnNames = new ArrayList<>();
-    if (columns.isEmpty()) {
-      errors.rejectValue(
-          context.getFieldName(),
-          "IncompleteSchemaDefinition",
-          "Each table must contain at least one column");
-    } else {
-      columns.stream().map(ColumnModel::getName).forEach(columnNames::add);
-    }
-
-    if (tableName != null) {
-      validateDataTypes(columns, errors, context);
-
-      if (ValidationUtils.hasDuplicates(columnNames)) {
-        List<String> duplicates = ValidationUtils.findDuplicates(columnNames);
-        errors.rejectValue(
-            context.getFieldName(),
-            "DuplicateColumnNames",
-            String.format("Duplicate columns: %s", String.join(", ", duplicates)));
-      }
-      if (primaryKeyList != null) {
-        if (!columnNames.containsAll(primaryKeyList)) {
-          List<String> missingKeys = new ArrayList<>(primaryKeyList);
-          missingKeys.removeAll(columnNames);
-          errors.rejectValue(
-              context.getFieldName(),
-              "MissingPrimaryKeyColumn",
-              String.format("Expected column(s): %s", String.join(", ", missingKeys)));
-        }
-      }
-      for (ColumnModel columnModel : table.getColumns()) {
-        if (primaryKeyList != null && primaryKeyList.contains(columnModel.getName())) {
-          validateColumnType(errors, columnModel, PRIMARY_KEY, context);
-        }
-        validateColumnMode(errors, columnModel, context);
-      }
-
-      context.addTable(tableName, columns);
-    }
-
-    TableModel.PartitionModeEnum mode = table.getPartitionMode();
-    DatePartitionOptionsModel dateOptions = table.getDatePartitionOptions();
-    IntPartitionOptionsModel intOptions = table.getIntPartitionOptions();
-
-    if (mode == TableModel.PartitionModeEnum.DATE) {
-      if (dateOptions == null) {
-        errors.rejectValue(
-            context.getFieldName(),
-            "MissingDatePartitionOptions",
-            "datePartitionOptions must be specified when using 'date' partitionMode");
-      } else {
-        validateDatePartitionOptions(dateOptions, columns, errors, context);
-      }
-    } else if (dateOptions != null) {
-      errors.rejectValue(
-          context.getFieldName(),
-          "InvalidDatePartitionOptions",
-          "datePartitionOptions can only be specified when using 'date' partitionMode");
-    }
-
-    if (mode == TableModel.PartitionModeEnum.INT) {
-      if (intOptions == null) {
-        errors.rejectValue(
-            context.getFieldName(),
-            "MissingIntPartitionOptions",
-            "intPartitionOptions must be specified when using 'int' partitionMode");
-      } else {
-        validateIntPartitionOptions(intOptions, columns, errors, context);
-      }
-    } else if (intOptions != null) {
-      errors.rejectValue(
-          context.getFieldName(),
-          "InvalidIntPartitionOptions",
-          "intPartitionOptions can only be specified when using 'int' partitionMode");
-    }
-  }
-
-  // Primary Keys and Foreign Keys cannot be filerefs or dirrefs and Primary keys cannot be arrays
-  private void validateColumnType(
-      Errors errors, ColumnModel columnModel, String keyType, SchemaValidationContext context) {
-    if (keyType.equals(PRIMARY_KEY) && columnModel.isArrayOf()) {
-      rejectKey(errors, keyType, columnModel.getName(), "array", context);
-    }
-
-    Set<TableDataType> invalidTypes = Set.of(TableDataType.DIRREF, TableDataType.FILEREF);
-    if (columnModel.getDatatype() != null && invalidTypes.contains(columnModel.getDatatype())) {
-      rejectKey(
-          errors, keyType, columnModel.getName(), columnModel.getDatatype().toString(), context);
-    }
-    if (PRIMARY_KEY.equals(keyType) && Boolean.FALSE.equals(columnModel.isRequired())) {
-      errors.rejectValue(
-          context.getFieldName(),
-          "OptionalPrimaryKeyColumn",
-          String.format("A %s column cannot be marked as not required", PRIMARY_KEY));
-    }
-  }
-
-  private void validateColumnMode(
-      Errors errors, ColumnModel columnModel, SchemaValidationContext context) {
-    // Explicitly check if isRequired is true to avoid a null pointer exception.
-    // isArrayOf has a default value set in the open-api spec so it does not require
-    // the same handling.
-    if (Boolean.TRUE.equals(columnModel.isRequired()) && columnModel.isArrayOf()) {
-      errors.rejectValue(
-          context.getFieldName(),
-          "InvalidColumnMode",
-          String.format("Array column %s cannot be marked as required", columnModel.getName()));
-    }
-  }
-
-  private void rejectKey(
-      Errors errors,
-      String keyType,
-      String columnName,
-      String type,
-      SchemaValidationContext context) {
-    errors.rejectValue(
-        context.getFieldName(),
-        String.format("Invalid%s", keyType),
-        String.format("%s %s cannot be a column with %s type", keyType, columnName, type));
-  }
-
-  private void validateDataTypes(
-      List<ColumnModel> columns, Errors errors, SchemaValidationContext context) {
-    List<ColumnModel> invalidColumns = new ArrayList<>();
-    for (ColumnModel column : columns) {
-      // spring defaults user input not belonging to the TableDataType enum to null
-      if (column.getDatatype() == null) {
-        invalidColumns.add(column);
-      }
-    }
-    if (!invalidColumns.isEmpty()) {
-      errors.rejectValue(
-          context.getFieldName(),
-          "InvalidDatatype",
-          "invalid datatype in table column(s): "
-              + invalidColumns.stream().map(ColumnModel::getName).collect(Collectors.joining(", "))
-              + ", DataTypes must be lowercase, valid DataTypes are "
-              + Arrays.toString(TableDataType.values()));
     }
   }
 
@@ -471,7 +154,7 @@ public class DatasetRequestValidator implements Validator {
       if (ValidationUtils.hasDuplicates(tableNames)) {
         errors.rejectValue(context.getFieldName(), "DuplicateTableNames");
       }
-      tables.forEach((table) -> validateTable(table, errors, context));
+      tables.forEach((table) -> context.validateTable(table, errors));
     }
 
     List<RelationshipModel> relationships = schema.getRelationships();

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -50,14 +50,31 @@ public class DatasetRequestValidator implements Validator {
 
   public static class SchemaValidationContext {
 
+    enum Operation {
+      CREATE("schema"),
+      UPDATE("changes");
+
+      private final String fieldName;
+
+      Operation(String fieldName) {
+        this.fieldName = fieldName;
+      }
+    }
+
     private HashMap<String, HashSet<String>> tableColumnMap;
     private HashMap<String, HashSet<String>> tableArrayColumns;
     private HashSet<String> relationshipNameSet;
+    private Operation operation;
 
-    SchemaValidationContext() {
+    SchemaValidationContext(Operation op) {
       tableColumnMap = new HashMap<>();
       tableArrayColumns = new HashMap<>();
       relationshipNameSet = new HashSet<>();
+      operation = op;
+    }
+
+    String getFieldName() {
+      return operation.fieldName;
     }
 
     void addTable(String tableName, List<ColumnModel> columns) {
@@ -106,11 +123,14 @@ public class DatasetRequestValidator implements Validator {
   }
 
   private void validateDatePartitionOptions(
-      DatePartitionOptionsModel options, List<ColumnModel> columns, Errors errors) {
+      DatePartitionOptionsModel options,
+      List<ColumnModel> columns,
+      Errors errors,
+      SchemaValidationContext context) {
     String targetColumn = options.getColumn();
 
     if (targetColumn == null) {
-      errors.rejectValue("schema", "MissingDatePartitionColumnName");
+      errors.rejectValue(context.getFieldName(), "MissingDatePartitionColumnName");
     } else if (!targetColumn.equals(PdaoConstant.PDAO_INGEST_DATE_COLUMN_ALIAS)) {
       Optional<ColumnModel> matchingColumn =
           columns.stream().filter(c -> targetColumn.equals(c.getName())).findFirst();
@@ -120,23 +140,28 @@ public class DatasetRequestValidator implements Validator {
 
         if (colType != TableDataType.DATE && colType != TableDataType.TIMESTAMP) {
           errors.rejectValue(
-              "schema",
+              context.getFieldName(),
               "InvalidDatePartitionColumnType",
               "partitionColumn in datePartitionOptions must refer to a DATE or TIMESTAMP column");
         }
       } else {
         errors.rejectValue(
-            "schema", "InvalidDatePartitionColumnName", "No such column: " + targetColumn);
+            context.getFieldName(),
+            "InvalidDatePartitionColumnName",
+            "No such column: " + targetColumn);
       }
     }
   }
 
   private void validateIntPartitionOptions(
-      IntPartitionOptionsModel options, List<ColumnModel> columns, Errors errors) {
+      IntPartitionOptionsModel options,
+      List<ColumnModel> columns,
+      Errors errors,
+      SchemaValidationContext context) {
     String targetColumn = options.getColumn();
 
     if (targetColumn == null) {
-      errors.rejectValue("schema", "MissingIntPartitionColumnName");
+      errors.rejectValue(context.getFieldName(), "MissingIntPartitionColumnName");
     } else {
       Optional<ColumnModel> matchingColumn =
           columns.stream().filter(c -> targetColumn.equals(c.getName())).findFirst();
@@ -146,13 +171,15 @@ public class DatasetRequestValidator implements Validator {
 
         if (colType != TableDataType.INTEGER && colType != TableDataType.INT64) {
           errors.rejectValue(
-              "schema",
+              context.getFieldName(),
               "InvalidIntPartitionColumnType",
               "partitionColumn in intPartitionOptions must refer to an INTEGER or INT64 column");
         }
       } else {
         errors.rejectValue(
-            "schema", "InvalidIntPartitionColumnName", "No such column: " + targetColumn);
+            context.getFieldName(),
+            "InvalidIntPartitionColumnName",
+            "No such column: " + targetColumn);
       }
     }
 
@@ -162,30 +189,31 @@ public class DatasetRequestValidator implements Validator {
 
     if (min == null || max == null || interval == null) {
       errors.rejectValue(
-          "schema",
+          context.getFieldName(),
           "MissingIntPartitionOptions",
           "intPartitionOptions must specify min, max, and interval");
     } else {
       if (max <= min) {
         errors.rejectValue(
-            "schema",
+            context.getFieldName(),
             "InvalidIntPartitionRange",
             "Max partition value must be larger than min partition value");
       }
       if (interval <= 0) {
         errors.rejectValue(
-            "schema", "InvalidIntPartitionInterval", "Partition interval must be >= 1");
+            context.getFieldName(),
+            "InvalidIntPartitionInterval",
+            "Partition interval must be >= 1");
       }
       if (max > min && interval > 0 && (max - min) / interval > 4000L) {
         errors.rejectValue(
-            "schema",
+            context.getFieldName(),
             "TooManyIntPartitions",
             "Cannot configure more than 4K partitions through min, max, and interval");
       }
     }
   }
 
-  // specifically this method that is shared between update schema and create dataset
   public void validateTable(TableModel table, Errors errors, SchemaValidationContext context) {
     String tableName = table.getName();
     List<ColumnModel> columns = table.getColumns();
@@ -193,18 +221,20 @@ public class DatasetRequestValidator implements Validator {
     List<String> columnNames = new ArrayList<>();
     if (columns.isEmpty()) {
       errors.rejectValue(
-          "changes", "IncompleteSchemaDefinition", "Each table must contain at least one column");
+          context.getFieldName(),
+          "IncompleteSchemaDefinition",
+          "Each table must contain at least one column");
     } else {
       columns.stream().map(ColumnModel::getName).forEach(columnNames::add);
     }
 
     if (tableName != null) {
-      validateDataTypes(columns, errors);
+      validateDataTypes(columns, errors, context);
 
       if (ValidationUtils.hasDuplicates(columnNames)) {
         List<String> duplicates = ValidationUtils.findDuplicates(columnNames);
         errors.rejectValue(
-            "schema",
+            context.getFieldName(),
             "DuplicateColumnNames",
             String.format("Duplicate columns: %s", String.join(", ", duplicates)));
       }
@@ -213,16 +243,16 @@ public class DatasetRequestValidator implements Validator {
           List<String> missingKeys = new ArrayList<>(primaryKeyList);
           missingKeys.removeAll(columnNames);
           errors.rejectValue(
-              "schema",
+              context.getFieldName(),
               "MissingPrimaryKeyColumn",
               String.format("Expected column(s): %s", String.join(", ", missingKeys)));
         }
       }
       for (ColumnModel columnModel : table.getColumns()) {
         if (primaryKeyList != null && primaryKeyList.contains(columnModel.getName())) {
-          validateColumnType(errors, columnModel, PRIMARY_KEY);
+          validateColumnType(errors, columnModel, PRIMARY_KEY, context);
         }
-        validateColumnMode(errors, columnModel);
+        validateColumnMode(errors, columnModel, context);
       }
 
       context.addTable(tableName, columns);
@@ -235,15 +265,15 @@ public class DatasetRequestValidator implements Validator {
     if (mode == TableModel.PartitionModeEnum.DATE) {
       if (dateOptions == null) {
         errors.rejectValue(
-            "schema",
+            context.getFieldName(),
             "MissingDatePartitionOptions",
             "datePartitionOptions must be specified when using 'date' partitionMode");
       } else {
-        validateDatePartitionOptions(dateOptions, columns, errors);
+        validateDatePartitionOptions(dateOptions, columns, errors, context);
       }
     } else if (dateOptions != null) {
       errors.rejectValue(
-          "schema",
+          context.getFieldName(),
           "InvalidDatePartitionOptions",
           "datePartitionOptions can only be specified when using 'date' partitionMode");
     }
@@ -251,58 +281,67 @@ public class DatasetRequestValidator implements Validator {
     if (mode == TableModel.PartitionModeEnum.INT) {
       if (intOptions == null) {
         errors.rejectValue(
-            "schema",
+            context.getFieldName(),
             "MissingIntPartitionOptions",
             "intPartitionOptions must be specified when using 'int' partitionMode");
       } else {
-        validateIntPartitionOptions(intOptions, columns, errors);
+        validateIntPartitionOptions(intOptions, columns, errors, context);
       }
     } else if (intOptions != null) {
       errors.rejectValue(
-          "schema",
+          context.getFieldName(),
           "InvalidIntPartitionOptions",
           "intPartitionOptions can only be specified when using 'int' partitionMode");
     }
   }
 
   // Primary Keys and Foreign Keys cannot be filerefs or dirrefs and Primary keys cannot be arrays
-  private void validateColumnType(Errors errors, ColumnModel columnModel, String keyType) {
+  private void validateColumnType(
+      Errors errors, ColumnModel columnModel, String keyType, SchemaValidationContext context) {
     if (keyType.equals(PRIMARY_KEY) && columnModel.isArrayOf()) {
-      rejectKey(errors, keyType, columnModel.getName(), "array");
+      rejectKey(errors, keyType, columnModel.getName(), "array", context);
     }
 
     Set<TableDataType> invalidTypes = Set.of(TableDataType.DIRREF, TableDataType.FILEREF);
     if (columnModel.getDatatype() != null && invalidTypes.contains(columnModel.getDatatype())) {
-      rejectKey(errors, keyType, columnModel.getName(), columnModel.getDatatype().toString());
+      rejectKey(
+          errors, keyType, columnModel.getName(), columnModel.getDatatype().toString(), context);
     }
     if (PRIMARY_KEY.equals(keyType) && Boolean.FALSE.equals(columnModel.isRequired())) {
       errors.rejectValue(
-          "schema",
+          context.getFieldName(),
           "OptionalPrimaryKeyColumn",
           String.format("A %s column cannot be marked as not required", PRIMARY_KEY));
     }
   }
 
-  private void validateColumnMode(Errors errors, ColumnModel columnModel) {
+  private void validateColumnMode(
+      Errors errors, ColumnModel columnModel, SchemaValidationContext context) {
     // Explicitly check if isRequired is true to avoid a null pointer exception.
     // isArrayOf has a default value set in the open-api spec so it does not require
     // the same handling.
     if (Boolean.TRUE.equals(columnModel.isRequired()) && columnModel.isArrayOf()) {
       errors.rejectValue(
-          "schema",
+          context.getFieldName(),
           "InvalidColumnMode",
           String.format("Array column %s cannot be marked as required", columnModel.getName()));
     }
   }
 
-  private void rejectKey(Errors errors, String keyType, String columnName, String type) {
+  private void rejectKey(
+      Errors errors,
+      String keyType,
+      String columnName,
+      String type,
+      SchemaValidationContext context) {
     errors.rejectValue(
-        "schema",
+        context.getFieldName(),
         String.format("Invalid%s", keyType),
         String.format("%s %s cannot be a column with %s type", keyType, columnName, type));
   }
 
-  private void validateDataTypes(List<ColumnModel> columns, Errors errors) {
+  private void validateDataTypes(
+      List<ColumnModel> columns, Errors errors, SchemaValidationContext context) {
     List<ColumnModel> invalidColumns = new ArrayList<>();
     for (ColumnModel column : columns) {
       // spring defaults user input not belonging to the TableDataType enum to null
@@ -312,7 +351,7 @@ public class DatasetRequestValidator implements Validator {
     }
     if (!invalidColumns.isEmpty()) {
       errors.rejectValue(
-          "schema",
+          context.getFieldName(),
           "InvalidDatatype",
           "invalid datatype in table column(s): "
               + invalidColumns.stream().map(ColumnModel::getName).collect(Collectors.joining(", "))
@@ -328,7 +367,7 @@ public class DatasetRequestValidator implements Validator {
       SchemaValidationContext context) {
     ArrayList<LinkedHashMap<String, String>> validationErrors =
         ValidationUtils.getRelationshipValidationErrors(relationship, tables);
-    validationErrors.forEach(e -> rejectValues(errors, e));
+    validationErrors.forEach(e -> rejectValues(errors, e, context));
 
     String relationshipName = relationship.getName();
     if (relationshipName != null) {
@@ -336,11 +375,12 @@ public class DatasetRequestValidator implements Validator {
     }
   }
 
-  private void rejectValues(Errors errors, Map<String, String> errorMap) {
+  private void rejectValues(
+      Errors errors, Map<String, String> errorMap, SchemaValidationContext context) {
     for (var entry : errorMap.entrySet()) {
       var errorCode = entry.getKey();
       var errorMessage = entry.getValue();
-      errors.rejectValue("schema", errorCode, errorMessage);
+      errors.rejectValue(context.getFieldName(), errorCode, errorMessage);
     }
   }
 
@@ -354,14 +394,15 @@ public class DatasetRequestValidator implements Validator {
       // specification.
       if (columnNames.size() == 0) {
         if (!context.isValidTable(tableName)) {
-          errors.rejectValue("schema", "InvalidAssetTable", "Invalid asset table: " + tableName);
+          errors.rejectValue(
+              context.getFieldName(), "InvalidAssetTable", "Invalid asset table: " + tableName);
         }
       } else {
         columnNames.forEach(
             (columnName) -> {
               if (!context.isValidTableColumn(tableName, columnName)) {
                 errors.rejectValue(
-                    "schema",
+                    context.getFieldName(),
                     "InvalidAssetTableColumn",
                     "Invalid asset table: " + tableName + " column: " + columnName);
               }
@@ -383,12 +424,12 @@ public class DatasetRequestValidator implements Validator {
         if (assetTable.getName().equals(rootTable)) {
           if (!context.isValidTableColumn(rootTable, rootColumn)) {
             errors.rejectValue(
-                "schema",
+                context.getFieldName(),
                 "InvalidRootColumn",
                 "Invalid root table column. Table: " + rootTable + " Column: " + rootColumn);
           } else if (context.isArrayColumn(rootTable, rootColumn)) {
             errors.rejectValue(
-                "schema",
+                context.getFieldName(),
                 "InvalidArrayRootColumn",
                 "Invalid use of array column as asset root. Table: "
                     + rootTable
@@ -399,7 +440,7 @@ public class DatasetRequestValidator implements Validator {
         }
       }
       if (!hasRootTable) {
-        errors.rejectValue("schema", "NoRootTable");
+        errors.rejectValue(context.getFieldName(), "NoRootTable");
       }
     }
 
@@ -407,7 +448,7 @@ public class DatasetRequestValidator implements Validator {
     if (follows != null) {
       if (follows.stream()
           .anyMatch(relationshipName -> !context.isValidRelationship(relationshipName))) {
-        errors.rejectValue("schema", "InvalidFollowsRelationship");
+        errors.rejectValue(context.getFieldName(), "InvalidFollowsRelationship");
       }
     }
     // TODO: There is another validation that can be done here to make sure that the graph is
@@ -416,16 +457,19 @@ public class DatasetRequestValidator implements Validator {
   }
 
   private void validateSchema(DatasetSpecificationModel schema, Errors errors) {
-    SchemaValidationContext context = new SchemaValidationContext();
+    SchemaValidationContext context =
+        new SchemaValidationContext(SchemaValidationContext.Operation.CREATE);
     List<TableModel> tables = schema.getTables();
     if (tables.isEmpty()) {
       errors.rejectValue(
-          "schema", "IncompleteSchemaDefinition", "Dataset tables must be defined in the schema");
+          context.getFieldName(),
+          "IncompleteSchemaDefinition",
+          "Dataset tables must be defined in the schema");
     } else {
       List<String> tableNames =
           tables.stream().map(TableModel::getName).collect(Collectors.toList());
       if (ValidationUtils.hasDuplicates(tableNames)) {
-        errors.rejectValue("schema", "DuplicateTableNames");
+        errors.rejectValue(context.getFieldName(), "DuplicateTableNames");
       }
       tables.forEach((table) -> validateTable(table, errors, context));
     }
@@ -435,7 +479,7 @@ public class DatasetRequestValidator implements Validator {
       List<String> relationshipNames =
           relationships.stream().map(RelationshipModel::getName).collect(Collectors.toList());
       if (ValidationUtils.hasDuplicates(relationshipNames)) {
-        errors.rejectValue("schema", "DuplicateRelationshipNames");
+        errors.rejectValue(context.getFieldName(), "DuplicateRelationshipNames");
       }
       relationships.forEach(
           (relationship) -> validateRelationship(relationship, tables, errors, context));
@@ -448,7 +492,7 @@ public class DatasetRequestValidator implements Validator {
       if (ValidationUtils.hasDuplicates(assetNames)) {
         List<String> duplicates = ValidationUtils.findDuplicates(assetNames);
         errors.rejectValue(
-            "schema",
+            context.getFieldName(),
             "DuplicateAssetNames",
             String.format("Duplicate asset names: %s", String.join(", ", duplicates)));
       }

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -3,16 +3,12 @@ package bio.terra.service.dataset;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.ValidationUtils;
 import bio.terra.model.AssetModel;
-import bio.terra.model.AssetTableModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSpecificationModel;
 import bio.terra.model.RelationshipModel;
 import bio.terra.model.TableModel;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -43,102 +39,6 @@ public class DatasetRequestValidator implements Validator {
     }
   }
 
-  private void validateRelationship(
-      RelationshipModel relationship,
-      List<TableModel> tables,
-      Errors errors,
-      SchemaValidationContext context) {
-    ArrayList<LinkedHashMap<String, String>> validationErrors =
-        ValidationUtils.getRelationshipValidationErrors(relationship, tables);
-    validationErrors.forEach(e -> rejectValues(errors, e, context));
-
-    String relationshipName = relationship.getName();
-    if (relationshipName != null) {
-      context.addRelationship(relationshipName);
-    }
-  }
-
-  private void rejectValues(
-      Errors errors, Map<String, String> errorMap, SchemaValidationContext context) {
-    for (var entry : errorMap.entrySet()) {
-      var errorCode = entry.getKey();
-      var errorMessage = entry.getValue();
-      errors.rejectValue(context.getFieldName(), errorCode, errorMessage);
-    }
-  }
-
-  private void validateAssetTable(
-      AssetTableModel assetTable, Errors errors, SchemaValidationContext context) {
-
-    String tableName = assetTable.getName();
-    List<String> columnNames = assetTable.getColumns();
-    if (tableName != null && columnNames != null) {
-      // An empty list acts like a wildcard to include all columns from a table in the asset
-      // specification.
-      if (columnNames.size() == 0) {
-        if (!context.isValidTable(tableName)) {
-          errors.rejectValue(
-              context.getFieldName(), "InvalidAssetTable", "Invalid asset table: " + tableName);
-        }
-      } else {
-        columnNames.forEach(
-            (columnName) -> {
-              if (!context.isValidTableColumn(tableName, columnName)) {
-                errors.rejectValue(
-                    context.getFieldName(),
-                    "InvalidAssetTableColumn",
-                    "Invalid asset table: " + tableName + " column: " + columnName);
-              }
-            });
-      }
-    }
-  }
-
-  private void validateAsset(AssetModel asset, Errors errors, SchemaValidationContext context) {
-    List<AssetTableModel> assetTables = asset.getTables();
-
-    String rootTable = asset.getRootTable();
-    String rootColumn = asset.getRootColumn();
-
-    if (assetTables != null) {
-      boolean hasRootTable = false;
-      for (AssetTableModel assetTable : assetTables) {
-        validateAssetTable(assetTable, errors, context);
-        if (assetTable.getName().equals(rootTable)) {
-          if (!context.isValidTableColumn(rootTable, rootColumn)) {
-            errors.rejectValue(
-                context.getFieldName(),
-                "InvalidRootColumn",
-                "Invalid root table column. Table: " + rootTable + " Column: " + rootColumn);
-          } else if (context.isArrayColumn(rootTable, rootColumn)) {
-            errors.rejectValue(
-                context.getFieldName(),
-                "InvalidArrayRootColumn",
-                "Invalid use of array column as asset root. Table: "
-                    + rootTable
-                    + " Column: "
-                    + rootColumn);
-          }
-          hasRootTable = true;
-        }
-      }
-      if (!hasRootTable) {
-        errors.rejectValue(context.getFieldName(), "NoRootTable");
-      }
-    }
-
-    List<String> follows = asset.getFollow();
-    if (follows != null) {
-      if (follows.stream()
-          .anyMatch(relationshipName -> !context.isValidRelationship(relationshipName))) {
-        errors.rejectValue(context.getFieldName(), "InvalidFollowsRelationship");
-      }
-    }
-    // TODO: There is another validation that can be done here to make sure that the graph is
-    // connected that has
-    // been left out to avoid complexity before we know if we're going keep using this or not.
-  }
-
   private void validateSchema(DatasetSpecificationModel schema, Errors errors) {
     SchemaValidationContext context = SchemaValidationContext.forCreate();
     List<TableModel> tables = schema.getTables();
@@ -164,7 +64,7 @@ public class DatasetRequestValidator implements Validator {
         errors.rejectValue(context.getFieldName(), "DuplicateRelationshipNames");
       }
       relationships.forEach(
-          (relationship) -> validateRelationship(relationship, tables, errors, context));
+          (relationship) -> context.validateRelationship(relationship, tables, errors));
     }
 
     List<AssetModel> assets = schema.getAssets();
@@ -178,7 +78,7 @@ public class DatasetRequestValidator implements Validator {
             "DuplicateAssetNames",
             String.format("Duplicate asset names: %s", String.join(", ", duplicates)));
       }
-      assets.forEach((asset) -> validateAsset(asset, errors, context));
+      assets.forEach((asset) -> context.validateAsset(asset, errors));
     }
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -193,7 +193,7 @@ public class DatasetRequestValidator implements Validator {
     List<String> columnNames = new ArrayList<>();
     if (columns.isEmpty()) {
       errors.rejectValue(
-          "schema", "IncompleteSchemaDefinition", "Each table must contain at least one column");
+          "changes", "IncompleteSchemaDefinition", "Each table must contain at least one column");
     } else {
       columns.stream().map(ColumnModel::getName).forEach(columnNames::add);
     }

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -185,6 +185,7 @@ public class DatasetRequestValidator implements Validator {
     }
   }
 
+  // specifically this method that is shared between update schema and create dataset
   public void validateTable(TableModel table, Errors errors, SchemaValidationContext context) {
     String tableName = table.getName();
     List<ColumnModel> columns = table.getColumns();

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -140,8 +140,7 @@ public class DatasetRequestValidator implements Validator {
   }
 
   private void validateSchema(DatasetSpecificationModel schema, Errors errors) {
-    SchemaValidationContext context =
-        new SchemaValidationContext(SchemaValidationContext.Operation.CREATE);
+    SchemaValidationContext context = SchemaValidationContext.forCreate();
     List<TableModel> tables = schema.getTables();
     if (tables.isEmpty()) {
       errors.rejectValue(

--- a/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetRequestValidator.java
@@ -153,7 +153,7 @@ public class DatasetRequestValidator implements Validator {
       if (ValidationUtils.hasDuplicates(tableNames)) {
         errors.rejectValue(context.getFieldName(), "DuplicateTableNames");
       }
-      tables.forEach((table) -> context.validateTable(table, errors));
+      tables.forEach(table -> context.validateTable(table, errors));
     }
 
     List<RelationshipModel> relationships = schema.getRelationships();

--- a/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
@@ -12,15 +12,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 @Component
 public class DatasetSchemaUpdateValidator implements Validator {
-
-  @Autowired private DatasetRequestValidator datasetRequestValidator;
 
   @Override
   public boolean supports(Class<?> clazz) {
@@ -29,11 +26,10 @@ public class DatasetSchemaUpdateValidator implements Validator {
 
   private void validateDatasetSchemaUpdate(DatasetSchemaUpdateModel updateModel, Errors errors) {
     if (DatasetSchemaUpdateUtils.hasTableAdditions(updateModel)) {
-      DatasetRequestValidator.SchemaValidationContext context =
-          new DatasetRequestValidator.SchemaValidationContext(
-              DatasetRequestValidator.SchemaValidationContext.Operation.UPDATE);
+      SchemaValidationContext context =
+          new SchemaValidationContext(SchemaValidationContext.Operation.UPDATE);
       for (TableModel tableModel : updateModel.getChanges().getAddTables()) {
-        datasetRequestValidator.validateTable(tableModel, errors, context);
+        context.validateTable(tableModel, errors);
       }
       List<String> newTableNames = DatasetSchemaUpdateUtils.getNewTableNames(updateModel);
       Object[] duplicateTables =

--- a/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
@@ -30,7 +30,8 @@ public class DatasetSchemaUpdateValidator implements Validator {
   private void validateDatasetSchemaUpdate(DatasetSchemaUpdateModel updateModel, Errors errors) {
     if (DatasetSchemaUpdateUtils.hasTableAdditions(updateModel)) {
       DatasetRequestValidator.SchemaValidationContext context =
-          new DatasetRequestValidator.SchemaValidationContext();
+          new DatasetRequestValidator.SchemaValidationContext(
+              DatasetRequestValidator.SchemaValidationContext.Operation.UPDATE);
       for (TableModel tableModel : updateModel.getChanges().getAddTables()) {
         datasetRequestValidator.validateTable(tableModel, errors, context);
       }

--- a/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSchemaUpdateValidator.java
@@ -26,8 +26,7 @@ public class DatasetSchemaUpdateValidator implements Validator {
 
   private void validateDatasetSchemaUpdate(DatasetSchemaUpdateModel updateModel, Errors errors) {
     if (DatasetSchemaUpdateUtils.hasTableAdditions(updateModel)) {
-      SchemaValidationContext context =
-          new SchemaValidationContext(SchemaValidationContext.Operation.UPDATE);
+      SchemaValidationContext context = SchemaValidationContext.forUpdate();
       for (TableModel tableModel : updateModel.getChanges().getAddTables()) {
         context.validateTable(tableModel, errors);
       }

--- a/src/main/java/bio/terra/service/dataset/SchemaValidationContext.java
+++ b/src/main/java/bio/terra/service/dataset/SchemaValidationContext.java
@@ -39,17 +39,25 @@ public class SchemaValidationContext {
   private final HashMap<String, HashSet<String>> tableColumnMap;
   private final HashMap<String, HashSet<String>> tableArrayColumns;
   private final HashSet<String> relationshipNameSet;
-  private final Operation operation;
+  private final String fieldName;
 
-  SchemaValidationContext(Operation op) {
+  SchemaValidationContext(String field) {
     tableColumnMap = new HashMap<>();
     tableArrayColumns = new HashMap<>();
     relationshipNameSet = new HashSet<>();
-    operation = op;
+    fieldName = field;
+  }
+
+  static SchemaValidationContext forUpdate() {
+    return new SchemaValidationContext("changes");
+  }
+
+  static SchemaValidationContext forCreate() {
+    return new SchemaValidationContext("schema");
   }
 
   String getFieldName() {
-    return operation.fieldName;
+    return fieldName;
   }
 
   void addTable(String tableName, List<ColumnModel> columns) {

--- a/src/main/java/bio/terra/service/dataset/SchemaValidationContext.java
+++ b/src/main/java/bio/terra/service/dataset/SchemaValidationContext.java
@@ -1,0 +1,307 @@
+package bio.terra.service.dataset;
+
+import bio.terra.common.PdaoConstant;
+import bio.terra.common.ValidationUtils;
+import bio.terra.model.ColumnModel;
+import bio.terra.model.DatePartitionOptionsModel;
+import bio.terra.model.IntPartitionOptionsModel;
+import bio.terra.model.TableDataType;
+import bio.terra.model.TableModel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.validation.Errors;
+
+/**
+ * SchemaValidationContext represents shared functionality between DatasetRequestValidator (used for
+ * creating dataset schemas) and DatasetSchemaUpdateValidator (used for updating dataset schemas).
+ */
+public class SchemaValidationContext {
+
+  private static final String PRIMARY_KEY = "PrimaryKey";
+
+  enum Operation {
+    CREATE("schema"),
+    UPDATE("changes");
+
+    private final String fieldName;
+
+    Operation(String fieldName) {
+      this.fieldName = fieldName;
+    }
+  }
+
+  private final HashMap<String, HashSet<String>> tableColumnMap;
+  private final HashMap<String, HashSet<String>> tableArrayColumns;
+  private final HashSet<String> relationshipNameSet;
+  private final Operation operation;
+
+  SchemaValidationContext(Operation op) {
+    tableColumnMap = new HashMap<>();
+    tableArrayColumns = new HashMap<>();
+    relationshipNameSet = new HashSet<>();
+    operation = op;
+  }
+
+  String getFieldName() {
+    return operation.fieldName;
+  }
+
+  void addTable(String tableName, List<ColumnModel> columns) {
+    HashSet<String> colNames = new HashSet<>();
+    HashSet<String> arrayCols = new HashSet<>();
+
+    for (ColumnModel col : columns) {
+      colNames.add(col.getName());
+      if (col.isArrayOf()) {
+        arrayCols.add(col.getName());
+      }
+    }
+
+    tableColumnMap.put(tableName, colNames);
+    tableArrayColumns.put(tableName, arrayCols);
+  }
+
+  void addRelationship(String relationshipName) {
+    relationshipNameSet.add(relationshipName);
+  }
+
+  boolean isValidTable(String tableName) {
+    return tableColumnMap.containsKey(tableName);
+  }
+
+  boolean isValidTableColumn(String tableName, String columnName) {
+    return isValidTable(tableName) && tableColumnMap.get(tableName).contains(columnName);
+  }
+
+  boolean isArrayColumn(String tableName, String columnName) {
+    return isValidTableColumn(tableName, columnName)
+        && tableArrayColumns.get(tableName).contains(columnName);
+  }
+
+  boolean isValidRelationship(String relationshipName) {
+    return relationshipNameSet.contains(relationshipName);
+  }
+
+  public void validateTable(TableModel table, Errors errors) {
+    String tableName = table.getName();
+    List<ColumnModel> columns = table.getColumns();
+    List<String> primaryKeyList = table.getPrimaryKey();
+    List<String> columnNames = new ArrayList<>();
+    if (columns.isEmpty()) {
+      errors.rejectValue(
+          getFieldName(),
+          "IncompleteSchemaDefinition",
+          "Each table must contain at least one column");
+    } else {
+      columns.stream().map(ColumnModel::getName).forEach(columnNames::add);
+    }
+
+    if (tableName != null) {
+      validateDataTypes(columns, errors);
+
+      if (ValidationUtils.hasDuplicates(columnNames)) {
+        List<String> duplicates = ValidationUtils.findDuplicates(columnNames);
+        errors.rejectValue(
+            getFieldName(),
+            "DuplicateColumnNames",
+            String.format("Duplicate columns: %s", String.join(", ", duplicates)));
+      }
+      if (primaryKeyList != null) {
+        if (!columnNames.containsAll(primaryKeyList)) {
+          List<String> missingKeys = new ArrayList<>(primaryKeyList);
+          missingKeys.removeAll(columnNames);
+          errors.rejectValue(
+              getFieldName(),
+              "MissingPrimaryKeyColumn",
+              String.format("Expected column(s): %s", String.join(", ", missingKeys)));
+        }
+      }
+      for (ColumnModel columnModel : table.getColumns()) {
+        if (primaryKeyList != null && primaryKeyList.contains(columnModel.getName())) {
+          validateColumnType(errors, columnModel, PRIMARY_KEY);
+        }
+        validateColumnMode(errors, columnModel);
+      }
+
+      addTable(tableName, columns);
+    }
+
+    TableModel.PartitionModeEnum mode = table.getPartitionMode();
+    DatePartitionOptionsModel dateOptions = table.getDatePartitionOptions();
+    IntPartitionOptionsModel intOptions = table.getIntPartitionOptions();
+
+    if (mode == TableModel.PartitionModeEnum.DATE) {
+      if (dateOptions == null) {
+        errors.rejectValue(
+            getFieldName(),
+            "MissingDatePartitionOptions",
+            "datePartitionOptions must be specified when using 'date' partitionMode");
+      } else {
+        validateDatePartitionOptions(dateOptions, columns, errors);
+      }
+    } else if (dateOptions != null) {
+      errors.rejectValue(
+          getFieldName(),
+          "InvalidDatePartitionOptions",
+          "datePartitionOptions can only be specified when using 'date' partitionMode");
+    }
+
+    if (mode == TableModel.PartitionModeEnum.INT) {
+      if (intOptions == null) {
+        errors.rejectValue(
+            getFieldName(),
+            "MissingIntPartitionOptions",
+            "intPartitionOptions must be specified when using 'int' partitionMode");
+      } else {
+        validateIntPartitionOptions(intOptions, columns, errors);
+      }
+    } else if (intOptions != null) {
+      errors.rejectValue(
+          getFieldName(),
+          "InvalidIntPartitionOptions",
+          "intPartitionOptions can only be specified when using 'int' partitionMode");
+    }
+  }
+
+  private void validateDataTypes(List<ColumnModel> columns, Errors errors) {
+    List<ColumnModel> invalidColumns = new ArrayList<>();
+    for (ColumnModel column : columns) {
+      // spring defaults user input not belonging to the TableDataType enum to null
+      if (column.getDatatype() == null) {
+        invalidColumns.add(column);
+      }
+    }
+    if (!invalidColumns.isEmpty()) {
+      errors.rejectValue(
+          getFieldName(),
+          "InvalidDatatype",
+          "invalid datatype in table column(s): "
+              + invalidColumns.stream().map(ColumnModel::getName).collect(Collectors.joining(", "))
+              + ", DataTypes must be lowercase, valid DataTypes are "
+              + Arrays.toString(TableDataType.values()));
+    }
+  }
+
+  // Primary Keys and Foreign Keys cannot be filerefs or dirrefs and Primary keys cannot be arrays
+  private void validateColumnType(Errors errors, ColumnModel columnModel, String keyType) {
+    if (keyType.equals(PRIMARY_KEY) && columnModel.isArrayOf()) {
+      rejectKey(errors, keyType, columnModel.getName(), "array");
+    }
+
+    Set<TableDataType> invalidTypes = Set.of(TableDataType.DIRREF, TableDataType.FILEREF);
+    if (columnModel.getDatatype() != null && invalidTypes.contains(columnModel.getDatatype())) {
+      rejectKey(errors, keyType, columnModel.getName(), columnModel.getDatatype().toString());
+    }
+    if (PRIMARY_KEY.equals(keyType) && Boolean.FALSE.equals(columnModel.isRequired())) {
+      errors.rejectValue(
+          getFieldName(),
+          "OptionalPrimaryKeyColumn",
+          String.format("A %s column cannot be marked as not required", PRIMARY_KEY));
+    }
+  }
+
+  private void validateColumnMode(Errors errors, ColumnModel columnModel) {
+    // Explicitly check if isRequired is true to avoid a null pointer exception.
+    // isArrayOf has a default value set in the open-api spec so it does not require
+    // the same handling.
+    if (Boolean.TRUE.equals(columnModel.isRequired()) && columnModel.isArrayOf()) {
+      errors.rejectValue(
+          getFieldName(),
+          "InvalidColumnMode",
+          String.format("Array column %s cannot be marked as required", columnModel.getName()));
+    }
+  }
+
+  private void validateDatePartitionOptions(
+      DatePartitionOptionsModel options, List<ColumnModel> columns, Errors errors) {
+    String targetColumn = options.getColumn();
+
+    if (targetColumn == null) {
+      errors.rejectValue(getFieldName(), "MissingDatePartitionColumnName");
+    } else if (!targetColumn.equals(PdaoConstant.PDAO_INGEST_DATE_COLUMN_ALIAS)) {
+      Optional<ColumnModel> matchingColumn =
+          columns.stream().filter(c -> targetColumn.equals(c.getName())).findFirst();
+
+      if (matchingColumn.isPresent()) {
+        TableDataType colType = matchingColumn.get().getDatatype();
+
+        if (colType != TableDataType.DATE && colType != TableDataType.TIMESTAMP) {
+          errors.rejectValue(
+              getFieldName(),
+              "InvalidDatePartitionColumnType",
+              "partitionColumn in datePartitionOptions must refer to a DATE or TIMESTAMP column");
+        }
+      } else {
+        errors.rejectValue(
+            getFieldName(), "InvalidDatePartitionColumnName", "No such column: " + targetColumn);
+      }
+    }
+  }
+
+  private void validateIntPartitionOptions(
+      IntPartitionOptionsModel options, List<ColumnModel> columns, Errors errors) {
+    String targetColumn = options.getColumn();
+
+    if (targetColumn == null) {
+      errors.rejectValue(getFieldName(), "MissingIntPartitionColumnName");
+    } else {
+      Optional<ColumnModel> matchingColumn =
+          columns.stream().filter(c -> targetColumn.equals(c.getName())).findFirst();
+
+      if (matchingColumn.isPresent()) {
+        TableDataType colType = matchingColumn.get().getDatatype();
+
+        if (colType != TableDataType.INTEGER && colType != TableDataType.INT64) {
+          errors.rejectValue(
+              getFieldName(),
+              "InvalidIntPartitionColumnType",
+              "partitionColumn in intPartitionOptions must refer to an INTEGER or INT64 column");
+        }
+      } else {
+        errors.rejectValue(
+            getFieldName(), "InvalidIntPartitionColumnName", "No such column: " + targetColumn);
+      }
+    }
+
+    Long min = options.getMin();
+    Long max = options.getMax();
+    Long interval = options.getInterval();
+
+    if (min == null || max == null || interval == null) {
+      errors.rejectValue(
+          getFieldName(),
+          "MissingIntPartitionOptions",
+          "intPartitionOptions must specify min, max, and interval");
+    } else {
+      if (max <= min) {
+        errors.rejectValue(
+            getFieldName(),
+            "InvalidIntPartitionRange",
+            "Max partition value must be larger than min partition value");
+      }
+      if (interval <= 0) {
+        errors.rejectValue(
+            getFieldName(), "InvalidIntPartitionInterval", "Partition interval must be >= 1");
+      }
+      if (max > min && interval > 0 && (max - min) / interval > 4000L) {
+        errors.rejectValue(
+            getFieldName(),
+            "TooManyIntPartitions",
+            "Cannot configure more than 4K partitions through min, max, and interval");
+      }
+    }
+  }
+
+  private void rejectKey(Errors errors, String keyType, String columnName, String type) {
+    errors.rejectValue(
+        getFieldName(),
+        String.format("Invalid%s", keyType),
+        String.format("%s %s cannot be a column with %s type", keyType, columnName, type));
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/SchemaValidationContext.java
+++ b/src/main/java/bio/terra/service/dataset/SchemaValidationContext.java
@@ -25,17 +25,6 @@ public class SchemaValidationContext {
 
   private static final String PRIMARY_KEY = "PrimaryKey";
 
-  enum Operation {
-    CREATE("schema"),
-    UPDATE("changes");
-
-    private final String fieldName;
-
-    Operation(String fieldName) {
-      this.fieldName = fieldName;
-    }
-  }
-
   private final HashMap<String, HashSet<String>> tableColumnMap;
   private final HashMap<String, HashSet<String>> tableArrayColumns;
   private final HashSet<String> relationshipNameSet;

--- a/src/main/java/bio/terra/service/dataset/SchemaValidationContext.java
+++ b/src/main/java/bio/terra/service/dataset/SchemaValidationContext.java
@@ -2,39 +2,42 @@ package bio.terra.service.dataset;
 
 import bio.terra.common.PdaoConstant;
 import bio.terra.common.ValidationUtils;
+import bio.terra.model.AssetModel;
+import bio.terra.model.AssetTableModel;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatePartitionOptionsModel;
 import bio.terra.model.IntPartitionOptionsModel;
+import bio.terra.model.RelationshipModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.TableModel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.validation.Errors;
 
 /**
- * SchemaValidationContext represents shared functionality between DatasetRequestValidator (used for
- * creating dataset schemas) and DatasetSchemaUpdateValidator (used for updating dataset schemas).
+ * SchemaValidationContext represents shared functionality used to validate schemas for datasets.
+ * Much of this functionality is shared between DatasetRequestValidator (used for creating dataset
+ * schemas) and DatasetSchemaUpdateValidator (used for updating dataset schemas).
  */
 public class SchemaValidationContext {
 
   private static final String PRIMARY_KEY = "PrimaryKey";
 
-  private final HashMap<String, HashSet<String>> tableColumnMap;
-  private final HashMap<String, HashSet<String>> tableArrayColumns;
-  private final HashSet<String> relationshipNameSet;
+  private final Map<String, Set<String>> tableColumnMap = new HashMap<>();
+  private final Map<String, Set<String>> tableArrayColumns = new HashMap<>();
+  private final Set<String> relationshipNameSet = new HashSet<>();
   private final String fieldName;
 
-  SchemaValidationContext(String field) {
-    tableColumnMap = new HashMap<>();
-    tableArrayColumns = new HashMap<>();
-    relationshipNameSet = new HashSet<>();
-    fieldName = field;
+  SchemaValidationContext(String fieldName) {
+    this.fieldName = fieldName;
   }
 
   static SchemaValidationContext forUpdate() {
@@ -109,15 +112,13 @@ public class SchemaValidationContext {
             "DuplicateColumnNames",
             String.format("Duplicate columns: %s", String.join(", ", duplicates)));
       }
-      if (primaryKeyList != null) {
-        if (!columnNames.containsAll(primaryKeyList)) {
-          List<String> missingKeys = new ArrayList<>(primaryKeyList);
-          missingKeys.removeAll(columnNames);
-          errors.rejectValue(
-              getFieldName(),
-              "MissingPrimaryKeyColumn",
-              String.format("Expected column(s): %s", String.join(", ", missingKeys)));
-        }
+      if (primaryKeyList != null && !new HashSet<>(columnNames).containsAll(primaryKeyList)) {
+        List<String> missingKeys = new ArrayList<>(primaryKeyList);
+        missingKeys.removeAll(columnNames);
+        errors.rejectValue(
+            getFieldName(),
+            "MissingPrimaryKeyColumn",
+            String.format("Expected column(s): %s", String.join(", ", missingKeys)));
       }
       for (ColumnModel columnModel : table.getColumns()) {
         if (primaryKeyList != null && primaryKeyList.contains(columnModel.getName())) {
@@ -300,5 +301,95 @@ public class SchemaValidationContext {
         getFieldName(),
         String.format("Invalid%s", keyType),
         String.format("%s %s cannot be a column with %s type", keyType, columnName, type));
+  }
+
+  void validateRelationship(
+      RelationshipModel relationship, List<TableModel> tables, Errors errors) {
+    ArrayList<LinkedHashMap<String, String>> validationErrors =
+        ValidationUtils.getRelationshipValidationErrors(relationship, tables);
+    validationErrors.forEach(e -> rejectValues(errors, e));
+
+    String relationshipName = relationship.getName();
+    if (relationshipName != null) {
+      addRelationship(relationshipName);
+    }
+  }
+
+  private void rejectValues(Errors errors, Map<String, String> errorMap) {
+    for (var entry : errorMap.entrySet()) {
+      var errorCode = entry.getKey();
+      var errorMessage = entry.getValue();
+      errors.rejectValue(getFieldName(), errorCode, errorMessage);
+    }
+  }
+
+  private void validateAssetTable(AssetTableModel assetTable, Errors errors) {
+
+    String tableName = assetTable.getName();
+    List<String> columnNames = assetTable.getColumns();
+    if (tableName != null && columnNames != null) {
+      // An empty list acts like a wildcard to include all columns from a table in the asset
+      // specification.
+      if (columnNames.isEmpty()) {
+        if (!isValidTable(tableName)) {
+          errors.rejectValue(
+              getFieldName(), "InvalidAssetTable", "Invalid asset table: " + tableName);
+        }
+      } else {
+        columnNames.forEach(
+            (columnName) -> {
+              if (!isValidTableColumn(tableName, columnName)) {
+                errors.rejectValue(
+                    getFieldName(),
+                    "InvalidAssetTableColumn",
+                    "Invalid asset table: " + tableName + " column: " + columnName);
+              }
+            });
+      }
+    }
+  }
+
+  void validateAsset(AssetModel asset, Errors errors) {
+    List<AssetTableModel> assetTables = asset.getTables();
+
+    String rootTable = asset.getRootTable();
+    String rootColumn = asset.getRootColumn();
+
+    if (assetTables != null) {
+      boolean hasRootTable = false;
+      for (AssetTableModel assetTable : assetTables) {
+        validateAssetTable(assetTable, errors);
+        if (assetTable.getName().equals(rootTable)) {
+          if (!isValidTableColumn(rootTable, rootColumn)) {
+            errors.rejectValue(
+                getFieldName(),
+                "InvalidRootColumn",
+                "Invalid root table column. Table: " + rootTable + " Column: " + rootColumn);
+          } else if (isArrayColumn(rootTable, rootColumn)) {
+            errors.rejectValue(
+                getFieldName(),
+                "InvalidArrayRootColumn",
+                "Invalid use of array column as asset root. Table: "
+                    + rootTable
+                    + " Column: "
+                    + rootColumn);
+          }
+          hasRootTable = true;
+        }
+      }
+      if (!hasRootTable) {
+        errors.rejectValue(getFieldName(), "NoRootTable");
+      }
+    }
+
+    List<String> follows = asset.getFollow();
+    if (follows != null) {
+      if (follows.stream().anyMatch(relationshipName -> !isValidRelationship(relationshipName))) {
+        errors.rejectValue(getFieldName(), "InvalidFollowsRelationship");
+      }
+    }
+    // TODO: There is another validation that can be done here to make sure that the graph is
+    // connected that has
+    // been left out to avoid complexity before we know if we're going keep using this or not.
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
@@ -150,4 +150,25 @@ class DatasetSchemaUpdateValidatorTest {
         errorModel.getErrorDetail().get(0),
         containsString("DuplicateRelationshipNames"));
   }
+
+  @Test
+  void testNoColumns() throws Exception {
+    String newTableName = "new_table";
+    String newTableColumnName = "new_table_column";
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("column addition tests")
+            .changes(
+                new DatasetSchemaUpdateModelChanges()
+                    .addTables(
+                        List.of(
+                            DatasetFixtures.tableModel(newTableName, List.of(newTableColumnName)),
+                            DatasetFixtures.tableModel(
+                                newTableName, List.of(newTableColumnName)))));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Required column throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("DuplicateTableNames"));
+  }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
@@ -287,8 +287,7 @@ class DatasetSchemaUpdateValidatorTest {
   @Test
   void testMissingDatePartitionColumnName() throws Exception {
     String newTableName = "new_table";
-    DatePartitionOptionsModel datePartitionOptions =
-        new DatePartitionOptionsModel();
+    DatePartitionOptionsModel datePartitionOptions = new DatePartitionOptionsModel();
     TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
     tableModel.setPartitionMode(TableModel.PartitionModeEnum.DATE);
     tableModel.setDatePartitionOptions(datePartitionOptions);
@@ -300,7 +299,8 @@ class DatasetSchemaUpdateValidatorTest {
     ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
     assertThat(
         "Missing date partition column name with new table throws error",
-        errorModel.getErrorDetail().get(0),
+        // first error is NotNull error for column, second is MissingDatePartitionColumnName
+        errorModel.getErrorDetail().get(1),
         containsString("MissingDatePartitionColumnName"));
   }
 
@@ -325,7 +325,7 @@ class DatasetSchemaUpdateValidatorTest {
     assertThat(
         "Invalid date partition column type with new table throws error",
         errorModel.getErrorDetail().get(0),
-        containsString("MissingDatePartitionColumnName"));
+        containsString("InvalidDatePartitionColumnType"));
   }
 
   @Test
@@ -348,21 +348,29 @@ class DatasetSchemaUpdateValidatorTest {
     assertThat(
         "Invalid date partition column name with new table throws error",
         errorModel.getErrorDetail().get(0),
-        containsString("MissingDatePartitionColumnName"));
+        containsString("InvalidDatePartitionColumnName"));
   }
 
   @Test
   void testInvalidDatePartitionOptions() throws Exception {
     String newTableName = "new_table";
     DatePartitionOptionsModel datePartitionOptions =
-        new DatePartitionOptionsModel();
-    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
+        new DatePartitionOptionsModel().column("column1");
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
+    tableModel.addColumnsItem(
+        DatasetFixtures.columnModel("column1", TableDataType.INTEGER, false, false));
     tableModel.setPartitionMode(TableModel.PartitionModeEnum.INT);
     tableModel.setDatePartitionOptions(datePartitionOptions);
+    IntPartitionOptionsModel intPartitionOptions = new IntPartitionOptionsModel();
+    intPartitionOptions.min(1L);
+    intPartitionOptions.max(10L);
+    intPartitionOptions.interval(1L);
+    intPartitionOptions.column("column1");
+    tableModel.setIntPartitionOptions(intPartitionOptions);
 
     DatasetSchemaUpdateModel updateModel =
         new DatasetSchemaUpdateModel()
-            .description("Invalid date partition options with new table")
+            .description("Invalid date partition options with mode Int with new table")
             .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
     ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
     assertThat(
@@ -392,6 +400,9 @@ class DatasetSchemaUpdateValidatorTest {
   void testMissingIntPartitionColumnName() throws Exception {
     String newTableName = "new_table";
     IntPartitionOptionsModel intPartitionOptions = new IntPartitionOptionsModel();
+    intPartitionOptions.min(1L);
+    intPartitionOptions.max(10L);
+    intPartitionOptions.interval(1L);
     TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
     tableModel.setPartitionMode(TableModel.PartitionModeEnum.INT);
     tableModel.setIntPartitionOptions(intPartitionOptions);
@@ -402,7 +413,8 @@ class DatasetSchemaUpdateValidatorTest {
     ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
     assertThat(
         "Missing int partition column name with new table throws error",
-        errorModel.getErrorDetail().get(0),
+        // first error is NotNull error for column, second is MissingIntPartitionColumnName
+        errorModel.getErrorDetail().get(1),
         containsString("MissingIntPartitionColumnName"));
   }
 
@@ -412,6 +424,9 @@ class DatasetSchemaUpdateValidatorTest {
     String newColumnName = "column1";
     IntPartitionOptionsModel intPartitionOptions =
         new IntPartitionOptionsModel().column(newColumnName);
+    intPartitionOptions.min(1L);
+    intPartitionOptions.max(10L);
+    intPartitionOptions.interval(1L);
     ColumnModel newColumn =
         DatasetFixtures.columnModel(newColumnName, TableDataType.STRING, false, true);
     TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
@@ -433,8 +448,10 @@ class DatasetSchemaUpdateValidatorTest {
   @Test
   void testInvalidIntPartitionColumnName() throws Exception {
     String newTableName = "new_table";
-    IntPartitionOptionsModel intPartitionOptions =
-        new IntPartitionOptionsModel().column("column1");
+    IntPartitionOptionsModel intPartitionOptions = new IntPartitionOptionsModel().column("column1");
+    intPartitionOptions.min(1L);
+    intPartitionOptions.max(10L);
+    intPartitionOptions.interval(1L);
     ColumnModel newColumn =
         DatasetFixtures.columnModel("column2", TableDataType.INTEGER, false, true);
     TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
@@ -457,12 +474,21 @@ class DatasetSchemaUpdateValidatorTest {
   void testInvalidIntPartitionOptions() throws Exception {
     String newTableName = "new_table";
     IntPartitionOptionsModel intPartitionOptions = new IntPartitionOptionsModel();
-    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
+    intPartitionOptions.min(1L);
+    intPartitionOptions.max(10L);
+    intPartitionOptions.interval(1L);
+    intPartitionOptions.column("column1");
+    DatePartitionOptionsModel datePartitionOptions =
+        new DatePartitionOptionsModel().column("column1");
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
+    tableModel.addColumnsItem(
+        DatasetFixtures.columnModel("column1", TableDataType.DATE, false, false));
     tableModel.setPartitionMode(TableModel.PartitionModeEnum.DATE);
+    tableModel.setDatePartitionOptions(datePartitionOptions);
     tableModel.setIntPartitionOptions(intPartitionOptions);
     DatasetSchemaUpdateModel updateModel =
         new DatasetSchemaUpdateModel()
-            .description("Invalid int partition options with new table")
+            .description("Invalid int partition options with mode Date with new table")
             .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
     ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
     assertThat(

--- a/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
@@ -29,7 +29,6 @@ import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -183,7 +182,7 @@ class DatasetSchemaUpdateValidatorTest {
     assertThat(
         "Invalid DataTypes are logged and returned",
         responseBody,
-        Matchers.containsString(
+        containsString(
             "invalid datatype in table column(s): bad_column, "
                 + "DataTypes must be lowercase, valid DataTypes are [string, boolean, bytes, date, datetime, dirref, fileref, "
                 + "float, float64, integer, int64, numeric, record, text, time, timestamp]"));

--- a/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
@@ -26,6 +26,7 @@ import bio.terra.service.snapshotbuilder.SnapshotBuilderService;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @ContextConfiguration(
     classes = {
       DatasetSchemaUpdateValidator.class,
+      DatasetRequestValidator.class,
       DatasetsApiController.class,
       ApiValidationExceptionHandler.class
     })
@@ -50,34 +52,46 @@ import org.springframework.test.web.servlet.MvcResult;
 @Tag(Unit.TAG)
 class DatasetSchemaUpdateValidatorTest {
 
-  @Autowired private MockMvc mvc;
+  @Autowired
+  private MockMvc mvc;
 
-  @MockBean private JobService jobService;
-  @MockBean private DatasetService datasetService;
-  @MockBean private IamService iamService;
-  @MockBean private FileService fileService;
-  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
-  @MockBean private SnapshotBuilderService snapshotBuilderService;
-  @MockBean private IngestRequestValidator ingestRequestValidator;
-  @MockBean private AssetModelValidator assetModelValidator;
-  @MockBean private DataDeletionRequestValidator dataDeletionRequestValidator;
-  @MockBean private DatasetRequestValidator datasetRequestValidator;
+  @MockBean
+  private JobService jobService;
+  @MockBean
+  private DatasetService datasetService;
+  @MockBean
+  private IamService iamService;
+  @MockBean
+  private FileService fileService;
+  @MockBean
+  private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockBean
+  private SnapshotBuilderService snapshotBuilderService;
+  @MockBean
+  private IngestRequestValidator ingestRequestValidator;
+  @MockBean
+  private AssetModelValidator assetModelValidator;
+  @MockBean
+  private DataDeletionRequestValidator dataDeletionRequestValidator;
 
   @BeforeEach
   void setup() throws Exception {
     when(ingestRequestValidator.supports(any())).thenReturn(true);
-    when(datasetRequestValidator.supports(any())).thenReturn(true);
     when(assetModelValidator.supports(any())).thenReturn(true);
     when(dataDeletionRequestValidator.supports(any())).thenReturn(true);
   }
 
   private ErrorModel expectBadDatasetUpdateRequest(DatasetSchemaUpdateModel datasetRequest)
       throws Exception {
+    return expectBadDatasetUpdateRequest(TestUtils.mapToJson(datasetRequest));
+  }
+
+  private ErrorModel expectBadDatasetUpdateRequest(String datasetRequest) throws Exception {
     MvcResult result =
         mvc.perform(
                 post("/api/repository/v1/datasets/{id}/updateSchema", UUID.randomUUID())
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(TestUtils.mapToJson(datasetRequest)))
+                    .content(datasetRequest))
             .andExpect(status().is4xxClientError())
             .andReturn();
 
@@ -154,21 +168,94 @@ class DatasetSchemaUpdateValidatorTest {
   @Test
   void testNoColumns() throws Exception {
     String newTableName = "new_table";
-    String newTableColumnName = "new_table_column";
     DatasetSchemaUpdateModel updateModel =
         new DatasetSchemaUpdateModel()
-            .description("column addition tests")
+            .description("No columns with new table")
+            .changes(
+                new DatasetSchemaUpdateModelChanges()
+                    .addTables(List.of(DatasetFixtures.tableModel(newTableName, List.of()))));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Required column with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("IncompleteSchemaDefinition"));
+  }
+
+  @Test
+  void testInvalidDatatypeColumns() throws Exception {
+    // Load bad data type from JSON b/c couldn't set it in the model
+    String json = TestUtils.loadJson("update-schema-bad-data-type.json");
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(json);
+    String responseBody = String.join(", ", errorModel.getErrorDetail());
+    assertThat(
+        "Invalid DataTypes are logged and returned",
+        responseBody,
+        Matchers.containsString(
+            "invalid datatype in table column(s): bad_column, "
+                + "DataTypes must be lowercase, valid DataTypes are [string, boolean, bytes, date, datetime, dirref, fileref, "
+                + "float, float64, integer, int64, numeric, record, text, time, timestamp]"));
+  }
+
+  @Test
+  void testDuplicateColumns() throws Exception {
+    String newTableName = "new_table";
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("No columns with new table")
             .changes(
                 new DatasetSchemaUpdateModelChanges()
                     .addTables(
                         List.of(
-                            DatasetFixtures.tableModel(newTableName, List.of(newTableColumnName)),
                             DatasetFixtures.tableModel(
-                                newTableName, List.of(newTableColumnName)))));
+                                newTableName, List.of("column1", "column1")))));
     ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
     assertThat(
-        "Required column throws error",
+        "Required column with new table throws error",
         errorModel.getErrorDetail().get(0),
-        containsString("DuplicateTableNames"));
+        containsString("DuplicateColumnNames"));
+  }
+
+  @Test
+  void testMissingPrimaryKeyColumn() {
+
+  }
+
+  @Test
+  void testOptionalPrimaryKeyColumn() {
+
+  }
+
+  @Test
+  void testInvalidColumnMode() {
+
+  }
+
+  @Test
+  void testMissingDatePartitionOptions() {
+
+  }
+
+  @Test
+  void testInvalidDatePartitionColumnType() {
+
+  }
+
+  @Test
+  void testInvalidDatePartitionColumnName() {
+
+  }
+
+  @Test
+  void testMissingIntPartitionOptions() {
+  }
+
+  @Test
+  void testMissingIntPartitionColumnName() {
+
+  }
+
+  @Test
+  void testInvalidIntPartitionColumnType() {
+
   }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateValidatorTest.java
@@ -17,8 +17,11 @@ import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetSchemaUpdateModel;
 import bio.terra.model.DatasetSchemaUpdateModelChanges;
+import bio.terra.model.DatePartitionOptionsModel;
 import bio.terra.model.ErrorModel;
+import bio.terra.model.IntPartitionOptionsModel;
 import bio.terra.model.TableDataType;
+import bio.terra.model.TableModel;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.filedata.FileService;
 import bio.terra.service.job.JobService;
@@ -52,27 +55,17 @@ import org.springframework.test.web.servlet.MvcResult;
 @Tag(Unit.TAG)
 class DatasetSchemaUpdateValidatorTest {
 
-  @Autowired
-  private MockMvc mvc;
+  @Autowired private MockMvc mvc;
 
-  @MockBean
-  private JobService jobService;
-  @MockBean
-  private DatasetService datasetService;
-  @MockBean
-  private IamService iamService;
-  @MockBean
-  private FileService fileService;
-  @MockBean
-  private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
-  @MockBean
-  private SnapshotBuilderService snapshotBuilderService;
-  @MockBean
-  private IngestRequestValidator ingestRequestValidator;
-  @MockBean
-  private AssetModelValidator assetModelValidator;
-  @MockBean
-  private DataDeletionRequestValidator dataDeletionRequestValidator;
+  @MockBean private JobService jobService;
+  @MockBean private DatasetService datasetService;
+  @MockBean private IamService iamService;
+  @MockBean private FileService fileService;
+  @MockBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockBean private SnapshotBuilderService snapshotBuilderService;
+  @MockBean private IngestRequestValidator ingestRequestValidator;
+  @MockBean private AssetModelValidator assetModelValidator;
+  @MockBean private DataDeletionRequestValidator dataDeletionRequestValidator;
 
   @BeforeEach
   void setup() throws Exception {
@@ -120,7 +113,7 @@ class DatasetSchemaUpdateValidatorTest {
                                 newTableName, List.of(newTableColumnName)))));
     ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
     assertThat(
-        "Required column throws error",
+        "Duplicate table throws error",
         errorModel.getErrorDetail().get(0),
         containsString("DuplicateTableNames"));
   }
@@ -176,7 +169,7 @@ class DatasetSchemaUpdateValidatorTest {
                     .addTables(List.of(DatasetFixtures.tableModel(newTableName, List.of()))));
     ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
     assertThat(
-        "Required column with new table throws error",
+        "No columns with new table throws error",
         errorModel.getErrorDetail().get(0),
         containsString("IncompleteSchemaDefinition"));
   }
@@ -201,7 +194,7 @@ class DatasetSchemaUpdateValidatorTest {
     String newTableName = "new_table";
     DatasetSchemaUpdateModel updateModel =
         new DatasetSchemaUpdateModel()
-            .description("No columns with new table")
+            .description("Duplicate columns with new table")
             .changes(
                 new DatasetSchemaUpdateModelChanges()
                     .addTables(
@@ -210,52 +203,271 @@ class DatasetSchemaUpdateValidatorTest {
                                 newTableName, List.of("column1", "column1")))));
     ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
     assertThat(
-        "Required column with new table throws error",
+        "Duplicate column with new table throws error",
         errorModel.getErrorDetail().get(0),
         containsString("DuplicateColumnNames"));
   }
 
   @Test
-  void testMissingPrimaryKeyColumn() {
+  void testMissingPrimaryKeyColumn() throws Exception {
+    String newTableName = "new_table";
+    String primaryKeyColumnName = "primary_key";
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
+    tableModel.addPrimaryKeyItem(primaryKeyColumnName);
 
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Missing primary key column with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Missing primary key column with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("MissingPrimaryKeyColumn"));
   }
 
   @Test
-  void testOptionalPrimaryKeyColumn() {
+  void testOptionalPrimaryKeyColumn() throws Exception {
+    String newTableName = "new_table";
+    String primaryKeyColumnName = "primary_key";
+    ColumnModel newColumn =
+        DatasetFixtures.columnModel(primaryKeyColumnName, TableDataType.STRING, false, false);
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
+    tableModel.addPrimaryKeyItem(primaryKeyColumnName);
+    tableModel.addColumnsItem(newColumn);
 
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Optional primary key column with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Optional primary key column with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("OptionalPrimaryKeyColumn"));
   }
 
   @Test
-  void testInvalidColumnMode() {
+  void testInvalidColumnMode() throws Exception {
+    String newTableName = "new_table";
+    ColumnModel newColumn =
+        DatasetFixtures.columnModel("column1", TableDataType.STRING, false, true);
+    newColumn.arrayOf(true);
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
+    tableModel.addColumnsItem(newColumn);
 
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Invalid Column Mode with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Invalid Column Mode with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("InvalidColumnMode"));
   }
 
   @Test
-  void testMissingDatePartitionOptions() {
+  void testMissingDatePartitionOptions() throws Exception {
+    String newTableName = "new_table";
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.DATE);
 
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Missing date partition options with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Missing date partition options with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("MissingDatePartitionOptions"));
   }
 
   @Test
-  void testInvalidDatePartitionColumnType() {
+  void testMissingDatePartitionColumnName() throws Exception {
+    String newTableName = "new_table";
+    DatePartitionOptionsModel datePartitionOptions =
+        new DatePartitionOptionsModel();
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.DATE);
+    tableModel.setDatePartitionOptions(datePartitionOptions);
 
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Missing date partition column name with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Missing date partition column name with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("MissingDatePartitionColumnName"));
   }
 
   @Test
-  void testInvalidDatePartitionColumnName() {
+  void testInvalidDatePartitionColumnType() throws Exception {
+    String newTableName = "new_table";
+    String newColumnName = "column1";
+    DatePartitionOptionsModel datePartitionOptions =
+        new DatePartitionOptionsModel().column(newColumnName);
+    ColumnModel newColumn =
+        DatasetFixtures.columnModel(newColumnName, TableDataType.STRING, false, true);
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
+    tableModel.addColumnsItem(newColumn);
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.DATE);
+    tableModel.setDatePartitionOptions(datePartitionOptions);
 
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Invalid date partition column type with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Invalid date partition column type with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("MissingDatePartitionColumnName"));
   }
 
   @Test
-  void testMissingIntPartitionOptions() {
+  void testInvalidDatePartitionColumnName() throws Exception {
+    String newTableName = "new_table";
+    DatePartitionOptionsModel datePartitionOptions =
+        new DatePartitionOptionsModel().column("column1");
+    ColumnModel newColumn =
+        DatasetFixtures.columnModel("column2", TableDataType.STRING, false, true);
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
+    tableModel.addColumnsItem(newColumn);
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.DATE);
+    tableModel.setDatePartitionOptions(datePartitionOptions);
+
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Invalid date partition column name with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Invalid date partition column name with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("MissingDatePartitionColumnName"));
   }
 
   @Test
-  void testMissingIntPartitionColumnName() {
+  void testInvalidDatePartitionOptions() throws Exception {
+    String newTableName = "new_table";
+    DatePartitionOptionsModel datePartitionOptions =
+        new DatePartitionOptionsModel();
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.INT);
+    tableModel.setDatePartitionOptions(datePartitionOptions);
 
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Invalid date partition options with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Invalid date partition options with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("InvalidDatePartitionOptions"));
   }
 
   @Test
-  void testInvalidIntPartitionColumnType() {
+  void testMissingIntPartitionOptions() throws Exception {
+    String newTableName = "new_table";
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.INT);
 
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Missing int partition options with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Missing int partition options with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("MissingIntPartitionOptions"));
+  }
+
+  @Test
+  void testMissingIntPartitionColumnName() throws Exception {
+    String newTableName = "new_table";
+    IntPartitionOptionsModel intPartitionOptions = new IntPartitionOptionsModel();
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.INT);
+    tableModel.setIntPartitionOptions(intPartitionOptions);
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Missing int partition column name with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Missing int partition column name with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("MissingIntPartitionColumnName"));
+  }
+
+  @Test
+  void testInvalidIntPartitionColumnType() throws Exception {
+    String newTableName = "new_table";
+    String newColumnName = "column1";
+    IntPartitionOptionsModel intPartitionOptions =
+        new IntPartitionOptionsModel().column(newColumnName);
+    ColumnModel newColumn =
+        DatasetFixtures.columnModel(newColumnName, TableDataType.STRING, false, true);
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
+    tableModel.addColumnsItem(newColumn);
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.INT);
+    tableModel.setIntPartitionOptions(intPartitionOptions);
+
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Invalid int partition column type with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Invalid int partition column type with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("InvalidIntPartitionColumnType"));
+  }
+
+  @Test
+  void testInvalidIntPartitionColumnName() throws Exception {
+    String newTableName = "new_table";
+    IntPartitionOptionsModel intPartitionOptions =
+        new IntPartitionOptionsModel().column("column1");
+    ColumnModel newColumn =
+        DatasetFixtures.columnModel("column2", TableDataType.INTEGER, false, true);
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of());
+    tableModel.addColumnsItem(newColumn);
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.INT);
+    tableModel.setIntPartitionOptions(intPartitionOptions);
+
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Invalid int partition column name with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Invalid int partition column name with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("InvalidIntPartitionColumnName"));
+  }
+
+  @Test
+  void testInvalidIntPartitionOptions() throws Exception {
+    String newTableName = "new_table";
+    IntPartitionOptionsModel intPartitionOptions = new IntPartitionOptionsModel();
+    TableModel tableModel = DatasetFixtures.tableModel(newTableName, List.of("column1"));
+    tableModel.setPartitionMode(TableModel.PartitionModeEnum.DATE);
+    tableModel.setIntPartitionOptions(intPartitionOptions);
+    DatasetSchemaUpdateModel updateModel =
+        new DatasetSchemaUpdateModel()
+            .description("Invalid int partition options with new table")
+            .changes(new DatasetSchemaUpdateModelChanges().addTables(List.of(tableModel)));
+    ErrorModel errorModel = expectBadDatasetUpdateRequest(updateModel);
+    assertThat(
+        "Invalid int partition options with new table throws error",
+        errorModel.getErrorDetail().get(0),
+        containsString("InvalidIntPartitionOptions"));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/update/DatasetSchemaUpdateValidateModelStepTest.java
@@ -61,7 +61,7 @@ import org.springframework.test.context.ContextConfiguration;
     })
 @WebMvcTest
 @Tag(Unit.TAG)
-class DatasetSchemaUpdateValidationTest {
+class DatasetSchemaUpdateValidateModelStepTest {
 
   @MockBean private JobService jobService;
   @MockBean private DatasetService datasetService;

--- a/src/test/resources/update-schema-bad-data-type.json
+++ b/src/test/resources/update-schema-bad-data-type.json
@@ -1,0 +1,25 @@
+{
+  "description":"Test invalid data type",
+  "changes":{
+    "addTables":[
+      {
+        "name":"new_table",
+        "columns":[
+          {
+            "name":"bad_column",
+            "datatype":"badDataType",
+            "array_of":false,
+            "required":false
+          }
+        ],
+        "primaryKey":null,
+        "partitionMode":"none",
+        "datePartitionOptions":null,
+        "intPartitionOptions":null,
+        "rowCount":null
+      }
+    ],
+    "addColumns":null,
+    "addRelationships":null
+  }
+}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-985

## Addresses
The field name "schema" was hardcoded in the validation error messages that were returned for errors that occurred both when creating a dataset schema and when updating a dataset schema. This was a problem because when updating the dataset schema there is not a field with the name "schema". This meant that when that real validation errors on dataset schema update were harder for users to fix due to the error message referencing this non-existant field.

## Summary of changes
1. Adds an operation type enum to the SchemaValidationContext object. This enum has a corresponding field name. 
2. When the context is created (in two places, the datasetRequestValidator (for create) and datasetSchemaUpdateValidator (for update)) it is given the operation type.
3. Replace hardcoded "schema" in error messages. Instead the enum's field name is used instead. 

<b> Design note </b>
I could move the definition of the context into the validate methods in datasetRequestValidator and datasetSchemaUpdateValidator so it is more top level in case any of the other methods are later shared/reused. Thoughts?

## Testing Strategy
Added unit tests
Tested via swagger updateSchema dataset endpoint with this payload:
```
{
  "description": "reproduce schema error - no columns in new table",
  "changes": {
    "addTables": [
      {
        "name": "test",
        "columns": []
      }
    ]
  }
}
```

Error before: 
```
{
  "message": "Invalid property 'schema' of bean class [bio.terra.model.DatasetSchemaUpdateModel]: Bean property 'schema' is not readable or has an invalid getter method: Does the return type of the getter match the parameter type of the setter?",
  "errorDetail": null
}
```
Error after:
```
{
  "message": "Validation errors - see error details",
  "errorDetail": [
    "changes: 'IncompleteSchemaDefinition' (Each table must contain at least one column)"
  ]
}
```

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
