### PR TITLE
[DT-1074] Move to request scoped metrics

### DIFF
--- a/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
@@ -1,6 +1,9 @@
 package bio.terra.app.usermetrics;
 
+import static org.springframework.web.context.WebApplicationContext.SCOPE_REQUEST;
+
 import java.util.HashMap;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 /**
@@ -11,10 +14,10 @@ import org.springframework.stereotype.Component;
  * API request will get grouped together even if they are set in different methods.
  */
 @Component
+@Scope(SCOPE_REQUEST)
 public class UserLoggingMetrics {
 
-  private static final ThreadLocal<HashMap<String, Object>> metrics =
-      ThreadLocal.withInitial(() -> new HashMap<>());
+  private final HashMap<String, Object> metrics = new HashMap<>();
 
   /**
    * Get the current thread's metrics instance. If no metrics have been set, return the default
@@ -23,7 +26,7 @@ public class UserLoggingMetrics {
    * @return HashMap<String, Object> metrics
    */
   public HashMap<String, Object> get() {
-    return metrics.get();
+    return metrics;
   }
 
   /**
@@ -31,7 +34,7 @@ public class UserLoggingMetrics {
    * this key it will be replaced.
    */
   public void set(String key, Object value) {
-    metrics.get().put(key, value);
+    metrics.put(key, value);
   }
 
   /**
@@ -41,8 +44,6 @@ public class UserLoggingMetrics {
    * @param value HashMap of metrics to add
    */
   public void setAll(HashMap<String, Object> value) {
-    HashMap<String, Object> properties = metrics.get();
-    properties.putAll(value);
-    metrics.set(properties);
+    metrics.putAll(value);
   }
 }

--- a/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
@@ -4,6 +4,7 @@ import static org.springframework.web.context.WebApplicationContext.SCOPE_REQUES
 
 import java.util.HashMap;
 import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 /**
@@ -14,7 +15,7 @@ import org.springframework.stereotype.Component;
  * API request will get grouped together even if they are set in different methods.
  */
 @Component
-@Scope(SCOPE_REQUEST)
+@Scope(value = SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class UserLoggingMetrics {
 
   private final HashMap<String, Object> metrics = new HashMap<>();

--- a/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserLoggingMetrics.java
@@ -1,11 +1,9 @@
 package bio.terra.app.usermetrics;
 
-import static org.springframework.web.context.WebApplicationContext.SCOPE_REQUEST;
-
 import java.util.HashMap;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
+import java.util.Map;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 
 /**
  * This class wraps a ThreadLocal variable to store API request properties to log (e.g. method,
@@ -15,24 +13,24 @@ import org.springframework.stereotype.Component;
  * API request will get grouped together even if they are set in different methods.
  */
 @Component
-@Scope(value = SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@RequestScope
 public class UserLoggingMetrics {
 
-  private final HashMap<String, Object> metrics = new HashMap<>();
+  private final Map<String, Object> metrics = new HashMap<>();
 
   /**
    * Get the current thread's metrics instance. If no metrics have been set, return the default
    * empty HashMap.
    *
-   * @return HashMap<String, Object> metrics
+   * @return Map<String, Object> metrics
    */
-  public HashMap<String, Object> get() {
+  public Map<String, Object> get() {
     return metrics;
   }
 
   /**
-   * Add a new value to the current thread's metrics map. If the map already contains a value for
-   * this key it will be replaced.
+   * Add a new value to the metrics map. If the map already contains a value for this key it will be
+   * replaced.
    */
   public void set(String key, Object value) {
     metrics.put(key, value);
@@ -42,9 +40,9 @@ public class UserLoggingMetrics {
    * Add multiple values to the current thread's metrics map. Any existing values with the same key
    * will get replaced.
    *
-   * @param value HashMap of metrics to add
+   * @param value Map of metrics to add
    */
-  public void setAll(HashMap<String, Object> value) {
+  public void setAll(Map<String, Object> value) {
     metrics.putAll(value);
   }
 }

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -25,6 +25,7 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
   private final ApplicationConfiguration applicationConfiguration;
   private final UserMetricsConfiguration metricsConfig;
+  private final UserLoggingMetrics userLoggingMetrics;
   private final ExecutorService metricsPerformanceThreadpool;
 
   @Autowired
@@ -33,11 +34,13 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
       ApplicationConfiguration applicationConfiguration,
       UserMetricsConfiguration metricsConfig,
+      UserLoggingMetrics userLoggingMetrics,
       @Qualifier("metricsReportingThreadpool") ExecutorService metricsPerformanceThreadpool) {
     this.bardClient = bardClient;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
     this.applicationConfiguration = applicationConfiguration;
     this.metricsConfig = metricsConfig;
+    this.userLoggingMetrics = userLoggingMetrics;
     this.metricsPerformanceThreadpool = metricsPerformanceThreadpool;
   }
 
@@ -66,6 +69,7 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
                 BardEventProperties.PATH_FIELD_NAME, path));
     addToPropertiesIfPresentInHeader(
         request, properties, "X-Transaction-Id", BardEventProperties.TRANSACTION_ID_FIELD_NAME);
+    properties.putAll(userLoggingMetrics.get());
 
     // Spawn a thread so that sending the metric doesn't slow down the initial request
     metricsPerformanceThreadpool.submit(

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -26,7 +26,6 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
   private final ApplicationConfiguration applicationConfiguration;
   private final UserMetricsConfiguration metricsConfig;
   private final ExecutorService metricsPerformanceThreadpool;
-  private final UserLoggingMetrics eventProperties;
 
   @Autowired
   public UserMetricsInterceptor(
@@ -34,14 +33,12 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
       AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
       ApplicationConfiguration applicationConfiguration,
       UserMetricsConfiguration metricsConfig,
-      UserLoggingMetrics eventProperties,
       @Qualifier("metricsReportingThreadpool") ExecutorService metricsPerformanceThreadpool) {
     this.bardClient = bardClient;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
     this.applicationConfiguration = applicationConfiguration;
     this.metricsConfig = metricsConfig;
     this.metricsPerformanceThreadpool = metricsPerformanceThreadpool;
-    this.eventProperties = eventProperties;
   }
 
   @Override
@@ -69,8 +66,6 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
                 BardEventProperties.PATH_FIELD_NAME, path));
     addToPropertiesIfPresentInHeader(
         request, properties, "X-Transaction-Id", BardEventProperties.TRANSACTION_ID_FIELD_NAME);
-    eventProperties.setAll(properties);
-    HashMap<String, Object> bardEventProperties = eventProperties.get();
 
     // Spawn a thread so that sending the metric doesn't slow down the initial request
     metricsPerformanceThreadpool.submit(
@@ -79,7 +74,7 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
                 userRequest,
                 new BardEvent(
                     API_EVENT_NAME,
-                    bardEventProperties,
+                    properties,
                     metricsConfig.appId(),
                     applicationConfiguration.getDnsName())));
   }

--- a/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
+++ b/src/main/java/bio/terra/app/usermetrics/UserMetricsInterceptor.java
@@ -61,15 +61,13 @@ public class UserMetricsInterceptor implements HandlerInterceptor {
     if (StringUtils.isEmpty(metricsConfig.bardBasePath()) || ignoreEventForPath(path)) {
       return;
     }
-
-    HashMap<String, Object> properties =
-        new HashMap<>(
-            Map.of(
-                BardEventProperties.METHOD_FIELD_NAME, method,
-                BardEventProperties.PATH_FIELD_NAME, path));
+    Map<String, Object> properties = new HashMap<>(userLoggingMetrics.get());
+    properties.putAll(
+        Map.of(
+            BardEventProperties.METHOD_FIELD_NAME, method,
+            BardEventProperties.PATH_FIELD_NAME, path));
     addToPropertiesIfPresentInHeader(
         request, properties, "X-Transaction-Id", BardEventProperties.TRANSACTION_ID_FIELD_NAME);
-    properties.putAll(userLoggingMetrics.get());
 
     // Spawn a thread so that sending the metric doesn't slow down the initial request
     metricsPerformanceThreadpool.submit(

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -87,7 +87,6 @@ class UserMetricsInterceptorTest {
             authenticatedUserRequestFactory,
             applicationConfiguration,
             metricsConfig,
-            eventProperties,
             metricsPerformanceThreadpool);
   }
 

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -87,6 +87,7 @@ class UserMetricsInterceptorTest {
             authenticatedUserRequestFactory,
             applicationConfiguration,
             metricsConfig,
+            eventProperties,
             metricsPerformanceThreadpool);
   }
 

--- a/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
+++ b/src/test/java/bio/terra/app/usermetrics/UserMetricsInterceptorTest.java
@@ -70,7 +70,6 @@ class UserMetricsInterceptorTest {
 
   @BeforeEach
   void setUp() {
-    eventProperties.get().clear();
     when(metricsConfig.ignorePaths()).thenReturn(List.of());
     when(metricsConfig.appId()).thenReturn(APP_ID);
     when(metricsConfig.bardBasePath()).thenReturn(BARD_BASE_PATH);


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/dt-1074

## Addresses
This adds request scoping to replace threads managing the cache. The advantage of this is the request scoping cleans things up for us, whereas if the thread is directly in control the cache may not be cleared. Making this change helps to ensure that data doesn't bleed from one request to another.

## Summary of changes

## Testing Strategy

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
