### PR TITLE
[DT-1122] Apply `zizmor` suggestions

### DIFF
--- a/.github/workflows/cherry-pick-image.yaml
+++ b/.github/workflows/cherry-pick-image.yaml
@@ -42,8 +42,12 @@ jobs:
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
       - name: "Perform cherry-pick"
         run: |
-          SOURCE_IMAGE="${{ inputs.source_gcr_url }}:${{ inputs.gcr_tag }}"
-          TARGET_IMAGE="${{ inputs.target_gcr_url }}:${{ inputs.gcr_tag }}"
-          echo "Cherry picking ${{ inputs.gcr_tag }} from ${SOURCE_IMAGE} to ${TARGET_IMAGE}"
+          SOURCE_IMAGE="${SOURCE_GCR_URL}:${GCR_TAG}"
+          TARGET_IMAGE="${TARGET_GCR_URL}:${GCR_TAG}"
+          echo "Cherry picking ${GCR_TAG} from ${SOURCE_IMAGE} to ${TARGET_IMAGE}"
           gcloud container images add-tag --quiet "${SOURCE_IMAGE}" "${TARGET_IMAGE}"
+        env:
+          SOURCE_GCR_URL: ${{ inputs.source_gcr_url }}
+          TARGET_GCR_URL: ${{ inputs.target_gcr_url }}
+          GCR_TAG: ${{ inputs.gcr_tag }}
 

--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
+          persist-credentials: false
       - name: "Bump the tag to a new version"
         id: bumperstep
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0
@@ -44,6 +45,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.bump_version.outputs.api_image_tag }}
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -51,7 +53,7 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
       - name: "Publish to Artifactory"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.12.0
         with:
           arguments: ':datarepo-client:artifactoryPublish'
         env:
@@ -68,6 +70,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.bump_version.outputs.api_image_tag }}
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -80,10 +83,10 @@ jobs:
           base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
           jq -r .private_key ${GOOGLE_APPLICATION_CREDENTIALS} > ${GOOGLE_SA_CERT}
           chmod 644 ${GOOGLE_SA_CERT}
-          # Set tag to semver version
-          export GCR_TAG=${{ needs.bump_version.outputs.api_image_tag }}
           # Build, tag and push the image
           ./gradlew jib
+        env:
+          GCR_TAG: ${{ needs.bump_version.outputs.api_image_tag }}
 
   cherry_pick_image_to_production_gcr:
     needs: [bump_version, build_container_and_publish]

--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -11,6 +11,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: develop
+          persist-credentials: false
       - name: 'Fetch latest jade-data-repo image tag'
         id: apiprevioustag
         run: |
@@ -22,6 +23,7 @@ jobs:
           repository: 'broadinstitute/datarepo-helm'
           path: datarepo-helm
           token: "${{ secrets.BROADBOT_TOKEN }}"
+          persist-credentials: false
       - name: "[datarepo-helm] [value.yaml] Update image tag"
         uses: docker://mikefarah/yq:3
         with:

--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -44,6 +45,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -92,6 +95,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -153,6 +158,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Get the latest git hash
         id: config
         run: |

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -24,6 +24,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python 3.7
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/staging-smoke-tests.yaml
+++ b/.github/workflows/staging-smoke-tests.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Setup Java 17"
         uses: actions/setup-java@v3
         with:
@@ -43,8 +44,11 @@ jobs:
       - name: "Checkout tag for DataBiosphere/jade-data-repo"
         if: github.ref == 'refs/heads/develop'
         run: |
-          git checkout ${{ steps.configuration.outputs.staging_version }}
-          echo "Current branch is ${{ github.ref }}"
+          git checkout "${STAGING_VERSION}"
+          echo "Current branch is ${GITHUB_REF}"
+        env:
+          STAGING_VERSION: ${{ steps.configuration.outputs.staging_version }}
+          GITHUB_REF: ${{ github.ref }}
       - name: "Perform IAM policy cleanup for staging"
         run: |
           # write token

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
+          persist-credentials: false
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
         uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
@@ -66,7 +67,9 @@ jobs:
       - name: Echo tag to console
         if: ${{ inputs.print-tag == 'true' }}
         run: |
-          echo "Newly created version tag: '${{ steps.tag.outputs.new_tag }}'"
+          echo "Newly created version tag: '${NEW_TAG}'"
           echo "build.gradle"
           echo "==============="
           cat build.gradle
+        env:
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up JDK 17 and cache Gradle build
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-1122

## Summary

- Do not persist credentials if not needed
- Use shell variable expansion instead of [template expansion](https://woodruffw.github.io/zizmor/audits/#template-injection)
- Pin `gradle/gradle-build-action` to `v2.12.0`, as previous versions have a vulnerability. Note that we cannot switch to `v3` due to https://broadworkbench.atlassian.net/browse/DT-1132

## Testing Strategy

In progress