### PR TITLE
DT-1199: Increase azure signed url TTL to 1 hour

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -99,7 +99,7 @@ public class DrsService {
   private static final String ACCESS_ID_SEPARATOR = "*";
   private static final String DRS_OBJECT_VERSION = "0";
   @VisibleForTesting static final Duration URL_TTL = Duration.ofMinutes(15);
-
+  static final Duration AZURE_URL_TTL = Duration.ofMinutes(60);
   private final SnapshotService snapshotService;
   private final FileService fileService;
   private final DrsIdService drsIdService;
@@ -571,7 +571,7 @@ public class DrsService {
                 storageAccountResource,
                 ((FSFile) fsItem).getCloudPath(),
                 new BlobSasTokenOptions(
-                    URL_TTL,
+                    AZURE_URL_TTL,
                     new BlobSasPermission().setReadPermission(true),
                     authUser.getEmail())));
   }

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -36,7 +36,7 @@ public final class MetadataDataAccessUtils {
 
   // Increasing the default SAS token expiration time to 60 minutes only for Azure
   // to allow for larger file downloads; This should not apply to TDR on GCP
-  //private static final Duration DEFAULT_SAS_TOKEN_EXPIRATION = Duration.ofMinutes(15);
+  // private static final Duration DEFAULT_SAS_TOKEN_EXPIRATION = Duration.ofMinutes(15);
   private static final Duration AZURE_SAS_TOKEN_EXPIRATION = Duration.ofMinutes(60);
   private static final String BIGQUERY_DATASET_LINK =
       "https://console.cloud.google.com/bigquery?project=<project>&"

--- a/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/MetadataDataAccessUtils.java
@@ -34,7 +34,10 @@ import org.stringtemplate.v4.ST;
 @Component
 public final class MetadataDataAccessUtils {
 
-  private static final Duration DEFAULT_SAS_TOKEN_EXPIRATION = Duration.ofMinutes(15);
+  // Increasing the default SAS token expiration time to 60 minutes only for Azure
+  // to allow for larger file downloads; This should not apply to TDR on GCP
+  //private static final Duration DEFAULT_SAS_TOKEN_EXPIRATION = Duration.ofMinutes(15);
+  private static final Duration AZURE_SAS_TOKEN_EXPIRATION = Duration.ofMinutes(60);
   private static final String BIGQUERY_DATASET_LINK =
       "https://console.cloud.google.com/bigquery?project=<project>&"
           + "ws=!<dataset>&d=<dataset>&p=<project>&page=<page>";
@@ -152,7 +155,7 @@ public final class MetadataDataAccessUtils {
 
     BlobSasTokenOptions blobSasTokenOptions =
         new BlobSasTokenOptions(
-            DEFAULT_SAS_TOKEN_EXPIRATION,
+            AZURE_SAS_TOKEN_EXPIRATION,
             new BlobSasPermission().setReadPermission(true).setListPermission(true),
             userRequest.getEmail());
 


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1199

## Addresses
The customer delivery team is running into timeout issues when downloading larger files via Azure signed urls. The current TTL (time to live) for the urls is 15 minutes. I think we can reasonably extend this to 1 hour (we already do this for snapshot export manifests). This will not solve all use cases, but we think it will get them most of the way. 

## Summary of changes
- increase signed url TTL for files to 1 hour

## Testing Strategy
- None, but we should get quick feedback from customer delivery team 

