### PR TITLE
[DT-1227] Add test for Swagger UI mismatch

### DIFF
--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -15,6 +15,8 @@ public class WebConfig implements WebMvcConfigurer {
   @Autowired private LoggerInterceptor loggerInterceptor;
   @Autowired private UserMetricsInterceptor metricsInterceptor;
 
+  public static final String SWAGGER_UI_VERSION = "5.20.0";
+
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(loggerInterceptor);
@@ -36,6 +38,8 @@ public class WebConfig implements WebMvcConfigurer {
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
     registry
         .addResourceHandler("/webjars/swagger-ui-dist/**")
-        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui-dist/5.20.0/");
+        .addResourceLocations(
+            String.format(
+                "classpath:/META-INF/resources/webjars/swagger-ui-dist/%s/", SWAGGER_UI_VERSION));
   }
 }

--- a/src/test/java/bio/terra/app/configuration/WebConfigTest.java
+++ b/src/test/java/bio/terra/app/configuration/WebConfigTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.common.category.Unit;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -24,17 +23,13 @@ class WebConfigTest {
     Resource[] resources =
         resolver.getResources("classpath:/META-INF/resources/webjars/swagger-ui-dist/*/");
 
+    assertEquals(
+        1, resources.length, "Expected one swagger-ui-dist resource, found " + resources.length);
+
     Pattern versionPattern = Pattern.compile(".+/swagger-ui-dist/(\\d+\\.\\d+\\.\\d+)/");
+    Matcher matcher = versionPattern.matcher(((ClassPathResource) resources[0]).getPath());
     Optional<String> currentVersion =
-        Arrays.stream(resources)
-            .map(
-                resource -> {
-                  Matcher matcher =
-                      versionPattern.matcher(((ClassPathResource) resource).getPath());
-                  return matcher.matches() ? matcher.group(1) : null;
-                })
-            .filter(v -> v != null)
-            .findFirst();
+        matcher.matches() ? Optional.of(matcher.group(1)) : Optional.empty();
 
     assertTrue(
         currentVersion.isPresent(),

--- a/src/test/java/bio/terra/app/configuration/WebConfigTest.java
+++ b/src/test/java/bio/terra/app/configuration/WebConfigTest.java
@@ -28,8 +28,7 @@ class WebConfigTest {
 
     Pattern versionPattern = Pattern.compile(".+/swagger-ui-dist/(\\d+\\.\\d+\\.\\d+)/");
     Matcher matcher = versionPattern.matcher(((ClassPathResource) resources[0]).getPath());
-    Optional<String> currentVersion =
-        matcher.matches() ? Optional.of(matcher.group(1)) : Optional.empty();
+    Optional<String> currentVersion = matcher.results().findFirst().map(m -> m.group(1));
 
     assertTrue(
         currentVersion.isPresent(),

--- a/src/test/java/bio/terra/app/configuration/WebConfigTest.java
+++ b/src/test/java/bio/terra/app/configuration/WebConfigTest.java
@@ -1,0 +1,51 @@
+package bio.terra.app.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.common.category.Unit;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+@Tag(Unit.TAG)
+class WebConfigTest {
+
+  @Test
+  void swaggerUiVersionMatchesClasspath() throws IOException {
+    PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+    Resource[] resources =
+        resolver.getResources("classpath:/META-INF/resources/webjars/swagger-ui-dist/*/");
+
+    Pattern versionPattern = Pattern.compile(".+/swagger-ui-dist/(\\d+\\.\\d+\\.\\d+)/");
+    Optional<String> currentVersion =
+        Arrays.stream(resources)
+            .map(
+                resource -> {
+                  Matcher matcher =
+                      versionPattern.matcher(((ClassPathResource) resource).getPath());
+                  return matcher.matches() ? matcher.group(1) : null;
+                })
+            .filter(v -> v != null)
+            .findFirst();
+
+    assertTrue(
+        currentVersion.isPresent(),
+        "Could not find swagger-ui-dist version in classpath. Check your build.gradle dependencies.");
+
+    assertEquals(
+        currentVersion.get(),
+        WebConfig.SWAGGER_UI_VERSION,
+        "SWAGGER_UI_VERSION in WebConfig.java does not match the version in build.gradle. "
+            + "Update the version in WebConfig.java to "
+            + currentVersion.get()
+            + " to match.");
+  }
+}


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-1227

## Summary of changes

* Refactors WebConfig to extract Swagger UI version
* Add test to ensure that the version in the WebConfig matches the one in the Gradle build

## Testing Strategy

The original ticket mentioned an integration test, but after reflection I hesitate to use this approach since these are heavyweight and slow to run. Instead I wrote a unit test which I think gets us 99% of the way there. It is technically possible for the Swagger UI to stop working after any update, but in all cases that I've seen it's because of a mismatch between the one we have defined in our Gradle dependencies and the one in the WebConfig.

This also suggests a longer term solution which is to extract the version on the classpath and use it for WebConfig.