### PR TITLE
[DDO-4001] Only get branch name for PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,8 +88,9 @@ jobs:
         id: determine-branch-name
         run: |
           # Get the branch name and replace any '/'s with '_'s
-          echo "Branch name: ${GITHUB_HEAD_REF//[\/]/_}"
-          echo "branch-name=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
+          BRANCH_NAME="${GITHUB_HEAD_REF//[\/]/_}"
+          echo "Branch name: ${BRANCH_NAME}"
+          echo "branch-name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
         shell: bash
 
   tag-image-with-branch-name:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,8 +87,10 @@ jobs:
       - name: Determine branch name
         id: determine-branch-name
         run: |
-          echo "Branch name: ${GITHUB_HEAD_REF}"
+          # Get the branch name and replace any '/'s with '_'s
+          echo "Branch name: ${GITHUB_HEAD_REF//[\/]/_}"
           echo "branch-name=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
+        shell: bash
 
   tag-image-with-branch-name:
     if: github.ref_name != github.event.repository.default_branch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,7 @@ jobs:
           GCR_TAG: ${{ needs.bump_version.outputs.tag }}
 
   get-branch-name:
+    if: github.ref_name != github.event.repository.default_branch
     runs-on: ubuntu-latest
     needs:
       - bump_version


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/4001

## Addresses

The `get-branch-name` job in the build workflow should only run on PRs, not on `develop`.

Also fixes a bug where `/` in branch names were getting used for docker image tags, which created push errors.

## Summary of changes

See diff.

## Testing Strategy

Merge the PR, see if the job skips on `develop`. For the branch name with `/`s fix testing, see #1920.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
