### PR TITLE
DT-1182: Fix issue where integration tests would delete the jade service account

### DIFF
--- a/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
+++ b/src/test/java/bio/terra/integration/IntegrationTestConfiguration.java
@@ -16,6 +16,7 @@ import bio.terra.service.resourcemanagement.google.GoogleResourceConfiguration;
 import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.OpenTelemetry;
+import java.io.IOException;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
@@ -53,10 +54,10 @@ import org.springframework.context.annotation.Profile;
 public class IntegrationTestConfiguration {
 
   @Bean("tdrServiceAccountEmail")
-  public String tdrServiceAccountEmail() {
-    // Provide a default value for the service account email when running a spring-context aware
-    // test to avoid having to set it in the test environment.
-    return "";
+  public String tdrServiceAccountEmail() throws IOException {
+    // Delegate to ApplicationConfiguration to get the service account email. Without this set,
+    // the service account would be deleted by tests on teardown.
+    return new ApplicationConfiguration().tdrServiceAccountEmail();
   }
 
   @Bean


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1182

## Addresses

Fix issue where an empty service account email would result in the SA being _deleted_ when running integration tests

## Summary of changes

The previous change replaced `ApplicationConfiguration` with `IntegrationTestConfiguration`, so integration tests would have a more limited application context (e.g., not including a database connection). To satisfy the `tdrServiceAccountEmail` injection I added a stub method to return an empty string, which seemed to work fine (as this value isn't needed for tests to work correctly). However, it's used during teardown to prevent the test from deleting a service account. This use wasn't immediately apparent so the change was merged.

The fixed code uses the `ApplicationConfiguration` implementation to return the service account email.

## Testing Strategy

After integration tests run, verify that the service account is still present.