### PR TITLE
[DT-1096] Update JIRA key to DT instead of DCJ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
       - "dependency"
       - "gradle"
     commit-message:
-      prefix: "[DCJ-400-gradle]"
+      prefix: "[DT-400-gradle]"
     ignore:
       # Google API dependencies use a version format that Dependabot wrongly interprets as semver.
       - dependency-name: "com.google.apis:*"


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-1096

## Summary of changes

Updates the JIRA key to `DT-` instead of `DCJ-`

## Testing Strategy

N/A

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
