### PR TITLE
DT-1184: update db retry catch to use new exception class

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
@@ -14,14 +14,14 @@ import bio.terra.stairway.StepStatus;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.TransientDataAccessException;
 
 public class CreateDatasetMetadataStep implements Step {
 
-  private DatasetDao datasetDao;
-  private DatasetRequestModel datasetRequest;
+  private final DatasetDao datasetDao;
+  private final DatasetRequestModel datasetRequest;
 
-  private static Logger logger = LoggerFactory.getLogger(CreateDatasetMetadataStep.class);
+  private static final Logger logger = LoggerFactory.getLogger(CreateDatasetMetadataStep.class);
 
   public CreateDatasetMetadataStep(DatasetDao datasetDao, DatasetRequestModel datasetRequest) {
     this.datasetDao = datasetDao;
@@ -46,7 +46,7 @@ public class CreateDatasetMetadataStep implements Step {
       return StepResult.getStepResultSuccess();
     } catch (InvalidDatasetException idEx) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, idEx);
-    } catch (CannotSerializeTransactionException ex) {
+    } catch (TransientDataAccessException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     } catch (Exception ex) {
       return new StepResult(

--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetMetadataStep.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.TransientDataAccessException;
+import org.springframework.transaction.TransactionSystemException;
 
 public class CreateDatasetMetadataStep implements Step {
 
@@ -46,7 +47,7 @@ public class CreateDatasetMetadataStep implements Step {
       return StepResult.getStepResultSuccess();
     } catch (InvalidDatasetException idEx) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, idEx);
-    } catch (TransientDataAccessException ex) {
+    } catch (TransientDataAccessException | TransactionSystemException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     } catch (Exception ex) {
       return new StepResult(

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStep.java
@@ -12,7 +12,7 @@ import bio.terra.stairway.exception.RetryException;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.transaction.TransactionSystemException;
 
 public class CountSnapshotTableRowsStep implements Step {
@@ -39,8 +39,8 @@ public class CountSnapshotTableRowsStep implements Step {
     Map<String, Long> tableRowCounts = bigQuerySnapshotPdao.getSnapshotTableRowCounts(snapshot);
     try {
       snapshotDao.updateSnapshotTableRowCounts(snapshot, tableRowCounts);
-    } catch (CannotSerializeTransactionException | TransactionSystemException ex) {
-      logger.error("Could not serialize the transaction. Retrying.", ex);
+    } catch (TransientDataAccessException | TransactionSystemException ex) {
+      logger.error("Transaction failed due to a transient error. Retrying.", ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
@@ -10,7 +10,6 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +36,7 @@ public class CreateSnapshotCountTableRowsAzureStep implements Step {
     FlightMap workingMap = flightContext.getWorkingMap();
     Snapshot snapshot = snapshotDao.retrieveSnapshotByName(snapshotReq.getName());
     Map<String, Long> tableRowCounts =
-        workingMap.get(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, new TypeReference<>() {});
+        workingMap.get(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, Map.class);
     try {
       snapshotDao.updateSnapshotTableRowCounts(snapshot, tableRowCounts);
     } catch (TransientDataAccessException | TransactionSystemException ex) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStep.java
@@ -10,11 +10,11 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
-import java.util.HashMap;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.transaction.TransactionSystemException;
 
 public class CreateSnapshotCountTableRowsAzureStep implements Step {
@@ -37,11 +37,11 @@ public class CreateSnapshotCountTableRowsAzureStep implements Step {
     FlightMap workingMap = flightContext.getWorkingMap();
     Snapshot snapshot = snapshotDao.retrieveSnapshotByName(snapshotReq.getName());
     Map<String, Long> tableRowCounts =
-        workingMap.get(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, HashMap.class);
+        workingMap.get(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, new TypeReference<>() {});
     try {
       snapshotDao.updateSnapshotTableRowCounts(snapshot, tableRowCounts);
-    } catch (CannotSerializeTransactionException | TransactionSystemException ex) {
-      logger.error("Could not serialize the transaction. Retrying.", ex);
+    } catch (TransientDataAccessException | TransactionSystemException ex) {
+      logger.error("Transaction failed due to a transient error. Retrying.", ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/CreateSnapshotMetadataStep.java
@@ -19,7 +19,7 @@ import bio.terra.stairway.StepStatus;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.TransactionSystemException;
 
@@ -71,8 +71,8 @@ public class CreateSnapshotMetadataStep implements Step {
     } catch (SnapshotNotFoundException ex) {
       FlightUtils.setErrorResponse(context, ex.toString(), HttpStatus.BAD_REQUEST);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);
-    } catch (CannotSerializeTransactionException | TransactionSystemException ex) {
-      logger.error("Could not serialize the transaction. Retrying.", ex);
+    } catch (TransientDataAccessException | TransactionSystemException ex) {
+      logger.error("Transaction failed due to a transient error. Retrying.", ex);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
@@ -9,7 +9,7 @@ import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.UUID;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.http.HttpStatus;
 
 public class DeleteSnapshotMetadataStep implements Step {
@@ -32,7 +32,7 @@ public class DeleteSnapshotMetadataStep implements Step {
               : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
     } catch (SnapshotNotFoundException ex) {
       stateEnum = DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
-    } catch (CannotSerializeTransactionException ex) {
+    } catch (TransientDataAccessException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotMetadataStep.java
@@ -11,6 +11,7 @@ import bio.terra.stairway.StepStatus;
 import java.util.UUID;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.TransactionSystemException;
 
 public class DeleteSnapshotMetadataStep implements Step {
 
@@ -32,7 +33,7 @@ public class DeleteSnapshotMetadataStep implements Step {
               : DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
     } catch (SnapshotNotFoundException ex) {
       stateEnum = DeleteResponseModel.ObjectStateEnum.NOT_FOUND;
-    } catch (TransientDataAccessException ex) {
+    } catch (TransientDataAccessException | TransactionSystemException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, ex);
     }
 

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStepTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.CannotAcquireLockException;
 
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
@@ -58,7 +58,7 @@ class CountSnapshotTableRowsStepTest {
   @Test
   void testDoStepRetry() throws InterruptedException {
     step = new CountSnapshotTableRowsStep(bigQuerySnapshotPdao, snapshotDao, snapshotReq);
-    doThrow(CannotSerializeTransactionException.class)
+    doThrow(CannotAcquireLockException.class)
         .when(snapshotDao)
         .updateSnapshotTableRowCounts(SNAPSHOT, tableRowCounts);
 

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CountSnapshotTableRowsStepTest.java
@@ -30,7 +30,7 @@ class CountSnapshotTableRowsStepTest {
   @Mock private BigQuerySnapshotPdao bigQuerySnapshotPdao;
   @Mock private SnapshotDao snapshotDao;
   @Mock private FlightContext flightContext;
-  //  private FlightMap workingMap;
+
   private static final UUID SNAPSHOT_ID = UUID.randomUUID();
   private static final Snapshot SNAPSHOT =
       new Snapshot().id(SNAPSHOT_ID).name("Snapshot-" + SNAPSHOT_ID);

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStepTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.CannotSerializeTransactionException;
+import org.springframework.dao.CannotAcquireLockException;
 
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
@@ -31,8 +31,6 @@ class CreateSnapshotCountTableRowsAzureStepTest {
   @Mock private SnapshotDao snapshotDao;
   @Mock private FlightContext flightContext;
 
-  private FlightMap workingMap;
-
   private static final UUID SNAPSHOT_ID = UUID.randomUUID();
   private static final Snapshot SNAPSHOT =
       new Snapshot().id(SNAPSHOT_ID).name("Snapshot-" + SNAPSHOT_ID);
@@ -40,14 +38,14 @@ class CreateSnapshotCountTableRowsAzureStepTest {
   private static final SnapshotRequestModel snapshotReq =
       new SnapshotRequestModel().name(SNAPSHOT.getName());
 
-  private HashMap<String, Long> tableRowCounts = new HashMap<>();
+  private final HashMap<String, Long> tableRowCounts = new HashMap<>();
   private CreateSnapshotCountTableRowsAzureStep step;
 
   @BeforeEach
   void setup() {
     when(snapshotDao.retrieveSnapshotByName(SNAPSHOT.getName())).thenReturn(SNAPSHOT);
-    tableRowCounts.put("table", (long) 5);
-    workingMap = new FlightMap();
+    tableRowCounts.put("table", 5L);
+    FlightMap workingMap = new FlightMap();
     workingMap.put(SnapshotWorkingMapKeys.TABLE_ROW_COUNT_MAP, tableRowCounts);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
   }
@@ -62,7 +60,7 @@ class CreateSnapshotCountTableRowsAzureStepTest {
   @Test
   void testDoStepRetry() throws InterruptedException {
     step = new CreateSnapshotCountTableRowsAzureStep(snapshotDao, snapshotReq);
-    doThrow(CannotSerializeTransactionException.class)
+    doThrow(CannotAcquireLockException.class)
         .when(snapshotDao)
         .updateSnapshotTableRowCounts(SNAPSHOT, tableRowCounts);
 

--- a/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/CreateSnapshotCountTableRowsAzureStepTest.java
@@ -15,6 +15,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -38,7 +39,7 @@ class CreateSnapshotCountTableRowsAzureStepTest {
   private static final SnapshotRequestModel snapshotReq =
       new SnapshotRequestModel().name(SNAPSHOT.getName());
 
-  private final HashMap<String, Long> tableRowCounts = new HashMap<>();
+  private final Map<String, Long> tableRowCounts = new HashMap<>();
   private CreateSnapshotCountTableRowsAzureStep step;
 
   @BeforeEach


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1184

## Addresses

If a SQL operation in a Step failed due to a conflict, it would no longer be retried, which was causing integration tests to fail, and could cause a user's flight to fail that would've otherwise succeeded.

## Summary of changes

[CannotSerializeTransactionException](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/dao/CannotSerializeTransactionException.html) was deprecated in spring framework [6.0.3](https://github.com/spring-projects/spring-framework/releases/tag/v6.0.3). At some point, this exception was no longer thrown by the spring SQL layer and code we have that depended on it stopped working.

There are a number of new possible exceptions to catch, but [TransientDataAccessException](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/dao/TransientDataAccessException.html) seems like the most general type of exception which indicates a retryable SQL operation.

## Testing Strategy

- unit tests
- integration tests