### PR TITLE
DT-1182: Convert integration tests to no longer require a full application context

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Follow our getting [started guide](docs/jade-getting-started.md) to get set up.
 If you are making code changes, run:
 `./scripts/run check`
 
-See [started guide](docs/jade-getting-started.md) for information on running connected and integraiton tests.
+See [started guide](docs/jade-getting-started.md) for information on running connected and integration tests.
 
 ### Run TDR locally
 

--- a/scripts/run
+++ b/scripts/run
@@ -87,7 +87,7 @@ run_connected_tests() {
 start_local() {
   eval "$("${SCRIPTS_DIR}"/render-configs.sh -e)"
   cd "$ROOT_DIR"
-  ./gradlew bootRun ${GRADLE_ARGS}
+  TDR_LOG_APPENDER=Console-Standard ./gradlew bootRun ${GRADLE_ARGS}
 }
 
 start_docker() {

--- a/src/test/java/bio/terra/app/controller/RepositoryApiControllerAccessTest.java
+++ b/src/test/java/bio/terra/app/controller/RepositoryApiControllerAccessTest.java
@@ -2,7 +2,8 @@ package bio.terra.app.controller;
 
 import static bio.terra.service.configuration.ConfigEnum.SAM_RETRY_INITIAL_WAIT_SECONDS;
 import static bio.terra.service.configuration.ConfigEnum.SAM_TIMEOUT_FAULT;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import bio.terra.common.category.Integration;
 import bio.terra.integration.DataRepoFixtures;
@@ -11,45 +12,46 @@ import bio.terra.integration.UsersBase;
 import bio.terra.model.ConfigGroupModel;
 import bio.terra.model.ConfigModel;
 import bio.terra.model.ConfigParameterModel;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * This is meant to be a very lightweight integration test to make sure that SAM actions are used as
  * expected.
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@Category(Integration.class)
-public class RepositoryApiControllerAccessTest extends UsersBase {
+@Tag(Integration.TAG)
+class RepositoryApiControllerAccessTest extends UsersBase {
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
 
-  @Before
+  @BeforeEach
+  @Override
   public void setup() throws Exception {
     super.setup();
   }
 
   @Test
-  public void testGetConfigList() throws Exception {
+  void testGetConfigList() throws Exception {
     // Assume this call is successful
     dataRepoFixtures.getConfigList(admin());
 
     // This call should be unsuccessful
-    assertThat(dataRepoFixtures.getConfigListRaw(reader()).getStatusCode())
-        .isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(
+        dataRepoFixtures.getConfigListRaw(reader()).getStatusCode(), is(HttpStatus.FORBIDDEN));
   }
 
   @Test
-  public void testSetConfigList() throws Exception {
+  void testSetConfigList() throws Exception {
     dataRepoFixtures.resetConfig(admin());
     ConfigGroupModel configGroup =
         new ConfigGroupModel()
@@ -64,46 +66,43 @@ public class RepositoryApiControllerAccessTest extends UsersBase {
     dataRepoFixtures.setConfigList(admin(), configGroup);
 
     // This call should be unsuccessful
-    assertThat(dataRepoFixtures.setConfigListRaw(reader(), configGroup).getStatusCode())
-        .isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(
+        dataRepoFixtures.setConfigListRaw(reader(), configGroup).getStatusCode(),
+        is(HttpStatus.FORBIDDEN));
 
     // Reset config changes
     dataRepoFixtures.resetConfig(admin());
   }
 
   @Test
-  public void testGetConfig() throws Exception {
+  void testGetConfig() throws Exception {
     assertThat(
-            dataRepoFixtures
-                .getConfig(admin(), SAM_RETRY_INITIAL_WAIT_SECONDS.name())
-                .getStatusCode())
-        .isEqualTo(HttpStatus.OK);
+        dataRepoFixtures.getConfig(admin(), SAM_RETRY_INITIAL_WAIT_SECONDS.name()).getStatusCode(),
+        is(HttpStatus.OK));
 
     assertThat(
-            dataRepoFixtures
-                .getConfig(reader(), SAM_RETRY_INITIAL_WAIT_SECONDS.name())
-                .getStatusCode())
-        .isEqualTo(HttpStatus.FORBIDDEN);
+        dataRepoFixtures.getConfig(reader(), SAM_RETRY_INITIAL_WAIT_SECONDS.name()).getStatusCode(),
+        is(HttpStatus.FORBIDDEN));
   }
 
   @Test
-  public void testSetFault() throws Exception {
-    assertThat(dataRepoFixtures.setFault(admin(), SAM_TIMEOUT_FAULT.name(), false).getStatusCode())
-        .isEqualTo(HttpStatus.NO_CONTENT);
+  void testSetFault() throws Exception {
+    assertThat(
+        dataRepoFixtures.setFault(admin(), SAM_TIMEOUT_FAULT.name(), false).getStatusCode(),
+        is(HttpStatus.NO_CONTENT));
 
-    assertThat(dataRepoFixtures.setFault(reader(), SAM_TIMEOUT_FAULT.name(), false).getStatusCode())
-        .isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(
+        dataRepoFixtures.setFault(reader(), SAM_TIMEOUT_FAULT.name(), false).getStatusCode(),
+        is(HttpStatus.FORBIDDEN));
 
     // Reset config changes
     dataRepoFixtures.resetConfig(admin());
   }
 
   @Test
-  public void testResetConfig() throws Exception {
-    assertThat(dataRepoFixtures.resetConfig(admin()).getStatusCode())
-        .isEqualTo(HttpStatus.NO_CONTENT);
+  void testResetConfig() throws Exception {
+    assertThat(dataRepoFixtures.resetConfig(admin()).getStatusCode(), is(HttpStatus.NO_CONTENT));
 
-    assertThat(dataRepoFixtures.resetConfig(reader()).getStatusCode())
-        .isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(dataRepoFixtures.resetConfig(reader()).getStatusCode(), is(HttpStatus.FORBIDDEN));
   }
 }

--- a/src/test/java/bio/terra/app/controller/RepositoryApiControllerAccessTest.java
+++ b/src/test/java/bio/terra/app/controller/RepositoryApiControllerAccessTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import bio.terra.common.category.Integration;
 import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.ConfigGroupModel;
 import bio.terra.model.ConfigModel;
@@ -15,7 +16,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
@@ -26,8 +26,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * expected.
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
 @Category(Integration.class)
 public class RepositoryApiControllerAccessTest extends UsersBase {

--- a/src/test/java/bio/terra/common/GcsUtils.java
+++ b/src/test/java/bio/terra/common/GcsUtils.java
@@ -1,42 +1,39 @@
 package bio.terra.common;
 
-import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.service.common.gcs.GcsUriUtils;
-import bio.terra.service.filedata.google.gcs.GcsPdao;
+import com.google.cloud.ServiceOptions;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Blob.BlobSourceOption;
+import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobGetOption;
 import com.google.cloud.storage.StorageOptions;
-import java.util.stream.Stream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GcsUtils {
 
-  private static Logger logger = LoggerFactory.getLogger(GcsUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(GcsUtils.class);
 
-  @Autowired private TestConfiguration testConfig;
-  @Autowired private GcsPdao gcsPdao;
+  private final String projectId = ServiceOptions.getDefaultProjectId();
+  private final Storage storage = StorageOptions.getDefaultInstance().getService();
 
-  private String projectId = StorageOptions.getDefaultProjectId();
-  private Storage storage = StorageOptions.getDefaultInstance().getService();
-
-  public String uploadTestFile(String ingestBucket, String name, Stream<String> lines) {
+  public String uploadTestFile(String ingestBucket, String name, List<String> lines) {
     String path = String.format("gs://%s/%s", ingestBucket, name);
     logger.info("Uploading test file to {}", path);
-    gcsPdao.createGcsFile(path, projectId);
-    gcsPdao.writeStreamToCloudFile(path, lines, projectId);
-
+    BlobInfo blobInfo = BlobInfo.newBuilder(ingestBucket, name).build();
+    byte[] content = String.join("\n", lines).getBytes(StandardCharsets.UTF_8);
+    storage.create(blobInfo, content, Storage.BlobTargetOption.userProject(projectId));
     return path;
   }
 
   public void deleteTestFile(String path) {
     logger.info("Removing test file at {}", path);
-    gcsPdao.deleteFileByGspath(path, projectId);
+    storage.delete(GcsUriUtils.parseBlobUri(path));
   }
 
   public boolean fileExists(String path) {

--- a/src/test/java/bio/terra/common/GcsUtils.java
+++ b/src/test/java/bio/terra/common/GcsUtils.java
@@ -5,6 +5,7 @@ import com.google.cloud.ServiceOptions;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Blob.BlobSourceOption;
 import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobGetOption;
 import com.google.cloud.storage.StorageOptions;
@@ -33,12 +34,21 @@ public class GcsUtils {
 
   public void deleteTestFile(String path) {
     logger.info("Removing test file at {}", path);
-    storage.delete(GcsUriUtils.parseBlobUri(path));
+    storage.delete(GcsUriUtils.parseBlobUri(path), Storage.BlobSourceOption.userProject(projectId));
   }
 
   public boolean fileExists(String path) {
     logger.info("Checking that file {} exists", path);
     Blob blob = storage.get(GcsUriUtils.parseBlobUri(path), BlobGetOption.userProject(projectId));
     return blob.exists(BlobSourceOption.userProject(projectId));
+  }
+
+  public byte[] getBlobBytes(String path, String projectId) {
+    Blob blob = storage.get(GcsUriUtils.parseBlobUri(path), BlobGetOption.userProject(projectId));
+    return blob.getContent();
+  }
+
+  public Bucket getCloudBucket(String bucketName) {
+    return storage.get(bucketName);
   }
 }

--- a/src/test/java/bio/terra/common/ParquetUtils.java
+++ b/src/test/java/bio/terra/common/ParquetUtils.java
@@ -1,10 +1,7 @@
 package bio.terra.common;
 
-import bio.terra.service.filedata.google.gcs.GcsPdao;
-import com.azure.storage.blob.BlobUrlParts;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -12,7 +9,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -25,9 +21,9 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 public class ParquetUtils {
 
   public static List<Map<String, Object>> readGcsParquetRecords(
-      GcsPdao gcsPdao, final String url, String googleProjectId) {
+      GcsUtils gcsUtils, final String url, String googleProjectId) {
     Configuration config = new Configuration();
-    byte[] contents = gcsPdao.getBlobBytes(url, googleProjectId);
+    byte[] contents = gcsUtils.getBlobBytes(url, googleProjectId);
     try {
       java.nio.file.Path tempParquetFile = Files.createTempFile("localGcs", ".parquet");
       Files.write(tempParquetFile, contents);
@@ -36,49 +32,6 @@ public class ParquetUtils {
     } catch (IOException e) {
       throw new RuntimeException("Could not write " + url + " to local temp file", e);
     }
-  }
-
-  /**
-   * Given a signed Azure URL, this method will read through the parquet data specified as list of
-   * maps that are keyed on column name and whose values are string representations of the parquet
-   * field values
-   *
-   * @param url The Azure URL to read from with a sas token included
-   * @return A java representation of the parquet record data
-   */
-  public static List<Map<String, String>> readParquetRecords(final String url) {
-    BlobUrlParts blobUrlParts = BlobUrlParts.parse(url);
-    Configuration config = new Configuration();
-    config.set("fs.azure", "org.apache.hadoop.fs.azure.NativeAzureFileSystem");
-    config.set(
-        "fs.azure.sas."
-            + blobUrlParts.getBlobContainerName()
-            + "."
-            + blobUrlParts.getAccountName()
-            + ".blob.core.windows.net",
-        blobUrlParts.getCommonSasQueryParameters().encode());
-
-    URI uri;
-    try {
-      uri =
-          new URI(
-              "wasbs://"
-                  + blobUrlParts.getBlobContainerName()
-                  + "@"
-                  + blobUrlParts.getAccountName()
-                  + ".blob.core.windows.net/"
-                  + blobUrlParts.getBlobName());
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
-
-    return readParquetRecordsFromUri(config, uri).stream()
-        .map(
-            m ->
-                m.entrySet().stream()
-                    .map(e -> Map.entry(e.getKey(), e.getValue().toString()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
-        .collect(Collectors.toList());
   }
 
   private static List<Map<String, Object>> readParquetRecordsFromUri(

--- a/src/test/java/bio/terra/common/auth/AuthService.java
+++ b/src/test/java/bio/terra/common/auth/AuthService.java
@@ -7,7 +7,7 @@ import com.google.api.client.auth.oauth2.TokenResponseException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.apache.commons.collections4.map.PassiveExpiringMap.ExpirationPolicy;
@@ -28,8 +27,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class AuthService {
-  private static Logger logger = LoggerFactory.getLogger(AuthService.class);
-  private static ExpirationPolicy<String, GoogleCredential> TOKEN_CACHE_EXPIRATION_POLICY =
+  private static final Logger logger = LoggerFactory.getLogger(AuthService.class);
+  private static final ExpirationPolicy<String, GoogleCredential> TOKEN_CACHE_EXPIRATION_POLICY =
       // Make sure this value never returns a negative since that means the entry never expires
       (key, value) ->
           Math.max(0, value.getExpirationTimeMilliseconds() - TimeUnit.MINUTES.toMillis(5));
@@ -37,25 +36,25 @@ public class AuthService {
   // the list of scopes we request from end users when they log in.
   // this should always match exactly what the UI requests, so our tests represent actual user
   // behavior:
-  private List<String> userLoginScopes =
+  private final List<String> userLoginScopes =
       List.of(
           "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-billing.readonly");
-  private List<String> directAccessScopes =
+  private final List<String> directAccessScopes =
       List.of(
           "https://www.googleapis.com/auth/bigquery",
           "https://www.googleapis.com/auth/devstorage.full_control");
-  private NetHttpTransport httpTransport;
-  private JacksonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+  private final NetHttpTransport httpTransport;
+  private final GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
   private File pemfile;
-  private String saEmail;
-  private Map<String, GoogleCredential> userTokens =
+  private final String saEmail;
+  private final Map<String, GoogleCredential> userTokens =
       Collections.synchronizedMap(new PassiveExpiringMap<>(TOKEN_CACHE_EXPIRATION_POLICY));
-  private Map<String, String> petAccountTokens =
+  private final Map<String, String> petAccountTokens =
       Collections.synchronizedMap(new PassiveExpiringMap<>(55, TimeUnit.MINUTES));
-  private Map<String, GoogleCredential> directAccessTokens =
+  private final Map<String, GoogleCredential> directAccessTokens =
       Collections.synchronizedMap(new PassiveExpiringMap<>(TOKEN_CACHE_EXPIRATION_POLICY));
-  private TestConfiguration testConfig;
-  private IamProviderInterface iamProvider;
+  private final TestConfiguration testConfig;
+  private final IamProviderInterface iamProvider;
 
   @Autowired
   public AuthService(TestConfiguration testConfig, IamProviderInterface iamProvider)
@@ -84,7 +83,7 @@ public class AuthService {
 
   private GoogleCredential buildCredential(String email, List<String> scopes)
       throws IOException, GeneralSecurityException {
-    if (!Optional.ofNullable(pemfile).isPresent()) {
+    if (pemfile == null) {
       throw new IllegalStateException(
           String.format("pemfile not found: %s", testConfig.getJadePemFileName()));
     }
@@ -100,9 +99,7 @@ public class AuthService {
 
   private GoogleCredential makeDirectAccessToken(String userEmail) {
     List<String> allScopes =
-        Stream.of(userLoginScopes, directAccessScopes)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList());
+        Stream.of(userLoginScopes, directAccessScopes).flatMap(Collection::stream).toList();
     return makeTokenForScopes(userEmail, allScopes);
   }
 

--- a/src/test/java/bio/terra/common/category/Integration.java
+++ b/src/test/java/bio/terra/common/category/Integration.java
@@ -1,4 +1,6 @@
 package bio.terra.common.category;
 
 /** Integration test category. */
-public interface Integration {}
+public interface Integration {
+  String TAG = "bio.terra.common.category.Integration";
+}

--- a/src/test/java/bio/terra/common/fixtures/JsonLoader.java
+++ b/src/test/java/bio/terra/common/fixtures/JsonLoader.java
@@ -16,12 +16,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JsonLoader {
-  private ClassLoader classLoader;
-  private ObjectMapper objectMapper;
+  private final ClassLoader classLoader;
+  private final ObjectMapper objectMapper;
 
   @Autowired
   public JsonLoader(ObjectMapper objectMapper) {
-    this.classLoader = getClass().getClassLoader();
+    classLoader = getClass().getClassLoader();
     this.objectMapper = objectMapper;
   }
 
@@ -50,7 +50,7 @@ public class JsonLoader {
       final String resourcePath, final TypeReference<T> innerObjectTypeReference)
       throws IOException {
     return Arrays.stream(loadJson(resourcePath).split("\n"))
-        .map(json -> this.loadJson(json, innerObjectTypeReference))
+        .map(json -> loadJson(json, innerObjectTypeReference))
         .collect(Collectors.toList());
   }
 

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -12,15 +12,14 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.app.model.AzureCloudResource;
 import bio.terra.app.model.AzureRegion;
 import bio.terra.common.CollectionType;
 import bio.terra.common.TestUtils;
-import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.common.configuration.TestConfiguration.User;
@@ -107,7 +106,6 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -124,37 +122,34 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.ResourceUtils;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class AzureIntegrationTest extends UsersBase {
+@Tag(Integration.TAG)
+class AzureIntegrationTest extends UsersBase {
   private static final Logger logger = LoggerFactory.getLogger(AzureIntegrationTest.class);
 
-  private static final String omopDatasetName = "it_dataset_omop";
-  private static final String omopDatasetDesc =
+  private static final String OMOP_DATASET_NAME = "it_dataset_omop";
+  private static final String OMOP_DATASET_DESC =
       "OMOP schema based on BigQuery schema from https://github.com/OHDSI/CommonDataModel/wiki with extra columns suffixed with _custom";
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private SamFixtures samFixtures;
-  @Autowired private AuthService authService;
   @Autowired private TestConfiguration testConfig;
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;
   @Autowired private JsonLoader jsonLoader;
@@ -174,9 +169,10 @@ public class AzureIntegrationTest extends UsersBase {
   private GcsBlobIOTestUtility gcsBlobIOTestUtility;
   private Set<String> storageAccounts;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
-    super.setup(false);
+    setup(false);
     // Voldemort is required by this test since the application is deployed with his user authz'ed
     steward = steward("voldemort");
     admin = admin("hermione");
@@ -203,7 +199,7 @@ public class AzureIntegrationTest extends UsersBase {
     storageAccounts = new TreeSet<>();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (releaseSnapshotId != null) {
       snapshotIds.add(releaseSnapshotId);
@@ -251,7 +247,7 @@ public class AzureIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void datasetsHappyPath() throws Exception {
+  void datasetsHappyPath() throws Exception {
     // Note: this region should not be the same as the default region in the application deployment
     // (eastus by default)
     AzureRegion region = AzureRegion.SOUTH_CENTRAL_US;
@@ -261,14 +257,14 @@ public class AzureIntegrationTest extends UsersBase {
             steward, profileId, "omop/it-dataset-omop.json", CloudPlatform.AZURE, false, region);
     datasetId = summaryModel.getId();
     String storageAccountName = recordStorageAccount(steward, CollectionType.DATASET, datasetId);
-    logger.info("dataset id is " + summaryModel.getId());
-    assertThat(summaryModel.getName(), startsWith(omopDatasetName));
-    assertThat(summaryModel.getDescription(), equalTo(omopDatasetDesc));
+    logger.info("dataset id is {}", summaryModel.getId());
+    assertThat(summaryModel.getName(), startsWith(OMOP_DATASET_NAME));
+    assertThat(summaryModel.getDescription(), equalTo(OMOP_DATASET_DESC));
 
     DatasetModel datasetModel = dataRepoFixtures.getDataset(steward, summaryModel.getId());
 
-    assertThat(datasetModel.getName(), startsWith(omopDatasetName));
-    assertThat(datasetModel.getDescription(), equalTo(omopDatasetDesc));
+    assertThat(datasetModel.getName(), startsWith(OMOP_DATASET_NAME));
+    assertThat(datasetModel.getDescription(), equalTo(OMOP_DATASET_DESC));
 
     // There is a delay from when a resource is created in SAM to when it is available in an
     // enumerate call.
@@ -283,8 +279,8 @@ public class AzureIntegrationTest extends UsersBase {
               boolean found = false;
               for (DatasetSummaryModel oneDataset : enumerateDatasetModel.getItems()) {
                 if (oneDataset.getId().equals(datasetModel.getId())) {
-                  assertThat(oneDataset.getName(), startsWith(omopDatasetName));
-                  assertThat(oneDataset.getDescription(), equalTo(omopDatasetDesc));
+                  assertThat(oneDataset.getName(), startsWith(OMOP_DATASET_NAME));
+                  assertThat(oneDataset.getDescription(), equalTo(OMOP_DATASET_DESC));
                   Map<String, StorageResourceModel> storageMap =
                       datasetModel.getStorage().stream()
                           .collect(
@@ -358,7 +354,7 @@ public class AzureIntegrationTest extends UsersBase {
               return found;
             });
 
-    assertTrue("dataset was found in enumeration", metExpectation);
+    assertTrue(metExpectation, "dataset was found in enumeration");
 
     // This should fail since it currently has dataset storage account within
     assertThrows(AssertionError.class, () -> dataRepoFixtures.deleteProfile(steward, profileId));
@@ -461,7 +457,7 @@ public class AzureIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testSnapshotCreateFromRequest() throws Exception {
+  void testSnapshotCreateFromRequest() throws Exception {
     populateOmopTable();
 
     SnapshotAccessRequestResponse approvedSnapshotAccessRequest =
@@ -502,7 +498,7 @@ public class AzureIntegrationTest extends UsersBase {
     SnapshotAccessRequestResponse updatedSnapshotAccessRequest =
         dataRepoFixtures.getSnapshotAccessRequest(steward, approvedSnapshotAccessRequest.getId());
     assertNotNull(
-        "Snapshot access request flightId is set", updatedSnapshotAccessRequest.getFlightid());
+        updatedSnapshotAccessRequest.getFlightid(), "Snapshot access request flightId is set");
     assertThat(
         "Snapshot access request createdSnapshotId is correct",
         updatedSnapshotAccessRequest.getCreatedSnapshotId(),
@@ -598,7 +594,7 @@ public class AzureIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testSnapshotBuilder() throws Exception {
+  void testSnapshotBuilder() throws Exception {
     populateOmopTable();
 
     var concept1 =
@@ -708,7 +704,7 @@ public class AzureIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void datasetIngestFileHappyPath() throws Exception {
+  void datasetIngestFileHappyPath() throws Exception {
     String blobName = "myBlob";
     long fileSize = MIB / 10;
     String sourceFileAzure = azureBlobIOTestUtility.uploadSourceFile(blobName, fileSize);
@@ -908,15 +904,15 @@ public class AzureIntegrationTest extends UsersBase {
             .get(0);
     assertThat(
         "record looks as expected - domain_id",
-        ((LinkedHashMap) firstDomainRow).get("domain_id").toString(),
+        ((Map) firstDomainRow).get("domain_id").toString(),
         equalTo(domainRowData.get("domain_id")));
     assertThat(
         "record looks as expected - domain_files_custom_2 file id- value",
-        ((ArrayList<String>) ((LinkedHashMap) firstDomainRow).get("domain_files_custom_2")).get(0),
+        ((List) ((Map) firstDomainRow).get("domain_files_custom_2")).get(0),
         equalTo(file2Model.getFileId()));
     assertThat(
         "record looks as expected - domain_files_custom_3 file id- value",
-        ((LinkedHashMap) firstDomainRow).get("domain_files_custom_3").toString(),
+        ((Map) firstDomainRow).get("domain_files_custom_3").toString(),
         equalTo(file4Model.getFileId()));
 
     // Ingest 2 rows from CSV
@@ -967,10 +963,8 @@ public class AzureIntegrationTest extends UsersBase {
     assertThat(
         "The new table is in the update response",
         response.getSchema().getTables().stream()
-            .filter(tableModel -> tableModel.getName().equals("new_table"))
-            .findFirst()
-            .isPresent());
-    Map<String, String> vocab_entry2 =
+            .anyMatch(tableModel -> tableModel.getName().equals("new_table")));
+    Map<String, String> vocabEntry2 =
         Map.of(
             "vocabulary_id",
             "3",
@@ -982,7 +976,7 @@ public class AzureIntegrationTest extends UsersBase {
             "3.0",
             newColumnName,
             "new_value");
-    testMetadataArrayIngest(vocabTableName, vocab_entry2);
+    testMetadataArrayIngest(vocabTableName, vocabEntry2);
     tableRowCount.put(vocabTableName, 3);
 
     // assert correct data returns from view data endpoint
@@ -1002,15 +996,15 @@ public class AzureIntegrationTest extends UsersBase {
             .getResult();
     assertThat(
         "record looks as expected - vocabulary_id",
-        ((LinkedHashMap) vocabRows.get(0)).get("vocabulary_id").toString(),
+        ((Map) vocabRows.get(0)).get("vocabulary_id").toString(),
         equalTo("1"));
     assertThat(
         "record looks as expected - vocabulary_id",
-        ((LinkedHashMap) vocabRows.get(1)).get("vocabulary_id").toString(),
+        ((Map) vocabRows.get(1)).get("vocabulary_id").toString(),
         equalTo("2"));
     assertThat(
         "record looks as expected - new column",
-        ((LinkedHashMap) vocabRows.get(2)).get(newColumnName).toString(),
+        ((Map) vocabRows.get(2)).get(newColumnName).toString(),
         equalTo("new_value"));
     List<String> vocabList =
         dataRepoFixtures.retrieveColumnTextValues(
@@ -1038,7 +1032,7 @@ public class AzureIntegrationTest extends UsersBase {
             .getResult();
     assertThat(
         "correct vocabulary_id returned",
-        ((LinkedHashMap) flippedVocabRows.get(0)).get("vocabulary_id").toString(),
+        ((Map) flippedVocabRows.get(0)).get("vocabulary_id").toString(),
         equalTo("3"));
     String qualifiedVocabTableName = String.format("%s.%s", datasetModel.getName(), vocabTableName);
     DatasetDataModel filteredVocabRows =
@@ -1060,7 +1054,7 @@ public class AzureIntegrationTest extends UsersBase {
         equalTo(tableRowCount.get(vocabTableName)));
     assertThat(
         "Correct row is returned",
-        ((LinkedHashMap) filteredVocabRows.getResult().get(0)).get("vocabulary_id").toString(),
+        ((Map) filteredVocabRows.getResult().get(0)).get("vocabulary_id").toString(),
         equalTo("1"));
 
     // test handling of empty dataset table
@@ -1114,14 +1108,14 @@ public class AzureIntegrationTest extends UsersBase {
         tableModel.setColumns(
             datasetSchema.getTables().stream()
                 .filter(t -> t.getName().equals(table.getName()))
-                .flatMap(t -> t.getColumns().stream().map(c -> c.getName()))
+                .flatMap(t -> t.getColumns().stream().map(ColumnModel::getName))
                 .toList());
         tableModel.setRowIds(
             dataRepoFixtures
                 .getRowIds(
                     steward, datasetModel, table.getName(), tableRowCount.get(table.getName()))
                 .stream()
-                .map(id -> UUID.fromString(id))
+                .map(UUID::fromString)
                 .toList());
         snapshotRequestRowIdModel.addTablesItem(tableModel);
       }
@@ -1201,19 +1195,20 @@ public class AzureIntegrationTest extends UsersBase {
             .getResult();
     List<String> drsIds =
         vocabSnapshotRows.stream()
-            .filter(r -> ((LinkedHashMap) r).get("vocabulary_reference") != null)
-            .map(r -> ((LinkedHashMap) r).get("vocabulary_reference").toString())
+            .map(r -> (Map) r)
+            .filter(r -> r.get("vocabulary_reference") != null)
+            .map(r -> r.get("vocabulary_reference").toString())
             .toList();
 
     Object firstVocabRow = vocabSnapshotRows.get(0);
     assertThat(
         "record looks as expected - vocabulary_id",
-        ((LinkedHashMap) firstVocabRow).get("vocabulary_id").toString(),
+        ((Map) firstVocabRow).get("vocabulary_id").toString(),
         equalTo("1"));
     Object secondVocabRow = vocabSnapshotRows.get(1);
     assertThat(
         "record looks as expected - vocabulary_id",
-        ((LinkedHashMap) secondVocabRow).get("vocabulary_id").toString(),
+        ((Map) secondVocabRow).get("vocabulary_id").toString(),
         equalTo("2"));
 
     // Test filtering results from snapshot preview endpoint and check row counts
@@ -1239,7 +1234,7 @@ public class AzureIntegrationTest extends UsersBase {
         equalTo(tableRowCount.get(vocabTableName)));
     assertThat(
         "Correct row is returned",
-        ((LinkedHashMap) filteredVocabRows.getResult().get(0)).get("vocabulary_id").toString(),
+        ((Map) filteredVocabRows.getResult().get(0)).get("vocabulary_id").toString(),
         equalTo("1"));
 
     // test handling of empty snapshot table
@@ -1270,31 +1265,32 @@ public class AzureIntegrationTest extends UsersBase {
 
     // Domain Table
     dataRepoFixtures.assertSnapshotTableCount(steward, snapshotAll, "domain", 1);
-    Object firstSnapshotDomainRow =
-        dataRepoFixtures.retrieveFirstResultSnapshotPreviewById(
-            steward, snapshotAll.getId(), "domain", 0, 1, null);
+    Map<?, ?> firstSnapshotDomainRow =
+        (Map<?, ?>)
+            dataRepoFixtures.retrieveFirstResultSnapshotPreviewById(
+                steward, snapshotAll.getId(), "domain", 0, 1, null);
     assertThat(
         "record looks as expected - domain_id",
-        ((LinkedHashMap) firstSnapshotDomainRow).get("domain_id").toString(),
+        firstSnapshotDomainRow.get("domain_id").toString(),
         equalTo(domainRowData.get("domain_id")));
     assertThat(
         "record looks as expected - domain_name",
-        ((LinkedHashMap) firstSnapshotDomainRow).get("domain_name").toString(),
+        firstSnapshotDomainRow.get("domain_name").toString(),
         equalTo(domainRowData.get("domain_name")));
     assertThat(
         "record looks as expected - domain_concept_id",
-        ((LinkedHashMap) firstSnapshotDomainRow).get("domain_concept_id").toString(),
+        firstSnapshotDomainRow.get("domain_concept_id").toString(),
         equalTo(domainRowData.get("domain_concept_id").toString()));
     assertThat(
         "record looks as expected - domain_array_tags_custom",
-        ((LinkedHashMap) firstSnapshotDomainRow).get("domain_array_tags_custom").toString(),
+        firstSnapshotDomainRow.get("domain_array_tags_custom").toString(),
         equalTo("[tag1, tag2]"));
     assertThat(
         "record looks as expected - domain_files_custom_1 drs ids",
-        (ArrayList<String>) ((LinkedHashMap) firstSnapshotDomainRow).get("domain_files_custom_1"),
+        (List<?>) firstSnapshotDomainRow.get("domain_files_custom_1"),
         containsInAnyOrder(drsIds.toArray()));
     List<String> embeddedDrsIds2 =
-        (ArrayList<String>) ((LinkedHashMap) firstSnapshotDomainRow).get("domain_files_custom_2");
+        (List<String>) firstSnapshotDomainRow.get("domain_files_custom_2");
     assertThat(
         "record looks as expected - domain_files_custom_2 drs ids - size",
         embeddedDrsIds2,
@@ -1305,8 +1301,7 @@ public class AzureIntegrationTest extends UsersBase {
         equalTo(String.format("v1_%s_%s", snapshotByFullViewId, file2Model.getFileId())));
     assertThat(
         "record looks as expected - domain_files_custom_3 drs id",
-        DrsIdService.fromUri(
-                ((LinkedHashMap) firstSnapshotDomainRow).get("domain_files_custom_3").toString())
+        DrsIdService.fromUri(firstSnapshotDomainRow.get("domain_files_custom_3").toString())
             .toDrsObjectId(),
         equalTo(String.format("v1_%s_%s", snapshotByFullViewId, file4Model.getFileId())));
 
@@ -1558,7 +1553,7 @@ public class AzureIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testDatasetFileIngestLoadHistory() throws Exception {
+  void testDatasetFileIngestLoadHistory() throws Exception {
     String blobName = "myBlob";
     long fileSize = MIB / 10;
     String sourceFile = azureBlobIOTestUtility.uploadSourceFile(blobName, fileSize);
@@ -1674,8 +1669,8 @@ public class AzureIntegrationTest extends UsersBase {
   }
 
   @Test
-  @Ignore("Ignoring due to flakiness and deprioritization of Azure")
-  public void testDatasetFileRefValidation() throws Exception {
+  @Disabled("Ignoring due to flakiness and deprioritization of Azure")
+  void testDatasetFileRefValidation() throws Exception {
     DatasetSummaryModel summaryModel =
         dataRepoFixtures.createDataset(
             steward, profileId, "dataset-ingest-azure-fileref.json", CloudPlatform.AZURE);
@@ -1805,7 +1800,7 @@ public class AzureIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testRequiredColumnsIngest() throws Exception {
+  void testRequiredColumnsIngest() throws Exception {
     DatasetSummaryModel summaryModel =
         dataRepoFixtures.createDataset(
             steward,
@@ -1817,7 +1812,7 @@ public class AzureIntegrationTest extends UsersBase {
 
     String controlFileContents;
     try (var resourceStream =
-        this.getClass().getResourceAsStream("/dataset-ingest-combined-control-azure.json")) {
+        getClass().getResourceAsStream("/dataset-ingest-combined-control-azure.json")) {
       controlFileContents = new String(resourceStream.readAllBytes(), StandardCharsets.UTF_8);
     }
 
@@ -1869,12 +1864,12 @@ public class AzureIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testDatasetCombinedIngest() throws Exception {
+  void testDatasetCombinedIngest() throws Exception {
     testDatasetCombinedIngest(true);
   }
 
   @Test
-  public void testDatasetCombinedIngestFromApi() throws Exception {
+  void testDatasetCombinedIngestFromApi() throws Exception {
     testDatasetCombinedIngest(false);
   }
 
@@ -1887,7 +1882,7 @@ public class AzureIntegrationTest extends UsersBase {
 
     String controlFileContents;
     try (var resourceStream =
-        this.getClass().getResourceAsStream("/dataset-ingest-combined-control-azure.json")) {
+        getClass().getResourceAsStream("/dataset-ingest-combined-control-azure.json")) {
       controlFileContents = new String(resourceStream.readAllBytes(), StandardCharsets.UTF_8);
     }
 
@@ -1907,7 +1902,7 @@ public class AzureIntegrationTest extends UsersBase {
     } else {
       List<Map<String, Object>> data =
           Arrays.stream(controlFileContents.split("\\n"))
-              .map(j -> jsonLoader.loadJson(j, new TypeReference<Map<String, Object>>() {}))
+              .map(s -> jsonLoader.loadJson(s, new TypeReference<Map<String, Object>>() {}))
               .toList();
       ingestRequest
           .records(Arrays.asList(data.toArray()))
@@ -1939,7 +1934,7 @@ public class AzureIntegrationTest extends UsersBase {
 
   private String getSourceStorageAccountPrimarySharedKey() {
     AzureResourceManager client =
-        this.azureResourceConfiguration.getClient(
+        azureResourceConfiguration.getClient(
             testConfig.getTargetTenantId(), testConfig.getTargetSubscriptionId());
 
     return client
@@ -2009,7 +2004,7 @@ public class AzureIntegrationTest extends UsersBase {
     logger.info("Verifying url %s".formatted(signedUrl));
     try (CloseableHttpClient client = HttpClients.createDefault()) {
       HttpUriRequest request = new HttpHead(signedUrl);
-      try (CloseableHttpResponse response = client.execute(request); ) {
+      try (CloseableHttpResponse response = client.execute(request)) {
         assertThat(
             "URL can be accessed",
             response.getStatusLine().getStatusCode(),

--- a/src/test/java/bio/terra/integration/DataRepoClient.java
+++ b/src/test/java/bio/terra/integration/DataRepoClient.java
@@ -44,8 +44,8 @@ public class DataRepoClient {
   public DataRepoClient() {
     restTemplate =
         new RestTemplateBuilder()
-            .setConnectTimeout(Duration.ofMinutes(5))
-            .setReadTimeout(Duration.ofMinutes(5))
+            .connectTimeout(Duration.ofMinutes(5))
+            .readTimeout(Duration.ofMinutes(5))
             .build();
     restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
     restTemplate.setErrorHandler(new DataRepoClientErrorHandler());

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -1,10 +1,10 @@
 package bio.terra.integration;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.TestUtils;
 import bio.terra.common.auth.AuthService;
@@ -30,7 +30,6 @@ import bio.terra.model.JobModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
-import bio.terra.service.job.JobService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
@@ -48,31 +47,28 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class FileTest extends UsersBase {
+@Tag(Integration.TAG)
+class FileTest extends UsersBase {
 
-  private static Logger logger = LoggerFactory.getLogger(FileTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(FileTest.class);
 
   private static final int NUM_FILES = 100;
   private static final int NUM_FAILED_FILES = 5;
@@ -85,19 +81,17 @@ public class FileTest extends UsersBase {
 
   @Autowired private TestConfiguration testConfiguration;
 
-  @MockitoBean private JobService jobService;
-
   private final Storage storage = StorageOptions.getDefaultInstance().getService();
 
   private ObjectMapper objectMapper;
   private DatasetSummaryModel datasetSummaryModel;
   private UUID datasetId;
   private UUID snapshotId;
-  private List<String> fileIds;
   private UUID profileId;
   private BlobId controlFileId;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     controlFileId = null;
@@ -110,20 +104,12 @@ public class FileTest extends UsersBase {
     objectMapper = new ObjectMapper().setDefaultPrettyPrinter(p);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (snapshotId != null) {
       dataRepoFixtures.deleteSnapshot(custodian(), snapshotId);
     }
     if (datasetId != null) {
-      fileIds.forEach(
-          f -> {
-            try {
-              dataRepoFixtures.deleteFile(steward(), datasetId, f);
-            } catch (Exception e) {
-              e.printStackTrace();
-            }
-          });
       dataRepoFixtures.deleteDataset(steward(), datasetId);
     }
     if (profileId != null) {
@@ -137,9 +123,9 @@ public class FileTest extends UsersBase {
   // The purpose of this test is to have a long-running workload that completes successfully
   // while we delete pods and have them recover.
   // Marked ignore for normal testing.
-  @Ignore
+  @Disabled("long running test")
   @Test
-  public void longFileLoadTest() throws Exception {
+  void longFileLoadTest() throws Exception {
     // TODO: want this to run about 5 minutes on 2 DRmanager instances. The speed of loads is when
     // they are
     //  not local is about 2.5GB/minutes. With a fixed size of 1GB, each instance should do 2.5
@@ -180,67 +166,67 @@ public class FileTest extends UsersBase {
 
   // The purpose of these tests is to ingest files using the bulk mode in various permutations
   @Test
-  public void bulkFileLoadTestTdrHostedRandomIdFile() throws Exception {
+  void bulkFileLoadTestTdrHostedRandomIdFile() throws Exception {
     bulkFileLoadTest(NUM_FILES, false, false, false);
   }
 
   @Test
-  public void bulkFileLoadTestTdrHostedRandomIdFileHandlesMaxFailedFiles() throws Exception {
+  void bulkFileLoadTestTdrHostedRandomIdFileHandlesMaxFailedFiles() throws Exception {
     bulkFileLoadTest(NUM_FILES, false, false, false, NUM_FAILED_FILES, NUM_FAILED_FILES);
   }
 
   @Test
-  public void bulkFileLoadTestTdrHostedRandomIdFileWithZeroMaxFailedFiles() throws Exception {
+  void bulkFileLoadTestTdrHostedRandomIdFileWithZeroMaxFailedFiles() throws Exception {
     bulkFileLoadTest(NUM_FILES, false, false, false, NUM_FAILED_FILES, 0);
   }
 
   @Test
-  public void bulkFileLoadTestTdrHostedRandomIdArray() throws Exception {
+  void bulkFileLoadTestTdrHostedRandomIdArray() throws Exception {
     bulkFileLoadTest(NUM_FILES, false, false, true);
   }
 
   @Test
-  public void bulkFileLoadTestTdrHostedRandomIdArrayHandlesMaxFailedFiles() throws Exception {
+  void bulkFileLoadTestTdrHostedRandomIdArrayHandlesMaxFailedFiles() throws Exception {
     bulkFileLoadTest(NUM_FILES, false, false, true, NUM_FAILED_FILES, NUM_FAILED_FILES);
   }
 
   @Test
-  public void bulkFileLoadTestTdrHostedRandomIdArrayZeroMaxFailedFiles() throws Exception {
+  void bulkFileLoadTestTdrHostedRandomIdArrayZeroMaxFailedFiles() throws Exception {
     bulkFileLoadTest(NUM_FILES, false, false, true, 1, 0);
   }
 
   @Test
-  public void bulkFileLoadTestTdrHostedPredictableIdFile() throws Exception {
+  void bulkFileLoadTestTdrHostedPredictableIdFile() throws Exception {
     bulkFileLoadTest(NUM_FILES, false, true, false);
   }
 
   @Test
-  public void bulkFileLoadTestTdrHostedPredictableIdArray() throws Exception {
+  void bulkFileLoadTestTdrHostedPredictableIdArray() throws Exception {
     bulkFileLoadTest(NUM_FILES, false, true, true);
   }
 
   @Test
-  public void bulkFileLoadTestSelfHostedRandomIdFile() throws Exception {
+  void bulkFileLoadTestSelfHostedRandomIdFile() throws Exception {
     bulkFileLoadTest(NUM_FILES, true, false, false);
   }
 
   @Test
-  public void bulkFileLoadTestSelfHostedRandomIdArray() throws Exception {
+  void bulkFileLoadTestSelfHostedRandomIdArray() throws Exception {
     bulkFileLoadTest(NUM_FILES, true, false, true);
   }
 
   @Test
-  public void bulkFileLoadTestSelfHostedPredictableIdFile() throws Exception {
+  void bulkFileLoadTestSelfHostedPredictableIdFile() throws Exception {
     bulkFileLoadTest(NUM_FILES, true, true, false);
   }
 
   @Test
-  public void bulkFileLoadTestSelfHostedPredictableIdArray() throws Exception {
+  void bulkFileLoadTestSelfHostedPredictableIdArray() throws Exception {
     bulkFileLoadTest(NUM_FILES, true, true, true);
   }
 
   @Test
-  public void bulkFileLoadTestSelfHostedPredictableIdMoveSourceFiles() throws Exception {
+  void bulkFileLoadTestSelfHostedPredictableIdMoveSourceFiles() throws Exception {
     // Run through basic ingest
     String loadTag = bulkFileLoadTest(NUM_FILES, true, true, true);
     String originalSourcePath = "gs://jade-testdata-uswestregion/fileloadprofiletest/1KBfile.txt";
@@ -591,7 +577,7 @@ public class FileTest extends UsersBase {
     // Use DRS API to lookup the file by DRS ID
     String drsObjectId = String.format("v1_%s_%s", snapshotId, fileId);
     // Should fail due to insufficient permissions
-    assertThatThrownBy(() -> dataRepoFixtures.drsGetObject(steward(), drsObjectId));
+    assertThrows(Exception.class, () -> dataRepoFixtures.drsGetObject(steward(), drsObjectId));
     DRSObject drsObject = dataRepoFixtures.drsGetObject(custodian(), drsObjectId);
 
     logger.info("Drs Object: {}", drsObject);
@@ -672,8 +658,7 @@ public class FileTest extends UsersBase {
     datasetSummaryModel = dataRepoFixtures.waitForDatasetCreate(steward(), datasetCreateJob);
     datasetId = datasetSummaryModel.getId();
     snapshotId = null;
-    fileIds = new ArrayList<>();
-    logger.info("created dataset " + datasetId);
+    logger.info("created dataset {}", datasetId);
     dataRepoFixtures.addDatasetPolicyMember(
         steward(), datasetId, IamRole.CUSTODIAN, custodian().getEmail());
   }

--- a/src/test/java/bio/terra/integration/FileTest.java
+++ b/src/test/java/bio/terra/integration/FileTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.common.TestUtils;
 import bio.terra.common.auth.AuthService;
@@ -577,7 +576,9 @@ class FileTest extends UsersBase {
     // Use DRS API to lookup the file by DRS ID
     String drsObjectId = String.format("v1_%s_%s", snapshotId, fileId);
     // Should fail due to insufficient permissions
-    assertThrows(Exception.class, () -> dataRepoFixtures.drsGetObject(steward(), drsObjectId));
+    var response = dataRepoFixtures.drsGetObjectRaw(steward(), drsObjectId);
+    assertThat(
+        "Steward is not authorized", response.getStatusCode(), equalTo(HttpStatus.FORBIDDEN));
     DRSObject drsObject = dataRepoFixtures.drsGetObject(custodian(), drsObjectId);
 
     logger.info("Drs Object: {}", drsObject);

--- a/src/test/java/bio/terra/integration/IngestSnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/IngestSnapshotIntegrationTest.java
@@ -20,23 +20,21 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class IngestSnapshotIntegrationTest extends UsersBase {
+@Tag(Integration.TAG)
+class IngestSnapshotIntegrationTest extends UsersBase {
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
 
@@ -45,7 +43,8 @@ public class IngestSnapshotIntegrationTest extends UsersBase {
   private UUID profileId;
   private final List<UUID> createdSnapshotIds = new ArrayList<>();
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
@@ -59,7 +58,7 @@ public class IngestSnapshotIntegrationTest extends UsersBase {
         steward(), datasetId, IamRole.CUSTODIAN, custodian().getEmail());
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     for (UUID snapshotId : createdSnapshotIds) {
       dataRepoFixtures.deleteSnapshotLog(custodian(), snapshotId);

--- a/src/test/java/bio/terra/integration/IngestTest.java
+++ b/src/test/java/bio/terra/integration/IngestTest.java
@@ -33,24 +33,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class IngestTest extends UsersBase {
+@Tag(Integration.TAG)
+class IngestTest extends UsersBase {
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
 
@@ -61,7 +59,8 @@ public class IngestTest extends UsersBase {
   private UUID datasetId;
   private UUID profileId;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
@@ -75,7 +74,7 @@ public class IngestTest extends UsersBase {
         steward(), datasetId, IamRole.CUSTODIAN, custodian().getEmail());
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (datasetId != null) {
       dataRepoFixtures.deleteDatasetLog(steward(), datasetId);
@@ -87,7 +86,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestAndUpdateParticipants() throws Exception {
+  void ingestAndUpdateParticipants() throws Exception {
     ingestAndUpdateParticipants(
         ingestFile -> {
           try {
@@ -99,7 +98,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestAndUpdateParticipantsViaDirectApi() throws Exception {
+  void ingestAndUpdateParticipantsViaDirectApi() throws Exception {
     ingestAndUpdateParticipants(
         ingestFile -> {
           try {
@@ -167,7 +166,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestAndUpdateParticipantsWithTransaction() throws Exception {
+  void ingestAndUpdateParticipantsWithTransaction() throws Exception {
     TransactionModel transaction =
         dataRepoFixtures.openTransaction(
             steward(), datasetId, new TransactionCreateModel().description("foo"));
@@ -188,7 +187,7 @@ public class IngestTest extends UsersBase {
 
     assertThat(
         "Error message looks reasonable",
-        badIngestResponse.getErrorObject().get().getMessage(),
+        badIngestResponse.getErrorObject().orElseThrow().getMessage(),
         startsWith(String.format("Transaction %s not found in dataset", badTransaction)));
 
     ingestRequest.transactionId(transaction.getId());
@@ -236,7 +235,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestJsonData() throws Exception {
+  void ingestJsonData() throws Exception {
     IngestRequestModel ingestRequest =
         dataRepoFixtures.buildSimpleIngest(
             "participant", "ingest-test/ingest-test-participant-with-json-data.json");
@@ -257,7 +256,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestWildcardSuffix() throws Exception {
+  void ingestWildcardSuffix() throws Exception {
     IngestRequestModel ingestRequest =
         dataRepoFixtures.buildSimpleIngest(
             "participant", "ingest-test/wildcard/ingest-test-participant*");
@@ -267,7 +266,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestWildcardMiddle() throws Exception {
+  void ingestWildcardMiddle() throws Exception {
     IngestRequestModel ingestRequest =
         dataRepoFixtures.buildSimpleIngest(
             "participant", "ingest-test/wildcard/ingest-test-p*t.json");
@@ -277,7 +276,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestAuthorizationTest() throws Exception {
+  void ingestAuthorizationTest() throws Exception {
     IngestRequestModel request =
         dataRepoFixtures.buildSimpleIngest(
             "participant", "ingest-test/ingest-test-participant.json");
@@ -293,7 +292,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestAppendNoPkTest() throws Exception {
+  void ingestAppendNoPkTest() throws Exception {
     IngestRequestModel request =
         dataRepoFixtures.buildSimpleIngest("file", "ingest-test/ingest-test-file.json");
     IngestResponseModel ingestResponse =
@@ -305,7 +304,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestBadPathTest() throws Exception {
+  void ingestBadPathTest() throws Exception {
     IngestRequestModel request =
         dataRepoFixtures.buildSimpleIngest("file", "totally-legit-file.json");
     DataRepoResponse<JobModel> ingestJobResponse =
@@ -320,7 +319,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestEmptyPatternTest() throws Exception {
+  void ingestEmptyPatternTest() throws Exception {
     IngestRequestModel request =
         dataRepoFixtures.buildSimpleIngest("file", "prefix-matching-nothing/*");
     DataRepoResponse<JobModel> ingestJobResponse =
@@ -335,7 +334,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestSingleFileMalformedTest() throws Exception {
+  void ingestSingleFileMalformedTest() throws Exception {
     IngestRequestModel request =
         dataRepoFixtures.buildSimpleIngest(
             "file", "ingest-test/ingest-test-prtcpnt-malformed.json");
@@ -351,7 +350,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestWildcardMalformedTest() throws Exception {
+  void ingestWildcardMalformedTest() throws Exception {
     IngestRequestModel request =
         dataRepoFixtures.buildSimpleIngest("file", "ingest-test/wildcard/ingest-test-p*.json");
     DataRepoResponse<JobModel> ingestJobResponse =
@@ -366,7 +365,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestMergeHappyPathTest() throws Exception {
+  void ingestMergeHappyPathTest() throws Exception {
     DatasetModel dataset =
         dataRepoFixtures.getDataset(
             steward(), datasetId, List.of(DatasetRequestAccessIncludeModel.ACCESS_INFORMATION));
@@ -426,7 +425,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestMergeNoTargetPKTest() throws Exception {
+  void ingestMergeNoTargetPKTest() throws Exception {
     IngestRequestModel mergeIngestRequest =
         dataRepoFixtures
             .buildSimpleIngest("file", "ingest-test/ingest-test-file.json")
@@ -441,12 +440,12 @@ public class IngestTest extends UsersBase {
         "ingest failed", mergeIngestResponse.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
     assertThat(
         "failure is explained",
-        mergeIngestResponse.getErrorObject().get().getMessage(),
+        mergeIngestResponse.getErrorObject().orElseThrow().getMessage(),
         equalTo("Cannot ingest to a table without a primary key defined."));
   }
 
   @Test
-  public void ingestMergeRowsMissingPKsTest() throws Exception {
+  void ingestMergeRowsMissingPKsTest() throws Exception {
     IngestRequestModel ingestRequest =
         dataRepoFixtures.buildSimpleIngest("sample", "ingest-test/ingest-test-sample.json");
     IngestResponseModel ingestResponse =
@@ -467,7 +466,7 @@ public class IngestTest extends UsersBase {
         "ingest failed", mergeIngestResponse.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
     assertThat(
         "failure is explained",
-        mergeIngestResponse.getErrorObject().get().getMessage(),
+        mergeIngestResponse.getErrorObject().orElseThrow().getMessage(),
         containsString("Ingest failed"));
     assertThat(
         "primary key specification is enforced",
@@ -476,7 +475,7 @@ public class IngestTest extends UsersBase {
   }
 
   @Test
-  public void ingestMergeRowsDuplicatePKsTest() throws Exception {
+  void ingestMergeRowsDuplicatePKsTest() throws Exception {
     IngestRequestModel ingestRequest =
         dataRepoFixtures.buildSimpleIngest("sample", "ingest-test/ingest-test-sample.json");
     IngestResponseModel ingestResponse =
@@ -497,16 +496,16 @@ public class IngestTest extends UsersBase {
         "ingest failed", mergeIngestResponse.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
     assertThat(
         "failure is explained",
-        mergeIngestResponse.getErrorObject().get().getMessage(),
+        mergeIngestResponse.getErrorObject().orElseThrow().getMessage(),
         containsString("Duplicate primary keys identified"));
     assertThat(
         "all duplicate primary keys are found in error details",
-        mergeIngestResponse.getErrorObject().get().getErrorDetail(),
+        mergeIngestResponse.getErrorObject().orElseThrow().getErrorDetail(),
         containsInAnyOrder(containsString("sample1")));
   }
 
   @Test
-  public void ingestMergeMismatchedWithTargetTest() throws Exception {
+  void ingestMergeMismatchedWithTargetTest() throws Exception {
     IngestRequestModel ingestRequest =
         dataRepoFixtures.buildSimpleIngest(
             "participant", "ingest-test/ingest-test-participant.json");
@@ -536,7 +535,7 @@ public class IngestTest extends UsersBase {
         "ingest failed", mergeIngestResponse.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
     assertThat(
         "failure is explained",
-        mergeIngestResponse.getErrorObject().get().getMessage(),
+        mergeIngestResponse.getErrorObject().orElseThrow().getMessage(),
         containsString("merge record(s) did not resolve to a single target record"));
     assertThat(
         "all primary keys without single target table matches are found in error details",

--- a/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
+++ b/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
@@ -2,6 +2,7 @@ package bio.terra.integration;
 
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.app.configuration.SamConfiguration;
+import bio.terra.common.GcsUtils;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.auth.Users;
 import bio.terra.common.configuration.TestConfiguration;
@@ -9,6 +10,7 @@ import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.service.auth.iam.sam.SamApiService;
 import bio.terra.service.auth.iam.sam.SamIam;
 import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.filedata.google.firestore.EncodeFixture;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,6 +32,8 @@ import org.springframework.context.annotation.Profile;
   SamFixtures.class,
   DataRepoFixtures.class,
   Users.class,
+  GcsUtils.class,
+  EncodeFixture.class,
   // These are required to support AuthService.makePetAccountToken()
   SamIam.class,
   SamApiService.class,

--- a/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
+++ b/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
@@ -1,0 +1,56 @@
+package bio.terra.integration;
+
+import bio.terra.app.configuration.ApplicationConfiguration;
+import bio.terra.app.configuration.SamConfiguration;
+import bio.terra.common.auth.AuthService;
+import bio.terra.common.auth.Users;
+import bio.terra.common.configuration.TestConfiguration;
+import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.service.auth.iam.sam.SamApiService;
+import bio.terra.service.auth.iam.sam.SamIam;
+import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.OpenTelemetry;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+  TestConfiguration.class,
+  AuthService.class,
+  ObjectMapper.class,
+  JsonLoader.class,
+  DataRepoClient.class,
+  SamFixtures.class,
+  DataRepoFixtures.class,
+  Users.class,
+  // These are required to support AuthService.makePetAccountToken()
+  SamIam.class,
+  SamApiService.class,
+  ConfigurationService.class,
+  SamApiService.class
+})
+@EnableConfigurationProperties({
+  SamConfiguration.class,
+  GoogleResourceConfiguration.class,
+  ApplicationConfiguration.class
+})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class IntegrationTestConfiguration {
+
+  @Bean("tdrServiceAccountEmail")
+  public String tdrServiceAccountEmail() {
+    // Provide a default value for the service account email when running a spring-context aware
+    // test to avoid having to set it in the test environment.
+    return "";
+  }
+
+  @Bean
+  public OpenTelemetry openTelemetry() {
+    return OpenTelemetry.noop();
+  }
+}

--- a/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
+++ b/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
@@ -13,6 +13,7 @@ import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.filedata.google.firestore.EncodeFixture;
 import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
+import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.OpenTelemetry;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.Profile;
   Users.class,
   GcsUtils.class,
   EncodeFixture.class,
+  GoogleResourceManagerService.class,
   // These are required to support AuthService.makePetAccountToken()
   SamIam.class,
   SamApiService.class,

--- a/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
+++ b/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
@@ -9,6 +9,7 @@ import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.service.auth.iam.sam.SamApiService;
 import bio.terra.service.auth.iam.sam.SamIam;
 import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.resourcemanagement.azure.AzureResourceConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.OpenTelemetry;
@@ -17,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
 @Import({
@@ -37,9 +39,11 @@ import org.springframework.context.annotation.Import;
 @EnableConfigurationProperties({
   SamConfiguration.class,
   GoogleResourceConfiguration.class,
-  ApplicationConfiguration.class
+  ApplicationConfiguration.class,
+  AzureResourceConfiguration.class
 })
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Profile("integrationtest")
 public class IntegrationTestConfiguration {
 
   @Bean("tdrServiceAccountEmail")

--- a/src/test/java/bio/terra/integration/SimpleScenarioFaultTests.java
+++ b/src/test/java/bio/terra/integration/SimpleScenarioFaultTests.java
@@ -17,28 +17,27 @@ import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import java.util.List;
 import java.util.UUID;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 // This test provides a method that performs a simple scenario of creating a dataset, ingesting some
-// rows,
-// making a snapshot, and then deleting everything.
+// rows, making a snapshot, and then deleting everything.
 //
 // The tests that drive that method can configure faults to test underlying mechanisms.
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@Category(Integration.class)
-public class SimpleScenarioFaultTests extends UsersBase {
+@Tag(Integration.TAG)
+class SimpleScenarioFaultTests extends UsersBase {
   private final Logger logger = LoggerFactory.getLogger(SimpleScenarioFaultTests.class);
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
@@ -47,7 +46,8 @@ public class SimpleScenarioFaultTests extends UsersBase {
   private UUID datasetId;
   private UUID snapshotId;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
@@ -57,7 +57,7 @@ public class SimpleScenarioFaultTests extends UsersBase {
 
   // This is belts and suspenders, since we try to do these deletes in the scenario.
   // However, since we are testing faults, there might be failures...
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     // Don't interrupt cleanup with the fault
     dataRepoFixtures.setFault(steward(), "SAM_TIMEOUT_FAULT", false);
@@ -75,7 +75,7 @@ public class SimpleScenarioFaultTests extends UsersBase {
   }
 
   @Test
-  public void testSamTimeout() throws Exception {
+  void testSamTimeout() throws Exception {
     ConfigGroupModel configGroup = buildConfigGroup(ConfigFaultCountedModel.RateStyleEnum.FIXED);
     List<ConfigModel> configList =
         dataRepoFixtures.setConfigList(steward(), configGroup).getItems();
@@ -138,11 +138,9 @@ public class SimpleScenarioFaultTests extends UsersBase {
   }
 
   private void printConfigList(String label, List<ConfigModel> configModelList) {
-    int index = 0;
-    logger.info("Config model list - " + label);
+    logger.info("Config model list - {}", label);
     for (ConfigModel configModel : configModelList) {
-      logger.info("Config model [" + index + "]: " + configModel);
-      index++;
+      logger.info("Config model [{}]: ", configModel);
     }
   }
 

--- a/src/test/java/bio/terra/integration/SimpleScenarioFaultTests.java
+++ b/src/test/java/bio/terra/integration/SimpleScenarioFaultTests.java
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -36,9 +35,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 //
 // The tests that drive that method can configure faults to test underlying mechanisms.
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
 @Category(Integration.class)
 public class SimpleScenarioFaultTests extends UsersBase {
   private final Logger logger = LoggerFactory.getLogger(SimpleScenarioFaultTests.class);

--- a/src/test/java/bio/terra/integration/UsersBase.java
+++ b/src/test/java/bio/terra/integration/UsersBase.java
@@ -1,6 +1,5 @@
 package bio.terra.integration;
 
-import bio.terra.common.auth.AuthService;
 import bio.terra.common.auth.Users;
 import bio.terra.common.configuration.TestConfiguration;
 import org.slf4j.Logger;
@@ -15,8 +14,6 @@ public class UsersBase {
   private static final String DISCOVERER_ROLE = "discoverer";
 
   @Autowired private Users users;
-
-  @Autowired private AuthService authService;
 
   private static Logger logger = LoggerFactory.getLogger(UsersBase.class);
   private TestConfiguration.User admin;

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
@@ -105,7 +105,8 @@ class SamRetryIntegrationTest extends UsersBase {
           firstSyncPolicy.getName(),
           (i + 1),
           firstSyncPolicyList.size());
-      assertEquals(firstSyncPolicy, secondSyncPolicy, "Policy should not have changed after second sync");
+      assertEquals(
+          firstSyncPolicy, secondSyncPolicy, "Policy should not have changed after second sync");
     }
   }
 

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
@@ -1,13 +1,13 @@
 package bio.terra.service.auth.iam.sam;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.app.configuration.SamConfiguration;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
@@ -20,32 +20,29 @@ import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.model.SyncReportEntry;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@Category(Integration.class)
-public class SamRetryIntegrationTest extends UsersBase {
+@Tag(Integration.TAG)
+class SamRetryIntegrationTest extends UsersBase {
   private static final Logger logger = LoggerFactory.getLogger(SamRetryIntegrationTest.class);
   @Autowired private AuthService authService;
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private IamProviderInterface iam;
   @Autowired private SamConfiguration samConfig;
 
-  private String stewardToken;
   private UUID fakeDatasetId;
   private AuthenticatedUserRequest userRequest;
   private GoogleApi samGoogleApi;
@@ -57,10 +54,11 @@ public class SamRetryIntegrationTest extends UsersBase {
     return apiClient.setBasePath(samConfig.basePath());
   }
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
-    stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
+    String stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
     dataRepoFixtures.resetConfig(steward());
     userRequest =
         AuthenticatedUserRequest.builder()
@@ -72,7 +70,7 @@ public class SamRetryIntegrationTest extends UsersBase {
     samGoogleApi = new GoogleApi(getApiClient(stewardToken));
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     dataRepoFixtures.resetConfig(steward());
 
@@ -80,36 +78,34 @@ public class SamRetryIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void retrySyncDatasetPolicies() throws InterruptedException, ApiException {
+  void retrySyncDatasetPolicies() throws InterruptedException, ApiException {
     iam.createDatasetResource(userRequest, fakeDatasetId, null);
 
     // Should be able to re-run syncDatasetResourcePolicies without an error being thrown
     // Otherwise, need to break up each "SamIam.syncOnePolicy" into own retry loop
     String policyEmail = SyncPolicy(IamResourceType.DATASET, fakeDatasetId, IamRole.STEWARD);
     logger.info("[TEST INFO] Policy email on first sync: {}", policyEmail);
-    List<SamPolicyModel> firstSync_policyList =
+    List<SamPolicyModel> firstSyncPolicyList =
         iam.retrievePolicies(userRequest, IamResourceType.DATASET, fakeDatasetId);
 
-    String second_policyEmail = SyncPolicy(IamResourceType.DATASET, fakeDatasetId, IamRole.STEWARD);
+    String secondPolicyEmail = SyncPolicy(IamResourceType.DATASET, fakeDatasetId, IamRole.STEWARD);
     logger.info("[TEST INFO] Policy email on second sync: {}", policyEmail);
-    List<SamPolicyModel> secondSync_policyList =
+    List<SamPolicyModel> secondSyncPolicyList =
         iam.retrievePolicies(userRequest, IamResourceType.DATASET, fakeDatasetId);
 
-    assertEquals("Policy Emails should be the same", policyEmail, second_policyEmail);
+    assertEquals("Policy Emails should be the same", policyEmail, secondPolicyEmail);
 
     // Let's make sure the policy model didn't change between the first and second sync
-    for (int i = 0; i < firstSync_policyList.size(); i++) {
-      SamPolicyModel firstSync_policy = firstSync_policyList.get(i);
-      SamPolicyModel secondSync_policy = secondSync_policyList.get(i);
+    for (int i = 0; i < firstSyncPolicyList.size(); i++) {
+      SamPolicyModel firstSyncPolicy = firstSyncPolicyList.get(i);
+      SamPolicyModel secondSyncPolicy = secondSyncPolicyList.get(i);
 
       logger.info(
           "[TEST INFO] Checking Role {} - {} of {} SAM policies synced",
-          firstSync_policy.getName(),
+          firstSyncPolicy.getName(),
           (i + 1),
-          firstSync_policyList.size());
-      assertTrue(
-          "Policy should not have changed after second sync",
-          firstSync_policy.equals(secondSync_policy));
+          firstSyncPolicyList.size());
+      assertEquals(firstSyncPolicy, secondSyncPolicy, "Policy should not have changed after second sync");
     }
   }
 

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamRetryIntegrationTest.java
@@ -93,7 +93,7 @@ class SamRetryIntegrationTest extends UsersBase {
     List<SamPolicyModel> secondSyncPolicyList =
         iam.retrievePolicies(userRequest, IamResourceType.DATASET, fakeDatasetId);
 
-    assertEquals("Policy Emails should be the same", policyEmail, secondPolicyEmail);
+    assertEquals(policyEmail, secondPolicyEmail, "Policy Emails should be the same");
 
     // Let's make sure the policy model didn't change between the first and second sync
     for (int i = 0; i < firstSyncPolicyList.size(); i++) {

--- a/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetControlFilesIntegrationTest.java
@@ -7,13 +7,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.DataRepoResponse;
-import bio.terra.integration.SamFixtures;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DataDeletionTableModel;
@@ -22,50 +21,45 @@ import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestResponseModel;
-import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 // TODO move me to integration dir
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class DatasetControlFilesIntegrationTest extends UsersBase {
+@Tag(Integration.TAG)
+class DatasetControlFilesIntegrationTest extends UsersBase {
 
-  @Autowired private AuthService authService;
   @Autowired private DataRepoFixtures dataRepoFixtures;
-  @Autowired private SamFixtures samFixtures;
   @Autowired private JsonLoader jsonLoader;
   @Autowired private TestConfiguration testConfiguration;
-  @Autowired private GoogleResourceManagerService resourceManagerService;
 
   private UUID datasetId;
   private UUID profileId;
   private String ingestBucket;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     dataRepoFixtures.resetConfig(steward());
     profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     dataRepoFixtures.resetConfig(steward());
 
@@ -79,7 +73,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testCombinedMetadataDataIngest() throws Exception {
+  void testCombinedMetadataDataIngest() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "dataset-ingest-combined-array.json");
     datasetId = datasetSummaryModel.getId();
@@ -158,7 +152,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testMaxBadRecords() throws Exception {
+  void testMaxBadRecords() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "dataset-ingest-combined-array.json");
     datasetId = datasetSummaryModel.getId();
@@ -200,7 +194,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testSourcePathAuth() throws Exception {
+  void testSourcePathAuth() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "dataset-ingest-combined-array.json");
     datasetId = datasetSummaryModel.getId();
@@ -232,7 +226,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testDirectIngestSourcePathAuth() throws Exception {
+  void testDirectIngestSourcePathAuth() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "dataset-ingest-combined-array.json");
     datasetId = datasetSummaryModel.getId();
@@ -256,7 +250,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testCopyingOfControlFiles() throws Exception {
+  void testCopyingOfControlFiles() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "dataset-ingest-combined-array.json");
     datasetId = datasetSummaryModel.getId();
@@ -292,7 +286,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testCopyingOfControlFilesMultiRegion() throws Exception {
+  void testCopyingOfControlFilesMultiRegion() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(
             steward(), profileId, "dataset-ingest-combined-array-us.json");
@@ -329,7 +323,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testInvalidControlFile() throws Exception {
+  void testInvalidControlFile() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(
             steward(), profileId, "dataset-ingest-combined-array-us.json");
@@ -356,7 +350,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void interactionsFromRequesterPaysBucket() throws Exception {
+  void interactionsFromRequesterPaysBucket() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "dataset-ingest-combined-array.json");
     datasetId = datasetSummaryModel.getId();
@@ -404,7 +398,7 @@ public class DatasetControlFilesIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void interactionsWithPerDatasetServiceAccount() throws Exception {
+  void interactionsWithPerDatasetServiceAccount() throws Exception {
     ingestBucket = "jade_testbucket_no_jade_sa";
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDatasetWithOwnServiceAccount(

--- a/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetIntegrationTest.java
@@ -11,16 +11,15 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertTrue;
 
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.TestUtils;
-import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.DataRepoResponse;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.AssetModel;
 import bio.terra.model.CloudPlatform;
@@ -39,7 +38,6 @@ import bio.terra.model.PolicyModel;
 import bio.terra.model.StorageResourceModel;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.configuration.ConfigEnum;
-import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
@@ -50,56 +48,52 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 // TODO move me to integration dir
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class DatasetIntegrationTest extends UsersBase {
-  private static final String omopDatasetName = "it_dataset_omop";
-  private static final String omopDatasetDesc =
+@Tag(Integration.TAG)
+class DatasetIntegrationTest extends UsersBase {
+  private static final String OMOP_DATASET_NAME = "it_dataset_omop";
+  private static final String OMOP_DATASET_DESC =
       "OMOP schema based on BigQuery schema from https://github.com/OHDSI/CommonDataModel/wiki with extra columns suffixed with _custom";
-  private static final String omopDatasetRegion = GoogleRegion.US_CENTRAL1.toString();
-  private static Logger logger = LoggerFactory.getLogger(DatasetIntegrationTest.class);
+  private static final String OMOP_DATASET_REGION = GoogleRegion.US_CENTRAL1.toString();
+  private static final Logger logger = LoggerFactory.getLogger(DatasetIntegrationTest.class);
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
-  @Autowired private AuthService authService;
   @Autowired private JsonLoader jsonLoader;
-  @Autowired private GoogleResourceManagerService resourceManagerService;
 
-  private String stewardToken;
   private UUID datasetId;
   private UUID profileId;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
-    stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
     dataRepoFixtures.resetConfig(steward());
     profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
     datasetId = null;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     dataRepoFixtures.resetConfig(steward());
 
@@ -113,22 +107,22 @@ public class DatasetIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void datasetHappyPath() throws Exception {
+  void datasetHappyPath() throws Exception {
     DatasetSummaryModel summaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "omop/it-dataset-omop.json");
     datasetId = summaryModel.getId();
 
-    logger.info("dataset id is " + summaryModel.getId());
-    assertThat(summaryModel.getName(), startsWith(omopDatasetName));
-    assertThat(summaryModel.getDescription(), equalTo(omopDatasetDesc));
+    logger.info("dataset id is {}", summaryModel.getId());
+    assertThat(summaryModel.getName(), startsWith(OMOP_DATASET_NAME));
+    assertThat(summaryModel.getDescription(), equalTo(OMOP_DATASET_DESC));
 
     List<String> stewardRoles = dataRepoFixtures.retrieveUserDatasetRoles(steward(), datasetId);
     assertThat("The Steward was given steward access", stewardRoles, hasItem("steward"));
 
     DatasetModel datasetModel = dataRepoFixtures.getDataset(steward(), summaryModel.getId());
 
-    assertThat(datasetModel.getName(), startsWith(omopDatasetName));
-    assertThat(datasetModel.getDescription(), equalTo(omopDatasetDesc));
+    assertThat(datasetModel.getName(), startsWith(OMOP_DATASET_NAME));
+    assertThat(datasetModel.getDescription(), equalTo(OMOP_DATASET_DESC));
 
     // There is a delay from when a resource is created in SAM to when it is available in an
     // enumerate call.
@@ -143,33 +137,28 @@ public class DatasetIntegrationTest extends UsersBase {
               boolean found = false;
               for (DatasetSummaryModel oneDataset : enumerateDatasetModel.getItems()) {
                 if (oneDataset.getId().equals(datasetModel.getId())) {
-                  assertThat(oneDataset.getName(), startsWith(omopDatasetName));
-                  assertThat(oneDataset.getDescription(), equalTo(omopDatasetDesc));
+                  assertThat(oneDataset.getName(), startsWith(OMOP_DATASET_NAME));
+                  assertThat(oneDataset.getDescription(), equalTo(OMOP_DATASET_DESC));
                   Map<String, StorageResourceModel> storageMap =
                       datasetModel.getStorage().stream()
                           .collect(
                               Collectors.toMap(
                                   StorageResourceModel::getCloudResource, Function.identity()));
 
-                  GoogleRegion omopDatasetGoogleRegion = GoogleRegion.fromValue(omopDatasetRegion);
-                  assert omopDatasetGoogleRegion != null;
+                  GoogleRegion omopDatasetGoogleRegion =
+                      Objects.requireNonNull(GoogleRegion.fromValue(OMOP_DATASET_REGION));
                   for (GoogleCloudResource cloudResource : GoogleCloudResource.values()) {
                     StorageResourceModel storage = storageMap.get(cloudResource.toString());
                     GoogleCloudResource resource =
-                        GoogleCloudResource.fromValue(storage.getCloudResource());
-                    assert resource != null;
-                    GoogleRegion expectedRegion;
-                    switch (resource) {
-                      case BUCKET:
-                        expectedRegion = omopDatasetGoogleRegion.getRegionOrFallbackBucketRegion();
-                        break;
-                      case FIRESTORE:
-                        expectedRegion =
-                            omopDatasetGoogleRegion.getRegionOrFallbackFirestoreRegion();
-                        break;
-                      default:
-                        expectedRegion = omopDatasetGoogleRegion;
-                    }
+                        Objects.requireNonNull(
+                            GoogleCloudResource.fromValue(storage.getCloudResource()));
+                    GoogleRegion expectedRegion =
+                        switch (resource) {
+                          case BUCKET -> omopDatasetGoogleRegion.getRegionOrFallbackBucketRegion();
+                          case FIRESTORE ->
+                              omopDatasetGoogleRegion.getRegionOrFallbackFirestoreRegion();
+                          case BIGQUERY -> omopDatasetGoogleRegion;
+                        };
 
                     assertThat(
                         String.format("dataset %s region is set", storage.getCloudResource()),
@@ -194,7 +183,7 @@ public class DatasetIntegrationTest extends UsersBase {
               return found;
             });
 
-    assertTrue("dataset was found in enumeration", metExpectation);
+    assertThat("dataset was found in enumeration", metExpectation);
 
     // Check permissions on lookupDatasetDataById
     dataRepoFixtures.retrieveDatasetData(
@@ -257,26 +246,26 @@ public class DatasetIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void datasetHappyPathWithPet() throws Exception {
+  void datasetHappyPathWithPet() throws Exception {
     DatasetSummaryModel summaryModel =
         dataRepoFixtures.createDataset(
             steward(), profileId, "omop/it-dataset-omop.json", CloudPlatform.GCP, true, null);
     datasetId = summaryModel.getId();
 
-    logger.info("dataset id is " + summaryModel.getId());
-    assertThat(summaryModel.getName(), startsWith(omopDatasetName));
-    assertThat(summaryModel.getDescription(), equalTo(omopDatasetDesc));
+    logger.info("dataset id is {}", summaryModel.getId());
+    assertThat(summaryModel.getName(), startsWith(OMOP_DATASET_NAME));
+    assertThat(summaryModel.getDescription(), equalTo(OMOP_DATASET_DESC));
 
     // We just need to validate the steward is able to read back the dataset (e.g. the pet account
     // resolved correctly)
     DatasetModel datasetModel = dataRepoFixtures.getDataset(steward(), summaryModel.getId());
 
-    assertThat(datasetModel.getName(), startsWith(omopDatasetName));
-    assertThat(datasetModel.getDescription(), equalTo(omopDatasetDesc));
+    assertThat(datasetModel.getName(), startsWith(OMOP_DATASET_NAME));
+    assertThat(datasetModel.getDescription(), equalTo(OMOP_DATASET_DESC));
   }
 
   @Test
-  public void datasetUnauthorizedPermissionsTest() throws Exception {
+  void datasetUnauthorizedPermissionsTest() throws Exception {
     // These should fail because they don't have access to the billing profile
     dataRepoFixtures.createDatasetError(
         custodian(), profileId, "dataset-minimal.json", HttpStatus.FORBIDDEN);
@@ -295,13 +284,12 @@ public class DatasetIntegrationTest extends UsersBase {
     }
     assertThat("Reader does not have access to datasets", enumDatasetsResp.getTotal(), equalTo(0));
 
-    DatasetSummaryModel summaryModel = null;
-
-    summaryModel = dataRepoFixtures.createDataset(steward(), profileId, "dataset-minimal.json");
+    DatasetSummaryModel summaryModel =
+        dataRepoFixtures.createDataset(steward(), profileId, "dataset-minimal.json");
     datasetId = summaryModel.getId();
 
     DataRepoResponse<DatasetModel> getDatasetResp =
-        dataRepoFixtures.getDatasetRaw(reader(), summaryModel.getId());
+        dataRepoFixtures.getDatasetRaw(reader(), datasetId);
     assertThat(
         "Reader is not authorized to get dataset",
         getDatasetResp.getStatusCode(),
@@ -309,7 +297,7 @@ public class DatasetIntegrationTest extends UsersBase {
 
     // make sure reader cannot delete dataset
     DataRepoResponse<JobModel> deleteResp1 =
-        dataRepoFixtures.deleteDatasetLaunch(reader(), summaryModel.getId());
+        dataRepoFixtures.deleteDatasetLaunch(reader(), datasetId);
     assertThat(
         "Reader is not authorized to delete datasets",
         deleteResp1.getStatusCode(),
@@ -355,7 +343,7 @@ public class DatasetIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testAssetCreationUndo() throws Exception {
+  void testAssetCreationUndo() throws Exception {
     // create a dataset
     DatasetSummaryModel summaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "omop/it-dataset-omop.json");
@@ -396,7 +384,7 @@ public class DatasetIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testCreateDatasetWithPolicies() throws Exception {
+  void testCreateDatasetWithPolicies() throws Exception {
     List<String> stewards = List.of(steward().getEmail(), admin().getEmail());
     String custodianEmail = custodian().getEmail();
     List<String> custodiansWithDuplicates = List.of(custodianEmail, custodianEmail);

--- a/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetSchemaUpdateIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import bio.terra.common.category.Integration;
 import bio.terra.common.fixtures.DatasetFixtures;
 import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.ColumnModel;
 import bio.terra.model.DatasetModel;
@@ -17,39 +18,39 @@ import bio.terra.model.TableModel;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 // TODO move me to integration dir
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class DatasetSchemaUpdateIntegrationTest extends UsersBase {
+@Tag(Integration.TAG)
+class DatasetSchemaUpdateIntegrationTest extends UsersBase {
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
   private UUID profileId;
   private UUID datasetId;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     dataRepoFixtures.resetConfig(steward());
     profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
-    datasetId = null;
+    DatasetSummaryModel datasetSummaryModel =
+        dataRepoFixtures.createDataset(steward(), profileId, "snapshot-test-dataset.json");
+    datasetId = datasetSummaryModel.getId();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     dataRepoFixtures.resetConfig(steward());
     if (datasetId != null) {
@@ -62,11 +63,7 @@ public class DatasetSchemaUpdateIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testDatasetAddNewTableSuccess() throws Exception {
-    DatasetSummaryModel datasetSummaryModel =
-        dataRepoFixtures.createDataset(steward(), profileId, "snapshot-test-dataset.json");
-    datasetId = datasetSummaryModel.getId();
-
+  void testDatasetAddNewTableSuccess() throws Exception {
     String newTableName = "new_table";
     String newTableColumnName = "new_table_column";
 
@@ -94,11 +91,7 @@ public class DatasetSchemaUpdateIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testDatasetAddNewColumnSuccess() throws Exception {
-    DatasetSummaryModel datasetSummaryModel =
-        dataRepoFixtures.createDataset(steward(), profileId, "snapshot-test-dataset.json");
-    datasetId = datasetSummaryModel.getId();
-
+  void testDatasetAddNewColumnSuccess() throws Exception {
     String existingTableName = "thetable";
     String existingTableColumnA = "added_column_a";
     String existingTableColumnB = "added_column_b";
@@ -123,17 +116,13 @@ public class DatasetSchemaUpdateIntegrationTest extends UsersBase {
     boolean addedColumns =
         existingTable.get().getColumns().stream()
             .map(ColumnModel::getName)
-            .collect(Collectors.toList())
+            .toList()
             .containsAll(List.of(existingTableColumnA, existingTableColumnB));
     assertThat("The existing table includes the new columns in the update response", addedColumns);
   }
 
   @Test
-  public void testDatasetAddColumnToNewTableSuccess() throws Exception {
-    DatasetSummaryModel datasetSummaryModel =
-        dataRepoFixtures.createDataset(steward(), profileId, "snapshot-test-dataset.json");
-    datasetId = datasetSummaryModel.getId();
-
+  void testDatasetAddColumnToNewTableSuccess() throws Exception {
     String newTableName = "added_table";
     String newTableColumnName = "added_table_column";
     String anotherNewColumnName = "another_added_table_column";
@@ -159,16 +148,13 @@ public class DatasetSchemaUpdateIntegrationTest extends UsersBase {
     boolean columns =
         newTable.get().getColumns().stream()
             .map(ColumnModel::getName)
-            .collect(Collectors.toList())
+            .toList()
             .containsAll(List.of(newTableColumnName, anotherNewColumnName));
     assertThat("The new table includes the new columns in the update response", columns);
   }
 
   @Test
-  public void testDatasetAddNewRelationshipSuccess() throws Exception {
-    DatasetSummaryModel datasetSummaryModel =
-        dataRepoFixtures.createDataset(steward(), profileId, "snapshot-test-dataset.json");
-    datasetId = datasetSummaryModel.getId();
+  void testDatasetAddNewRelationshipSuccess() throws Exception {
     String relationshipName = "testRelationship";
     RelationshipModel relationshipModel =
         new RelationshipModel()

--- a/src/test/java/bio/terra/service/dataset/DatasetSoftDeletesTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetSoftDeletesTest.java
@@ -3,11 +3,11 @@ package bio.terra.service.dataset;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.configuration.TestConfiguration;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.DataDeletionRequest;
 import bio.terra.model.DataDeletionTableModel;
@@ -23,45 +23,42 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 // TODO move me to integration dir
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class DatasetSoftDeletesTest extends UsersBase {
+@Tag(Integration.TAG)
+class DatasetSoftDeletesTest extends UsersBase {
 
   @Autowired private JsonLoader jsonLoader;
   @Autowired private DataRepoFixtures dataRepoFixtures;
-  @Autowired private AuthService authService;
   @Autowired private TestConfiguration testConfiguration;
 
   private UUID datasetId;
   private UUID profileId;
   private List<UUID> snapshotIds;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     dataRepoFixtures.resetConfig(steward());
     profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
-    datasetId = null;
     snapshotIds = new LinkedList<>();
+    ingestDataset();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     dataRepoFixtures.resetConfig(steward());
     for (UUID snapshotId : snapshotIds) {
@@ -78,9 +75,7 @@ public class DatasetSoftDeletesTest extends UsersBase {
   }
 
   @Test
-  public void testSoftDeleteHappyPath() throws Exception {
-    datasetId = ingestedDataset();
-
+  void testSoftDeleteHappyPath() throws Exception {
     // get row ids
     DatasetModel dataset = dataRepoFixtures.getDataset(steward(), datasetId);
     List<String> participantRowIds =
@@ -112,19 +107,17 @@ public class DatasetSoftDeletesTest extends UsersBase {
   }
 
   @Test
-  public void testSoftDeleteJsonArrayHappyPath() throws Exception {
-    datasetId = ingestedDataset();
-
+  void testSoftDeleteJsonArrayHappyPath() throws Exception {
     // get row ids
     DatasetModel dataset = dataRepoFixtures.getDataset(steward(), datasetId);
     List<UUID> participantRowIds =
         dataRepoFixtures.getRowIds(steward(), dataset, "participant", 3).stream()
             .map(UUID::fromString)
-            .collect(Collectors.toList());
+            .toList();
     List<UUID> sampleRowIds =
         dataRepoFixtures.getRowIds(steward(), dataset, "sample", 2).stream()
             .map(UUID::fromString)
-            .collect(Collectors.toList());
+            .toList();
 
     // build the deletion request with pointers to the two files with row ids to soft delete
     List<DataDeletionTableModel> dataDeletionTableModels =
@@ -145,8 +138,7 @@ public class DatasetSoftDeletesTest extends UsersBase {
   }
 
   @Test
-  public void wildcardSoftDelete() throws Exception {
-    datasetId = ingestedDataset();
+  void wildcardSoftDelete() throws Exception {
     String pathPrefix = "softDelWildcard" + UUID.randomUUID();
 
     // get 5 row ids, we'll write them out to 5 separate files
@@ -174,9 +166,7 @@ public class DatasetSoftDeletesTest extends UsersBase {
   }
 
   @Test
-  public void testSoftDeleteNotInFullView() throws Exception {
-    datasetId = ingestedDataset();
-
+  void testSoftDeleteNotInFullView() throws Exception {
     // get row ids
     DatasetModel dataset = dataRepoFixtures.getDataset(steward(), datasetId);
     List<String> participantRowIds =
@@ -242,10 +232,10 @@ public class DatasetSoftDeletesTest extends UsersBase {
     dataRepoFixtures.assertSnapshotTableCount(steward(), snapshotLess, "sample", 5);
   }
 
-  private UUID ingestedDataset() throws Exception {
+  private void ingestDataset() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "ingest-test-dataset.json");
-    UUID datasetId = datasetSummaryModel.getId();
+    datasetId = datasetSummaryModel.getId();
     IngestRequestModel ingestRequest =
         dataRepoFixtures.buildSimpleIngest(
             "participant", "ingest-test/ingest-test-participant.json");
@@ -257,6 +247,5 @@ public class DatasetSoftDeletesTest extends UsersBase {
         dataRepoFixtures.buildSimpleIngest("sample", "ingest-test/ingest-test-sample.json");
     ingestResponse = dataRepoFixtures.ingestJsonData(steward(), datasetId, ingestRequest);
     assertThat("correct sample row count", ingestResponse.getRowCount(), equalTo(7L));
-    return datasetId;
   }
 }

--- a/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
@@ -118,20 +118,23 @@ class SecureMonitoringIntegrationTest extends UsersBase {
         snapshot.getSource().get(0).getDataset().isSecureMonitoringEnabled());
 
     SnapshotSummaryModel enumeratedModel =
-        dataRepoFixtures.enumerateSnapshots(steward())
-            .getItems().stream()
+        dataRepoFixtures.enumerateSnapshots(steward()).getItems().stream()
             .filter(s -> s.getId().equals(snapshotId))
-            .findFirst().orElseThrow();
+            .findFirst()
+            .orElseThrow();
 
     assertThat(
         "Enumerated snapshot model has secure monitoring flag",
         enumeratedModel.isSecureMonitoringEnabled());
 
     SnapshotSummaryModel enumeratedByDatasetModel =
-        dataRepoFixtures.enumerateSnapshotsByDatasetIds(steward(), List.of(datasetId))
-            .getItems().stream()
+        dataRepoFixtures
+            .enumerateSnapshotsByDatasetIds(steward(), List.of(datasetId))
+            .getItems()
+            .stream()
             .filter(s -> s.getId().equals(snapshotId))
-            .findFirst().orElseThrow();
+            .findFirst()
+            .orElseThrow();
 
     assertThat(
         "Enumerated by dataset id snapshot model has secure monitoring flag",
@@ -146,14 +149,13 @@ class SecureMonitoringIntegrationTest extends UsersBase {
         equalTo(googleResourceConfiguration.secureFolderResourceId()));
   }
 
-  private DatasetSummaryModel datasetWithSecureMonitoring()
-      throws Exception {
+  private DatasetSummaryModel datasetWithSecureMonitoring() throws Exception {
     DatasetRequestModel requestModel =
         jsonLoader.loadObject("ingest-test-dataset.json", DatasetRequestModel.class);
     requestModel.setDefaultProfileId(profileId);
     requestModel.setName(Names.randomizeName(requestModel.getName()));
     requestModel.setCloudPlatform(CloudPlatform.GCP);
-      requestModel.setEnableSecureMonitoring(true);
+    requestModel.setEnableSecureMonitoring(true);
     requestModel.dedicatedIngestServiceAccount(false);
     DatasetSummaryModel summaryModel =
         dataRepoFixtures.createDataset(steward(), requestModel, false);

--- a/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
@@ -2,13 +2,12 @@ package bio.terra.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
-import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.Names;
 import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.CloudPlatform;
 import bio.terra.model.DatasetModel;
@@ -23,34 +22,26 @@ import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.api.services.cloudresourcemanager.model.ResourceId;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 // TODO move me to integration dir
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class SecureMonitoringIntegrationTest extends UsersBase {
-
-  private static Logger logger = LoggerFactory.getLogger(SecureMonitoringIntegrationTest.class);
+@Tag(Integration.TAG)
+class SecureMonitoringIntegrationTest extends UsersBase {
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
-  @Autowired private AuthService authService;
   @Autowired private JsonLoader jsonLoader;
   @Autowired private GoogleResourceManagerService resourceManagerService;
   @Autowired private GoogleResourceConfiguration googleResourceConfiguration;
@@ -59,7 +50,8 @@ public class SecureMonitoringIntegrationTest extends UsersBase {
   private UUID snapshotId;
   private UUID profileId;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     dataRepoFixtures.resetConfig(steward());
@@ -67,7 +59,7 @@ public class SecureMonitoringIntegrationTest extends UsersBase {
     datasetId = null;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     dataRepoFixtures.resetConfig(steward());
 
@@ -85,19 +77,17 @@ public class SecureMonitoringIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testDatasetWithSecureMonitoring() throws Exception {
-    DatasetSummaryModel summary = datasetWithSecureMonitoring(true);
+  void testDatasetWithSecureMonitoring() throws Exception {
+    DatasetSummaryModel summary = datasetWithSecureMonitoring();
     DatasetModel dataset = dataRepoFixtures.getDataset(steward(), summary.getId());
 
     assertThat(
         "Secure monitoring enabled on the dataset summary model",
-        summary.isSecureMonitoringEnabled(),
-        is(true));
+        summary.isSecureMonitoringEnabled());
 
     assertThat(
         "Secure monitoring flag was propagated to the dataset model",
-        dataset.isSecureMonitoringEnabled(),
-        is(true));
+        dataset.isSecureMonitoringEnabled());
 
     var datasetGoogleDataProject = dataset.getDataProject();
     Project datasetProject = resourceManagerService.getProject(datasetGoogleDataProject);
@@ -119,38 +109,33 @@ public class SecureMonitoringIntegrationTest extends UsersBase {
 
     assertThat(
         "Snapshot summary denotes secure monitoring enabled",
-        snapshotSummary.isSecureMonitoringEnabled(),
-        is(true));
+        snapshotSummary.isSecureMonitoringEnabled());
 
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotId, List.of());
 
     assertThat(
         "Snapshot model denotes secure monitoring enabled",
-        snapshot.getSource().get(0).getDataset().isSecureMonitoringEnabled(),
-        is(true));
+        snapshot.getSource().get(0).getDataset().isSecureMonitoringEnabled());
 
-    Optional<SnapshotSummaryModel> enumeratedModel =
-        dataRepoFixtures.enumerateSnapshots(steward()).getItems().stream()
+    SnapshotSummaryModel enumeratedModel =
+        dataRepoFixtures.enumerateSnapshots(steward())
+            .getItems().stream()
             .filter(s -> s.getId().equals(snapshotId))
-            .findFirst();
+            .findFirst().orElseThrow();
 
     assertThat(
         "Enumerated snapshot model has secure monitoring flag",
-        enumeratedModel.get().isSecureMonitoringEnabled(),
-        is(true));
+        enumeratedModel.isSecureMonitoringEnabled());
 
-    Optional<SnapshotSummaryModel> enumeratedByDatasetModel =
-        dataRepoFixtures
-            .enumerateSnapshotsByDatasetIds(steward(), List.of(datasetId))
-            .getItems()
-            .stream()
+    SnapshotSummaryModel enumeratedByDatasetModel =
+        dataRepoFixtures.enumerateSnapshotsByDatasetIds(steward(), List.of(datasetId))
+            .getItems().stream()
             .filter(s -> s.getId().equals(snapshotId))
-            .findFirst();
+            .findFirst().orElseThrow();
 
     assertThat(
         "Enumerated by dataset id snapshot model has secure monitoring flag",
-        enumeratedByDatasetModel.get().isSecureMonitoringEnabled(),
-        is(true));
+        enumeratedByDatasetModel.isSecureMonitoringEnabled());
 
     var snapshotGoogleProject = snapshot.getDataProject();
     Project snapshotProject = resourceManagerService.getProject(snapshotGoogleProject);
@@ -161,14 +146,14 @@ public class SecureMonitoringIntegrationTest extends UsersBase {
         equalTo(googleResourceConfiguration.secureFolderResourceId()));
   }
 
-  private DatasetSummaryModel datasetWithSecureMonitoring(boolean secureMonitoringEnabled)
+  private DatasetSummaryModel datasetWithSecureMonitoring()
       throws Exception {
     DatasetRequestModel requestModel =
         jsonLoader.loadObject("ingest-test-dataset.json", DatasetRequestModel.class);
     requestModel.setDefaultProfileId(profileId);
     requestModel.setName(Names.randomizeName(requestModel.getName()));
     requestModel.setCloudPlatform(CloudPlatform.GCP);
-    requestModel.setEnableSecureMonitoring(secureMonitoringEnabled);
+      requestModel.setEnableSecureMonitoring(true);
     requestModel.dedicatedIngestServiceAccount(false);
     DatasetSummaryModel summaryModel =
         dataRepoFixtures.createDataset(steward(), requestModel, false);

--- a/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
@@ -16,7 +16,7 @@ import bio.terra.common.category.Integration;
 import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.DataRepoResponse;
-import bio.terra.integration.SamFixtures;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadArrayResultModel;
@@ -37,7 +37,6 @@ import bio.terra.model.JobModel;
 import bio.terra.model.SnapshotExportResponseModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.common.gcs.GcsUriUtils;
-import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -48,48 +47,40 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 // TODO move me to integration dir
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class SelfHostedDatasetIntegrationTest extends UsersBase {
-  private static Logger logger = LoggerFactory.getLogger(SelfHostedDatasetIntegrationTest.class);
-
+@Tag(Integration.TAG)
+class SelfHostedDatasetIntegrationTest extends UsersBase {
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private DataRepoClient dataRepoClient;
   @Autowired private AuthService authService;
   @Autowired private GcsUtils gcsUtils;
-  @Autowired private SamFixtures samFixtures;
-  @Autowired private GoogleResourceManagerService resourceManagerService;
 
   // Disabling check while we debug failing tests.
   // See https://broadworkbench.atlassian.net/browse/DR-2858
-  private static final Boolean SHOULD_ASSERT_HTTPS_ACCESSIBILITY = false;
+  private static final boolean SHOULD_ASSERT_HTTPS_ACCESSIBILITY = false;
 
   private String stewardToken;
   private UUID datasetId;
   private UUID snapshotId;
-  private String snapshotProject;
   private UUID profileId;
   private List<String> uploadedFiles;
   private String ingestBucket;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
@@ -98,7 +89,7 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
     uploadedFiles = new ArrayList<>();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     dataRepoFixtures.resetConfig(steward());
 
@@ -120,19 +111,19 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void testSelfHostedDatasetLifecycle() throws Exception {
+  void testSelfHostedDatasetLifecycle() throws Exception {
     ingestBucket = "jade-testdata-useastregion";
     testSelfHostedDatasetLifecycle(false);
   }
 
   @Test
-  public void testSelfHostedDatasetWithDedicatedSALifecycle() throws Exception {
+  void testSelfHostedDatasetWithDedicatedSALifecycle() throws Exception {
     ingestBucket = "jade_testbucket_no_jade_sa";
     testSelfHostedDatasetLifecycle(true);
   }
 
   @Test
-  public void testSelfHostedDatasetRequesterPaysLifecycle() throws Exception {
+  void testSelfHostedDatasetRequesterPaysLifecycle() throws Exception {
     ingestBucket = "jade_testbucket_requester_pays";
     testSelfHostedDatasetLifecycle(true);
   }
@@ -209,11 +200,13 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
             "WGS_VCF_INDEX_FILE_ID",
                 targetPathToFileId.get("/vcfs/downsampled/wgs/NA12878_PLUMBING.g.vcf.gz.tbi"));
 
-    Stream<String> lines =
-        Files.lines(
+    List<String> lines =
+        Files.readAllLines(
                 Paths.get(ClassLoader.getSystemResource("self-hosted-dataset-ingest.json").toURI()))
+            .stream()
             .map(line -> replaceVars(line, fileReplaceMap))
-            .map(line -> replaceVars(line, Map.of("INGEST_BUCKET", ingestBucket)));
+            .map(line -> replaceVars(line, Map.of("INGEST_BUCKET", ingestBucket)))
+            .toList();
 
     // Ingest metadata + 1 combined ingest file
     String ingestPath =
@@ -260,7 +253,6 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
         dataRepoFixtures.createSnapshot(
             steward(), dataset.getName(), profileId, "dataset-ingest-combined-array-snapshot.json");
     snapshotId = snapshot.getId();
-    snapshotProject = snapshot.getDataProject();
 
     assertThat(
         "a snapshot created from a self-hosted dataset says its self-hosted too",
@@ -285,7 +277,7 @@ public class SelfHostedDatasetIntegrationTest extends UsersBase {
           drsObject.getAccessMethods(), stewardToken, SHOULD_ASSERT_HTTPS_ACCESSIBILITY);
       DRSAccessMethod gsAccessMethod =
           drsObject.getAccessMethods().stream()
-              .filter(accessMethod -> accessMethod.getType().equals(DRSAccessMethod.TypeEnum.GS))
+              .filter(accessMethod -> accessMethod.getType() == DRSAccessMethod.TypeEnum.GS)
               .findFirst()
               .orElseThrow();
       assertThat(

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -29,9 +29,9 @@ import bio.terra.model.DRSObject;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.FileModel;
 import bio.terra.model.SnapshotModel;
+import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
-import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.filedata.google.firestore.EncodeFixture;
 import bio.terra.service.resourcemanagement.ResourceService;
 import com.google.api.services.cloudresourcemanager.model.Binding;
@@ -93,7 +93,7 @@ class DrsTest extends UsersBase {
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private EncodeFixture encodeFixture;
   @Autowired private AuthService authService;
-  @Autowired private IamService iamService;
+  @Autowired private IamProviderInterface iamService;
 
   private DatasetModel datasetModel;
   private SnapshotModel snapshotModel;
@@ -193,7 +193,7 @@ class DrsTest extends UsersBase {
             .filter(accessMethod -> accessMethod.getType() == TypeEnum.GS)
             .findFirst();
 
-    assertThat("DRS access method is present", drsAccessMethod.isPresent(), equalTo(true));
+    assertThat("DRS access method is present", drsAccessMethod.isPresent());
 
     String drsAccessId = drsAccessMethod.get().getAccessId();
     DrsResponse<DRSAccessURL> drsAccessUrlResponse =

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -115,19 +115,20 @@ class DrsTest extends UsersBase {
         dataRepoFixtures.getSnapshot(steward(), setupResult.summaryModel().getId(), null);
     profileId = setupResult.profileId();
     datasetId = setupResult.datasetId();
-    AuthenticatedUserRequest stewardUser = AuthenticatedUserRequest.builder()
-        .setSubjectId("DRSIntegration")
-        .setEmail(steward().getEmail())
-        .setToken(stewardToken)
-        .build();
-    AuthenticatedUserRequest custodianUser = AuthenticatedUserRequest.builder()
-        .setSubjectId("DRSIntegration")
-        .setEmail(custodian().getEmail())
-        .setToken(custodianToken)
-        .build();
+    AuthenticatedUserRequest stewardUser =
+        AuthenticatedUserRequest.builder()
+            .setSubjectId("DRSIntegration")
+            .setEmail(steward().getEmail())
+            .setToken(stewardToken)
+            .build();
+    AuthenticatedUserRequest custodianUser =
+        AuthenticatedUserRequest.builder()
+            .setSubjectId("DRSIntegration")
+            .setEmail(custodian().getEmail())
+            .setToken(custodianToken)
+            .build();
     datasetIamRoles =
-        iamService.retrievePolicyEmails(
-            stewardUser, IamResourceType.DATASET, datasetId);
+        iamService.retrievePolicyEmails(stewardUser, IamResourceType.DATASET, datasetId);
     snapshotIamRoles =
         iamService.retrievePolicyEmails(
             custodianUser, IamResourceType.DATASNAPSHOT, snapshotModel.getId());
@@ -229,8 +230,10 @@ class DrsTest extends UsersBase {
     logger.info("DRS Object Id - dir: {}", dirObjectId);
 
     validateDrsObject(drsObjectDirectory, dirObjectId);
-    assertThat("Contents of directory is not null", drsObjectDirectory.getContents(), notNullValue());
-    assertThat("Access method of directory is null", drsObjectDirectory.getAccessMethods(), nullValue());
+    assertThat(
+        "Contents of directory is not null", drsObjectDirectory.getContents(), notNullValue());
+    assertThat(
+        "Access method of directory is null", drsObjectDirectory.getAccessMethods(), nullValue());
 
     // When all is done, delete the snapshot and ensure that there are fewer acls
     dataRepoFixtures.deleteSnapshotLog(custodian(), snapshotModel.getId());

--- a/src/test/java/bio/terra/service/filedata/DrsTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsTest.java
@@ -1,16 +1,17 @@
 package bio.terra.service.filedata;
 
-import static bio.terra.service.resourcemanagement.ResourceService.BQ_JOB_USER_ROLE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertNotNull;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import bio.terra.common.TestUtils;
 import bio.terra.common.auth.AuthService;
@@ -18,9 +19,11 @@ import bio.terra.common.category.Integration;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.DRSAccessMethod;
 import bio.terra.model.DRSAccessMethod.TypeEnum;
+import bio.terra.model.DRSAccessURL;
 import bio.terra.model.DRSChecksum;
 import bio.terra.model.DRSObject;
 import bio.terra.model.DatasetModel;
@@ -30,6 +33,7 @@ import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.filedata.google.firestore.EncodeFixture;
+import bio.terra.service.resourcemanagement.ResourceService;
 import com.google.api.services.cloudresourcemanager.model.Binding;
 import com.google.cloud.storage.Acl;
 import java.io.IOException;
@@ -51,33 +55,30 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /*
  * WARNING: if making any changes to these tests make sure to notify the #dsp-batch channel! Describe the change and
  * any consequences downstream to DRS clients.
  */
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@Category(Integration.class)
-public class DrsTest extends UsersBase {
+@Tag(Integration.TAG)
+class DrsTest extends UsersBase {
 
   private static final Logger logger = LoggerFactory.getLogger(DrsTest.class);
 
@@ -94,50 +95,46 @@ public class DrsTest extends UsersBase {
   @Autowired private AuthService authService;
   @Autowired private IamService iamService;
 
-  private String custodianToken;
   private DatasetModel datasetModel;
   private SnapshotModel snapshotModel;
   private UUID profileId;
   private UUID datasetId;
   private Map<IamRole, String> datasetIamRoles;
   private Map<IamRole, String> snapshotIamRoles;
-  private AuthenticatedUserRequest authenticatedStewardRequest;
-  private AuthenticatedUserRequest authenticatedCustodianRequest;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
-    custodianToken = authService.getDirectAccessAuthToken(custodian().getEmail());
+    String custodianToken = authService.getDirectAccessAuthToken(custodian().getEmail());
     String stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
     EncodeFixture.SetupResult setupResult =
         encodeFixture.setupEncode(steward(), custodian(), reader(), SHOULD_ASSERT_BQ_ACCESSIBLE);
-    datasetModel = dataRepoFixtures.getDataset(steward(), setupResult.getDatasetId());
+    datasetModel = dataRepoFixtures.getDataset(steward(), setupResult.datasetId());
     snapshotModel =
-        dataRepoFixtures.getSnapshot(steward(), setupResult.getSummaryModel().getId(), null);
-    profileId = setupResult.getProfileId();
-    datasetId = setupResult.getDatasetId();
-    authenticatedStewardRequest =
-        AuthenticatedUserRequest.builder()
-            .setSubjectId("DRSIntegration")
-            .setEmail(steward().getEmail())
-            .setToken(stewardToken)
-            .build();
-    authenticatedCustodianRequest =
-        AuthenticatedUserRequest.builder()
-            .setSubjectId("DRSIntegration")
-            .setEmail(custodian().getEmail())
-            .setToken(custodianToken)
-            .build();
+        dataRepoFixtures.getSnapshot(steward(), setupResult.summaryModel().getId(), null);
+    profileId = setupResult.profileId();
+    datasetId = setupResult.datasetId();
+    AuthenticatedUserRequest stewardUser = AuthenticatedUserRequest.builder()
+        .setSubjectId("DRSIntegration")
+        .setEmail(steward().getEmail())
+        .setToken(stewardToken)
+        .build();
+    AuthenticatedUserRequest custodianUser = AuthenticatedUserRequest.builder()
+        .setSubjectId("DRSIntegration")
+        .setEmail(custodian().getEmail())
+        .setToken(custodianToken)
+        .build();
     datasetIamRoles =
         iamService.retrievePolicyEmails(
-            authenticatedStewardRequest, IamResourceType.DATASET, datasetId);
+            stewardUser, IamResourceType.DATASET, datasetId);
     snapshotIamRoles =
         iamService.retrievePolicyEmails(
-            authenticatedCustodianRequest, IamResourceType.DATASNAPSHOT, snapshotModel.getId());
+            custodianUser, IamResourceType.DATASNAPSHOT, snapshotModel.getId());
     logger.info("setup complete");
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     try {
       dataRepoFixtures.deleteSnapshotLog(custodian(), snapshotModel.getId());
@@ -158,7 +155,7 @@ public class DrsTest extends UsersBase {
   }
 
   @Test
-  public void drsHackyTest() throws Exception {
+  void drsHackyTest() throws Exception {
     // Get a DRS ID from the snapshot preview as a reader.
     String drsObjectId =
         dataRepoFixtures.retrieveDrsIdFromSnapshotPreview(
@@ -192,24 +189,24 @@ public class DrsTest extends UsersBase {
 
     Optional<DRSAccessMethod> drsAccessMethod =
         drsObjectFile.getAccessMethods().stream()
-            .filter(accessMethod -> accessMethod.getType().equals(TypeEnum.GS))
+            .filter(accessMethod -> accessMethod.getType() == TypeEnum.GS)
             .findFirst();
 
     assertThat("DRS access method is present", drsAccessMethod.isPresent(), equalTo(true));
 
     String drsAccessId = drsAccessMethod.get().getAccessId();
-    DrsResponse<bio.terra.model.DRSAccessURL> drsAccessUrlResponse =
+    DrsResponse<DRSAccessURL> drsAccessUrlResponse =
         dataRepoFixtures.getObjectAccessUrl(custodian(), drsObjectId, drsAccessId);
 
     if (drsAccessUrlResponse.getResponseObject().isEmpty()) {
-      Assert.fail("Access URL response object is empty");
+      fail("Access URL response object is empty");
     }
 
-    bio.terra.model.DRSAccessURL drsAccessURL = drsAccessUrlResponse.getResponseObject().get();
+    DRSAccessURL drsAccessURL = drsAccessUrlResponse.getResponseObject().get();
 
     try (CloseableHttpClient client = HttpClients.createDefault()) {
       HttpUriRequest request = new HttpHead(drsAccessURL.getUrl());
-      try (CloseableHttpResponse response = client.execute(request); ) {
+      try (CloseableHttpResponse response = client.execute(request)) {
         assertThat(
             "Drs signed URL is accessible",
             response.getStatusLine().getStatusCode(),
@@ -232,8 +229,8 @@ public class DrsTest extends UsersBase {
     logger.info("DRS Object Id - dir: {}", dirObjectId);
 
     validateDrsObject(drsObjectDirectory, dirObjectId);
-    assertNotNull("Contents of directory is not null", drsObjectDirectory.getContents());
-    assertNull("Access method of directory is null", drsObjectDirectory.getAccessMethods());
+    assertThat("Contents of directory is not null", drsObjectDirectory.getContents(), notNullValue());
+    assertThat("Access method of directory is null", drsObjectDirectory.getAccessMethods(), nullValue());
 
     // When all is done, delete the snapshot and ensure that there are fewer acls
     dataRepoFixtures.deleteSnapshotLog(custodian(), snapshotModel.getId());
@@ -266,7 +263,7 @@ public class DrsTest extends UsersBase {
   }
 
   @Test
-  public void testDrsErrorResponses() throws Exception {
+  void testDrsErrorResponses() throws Exception {
     // Get a DRS ID from the snapshot preview as a reader.
     String drsObjectId =
         dataRepoFixtures.retrieveDrsIdFromSnapshotPreview(
@@ -322,7 +319,7 @@ public class DrsTest extends UsersBase {
   }
 
   private void validateDrsObject(DRSObject drsObject, String drsObjectId) {
-    logger.info("DrsObject is:" + drsObject);
+    logger.info("DrsObject is: {}", drsObject);
     assertThat("DRS id matches", drsObject.getId(), equalTo(drsObjectId));
     assertThat(
         "Create and update dates match",
@@ -331,10 +328,10 @@ public class DrsTest extends UsersBase {
     assertThat("DRS version is right", drsObject.getVersion(), equalTo("0"));
 
     for (DRSChecksum checksum : drsObject.getChecksums()) {
-      assertTrue(
+      assertThat(
           "checksum is md5 or crc32c",
-          StringUtils.equals(checksum.getType(), "md5")
-              || StringUtils.equals(checksum.getType(), "crc32c"));
+          checksum.getType(),
+          anyOf(equalTo("md5"), equalTo("crc32c")));
     }
 
     if (drsObject.getAccessMethods() != null) {
@@ -403,7 +400,7 @@ public class DrsTest extends UsersBase {
     List<Binding> bindings = TestUtils.getPolicy(dataProject).getBindings();
     bindings.forEach(
         b -> {
-          if (Objects.equals(b.getRole(), BQ_JOB_USER_ROLE)) {
+          if (Objects.equals(b.getRole(), ResourceService.BQ_JOB_USER_ROLE)) {
             members.forEach(
                 m ->
                     assertThat(
@@ -422,7 +419,7 @@ public class DrsTest extends UsersBase {
     List<Binding> bindings = TestUtils.getPolicy(dataProject).getBindings();
     bindings.forEach(
         b -> {
-          if (Objects.equals(b.getRole(), BQ_JOB_USER_ROLE)) {
+          if (Objects.equals(b.getRole(), ResourceService.BQ_JOB_USER_ROLE)) {
             members.forEach(
                 m ->
                     assertThat(

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -44,8 +44,7 @@ public class EncodeFixture {
   @Autowired private AuthService authService;
   @Autowired private TestConfiguration testConfiguration;
 
-  public record SetupResult(UUID profileId, UUID datasetId, SnapshotSummaryModel summaryModel) {
-  }
+  public record SetupResult(UUID profileId, UUID datasetId, SnapshotSummaryModel summaryModel) {}
 
   // Create dataset, load files and tables. Create and return snapshot.
   // Steward owns dataset; custodian is custodian on dataset; reader has access to the snapshot.

--- a/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/EncodeFixture.java
@@ -3,9 +3,7 @@ package bio.terra.service.filedata.google.firestore;
 import bio.terra.common.TestUtils;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.configuration.TestConfiguration;
-import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.integration.BigQueryFixtures;
-import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadArrayResultModel;
@@ -19,7 +17,6 @@ import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.filedata.google.gcs.GcsChannelWriter;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -43,35 +40,11 @@ import org.springframework.test.context.ActiveProfiles;
 public class EncodeFixture {
   private static final Logger logger = LoggerFactory.getLogger(EncodeFixture.class);
 
-  @Autowired private JsonLoader jsonLoader;
-  @Autowired private ObjectMapper objectMapper;
-  @Autowired private DataRepoClient dataRepoClient;
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private AuthService authService;
   @Autowired private TestConfiguration testConfiguration;
 
-  public static class SetupResult {
-    private final UUID profileId;
-    private final UUID datasetId;
-    private final SnapshotSummaryModel summaryModel;
-
-    public SetupResult(UUID profileId, UUID datasetId, SnapshotSummaryModel summaryModel) {
-      this.profileId = profileId;
-      this.datasetId = datasetId;
-      this.summaryModel = summaryModel;
-    }
-
-    public UUID getDatasetId() {
-      return datasetId;
-    }
-
-    public UUID getProfileId() {
-      return profileId;
-    }
-
-    public SnapshotSummaryModel getSummaryModel() {
-      return summaryModel;
-    }
+  public record SetupResult(UUID profileId, UUID datasetId, SnapshotSummaryModel summaryModel) {
   }
 
   // Create dataset, load files and tables. Create and return snapshot.

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -1,13 +1,14 @@
 package bio.terra.service.job;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.common.GcsUtils;
 import bio.terra.common.category.Integration;
 import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.DataRepoResponse;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.BulkLoadArrayRequestModel;
 import bio.terra.model.BulkLoadArrayResultModel;
@@ -24,28 +25,27 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@AutoConfigureMockMvc
-@Category(Integration.class)
-public class JobPermissionTest extends UsersBase {
+@Tag(Integration.TAG)
+class JobPermissionTest extends UsersBase {
   private static final Logger logger = LoggerFactory.getLogger(JobPermissionTest.class);
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
@@ -55,7 +55,8 @@ public class JobPermissionTest extends UsersBase {
   private UUID datasetId;
   private UUID profileId;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     dataRepoFixtures.resetConfig(steward());
@@ -64,7 +65,7 @@ public class JobPermissionTest extends UsersBase {
         steward(), profileId, IamRole.OWNER, custodian().getEmail(), IamResourceType.SPEND_PROFILE);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     dataRepoFixtures.resetConfig(steward());
 
@@ -74,8 +75,8 @@ public class JobPermissionTest extends UsersBase {
   }
 
   @Test
-  @Ignore("Ignoring until DR-2723 is in so that we can pin job enumeration")
-  public void testJobPermissions() throws Exception {
+  @Disabled("Ignoring until DR-2723 is in so that we can pin job enumeration")
+  void testJobPermissions() throws Exception {
     // Create dataset
     DataRepoResponse<JobModel> jobResponse =
         dataRepoFixtures.createDatasetRaw(
@@ -112,7 +113,7 @@ public class JobPermissionTest extends UsersBase {
 
     DataRepoResponse<FileModel> fileIngestResponse =
         dataRepoClient.waitForResponse(steward(), fileIngestJobResponse, new TypeReference<>() {});
-    assert (fileIngestResponse.getStatusCode().is2xxSuccessful());
+    assertTrue(fileIngestResponse.getStatusCode().is2xxSuccessful());
 
     String vcfIndexFilePath =
         gcsUtils.uploadTestFile(
@@ -151,7 +152,7 @@ public class JobPermissionTest extends UsersBase {
                 .maxFailedFileLoads(0));
     DataRepoResponse<BulkLoadArrayResultModel> bulkLoadResponse =
         dataRepoClient.waitForResponse(steward(), bulkLoadJobResponse, new TypeReference<>() {});
-    assert (bulkLoadResponse.getStatusCode().is2xxSuccessful());
+    assertTrue(bulkLoadResponse.getStatusCode().is2xxSuccessful());
 
     // Ingest metadata
     IngestRequestModel metadataIngestRequest =
@@ -163,7 +164,7 @@ public class JobPermissionTest extends UsersBase {
 
     DataRepoResponse<JobModel> metadataIngestJobResponse =
         dataRepoFixtures.ingestJsonDataLaunch(steward(), datasetId, metadataIngestRequest);
-    assert (metadataIngestJobResponse.getStatusCode().is2xxSuccessful());
+    assertTrue(metadataIngestJobResponse.getStatusCode().is2xxSuccessful());
 
     // Ingest metadata and files
     IngestRequestModel combinedIngestRequest =
@@ -177,7 +178,7 @@ public class JobPermissionTest extends UsersBase {
 
     DataRepoResponse<JobModel> combinedIngestJobResponse =
         dataRepoFixtures.ingestJsonDataLaunch(steward(), datasetId, combinedIngestRequest);
-    assert (combinedIngestJobResponse.getStatusCode().is2xxSuccessful());
+    assertTrue(combinedIngestJobResponse.getStatusCode().is2xxSuccessful());
 
     // Verify custodian can view jobs
     JobModel datasetCreateJob = jobResponse.getResponseObject().get();
@@ -199,17 +200,17 @@ public class JobPermissionTest extends UsersBase {
         List.of(datasetCreateJob, fileIngestJob, bulkLoadJob, metadataIngestJob, combinedIngestJob);
 
     assertTrue(
-        "Admin can list jobs",
-        containsJobIds(dataRepoFixtures.enumerateJobs(admin(), 0, 20), jobIds));
+        containsJobIds(dataRepoFixtures.enumerateJobs(admin(), 0, 20), jobIds),
+        "Admin can list jobs");
     assertTrue(
-        "Steward can list jobs",
-        containsJobIds(dataRepoFixtures.enumerateJobs(steward(), 0, 20), jobIds));
+        containsJobIds(dataRepoFixtures.enumerateJobs(steward(), 0, 20), jobIds),
+        "Steward can list jobs");
     assertTrue(
-        "Custodian can list jobs",
-        containsJobIds(dataRepoFixtures.enumerateJobs(custodian(), 0, 20), jobIds));
+        containsJobIds(dataRepoFixtures.enumerateJobs(custodian(), 0, 20), jobIds),
+        "Custodian can list jobs");
     assertFalse(
-        "Reader cannot list jobs",
-        containsJobIds(dataRepoFixtures.enumerateJobs(reader(), 0, 10), jobIds));
+        containsJobIds(dataRepoFixtures.enumerateJobs(reader(), 0, 10), jobIds),
+        "Reader cannot list jobs");
   }
 
   private boolean containsJobIds(List<JobModel> jobs, List<JobModel> expectedJobIds) {
@@ -217,7 +218,7 @@ public class JobPermissionTest extends UsersBase {
 
     Map<String, JobModel> jobsById;
     try {
-      jobsById = jobs.stream().collect(Collectors.toMap(JobModel::getId, j -> j));
+      jobsById = jobs.stream().collect(Collectors.toMap(JobModel::getId, Function.identity()));
     } catch (IllegalStateException e) {
       logger.error("There appear to be duplicate jobs in the response:\n{}", jobs);
       throw e;

--- a/src/test/java/bio/terra/service/job/JobPermissionTest.java
+++ b/src/test/java/bio/terra/service/job/JobPermissionTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -101,7 +100,7 @@ class JobPermissionTest extends UsersBase {
         gcsUtils.uploadTestFile(
             ingestBucket,
             String.format("jobPermissionTest/%s/fake-exome.g.vcf.gz", datasetId),
-            Stream.of("test vcf file"));
+            List.of("test vcf file"));
 
     DataRepoResponse<JobModel> fileIngestJobResponse =
         dataRepoFixtures.ingestFileLaunch(
@@ -119,13 +118,13 @@ class JobPermissionTest extends UsersBase {
         gcsUtils.uploadTestFile(
             ingestBucket,
             String.format("jobPermissionTest/%s/fake-vcf-index.g.vcf.gz.tbi", datasetId),
-            Stream.of("test vcf index file"));
+            List.of("test vcf index file"));
 
     String vcfIndexFilePath2 =
         gcsUtils.uploadTestFile(
             ingestBucket,
             String.format("jobPermissionTest/%s/fake-vcf-index2.g.vcf.gz.tbi", datasetId),
-            Stream.of("another test vcf index file"));
+            List.of("another test vcf index file"));
 
     List<BulkLoadFileModel> vcfIndexLoadModels =
         List.of(
@@ -181,19 +180,19 @@ class JobPermissionTest extends UsersBase {
     assertTrue(combinedIngestJobResponse.getStatusCode().is2xxSuccessful());
 
     // Verify custodian can view jobs
-    JobModel datasetCreateJob = jobResponse.getResponseObject().get();
+    JobModel datasetCreateJob = jobResponse.getResponseObject().orElseThrow();
     dataRepoFixtures.getJobSuccess(datasetCreateJob.getId(), custodian());
 
-    JobModel fileIngestJob = fileIngestJobResponse.getResponseObject().get();
+    JobModel fileIngestJob = fileIngestJobResponse.getResponseObject().orElseThrow();
     dataRepoFixtures.getJobSuccess(fileIngestJob.getId(), custodian());
 
-    JobModel bulkLoadJob = bulkLoadJobResponse.getResponseObject().get();
+    JobModel bulkLoadJob = bulkLoadJobResponse.getResponseObject().orElseThrow();
     dataRepoFixtures.getJobSuccess(bulkLoadJob.getId(), custodian());
 
-    JobModel metadataIngestJob = metadataIngestJobResponse.getResponseObject().get();
+    JobModel metadataIngestJob = metadataIngestJobResponse.getResponseObject().orElseThrow();
     dataRepoFixtures.getJobSuccess(metadataIngestJob.getId(), custodian());
 
-    JobModel combinedIngestJob = combinedIngestJobResponse.getResponseObject().get();
+    JobModel combinedIngestJob = combinedIngestJobResponse.getResponseObject().orElseThrow();
     dataRepoFixtures.getJobSuccess(combinedIngestJob.getId(), custodian());
 
     List<JobModel> jobIds =

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThrows;
 
+import bio.terra.common.GcsUtils;
 import bio.terra.common.ParquetUtils;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
@@ -34,8 +35,6 @@ import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.common.gcs.GcsUriUtils;
-import bio.terra.service.filedata.google.gcs.GcsPdao;
-import bio.terra.service.resourcemanagement.google.GoogleBucketService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auth.oauth2.AccessToken;
@@ -54,7 +53,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,8 +75,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 class SnapshotExportIntegrationTest extends UsersBase {
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
-  @Autowired private GcsPdao gcsPdao;
-  @Autowired private GoogleBucketService googleBucketService;
+  @Autowired private GcsUtils gcsUtils;
   @Autowired private AuthService authService;
 
   @Autowired
@@ -200,9 +197,8 @@ class SnapshotExportIntegrationTest extends UsersBase {
       manifestBucket = manifestBlob.getBucket();
       String bucketProject = manifestBlob.getBucket().replace("-snapshot-export-bucket", "");
       manifestContentsRaw =
-          gcsPdao
-              .getBlobsLinesStream(parquet.getManifest(), bucketProject, null)
-              .collect(Collectors.joining("\n"));
+          new String(
+              gcsUtils.getBlobBytes(parquet.getManifest(), bucketProject), StandardCharsets.UTF_8);
     }
     TypeReference<SnapshotExportResponseModel> ref = new TypeReference<>() {};
     SnapshotExportResponseModel manifestContents =
@@ -220,7 +216,7 @@ class SnapshotExportIntegrationTest extends UsersBase {
 
     Integer deleteAge = 1;
 
-    var lifecycleRules = googleBucketService.getCloudBucket(manifestBucket).getLifecycleRules();
+    var lifecycleRules = gcsUtils.getCloudBucket(manifestBucket).getLifecycleRules();
 
     var lifecycleRule = lifecycleRules.get(0);
     var lifecycleAction = lifecycleRule.getAction();
@@ -316,7 +312,7 @@ class SnapshotExportIntegrationTest extends UsersBase {
     List<Map<String, Object>> records = new ArrayList<>();
     for (String path : sampleVcfTablePaths) {
       records.addAll(
-          ParquetUtils.readGcsParquetRecords(gcsPdao, path, snapshotSummary.getDataProject()));
+          ParquetUtils.readGcsParquetRecords(gcsUtils, path, snapshotSummary.getDataProject()));
     }
 
     for (var parquetRecord : records) {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -262,9 +262,15 @@ class SnapshotExportIntegrationTest extends UsersBase {
         assertThat("Authorized user can read " + path, blob, notNullValue());
 
         StorageException notAuthorizedException =
-            assertThrows("Unauthorized user cannot read " + path, StorageException.class, () -> unauthedStorage.get(blobId));
+            assertThrows(
+                "Unauthorized user cannot read " + path,
+                StorageException.class,
+                () -> unauthedStorage.get(blobId));
 
-        assertThat("Unauthorized user cannot read " + path, notAuthorizedException.getCode(), equalTo(403));
+        assertThat(
+            "Unauthorized user cannot read " + path,
+            notAuthorizedException.getCode(),
+            equalTo(403));
       }
     }
   }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -77,10 +77,7 @@ class SnapshotExportIntegrationTest extends UsersBase {
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private GcsUtils gcsUtils;
   @Autowired private AuthService authService;
-
-  @Autowired
-  @Qualifier("objectMapper")
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
   private static final Logger logger = LoggerFactory.getLogger(SnapshotExportIntegrationTest.class);
   private String stewardToken;

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -20,6 +20,7 @@ import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.DataRepoResponse;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.ErrorModel;
@@ -55,27 +56,25 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@Category(Integration.class)
-public class SnapshotExportIntegrationTest extends UsersBase {
+@Tag(Integration.TAG)
+class SnapshotExportIntegrationTest extends UsersBase {
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
   @Autowired private GcsPdao gcsPdao;
@@ -86,14 +85,15 @@ public class SnapshotExportIntegrationTest extends UsersBase {
   @Qualifier("objectMapper")
   private ObjectMapper objectMapper;
 
-  private static final Logger logger = LoggerFactory.getLogger(SnapshotIntegrationTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(SnapshotExportIntegrationTest.class);
   private String stewardToken;
   private String readerToken;
   private UUID profileId;
   private final List<UUID> createdDatasetsIds = new ArrayList<>();
   private final List<UUID> createdSnapshotIds = new ArrayList<>();
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
@@ -103,14 +103,13 @@ public class SnapshotExportIntegrationTest extends UsersBase {
         steward(), profileId, IamRole.USER, custodian().getEmail(), IamResourceType.SPEND_PROFILE);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     for (UUID snapshotId : createdSnapshotIds) {
       try {
         dataRepoFixtures.deleteSnapshot(steward(), snapshotId);
       } catch (Exception ex) {
-        logger.warn("cleanup failed when deleting snapshot " + snapshotId);
-        ex.printStackTrace();
+        logger.warn("cleanup failed when deleting snapshot " + snapshotId, ex);
       }
     }
 
@@ -124,7 +123,7 @@ public class SnapshotExportIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void snapshotExportTest() throws Exception {
+  void snapshotExportTest() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "ingest-test-dataset.json");
     UUID datasetId = datasetSummaryModel.getId();
@@ -258,19 +257,14 @@ public class SnapshotExportIntegrationTest extends UsersBase {
         assertThat(
             "Signed URL is accessible and parquet isn't empty", bytes.length, greaterThan(0));
       } else {
-        Blob blob = authedStorage.get(GcsUriUtils.parseBlobUri(parquet.getManifest()));
+        BlobId blobId = GcsUriUtils.parseBlobUri(parquet.getManifest());
+        Blob blob = authedStorage.get(blobId);
         assertThat("Authorized user can read " + path, blob, notNullValue());
 
         StorageException notAuthorizedException =
-            assertThrows(
-                "Unauthorized user cannot read " + path,
-                StorageException.class,
-                () -> unauthedStorage.get(GcsUriUtils.parseBlobUri(parquet.getManifest())));
+            assertThrows("Unauthorized user cannot read " + path, StorageException.class, () -> unauthedStorage.get(blobId));
 
-        assertThat(
-            "Unauthorized user cannot read " + path,
-            notAuthorizedException.getCode(),
-            equalTo(403));
+        assertThat("Unauthorized user cannot read " + path, notAuthorizedException.getCode(), equalTo(403));
       }
     }
   }
@@ -282,7 +276,7 @@ public class SnapshotExportIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void snapshotGsPathExportTest() throws Exception {
+  void snapshotGsPathExportTest() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "dataset-ingest-combined-array.json");
     UUID datasetId = datasetSummaryModel.getId();
@@ -319,17 +313,17 @@ public class SnapshotExportIntegrationTest extends UsersBase {
           ParquetUtils.readGcsParquetRecords(gcsPdao, path, snapshotSummary.getDataProject()));
     }
 
-    for (var record : records) {
-      final String vcfFileRef = (String) record.get("vcf_file_ref");
-      final List<String> vcfIndexFileRefs = (List<String>) record.get("vcf_index_file_ref");
-      if (record.get("sample_name").equals("NA12878_exome")) {
+    for (var parquetRecord : records) {
+      final String vcfFileRef = (String) parquetRecord.get("vcf_file_ref");
+      final List<String> vcfIndexFileRefs = (List<String>) parquetRecord.get("vcf_index_file_ref");
+      if (parquetRecord.get("sample_name").equals("NA12878_exome")) {
         assertThat(
             "fileref values with multiple elements are mapped as lists of gs-paths",
             vcfIndexFileRefs,
             iterableWithSize(2));
         isGsPath(vcfFileRef);
         vcfIndexFileRefs.forEach(SnapshotExportIntegrationTest::isGsPath);
-      } else if (record.get("sample_name").equals("nofile")) {
+      } else if (parquetRecord.get("sample_name").equals("nofile")) {
         assertThat("Null fileref values stay null", vcfFileRef, nullValue());
         assertThat("arrayOf fileref values have no elements", vcfIndexFileRefs, emptyIterable());
       } else {
@@ -340,7 +334,7 @@ public class SnapshotExportIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void snapshotExportValidationTest() throws Exception {
+  void snapshotExportValidationTest() throws Exception {
     DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "ingest-test-dataset.json");
     UUID datasetId = datasetSummaryModel.getId();

--- a/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotExportIntegrationTest.java
@@ -62,7 +62,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -15,8 +15,8 @@ import bio.terra.common.PdaoConstant;
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.fixtures.JsonLoader;
-import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.DatasetDataModel;
 import bio.terra.model.DatasetModel;
@@ -32,7 +32,6 @@ import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -46,19 +45,15 @@ import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
 @Category(Integration.class)
 public class SnapshotIntegrationTest extends UsersBase {
-  @Autowired private DataRepoClient dataRepoClient;
-
   @Autowired private JsonLoader jsonLoader;
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
@@ -67,22 +62,19 @@ public class SnapshotIntegrationTest extends UsersBase {
 
   private static final Logger logger = LoggerFactory.getLogger(SnapshotIntegrationTest.class);
   private UUID profileId;
-  private DatasetSummaryModel datasetSummaryModel;
   private UUID datasetId;
   private final List<UUID> createdSnapshotIds = new ArrayList<>();
-  private String stewardToken;
   String participantTableName;
   int participantTableRowCount;
 
   @Before
   public void setup() throws Exception {
     super.setup();
-    stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
     profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
     dataRepoFixtures.addPolicyMember(
         steward(), profileId, IamRole.USER, custodian().getEmail(), IamResourceType.SPEND_PROFILE);
 
-    datasetSummaryModel =
+    DatasetSummaryModel datasetSummaryModel =
         dataRepoFixtures.createDataset(steward(), profileId, "ingest-test-dataset.json");
     datasetId = datasetSummaryModel.getId();
     dataRepoFixtures.addDatasetPolicyMember(
@@ -132,10 +124,7 @@ public class SnapshotIntegrationTest extends UsersBase {
             .getResult();
     List<UUID> participantIds =
         participantResults.stream()
-            .map(
-                r ->
-                    UUID.fromString(
-                        ((LinkedHashMap) r).get(PdaoConstant.PDAO_ROW_ID_COLUMN).toString()))
+            .map(r -> UUID.fromString(((Map) r).get(PdaoConstant.PDAO_ROW_ID_COLUMN).toString()))
             .toList();
     List<Object> sampleResults =
         dataRepoFixtures
@@ -143,10 +132,7 @@ public class SnapshotIntegrationTest extends UsersBase {
             .getResult();
     List<UUID> sampleIds =
         sampleResults.stream()
-            .map(
-                r ->
-                    UUID.fromString(
-                        ((LinkedHashMap) r).get(PdaoConstant.PDAO_ROW_ID_COLUMN).toString()))
+            .map(r -> UUID.fromString(((Map) r).get(PdaoConstant.PDAO_ROW_ID_COLUMN).toString()))
             .toList();
 
     // swap in these row ids in the request

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -6,13 +6,13 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.AssertionErrors.assertFalse;
 
 import bio.terra.common.PdaoConstant;
-import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.integration.DataRepoFixtures;
@@ -37,28 +37,26 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@Category(Integration.class)
-public class SnapshotIntegrationTest extends UsersBase {
+@Tag(Integration.TAG)
+class SnapshotIntegrationTest extends UsersBase {
   @Autowired private JsonLoader jsonLoader;
 
   @Autowired private DataRepoFixtures dataRepoFixtures;
-
-  @Autowired private AuthService authService;
 
   private static final Logger logger = LoggerFactory.getLogger(SnapshotIntegrationTest.class);
   private UUID profileId;
@@ -67,7 +65,8 @@ public class SnapshotIntegrationTest extends UsersBase {
   String participantTableName;
   int participantTableRowCount;
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     profileId = dataRepoFixtures.createBillingProfile(steward()).getId();
@@ -90,7 +89,7 @@ public class SnapshotIntegrationTest extends UsersBase {
     dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     createdSnapshotIds.forEach(
         snapshot -> {
@@ -112,7 +111,7 @@ public class SnapshotIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void snapshotRowIdsHappyPathTest() throws Exception {
+  void snapshotRowIdsHappyPathTest() throws Exception {
     // fetch rowIds from the ingested dataset by querying the participant table
     DatasetModel dataset = dataRepoFixtures.getDataset(steward(), datasetId);
     String participantTable = "participant";
@@ -147,11 +146,11 @@ public class SnapshotIntegrationTest extends UsersBase {
     TimeUnit.SECONDS.sleep(10);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
-    assertEquals(
+    assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
+    assertThat(
         "new snapshot has the correct number of tables",
-        requestModel.getContents().get(0).getRowIdSpec().getTables().size(),
-        snapshot.getTables().size());
+        snapshot.getTables(),
+        hasSize(requestModel.getContents().get(0).getRowIdSpec().getTables().size()));
     // TODO: get the snapshot and make sure the number of rows matches with the row ids input
     assertThat(
         "The secure monitoring is propagated from the dataset",
@@ -296,7 +295,7 @@ public class SnapshotIntegrationTest extends UsersBase {
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
     assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
-    assertEquals("the relationship comes through", 1, snapshot.getRelationships().size());
+    assertThat("the relationship comes through", snapshot.getRelationships(), hasSize(1));
 
     // Empty snapshot table
     dataRepoFixtures.assertSnapshotTableCount(steward(), snapshot, "file", 0);
@@ -368,7 +367,7 @@ public class SnapshotIntegrationTest extends UsersBase {
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
     assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
-    assertEquals("the relationship comes through", 1, snapshot.getRelationships().size());
+    assertThat("the relationship comes through", snapshot.getRelationships(), hasSize(1));
   }
 
   private SnapshotRequestModel snapshotByQueryRequestModel(DatasetModel dataset) throws Exception {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.util.AssertionErrors.assertFalse;
 
 import bio.terra.common.PdaoConstant;
@@ -187,7 +186,7 @@ class SnapshotIntegrationTest extends UsersBase {
     TimeUnit.SECONDS.sleep(10);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
+    assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
   }
 
   @Test
@@ -204,7 +203,7 @@ class SnapshotIntegrationTest extends UsersBase {
     TimeUnit.SECONDS.sleep(10);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
+    assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
   }
 
   @Test
@@ -294,7 +293,7 @@ class SnapshotIntegrationTest extends UsersBase {
     TimeUnit.SECONDS.sleep(10);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
+    assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
     assertThat("the relationship comes through", snapshot.getRelationships(), hasSize(1));
 
     // Empty snapshot table
@@ -366,7 +365,7 @@ class SnapshotIntegrationTest extends UsersBase {
     TimeUnit.SECONDS.sleep(10);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
+    assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
     assertThat("the relationship comes through", snapshot.getRelationships(), hasSize(1));
   }
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
@@ -3,7 +3,7 @@ package bio.terra.service.snapshot;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.hasSize;
 
 import bio.terra.common.auth.AuthService;
 import bio.terra.common.category.Integration;
@@ -12,6 +12,7 @@ import bio.terra.integration.BigQueryFixtures;
 import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
 import bio.terra.integration.DataRepoResponse;
+import bio.terra.integration.IntegrationTestConfiguration;
 import bio.terra.integration.UsersBase;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetSummaryModel;
@@ -33,25 +34,23 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
-@Category(Integration.class)
-public class SnapshotPermissionsIntegrationTest extends UsersBase {
+@Tag(Integration.TAG)
+class SnapshotPermissionsIntegrationTest extends UsersBase {
 
   private static final Logger logger =
       LoggerFactory.getLogger(SnapshotPermissionsIntegrationTest.class);
@@ -67,7 +66,8 @@ public class SnapshotPermissionsIntegrationTest extends UsersBase {
   private DatasetSummaryModel datasetSummaryModel;
   private final List<UUID> createdSnapshotIds = new ArrayList<>();
 
-  @Before
+  @Override
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     stewardToken = authService.getDirectAccessAuthToken(steward().getEmail());
@@ -89,15 +89,14 @@ public class SnapshotPermissionsIntegrationTest extends UsersBase {
     dataRepoFixtures.ingestJsonData(steward(), datasetId, request);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     createdSnapshotIds.forEach(
         snapshot -> {
           try {
             dataRepoFixtures.deleteSnapshot(steward(), snapshot);
           } catch (Exception ex) {
-            logger.warn("cleanup failed when deleting snapshot " + snapshot);
-            ex.printStackTrace();
+            logger.warn("cleanup failed when deleting snapshot " + snapshot, ex);
           }
         });
 
@@ -111,7 +110,7 @@ public class SnapshotPermissionsIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void snapshotInvalidEmailTest() throws Exception {
+  void snapshotInvalidEmailTest() throws Exception {
     SnapshotRequestModel requestModel =
         jsonLoader.loadObject("ingest-test-snapshot.json", SnapshotRequestModel.class);
 
@@ -148,7 +147,7 @@ public class SnapshotPermissionsIntegrationTest extends UsersBase {
   }
 
   @Test
-  public void snapshotAclTest() throws Exception {
+  void snapshotAclTest() throws Exception {
     DatasetModel dataset = dataRepoFixtures.getDataset(steward(), datasetId);
 
     String datasetName = dataset.getName();
@@ -165,8 +164,8 @@ public class SnapshotPermissionsIntegrationTest extends UsersBase {
         dataRepoFixtures.createSnapshotWithRequest(steward(), datasetName, profileId, requestModel);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    assertEquals("new snapshot has been created", snapshot.getName(), requestModel.getName());
-    assertEquals("There should be 1 snapshot relationship", 1, snapshot.getRelationships().size());
+    assertThat("new snapshot has been created", requestModel.getName(), equalTo(snapshot.getName()));
+    assertThat("There should be 1 snapshot relationship", snapshot.getRelationships(), hasSize(1));
 
     // fetch Acls
     logger.info("---- Dataset Acls after snapshot create-----");
@@ -182,11 +181,8 @@ public class SnapshotPermissionsIntegrationTest extends UsersBase {
     logger.info("---- Dataset Acls after snapshot delete-----");
     int datasetMinusSnapshotAclCount =
         retryAclUpdate(datasetName, datasetAclCount, AclCheck.EQUALTO);
-    assertEquals(
-        "We should be back to the same number of Acls on the dataset after snapshot delete",
-        datasetAclCount,
-        datasetMinusSnapshotAclCount);
-    // Don't need to tear down snashot
+    assertThat("We should be back to the same number of Acls on the dataset after snapshot delete", datasetMinusSnapshotAclCount, equalTo(datasetAclCount));
+    // Don't need to tear down snapshot
     createdSnapshotIds.remove(snapshotSummary.getId());
   }
 
@@ -234,7 +230,7 @@ public class SnapshotPermissionsIntegrationTest extends UsersBase {
       if (check.compare(datasetPlusSnapshotCount, datasetAclCount)) {
         break;
       }
-      double delayInSeconds = ((1d / 2d) * (Math.pow(2d, n) - 1d));
+      double delayInSeconds = ((1.0 / 2) * (Math.pow(2, n) - 1));
       waitInterval = (int) Math.min(maxDelayInSeconds, delayInSeconds);
       totalWaitTime += waitInterval;
       logger.info(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
@@ -164,7 +164,8 @@ class SnapshotPermissionsIntegrationTest extends UsersBase {
         dataRepoFixtures.createSnapshotWithRequest(steward(), datasetName, profileId, requestModel);
     createdSnapshotIds.add(snapshotSummary.getId());
     SnapshotModel snapshot = dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null);
-    assertThat("new snapshot has been created", requestModel.getName(), equalTo(snapshot.getName()));
+    assertThat(
+        "new snapshot has been created", requestModel.getName(), equalTo(snapshot.getName()));
     assertThat("There should be 1 snapshot relationship", snapshot.getRelationships(), hasSize(1));
 
     // fetch Acls
@@ -181,7 +182,10 @@ class SnapshotPermissionsIntegrationTest extends UsersBase {
     logger.info("---- Dataset Acls after snapshot delete-----");
     int datasetMinusSnapshotAclCount =
         retryAclUpdate(datasetName, datasetAclCount, AclCheck.EQUALTO);
-    assertThat("We should be back to the same number of Acls on the dataset after snapshot delete", datasetMinusSnapshotAclCount, equalTo(datasetAclCount));
+    assertThat(
+        "We should be back to the same number of Acls on the dataset after snapshot delete",
+        datasetMinusSnapshotAclCount,
+        equalTo(datasetAclCount));
     // Don't need to tear down snapshot
     createdSnapshotIds.remove(snapshotSummary.getId());
   }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1182

## Addresses

To help address integration test flakiness, change tests to create a more restricted spring container. Most notably, this prevents the JUnit test from starting up a database connection to the integration test server.

## Summary of changes

A new test configuration, `IntegrationTestConfiguration`, was added to support integration tests. This configuration specifies the only (not mocked) components that can be autowired into a test. The classes allowed are all "test fixture" classes, with the exception of `SamIam` and related classes, which were added to support `getPetToken()` calls. This could also be changed to only use text fixtures in the future.

While making this change, I also fixed a few other minor issues:

- migrated tests to JUnit 5
- fixed many sonar errors
- other minor stylistic changes

## Testing Strategy

Integration tests pass. Since integration tests don't report coverage, there's no automated way to tell if the new tests are equivalent to the old ones, so code review inspection is needed.