### PR TITLE
[DT-821]Possibly fix 401 and 500 error during dataset creation using retries

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
@@ -1,5 +1,6 @@
 package bio.terra.service.dataset.flight.create;
 
+import bio.terra.common.exception.ErrorReportException;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -28,9 +29,10 @@ public class CreateDatasetRegisterIngestServiceAccountStep implements Step {
 
     try {
       iamService.registerUser(datasetServiceAccount);
-    } catch (Exception e) {
-      // catch transient errors from Sam, where the service account created in the previous step
-      // may not be ready to use yet
+    } catch (ErrorReportException e) {
+      // This is the super class type of IamExceptions (i.e. IAmNotFoundException) and ApiExceptions
+      // Catch transient errors from Sam, where the service account created in the previous step
+      // may not be ready to use yet. Do not catch InterruptedExceptions.
       logger.warn(
           String.format(
               "Service account, %s, may not be ready to use yet. Retrying.", datasetServiceAccount),

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
@@ -29,6 +29,8 @@ public class CreateDatasetRegisterIngestServiceAccountStep implements Step {
     try {
       iamService.registerUser(datasetServiceAccount);
     } catch (Exception e) {
+      // catch transient errors from Sam, where the service account created in the previous step
+      // may not be ready to use yet
       logger.warn(
           String.format(
               "Service account, %s, may not be ready to use yet. Retrying.", datasetServiceAccount),

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
@@ -1,8 +1,6 @@
 package bio.terra.service.dataset.flight.create;
 
 import bio.terra.service.auth.iam.IamService;
-import bio.terra.service.auth.iam.exception.IamNotFoundException;
-import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -30,10 +28,10 @@ public class CreateDatasetRegisterIngestServiceAccountStep implements Step {
 
     try {
       iamService.registerUser(datasetServiceAccount);
-    } catch (IamNotFoundException | IamUnauthorizedException e) {
+    } catch (Exception e) {
       logger.warn(
           String.format(
-              "Service account, %s, is not yet ready to use. Retrying.", datasetServiceAccount),
+              "Service account, %s, may not be ready to use yet. Retrying.", datasetServiceAccount),
           e);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStep.java
@@ -1,15 +1,21 @@
 package bio.terra.service.dataset.flight.create;
 
 import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.auth.iam.exception.IamNotFoundException;
+import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** The step is only meant to be invoked for GCP backed datasets. */
 public class CreateDatasetRegisterIngestServiceAccountStep implements Step {
-
+  private static final Logger logger =
+      LoggerFactory.getLogger(CreateDatasetRegisterIngestServiceAccountStep.class);
   private final IamService iamService;
 
   public CreateDatasetRegisterIngestServiceAccountStep(IamService iamService) {
@@ -22,7 +28,15 @@ public class CreateDatasetRegisterIngestServiceAccountStep implements Step {
     String datasetServiceAccount =
         workingMap.get(DatasetWorkingMapKeys.SERVICE_ACCOUNT_EMAIL, String.class);
 
-    iamService.registerUser(datasetServiceAccount);
+    try {
+      iamService.registerUser(datasetServiceAccount);
+    } catch (IamNotFoundException | IamUnauthorizedException e) {
+      logger.warn(
+          String.format(
+              "Service account, %s, is not yet ready to use. Retrying.", datasetServiceAccount),
+          e);
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    }
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -102,7 +102,7 @@ public class DatasetCreateFlight extends Flight {
       // Create the service account to use to ingest data and register it in Terra
       if (datasetRequest.isDedicatedIngestServiceAccount()) {
         addStep(new CreateDatasetCreateIngestServiceAccountStep(resourceService, datasetRequest));
-        addStep(new CreateDatasetRegisterIngestServiceAccountStep(iamService));
+        addStep(new CreateDatasetRegisterIngestServiceAccountStep(iamService), getDefaultExponentialBackoffRetryRule());
       }
     }
 

--- a/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/DatasetCreateFlight.java
@@ -102,7 +102,9 @@ public class DatasetCreateFlight extends Flight {
       // Create the service account to use to ingest data and register it in Terra
       if (datasetRequest.isDedicatedIngestServiceAccount()) {
         addStep(new CreateDatasetCreateIngestServiceAccountStep(resourceService, datasetRequest));
-        addStep(new CreateDatasetRegisterIngestServiceAccountStep(iamService), getDefaultExponentialBackoffRetryRule());
+        addStep(
+            new CreateDatasetRegisterIngestServiceAccountStep(iamService),
+            getDefaultExponentialBackoffRetryRule());
       }
     }
 

--- a/src/test/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStepTest.java
@@ -2,13 +2,14 @@ package bio.terra.service.dataset.flight.create;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import bio.terra.app.controller.exception.ApiException;
 import bio.terra.common.category.Unit;
 import bio.terra.service.auth.iam.IamService;
-import bio.terra.service.auth.iam.exception.IamInternalServerErrorException;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -43,18 +44,22 @@ class CreateDatasetRegisterIngestServiceAccountStepTest {
   }
 
   @Test
-  void doStep_Retry401() throws InterruptedException {
+  void doStep_RetryIAmException() throws InterruptedException {
     doThrow(new IamUnauthorizedException("Unauthorized")).when(iamService).registerUser("email");
     assertThat(
         step.doStep(flightContext).getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
   }
 
   @Test
-  void doStep_500() throws InterruptedException {
-    doThrow(new IamInternalServerErrorException("Internal Server Error"))
-        .when(iamService)
-        .registerUser("email");
+  void doStep_ApiException() throws InterruptedException {
+    doThrow(new ApiException("ApiException")).when(iamService).registerUser("email");
     assertThat(
         step.doStep(flightContext).getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+
+  @Test
+  void doStep_NullPointerException() {
+    doThrow(new NullPointerException()).when(iamService).registerUser("email");
+    assertThrows(NullPointerException.class, () -> step.doStep(flightContext));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStepTest.java
@@ -2,7 +2,6 @@ package bio.terra.service.dataset.flight.create;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -10,7 +9,6 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.category.Unit;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.exception.IamInternalServerErrorException;
-import bio.terra.service.auth.iam.exception.IamNotFoundException;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -52,19 +50,11 @@ class CreateDatasetRegisterIngestServiceAccountStepTest {
   }
 
   @Test
-  void doStep_Retry404() throws InterruptedException {
-    doThrow(new IamNotFoundException(new Throwable("Not Found")))
+  void doStep_500() throws InterruptedException {
+    doThrow(new IamInternalServerErrorException("Internal Server Error"))
         .when(iamService)
         .registerUser("email");
     assertThat(
         step.doStep(flightContext).getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
-  }
-
-  @Test
-  void doStep_500() {
-    doThrow(new IamInternalServerErrorException("Internal Server Error"))
-        .when(iamService)
-        .registerUser("email");
-    assertThrows(IamInternalServerErrorException.class, () -> step.doStep(flightContext));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/create/CreateDatasetRegisterIngestServiceAccountStepTest.java
@@ -1,0 +1,70 @@
+package bio.terra.service.dataset.flight.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.auth.iam.exception.IamInternalServerErrorException;
+import bio.terra.service.auth.iam.exception.IamNotFoundException;
+import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Tag(Unit.TAG)
+@ExtendWith(MockitoExtension.class)
+class CreateDatasetRegisterIngestServiceAccountStepTest {
+  @Mock private IamService iamService;
+  @Mock private FlightContext flightContext;
+  private CreateDatasetRegisterIngestServiceAccountStep step;
+
+  @BeforeEach
+  void setup() {
+    step = new CreateDatasetRegisterIngestServiceAccountStep(iamService);
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(DatasetWorkingMapKeys.SERVICE_ACCOUNT_EMAIL, "email");
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void doStep() throws InterruptedException {
+    assertThat(step.doStep(flightContext).getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    verify(iamService).registerUser("email");
+  }
+
+  @Test
+  void doStep_Retry401() throws InterruptedException {
+    doThrow(new IamUnauthorizedException("Unauthorized")).when(iamService).registerUser("email");
+    assertThat(
+        step.doStep(flightContext).getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+
+  @Test
+  void doStep_Retry404() throws InterruptedException {
+    doThrow(new IamNotFoundException(new Throwable("Not Found")))
+        .when(iamService)
+        .registerUser("email");
+    assertThat(
+        step.doStep(flightContext).getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+  }
+
+  @Test
+  void doStep_500() {
+    doThrow(new IamInternalServerErrorException("Internal Server Error"))
+        .when(iamService)
+        .registerUser("email");
+    assertThrows(IamInternalServerErrorException.class, () -> step.doStep(flightContext));
+  }
+}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-821

## Addresses
User issues involving the google access token not being able to be used in CreateDatasetRegisterIngestServiceAccountStep. This is unexpected since the token was just generated and we’d expect it to be valid when calling Sam immediately afterwards. We have a theory that the service account, which was created in the previous step, CreateDatasetCreateIngestServiceAccountStep, is not yet ready to use, pending an incomplete cloud operation internal to the GCS APIs. So, by retrying, we are giving it more time to complete.

## Summary of changes
Add a retry for all errors from Sam in the CreateDatasetRegisterIngestServiceAccountStep. I chose to add a retry for all errors instead of just a 401 and a 500 since the issue is transient and cannot be tested right now. If we have seen at least two different error statuses returned from this call, we may see a different error status in the future. Additionally, it is low overhead to retry the step on a failure, even if the retry does not solve the error in all cases.

## Testing Strategy
Add unit tests

## Question
What is the error thrown by Sam? In this PR, I add a catch for the IamUnauthorized and IamNotFound exceptions and I see other examples doing that in the code (CreateSnapshotSamGroupNameStep), but I also see other places catching ApiExceptions from sam (SnapshotBuilderService)

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
