### PR TITLE
Partially revert "[DT-1122] Apply `zizmor` suggestions (#1879)"

### DIFF
--- a/.github/workflows/dev-image-update.yaml
+++ b/.github/workflows/dev-image-update.yaml
@@ -24,7 +24,6 @@ jobs:
         with:
           ref: develop
           token: ${{ secrets.BROADBOT_TOKEN }}
-          persist-credentials: false
       - name: "Bump the tag to a new version"
         id: bumperstep
         uses: broadinstitute/datarepo-actions/actions/main@0.74.0


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-1122

## Summary of changes

This partially reverts commit 8501e148331edd5c564a37c71d4fd48c6658e0df. The bumper needs the GitHub token to be able to bump the versions.