### PR TITLE
DT-1202: Add "inherit steward" support to snapshot creation

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -125,11 +125,15 @@ public interface IamProviderInterface {
    *
    * @param userReq authenticated user
    * @param snapshotId id of the snapshot
+   * @param parent id of the parent (dataset) of the snapshot
    * @param policies user emails to add as snapshot policy members
    * @return Map of policy group emails for the snapshot policies
    */
   Map<IamRole, String> createSnapshotResource(
-      AuthenticatedUserRequest userReq, UUID snapshotId, SnapshotRequestModelPolicies policies)
+      AuthenticatedUserRequest userReq,
+      UUID snapshotId,
+      UUID parent,
+      SnapshotRequestModelPolicies policies)
       throws InterruptedException;
 
   /**

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -125,14 +125,14 @@ public interface IamProviderInterface {
    *
    * @param userReq authenticated user
    * @param snapshotId id of the snapshot
-   * @param parent id of the parent (dataset) of the snapshot
+   * @param parentId id of the parent dataset of the snapshot
    * @param policies user emails to add as snapshot policy members
    * @return Map of policy group emails for the snapshot policies
    */
   Map<IamRole, String> createSnapshotResource(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
-      UUID parent,
+      UUID parentId,
       SnapshotRequestModelPolicies policies)
       throws InterruptedException;
 

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -125,14 +125,14 @@ public interface IamProviderInterface {
    *
    * @param userReq authenticated user
    * @param snapshotId id of the snapshot
-   * @param parentId id of the parent dataset of the snapshot
+   * @param parentDatasetId id of the parent dataset of the snapshot
    * @param policies user emails to add as snapshot policy members
    * @return Map of policy group emails for the snapshot policies
    */
   Map<IamRole, String> createSnapshotResource(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
-      UUID parentId,
+      UUID parentDatasetId,
       SnapshotRequestModelPolicies policies)
       throws InterruptedException;
 

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -285,12 +285,17 @@ public class IamService {
    *
    * @param userReq authenticated user
    * @param snapshotId id of the snapshot
+   * @param parentDataset id of the snapshot's parent dataset
    * @param policies user emails to add as snapshot policy members
    * @return Map of policy group emails for the snapshot policies
    */
   public Map<IamRole, String> createSnapshotResource(
-      AuthenticatedUserRequest userReq, UUID snapshotId, SnapshotRequestModelPolicies policies) {
-    return callProvider(() -> iamProvider.createSnapshotResource(userReq, snapshotId, policies));
+      AuthenticatedUserRequest userReq,
+      UUID snapshotId,
+      UUID parentDataset,
+      SnapshotRequestModelPolicies policies) {
+    return callProvider(
+        () -> iamProvider.createSnapshotResource(userReq, snapshotId, parentDataset, policies));
   }
 
   /**

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -285,17 +285,17 @@ public class IamService {
    *
    * @param userReq authenticated user
    * @param snapshotId id of the snapshot
-   * @param parentDataset id of the snapshot's parent dataset
+   * @param parentDatasetId id of the snapshot's parent dataset
    * @param policies user emails to add as snapshot policy members
    * @return Map of policy group emails for the snapshot policies
    */
   public Map<IamRole, String> createSnapshotResource(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
-      UUID parentDataset,
+      UUID parentDatasetId,
       SnapshotRequestModelPolicies policies) {
     return callProvider(
-        () -> iamProvider.createSnapshotResource(userReq, snapshotId, parentDataset, policies));
+        () -> iamProvider.createSnapshotResource(userReq, snapshotId, parentDatasetId, policies));
   }
 
   /**

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -263,25 +263,36 @@ public class SamIam implements IamProviderInterface {
 
   @Override
   public Map<IamRole, String> createSnapshotResource(
-      AuthenticatedUserRequest userReq, UUID snapshotId, SnapshotRequestModelPolicies policies)
+      AuthenticatedUserRequest userReq,
+      UUID snapshotId,
+      UUID parent,
+      SnapshotRequestModelPolicies policies)
       throws InterruptedException {
     SamRetry.retry(
-        configurationService, () -> createSnapshotResourceInnerV2(userReq, snapshotId, policies));
+        configurationService,
+        () -> createSnapshotResourceInnerV2(userReq, snapshotId, parent, policies));
     return SamRetry.retry(
         configurationService, () -> syncSnapshotResourcePoliciesInner(userReq, snapshotId));
   }
 
   private void createSnapshotResourceInnerV2(
-      AuthenticatedUserRequest userReq, UUID snapshotId, SnapshotRequestModelPolicies policies)
+      AuthenticatedUserRequest userReq,
+      UUID snapshotId,
+      UUID parent,
+      SnapshotRequestModelPolicies policies)
       throws ApiException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
-    CreateResourceRequestV2 req = createSnapshotResourceRequest(userReq, snapshotId, policies);
+    CreateResourceRequestV2 req =
+        createSnapshotResourceRequest(userReq, snapshotId, parent, policies);
     samResourceApi.createResourceV2(IamResourceType.DATASNAPSHOT.toString(), req);
   }
 
   @VisibleForTesting
   CreateResourceRequestV2 createSnapshotResourceRequest(
-      AuthenticatedUserRequest userReq, UUID snapshotId, SnapshotRequestModelPolicies policies) {
+      AuthenticatedUserRequest userReq,
+      UUID snapshotId,
+      UUID parent,
+      SnapshotRequestModelPolicies policies) {
     policies = Optional.ofNullable(policies).orElse(new SnapshotRequestModelPolicies());
     UserStatusInfo userStatusInfo = getUserInfoAndVerify(userReq);
     CreateResourceRequestV2 req = new CreateResourceRequestV2().resourceId(snapshotId.toString());
@@ -306,7 +317,15 @@ public class SamIam implements IamProviderInterface {
         createAccessPolicy(IamRole.AGGREGATE_DATA_READER, policies.getAggregateDataReaders()));
 
     req.authDomain(List.of());
-    logger.debug("SAM request: " + req);
+
+    if (parent != null) {
+      req.setParent(
+          new FullyQualifiedResourceId()
+              .resourceTypeName(IamResourceType.DATASET.toString())
+              .resourceId(parent.toString()));
+    }
+
+    logger.debug("SAM request: {}", req);
     return req;
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -265,12 +265,12 @@ public class SamIam implements IamProviderInterface {
   public Map<IamRole, String> createSnapshotResource(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
-      UUID parent,
+      UUID parentId,
       SnapshotRequestModelPolicies policies)
       throws InterruptedException {
     SamRetry.retry(
         configurationService,
-        () -> createSnapshotResourceInnerV2(userReq, snapshotId, parent, policies));
+        () -> createSnapshotResourceInnerV2(userReq, snapshotId, parentId, policies));
     return SamRetry.retry(
         configurationService, () -> syncSnapshotResourcePoliciesInner(userReq, snapshotId));
   }
@@ -278,12 +278,12 @@ public class SamIam implements IamProviderInterface {
   private void createSnapshotResourceInnerV2(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
-      UUID parent,
+      UUID parentId,
       SnapshotRequestModelPolicies policies)
       throws ApiException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
     CreateResourceRequestV2 req =
-        createSnapshotResourceRequest(userReq, snapshotId, parent, policies);
+        createSnapshotResourceRequest(userReq, snapshotId, parentId, policies);
     samResourceApi.createResourceV2(IamResourceType.DATASNAPSHOT.toString(), req);
   }
 
@@ -291,7 +291,7 @@ public class SamIam implements IamProviderInterface {
   CreateResourceRequestV2 createSnapshotResourceRequest(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
-      UUID parent,
+      UUID parentId,
       SnapshotRequestModelPolicies policies) {
     policies = Optional.ofNullable(policies).orElse(new SnapshotRequestModelPolicies());
     UserStatusInfo userStatusInfo = getUserInfoAndVerify(userReq);
@@ -318,11 +318,11 @@ public class SamIam implements IamProviderInterface {
 
     req.authDomain(List.of());
 
-    if (parent != null) {
+    if (parentId != null) {
       req.setParent(
           new FullyQualifiedResourceId()
               .resourceTypeName(IamResourceType.DATASET.toString())
-              .resourceId(parent.toString()));
+              .resourceId(parentId.toString()));
     }
 
     logger.debug("SAM request: {}", req);

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -280,7 +280,7 @@ public class SamIam implements IamProviderInterface {
       UUID snapshotId,
       UUID parentDatasetId,
       SnapshotRequestModelPolicies policies)
-      throws ApiException {
+      throws ApiException, InterruptedException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
     CreateResourceRequestV2 req =
         createSnapshotResourceRequest(userReq, snapshotId, parentDatasetId, policies);
@@ -292,16 +292,22 @@ public class SamIam implements IamProviderInterface {
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
       UUID parentDatasetId,
-      SnapshotRequestModelPolicies policies) {
+      SnapshotRequestModelPolicies policies)
+      throws InterruptedException {
     policies = Optional.ofNullable(policies).orElse(new SnapshotRequestModelPolicies());
-    UserStatusInfo userStatusInfo = getUserInfoAndVerify(userReq);
     CreateResourceRequestV2 req = new CreateResourceRequestV2().resourceId(snapshotId.toString());
 
     req.putPoliciesItem(
         IamRole.ADMIN.toString(), createAccessPolicy(IamRole.ADMIN, getAdminEmailList()));
 
     List<String> stewards = new ArrayList<>();
-    stewards.add(userStatusInfo.getUserEmail());
+    if (parentDatasetId != null) {
+      List<String> roles = retrieveUserRoles(userReq, IamResourceType.DATASET, parentDatasetId);
+      if (!roles.contains(IamRole.CUSTODIAN.toString())) {
+        // Only add the current user as a steward if they are not a custodian of the parent dataset.
+        stewards.add(getUserInfoAndVerify(userReq).getUserEmail());
+      }
+    }
     stewards.addAll(ListUtils.emptyIfNull(policies.getStewards()));
     req.putPoliciesItem(IamRole.STEWARD.toString(), createAccessPolicy(IamRole.STEWARD, stewards));
 

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -304,7 +304,8 @@ public class SamIam implements IamProviderInterface {
     if (parentDatasetId == null
         || !retrieveUserRoles(userReq, IamResourceType.DATASET, parentDatasetId)
             .contains(IamRole.CUSTODIAN.toString())) {
-      // Only add the current user as a steward if they are not a custodian of the parent dataset.
+      // Add the current user as a steward if there is no parent dataset, or they are not
+      // a custodian of the parent.
       stewards.add(getUserInfoAndVerify(userReq).getUserEmail());
     }
     stewards.addAll(ListUtils.emptyIfNull(policies.getStewards()));

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -301,12 +301,11 @@ public class SamIam implements IamProviderInterface {
         IamRole.ADMIN.toString(), createAccessPolicy(IamRole.ADMIN, getAdminEmailList()));
 
     List<String> stewards = new ArrayList<>();
-    if (parentDatasetId != null) {
-      List<String> roles = retrieveUserRoles(userReq, IamResourceType.DATASET, parentDatasetId);
-      if (!roles.contains(IamRole.CUSTODIAN.toString())) {
-        // Only add the current user as a steward if they are not a custodian of the parent dataset.
-        stewards.add(getUserInfoAndVerify(userReq).getUserEmail());
-      }
+    if (parentDatasetId == null
+        || !retrieveUserRoles(userReq, IamResourceType.DATASET, parentDatasetId)
+            .contains(IamRole.CUSTODIAN.toString())) {
+      // Only add the current user as a steward if they are not a custodian of the parent dataset.
+      stewards.add(getUserInfoAndVerify(userReq).getUserEmail());
     }
     stewards.addAll(ListUtils.emptyIfNull(policies.getStewards()));
     req.putPoliciesItem(IamRole.STEWARD.toString(), createAccessPolicy(IamRole.STEWARD, stewards));

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -265,12 +265,12 @@ public class SamIam implements IamProviderInterface {
   public Map<IamRole, String> createSnapshotResource(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
-      UUID parentId,
+      UUID parentDatasetId,
       SnapshotRequestModelPolicies policies)
       throws InterruptedException {
     SamRetry.retry(
         configurationService,
-        () -> createSnapshotResourceInnerV2(userReq, snapshotId, parentId, policies));
+        () -> createSnapshotResourceInnerV2(userReq, snapshotId, parentDatasetId, policies));
     return SamRetry.retry(
         configurationService, () -> syncSnapshotResourcePoliciesInner(userReq, snapshotId));
   }
@@ -278,12 +278,12 @@ public class SamIam implements IamProviderInterface {
   private void createSnapshotResourceInnerV2(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
-      UUID parentId,
+      UUID parentDatasetId,
       SnapshotRequestModelPolicies policies)
       throws ApiException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
     CreateResourceRequestV2 req =
-        createSnapshotResourceRequest(userReq, snapshotId, parentId, policies);
+        createSnapshotResourceRequest(userReq, snapshotId, parentDatasetId, policies);
     samResourceApi.createResourceV2(IamResourceType.DATASNAPSHOT.toString(), req);
   }
 
@@ -291,7 +291,7 @@ public class SamIam implements IamProviderInterface {
   CreateResourceRequestV2 createSnapshotResourceRequest(
       AuthenticatedUserRequest userReq,
       UUID snapshotId,
-      UUID parentId,
+      UUID parentDatasetId,
       SnapshotRequestModelPolicies policies) {
     policies = Optional.ofNullable(policies).orElse(new SnapshotRequestModelPolicies());
     UserStatusInfo userStatusInfo = getUserInfoAndVerify(userReq);
@@ -318,11 +318,11 @@ public class SamIam implements IamProviderInterface {
 
     req.authDomain(List.of());
 
-    if (parentId != null) {
+    if (parentDatasetId != null) {
       req.setParent(
           new FullyQualifiedResourceId()
               .resourceTypeName(IamResourceType.DATASET.toString())
-              .resourceId(parentId.toString()));
+              .resourceId(parentDatasetId.toString()));
     }
 
     logger.debug("SAM request: {}", req);

--- a/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
@@ -26,4 +26,5 @@ public final class SnapshotWorkingMapKeys extends ProjectCreatingFlightKeys {
   public static final String SNAPSHOT_FIRECLOUD_GROUP_EMAIL = "snapshotFirecloudGroupEmail";
   public static final String SNAPSHOT_DATA_ACCESS_CONTROL_GROUPS =
       "snapshotDataAccessControlGroups";
+  public static final String SNAPSHOT_PARENT_DATASET_ID = "snapshotParentDatasetId";
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
@@ -26,5 +26,5 @@ public final class SnapshotWorkingMapKeys extends ProjectCreatingFlightKeys {
   public static final String SNAPSHOT_FIRECLOUD_GROUP_EMAIL = "snapshotFirecloudGroupEmail";
   public static final String SNAPSHOT_DATA_ACCESS_CONTROL_GROUPS =
       "snapshotDataAccessControlGroups";
-  public static final String SNAPSHOT_PARENT_DATASET_ID = "snapshotParentDatasetId";
+  public static final String SNAPSHOT_INHERIT_STEWARD_ENABLED = "snapshotInheritStewardEnabled";
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -6,7 +6,6 @@ import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.resourcemanagement.ResourceService;
-import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -46,15 +45,14 @@ public class SnapshotAuthzBqJobUserStep implements Step {
     Map<IamRole, String> policyMap =
         workingMap.get(SnapshotWorkingMapKeys.POLICY_MAP, new TypeReference<>() {});
 
-    Snapshot snapshot = snapshotService.retrieveByName(snapshotName);
+    String googleProjectId =
+        snapshotService.retrieveByName(snapshotName).getProjectResource().getGoogleProjectId();
 
     // Allow the steward and reader to make queries in this project.
     // The underlying service provides retries so we do not need to retry this operation
     resourceService.grantPoliciesBqJobUser(
-        snapshot.getProjectResource().getGoogleProjectId(),
-        List.of(policyMap.get(IamRole.STEWARD)));
-    resourceService.grantPoliciesBqJobUser(
-        snapshot.getProjectResource().getGoogleProjectId(), List.of(policyMap.get(IamRole.READER)));
+        googleProjectId, List.of(policyMap.get(IamRole.STEWARD)));
+    resourceService.grantPoliciesBqJobUser(googleProjectId, List.of(policyMap.get(IamRole.READER)));
 
     Boolean inheritEnabled =
         context
@@ -65,8 +63,7 @@ public class SnapshotAuthzBqJobUserStep implements Step {
           sam.retrievePolicyEmails(request, IamResourceType.DATASET, sourceDataset.getId());
       // Allow the custodian to make queries in this project.
       resourceService.grantPoliciesBqJobUser(
-          snapshot.getProjectResource().getGoogleProjectId(),
-          List.of(datasetPolicyMap.get(IamRole.CUSTODIAN)));
+          googleProjectId, List.of(datasetPolicyMap.get(IamRole.CUSTODIAN)));
     }
 
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -70,7 +70,7 @@ public class SnapshotAuthzBqJobUserStep implements Step {
   }
 
   @Override
-  public StepResult undoStep(FlightContext context) throws InterruptedException {
+  public StepResult undoStep(FlightContext context) {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -1,6 +1,9 @@
 package bio.terra.service.snapshot.flight.create;
 
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
@@ -10,18 +13,27 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.fasterxml.jackson.core.type.TypeReference;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class SnapshotAuthzBqJobUserStep implements Step {
   private final SnapshotService snapshotService;
   private final ResourceService resourceService;
+  private final IamService sam;
+  private final AuthenticatedUserRequest request;
   private final String snapshotName;
 
   public SnapshotAuthzBqJobUserStep(
-      SnapshotService snapshotService, ResourceService resourceService, String snapshotName) {
+      SnapshotService snapshotService,
+      ResourceService resourceService,
+      IamService sam,
+      AuthenticatedUserRequest request,
+      String snapshotName) {
     this.snapshotService = snapshotService;
     this.resourceService = resourceService;
+    this.sam = sam;
+    this.request = request;
     this.snapshotName = snapshotName;
   }
 
@@ -37,10 +49,22 @@ public class SnapshotAuthzBqJobUserStep implements Step {
     // The underlying service provides retries so we do not need to retry this operation
     resourceService.grantPoliciesBqJobUser(
         snapshot.getProjectResource().getGoogleProjectId(),
-        Collections.singletonList(policyMap.get(IamRole.STEWARD)));
+        List.of(policyMap.get(IamRole.STEWARD)));
     resourceService.grantPoliciesBqJobUser(
-        snapshot.getProjectResource().getGoogleProjectId(),
-        Collections.singletonList(policyMap.get(IamRole.READER)));
+        snapshot.getProjectResource().getGoogleProjectId(), List.of(policyMap.get(IamRole.READER)));
+
+    UUID parentDatasetId =
+        workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_PARENT_DATASET_ID, UUID.class);
+    if (parentDatasetId != null) {
+      var datasetPolicyMap =
+          sam.retrievePolicyEmails(request, IamResourceType.DATASET, parentDatasetId);
+      // Allow the custodian to make queries in this project.
+      // FIXME: Is this necessary? The dataset custodian should already BQ job access to the
+      // snapshot's project.
+      resourceService.grantPoliciesBqJobUser(
+          snapshot.getProjectResource().getGoogleProjectId(),
+          List.of(datasetPolicyMap.get(IamRole.CUSTODIAN)));
+    }
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -64,8 +64,6 @@ public class SnapshotAuthzBqJobUserStep implements Step {
       var datasetPolicyMap =
           sam.retrievePolicyEmails(request, IamResourceType.DATASET, sourceDataset.getId());
       // Allow the custodian to make queries in this project.
-      // FIXME: Is this necessary? The dataset custodian should already BQ job access to the
-      // snapshot's project.
       resourceService.grantPoliciesBqJobUser(
           snapshot.getProjectResource().getGoogleProjectId(),
           List.of(datasetPolicyMap.get(IamRole.CUSTODIAN)));

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -13,6 +13,7 @@ import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -49,10 +50,8 @@ public class SnapshotAuthzBqJobUserStep implements Step {
         snapshotService.retrieveByName(snapshotName).getProjectResource().getGoogleProjectId();
 
     // Allow the steward and reader to make queries in this project.
-    // The underlying service provides retries so we do not need to retry this operation
-    resourceService.grantPoliciesBqJobUser(
-        googleProjectId, List.of(policyMap.get(IamRole.STEWARD)));
-    resourceService.grantPoliciesBqJobUser(googleProjectId, List.of(policyMap.get(IamRole.READER)));
+    List<String> policyEmails =
+        new ArrayList<>(List.of(policyMap.get(IamRole.STEWARD), policyMap.get(IamRole.READER)));
 
     Boolean inheritEnabled =
         context
@@ -62,9 +61,10 @@ public class SnapshotAuthzBqJobUserStep implements Step {
       var datasetPolicyMap =
           sam.retrievePolicyEmails(request, IamResourceType.DATASET, sourceDataset.getId());
       // Allow the custodian to make queries in this project.
-      resourceService.grantPoliciesBqJobUser(
-          googleProjectId, List.of(datasetPolicyMap.get(IamRole.CUSTODIAN)));
+      policyEmails.add(datasetPolicyMap.get(IamRole.CUSTODIAN));
     }
+    // The underlying service provides retries so we do not need to retry this operation
+    resourceService.grantPoliciesBqJobUser(googleProjectId, policyEmails);
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -4,6 +4,7 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
@@ -15,7 +16,6 @@ import bio.terra.stairway.StepResult;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class SnapshotAuthzBqJobUserStep implements Step {
   private final SnapshotService snapshotService;
@@ -23,18 +23,21 @@ public class SnapshotAuthzBqJobUserStep implements Step {
   private final IamService sam;
   private final AuthenticatedUserRequest request;
   private final String snapshotName;
+  private final Dataset sourceDataset;
 
   public SnapshotAuthzBqJobUserStep(
       SnapshotService snapshotService,
       ResourceService resourceService,
       IamService sam,
       AuthenticatedUserRequest request,
-      String snapshotName) {
+      String snapshotName,
+      Dataset sourceDataset) {
     this.snapshotService = snapshotService;
     this.resourceService = resourceService;
     this.sam = sam;
     this.request = request;
     this.snapshotName = snapshotName;
+    this.sourceDataset = sourceDataset;
   }
 
   @Override
@@ -53,11 +56,13 @@ public class SnapshotAuthzBqJobUserStep implements Step {
     resourceService.grantPoliciesBqJobUser(
         snapshot.getProjectResource().getGoogleProjectId(), List.of(policyMap.get(IamRole.READER)));
 
-    UUID parentDatasetId =
-        workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_PARENT_DATASET_ID, UUID.class);
-    if (parentDatasetId != null) {
+    Boolean inheritEnabled =
+        context
+            .getInputParameters()
+            .get(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, Boolean.class);
+    if (inheritEnabled != null && inheritEnabled) {
       var datasetPolicyMap =
-          sam.retrievePolicyEmails(request, IamResourceType.DATASET, parentDatasetId);
+          sam.retrievePolicyEmails(request, IamResourceType.DATASET, sourceDataset.getId());
       // Allow the custodian to make queries in this project.
       // FIXME: Is this necessary? The dataset custodian should already BQ job access to the
       // snapshot's project.

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
@@ -9,7 +9,6 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
-import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosFlightUtils;
 import bio.terra.stairway.FlightContext;
@@ -23,7 +22,6 @@ import org.slf4j.LoggerFactory;
 
 public class SnapshotAuthzIamStep implements Step {
   private final IamService sam;
-  private final SnapshotService snapshotService;
   private final SnapshotRequestModel snapshotRequestModel;
   private final AuthenticatedUserRequest userReq;
   private final UUID snapshotId;
@@ -31,12 +29,10 @@ public class SnapshotAuthzIamStep implements Step {
 
   public SnapshotAuthzIamStep(
       IamService sam,
-      SnapshotService snapshotService,
       SnapshotRequestModel snapshotRequestModel,
       AuthenticatedUserRequest userReq,
       UUID snapshotId) {
     this.sam = sam;
-    this.snapshotService = snapshotService;
     this.snapshotRequestModel = snapshotRequestModel;
     this.userReq = userReq;
     this.snapshotId = snapshotId;
@@ -57,8 +53,12 @@ public class SnapshotAuthzIamStep implements Step {
           workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_FIRECLOUD_GROUP_EMAIL, String.class);
       derivedPolicies.addReadersItem(snapshotFirecloudGroupEmail);
     }
+    UUID parentDataset =
+        context
+            .getInputParameters()
+            .get(SnapshotWorkingMapKeys.SNAPSHOT_PARENT_DATASET_ID, UUID.class);
     Map<IamRole, String> policies =
-        sam.createSnapshotResource(userReq, snapshotId, derivedPolicies);
+        sam.createSnapshotResource(userReq, snapshotId, parentDataset, derivedPolicies);
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policies);
     return StepResult.getStepResultSuccess();
   }
@@ -71,7 +71,7 @@ public class SnapshotAuthzIamStep implements Step {
       // when SAM deletes the ACL. How 'bout that!
     } catch (UnauthorizedException ex) {
       // suppress exception
-      logger.error("NEEDS CLEANUP: delete sam resource for snapshot " + snapshotId.toString());
+      logger.error("NEEDS CLEANUP: delete sam resource for snapshot {}", snapshotId);
       logger.warn(ex.getMessage());
     } catch (NotFoundException ex) {
       // suppress exception

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
@@ -9,6 +9,7 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosFlightUtils;
 import bio.terra.stairway.FlightContext;
@@ -25,17 +26,20 @@ public class SnapshotAuthzIamStep implements Step {
   private final SnapshotRequestModel snapshotRequestModel;
   private final AuthenticatedUserRequest userReq;
   private final UUID snapshotId;
+  private final Dataset sourceDataset;
   private static final Logger logger = LoggerFactory.getLogger(SnapshotAuthzIamStep.class);
 
   public SnapshotAuthzIamStep(
       IamService sam,
       SnapshotRequestModel snapshotRequestModel,
       AuthenticatedUserRequest userReq,
-      UUID snapshotId) {
+      UUID snapshotId,
+      Dataset sourceDataset) {
     this.sam = sam;
     this.snapshotRequestModel = snapshotRequestModel;
     this.userReq = userReq;
     this.snapshotId = snapshotId;
+    this.sourceDataset = sourceDataset;
   }
 
   @Override
@@ -53,12 +57,18 @@ public class SnapshotAuthzIamStep implements Step {
           workingMap.get(SnapshotWorkingMapKeys.SNAPSHOT_FIRECLOUD_GROUP_EMAIL, String.class);
       derivedPolicies.addReadersItem(snapshotFirecloudGroupEmail);
     }
-    UUID parentDataset =
+    final UUID parentDatasetId;
+    Boolean inheritEnabled =
         context
             .getInputParameters()
-            .get(SnapshotWorkingMapKeys.SNAPSHOT_PARENT_DATASET_ID, UUID.class);
+            .get(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, Boolean.class);
+    if (inheritEnabled != null && inheritEnabled) {
+      parentDatasetId = sourceDataset.getId();
+    } else {
+      parentDatasetId = null;
+    }
     Map<IamRole, String> policies =
-        sam.createSnapshotResource(userReq, snapshotId, parentDataset, derivedPolicies);
+        sam.createSnapshotResource(userReq, snapshotId, parentDatasetId, derivedPolicies);
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policies);
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -9,6 +9,7 @@ import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
@@ -31,23 +32,26 @@ public class SnapshotAuthzTabularAclStep implements Step {
   private final BigQuerySnapshotPdao bigQuerySnapshotPdao;
   private final SnapshotService snapshotService;
   private final ConfigurationService configService;
+  private final IamService iamService;
   private final UUID snapshotId;
   private final AuthenticatedUserRequest userReq;
-  private final IamService iamService;
+  private final Dataset sourceDataset;
 
   public SnapshotAuthzTabularAclStep(
       BigQuerySnapshotPdao bigQuerySnapshotPdao,
       SnapshotService snapshotService,
       ConfigurationService configService,
+      IamService iamService,
       UUID snapshotId,
       AuthenticatedUserRequest userReq,
-      IamService iamService) {
+      Dataset sourceDataset) {
     this.bigQuerySnapshotPdao = bigQuerySnapshotPdao;
     this.snapshotService = snapshotService;
     this.configService = configService;
     this.snapshotId = snapshotId;
     this.userReq = userReq;
     this.iamService = iamService;
+    this.sourceDataset = sourceDataset;
   }
 
   @Override
@@ -62,13 +66,13 @@ public class SnapshotAuthzTabularAclStep implements Step {
     emails.add(policies.get(IamRole.STEWARD));
     emails.add(policies.get(IamRole.READER));
 
-    UUID parentDatasetId =
+    Boolean inheritEnabled =
         context
             .getInputParameters()
-            .get(SnapshotWorkingMapKeys.SNAPSHOT_PARENT_DATASET_ID, UUID.class);
-    if (parentDatasetId != null) {
+            .get(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, Boolean.class);
+    if (inheritEnabled != null && inheritEnabled) {
       var datasetPolicyMap =
-          iamService.retrievePolicyEmails(userReq, IamResourceType.DATASET, parentDatasetId);
+          iamService.retrievePolicyEmails(userReq, IamResourceType.DATASET, sourceDataset.getId());
       emails.add(datasetPolicyMap.get(IamRole.CUSTODIAN));
     }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -4,7 +4,10 @@ import static bio.terra.service.configuration.ConfigEnum.SNAPSHOT_GRANT_ACCESS_F
 
 import bio.terra.common.FlightUtils;
 import bio.terra.common.exception.PdaoException;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
@@ -29,16 +32,22 @@ public class SnapshotAuthzTabularAclStep implements Step {
   private final SnapshotService snapshotService;
   private final ConfigurationService configService;
   private final UUID snapshotId;
+  private final AuthenticatedUserRequest userReq;
+  private final IamService iamService;
 
   public SnapshotAuthzTabularAclStep(
       BigQuerySnapshotPdao bigQuerySnapshotPdao,
       SnapshotService snapshotService,
       ConfigurationService configService,
-      UUID snapshotId) {
+      UUID snapshotId,
+      AuthenticatedUserRequest userReq,
+      IamService iamService) {
     this.bigQuerySnapshotPdao = bigQuerySnapshotPdao;
     this.snapshotService = snapshotService;
     this.configService = configService;
     this.snapshotId = snapshotId;
+    this.userReq = userReq;
+    this.iamService = iamService;
   }
 
   @Override
@@ -52,6 +61,16 @@ public class SnapshotAuthzTabularAclStep implements Step {
     List<String> emails = new ArrayList<>();
     emails.add(policies.get(IamRole.STEWARD));
     emails.add(policies.get(IamRole.READER));
+
+    UUID parentDatasetId =
+        context
+            .getInputParameters()
+            .get(SnapshotWorkingMapKeys.SNAPSHOT_PARENT_DATASET_ID, UUID.class);
+    if (parentDatasetId != null) {
+      var datasetPolicyMap =
+          iamService.retrievePolicyEmails(userReq, IamResourceType.DATASET, parentDatasetId);
+      emails.add(datasetPolicyMap.get(IamRole.CUSTODIAN));
+    }
 
     try {
       if (configService.testInsertFault(SNAPSHOT_GRANT_ACCESS_FAULT)) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -312,7 +312,7 @@ public class SnapshotCreateFlight extends Flight {
 
     // Create the IAM resource and readers for the snapshot
     // The IAM code contains retries, so we don't make a retry rule here.
-    addStep(new SnapshotAuthzIamStep(iamClient, snapshotService, snapshotReq, userReq, snapshotId));
+    addStep(new SnapshotAuthzIamStep(iamClient, snapshotReq, userReq, snapshotId));
 
     // Now that the snapshot exists in Sam, we can add data access control groups to the snapshot
     addStep(new CreateSnapshotSetDataAccessGroupsStep(snapshotReq.getDataAccessControlGroups()));
@@ -350,7 +350,12 @@ public class SnapshotCreateFlight extends Flight {
       // Apply the IAM readers to the BQ dataset
       addStep(
           new SnapshotAuthzTabularAclStep(
-              bigQuerySnapshotPdao, snapshotService, configService, snapshotId),
+              bigQuerySnapshotPdao,
+              snapshotService,
+              configService,
+              snapshotId,
+              userReq,
+              iamService),
           pdaoAclRetryRule);
 
       // Apply the IAM readers to the GCS files
@@ -361,7 +366,9 @@ public class SnapshotCreateFlight extends Flight {
             pdaoAclRetryRule);
       }
 
-      addStep(new SnapshotAuthzBqJobUserStep(snapshotService, resourceService, snapshotName));
+      addStep(
+          new SnapshotAuthzBqJobUserStep(
+              snapshotService, resourceService, iamService, userReq, snapshotName));
       addStep(
           new SnapshotAuthzServiceAccountConsumerStep(
               snapshotService, resourceService, snapshotName, tdrServiceAccountEmail));

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -312,7 +312,7 @@ public class SnapshotCreateFlight extends Flight {
 
     // Create the IAM resource and readers for the snapshot
     // The IAM code contains retries, so we don't make a retry rule here.
-    addStep(new SnapshotAuthzIamStep(iamClient, snapshotReq, userReq, snapshotId));
+    addStep(new SnapshotAuthzIamStep(iamClient, snapshotReq, userReq, snapshotId, sourceDataset));
 
     // Now that the snapshot exists in Sam, we can add data access control groups to the snapshot
     addStep(new CreateSnapshotSetDataAccessGroupsStep(snapshotReq.getDataAccessControlGroups()));
@@ -353,9 +353,10 @@ public class SnapshotCreateFlight extends Flight {
               bigQuerySnapshotPdao,
               snapshotService,
               configService,
+              iamService,
               snapshotId,
               userReq,
-              iamService),
+              sourceDataset),
           pdaoAclRetryRule);
 
       // Apply the IAM readers to the GCS files
@@ -368,7 +369,7 @@ public class SnapshotCreateFlight extends Flight {
 
       addStep(
           new SnapshotAuthzBqJobUserStep(
-              snapshotService, resourceService, iamService, userReq, snapshotName));
+              snapshotService, resourceService, iamService, userReq, snapshotName, sourceDataset));
       addStep(
           new SnapshotAuthzServiceAccountConsumerStep(
               snapshotService, resourceService, snapshotName, tdrServiceAccountEmail));

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzBqAclsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzBqAclsStep.java
@@ -13,6 +13,7 @@ import bio.terra.stairway.StepResult;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,22 +44,27 @@ public class DeleteSnapshotAuthzBqAclsStep implements Step {
     Snapshot snapshot = snapshotService.retrieve(snapshotId);
 
     // These policy emails should not change since the snapshot is locked by the flight
-    Map<IamRole, String> policyEmails =
-        sam.retrievePolicyEmails(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
+    List<String> policyEmails =
+        sam
+            .retrievePolicyEmails(userReq, IamResourceType.DATASNAPSHOT, snapshotId)
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getKey() == IamRole.STEWARD || entry.getKey() == IamRole.READER)
+            .map(Map.Entry::getValue)
+            .collect(Collectors.toList());
 
     // If the dataset custodian inherited permissions, remove them now.
     var datasetPolicyEmails =
         sam.retrievePolicyEmails(
             userReq, IamResourceType.DATASET, snapshot.getSourceDataset().getId());
+    if (datasetPolicyEmails.containsKey(IamRole.CUSTODIAN)) {
+      policyEmails.add(datasetPolicyEmails.get(IamRole.CUSTODIAN));
+    }
 
     // Remove access added by SnapshotAuthzBqJobUserStep.
     // The underlying service provides retries so we do not need to retry this operation
     resourceService.revokePoliciesBqJobUser(
-        snapshot.getProjectResource().getGoogleProjectId(),
-        List.of(
-            policyEmails.get(IamRole.STEWARD),
-            policyEmails.get(IamRole.READER),
-            datasetPolicyEmails.get(IamRole.CUSTODIAN)));
+        snapshot.getProjectResource().getGoogleProjectId(), policyEmails);
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzBqAclsStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzBqAclsStep.java
@@ -10,7 +10,7 @@ import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -46,11 +46,19 @@ public class DeleteSnapshotAuthzBqAclsStep implements Step {
     Map<IamRole, String> policyEmails =
         sam.retrievePolicyEmails(userReq, IamResourceType.DATASNAPSHOT, snapshotId);
 
-    // Remove the custodian's access to make queries in this project.
+    // If the dataset custodian inherited permissions, remove them now.
+    var datasetPolicyEmails =
+        sam.retrievePolicyEmails(
+            userReq, IamResourceType.DATASET, snapshot.getSourceDataset().getId());
+
+    // Remove access added by SnapshotAuthzBqJobUserStep.
     // The underlying service provides retries so we do not need to retry this operation
     resourceService.revokePoliciesBqJobUser(
         snapshot.getProjectResource().getGoogleProjectId(),
-        Arrays.asList(policyEmails.get(IamRole.STEWARD), policyEmails.get(IamRole.READER)));
+        List.of(
+            policyEmails.get(IamRole.STEWARD),
+            policyEmails.get(IamRole.READER),
+            datasetPolicyEmails.get(IamRole.CUSTODIAN)));
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -142,7 +142,8 @@ public class ConnectedOperations {
     datasetPolicies.put(IamRole.STEWARD, "jadeteam@broadinstitute.org");
     datasetPolicies.put(IamRole.SNAPSHOT_CREATOR, "jadeteam@broadinstitute.org");
 
-    when(samService.createSnapshotResource(any(), any(), any())).thenReturn(snapshotPolicies);
+    when(samService.createSnapshotResource(any(), any(), any(), any()))
+        .thenReturn(snapshotPolicies);
     when(samService.isAuthorized(any(), any(), any(), any())).thenReturn(Boolean.TRUE);
     when(samService.createDatasetResource(any(), any(), any())).thenReturn(datasetPolicies);
     when(samService.listActions(any(), eq(IamResourceType.DATASET), any()))

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -189,6 +189,15 @@ class IamServiceTest {
   }
 
   @Test
+  void createSnapshotResource() throws Exception {
+    UUID snapshotId = UUID.randomUUID();
+    UUID parentId = UUID.randomUUID();
+    SnapshotRequestModelPolicies policies = new SnapshotRequestModelPolicies();
+    iamService.createSnapshotResource(TEST_USER, snapshotId, parentId, policies);
+    verify(iamProvider).createSnapshotResource(TEST_USER, snapshotId, parentId, policies);
+  }
+
+  @Test
   void testDeriveSnapshotPolicies() {
     assertThat(
         "Request without policies or readers returns new policy object",

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -191,10 +191,10 @@ class IamServiceTest {
   @Test
   void createSnapshotResource() throws Exception {
     UUID snapshotId = UUID.randomUUID();
-    UUID parentId = UUID.randomUUID();
+    UUID parentDatasetId = UUID.randomUUID();
     SnapshotRequestModelPolicies policies = new SnapshotRequestModelPolicies();
-    iamService.createSnapshotResource(TEST_USER, snapshotId, parentId, policies);
-    verify(iamProvider).createSnapshotResource(TEST_USER, snapshotId, parentId, policies);
+    iamService.createSnapshotResource(TEST_USER, snapshotId, parentDatasetId, policies);
+    verify(iamProvider).createSnapshotResource(TEST_USER, snapshotId, parentDatasetId, policies);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -10,6 +10,8 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -71,6 +73,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -567,6 +570,33 @@ class SamIamTest {
           is(
               syncedPolicies.stream()
                   .collect(Collectors.toMap(p -> p, p -> "policygroup-" + p + "@firecloud.org"))));
+    }
+
+    @Test
+    void testCreateSnapshotWithParent() throws Exception {
+      mockSamGoogleApi();
+      final String userSubjectId = "userid";
+      final String userEmail = "a@a.com";
+      mockUserInfo(userSubjectId, userEmail);
+
+      UUID snapshotId = UUID.randomUUID();
+      UUID parentId = UUID.randomUUID();
+
+      when(samGoogleApi.syncPolicy(
+              eq(IamResourceType.DATASNAPSHOT.getSamResourceName()),
+              eq(snapshotId.toString()),
+              any(),
+              any()))
+          .thenReturn(Map.of("key", List.of()));
+
+      samIam.createSnapshotResource(TEST_USER, snapshotId, parentId, null);
+      var argument = ArgumentCaptor.forClass(CreateResourceRequestV2.class);
+      verify(samResourceApi)
+          .createResourceV2(eq(IamResourceType.DATASNAPSHOT.toString()), argument.capture());
+      assertThat(argument.getValue().getParent().getResourceId(), is(parentId.toString()));
+      assertThat(
+          argument.getValue().getParent().getResourceTypeName(),
+          is(IamResourceType.DATASET.toString()));
     }
 
     @Test

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -230,10 +230,10 @@ class SamIamTest {
     final UUID snapshotId = UUID.randomUUID();
 
     CreateResourceRequestV2 reqNullPolicies =
-        samIam.createSnapshotResourceRequest(TEST_USER, snapshotId, null);
+        samIam.createSnapshotResourceRequest(TEST_USER, snapshotId, null, null);
     CreateResourceRequestV2 reqEmptyPolicies =
         samIam.createSnapshotResourceRequest(
-            TEST_USER, snapshotId, new SnapshotRequestModelPolicies());
+            TEST_USER, snapshotId, null, new SnapshotRequestModelPolicies());
 
     for (CreateResourceRequestV2 req : List.of(reqNullPolicies, reqEmptyPolicies)) {
       assertThat(req.getResourceId(), is(snapshotId.toString()));
@@ -287,7 +287,7 @@ class SamIamTest {
             .addReadersItem(readerEmail)
             .addDiscoverersItem(discovererEmail);
     CreateResourceRequestV2 req =
-        samIam.createSnapshotResourceRequest(TEST_USER, snapshotId, policySpecs);
+        samIam.createSnapshotResourceRequest(TEST_USER, snapshotId, null, policySpecs);
 
     assertThat(req.getResourceId(), is(snapshotId.toString()));
 
@@ -563,7 +563,7 @@ class SamIamTest {
       }
 
       assertThat(
-          samIam.createSnapshotResource(TEST_USER, snapshotId, null),
+          samIam.createSnapshotResource(TEST_USER, snapshotId, null, null),
           is(
               syncedPolicies.stream()
                   .collect(Collectors.toMap(p -> p, p -> "policygroup-" + p + "@firecloud.org"))));

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -225,7 +225,7 @@ class SamIamTest {
   }
 
   @Test
-  void testCreateSnapshotResourceRequestWithoutPolicySpecifications() throws ApiException {
+  void testCreateSnapshotResourceRequestWithoutPolicySpecifications() throws Exception {
     final String userSubjectId = "userid";
     final String userEmail = "a@a.com";
     mockUserInfo(userSubjectId, userEmail);
@@ -272,7 +272,7 @@ class SamIamTest {
   }
 
   @Test
-  void testCreateSnapshotResourceRequestWithPolicySpecifications() throws ApiException {
+  void testCreateSnapshotResourceRequestWithPolicySpecifications() throws Exception {
     final String userSubjectId = "userid";
     final String userEmail = "a@a.com";
     mockUserInfo(userSubjectId, userEmail);

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -575,9 +575,6 @@ class SamIamTest {
     @Test
     void testCreateSnapshotWithParent() throws Exception {
       mockSamGoogleApi();
-      final String userSubjectId = "userid";
-      final String userEmail = "a@a.com";
-      mockUserInfo(userSubjectId, userEmail);
 
       UUID snapshotId = UUID.randomUUID();
       UUID parentDatasetId = UUID.randomUUID();
@@ -588,15 +585,22 @@ class SamIamTest {
               any(),
               any()))
           .thenReturn(Map.of("key", List.of()));
+      when(samResourceApi.resourceRolesV2(
+              IamResourceType.DATASET.toString(), parentDatasetId.toString()))
+          .thenReturn(List.of(IamRole.CUSTODIAN.toString()));
 
       samIam.createSnapshotResource(TEST_USER, snapshotId, parentDatasetId, null);
       var argument = ArgumentCaptor.forClass(CreateResourceRequestV2.class);
       verify(samResourceApi)
           .createResourceV2(eq(IamResourceType.DATASNAPSHOT.toString()), argument.capture());
-      assertThat(argument.getValue().getParent().getResourceId(), is(parentDatasetId.toString()));
+      CreateResourceRequestV2 request = argument.getValue();
+      assertThat(request.getParent().getResourceId(), is(parentDatasetId.toString()));
+      assertThat(request.getParent().getResourceTypeName(), is(IamResourceType.DATASET.toString()));
+      assertThat(request.getResourceId(), is(snapshotId.toString()));
+      var policies = request.getPolicies();
+      assertThat(policies.get(IamRole.STEWARD.toString()).getMemberEmails(), empty());
       assertThat(
-          argument.getValue().getParent().getResourceTypeName(),
-          is(IamResourceType.DATASET.toString()));
+          policies.get(IamRole.ADMIN.toString()).getMemberEmails(), is(List.of(ADMIN_EMAIL)));
     }
 
     @Test

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -580,7 +580,7 @@ class SamIamTest {
       mockUserInfo(userSubjectId, userEmail);
 
       UUID snapshotId = UUID.randomUUID();
-      UUID parentId = UUID.randomUUID();
+      UUID parentDatasetId = UUID.randomUUID();
 
       when(samGoogleApi.syncPolicy(
               eq(IamResourceType.DATASNAPSHOT.getSamResourceName()),
@@ -589,11 +589,11 @@ class SamIamTest {
               any()))
           .thenReturn(Map.of("key", List.of()));
 
-      samIam.createSnapshotResource(TEST_USER, snapshotId, parentId, null);
+      samIam.createSnapshotResource(TEST_USER, snapshotId, parentDatasetId, null);
       var argument = ArgumentCaptor.forClass(CreateResourceRequestV2.class);
       verify(samResourceApi)
           .createResourceV2(eq(IamResourceType.DATASNAPSHOT.toString()), argument.capture());
-      assertThat(argument.getValue().getParent().getResourceId(), is(parentId.toString()));
+      assertThat(argument.getValue().getParent().getResourceId(), is(parentDatasetId.toString()));
       assertThat(
           argument.getValue().getParent().getResourceTypeName(),
           is(IamResourceType.DATASET.toString()));

--- a/src/test/java/bio/terra/service/snapshot/flight/SnapshotAuthzIamStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/SnapshotAuthzIamStepTest.java
@@ -19,7 +19,6 @@ import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.Dataset;
-import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.create.SnapshotAuthzIamStep;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -28,7 +27,7 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -44,7 +43,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @Tag(Unit.TAG)
 class SnapshotAuthzIamStepTest {
   @Mock private IamService iamService;
-  @Mock private SnapshotService snapshotService;
   @Mock private FlightContext flightContext;
 
   private static final AuthenticatedUserRequest TEST_USER =
@@ -127,7 +125,7 @@ class SnapshotAuthzIamStepTest {
     overrideSnapshotRequestMode(SnapshotRequestContentsModel.ModeEnum.BYREQUESTID);
     var expectedPolicies =
         new SnapshotRequestModelPolicies().addReadersItem(SNAPSHOT_FIRECLOUD_GROUP_EMAIL);
-    Map<IamRole, String> expectedPoliciesMap = new HashMap<>();
+    Map<IamRole, String> expectedPoliciesMap = new EnumMap<>(IamRole.class);
     expectedPoliciesMap.put(IamRole.READER, SNAPSHOT_FIRECLOUD_GROUP_EMAIL);
     when(iamService.createSnapshotResource(TEST_USER, SNAPSHOT_ID, null, expectedPolicies))
         .thenReturn(expectedPoliciesMap);

--- a/src/test/java/bio/terra/service/snapshot/flight/SnapshotAuthzIamStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/SnapshotAuthzIamStepTest.java
@@ -18,6 +18,7 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.create.SnapshotAuthzIamStep;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
@@ -52,6 +53,7 @@ class SnapshotAuthzIamStepTest {
   private static final String DUOS_ID = "DUOS-123456";
   private static final DuosFirecloudGroupModel DUOS_FIRECLOUD_GROUP =
       DuosFixtures.createDbFirecloudGroup(DUOS_ID);
+  private static final Dataset SOURCE_DATASET = new Dataset().id(UUID.randomUUID());
   private static final String SNAPSHOT_FIRECLOUD_GROUP_EMAIL = UUID.randomUUID() + "-users";
 
   private SnapshotAuthzIamStep step;
@@ -75,16 +77,18 @@ class SnapshotAuthzIamStepTest {
 
   @Test
   void testDoAndUndoStep() throws InterruptedException {
-    UUID datasetId = UUID.randomUUID();
-    inputMap.put(SnapshotWorkingMapKeys.SNAPSHOT_PARENT_DATASET_ID, datasetId);
-    step = new SnapshotAuthzIamStep(iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID);
+    inputMap.put(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, true);
+    step =
+        new SnapshotAuthzIamStep(
+            iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID, SOURCE_DATASET);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
 
     ArgumentCaptor<SnapshotRequestModelPolicies> argument =
         ArgumentCaptor.forClass(SnapshotRequestModelPolicies.class);
     verify(iamService)
-        .createSnapshotResource(eq(TEST_USER), eq(SNAPSHOT_ID), eq(datasetId), argument.capture());
+        .createSnapshotResource(
+            eq(TEST_USER), eq(SNAPSHOT_ID), eq(SOURCE_DATASET.getId()), argument.capture());
     List<String> readers = argument.getValue().getReaders();
     assertFalse(readers.contains(DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail()));
 
@@ -98,7 +102,9 @@ class SnapshotAuthzIamStepTest {
     workingMap.put(SnapshotDuosMapKeys.FIRECLOUD_GROUP, DUOS_FIRECLOUD_GROUP);
 
     snapshotRequestModel.duosId(DUOS_ID);
-    step = new SnapshotAuthzIamStep(iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID);
+    step =
+        new SnapshotAuthzIamStep(
+            iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID, SOURCE_DATASET);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
 
@@ -125,7 +131,9 @@ class SnapshotAuthzIamStepTest {
     expectedPoliciesMap.put(IamRole.READER, SNAPSHOT_FIRECLOUD_GROUP_EMAIL);
     when(iamService.createSnapshotResource(TEST_USER, SNAPSHOT_ID, null, expectedPolicies))
         .thenReturn(expectedPoliciesMap);
-    step = new SnapshotAuthzIamStep(iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID);
+    step =
+        new SnapshotAuthzIamStep(
+            iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID, SOURCE_DATASET);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     Map<IamRole, String> workingMapPolicies =

--- a/src/test/java/bio/terra/service/snapshot/flight/SnapshotAuthzIamStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/SnapshotAuthzIamStepTest.java
@@ -56,11 +56,15 @@ class SnapshotAuthzIamStepTest {
 
   private SnapshotAuthzIamStep step;
   private FlightMap workingMap;
+  private FlightMap inputMap;
   private SnapshotRequestModel snapshotRequestModel;
 
   @BeforeEach
   void setup() {
     workingMap = new FlightMap();
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    inputMap = new FlightMap();
+    when(flightContext.getInputParameters()).thenReturn(inputMap);
     snapshotRequestModel = new SnapshotRequestModel();
     // Set mode to something other than byRequestId
     snapshotRequestModel.addContentsItem(
@@ -71,16 +75,16 @@ class SnapshotAuthzIamStepTest {
 
   @Test
   void testDoAndUndoStep() throws InterruptedException {
-    when(flightContext.getWorkingMap()).thenReturn(workingMap);
-    step =
-        new SnapshotAuthzIamStep(
-            iamService, snapshotService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID);
+    UUID datasetId = UUID.randomUUID();
+    inputMap.put(SnapshotWorkingMapKeys.SNAPSHOT_PARENT_DATASET_ID, datasetId);
+    step = new SnapshotAuthzIamStep(iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
 
     ArgumentCaptor<SnapshotRequestModelPolicies> argument =
         ArgumentCaptor.forClass(SnapshotRequestModelPolicies.class);
-    verify(iamService).createSnapshotResource(eq(TEST_USER), eq(SNAPSHOT_ID), argument.capture());
+    verify(iamService)
+        .createSnapshotResource(eq(TEST_USER), eq(SNAPSHOT_ID), eq(datasetId), argument.capture());
     List<String> readers = argument.getValue().getReaders();
     assertFalse(readers.contains(DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail()));
 
@@ -92,18 +96,16 @@ class SnapshotAuthzIamStepTest {
   @Test
   void testDoAndUndoStepWithDUOS() throws InterruptedException {
     workingMap.put(SnapshotDuosMapKeys.FIRECLOUD_GROUP, DUOS_FIRECLOUD_GROUP);
-    when(flightContext.getWorkingMap()).thenReturn(workingMap);
 
     snapshotRequestModel.duosId(DUOS_ID);
-    step =
-        new SnapshotAuthzIamStep(
-            iamService, snapshotService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID);
+    step = new SnapshotAuthzIamStep(iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
 
     ArgumentCaptor<SnapshotRequestModelPolicies> argument =
         ArgumentCaptor.forClass(SnapshotRequestModelPolicies.class);
-    verify(iamService).createSnapshotResource(eq(TEST_USER), eq(SNAPSHOT_ID), argument.capture());
+    verify(iamService)
+        .createSnapshotResource(eq(TEST_USER), eq(SNAPSHOT_ID), eq(null), argument.capture());
     List<String> readers = argument.getValue().getReaders();
     assertTrue(readers.contains(DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail()));
 
@@ -116,17 +118,14 @@ class SnapshotAuthzIamStepTest {
   void testDoAndUndoWithSnapshotFirecloudGroup() throws InterruptedException {
     workingMap.put(
         SnapshotWorkingMapKeys.SNAPSHOT_FIRECLOUD_GROUP_EMAIL, SNAPSHOT_FIRECLOUD_GROUP_EMAIL);
-    when(flightContext.getWorkingMap()).thenReturn(workingMap);
     overrideSnapshotRequestMode(SnapshotRequestContentsModel.ModeEnum.BYREQUESTID);
     var expectedPolicies =
         new SnapshotRequestModelPolicies().addReadersItem(SNAPSHOT_FIRECLOUD_GROUP_EMAIL);
     Map<IamRole, String> expectedPoliciesMap = new HashMap<>();
     expectedPoliciesMap.put(IamRole.READER, SNAPSHOT_FIRECLOUD_GROUP_EMAIL);
-    when(iamService.createSnapshotResource(TEST_USER, SNAPSHOT_ID, expectedPolicies))
+    when(iamService.createSnapshotResource(TEST_USER, SNAPSHOT_ID, null, expectedPolicies))
         .thenReturn(expectedPoliciesMap);
-    step =
-        new SnapshotAuthzIamStep(
-            iamService, snapshotService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID);
+    step = new SnapshotAuthzIamStep(iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
     Map<IamRole, String> workingMapPolicies =

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStepTest.java
@@ -1,9 +1,12 @@
 package bio.terra.service.snapshot.flight.create;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -23,6 +26,7 @@ import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -51,11 +55,12 @@ class SnapshotAuthzBqJobUserStepTest {
           .projectResource(new GoogleProjectResource().googleProjectId(GOOGLE_PROJECT_ID));
   private static final Dataset SOURCE_DATASET = new Dataset().id(UUID.randomUUID());
 
+  private final List<String> addedEmails = new ArrayList<>();
   private SnapshotAuthzBqJobUserStep step;
   private FlightMap inputMap;
 
   @BeforeEach
-  void beforeEach() {
+  void beforeEach() throws Exception {
     FlightMap workingMap = new FlightMap();
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
     inputMap = new FlightMap();
@@ -67,6 +72,15 @@ class SnapshotAuthzBqJobUserStepTest {
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policyMap);
     when(snapshotService.retrieveByName(SNAPSHOT_NAME)).thenReturn(SNAPSHOT);
 
+    doAnswer(
+            invocation -> {
+              List<String> emails = invocation.getArgument(1);
+              addedEmails.addAll(emails);
+              return null;
+            })
+        .when(resourceService)
+        .grantPoliciesBqJobUser(eq(GOOGLE_PROJECT_ID), anyList());
+
     step =
         new SnapshotAuthzBqJobUserStep(
             snapshotService, resourceService, iamService, TEST_USER, SNAPSHOT_NAME, SOURCE_DATASET);
@@ -75,8 +89,7 @@ class SnapshotAuthzBqJobUserStepTest {
   @Test
   void doStep() throws Exception {
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("steward"));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("reader"));
+    assertThat(addedEmails, containsInAnyOrder("steward", "reader"));
     verifyNoMoreInteractions(resourceService);
     verifyNoInteractions(iamService);
   }
@@ -88,14 +101,12 @@ class SnapshotAuthzBqJobUserStepTest {
             TEST_USER, IamResourceType.DATASET, SOURCE_DATASET.getId()))
         .thenReturn(Map.of(IamRole.CUSTODIAN, "custodian"));
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("steward"));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("reader"));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("custodian"));
+    assertThat(addedEmails, containsInAnyOrder("steward", "reader", "custodian"));
   }
 
   @Test
   void undoStep() {
-    reset(snapshotService, flightContext);
+    reset(snapshotService, flightContext, resourceService);
     assertThat(step.undoStep(flightContext), is(StepResult.getStepResultSuccess()));
     verifyNoInteractions(snapshotService, resourceService, iamService, flightContext);
   }

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStepTest.java
@@ -1,0 +1,102 @@
+package bio.terra.service.snapshot.flight.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class SnapshotAuthzBqJobUserStepTest {
+  @Mock private SnapshotService snapshotService;
+  @Mock private ResourceService resourceService;
+  @Mock private IamService iamService;
+  @Mock private FlightContext flightContext;
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private static final String SNAPSHOT_NAME = "snapshotName";
+  private static final String GOOGLE_PROJECT_ID = "google project id";
+  private static final Snapshot SNAPSHOT =
+      new Snapshot()
+          .projectResource(new GoogleProjectResource().googleProjectId(GOOGLE_PROJECT_ID));
+  private static final Dataset SOURCE_DATASET = new Dataset().id(UUID.randomUUID());
+
+  private SnapshotAuthzBqJobUserStep step;
+  private FlightMap inputMap;
+
+  @BeforeEach
+  void beforeEach() {
+    FlightMap workingMap = new FlightMap();
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    inputMap = new FlightMap();
+    when(flightContext.getInputParameters()).thenReturn(inputMap);
+
+    var policyMap = new EnumMap<>(IamRole.class);
+    policyMap.put(IamRole.STEWARD, "steward");
+    policyMap.put(IamRole.READER, "reader");
+    workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policyMap);
+    when(snapshotService.retrieveByName(SNAPSHOT_NAME)).thenReturn(SNAPSHOT);
+
+    step =
+        new SnapshotAuthzBqJobUserStep(
+            snapshotService, resourceService, iamService, TEST_USER, SNAPSHOT_NAME, SOURCE_DATASET);
+  }
+
+  @Test
+  void doStep() throws Exception {
+    step.doStep(flightContext);
+    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("steward"));
+    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("reader"));
+    verifyNoMoreInteractions(resourceService);
+    verifyNoInteractions(iamService);
+  }
+
+  @Test
+  void doStepInheritEnabled() throws Exception {
+    inputMap.put(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, true);
+    when(iamService.retrievePolicyEmails(
+            TEST_USER, IamResourceType.DATASET, SOURCE_DATASET.getId()))
+        .thenReturn(Map.of(IamRole.CUSTODIAN, "custodian"));
+    step.doStep(flightContext);
+    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("steward"));
+    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("reader"));
+    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("custodian"));
+  }
+
+  @Test
+  void undoStep() throws Exception {
+    reset(snapshotService, flightContext);
+    assertThat(step.undoStep(flightContext), is(StepResult.getStepResultSuccess()));
+    verifyNoInteractions(snapshotService, resourceService, iamService, flightContext);
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
@@ -81,7 +81,7 @@ class SnapshotAuthzTabularAclStepTest {
 
   @Test
   void doStep() throws Exception {
-    step.doStep(flightContext);
+    assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
     verify(bigQuerySnapshotPdao).grantReadAccessToSnapshot(SNAPSHOT, List.of("steward", "reader"));
     verifyNoInteractions(iamService);
   }

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
@@ -2,10 +2,10 @@ package bio.terra.service.snapshot.flight.create;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
@@ -14,15 +14,18 @@ import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
-import bio.terra.service.resourcemanagement.ResourceService;
-import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.BigQueryException;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -36,22 +39,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
-class SnapshotAuthzBqJobUserStepTest {
+class SnapshotAuthzTabularAclStepTest {
+  @Mock private BigQuerySnapshotPdao bigQuerySnapshotPdao;
   @Mock private SnapshotService snapshotService;
-  @Mock private ResourceService resourceService;
+  @Mock private ConfigurationService configService;
   @Mock private IamService iamService;
   @Mock private FlightContext flightContext;
 
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
-  private static final String SNAPSHOT_NAME = "snapshotName";
-  private static final String GOOGLE_PROJECT_ID = "google project id";
-  private static final Snapshot SNAPSHOT =
-      new Snapshot()
-          .projectResource(new GoogleProjectResource().googleProjectId(GOOGLE_PROJECT_ID));
+  private static final Snapshot SNAPSHOT = new Snapshot().id(UUID.randomUUID());
   private static final Dataset SOURCE_DATASET = new Dataset().id(UUID.randomUUID());
 
-  private SnapshotAuthzBqJobUserStep step;
+  private SnapshotAuthzTabularAclStep step;
   private FlightMap inputMap;
 
   @BeforeEach
@@ -65,19 +65,24 @@ class SnapshotAuthzBqJobUserStepTest {
     policyMap.put(IamRole.STEWARD, "steward");
     policyMap.put(IamRole.READER, "reader");
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policyMap);
-    when(snapshotService.retrieveByName(SNAPSHOT_NAME)).thenReturn(SNAPSHOT);
+
+    when(snapshotService.retrieve(SNAPSHOT.getId())).thenReturn(SNAPSHOT);
 
     step =
-        new SnapshotAuthzBqJobUserStep(
-            snapshotService, resourceService, iamService, TEST_USER, SNAPSHOT_NAME, SOURCE_DATASET);
+        new SnapshotAuthzTabularAclStep(
+            bigQuerySnapshotPdao,
+            snapshotService,
+            configService,
+            iamService,
+            SNAPSHOT.getId(),
+            TEST_USER,
+            SOURCE_DATASET);
   }
 
   @Test
   void doStep() throws Exception {
-    assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("steward"));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("reader"));
-    verifyNoMoreInteractions(resourceService);
+    step.doStep(flightContext);
+    verify(bigQuerySnapshotPdao).grantReadAccessToSnapshot(SNAPSHOT, List.of("steward", "reader"));
     verifyNoInteractions(iamService);
   }
 
@@ -88,15 +93,27 @@ class SnapshotAuthzBqJobUserStepTest {
             TEST_USER, IamResourceType.DATASET, SOURCE_DATASET.getId()))
         .thenReturn(Map.of(IamRole.CUSTODIAN, "custodian"));
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("steward"));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("reader"));
-    verify(resourceService).grantPoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("custodian"));
+    verify(bigQuerySnapshotPdao)
+        .grantReadAccessToSnapshot(SNAPSHOT, List.of("steward", "reader", "custodian"));
+  }
+
+  @Test
+  void doStepDatabaseRetry() throws Exception {
+    doThrow(
+            new BigQueryException(
+                500,
+                "IAM setPolicy",
+                new BigQueryError("invalid", "fake", "IAM setPolicy fake failure")))
+        .when(bigQuerySnapshotPdao)
+        .grantReadAccessToSnapshot(SNAPSHOT, List.of("steward", "reader"));
+    assertThat(
+        step.doStep(flightContext).getStepStatus(), is(StepStatus.STEP_RESULT_FAILURE_RETRY));
   }
 
   @Test
   void undoStep() {
     reset(snapshotService, flightContext);
     assertThat(step.undoStep(flightContext), is(StepResult.getStepResultSuccess()));
-    verifyNoInteractions(snapshotService, resourceService, iamService, flightContext);
+    verifyNoInteractions(snapshotService, bigQuerySnapshotPdao, iamService, flightContext);
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzBqAclsStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzBqAclsStepTest.java
@@ -1,0 +1,73 @@
+package bio.terra.service.snapshot.flight.delete;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.SnapshotSource;
+import bio.terra.stairway.StepResult;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class DeleteSnapshotAuthzBqAclsStepTest {
+  @Mock private IamService sam;
+  @Mock private ResourceService resourceService;
+  @Mock private SnapshotService snapshotService;
+
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private static final Dataset DATASET = new Dataset().id(UUID.randomUUID());
+  private static final String GOOGLE_PROJECT_ID = "googleProjectId";
+  private static final Snapshot SNAPSHOT =
+      new Snapshot()
+          .id(UUID.randomUUID())
+          .snapshotSources(List.of(new SnapshotSource().dataset(DATASET)))
+          .projectResource(new GoogleProjectResource().googleProjectId(GOOGLE_PROJECT_ID));
+
+  private DeleteSnapshotAuthzBqAclsStep step;
+
+  @BeforeEach
+  void beforeEach() {
+    step =
+        new DeleteSnapshotAuthzBqAclsStep(
+            sam, resourceService, snapshotService, SNAPSHOT.getId(), TEST_USER);
+  }
+
+  @Test
+  void doStep() throws Exception {
+    when(snapshotService.retrieve(SNAPSHOT.getId())).thenReturn(SNAPSHOT);
+    when(sam.retrievePolicyEmails(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT.getId()))
+        .thenReturn(Map.of(IamRole.STEWARD, "steward", IamRole.READER, "reader"));
+    when(sam.retrievePolicyEmails(TEST_USER, IamResourceType.DATASET, DATASET.getId()))
+        .thenReturn(Map.of(IamRole.CUSTODIAN, "custodian"));
+    assertThat(step.doStep(null), is(StepResult.getStepResultSuccess()));
+    verify(resourceService)
+        .revokePoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("steward", "reader", "custodian"));
+  }
+
+  @Test
+  void undoStep() {
+    assertThat(step.undoStep(null), is(StepResult.getStepResultSuccess()));
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzBqAclsStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/delete/DeleteSnapshotAuthzBqAclsStepTest.java
@@ -1,7 +1,10 @@
 package bio.terra.service.snapshot.flight.delete;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,10 +24,15 @@ import bio.terra.stairway.StepResult;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -49,25 +57,35 @@ class DeleteSnapshotAuthzBqAclsStepTest {
 
   @BeforeEach
   void beforeEach() {
+    when(snapshotService.retrieve(SNAPSHOT.getId())).thenReturn(SNAPSHOT);
+    when(sam.retrievePolicyEmails(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT.getId()))
+        .thenReturn(Map.of(IamRole.STEWARD, "steward", IamRole.READER, "reader"));
     step =
         new DeleteSnapshotAuthzBqAclsStep(
             sam, resourceService, snapshotService, SNAPSHOT.getId(), TEST_USER);
   }
 
-  @Test
-  void doStep() throws Exception {
-    when(snapshotService.retrieve(SNAPSHOT.getId())).thenReturn(SNAPSHOT);
-    when(sam.retrievePolicyEmails(TEST_USER, IamResourceType.DATASNAPSHOT, SNAPSHOT.getId()))
-        .thenReturn(Map.of(IamRole.STEWARD, "steward", IamRole.READER, "reader"));
+  private static Stream<Arguments> doStep() {
+    return Stream.of(
+        Arguments.of(
+            Map.of(IamRole.CUSTODIAN, "custodian"), List.of("steward", "reader", "custodian")),
+        Arguments.of(Map.of(), List.of("steward", "reader")));
+  }
+
+  @MethodSource
+  @ParameterizedTest
+  void doStep(Map<IamRole, String> custodianPolicy, List<String> expectedEmails) throws Exception {
     when(sam.retrievePolicyEmails(TEST_USER, IamResourceType.DATASET, DATASET.getId()))
-        .thenReturn(Map.of(IamRole.CUSTODIAN, "custodian"));
+        .thenReturn(custodianPolicy);
     assertThat(step.doStep(null), is(StepResult.getStepResultSuccess()));
-    verify(resourceService)
-        .revokePoliciesBqJobUser(GOOGLE_PROJECT_ID, List.of("steward", "reader", "custodian"));
+    ArgumentCaptor<List<String>> argument = ArgumentCaptor.captor();
+    verify(resourceService).revokePoliciesBqJobUser(eq(GOOGLE_PROJECT_ID), argument.capture());
+    assertThat(argument.getValue(), containsInAnyOrder(expectedEmails.toArray()));
   }
 
   @Test
   void undoStep() {
+    reset(snapshotService, sam);
     assertThat(step.undoStep(null), is(StepResult.getStepResultSuccess()));
   }
 }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1202

## Addresses

Add support to snapshot creation so the dataset custodian is optionally granted steward permissions on the snapshot.

## Summary of changes

In the snapshot creation flight, if the `inheritSteward` flag is set:

- the parent dataset id is passed to Sam when creating the snapshot, and the current user is _not_ added as a snapshot steward if they are a custodian of the parent dataset
- the dataset custodian proxy user is added as a reader on the BQ project
- the dataset custodian proxy user is added as a job executor to the BQ project

## Testing Strategy

- unit tests
- manual BEE testing to create snapshot and observe its behavior