### PR TITLE
[DT-1210] Bump resource location to 5.18.3

### DIFF
--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -36,6 +36,6 @@ public class WebConfig implements WebMvcConfigurer {
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
     registry
         .addResourceHandler("/webjars/swagger-ui-dist/**")
-        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui-dist/5.18.2/");
+        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui-dist/5.18.3/");
   }
 }


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-1210

## Summary of changes

https://github.com/DataBiosphere/jade-data-repo/pull/1898 did not bump this file.

## Testing

Tested using a local instance with `./gradlew bootRun`
