### PR TITLE
DT-1129: Add DAO support to list resources by billing profile ID

### DIFF
--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -13,6 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,8 +66,7 @@ public class ProfileDao {
             + " (:id, :name, :biller, :billing_account_id, :description, :cloud_platform, "
             + "     :tenant_id, :subscription_id, :resource_group_name, :application_deployment_name, :created_by)";
 
-    String billingAccountId =
-        Optional.ofNullable(profileRequest.getBillingAccountId()).orElse(null);
+    String billingAccountId = profileRequest.getBillingAccountId();
     String cloudPlatform =
         Optional.ofNullable(profileRequest.getCloudPlatform())
             .or(() -> Optional.of(CloudPlatform.GCP))
@@ -74,10 +74,8 @@ public class ProfileDao {
             .get();
     UUID tenantId = profileRequest.getTenantId();
     UUID subscriptionId = profileRequest.getSubscriptionId();
-    String resourceGroupName =
-        Optional.ofNullable(profileRequest.getResourceGroupName()).orElse(null);
-    String applicationDeploymentName =
-        Optional.ofNullable(profileRequest.getApplicationDeploymentName()).orElse(null);
+    String resourceGroupName = profileRequest.getResourceGroupName();
+    String applicationDeploymentName = profileRequest.getApplicationDeploymentName();
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -190,6 +188,25 @@ public class ProfileDao {
       // handle a case of some active references.
       throw new ProfileInUseException("Profile is in use and cannot be deleted", ex);
     }
+  }
+
+  @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
+  public List<ProfileOwnedResource> listProfileOwnedResources(UUID profileId) {
+    String sql =
+        "select dataset.id as id, dataset.name as name, dataset.description as description, 'DATASET' as type "
+            + "from dataset where dataset.default_profile_id = :profile_id "
+            + "union all "
+            + "select snapshot.id as id, snapshot.name as name, snapshot.description as description, 'SNAPSHOT' as type "
+            + "from snapshot where snapshot.profile_id = :profile_id";
+    return jdbcTemplate.query(
+        sql,
+        Map.of("profile_id", profileId),
+        (rs, rowNum) ->
+            new ProfileOwnedResource(
+                rs.getObject("id", UUID.class),
+                rs.getString("name"),
+                rs.getString("description"),
+                ProfileOwnedResource.Type.valueOf(rs.getString("type"))));
   }
 
   /**

--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -193,10 +193,10 @@ public class ProfileDao {
   @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
   public List<ProfileOwnedResource> listProfileOwnedResources(UUID profileId) {
     String sql =
-        "SELECT dataset.id AS id, dataset.name AS name, dataset.description AS description, 'DATASET' AS type "
+        "SELECT dataset.id AS id, dataset.name AS name, dataset.description AS description, dataset.created_date as created_date, 'DATASET' AS type "
             + "FROM dataset WHERE dataset.default_profile_id = :profile_id "
             + "UNION ALL "
-            + "SELECT snapshot.id AS id, snapshot.name AS name, snapshot.description AS description, 'SNAPSHOT' AS type "
+            + "SELECT snapshot.id AS id, snapshot.name AS name, snapshot.description AS description, snapshot.created_date as created_date, 'SNAPSHOT' AS type "
             + "FROM snapshot WHERE snapshot.profile_id = :profile_id";
     return jdbcTemplate.query(
         sql,
@@ -206,6 +206,7 @@ public class ProfileDao {
                 rs.getObject("id", UUID.class),
                 rs.getString("name"),
                 rs.getString("description"),
+                rs.getTimestamp("created_date").toInstant(),
                 ProfileOwnedResource.Type.valueOf(rs.getString("type"))));
   }
 

--- a/src/main/java/bio/terra/service/profile/ProfileDao.java
+++ b/src/main/java/bio/terra/service/profile/ProfileDao.java
@@ -193,11 +193,11 @@ public class ProfileDao {
   @Transactional(propagation = Propagation.REQUIRED, readOnly = true)
   public List<ProfileOwnedResource> listProfileOwnedResources(UUID profileId) {
     String sql =
-        "select dataset.id as id, dataset.name as name, dataset.description as description, 'DATASET' as type "
-            + "from dataset where dataset.default_profile_id = :profile_id "
-            + "union all "
-            + "select snapshot.id as id, snapshot.name as name, snapshot.description as description, 'SNAPSHOT' as type "
-            + "from snapshot where snapshot.profile_id = :profile_id";
+        "SELECT dataset.id AS id, dataset.name AS name, dataset.description AS description, 'DATASET' AS type "
+            + "FROM dataset WHERE dataset.default_profile_id = :profile_id "
+            + "UNION ALL "
+            + "SELECT snapshot.id AS id, snapshot.name AS name, snapshot.description AS description, 'SNAPSHOT' AS type "
+            + "FROM snapshot WHERE snapshot.profile_id = :profile_id";
     return jdbcTemplate.query(
         sql,
         Map.of("profile_id", profileId),

--- a/src/main/java/bio/terra/service/profile/ProfileOwnedResource.java
+++ b/src/main/java/bio/terra/service/profile/ProfileOwnedResource.java
@@ -1,0 +1,10 @@
+package bio.terra.service.profile;
+
+import java.util.UUID;
+
+public record ProfileOwnedResource(UUID id, String name, String description, Type type) {
+  public enum Type {
+    DATASET,
+    SNAPSHOT,
+  }
+}

--- a/src/main/java/bio/terra/service/profile/ProfileOwnedResource.java
+++ b/src/main/java/bio/terra/service/profile/ProfileOwnedResource.java
@@ -1,8 +1,10 @@
 package bio.terra.service.profile;
 
+import java.time.Instant;
 import java.util.UUID;
 
-public record ProfileOwnedResource(UUID id, String name, String description, Type type) {
+public record ProfileOwnedResource(
+    UUID id, String name, String description, Instant createdDate, Type type) {
   public enum Type {
     DATASET,
     SNAPSHOT,

--- a/src/test/java/bio/terra/common/fixtures/DaoOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/DaoOperations.java
@@ -61,12 +61,15 @@ public class DaoOperations {
     BillingProfileRequestModel profileRequest = ProfileFixtures.randomBillingProfileRequest();
     BillingProfileModel billingProfile =
         profileDao.createBillingProfile(profileRequest, "testUser");
+    return createDataset(billingProfile.getId(), path);
+  }
 
+  public Dataset createDataset(UUID billingProfileId, String path) throws IOException {
+    BillingProfileModel billingProfile = profileDao.getBillingProfileById(billingProfileId);
     GoogleProjectResource projectResource = ResourceFixtures.randomProjectResource(billingProfile);
     UUID projectId = resourceDao.createProject(projectResource);
     projectResource.id(projectId);
-
-    return createDataset(billingProfile.getId(), projectId, path);
+    return createDataset(billingProfileId, projectId, path);
   }
 
   public Dataset createDataset(UUID billingProfileId, UUID projectResourceId, String path)

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
@@ -246,11 +246,13 @@ class ProfileDaoTest {
                 dataset.getId(),
                 dataset.getName(),
                 dataset.getDescription(),
+                dataset.getCreatedDate(),
                 ProfileOwnedResource.Type.DATASET),
             new ProfileOwnedResource(
                 snapshot.getId(),
                 snapshot.getName(),
                 snapshot.getDescription(),
+                snapshot.getCreatedDate(),
                 ProfileOwnedResource.Type.SNAPSHOT)));
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
@@ -17,7 +18,6 @@ import bio.terra.model.BillingProfileUpdateModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.EnumerateBillingProfileModel;
 import bio.terra.service.profile.ProfileDao;
-import bio.terra.service.profile.ProfileService;
 import bio.terra.service.profile.exception.ProfileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,42 +26,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
+@Tag(Unit.TAG)
 @EmbeddedDatabaseTest
-public class ProfileDaoTest {
+class ProfileDaoTest {
 
   @Autowired private ProfileDao profileDao;
-
-  @Autowired private ProfileService profileService;
-
-  private ArrayList<UUID> profileIds;
-
-  @Before
-  public void setup() throws Exception {
-    profileIds = new ArrayList<>();
-  }
-
-  @After
-  public void teardown() throws Exception {
-    for (UUID profileId : profileIds) {
-      profileDao.deleteBillingProfileById(profileId);
-    }
-  }
 
   // keeps track of the profiles that are made so they can be cleaned up
   private BillingProfileModel makeProfile() {
@@ -69,13 +48,11 @@ public class ProfileDaoTest {
     BillingProfileModel billingProfileModel =
         profileDao.createBillingProfile(profileRequest, "me@me.me");
     assertRequestMatchesResult(profileRequest, billingProfileModel);
-    UUID profileId = billingProfileModel.getId();
-    profileIds.add(profileId);
     return billingProfileModel;
   }
 
   @Test
-  public void profileCloudProvidersTest() throws Exception {
+  void profileCloudProvidersTest() {
     var googleBillingProfile = makeProfile();
     var tenant = UUID.randomUUID();
     var subscription = UUID.randomUUID();
@@ -91,8 +68,6 @@ public class ProfileDaoTest {
     var azureBillingProfile =
         profileDao.createBillingProfile(azureBillingProfileRequest, "me@me.me");
     assertRequestMatchesResult(azureBillingProfileRequest, azureBillingProfile);
-    var azureProfileId = azureBillingProfile.getId();
-    profileIds.add(azureProfileId);
 
     var retrievedGoogleBillingProfile =
         profileDao.getBillingProfileById(googleBillingProfile.getId());
@@ -132,16 +107,16 @@ public class ProfileDaoTest {
         contains(tenant, subscription, resourceGroup, applicationName));
   }
 
-  @Test(expected = ProfileNotFoundException.class)
-  public void profileDeleteTest() {
+  @Test
+  void profileDeleteTest() {
     UUID profileId = makeProfile().getId();
     boolean deleted = profileDao.deleteBillingProfileById(profileId);
     assertThat("able to delete", deleted, equalTo(true));
-    profileDao.getBillingProfileById(profileId);
+    assertThrows(ProfileNotFoundException.class, () -> profileDao.getBillingProfileById(profileId));
   }
 
   @Test
-  public void profileUpdate() {
+  void profileUpdate() {
     BillingProfileModel profile = makeProfile();
 
     // Start with old Billing account, then set to newBillingAccount
@@ -168,18 +143,19 @@ public class ProfileDaoTest {
         "Description should be updated", newProfile.getDescription(), containsString("updated"));
   }
 
-  @Test(expected = ProfileNotFoundException.class)
-  public void updateNonExistentProfile() {
+  @Test
+  void updateNonExistentProfile() {
     BillingProfileUpdateModel updateModel =
         new BillingProfileUpdateModel()
             .id(UUID.randomUUID())
             .billingAccountId(ProfileFixtures.randomBillingAccountId())
             .description("random");
-    profileDao.updateBillingProfileById(updateModel);
+    assertThrows(
+        ProfileNotFoundException.class, () -> profileDao.updateBillingProfileById(updateModel));
   }
 
   @Test
-  public void profileEnumerateTest() throws Exception {
+  void profileEnumerateTest() {
     Map<UUID, String> profileIdToAccountId = new HashMap<>();
     List<UUID> accessibleProfileId = new ArrayList<>();
     for (int i = 0; i < 6; i++) {

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileDaoTest.java
@@ -2,7 +2,9 @@ package bio.terra.service.resourcemanagement;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
@@ -11,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.DaoOperations;
 import bio.terra.common.fixtures.ProfileFixtures;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.BillingProfileRequestModel;
@@ -18,6 +21,7 @@ import bio.terra.model.BillingProfileUpdateModel;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.EnumerateBillingProfileModel;
 import bio.terra.service.profile.ProfileDao;
+import bio.terra.service.profile.ProfileOwnedResource;
 import bio.terra.service.profile.exception.ProfileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +45,8 @@ import org.springframework.test.context.ActiveProfiles;
 class ProfileDaoTest {
 
   @Autowired private ProfileDao profileDao;
+
+  @Autowired private DaoOperations daoOperations;
 
   // keeps track of the profiles that are made so they can be cleaned up
   private BillingProfileModel makeProfile() {
@@ -224,5 +230,27 @@ class ProfileDaoTest {
         "Application deployments match",
         result.getApplicationDeploymentName(),
         equalTo(request.getApplicationDeploymentName()));
+  }
+
+  @Test
+  void listProfileOwnedResources() throws Exception {
+    UUID profileId = makeProfile().getId();
+    assertThat(profileDao.listProfileOwnedResources(profileId), empty());
+
+    var dataset = daoOperations.createDataset(profileId, "snapshot-test-dataset.json");
+    var snapshot = daoOperations.createAndIngestSnapshot(dataset, "snapshot-test-snapshot.json");
+    assertThat(
+        profileDao.listProfileOwnedResources(profileId),
+        containsInAnyOrder(
+            new ProfileOwnedResource(
+                dataset.getId(),
+                dataset.getName(),
+                dataset.getDescription(),
+                ProfileOwnedResource.Type.DATASET),
+            new ProfileOwnedResource(
+                snapshot.getId(),
+                snapshot.getName(),
+                snapshot.getDescription(),
+                ProfileOwnedResource.Type.SNAPSHOT)));
   }
 }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1129

## Addresses

Given a billing profile ID, return the resources that were created using that ID.

In this PR, only the ID, name, description and type are returned for a resource. More fields can be added as needed when the external API is created.

Since this is DAO code, no authorization check is done.

## Summary of changes

- add new DAO API and unit test
- convert test to JUnit 5

## Testing Strategy

Unit testing