### PR TITLE
DT-1050: Upgrade to current swagger-ui-dist library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,7 @@ dependencies {
     generatedCompile 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.webjars:webjars-locator-core'
-    runtimeOnly 'org.webjars.npm:swagger-ui-dist:4.3.0'
+    runtimeOnly 'org.webjars.npm:swagger-ui-dist:5.18.2'
     generatedCompile 'io.swagger.core.v3:swagger-annotations'
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -36,6 +36,6 @@ public class WebConfig implements WebMvcConfigurer {
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
     registry
         .addResourceHandler("/webjars/swagger-ui-dist/**")
-        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui-dist/4.3.0/");
+        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui-dist/5.18.2/");
   }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -121,7 +121,7 @@
                   ac.classList.add('hidden');
                 } else {
                   // Set the correct client ID value using the native input component (needed for newer react versions used by Swagger UI)
-                  var clientIdInput = ac.querySelector('#client_id');
+                  var clientIdInput = ac.querySelector('#client_id_authorizationCode');
                   if (clientIdInput) {
                     var nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
                     nativeInputValueSetter.call(clientIdInput, clientIds[scheme]);


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1050

## Addresses

Upgrade to latest swagger-ui-dist; fix code so that the client ID is populated in the swagger page.

## Summary of changes

From page inspection, the selector for the client ID input is now `client_id_authorizationCode`. Verified this fix by running TDR locally.

## Testing Strategy

Manually tested by opening the swagger UI page locally and using b2c auth to login. Verified that the fix was working by reverting the change and noting that the "client id" field was now empty.
