### PR TITLE
DT-1197: Add "inherit steward" property to dataset APIs and use it in create dataset flight

### DIFF
--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -386,6 +386,10 @@ public class Dataset implements FSContainerInterface, LogPrintable {
     return datasetSummary.getResourceLocks();
   }
 
+  public boolean isInheritSteward() {
+    return datasetSummary.isInheritSteward();
+  }
+
   @Override
   public String toLogString() {
     return String.format("%s (%s)", this.getName(), this.getId());

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -80,7 +80,8 @@ public class DatasetDao implements TaggableResourceDao {
   private static final String summaryQueryColumns =
       " dataset.id, dataset.name, description, default_profile_id, project_resource_id, "
           + "dataset.application_resource_id, secure_monitoring, phs_id, self_hosted, "
-          + "properties, created_date, predictable_file_ids, tags, flightid, sharedlock,";
+          + "properties, created_date, predictable_file_ids, tags, flightid, sharedlock, "
+          + "inherit_steward, ";
 
   private static final String summaryCloudPlatformQuery =
       "(SELECT pr.google_project_id "
@@ -406,10 +407,10 @@ public class DatasetDao implements TaggableResourceDao {
         INSERT INTO dataset
         (name, default_profile_id, id, project_resource_id, application_resource_id, flightid,
          description, secure_monitoring, phs_id, self_hosted, properties, sharedlock,
-         predictable_file_ids, tags)
+         predictable_file_ids, tags, inherit_steward)
         VALUES (:name, :default_profile_id, :id, :project_resource_id, :application_resource_id,
          :flightid, :description, :secure_monitoring, :phs_id, :self_hosted,
-         cast(:properties as jsonb), ARRAY[]::TEXT[], :predictable_file_ids, :tags)
+         cast(:properties as jsonb), ARRAY[]::TEXT[], :predictable_file_ids, :tags, :inherit_steward)
        """;
 
     Array tags;
@@ -433,7 +434,8 @@ public class DatasetDao implements TaggableResourceDao {
             .addValue(
                 "properties", DaoUtils.propertiesToString(objectMapper, dataset.getProperties()))
             .addValue("predictable_file_ids", dataset.hasPredictableFileIds())
-            .addValue("tags", tags);
+            .addValue("tags", tags)
+            .addValue("inherit_steward", dataset.getDatasetSummary().isInheritSteward());
 
     DaoKeyHolder keyHolder = new DaoKeyHolder();
     try {
@@ -717,7 +719,8 @@ public class DatasetDao implements TaggableResourceDao {
           .properties(properties)
           .tags(DaoUtils.getStringList(rs, "tags"))
           .resourceLocks(
-              new ResourceLocks().exclusive(rs.getString("flightid")).shared(sharedLocks));
+              new ResourceLocks().exclusive(rs.getString("flightid")).shared(sharedLocks))
+          .inheritSteward(rs.getBoolean("inherit_steward"));
     }
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -88,7 +88,8 @@ public final class DatasetJsonConversion {
                 .selfHosted(datasetRequest.isExperimentalSelfHosted())
                 .properties(datasetRequest.getProperties())
                 .predictableFileIds(datasetRequest.isExperimentalPredictableFileIds())
-                .tags(TagUtils.sanitizeTags(datasetRequest.getTags())))
+                .tags(TagUtils.sanitizeTags(datasetRequest.getTags()))
+                .inheritSteward(datasetRequest.isInheritSteward()))
         .tables(new ArrayList<>(tablesMap.values()))
         .relationships(new ArrayList<>(relationshipsMap.values()))
         .assetSpecifications(assetSpecifications);
@@ -109,7 +110,8 @@ public final class DatasetJsonConversion {
             .selfHosted(dataset.isSelfHosted())
             .predictableFileIds(dataset.hasPredictableFileIds())
             .tags(dataset.getTags())
-            .resourceLocks(dataset.getResourceLocks());
+            .resourceLocks(dataset.getResourceLocks())
+            .inheritSteward(dataset.isInheritSteward());
 
     if (include.contains(DatasetRequestAccessIncludeModel.NONE)) {
       return datasetModel;

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -37,6 +37,7 @@ public class DatasetSummary {
   private boolean predictableFileIds;
   private List<String> tags;
   private ResourceLocks resourceLocks;
+  private boolean inheritSteward;
 
   public UUID getId() {
     return id;
@@ -253,6 +254,15 @@ public class DatasetSummary {
     return this;
   }
 
+  public boolean isInheritSteward() {
+    return inheritSteward;
+  }
+
+  public DatasetSummary inheritSteward(boolean inheritSteward) {
+    this.inheritSteward = inheritSteward;
+    return this;
+  }
+
   public DatasetSummaryModel toModel() {
     return new DatasetSummaryModel()
         .id(getId())
@@ -269,7 +279,8 @@ public class DatasetSummary {
         .selfHosted(isSelfHosted())
         .predictableFileIds(hasPredictableFileIds())
         .tags(getTags())
-        .resourceLocks(getResourceLocks());
+        .resourceLocks(getResourceLocks())
+        .inheritSteward(inheritSteward);
   }
 
   List<StorageResourceModel> toStorageResourceModel() {

--- a/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
@@ -26,5 +26,4 @@ public final class SnapshotWorkingMapKeys extends ProjectCreatingFlightKeys {
   public static final String SNAPSHOT_FIRECLOUD_GROUP_EMAIL = "snapshotFirecloudGroupEmail";
   public static final String SNAPSHOT_DATA_ACCESS_CONTROL_GROUPS =
       "snapshotDataAccessControlGroups";
-  public static final String SNAPSHOT_INHERIT_STEWARD_ENABLED = "snapshotInheritStewardEnabled";
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -53,11 +53,7 @@ public class SnapshotAuthzBqJobUserStep implements Step {
     List<String> policyEmails =
         new ArrayList<>(List.of(policyMap.get(IamRole.STEWARD), policyMap.get(IamRole.READER)));
 
-    Boolean inheritEnabled =
-        context
-            .getInputParameters()
-            .get(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, Boolean.class);
-    if (inheritEnabled != null && inheritEnabled) {
+    if (sourceDataset.isInheritSteward()) {
       var datasetPolicyMap =
           sam.retrievePolicyEmails(request, IamResourceType.DATASET, sourceDataset.getId());
       // Allow the custodian to make queries in this project.

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
@@ -58,11 +58,7 @@ public class SnapshotAuthzIamStep implements Step {
       derivedPolicies.addReadersItem(snapshotFirecloudGroupEmail);
     }
     final UUID parentDatasetId;
-    Boolean inheritEnabled =
-        context
-            .getInputParameters()
-            .get(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, Boolean.class);
-    if (inheritEnabled != null && inheritEnabled) {
+    if (sourceDataset.isInheritSteward()) {
       parentDatasetId = sourceDataset.getId();
     } else {
       parentDatasetId = null;

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -66,11 +66,7 @@ public class SnapshotAuthzTabularAclStep implements Step {
     emails.add(policies.get(IamRole.STEWARD));
     emails.add(policies.get(IamRole.READER));
 
-    Boolean inheritEnabled =
-        context
-            .getInputParameters()
-            .get(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, Boolean.class);
-    if (inheritEnabled != null && inheritEnabled) {
+    if (sourceDataset.isInheritSteward()) {
       var datasetPolicyMap =
           iamService.retrievePolicyEmails(userReq, IamResourceType.DATASET, sourceDataset.getId());
       emails.add(datasetPolicyMap.get(IamRole.CUSTODIAN));

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -5366,6 +5366,12 @@ components:
             $ref: '#/components/schemas/Tag'
         resourceLocks:
           $ref: '#/components/schemas/ResourceLocks'
+        inheritSteward:
+          type: boolean
+          default: false
+          description: >
+            If true, all snapshots created from this dataset will grant dataset custodians
+            the steward (owner) role on the snapshots.
       description: >
         Complete definition of a dataset.
     DatasetSummaryModel:
@@ -5417,6 +5423,12 @@ components:
             $ref: '#/components/schemas/Tag'
         resourceLocks:
           $ref: '#/components/schemas/ResourceLocks'
+        inheritSteward:
+          type: boolean
+          default: false
+          description: >
+            If true, all snapshots created from this dataset will grant dataset custodians
+            the steward (owner) role on the snapshots.
       description: >
         Summary of a dataset.
     DatasetRequestModel:
@@ -5507,6 +5519,17 @@ components:
               type: array
               items:
                 type: string
+        inheritSteward:
+          type: boolean
+          default: false
+          description: >
+            If true, all snapshots created from this dataset will grant dataset custodians
+            the steward (owner) role on the snapshots. This is intended to be used in cases where
+            a dataset will have many (> 1000) snapshots and the user wants all dataset custodians
+            to have this role on all snapshots.
+
+            Using this flag is a more efficient way to grant this role, and will avoid using up
+            google resource quotas.
         tags:
           $ref: '#/components/schemas/ResourceCreateTags'
       description: >

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -91,4 +91,5 @@
     <include file="changesets/20240816_addsamgrouptorequest.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20240830_dataset_table_dataset_id_index.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20241127_asset_column_asset_id_index.yaml" relativeToChangelogFile="true" />
+    <include file="changesets/20250218_dataset_inherit_steward_flag.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20250218_dataset_inherit_steward_flag.yaml
+++ b/src/main/resources/db/changesets/20250218_dataset_inherit_steward_flag.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: dataset_inherit_steward_flag
+      author: pshapiro
+      changes:
+        - addColumn:
+            tableName: dataset
+            columns:
+              - column:
+                  name: inherit_steward
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -1,13 +1,14 @@
 package bio.terra.common.fixtures;
 
 import static bio.terra.common.PdaoConstant.PDAO_ROW_ID_COLUMN;
-import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.oneOf;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -37,8 +38,6 @@ import bio.terra.model.DatasetModel;
 import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.DeleteResponseModel;
-import bio.terra.model.EnumerateDatasetModel;
-import bio.terra.model.EnumerateSnapshotModel;
 import bio.terra.model.ErrorModel;
 import bio.terra.model.FileLoadModel;
 import bio.terra.model.FileModel;
@@ -69,7 +68,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,9 +76,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
-import org.hamcrest.CoreMatchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -96,19 +93,22 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @Component
 public class ConnectedOperations {
   private static final Logger logger = LoggerFactory.getLogger(ConnectedOperations.class);
+  // The policy email must be a real google group, otherwise requests that
+  // update bigquery dataset policies will fail.
+  public static final String POLICY_EMAIL = "jadeteam@broadinstitute.org";
 
   private final MockMvc mvc;
   private final JsonLoader jsonLoader;
   private final Storage storage = StorageOptions.getDefaultInstance().getService();
   private final ConnectedTestConfiguration testConfig;
 
-  private boolean deleteOnTeardown;
-  private List<UUID> createdSnapshotIds;
-  private List<UUID> createdDatasetIds;
-  private List<UUID> createdProfileIds;
-  private List<String[]> createdFileIds; // [0] is datasetid, [1] is fileid
-  private List<String> createdBuckets;
-  private List<String> createdScratchFiles;
+  private final List<UUID> createdSnapshotIds = new ArrayList<>();
+  private final List<UUID> createdDatasetIds = new ArrayList<>();
+  private final List<UUID> createdProfileIds = new ArrayList<>();
+  private final List<String[]> createdFileIds =
+      new ArrayList<>(); // [0] is datasetid, [1] is fileid
+  private final List<String> createdBuckets = new ArrayList<>();
+  private final List<String> createdScratchFiles = new ArrayList<>();
 
   @Autowired
   public ConnectedOperations(
@@ -116,14 +116,6 @@ public class ConnectedOperations {
     this.mvc = mvc;
     this.jsonLoader = jsonLoader;
     this.testConfig = testConfig;
-
-    createdSnapshotIds = new ArrayList<>();
-    createdDatasetIds = new ArrayList<>();
-    createdFileIds = new ArrayList<>();
-    createdProfileIds = new ArrayList<>();
-    deleteOnTeardown = true;
-    createdBuckets = new ArrayList<>();
-    createdScratchFiles = new ArrayList<>();
   }
 
   private static Map<UUID, Set<IamRole>> uuidsToAuthMap(List<UUID> uuids) {
@@ -132,15 +124,17 @@ public class ConnectedOperations {
   }
 
   public void stubOutSamCalls(IamProviderInterface samService) throws Exception {
-    // The policy email must be a real google group, otherwise request that
-    // update bigquery dataset policies will fail
-    Map<IamRole, String> snapshotPolicies = new HashMap<>();
-    snapshotPolicies.put(IamRole.STEWARD, "jadeteam@broadinstitute.org");
-    snapshotPolicies.put(IamRole.READER, "jadeteam@broadinstitute.org");
-    Map<IamRole, String> datasetPolicies = new HashMap<>();
-    datasetPolicies.put(IamRole.CUSTODIAN, "jadeteam@broadinstitute.org");
-    datasetPolicies.put(IamRole.STEWARD, "jadeteam@broadinstitute.org");
-    datasetPolicies.put(IamRole.SNAPSHOT_CREATOR, "jadeteam@broadinstitute.org");
+    Map<IamRole, String> snapshotPolicies =
+        new EnumMap<>(
+            Map.of(
+                IamRole.STEWARD, POLICY_EMAIL,
+                IamRole.READER, POLICY_EMAIL));
+    Map<IamRole, String> datasetPolicies =
+        new EnumMap<>(
+            Map.of(
+                IamRole.CUSTODIAN, POLICY_EMAIL,
+                IamRole.STEWARD, POLICY_EMAIL,
+                IamRole.SNAPSHOT_CREATOR, POLICY_EMAIL));
 
     when(samService.createSnapshotResource(any(), any(), any(), any()))
         .thenReturn(snapshotPolicies);
@@ -178,7 +172,6 @@ public class ConnectedOperations {
    *
    * @param resourcePath path to json used for a dataset create request
    * @return summary of the dataset created
-   * @throws Exception
    */
   public DatasetSummaryModel createDataset(BillingProfileModel profileModel, String resourcePath)
       throws Exception {
@@ -215,8 +208,7 @@ public class ConnectedOperations {
                     .content(TestUtils.mapToJson(datasetRequest)))
             .andReturn();
     MockHttpServletResponse response = validateJobModelAndWait(result);
-    ErrorModel errorModel = handleFailureCase(response, expectedStatus);
-    return errorModel;
+    return handleFailureCase(response, expectedStatus);
   }
 
   public BillingProfileModel createProfileForAccount(String billingAccountId) throws Exception {
@@ -303,28 +295,8 @@ public class ConnectedOperations {
 
     MockHttpServletResponse response =
         launchCreateSnapshot(datasetSummaryModel, snapshotRequest, infix);
-    SnapshotSummaryModel snapshotSummary = handleCreateSnapshotSuccessCase(response);
 
-    return snapshotSummary;
-  }
-
-  public ErrorModel createSnapshotExpectError(
-      DatasetSummaryModel datasetSummaryModel,
-      String resourcePath,
-      String infix,
-      HttpStatus expectedStatus)
-      throws Exception {
-
-    MockHttpServletResponse response =
-        launchCreateSnapshot(datasetSummaryModel, resourcePath, infix);
-    return handleFailureCase(response, expectedStatus);
-  }
-
-  public MockHttpServletResponse launchCreateSnapshot(
-      DatasetSummaryModel datasetSummaryModel, String resourcePath, String infix) throws Exception {
-    SnapshotRequestModel snapshotRequest =
-        jsonLoader.loadObject(resourcePath, SnapshotRequestModel.class);
-    return launchCreateSnapshot(datasetSummaryModel, snapshotRequest, infix);
+    return handleCreateSnapshotSuccessCase(response);
   }
 
   public MockHttpServletResponse launchCreateSnapshot(
@@ -340,7 +312,7 @@ public class ConnectedOperations {
       SnapshotRequestModel snapshotRequest,
       String snapshotName)
       throws Exception {
-    // TODO: the next two lines assume SingleDatasetSnapshot
+
     snapshotRequest.getContents().get(0).setDatasetName(datasetSummaryModel.getName());
     snapshotRequest.profileId(datasetSummaryModel.getDefaultProfileId());
     snapshotRequest.setName(snapshotName);
@@ -351,8 +323,7 @@ public class ConnectedOperations {
                     .content(TestUtils.mapToJson(snapshotRequest)))
             .andReturn();
 
-    MockHttpServletResponse response = validateJobModelAndWait(result);
-    return response;
+    return validateJobModelAndWait(result);
   }
 
   public SnapshotModel getSnapshot(UUID snapshotId) throws Exception {
@@ -361,10 +332,9 @@ public class ConnectedOperations {
     return TestUtils.mapFromJson(response.getContentAsString(), SnapshotModel.class);
   }
 
-  public ErrorModel getSnapshotExpectError(UUID snapshotId, HttpStatus expectedStatus)
-      throws Exception {
+  public void getSnapshotExpectError(UUID snapshotId, HttpStatus expectedStatus) throws Exception {
     MvcResult result = mvc.perform(get("/api/repository/v1/snapshots/" + snapshotId)).andReturn();
-    return handleFailureCase(result.getResponse(), expectedStatus);
+    handleFailureCase(result.getResponse(), expectedStatus);
   }
 
   public DatasetModel getDataset(UUID datasetId) throws Exception {
@@ -372,56 +342,9 @@ public class ConnectedOperations {
     return handleSuccessCase(result.getResponse(), DatasetModel.class);
   }
 
-  public ErrorModel getDatasetExpectError(UUID datasetId, HttpStatus expectedStatus)
-      throws Exception {
+  public void getDatasetExpectError(UUID datasetId, HttpStatus expectedStatus) throws Exception {
     MvcResult result = mvc.perform(get("/api/repository/v1/datasets/" + datasetId)).andReturn();
-    return handleFailureCase(result.getResponse(), expectedStatus);
-  }
-
-  public MvcResult enumerateDatasetsRaw(String filter) throws Exception {
-    String direction = "desc"; // options: asc, desc
-    int limit = 10;
-    int offset = 0;
-    String sort = "created_date"; // options: name, description, created_date
-
-    String args =
-        "direction="
-            + direction
-            + "&limit="
-            + limit
-            + "&offset="
-            + offset
-            + "&sort="
-            + sort; // + "&filter=" + filter;
-    return mvc.perform(get("/api/repository/v1/datasets?" + args)).andReturn();
-  }
-
-  public EnumerateDatasetModel enumerateDatasets(String filter) throws Exception {
-    MvcResult result = enumerateDatasetsRaw(filter);
-    return handleSuccessCase(result.getResponse(), EnumerateDatasetModel.class);
-  }
-
-  public MvcResult enumerateSnapshotsRaw(String filter) throws Exception {
-    String direction = "desc"; // options: asc, desc
-    int limit = 10;
-    int offset = 0;
-    String sort = "created_date"; // options: name, description, created_date
-
-    String args =
-        "direction="
-            + direction
-            + "&limit="
-            + limit
-            + "&offset="
-            + offset
-            + "&sort="
-            + sort; // + "&filter=" + filter;
-    return mvc.perform(get("/api/repository/v1/snapshots?" + args)).andReturn();
-  }
-
-  public EnumerateSnapshotModel enumerateSnapshots(String filter) throws Exception {
-    MvcResult result = enumerateSnapshotsRaw(filter);
-    return handleSuccessCase(result.getResponse(), EnumerateSnapshotModel.class);
+    handleFailureCase(result.getResponse(), expectedStatus);
   }
 
   public SnapshotSummaryModel handleCreateSnapshotSuccessCase(MockHttpServletResponse response)
@@ -437,7 +360,7 @@ public class ConnectedOperations {
     HttpStatus responseStatus = HttpStatus.valueOf(response.getStatus());
     if (!responseStatus.is2xxSuccessful()) {
       String failMessage =
-          "Request for " + returnClass.getName() + " failed: status=" + responseStatus.toString();
+          "Request for " + returnClass.getName() + " failed: status=" + responseStatus;
       if (StringUtils.contains(responseBody, "message")) {
         // If the responseBody contains the word 'message', then we try to decode it as an
         // ErrorModel
@@ -464,14 +387,13 @@ public class ConnectedOperations {
     // check the failure status matches the expected
     // if no specific status is specified, just check that it's not successful
     if (expectedStatus == null) {
-      assertFalse("Expect failure", responseStatus.is2xxSuccessful());
+      assertThat("Expect failure", not(responseStatus.is2xxSuccessful()));
     } else {
-      assertEquals("Expect specific failure status", expectedStatus, responseStatus);
+      assertThat("Expect specific failure status", responseStatus, is(expectedStatus));
     }
 
     String responseBody = response.getContentAsString();
-    assertTrue(
-        "Error model was returned on failure", StringUtils.contains(responseBody, "message"));
+    assertThat("Error model was returned on failure", responseBody, containsString("message"));
 
     return TestUtils.mapFromJson(responseBody, ErrorModel.class);
   }
@@ -481,33 +403,33 @@ public class ConnectedOperations {
     removeDatasetFromTracking(id);
   }
 
-  public boolean deleteTestDataset(UUID id) throws Exception {
+  public void deleteTestDataset(UUID id) throws Exception {
     MvcResult result = mvc.perform(delete("/api/repository/v1/datasets/" + id)).andReturn();
     MockHttpServletResponse response = validateJobModelAndWait(result);
-    return checkDeleteResponse(response);
+    checkDeleteResponse(response);
   }
 
-  public boolean deleteTestProfile(UUID id) throws Exception {
+  public void deleteTestProfile(UUID id) throws Exception {
     MvcResult result =
         mvc.perform(delete("/api/resources/v1/profiles/{id}?deleteCloudResources=true", id))
             .andReturn();
     MockHttpServletResponse response = validateJobModelAndWait(result);
-    return checkDeleteResponse(response);
+    checkDeleteResponse(response);
   }
 
-  public boolean deleteTestSnapshot(UUID id) throws Exception {
+  public void deleteTestSnapshot(UUID id) throws Exception {
     MvcResult result = mvc.perform(delete("/api/repository/v1/snapshots/" + id)).andReturn();
     MockHttpServletResponse response = validateJobModelAndWait(result);
-    return checkDeleteResponse(response);
+    checkDeleteResponse(response);
   }
 
-  public boolean deleteTestFile(UUID datasetId, String fileId) throws Exception {
+  public void deleteTestFile(UUID datasetId, String fileId) throws Exception {
     MvcResult result =
         mvc.perform(delete("/api/repository/v1/datasets/" + datasetId + "/files/" + fileId))
             .andReturn();
     logger.info("deleting test file -  datasetId:{} objectId:{}", datasetId, fileId);
     MockHttpServletResponse response = validateJobModelAndWait(result);
-    return checkDeleteResponse(response);
+    checkDeleteResponse(response);
   }
 
   public void deleteTestBucket(String bucketName) {
@@ -521,25 +443,22 @@ public class ConnectedOperations {
     }
   }
 
-  public boolean checkDeleteResponse(MockHttpServletResponse response) throws Exception {
+  public void checkDeleteResponse(MockHttpServletResponse response) throws Exception {
     HttpStatus status = HttpStatus.valueOf(response.getStatus());
     if (status.is2xxSuccessful()) {
       DeleteResponseModel responseModel =
           TestUtils.mapFromJson(response.getContentAsString(), DeleteResponseModel.class);
-      assertTrue(
+      assertThat(
           "Valid delete response object state enumeration",
-          (responseModel.getObjectState() == DeleteResponseModel.ObjectStateEnum.DELETED
-              || responseModel.getObjectState() == DeleteResponseModel.ObjectStateEnum.NOT_FOUND));
-      return true;
+          responseModel.getObjectState(),
+          is(
+              oneOf(
+                  DeleteResponseModel.ObjectStateEnum.DELETED,
+                  DeleteResponseModel.ObjectStateEnum.NOT_FOUND)));
+    } else {
+      ErrorModel errorModel = handleFailureCase(response, HttpStatus.NOT_FOUND);
+      assertThat("error model returned", errorModel, notNullValue());
     }
-    ErrorModel errorModel = handleFailureCase(response, HttpStatus.NOT_FOUND);
-    assertNotNull("error model returned", errorModel);
-    return false;
-  }
-
-  public MvcResult ingestTableRaw(UUID datasetId, IngestRequestModel ingestRequestModel)
-      throws Exception {
-    return ingestTableRaw(datasetId, ingestRequestModel, null);
   }
 
   public MvcResult ingestTableRaw(
@@ -566,12 +485,11 @@ public class ConnectedOperations {
     MvcResult result = ingestTableRaw(datasetId, ingestRequestModel, userRequest);
     MockHttpServletResponse response = validateJobModelAndWait(result);
 
-    IngestResponseModel ingestResponse = checkIngestTableResponse(response);
-    return ingestResponse;
+    return checkIngestTableResponse(response);
   }
 
   public void checkTableRowCount(
-      FSContainerInterface tdrResource, String tableName, String prefix, int expectedRowCount) {
+      FSContainerInterface tdrResource, String tableName, int expectedRowCount) {
     int rowCount = BigQueryPdao.getTableTotalRowCount(tdrResource, tableName);
     assertThat("Expected row count", rowCount, equalTo(expectedRowCount));
   }
@@ -579,7 +497,6 @@ public class ConnectedOperations {
   public void checkDataModel(
       FSContainerInterface tdrResource,
       List<String> columnNames,
-      String prefix,
       String tableName,
       int expectedRowCount)
       throws InterruptedException {
@@ -594,7 +511,8 @@ public class ConnectedOperations {
             null,
             null);
     DataResultModel result = results.get(0);
-    assertNotNull("collection type should be defined as a snapshot or dataset.", tdrResource);
+    assertThat(
+        "collection type should be defined as a snapshot or dataset.", tdrResource, notNullValue());
     switch (tdrResource.getCollectionType()) {
       case DATASET:
         assertThat(
@@ -620,17 +538,17 @@ public class ConnectedOperations {
     return ingestResponse;
   }
 
-  public ErrorModel ingestTableFailure(UUID datasetId, IngestRequestModel ingestRequestModel)
+  public void ingestTableFailure(UUID datasetId, IngestRequestModel ingestRequestModel)
       throws Exception {
-    return ingestTableFailure(datasetId, ingestRequestModel, null);
+    ingestTableFailure(datasetId, ingestRequestModel, null);
   }
 
-  public ErrorModel ingestTableFailure(
+  public void ingestTableFailure(
       UUID datasetId, IngestRequestModel ingestRequestModel, AuthenticatedUserRequest userRequest)
       throws Exception {
     MvcResult result = ingestTableRaw(datasetId, ingestRequestModel, userRequest);
     MockHttpServletResponse response = validateJobModelAndWait(result);
-    return handleFailureCase(response);
+    handleFailureCase(response);
   }
 
   public FileModel ingestFileSuccess(UUID datasetId, FileLoadModel fileLoadModel) throws Exception {
@@ -649,8 +567,8 @@ public class ConnectedOperations {
   }
 
   public enum RetryType {
-    lock,
-    unlock
+    LOCK,
+    UNLOCK
   }
 
   /*
@@ -689,10 +607,10 @@ public class ConnectedOperations {
     TimeUnit.SECONDS.sleep(5); // give the flight time to fail a couple of times
     DatasetDaoUtils datasetDaoUtils = new DatasetDaoUtils();
     String[] sharedLocks = datasetDaoUtils.getSharedLocks(datasetDao, datasetId);
-    if (retryType.equals(RetryType.lock)) {
-      assertEquals("no shared locks after first call", 0, sharedLocks.length);
+    if (retryType == RetryType.LOCK) {
+      assertThat("no shared locks after first call", sharedLocks.length, is(0));
     } else {
-      assertEquals("Acquire shared locks after first call", 1, sharedLocks.length);
+      assertThat("Acquire shared locks after first call", sharedLocks.length, is(1));
     }
 
     if (removeFault) {
@@ -706,7 +624,7 @@ public class ConnectedOperations {
       // make sure successful unlock
       TimeUnit.SECONDS.sleep(5);
       String[] sharedLocks3 = datasetDaoUtils.getSharedLocks(datasetDao, datasetId);
-      assertEquals("successful unlock", 0, sharedLocks3.length);
+      assertThat("successful unlock", sharedLocks3.length, is(0));
 
       // Check if the flight successfully completed
       // Assume that if it successfully completed, then it was able to retry and acquire the shared
@@ -729,19 +647,14 @@ public class ConnectedOperations {
   private void checkSuccessfulFileLoad(
       FileLoadModel fileLoadModel, FileModel fileModel, UUID datasetId) {
     assertThat(
-        "description matches",
-        fileModel.getDescription(),
-        CoreMatchers.equalTo(fileLoadModel.getDescription()));
+        "description matches", fileModel.getDescription(), is(fileLoadModel.getDescription()));
     assertThat(
         "mime type matches",
         fileModel.getFileDetail().getMimeType(),
-        CoreMatchers.equalTo(fileLoadModel.getMimeType()));
+        is(fileLoadModel.getMimeType()));
 
     for (DRSChecksum checksum : fileModel.getChecksums()) {
-      assertTrue(
-          "valid checksum type",
-          (StringUtils.equals(checksum.getType(), "crc32c")
-              || StringUtils.equals(checksum.getType(), "md5")));
+      assertThat("valid checksum type", checksum.getType(), is(oneOf("crc32c", "md5")));
     }
 
     logger.info("addFile datasetId:{} objectId:{}", datasetId, fileModel.getFileId());
@@ -758,11 +671,11 @@ public class ConnectedOperations {
         .andReturn();
   }
 
-  public DeleteResponseModel softDeleteSuccess(
-      UUID datasetId, DataDeletionRequest softDeleteRequest) throws Exception {
+  public void softDeleteSuccess(UUID datasetId, DataDeletionRequest softDeleteRequest)
+      throws Exception {
     MvcResult result = softDeleteRaw(datasetId, softDeleteRequest);
     MockHttpServletResponse response = validateJobModelAndWait(result);
-    return handleSuccessCase(response, DeleteResponseModel.class);
+    handleSuccessCase(response, DeleteResponseModel.class);
   }
 
   public BulkLoadArrayResultModel ingestArraySuccess(
@@ -843,12 +756,6 @@ public class ConnectedOperations {
     return result.getResponse();
   }
 
-  public FileModel lookupFileSuccess(UUID datasetId, String fileId) throws Exception {
-    MockHttpServletResponse response = lookupFileRaw(datasetId, fileId);
-    assertThat(response.getStatus(), equalTo(HttpStatus.OK.value()));
-    return TestUtils.mapFromJson(response.getContentAsString(), FileModel.class);
-  }
-
   public MockHttpServletResponse lookupFileByPathRaw(UUID datasetId, String filePath, long depth)
       throws Exception {
     String url = "/api/repository/v1/datasets/" + datasetId + "/filesystem/objects";
@@ -860,13 +767,6 @@ public class ConnectedOperations {
                     .contentType(MediaType.APPLICATION_JSON))
             .andReturn();
     return result.getResponse();
-  }
-
-  public FileModel lookupFileByPathSuccess(UUID datasetId, String filePath, long depth)
-      throws Exception {
-    MockHttpServletResponse response = lookupFileByPathRaw(datasetId, filePath, depth);
-    assertThat(response.getStatus(), equalTo(HttpStatus.OK.value()));
-    return TestUtils.mapFromJson(response.getContentAsString(), FileModel.class);
   }
 
   public MockHttpServletResponse lookupSnapshotFileRaw(UUID snapshotId, String objectId)
@@ -966,7 +866,7 @@ public class ConnectedOperations {
   public enum TdrResourceType {
     SNAPSHOT,
     DATASET
-  };
+  }
 
   public List<Object> retrieveDataSuccess(
       TdrResourceType resourceType,
@@ -977,17 +877,14 @@ public class ConnectedOperations {
       String filter,
       String sort)
       throws Exception {
-    switch (resourceType) {
-      case SNAPSHOT:
-        return retrieveSnapshotPreviewByIdSuccess(
-                resourceId, tableName, limit, offset, filter, sort)
-            .getResult();
-      case DATASET:
-        return retrieveDatasetDataByIdSuccess(resourceId, tableName, limit, offset, filter, sort)
-            .getResult();
-      default:
-        throw new NotImplementedException();
-    }
+    return switch (resourceType) {
+      case SNAPSHOT ->
+          retrieveSnapshotPreviewByIdSuccess(resourceId, tableName, limit, offset, filter, sort)
+              .getResult();
+      case DATASET ->
+          retrieveDatasetDataByIdSuccess(resourceId, tableName, limit, offset, filter, sort)
+              .getResult();
+    };
   }
 
   public ErrorModel retrieveDataFailure(
@@ -1000,16 +897,14 @@ public class ConnectedOperations {
       String sort,
       HttpStatus expectedStatus)
       throws Exception {
-    switch (resourceType) {
-      case SNAPSHOT:
-        return retrieveSnapshotPreviewByIdFailure(
-            resourceId, tableName, limit, offset, filter, sort, expectedStatus);
-      case DATASET:
-        return retrieveDatasetDataByIdFailure(
-            resourceId, tableName, limit, offset, filter, sort, expectedStatus);
-      default:
-        throw new NotImplementedException();
-    }
+    return switch (resourceType) {
+      case SNAPSHOT ->
+          retrieveSnapshotPreviewByIdFailure(
+              resourceId, tableName, limit, offset, filter, sort, expectedStatus);
+      case DATASET ->
+          retrieveDatasetDataByIdFailure(
+              resourceId, tableName, limit, offset, filter, sort, expectedStatus);
+    };
   }
 
   public SnapshotPreviewModel retrieveSnapshotPreviewByIdSuccess(
@@ -1068,14 +963,15 @@ public class ConnectedOperations {
       if (status == HttpStatus.NOT_FOUND) {
         return result.getResponse();
       }
-      assertTrue(
-          "expected jobs polling status, got " + status.toString(),
-          (status == HttpStatus.ACCEPTED || status == HttpStatus.OK));
+      assertThat(
+          "expected jobs polling status, got " + status,
+          status,
+          is(oneOf(HttpStatus.ACCEPTED, HttpStatus.OK)));
 
       JobModel jobModel = TestUtils.mapFromJson(response.getContentAsString(), JobModel.class);
-      String jobId = jobModel.getId().toString();
+      String jobId = jobModel.getId();
       String locationUrl = response.getHeader("Location");
-      assertNotNull("location URL was specified", locationUrl);
+      assertThat("location URL was specified", locationUrl, notNullValue());
 
       switch (status) {
         case ACCEPTED:
@@ -1127,7 +1023,7 @@ public class ConnectedOperations {
   }
 
   public void addFile(String datasetId, String fileId) {
-    String[] createdFile = new String[] {datasetId, fileId};
+    String[] createdFile = {datasetId, fileId};
     createdFileIds.add(createdFile);
   }
 
@@ -1161,77 +1057,61 @@ public class ConnectedOperations {
     createdScratchFiles.add(path);
   }
 
-  public void setDeleteOnTeardown(boolean deleteOnTeardown) {
-    this.deleteOnTeardown = deleteOnTeardown;
-  }
-
-  public void addLabelsToGoogleProject(String googleProjectId, Map<String, String> labels) {}
-
   public void teardown() throws Exception {
     // call the reset configuration endpoint to disable all faults
     resetConfiguration();
 
-    if (deleteOnTeardown) {
-      // Order is important: delete all the snapshots first so we eliminate dependencies
-      // Then delete the files before the datasets
-      for (UUID snapshotId : createdSnapshotIds) {
-        try {
-          deleteTestSnapshot(snapshotId);
-        } catch (Exception ex) {
-          logger.info(
-              "CLEANUP ERROR! Error deleting snapshot. SnapshotId: {}", snapshotId.toString());
-        }
-      }
-
-      for (String[] fileInfo : createdFileIds) {
-        try {
-          deleteTestFile(UUID.fromString(fileInfo[0]), fileInfo[1]);
-        } catch (Exception ex) {
-          logger.info("CLEANUP ERROR! Error deleting file. FileId: {}", fileInfo[0]);
-        }
-      }
-
-      logger.info("Cleanup Tracking: {} datasets to be removed.", createdDatasetIds.size());
-      for (UUID datasetId : createdDatasetIds) {
-        logger.info("Cleanup Tracking: Dataset to be deleted {}", datasetId);
-        try {
-          deleteTestDataset(datasetId);
-        } catch (Exception ex) {
-          logger.info("CLEANUP ERROR! Error deleting dataset. DatasetId: {}", datasetId.toString());
-        }
-      }
-
-      for (UUID profileId : createdProfileIds) {
-        try {
-          deleteTestProfile(profileId);
-        } catch (Exception ex) {
-          logger.info("CLEANUP ERROR! Error deleting profile. ProfileId: {}", profileId.toString());
-        }
-      }
-
-      for (String bucketName : createdBuckets) {
-        try {
-          deleteTestBucket(bucketName);
-        } catch (Exception ex) {
-          logger.info("CLEANUP ERROR! Error deleting bucket. BucketName: {}", bucketName);
-        }
-      }
-
-      for (String path : createdScratchFiles) {
-        try {
-          deleteTestScratchFile(path);
-        } catch (Exception ex) {
-          logger.info("CLEANUP ERROR! Error deleting scratch file. Path: {}", path);
-        }
+    // Order is important: delete all the snapshots first so we eliminate dependencies
+    // Then delete the files before the datasets
+    for (UUID snapshotId : createdSnapshotIds) {
+      try {
+        deleteTestSnapshot(snapshotId);
+      } catch (Exception ex) {
+        logger.info("CLEANUP ERROR! Error deleting snapshot. SnapshotId: {}", snapshotId);
       }
     }
 
-    createdSnapshotIds = new ArrayList<>();
-    createdFileIds = new ArrayList<>();
-    createdDatasetIds = new ArrayList<>();
-    createdProfileIds = new ArrayList<>();
-    createdBuckets = new ArrayList<>();
-    createdScratchFiles = new ArrayList<>();
+    for (String[] fileInfo : createdFileIds) {
+      try {
+        deleteTestFile(UUID.fromString(fileInfo[0]), fileInfo[1]);
+      } catch (Exception ex) {
+        logger.info("CLEANUP ERROR! Error deleting file. FileId: {}", fileInfo[0]);
+      }
+    }
+
+    logger.info("Cleanup Tracking: {} datasets to be removed.", createdDatasetIds.size());
+    for (UUID datasetId : createdDatasetIds) {
+      logger.info("Cleanup Tracking: Dataset to be deleted {}", datasetId);
+      try {
+        deleteTestDataset(datasetId);
+      } catch (Exception ex) {
+        logger.info("CLEANUP ERROR! Error deleting dataset. DatasetId: {}", datasetId);
+      }
+    }
+
+    for (UUID profileId : createdProfileIds) {
+      try {
+        deleteTestProfile(profileId);
+      } catch (Exception ex) {
+        logger.info("CLEANUP ERROR! Error deleting profile. ProfileId: {}", profileId);
+      }
+    }
+
+    for (String bucketName : createdBuckets) {
+      try {
+        deleteTestBucket(bucketName);
+      } catch (Exception ex) {
+        logger.info("CLEANUP ERROR! Error deleting bucket. BucketName: {}", bucketName);
+      }
+    }
+
+    for (String path : createdScratchFiles) {
+      try {
+        deleteTestScratchFile(path);
+      } catch (Exception ex) {
+        logger.info("CLEANUP ERROR! Error deleting scratch file. Path: {}", path);
+      }
+    }
   }
 
   public void deleteLoadHistory(UUID datasetId, TableServiceClient serviceClient) {

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -646,7 +647,7 @@ class DatasetDaoTest {
     assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 2");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("two shared locks after step 2", sharedLocks, hasSize(2));
-    assertThat("flightid2 has shared lock after step 2", sharedLocks, contains(sharedLock2));
+    assertThat("flightid2 has shared lock after step 2", sharedLocks, hasItem(sharedLock2));
 
     // 3. try to take out an exclusive lock
     // confirm that it fails with a DatasetLockException

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -10,11 +10,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.app.model.CloudRegion;
 import bio.terra.app.model.GoogleCloudResource;
@@ -57,26 +55,26 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "unittest"})
-@Category(Unit.class)
+@Tag(Unit.TAG)
 @EmbeddedDatabaseTest
-public class DatasetDaoTest {
+class DatasetDaoTest {
 
   @Autowired private JsonLoader jsonLoader;
 
@@ -121,8 +119,8 @@ public class DatasetDaoTest {
     return createDataset(datasetRequest, datasetRequest.getName() + UUID.randomUUID(), null);
   }
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     BillingProfileRequestModel profileRequest = ProfileFixtures.randomBillingProfileRequest();
     billingProfile = profileDao.createBillingProfile(profileRequest, "hi@hi.hi");
 
@@ -132,21 +130,21 @@ public class DatasetDaoTest {
     datasetIds = new ArrayList<>();
   }
 
-  @After
-  public void teardown() {
+  @AfterEach
+  void teardown() {
     for (UUID datasetId : datasetIds) {
-      assertTrue("Dataset %s was deleted".formatted(datasetId), datasetDao.delete(datasetId));
+      assertThat("Dataset %s was deleted".formatted(datasetId), datasetDao.delete(datasetId));
       assertThrows(
-          "Dataset %s cannot be retrieved after deletion".formatted(datasetId),
           DatasetNotFoundException.class,
-          () -> datasetDao.retrieve(datasetId));
+          () -> datasetDao.retrieve(datasetId),
+          () -> "Dataset %s cannot be retrieved after deletion".formatted(datasetId));
     }
     resourceDao.deleteProject(projectId);
     profileDao.deleteBillingProfileById(billingProfile.getId());
   }
 
   @Test
-  public void setSecureMonitoringTest() throws Exception {
+  void setSecureMonitoringTest() throws Exception {
     UUID datasetId = createDataset("dataset-minimal.json");
     Dataset dataset = datasetDao.retrieve(datasetId);
     assertThat(
@@ -265,7 +263,7 @@ public class DatasetDaoTest {
         "dataset filter by default GCS region returns correct total",
         filteredDefaultRegionDatasets,
         hasSize(1));
-    assertTrue(
+    assertThat(
         "dataset filter by default GCS region returns correct datasets",
         filteredDefaultRegionDatasets.stream()
             .allMatch(
@@ -292,7 +290,7 @@ public class DatasetDaoTest {
         "dataset filter by name and region returns dataset with correct name",
         filteredNameAndRegionDatasets.get(0).getName(),
         equalTo(dataset1.getName()));
-    assertTrue(
+    assertThat(
         "dataset filter by name and region returns dataset with correct region",
         filteredNameAndRegionDatasets.stream()
             .allMatch(
@@ -324,7 +322,7 @@ public class DatasetDaoTest {
         "dataset filter by non-default GCS region returns correct total",
         filteredRegionDatasets,
         hasSize(1));
-    assertTrue(
+    assertThat(
         "dataset filter by non-default region returns correct dataset",
         filteredRegionDatasets.stream()
             .allMatch(
@@ -623,11 +621,11 @@ public class DatasetDaoTest {
   }
 
   @Test
-  public void mixingSharedAndExclusiveLocksTest() throws Exception {
+  void mixingSharedAndExclusiveLocksTest() throws Exception {
     UUID datasetId = createDataset("dataset-primary-key.json");
 
     // check that there are no outstanding locks
-    assertNull("no exclusive lock after creation", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after creation");
     List<String> sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after creation", sharedLocks, empty());
 
@@ -635,42 +633,42 @@ public class DatasetDaoTest {
     // confirm that there are no exclusive locks and one shared lock
     String sharedLock1 = "flightid1";
     datasetDao.lockShared(datasetId, sharedLock1);
-    assertNull("no exclusive lock after step 1", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 1");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("one shared lock after step 1", sharedLocks, hasSize(1));
-    assertEquals("flightid1 has shared lock after step 1", sharedLocks.get(0), sharedLock1);
+    assertThat("flightid1 has shared lock after step 1", sharedLocks.get(0), is(sharedLock1));
 
     // 2. take out another shared lock
     // confirm that there are no exclusive locks and two shared locks
     String sharedLock2 = "flightid2";
     datasetDao.lockShared(datasetId, sharedLock2);
-    assertNull("no exclusive lock after step 2", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 2");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("two shared locks after step 2", sharedLocks, hasSize(2));
-    assertTrue("flightid2 has shared lock after step 2", sharedLocks.contains(sharedLock2));
+    assertThat("flightid2 has shared lock after step 2", sharedLocks.contains(sharedLock2));
 
     // 3. try to take out an exclusive lock
     // confirm that it fails with a DatasetLockException
     assertThrows(
-        "exclusive lock threw exception in step 3",
         DatasetLockException.class,
-        () -> datasetDao.lockExclusive(datasetId, "flightid3"));
+        () -> datasetDao.lockExclusive(datasetId, "flightid3"),
+        "exclusive lock threw exception in step 3");
 
     // 4. release the first shared lock
     // confirm that there are no exclusive locks and one shared lock
     datasetDao.unlockShared(datasetId, sharedLock1);
-    assertNull("no exclusive lock after step 4", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 4");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("one shared lock after step 4", sharedLocks, hasSize(1));
-    assertFalse(
-        "flightid1 no longer has shared lock after step 4", sharedLocks.contains(sharedLock1));
+    assertThat(
+        "flightid1 no longer has shared lock after step 4", not(sharedLocks.contains(sharedLock1)));
 
     // 5. try to take out an exclusive lock
     // confirm that it fails with a DatasetLockException
     assertThrows(
-        "exclusive lock threw exception in step 5",
         DatasetLockException.class,
-        () -> datasetDao.lockExclusive(datasetId, "flightid4"));
+        () -> datasetDao.lockExclusive(datasetId, "flightid4"),
+        "exclusive lock threw exception in step 5");
 
     // 6. take out five shared locks
     // confirm that there are no exclusive locks and six shared locks
@@ -683,7 +681,7 @@ public class DatasetDaoTest {
     expectedSharedLocks.add(sharedLock2);
     expectedSharedLocks.addAll(bulkSharedLocks);
 
-    assertNull("no exclusive lock after step 6", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 6");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat(
         "all expected shared locks after step 6",
@@ -693,7 +691,7 @@ public class DatasetDaoTest {
     // 7. release all the shared locks
     // confirm that there are no outstanding locks
     expectedSharedLocks.forEach(sharedLock -> datasetDao.unlockShared(datasetId, sharedLock));
-    assertNull("no exclusive lock after step 7", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 7");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 7", sharedLocks, empty());
 
@@ -701,34 +699,34 @@ public class DatasetDaoTest {
     // confirm that there is an exclusive lock and no shared locks
     String expectedExclusiveLock = "flightid10";
     datasetDao.lockExclusive(datasetId, expectedExclusiveLock);
-    assertEquals(
+    assertThat(
         "exclusive lock taken out after step 8",
-        expectedExclusiveLock,
-        getExclusiveLock(datasetId));
+        getExclusiveLock(datasetId),
+        is(expectedExclusiveLock));
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 8", sharedLocks, empty());
 
     // 9. try to take out a shared lock
     // confirm that it fails with a DatasetLockException
     assertThrows(
-        "shared lock threw exception in step 9",
         DatasetLockException.class,
-        () -> datasetDao.lockShared(datasetId, "flightid11"));
+        () -> datasetDao.lockShared(datasetId, "flightid11"),
+        "shared lock threw exception in step 9");
 
     // 10. release the exclusive lock
     // confirm that there are no outstanding locks
     datasetDao.unlockExclusive(datasetId, expectedExclusiveLock);
-    assertNull("no exclusive lock after step 10", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 10");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 10", sharedLocks, empty());
   }
 
   @Test
-  public void duplicateCallsForExclusiveLockTest() throws Exception {
+  void duplicateCallsForExclusiveLockTest() throws Exception {
     UUID datasetId = createDataset("dataset-primary-key.json");
 
     // check that there are no outstanding locks
-    assertNull("no exclusive lock after creation", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after creation");
     List<String> sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after creation", sharedLocks, empty());
 
@@ -736,16 +734,16 @@ public class DatasetDaoTest {
     // confirm that there is an exclusive lock and no shared locks
     String exclusiveLock1 = "flightId20";
     datasetDao.lockExclusive(datasetId, exclusiveLock1);
-    assertEquals(
-        "exclusive lock taken out after step 1", exclusiveLock1, getExclusiveLock(datasetId));
+    assertThat(
+        "exclusive lock taken out after step 1", getExclusiveLock(datasetId), is(exclusiveLock1));
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 1", sharedLocks, empty());
 
     // 2. try to take out an exclusive lock again with the same flightid
     // confirm that the exclusive lock is still there and there are no shared locks
     datasetDao.lockExclusive(datasetId, exclusiveLock1);
-    assertEquals(
-        "exclusive lock taken out after step 2", exclusiveLock1, getExclusiveLock(datasetId));
+    assertThat(
+        "exclusive lock taken out after step 2", getExclusiveLock(datasetId), is(exclusiveLock1));
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 2", sharedLocks, empty());
 
@@ -753,36 +751,38 @@ public class DatasetDaoTest {
     // confirm that the exclusive lock is still there and there are no shared locks
     String exclusiveLock2 = "flightId21";
     boolean rowUnlocked = datasetDao.unlockExclusive(datasetId, exclusiveLock2);
-    assertFalse(
-        "no rows updated on call to unlock with different flightid after step 3", rowUnlocked);
-    assertEquals(
-        "exclusive lock still taken out after step 3", exclusiveLock1, getExclusiveLock(datasetId));
+    assertThat(
+        "no rows updated on call to unlock with different flightid after step 3", not(rowUnlocked));
+    assertThat(
+        "exclusive lock still taken out after step 3",
+        getExclusiveLock(datasetId),
+        is(exclusiveLock1));
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 3", sharedLocks, empty());
 
     // 4. unlock the exclusive lock
     // confirm that there are no outstanding exclusive or shared locks
     rowUnlocked = datasetDao.unlockExclusive(datasetId, exclusiveLock1);
-    assertTrue("row was updated on first call to unlock after step 4", rowUnlocked);
-    assertNull("no exclusive lock after step 4", getExclusiveLock(datasetId));
+    assertThat("row was updated on first call to unlock after step 4", rowUnlocked);
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 4");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 4", sharedLocks, empty());
 
     // 5. unlock the exclusive lock again with the same flightid
     // confirm that there are still no outstanding exclusive or shared locks
     rowUnlocked = datasetDao.unlockExclusive(datasetId, exclusiveLock1);
-    assertFalse("no rows updated on second call to unlock after step 5", rowUnlocked);
-    assertNull("no exclusive lock after step 5", getExclusiveLock(datasetId));
+    assertThat("no rows updated on second call to unlock after step 5", not(rowUnlocked));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 5");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 5", sharedLocks, empty());
   }
 
   @Test
-  public void duplicateCallsForSharedLockTest() throws Exception {
+  void duplicateCallsForSharedLockTest() throws Exception {
     UUID datasetId = createDataset("dataset-primary-key.json");
 
     // check that there are no outstanding locks
-    assertNull("no exclusive lock after creation", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after creation");
     List<String> sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after creation", sharedLocks, empty());
 
@@ -790,80 +790,81 @@ public class DatasetDaoTest {
     // confirm that there is no exclusive lock and one shared lock
     String sharedLock1 = "flightid30";
     datasetDao.lockShared(datasetId, sharedLock1);
-    assertNull("no exclusive lock after step 1", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 1");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("one shared lock after step 1", sharedLocks, hasSize(1));
-    assertEquals("flightid30 has shared lock after step 1", sharedLocks.get(0), sharedLock1);
+    assertThat("flightid30 has shared lock after step 1", sharedLocks.get(0), is(sharedLock1));
 
     // 2. try to take out a shared lock again with the same flightid
     // confirm that the shared lock is still there and there is no exclusive lock
     datasetDao.lockShared(datasetId, sharedLock1);
-    assertNull("no exclusive lock after step 2", getExclusiveLock(datasetId));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 2");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("one shared lock after step 2", sharedLocks, hasSize(1));
-    assertEquals("flightid30 has shared lock after step 2", sharedLocks.get(0), sharedLock1);
+    assertThat("flightid30 has shared lock after step 2", sharedLocks.get(0), is(sharedLock1));
 
     // 3. try to unlock the shared lock with a different flightid
     // confirm that the shared lock is still there and there is no exclusive lock
     String sharedLock2 = "flightid31";
     boolean rowUnlocked = datasetDao.unlockShared(datasetId, sharedLock2);
-    assertFalse(
-        "no rows updated on call to unlock with different flightid after step 3", rowUnlocked);
-    assertNull("no exclusive lock after step 3", getExclusiveLock(datasetId));
+    assertThat(
+        "no rows updated on call to unlock with different flightid after step 3", not(rowUnlocked));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 3");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("one shared lock after step 3", sharedLocks, hasSize(1));
-    assertEquals("flightid30 still has shared lock after step 3", sharedLocks.get(0), sharedLock1);
+    assertThat(
+        "flightid30 still has shared lock after step 3", sharedLocks.get(0), is(sharedLock1));
 
     // 4. unlock the shared lock
     // confirm that there are no outstanding exclusive or shared locks
     rowUnlocked = datasetDao.unlockShared(datasetId, sharedLock1);
-    assertTrue("row was updated on first call to unlock after step 4", rowUnlocked);
-    assertNull("no exclusive lock after step 4", getExclusiveLock(datasetId));
+    assertThat("row was updated on first call to unlock after step 4", rowUnlocked);
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 4");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 4", sharedLocks, empty());
 
     // 5. unlock the exclusive lock again with the same flightid
     // confirm that there are still no outstanding exclusive or shared locks
     rowUnlocked = datasetDao.unlockShared(datasetId, sharedLock1);
-    assertFalse("no rows updated on second call to unlock after step 5", rowUnlocked);
-    assertNull("no exclusive lock after step 5", getExclusiveLock(datasetId));
+    assertThat("no rows updated on second call to unlock after step 5", not(rowUnlocked));
+    assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 5");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 5", sharedLocks, empty());
   }
 
   @Test
-  public void lockNonExistentDatasetTest() {
+  void lockNonExistentDatasetTest() {
     UUID nonExistentDatasetId = UUID.randomUUID();
 
     // try to take out an exclusive lock
     // confirm that it fails with a DatasetNotFoundException
     String exclusiveLock = "flightid40";
     assertThrows(
-        "exclusive lock threw not found exception",
         DatasetNotFoundException.class,
-        () -> datasetDao.lockExclusive(nonExistentDatasetId, exclusiveLock));
+        () -> datasetDao.lockExclusive(nonExistentDatasetId, exclusiveLock),
+        "exclusive lock threw not found exception");
 
     // try to release an exclusive lock
     // confirm that it succeeds with no rows updated
     boolean rowUpdated = datasetDao.unlockExclusive(nonExistentDatasetId, exclusiveLock);
-    assertFalse("exclusive unlock did not update any rows", rowUpdated);
+    assertThat("exclusive unlock did not update any rows", not(rowUpdated));
 
     // try to take out a shared lock
     // confirm that it fails with a DatasetNotFoundException
     String sharedLock = "flightid41";
     assertThrows(
-        "shared lock threw not found exception",
         DatasetNotFoundException.class,
-        () -> datasetDao.lockShared(nonExistentDatasetId, sharedLock));
+        () -> datasetDao.lockShared(nonExistentDatasetId, sharedLock),
+        "shared lock threw not found exception");
 
     // try to release a shared lock
     // confirm that it succeeds with no rows updated
     rowUpdated = datasetDao.unlockExclusive(nonExistentDatasetId, sharedLock);
-    assertFalse("shared unlock did not update any rows", rowUpdated);
+    assertThat("shared unlock did not update any rows", not(rowUpdated));
   }
 
   @Test
-  public void rowMetadataTable() throws Exception {
+  void rowMetadataTable() throws Exception {
     UUID datasetId = createDataset("dataset-minimal.json");
     Dataset dataset = datasetDao.retrieve(datasetId);
     dataset
@@ -877,7 +878,7 @@ public class DatasetDaoTest {
   }
 
   @Test
-  public void columnOrderCreationTest() throws Exception {
+  void columnOrderCreationTest() throws Exception {
     String dsName1 = "ds1";
     String dsName2 = "ds2";
     String tableName = "myTable";
@@ -941,10 +942,10 @@ public class DatasetDaoTest {
   }
 
   @Test
-  public void patchDatasetPhsId() throws Exception {
+  void patchDatasetPhsId() throws Exception {
     UUID datasetId = createDataset("dataset-create-test.json");
 
-    assertNull("dataset's PHS ID is null before patch", datasetDao.retrieve(datasetId).getPhsId());
+    assertNull(datasetDao.retrieve(datasetId).getPhsId(), "dataset's PHS ID is null before patch");
 
     String phsIdSet = "phs000000";
     DatasetPatchRequestModel patchRequestSet = new DatasetPatchRequestModel().phsId(phsIdSet);
@@ -978,7 +979,7 @@ public class DatasetDaoTest {
   }
 
   @Test
-  public void createDatasetWithProperties() throws Exception {
+  void createDatasetWithProperties() throws Exception {
     DatasetRequestModel request =
         jsonLoader.loadObject("dataset-create-with-properties.json", DatasetRequestModel.class);
     String expectedName = request.getName() + UUID.randomUUID();
@@ -991,24 +992,24 @@ public class DatasetDaoTest {
   }
 
   @Test
-  public void updatePredictableFileIdsFlag() throws Exception {
+  void updatePredictableFileIdsFlag() throws Exception {
     UUID datasetId = createDataset("dataset-minimal.json");
-    assertFalse(
+    assertThat(
         "predictable file ids flag is false",
-        datasetDao.retrieve(datasetId).hasPredictableFileIds());
+        not(datasetDao.retrieve(datasetId).hasPredictableFileIds()));
     datasetDao.setPredictableFileId(datasetId, true);
-    assertTrue(
+    assertThat(
         "predictable file ids flag is true",
         datasetDao.retrieve(datasetId).hasPredictableFileIds());
   }
 
   @Test
-  public void patchDatasetProperties() throws Exception {
+  void patchDatasetProperties() throws Exception {
     UUID datasetId = createDataset("dataset-create-test.json");
 
     String defaultDesc = datasetDao.retrieve(datasetId).getDescription();
     assertNull(
-        "dataset properties is null before patch", datasetDao.retrieve(datasetId).getProperties());
+        datasetDao.retrieve(datasetId).getProperties(), "dataset properties is null before patch");
 
     String updatedProperties = "{\"projectName\":\"updatedProject\"}";
     Object updatedDatasetProperties =
@@ -1081,7 +1082,7 @@ public class DatasetDaoTest {
   }
 
   @Test
-  public void createTaggedDatasetAndGetTags() throws Exception {
+  void createTaggedDatasetAndGetTags() throws Exception {
     DatasetRequestModel requestNullTags =
         jsonLoader.loadObject("dataset-create-test.json", DatasetRequestModel.class).tags(null);
     String nameNullTags = requestNullTags.getName() + UUID.randomUUID();
@@ -1162,7 +1163,7 @@ public class DatasetDaoTest {
   }
 
   @Test
-  public void updateTags() throws Exception {
+  void updateTags() throws Exception {
     UUID datasetId = createDataset("dataset-minimal.json");
 
     List<String> add = new ArrayList<>(List.of(" a ", "b", "b ", "c,d", "e", " "));
@@ -1205,13 +1206,13 @@ public class DatasetDaoTest {
         datasetDao.retrieve(datasetId).getTags(),
         equalTo(expectedTags));
 
-    assertFalse(
+    assertThat(
         "No rows are updated when updating tags on nonexistent dataset",
-        datasetDao.updateTags(UUID.randomUUID(), new TagUpdateRequestModel()));
+        not(datasetDao.updateTags(UUID.randomUUID(), new TagUpdateRequestModel())));
   }
 
   @Test
-  public void testRetrieveExclusivelyLockedDataset() throws Exception {
+  void testRetrieveExclusivelyLockedDataset() throws Exception {
     UUID datasetId = createDataset("dataset-minimal.json");
     String flightId = "flightId";
 
@@ -1242,7 +1243,7 @@ public class DatasetDaoTest {
   }
 
   @Test
-  public void testRetrieveSharedLock() throws Exception {
+  void testRetrieveSharedLock() throws Exception {
     UUID datasetId = createDataset("dataset-minimal.json");
     String flightId = ShortUUID.get();
     datasetDao.lockShared(datasetId, flightId);

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -164,7 +164,7 @@ class DatasetDaoTest {
   }
 
   @Test
-  public void enumerateTest() throws Exception {
+  void enumerateTest() throws Exception {
     UUID datasetId1 = createDataset("dataset-minimal.json");
     Dataset dataset1 = datasetDao.retrieve(datasetId1);
     UUID datasetId2 = createDataset("ingest-test-dataset-east.json");
@@ -416,17 +416,17 @@ class DatasetDaoTest {
   }
 
   @Test
-  public void datasetTest() throws Exception {
+  void datasetTest() throws Exception {
     datasetTest(true, true);
   }
 
   @Test
-  public void datasetTest_noRelationships() throws Exception {
+  void datasetTest_noRelationships() throws Exception {
     datasetTest(false, true);
   }
 
   @Test
-  public void datasetTest_noAssets() throws Exception {
+  void datasetTest_noAssets() throws Exception {
     datasetTest(true, false);
   }
 
@@ -488,7 +488,7 @@ class DatasetDaoTest {
   }
 
   @Test
-  public void datasetRegionFirestoreFallbackTest() throws Exception {
+  void datasetRegionFirestoreFallbackTest() throws Exception {
     DatasetRequestModel request =
         jsonLoader.loadObject("dataset-create-test.json", DatasetRequestModel.class).region("US");
     String expectedName = request.getName() + UUID.randomUUID();
@@ -497,8 +497,7 @@ class DatasetDaoTest {
     Dataset fromDB = datasetDao.retrieve(datasetId);
 
     for (GoogleCloudResource resource : GoogleCloudResource.values()) {
-      CloudRegion region =
-          (GoogleRegion) fromDB.getDatasetSummary().getStorageResourceRegion(resource);
+      CloudRegion region = fromDB.getDatasetSummary().getStorageResourceRegion(resource);
       GoogleRegion expectedRegion =
           (resource == GoogleCloudResource.BIGQUERY) ? GoogleRegion.US : GoogleRegion.US_EAST4;
       assertThat(
@@ -509,7 +508,7 @@ class DatasetDaoTest {
   }
 
   @Test
-  public void partitionTest() throws Exception {
+  void partitionTest() throws Exception {
     UUID datasetId = createDataset("ingest-test-partitioned-dataset.json");
     Dataset fromDB = datasetDao.retrieve(datasetId);
     DatasetTable participants =
@@ -532,7 +531,7 @@ class DatasetDaoTest {
   }
 
   @Test
-  public void primaryKeyTest() throws Exception {
+  void primaryKeyTest() throws Exception {
     UUID datasetId = createDataset("dataset-primary-key.json");
     Dataset fromDB = datasetDao.retrieve(datasetId);
     DatasetTable variants =
@@ -647,7 +646,7 @@ class DatasetDaoTest {
     assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 2");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("two shared locks after step 2", sharedLocks, hasSize(2));
-    assertThat("flightid2 has shared lock after step 2", sharedLocks.contains(sharedLock2));
+    assertThat("flightid2 has shared lock after step 2", sharedLocks, contains(sharedLock2));
 
     // 3. try to take out an exclusive lock
     // confirm that it fails with a DatasetLockException

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -113,10 +113,12 @@ class DatasetDaoTest {
     return datasetId;
   }
 
-  private UUID createDataset(String datasetFile) throws Exception {
-    DatasetRequestModel datasetRequest =
-        jsonLoader.loadObject(datasetFile, DatasetRequestModel.class);
+  private UUID createDataset(DatasetRequestModel datasetRequest) throws Exception {
     return createDataset(datasetRequest, datasetRequest.getName() + UUID.randomUUID(), null);
+  }
+
+  private UUID createDataset(String datasetFile) throws Exception {
+    return createDataset(jsonLoader.loadObject(datasetFile, DatasetRequestModel.class));
   }
 
   @BeforeEach
@@ -1115,7 +1117,7 @@ class DatasetDaoTest {
     tags2.addAll(List.of("duplicate", "yet another tag"));
     DatasetRequestModel request2WithTags =
         jsonLoader.loadObject("dataset-create-test.json", DatasetRequestModel.class).tags(tags2);
-    createDataset(request2WithTags, request2WithTags.getName() + UUID.randomUUID(), null);
+    createDataset(request2WithTags);
 
     assertThat(
         "Get tags without restriction returns all tags and counts",
@@ -1250,5 +1252,18 @@ class DatasetDaoTest {
     Dataset lockedDataset = datasetDao.retrieve(datasetId);
     var datasetSharedLocks = ResourceLocksUtils.getSharedLock(lockedDataset.getResourceLocks());
     assertThat("Correct shared lock is returned", datasetSharedLocks, contains(flightId));
+  }
+
+  @Test
+  void createDatasetInherit() throws Exception {
+    var datasetRequest = jsonLoader.loadObject("dataset-minimal.json", DatasetRequestModel.class);
+    var datasetId = createDataset(datasetRequest);
+    var dataset = datasetDao.retrieve(datasetId);
+    assertThat("Inherit steward defaults to false", not(dataset.isInheritSteward()));
+
+    datasetRequest.setInheritSteward(true);
+    datasetId = createDataset(datasetRequest);
+    dataset = datasetDao.retrieve(datasetId);
+    assertThat("Inherit steward is set", dataset.isInheritSteward());
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FileOperationTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FileOperationTest.java
@@ -205,7 +205,7 @@ public class FileOperationTest {
     FileLoadModel fileLoadModel = makeFileLoad(profileModel.getId());
 
     connectedOperations.retryAcquireLockIngestFileSuccess(
-        ConnectedOperations.RetryType.lock,
+        ConnectedOperations.RetryType.LOCK,
         true,
         true,
         ConfigEnum.FILE_INGEST_LOCK_RETRY_FAULT,
@@ -220,7 +220,7 @@ public class FileOperationTest {
     FileLoadModel fileLoadModel = makeFileLoad(profileModel.getId());
 
     connectedOperations.retryAcquireLockIngestFileSuccess(
-        ConnectedOperations.RetryType.unlock,
+        ConnectedOperations.RetryType.UNLOCK,
         true,
         true,
         ConfigEnum.FILE_INGEST_UNLOCK_RETRY_FAULT,
@@ -239,7 +239,7 @@ public class FileOperationTest {
     FileLoadModel fileLoadModel = makeFileLoad(profileModel.getId());
 
     connectedOperations.retryAcquireLockIngestFileSuccess(
-        ConnectedOperations.RetryType.lock,
+        ConnectedOperations.RetryType.LOCK,
         false,
         false,
         ConfigEnum.FILE_INGEST_LOCK_RETRY_FAULT,
@@ -256,7 +256,7 @@ public class FileOperationTest {
     FileLoadModel fileLoadModel = makeFileLoad(profileModel.getId());
 
     connectedOperations.retryAcquireLockIngestFileSuccess(
-        ConnectedOperations.RetryType.unlock,
+        ConnectedOperations.RetryType.UNLOCK,
         false,
         true,
         ConfigEnum.FILE_INGEST_UNLOCK_FATAL_FAULT,
@@ -272,7 +272,7 @@ public class FileOperationTest {
     FileLoadModel fileLoadModel = makeFileLoad(profileModel.getId());
 
     connectedOperations.retryAcquireLockIngestFileSuccess(
-        ConnectedOperations.RetryType.lock,
+        ConnectedOperations.RetryType.LOCK,
         false,
         true,
         ConfigEnum.FILE_INGEST_LOCK_FATAL_FAULT,

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -11,6 +11,8 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -22,9 +24,11 @@ import bio.terra.common.TestUtils;
 import bio.terra.common.category.Connected;
 import bio.terra.common.fixtures.ConnectedOperations;
 import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.common.fixtures.Names;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.DatasetPatchRequestModel;
+import bio.terra.model.DatasetRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.EnumerateSnapshotModel;
 import bio.terra.model.ErrorModel;
@@ -93,7 +97,6 @@ class SnapshotConnectedTest {
   private String snapshotOriginalName;
   private BillingProfileModel billingProfile;
   private final Storage storage = StorageOptions.getDefaultInstance().getService();
-  private DatasetSummaryModel datasetSummary;
 
   private static final String CONSENT_CODE = "c99";
   private static final String PHS_ID = "phs123456";
@@ -113,7 +116,10 @@ class SnapshotConnectedTest {
     configService.reset();
     billingProfile =
         connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
-    datasetSummary =
+  }
+
+  DatasetSummaryModel createTestDataset() throws Exception {
+    var datasetSummary =
         SnapshotConnectedTestUtils.createTestDataset(
             connectedOperations, billingProfile, "snapshot-test-dataset.json");
     SnapshotConnectedTestUtils.loadCsvData(
@@ -124,6 +130,7 @@ class SnapshotConnectedTest {
         datasetSummary.getId(),
         "thetable",
         "snapshot-test-dataset-data-row-ids.csv");
+    return datasetSummary;
   }
 
   @AfterEach
@@ -153,23 +160,28 @@ class SnapshotConnectedTest {
             datasetArraySummary.getDefaultProfileId());
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
+
+    // Verify that the parent id wasn't set on snapshot creation.
+    verify(samService).createSnapshotResource(any(), eq(summaryModel.getId()), eq(null), any());
+
     SnapshotConnectedTestUtils.getTestSnapshot(
         mvc, objectMapper, summaryModel.getId(), snapshotRequest, datasetArraySummary);
 
-    BigQueryProject bigQuerySnaphsotProject =
+    BigQueryProject bigQuerySnapshotProject =
         TestUtils.bigQueryProjectForSnapshotName(snapshotDao, summaryModel.getName());
     long snapshotParticipants =
         SnapshotConnectedTestUtils.queryForCount(
-            summaryModel.getName(), "participant", bigQuerySnaphsotProject);
+            summaryModel.getName(), "participant", bigQuerySnapshotProject);
     assertThat("dataset participants loaded properly", snapshotParticipants, equalTo(2L));
     long snapshotSamples =
         SnapshotConnectedTestUtils.queryForCount(
-            summaryModel.getName(), "sample", bigQuerySnaphsotProject);
+            summaryModel.getName(), "sample", bigQuerySnapshotProject);
     assertThat("dataset samples loaded properly", snapshotSamples, equalTo(3L));
   }
 
   @Test
   void testEnumeration() throws Exception {
+    var datasetSummary = createTestDataset();
     datasetDao.patch(
         datasetSummary.getId(), new DatasetPatchRequestModel().phsId(PHS_ID), TEST_USER);
 
@@ -270,6 +282,7 @@ class SnapshotConnectedTest {
 
   @Test
   void testBadData() throws Exception {
+    var datasetSummary = createTestDataset();
     SnapshotRequestModel badDataRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
             jsonLoader,
@@ -284,6 +297,7 @@ class SnapshotConnectedTest {
 
   @Test
   void testDuplicateName() throws Exception {
+    var datasetSummary = createTestDataset();
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
@@ -330,17 +344,7 @@ class SnapshotConnectedTest {
   @Test
   void testDeleteRecreateSnapshot() throws Exception {
     // create a dataset and load some tabular data
-    DatasetSummaryModel datasetSummary =
-        SnapshotConnectedTestUtils.createTestDataset(
-            connectedOperations, billingProfile, "snapshot-test-dataset.json");
-    SnapshotConnectedTestUtils.loadCsvData(
-        connectedOperations,
-        jsonLoader,
-        storage,
-        testConfig.getIngestbucket(),
-        datasetSummary.getId(),
-        "thetable",
-        "snapshot-test-dataset-data-row-ids.csv");
+    DatasetSummaryModel datasetSummary = createTestDataset();
 
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
@@ -381,17 +385,7 @@ class SnapshotConnectedTest {
   @Test
   void testProjectDeleteAfterSnapshotDelete() throws Exception {
     // create a dataset and load some tabular data
-    DatasetSummaryModel datasetSummary =
-        SnapshotConnectedTestUtils.createTestDataset(
-            connectedOperations, billingProfile, "snapshot-test-dataset.json");
-    SnapshotConnectedTestUtils.loadCsvData(
-        connectedOperations,
-        jsonLoader,
-        storage,
-        testConfig.getIngestbucket(),
-        datasetSummary.getId(),
-        "thetable",
-        "snapshot-test-dataset-data-row-ids.csv");
+    DatasetSummaryModel datasetSummary = createTestDataset();
 
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
@@ -425,6 +419,50 @@ class SnapshotConnectedTest {
     assertThat(
         googleResourceManagerService.getProject(googleProjectId).getLifecycleState(),
         is(LifecycleState.DELETE_REQUESTED.toString()));
+  }
+
+  @Test
+  void createSnapshotInheritSteward() throws Exception {
+    // create a dataset and load some tabular data
+    DatasetRequestModel datasetRequest =
+        jsonLoader.loadObject("snapshot-test-dataset.json", DatasetRequestModel.class);
+    datasetRequest
+        .name(Names.randomizeName(datasetRequest.getName()))
+        .defaultProfileId(billingProfile.getId())
+        .cloudPlatform(billingProfile.getCloudPlatform())
+        .inheritSteward(true);
+
+    DatasetSummaryModel datasetSummary = connectedOperations.createDataset(datasetRequest);
+
+    SnapshotConnectedTestUtils.loadCsvData(
+        connectedOperations,
+        jsonLoader,
+        storage,
+        testConfig.getIngestbucket(),
+        datasetSummary.getId(),
+        "thetable",
+        "snapshot-test-dataset-data-row-ids.csv");
+
+    // create a snapshot
+    SnapshotRequestModel snapshotRequest =
+        SnapshotConnectedTestUtils.makeSnapshotTestRequest(
+            jsonLoader,
+            datasetSummary,
+            "snapshot-test-snapshot.json",
+            datasetSummary.getDefaultProfileId());
+
+    MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
+    SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
+
+    // fetch the snapshot and confirm the metadata matches the request
+    SnapshotModel snapshotModel =
+        SnapshotConnectedTestUtils.getTestSnapshot(
+            mvc, objectMapper, summaryModel.getId(), snapshotRequest, datasetSummary);
+
+    // Verify that the parent id is the dataset id set on snapshot creation.
+    verify(samService)
+        .createSnapshotResource(
+            any(), eq(snapshotModel.getId()), eq(datasetSummary.getId()), any());
   }
 
   private DatasetSummaryModel setupArrayStructDataset() throws Exception {

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -6,11 +6,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -39,7 +38,6 @@ import bio.terra.service.auth.ras.EcmService;
 import bio.terra.service.auth.ras.RasDbgapPermissions;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.DatasetDao;
-import bio.terra.service.filedata.DrsIdService;
 import bio.terra.service.resourcemanagement.google.GoogleResourceManagerService;
 import bio.terra.service.tabulardata.google.BigQueryProject;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,12 +53,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -69,23 +66,17 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"google", "connectedtest"})
-@Category(Connected.class)
+@Tag(Connected.TAG)
 @EmbeddedDatabaseTest
-public class SnapshotConnectedTest {
-  // TODO: MORE TESTS to be done when we can ingest data:
-  // - test more complex datasets with relationships
-  // - test relationship walking with valid and invalid setups
-  // TODO: MORE TESTS when we separate the value translation from the create
-  // - test invalid row ids
-
+class SnapshotConnectedTest {
   @Autowired private MockMvc mvc;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private JsonLoader jsonLoader;
@@ -94,7 +85,6 @@ public class SnapshotConnectedTest {
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private ConnectedTestConfiguration testConfig;
   @Autowired private ConfigurationService configService;
-  @Autowired private DrsIdService drsIdService;
   @Autowired private GoogleResourceManagerService googleResourceManagerService;
 
   @MockitoBean private IamProviderInterface samService;
@@ -115,8 +105,8 @@ public class SnapshotConnectedTest {
           .setToken("token")
           .build();
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeEach
+  void setup() throws Exception {
     connectedOperations.stubOutSamCalls(samService);
     when(ecmService.getRasDbgapPermissions(any()))
         .thenReturn(List.of(new RasDbgapPermissions(CONSENT_CODE, PHS_ID)));
@@ -136,14 +126,14 @@ public class SnapshotConnectedTest {
         "snapshot-test-dataset-data-row-ids.csv");
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterEach
+  void tearDown() throws Exception {
     connectedOperations.teardown();
     configService.reset();
   }
 
   @Test
-  public void testArrayStruct() throws Exception {
+  void testArrayStruct() throws Exception {
     DatasetSummaryModel datasetArraySummary = setupArrayStructDataset();
     String datasetName = PDAO_PREFIX + datasetArraySummary.getName();
     BigQueryProject bigQueryProject =
@@ -179,7 +169,7 @@ public class SnapshotConnectedTest {
   }
 
   @Test
-  public void testEnumeration() throws Exception {
+  void testEnumeration() throws Exception {
     datasetDao.patch(
         datasetSummary.getId(), new DatasetPatchRequestModel().phsId(PHS_ID), TEST_USER);
 
@@ -279,7 +269,7 @@ public class SnapshotConnectedTest {
   }
 
   @Test
-  public void testBadData() throws Exception {
+  void testBadData() throws Exception {
     SnapshotRequestModel badDataRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
             jsonLoader,
@@ -293,7 +283,7 @@ public class SnapshotConnectedTest {
   }
 
   @Test
-  public void testDuplicateName() throws Exception {
+  void testDuplicateName() throws Exception {
     // create a snapshot
     SnapshotRequestModel snapshotRequest =
         SnapshotConnectedTestUtils.makeSnapshotTestRequest(
@@ -308,12 +298,13 @@ public class SnapshotConnectedTest {
     SnapshotModel snapshotModel =
         SnapshotConnectedTestUtils.getTestSnapshot(
             mvc, objectMapper, summaryModel.getId(), snapshotRequest, datasetSummary);
-    assertNotNull("fetched snapshot successfully after creation", snapshotModel);
+    assertThat("fetched snapshot successfully after creation", snapshotModel, notNullValue());
 
     // check that the snapshot metadata row is unlocked
-    assertNull(
+    assertThat(
         "snapshot row is unlocked",
-        ResourceLocksUtils.getExclusiveLock(snapshotModel.getResourceLocks()));
+        ResourceLocksUtils.getExclusiveLock(snapshotModel.getResourceLocks()),
+        nullValue());
 
     // try to create the same snapshot again and check that it fails
     snapshotRequest.setName(snapshotModel.getName());
@@ -329,7 +320,7 @@ public class SnapshotConnectedTest {
     SnapshotModel origModel =
         SnapshotConnectedTestUtils.getTestSnapshot(
             mvc, objectMapper, summaryModel.getId(), snapshotRequest, datasetSummary);
-    assertEquals("fetched snapshot remains unchanged", snapshotModel, origModel);
+    assertThat("fetched snapshot remains unchanged", origModel, is(snapshotModel));
 
     // delete and confirm deleted
     connectedOperations.deleteTestSnapshot(snapshotModel.getId());
@@ -337,7 +328,7 @@ public class SnapshotConnectedTest {
   }
 
   @Test
-  public void testDeleteRecreateSnapshot() throws Exception {
+  void testDeleteRecreateSnapshot() throws Exception {
     // create a dataset and load some tabular data
     DatasetSummaryModel datasetSummary =
         SnapshotConnectedTestUtils.createTestDataset(
@@ -365,12 +356,13 @@ public class SnapshotConnectedTest {
     SnapshotModel snapshotModel =
         SnapshotConnectedTestUtils.getTestSnapshot(
             mvc, objectMapper, summaryModel.getId(), snapshotRequest, datasetSummary);
-    assertNotNull("fetched snapshot successfully after creation", snapshotModel);
+    assertThat("fetched snapshot successfully after creation", snapshotModel, notNullValue());
 
     // check that the snapshot metadata row is unlocked
-    assertNull(
+    assertThat(
         "snapshot row is unlocked",
-        ResourceLocksUtils.getExclusiveLock(snapshotModel.getResourceLocks()));
+        ResourceLocksUtils.getExclusiveLock(snapshotModel.getResourceLocks()),
+        nullValue());
 
     // delete and confirm deleted
     connectedOperations.deleteTestSnapshot(snapshotModel.getId());
@@ -387,7 +379,7 @@ public class SnapshotConnectedTest {
   }
 
   @Test
-  public void testProjectDeleteAfterSnapshotDelete() throws Exception {
+  void testProjectDeleteAfterSnapshotDelete() throws Exception {
     // create a dataset and load some tabular data
     DatasetSummaryModel datasetSummary =
         SnapshotConnectedTestUtils.createTestDataset(
@@ -415,24 +407,24 @@ public class SnapshotConnectedTest {
     SnapshotModel snapshotModel =
         SnapshotConnectedTestUtils.getTestSnapshot(
             mvc, objectMapper, summaryModel.getId(), snapshotRequest, datasetSummary);
-    assertNotNull("fetched snapshot successfully after creation", snapshotModel);
+    assertThat("fetched snapshot successfully after creation", snapshotModel, notNullValue());
     String googleProjectId = snapshotModel.getDataProject();
 
     // ensure that google project exists
     Project project = googleResourceManagerService.getProject(googleProjectId);
-    assertNotNull(project);
+    assertThat(project, notNullValue());
 
     // Ensure that the name is correct
-    assertEquals("TDR Snapshot Project", project.getName());
+    assertThat(project.getName(), is("TDR Snapshot Project"));
 
     // delete snapshot
     connectedOperations.deleteTestSnapshot(snapshotModel.getId());
     connectedOperations.getSnapshotExpectError(snapshotModel.getId(), HttpStatus.NOT_FOUND);
 
     // check that google project doesn't exist
-    assertEquals(
-        LifecycleState.DELETE_REQUESTED.toString(),
-        googleResourceManagerService.getProject(googleProjectId).getLifecycleState());
+    assertThat(
+        googleResourceManagerService.getProject(googleProjectId).getLifecycleState(),
+        is(LifecycleState.DELETE_REQUESTED.toString()));
   }
 
   private DatasetSummaryModel setupArrayStructDataset() throws Exception {
@@ -462,8 +454,7 @@ public class SnapshotConnectedTest {
       SnapshotRequestModel snapshotRequest, String infix) throws Exception {
     snapshotOriginalName = snapshotRequest.getName();
     MvcResult result = SnapshotConnectedTestUtils.launchCreateSnapshot(mvc, snapshotRequest, infix);
-    MockHttpServletResponse response = connectedOperations.validateJobModelAndWait(result);
-    return response;
+    return connectedOperations.validateJobModelAndWait(result);
   }
 
   private SnapshotSummaryModel validateSnapshotCreated(
@@ -484,10 +475,9 @@ public class SnapshotConnectedTest {
       throws Exception {
     String responseBody = response.getContentAsString();
     HttpStatus responseStatus = HttpStatus.valueOf(response.getStatus());
-    assertFalse("Expect create snapshot failure", responseStatus.is2xxSuccessful());
+    assertThat("Expect create snapshot failure", not(responseStatus.is2xxSuccessful()));
 
-    assertTrue(
-        "Error model was returned on failure", StringUtils.contains(responseBody, "message"));
+    assertThat("Error model was returned on failure", responseBody, containsString("message"));
 
     return TestUtils.mapFromJson(responseBody, ErrorModel.class);
   }
@@ -499,8 +489,6 @@ public class SnapshotConnectedTest {
             .andReturn();
 
     MockHttpServletResponse response = result.getResponse();
-    EnumerateSnapshotModel summary =
-        TestUtils.mapFromJson(response.getContentAsString(), EnumerateSnapshotModel.class);
-    return summary;
+    return TestUtils.mapFromJson(response.getContentAsString(), EnumerateSnapshotModel.class);
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/SnapshotAuthzIamStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/SnapshotAuthzIamStepTest.java
@@ -19,6 +19,7 @@ import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetSummary;
 import bio.terra.service.snapshot.flight.create.SnapshotAuthzIamStep;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
 import bio.terra.stairway.FlightContext;
@@ -56,15 +57,12 @@ class SnapshotAuthzIamStepTest {
 
   private SnapshotAuthzIamStep step;
   private FlightMap workingMap;
-  private FlightMap inputMap;
   private SnapshotRequestModel snapshotRequestModel;
 
   @BeforeEach
   void setup() {
     workingMap = new FlightMap();
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
-    inputMap = new FlightMap();
-    when(flightContext.getInputParameters()).thenReturn(inputMap);
     snapshotRequestModel = new SnapshotRequestModel();
     // Set mode to something other than byRequestId
     snapshotRequestModel.addContentsItem(
@@ -75,10 +73,11 @@ class SnapshotAuthzIamStepTest {
 
   @Test
   void testDoAndUndoStep() throws InterruptedException {
-    inputMap.put(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, true);
+    var sourceDataset =
+        new Dataset(new DatasetSummary().inheritSteward(true)).id(UUID.randomUUID());
     step =
         new SnapshotAuthzIamStep(
-            iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID, SOURCE_DATASET);
+            iamService, snapshotRequestModel, TEST_USER, SNAPSHOT_ID, sourceDataset);
     StepResult doResult = step.doStep(flightContext);
     assertThat(doResult.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
 
@@ -86,7 +85,7 @@ class SnapshotAuthzIamStepTest {
         ArgumentCaptor.forClass(SnapshotRequestModelPolicies.class);
     verify(iamService)
         .createSnapshotResource(
-            eq(TEST_USER), eq(SNAPSHOT_ID), eq(SOURCE_DATASET.getId()), argument.capture());
+            eq(TEST_USER), eq(SNAPSHOT_ID), eq(sourceDataset.getId()), argument.capture());
     List<String> readers = argument.getValue().getReaders();
     assertFalse(readers.contains(DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail()));
 

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStepTest.java
@@ -18,6 +18,7 @@ import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetSummary;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.Snapshot;
@@ -53,18 +54,14 @@ class SnapshotAuthzBqJobUserStepTest {
   private static final Snapshot SNAPSHOT =
       new Snapshot()
           .projectResource(new GoogleProjectResource().googleProjectId(GOOGLE_PROJECT_ID));
-  private static final Dataset SOURCE_DATASET = new Dataset().id(UUID.randomUUID());
 
   private final List<String> addedEmails = new ArrayList<>();
   private SnapshotAuthzBqJobUserStep step;
-  private FlightMap inputMap;
 
   @BeforeEach
   void beforeEach() throws Exception {
     FlightMap workingMap = new FlightMap();
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
-    inputMap = new FlightMap();
-    when(flightContext.getInputParameters()).thenReturn(inputMap);
 
     var policyMap = new EnumMap<>(IamRole.class);
     policyMap.put(IamRole.STEWARD, "steward");
@@ -80,14 +77,13 @@ class SnapshotAuthzBqJobUserStepTest {
             })
         .when(resourceService)
         .grantPoliciesBqJobUser(eq(GOOGLE_PROJECT_ID), anyList());
-
-    step =
-        new SnapshotAuthzBqJobUserStep(
-            snapshotService, resourceService, iamService, TEST_USER, SNAPSHOT_NAME, SOURCE_DATASET);
   }
 
   @Test
   void doStep() throws Exception {
+    step =
+        new SnapshotAuthzBqJobUserStep(
+            snapshotService, resourceService, iamService, TEST_USER, SNAPSHOT_NAME, new Dataset());
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
     assertThat(addedEmails, containsInAnyOrder("steward", "reader"));
     verifyNoMoreInteractions(resourceService);
@@ -96,9 +92,12 @@ class SnapshotAuthzBqJobUserStepTest {
 
   @Test
   void doStepInheritEnabled() throws Exception {
-    inputMap.put(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, true);
-    when(iamService.retrievePolicyEmails(
-            TEST_USER, IamResourceType.DATASET, SOURCE_DATASET.getId()))
+    var sourceDataset =
+        new Dataset(new DatasetSummary().inheritSteward(true)).id(UUID.randomUUID());
+    step =
+        new SnapshotAuthzBqJobUserStep(
+            snapshotService, resourceService, iamService, TEST_USER, SNAPSHOT_NAME, sourceDataset);
+    when(iamService.retrievePolicyEmails(TEST_USER, IamResourceType.DATASET, sourceDataset.getId()))
         .thenReturn(Map.of(IamRole.CUSTODIAN, "custodian"));
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
     assertThat(addedEmails, containsInAnyOrder("steward", "reader", "custodian"));
@@ -107,6 +106,9 @@ class SnapshotAuthzBqJobUserStepTest {
   @Test
   void undoStep() {
     reset(snapshotService, flightContext, resourceService);
+    step =
+        new SnapshotAuthzBqJobUserStep(
+            snapshotService, resourceService, iamService, TEST_USER, SNAPSHOT_NAME, new Dataset());
     assertThat(step.undoStep(flightContext), is(StepResult.getStepResultSuccess()));
     verifyNoInteractions(snapshotService, resourceService, iamService, flightContext);
   }

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
@@ -16,6 +16,7 @@ import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetSummary;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
@@ -49,17 +50,13 @@ class SnapshotAuthzTabularAclStepTest {
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
   private static final Snapshot SNAPSHOT = new Snapshot().id(UUID.randomUUID());
-  private static final Dataset SOURCE_DATASET = new Dataset().id(UUID.randomUUID());
 
   private SnapshotAuthzTabularAclStep step;
-  private FlightMap inputMap;
 
   @BeforeEach
   void beforeEach() {
     FlightMap workingMap = new FlightMap();
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
-    inputMap = new FlightMap();
-    when(flightContext.getInputParameters()).thenReturn(inputMap);
 
     var policyMap = new EnumMap<>(IamRole.class);
     policyMap.put(IamRole.STEWARD, "steward");
@@ -67,7 +64,6 @@ class SnapshotAuthzTabularAclStepTest {
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policyMap);
 
     when(snapshotService.retrieve(SNAPSHOT.getId())).thenReturn(SNAPSHOT);
-
     step =
         new SnapshotAuthzTabularAclStep(
             bigQuerySnapshotPdao,
@@ -76,7 +72,7 @@ class SnapshotAuthzTabularAclStepTest {
             iamService,
             SNAPSHOT.getId(),
             TEST_USER,
-            SOURCE_DATASET);
+            new Dataset());
   }
 
   @Test
@@ -88,9 +84,18 @@ class SnapshotAuthzTabularAclStepTest {
 
   @Test
   void doStepInheritEnabled() throws Exception {
-    inputMap.put(SnapshotWorkingMapKeys.SNAPSHOT_INHERIT_STEWARD_ENABLED, true);
-    when(iamService.retrievePolicyEmails(
-            TEST_USER, IamResourceType.DATASET, SOURCE_DATASET.getId()))
+    Dataset sourceDataset =
+        new Dataset(new DatasetSummary().inheritSteward(true)).id(UUID.randomUUID());
+    step =
+        new SnapshotAuthzTabularAclStep(
+            bigQuerySnapshotPdao,
+            snapshotService,
+            configService,
+            iamService,
+            SNAPSHOT.getId(),
+            TEST_USER,
+            sourceDataset);
+    when(iamService.retrievePolicyEmails(TEST_USER, IamResourceType.DATASET, sourceDataset.getId()))
         .thenReturn(Map.of(IamRole.CUSTODIAN, "custodian"));
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
     verify(bigQuerySnapshotPdao)

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -2,7 +2,6 @@ package bio.terra.service.tabulardata.google;
 
 import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_STAGING_TABLE_PREFIX;
 import static bio.terra.common.PdaoConstant.PDAO_LOAD_HISTORY_TABLE;
-import static bio.terra.common.PdaoConstant.PDAO_PREFIX;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -346,8 +345,7 @@ public class BigQueryPdaoTest {
     void waitForCompletion(Dataset dataset) throws Exception {
       MockHttpServletResponse response = connectedOperations.validateJobModelAndWait(result);
       connectedOperations.checkIngestTableResponse(response);
-      connectedOperations.checkTableRowCount(
-          dataset, source.tableName, PDAO_PREFIX, source.expectedRowCount());
+      connectedOperations.checkTableRowCount(dataset, source.tableName, source.expectedRowCount());
     }
   }
 
@@ -595,19 +593,18 @@ public class BigQueryPdaoTest {
       String participantTableName = "participant";
       connectedOperations.ingestTableSuccess(
           datasetId, ingestRequest.table(participantTableName).path(gsPath(participantBlob)));
-      connectedOperations.checkTableRowCount(dataset, participantTableName, PDAO_PREFIX, 5);
-      connectedOperations.checkDataModel(
-          dataset, List.of("id", "age"), PDAO_PREFIX, participantTableName, 5);
+      connectedOperations.checkTableRowCount(dataset, participantTableName, 5);
+      connectedOperations.checkDataModel(dataset, List.of("id", "age"), participantTableName, 5);
       // sample table
       String sampleTableName = "sample";
       connectedOperations.ingestTableSuccess(
           datasetId, ingestRequest.table(sampleTableName).path(gsPath(sampleBlob)));
-      connectedOperations.checkTableRowCount(dataset, sampleTableName, PDAO_PREFIX, 7);
+      connectedOperations.checkTableRowCount(dataset, sampleTableName, 7);
       // file table
       String fileTableName = "file";
       connectedOperations.ingestTableSuccess(
           datasetId, ingestRequest.table(fileTableName).path(gsPath(fileBlob)));
-      connectedOperations.checkTableRowCount(dataset, fileTableName, PDAO_PREFIX, 1);
+      connectedOperations.checkTableRowCount(dataset, fileTableName, 1);
 
       // Create a full-view snapshot!
       DatasetSummaryModel datasetSummary = dataset.getDatasetSummary().toModel();
@@ -615,11 +612,10 @@ public class BigQueryPdaoTest {
           connectedOperations.createSnapshot(
               datasetSummary, "snapshot-fullviews-test-snapshot.json", "");
       Snapshot snapshot = snapshotService.retrieve(snapshotSummary.getId());
-      connectedOperations.checkTableRowCount(snapshot, participantTableName, "", 5);
-      connectedOperations.checkDataModel(
-          snapshot, List.of("id", "age"), "", participantTableName, 5);
-      connectedOperations.checkTableRowCount(snapshot, sampleTableName, "", 7);
-      connectedOperations.checkTableRowCount(snapshot, fileTableName, "", 1);
+      connectedOperations.checkTableRowCount(snapshot, participantTableName, 5);
+      connectedOperations.checkDataModel(snapshot, List.of("id", "age"), participantTableName, 5);
+      connectedOperations.checkTableRowCount(snapshot, sampleTableName, 7);
+      connectedOperations.checkTableRowCount(snapshot, fileTableName, 1);
 
       BigQueryProject bigQuerySnapshotProject =
           TestUtils.bigQueryProjectForSnapshotName(snapshotDao, snapshot.getName());

--- a/tools/setupResourceScripts/setup_tdr_resources.py
+++ b/tools/setupResourceScripts/setup_tdr_resources.py
@@ -71,9 +71,7 @@ def dataset_ingest_array(clients, dataset_id, dataset_to_upload):
             }
             print(f"Ingesting data into {dataset_to_upload['name']}/{table}")
             jobs.append(
-                clients.datasets_api.ingest_dataset(
-                    dataset_id, ingest=ingest_request
-                ),
+                clients.datasets_api.ingest_dataset(dataset_id, ingest=ingest_request),
             )
     wait_for_jobs(clients, jobs)
 
@@ -107,9 +105,9 @@ def create_billing_profile(
         )
 
         if azure_managed_app_name:
-            billing_profile_request[
-                "applicationDeploymentName"
-            ] = azure_managed_app_name
+            billing_profile_request["applicationDeploymentName"] = (
+                azure_managed_app_name
+            )
             print(
                 f"Checking if billing profile with managed app name {azure_managed_app_name} already exists"
             )
@@ -152,8 +150,9 @@ def create_ingest_request(table, upload_prefix, format):
         "csv_skip_leading_rows": 1,
         "format": format,
         "path": f"{upload_prefix}/{table}.{format}",
-        "table": table
+        "table": table,
     }
+
 
 def dataset_ingest(clients, dataset_id, dataset_to_upload, format):
     jobs = []
@@ -289,16 +288,23 @@ def find_dataset_by_name(name):
     return find_dataset
 
 
+def delete_dataset_snapshots(clients, dataset_id):
+    snapshots = clients.snapshots_api.enumerate_snapshots(dataset_ids=[dataset_id])
+    for snapshot in snapshots.items:
+        print(f"Deleting snapshot {snapshot.name}")
+        wait_for_job(clients, clients.snapshots_api.delete_snapshot(snapshot.id))
+
+
 def delete_dataset_if_exists(name, clients):
     print(f"Checking if dataset {name} exists")
     datasets = clients.datasets_api.enumerate_datasets()
     filtered_datasets = list(filter(find_dataset_by_name(name), datasets.items))
     if len(filtered_datasets) > 0:
-        print(f"Found dataset {name} with ID {filtered_datasets[0].id}")
-        wait_for_job(
-            clients, clients.datasets_api.delete_dataset(filtered_datasets[0].id)
-        )
-        print(f"Deleted dataset {filtered_datasets[0].id}")
+        dataset_id = filtered_datasets[0].id
+        print(f"Found dataset {name} with ID {dataset_id}")
+        delete_dataset_snapshots(clients, dataset_id)
+        wait_for_job(clients, clients.datasets_api.delete_dataset(dataset_id))
+        print(f"Deleted dataset {dataset_id}")
 
 
 def add_snapshot_builder_settings(


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1197

## Addresses

Adds API support for `inherit steward` dataset feature, which will affect snapshots created from a dataset.

## Summary of changes

- migrate DatasetDaoTest to JUnit 5
- add new boolean to db for datasets
- add new boolean field to the openapi spec for create dataset operation
- `inheritSteward` is `false` by default
- can retrieve value for inheritSteward with the retrieveDataset endpoint
- createSnapshotFlight is updated to use the inheritSteward dataset property

Note for reviewers, this PR includes changes to migrate `DatasetDaoTest` and `SnapshotConnectedTest` to JUnit 5. These were committed separately if you want to look at those changes in isolation.

## Testing Strategy

- [x] unit tests
- [x] connected/integration tests
- [x] manual testing