### PR TITLE
DT-1108: Use workload identity for GCR SA in cherry pick action

### DIFF
--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -32,14 +32,20 @@ on:
 jobs:
   cherry-pick-image:
     runs-on: ubuntu-latest
+    # Needed for integration with workload identity
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
-      - name: "Authenticate with GCR SA Credentials"
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcr-sa.json
-        run: |
-          # write token
-          base64 --decode <<< ${{ secrets.GCR_SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
-          gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
+      # Needed for integration with workload identity
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: 'Auth as gcr-sa'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'gcr-sa@datarepo-public-gcr.iam.gserviceaccount.com'
       - name: "Perform cherry-pick"
         run: |
           SOURCE_IMAGE="${{ inputs.source_gcr_url }}:${{ inputs.gcr_tag }}"

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ gha-creds-*.json
 #tools output
 tools/setupResourceScripts/*_outputs.json
 tools/profileEndpoints/results_*.csv
+
+
+gha-creds-*.json


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1108

## Addresses
Where possible, we should use workload identity rather than rotating service account keys. We hope to get rid of this action soon, but this was a relatively easy change and a proof of concept for other workload identity work. We also were not rotating the keys for this SA, so it will be safer. 

## Summary of changes
- Followed [these instructions](https://docs.google.com/document/d/1bnhDmWQHAMat_Saoa_z28FHwXmGWw6kywjdbKf208h4/edit?tab=t.0)
- Switch from authenticating as the GCR service account via key stored in github action secret to instead using workload identity. 

## Merge order
- https://github.com/broadinstitute/terraform-ap-deployments/pull/1778 **Must merge first**
- merge this PR
- Then, we can clean up references to this SA in terrafrom-ap-deployments (https://github.com/broadinstitute/terraform-ap-deployments/pull/1779)

## Testing Strategy
Successful test run: https://github.com/DataBiosphere/jade-data-repo/actions/runs/12379744534/job/34554576957
