### PR TITLE
DT-1105: Pin ubuntu version to unblock python client generation github action

### DIFF
--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release
     permissions:


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1105

## Addresses
Python 3.7 is not included in ubuntu 24.04. 
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/04fe896f-a95b-4081-8921-9f6e49971284" />
https://github.com/actions/runner-images/issues/10636

## Summary of changes
Pin to ubuntu version 22.04 for now. We'll need to upgrade to python version 3.9 as a long term solution. 

## Testing Strategy
Run action on branch: https://github.com/DataBiosphere/jade-data-repo/actions/runs/12359971465/job/34493830853

## Next steps
https://broadworkbench.atlassian.net/browse/DT-1106