### PR TITLE
[DT-1236]Push tagged docker image on branches

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -161,11 +161,39 @@ jobs:
           GIT_HASH=$(git rev-parse --short HEAD)
           echo "GIT_HASH=${GIT_HASH}" >> $GITHUB_OUTPUT
           echo "Latest git hash in branch is ${GIT_HASH}"
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    needs:
+      - git_hash
+    steps:
+      - name: Checkout tagged branch of jade-data-repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+      - name: 'Build and push image GAR'
+        run: |
+          # extract service account credentials
+          base64 --decode <<< ${{ secrets.SA_B64_CREDENTIALS }} > ${GOOGLE_APPLICATION_CREDENTIALS}
+          jq -r .private_key ${GOOGLE_APPLICATION_CREDENTIALS} > ${GOOGLE_SA_CERT}
+          chmod 644 ${GOOGLE_SA_CERT}
+          # Build, tag and push the image
+          ./gradlew jib
+        env:
+          GCR_TAG: ${{ needs.git_hash.outputs.version }}
+          GOOGLE_APPLICATION_CREDENTIALS: jade-dev-account.json
+          GOOGLE_SA_CERT: jade-dev-account.pem
   report-to-sherlock:
     # only runs on pull requests and reports the appVersion even if tests fail
     if: github.event_name == 'pull_request'
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: git_hash
+    needs: [git_hash, build-and-push-image]
     with:
       new-version: ${{ needs.git_hash.outputs.version }}
       chart-name: 'datarepo'


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1236

## Addresses
We weren't pushing images for branches in jade-data-repo.  This means we couldn’t point BEEs to a TDR branch. 

## Summary of changes
add build and push image job to int and connected test run workflow

## Testing Strategy
check that the image is published to GAR (588deb)
spin the branch up on a BEE

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
