### PR TITLE
Partially revert "[DT-1122] Apply `zizmor` suggestions (#1879)"

### DIFF
--- a/.github/workflows/helmtagbumper.yaml
+++ b/.github/workflows/helmtagbumper.yaml
@@ -23,7 +23,6 @@ jobs:
           repository: 'broadinstitute/datarepo-helm'
           path: datarepo-helm
           token: "${{ secrets.BROADBOT_TOKEN }}"
-          persist-credentials: false
       - name: "[datarepo-helm] [value.yaml] Update image tag"
         uses: docker://mikefarah/yq:3
         with:


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-1122

## Summary of changes

This partially reverts commit 8501e148331edd5c564a37c71d4fd48c6658e0df. The merge chart version update step needs the GitHub token to be able to merge the new version.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
