### PR TITLE
DT-1194: Fix issue where using Awaitility was causing code to run on a different thread

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateBucketStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/create/CreateDatasetGetOrCreateBucketStep.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.transaction.TransactionSystemException;
 
 public class CreateDatasetGetOrCreateBucketStep implements Step {
@@ -80,7 +81,7 @@ public class CreateDatasetGetOrCreateBucketStep implements Step {
               googleProjectResource.getServiceAccount());
 
       workingMap.put(FileMapKeys.BUCKET_INFO, bucketForFile);
-    } catch (BucketLockException | TransactionSystemException e) {
+    } catch (BucketLockException | TransientDataAccessException | TransactionSystemException e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     } catch (GoogleResourceNamingException ex) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, ex);

--- a/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SecureMonitoringIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import bio.terra.common.auth.Users;
 import bio.terra.common.category.Integration;
-import bio.terra.common.configuration.TestConfiguration;
+import bio.terra.common.configuration.TestConfiguration.User;
 import bio.terra.common.fixtures.JsonLoader;
 import bio.terra.common.fixtures.Names;
 import bio.terra.integration.DataRepoFixtures;
@@ -55,7 +55,7 @@ class SecureMonitoringIntegrationTest {
   private UUID snapshotId;
   private UUID profileId;
 
-  private TestConfiguration.User steward() {
+  private User steward() {
     return testUsers.steward();
   }
 
@@ -118,10 +118,11 @@ class SecureMonitoringIntegrationTest {
         "Snapshot summary denotes secure monitoring enabled",
         snapshotSummary.isSecureMonitoringEnabled());
 
+    User steward = steward();
     SnapshotModel snapshot =
         Awaitility.waitAtMost(Duration.ofSeconds(10))
             .until(
-                () -> dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null),
+                () -> dataRepoFixtures.getSnapshot(steward, snapshotSummary.getId(), null),
                 Objects::nonNull);
 
     assertThat(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -170,10 +170,11 @@ class SnapshotIntegrationTest {
         dataRepoFixtures.createSnapshotWithRequest(
             steward(), dataset.getName(), profileId, requestModel);
     createdSnapshotId.set(snapshotSummary.getId());
+    User steward = steward();
     SnapshotModel snapshot =
         Awaitility.waitAtMost(Duration.ofSeconds(10))
             .until(
-                () -> dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null),
+                () -> dataRepoFixtures.getSnapshot(steward, snapshotSummary.getId(), null),
                 Objects::nonNull);
     assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
     assertThat(
@@ -216,10 +217,11 @@ class SnapshotIntegrationTest {
         dataRepoFixtures.createSnapshotWithRequest(
             steward(), dataset.getName(), profileId, requestModel);
     createdSnapshotId.set(snapshotSummary.getId());
+    User steward = steward();
     SnapshotModel snapshot =
         Awaitility.waitAtMost(Duration.ofSeconds(10))
             .until(
-                () -> dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null),
+                () -> dataRepoFixtures.getSnapshot(steward, snapshotSummary.getId(), null),
                 Objects::nonNull);
     assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
   }
@@ -238,10 +240,11 @@ class SnapshotIntegrationTest {
         dataRepoFixtures.createSnapshotWithRequest(
             steward(), dataset.getName(), profileId, requestModel);
     createdSnapshotId.set(snapshotSummary.getId());
+    User steward = steward();
     SnapshotModel snapshot =
         Awaitility.waitAtMost(Duration.ofSeconds(10))
             .until(
-                () -> dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null),
+                () -> dataRepoFixtures.getSnapshot(steward, snapshotSummary.getId(), null),
                 Objects::nonNull);
     assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
   }
@@ -255,9 +258,9 @@ class SnapshotIntegrationTest {
     SnapshotSummaryModel snapshotSummary =
         dataRepoFixtures.createSnapshotWithRequest(
             steward(), dataset.getName(), profileId, requestModel);
+    User steward = steward();
     Awaitility.waitAtMost(Duration.ofSeconds(10))
-        .until(
-            () -> dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null) != null);
+        .until(() -> dataRepoFixtures.getSnapshot(steward, snapshotSummary.getId(), null) != null);
     ErrorModel errorModel =
         dataRepoFixtures.deleteDatasetAssetExpectFailure(
             steward(), dataset.getId(), "sample_centric");
@@ -338,10 +341,11 @@ class SnapshotIntegrationTest {
     SnapshotSummaryModel snapshotSummary =
         dataRepoFixtures.createSnapshotWithRequest(steward(), datasetName, profileId, requestModel);
     createdSnapshotId.set(snapshotSummary.getId());
+    User steward = steward();
     SnapshotModel snapshot =
         Awaitility.waitAtMost(Duration.ofSeconds(10))
             .until(
-                () -> dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null),
+                () -> dataRepoFixtures.getSnapshot(steward, snapshotSummary.getId(), null),
                 Objects::nonNull);
     assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
     assertThat("the relationship comes through", snapshot.getRelationships(), hasSize(1));
@@ -415,10 +419,11 @@ class SnapshotIntegrationTest {
         dataRepoFixtures.createSnapshotWithRequest(
             steward(), datasetName, profileId, requestModel, true, true);
     createdSnapshotId.set(snapshotSummary.getId());
+    User steward = steward();
     SnapshotModel snapshot =
         Awaitility.waitAtMost(Duration.ofSeconds(10))
             .until(
-                () -> dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null),
+                () -> dataRepoFixtures.getSnapshot(steward, snapshotSummary.getId(), null),
                 Objects::nonNull);
     assertThat("new snapshot has been created", snapshot.getName(), is(requestModel.getName()));
     assertThat("the relationship comes through", snapshot.getRelationships(), hasSize(1));
@@ -471,9 +476,9 @@ class SnapshotIntegrationTest {
         dataRepoFixtures.createSnapshotWithRequest(steward(), datasetName, profileId, requestModel);
     UUID snapshotId = snapshotSummary.getId();
     createdSnapshotId.set(snapshotId);
+    User steward = steward();
     Awaitility.waitAtMost(Duration.ofSeconds(10))
-        .until(
-            () -> dataRepoFixtures.getSnapshot(steward(), snapshotSummary.getId(), null) != null);
+        .until(() -> dataRepoFixtures.getSnapshot(steward, snapshotSummary.getId(), null) != null);
 
     Map<String, List<String>> rolesToPolicies =
         dataRepoFixtures.retrieveSnapshotPolicies(steward(), snapshotId).getPolicies().stream()


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1194

## Addresses

Using `Awaitility` instead of `sleep()` causes code to run on a different thread. Any thread-local data must be extracted before calling `Awaitility`.

## Summary of changes

Move calls to `steward()` out of the `Awaitilty` method call. This problem was noticed and fixed while working on https://github.com/DataBiosphere/jade-data-repo/pull/1896, but the fix was inadvertently lost while reverting other unnecessary changes.

## Testing Strategy

Integration tests pass without need to retry.