### PR TITLE
DT-1255: Fix issue where actions/cache@v2 is deprecated

### DIFF
--- a/.github/workflows/verify_consumer_pacts.yaml
+++ b/.github/workflows/verify_consumer_pacts.yaml
@@ -197,7 +197,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
Jira Ticket: http://broadworkbench.atlassian.net/browse/DT-1255

## Addresses

Github action `actions/cache@v2` is deprecated in favor of a newer release. See https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

See failing build here https://github.com/DataBiosphere/jade-data-repo/actions/runs/13398085915/job/37422041766?pr=1909

## Summary of changes

Update to use current `v4` version.

## Testing Strategy

pact workflow passes