### PR TITLE
DT-1247: Enable/revoke BigQuery Job access in flight

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -761,11 +761,16 @@ public class DatasetService {
 
   public String enableInheritSteward(UUID datasetId, AuthenticatedUserRequest userReq) {
     String description = "Enable InheritSteward for dataset " + datasetId;
+    var custodianEmail =
+        iamService
+            .retrievePolicyEmails(userReq, IamResourceType.DATASET, datasetId)
+            .get(IamRole.CUSTODIAN);
     return jobService
         .newJob(description, EnableInheritStewardFlight.class, null, userReq)
         .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
         .addParameter(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), datasetId)
         .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD)
+        .addParameter(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), custodianEmail)
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/dataset/flight/DatasetWorkingMapKeys.java
+++ b/src/main/java/bio/terra/service/dataset/flight/DatasetWorkingMapKeys.java
@@ -16,6 +16,7 @@ public final class DatasetWorkingMapKeys extends ProjectCreatingFlightKeys {
   public static final String STORAGE_ACCOUNT_RESOURCE_ID = "storageAccountResourceId";
   public static final String SERVICE_ACCOUNT_EMAIL = "serviceAccountEmail";
   public static final String SECURE_MONITORING_ENABLED = "secureMonitoringEnabled";
+  public static final String SNAPSHOT_GOOGLE_PROJECT_IDS = "snapshotGoogleProjectIds";
 
   public static final String IS_SHARED_LOCK = "isSharedLock";
 }

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlight.java
@@ -2,6 +2,8 @@ package bio.terra.service.dataset.flight.inheritsteward;
 
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import java.util.UUID;
@@ -14,10 +16,16 @@ public class EnableInheritStewardFlight extends Flight {
     // Get the required DAOs and services to pass into the steps
     ApplicationContext appContext = (ApplicationContext) applicationContext;
     DatasetDao datasetDao = appContext.getBean(DatasetDao.class);
+    ResourceService resourceService = appContext.getBean(ResourceService.class);
+    SnapshotService snapshotService = appContext.getBean(SnapshotService.class);
 
     // Get the input parameters
     UUID datasetId = inputParameters.get(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), UUID.class);
+    String custodianEmail =
+        inputParameters.get(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), String.class);
 
     addStep(new InheritStewardSetFlagStep(datasetDao, datasetId, true));
+    addStep(new GetSnapshotGoogleProjectIdsStep(snapshotService, datasetId));
+    addStep(new SetAuthBqJobUserStep(resourceService, custodianEmail, true));
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/GetSnapshotGoogleProjectIdsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/GetSnapshotGoogleProjectIdsStep.java
@@ -1,0 +1,28 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+
+public record GetSnapshotGoogleProjectIdsStep(SnapshotService snapshotService, UUID datasetId)
+    implements Step {
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    var projectIds = snapshotService.getSnapshotGoogleProjectIds(datasetId);
+    flightContext
+        .getWorkingMap()
+        .put(DatasetWorkingMapKeys.SNAPSHOT_GOOGLE_PROJECT_IDS, projectIds);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/GetSnapshotGoogleProjectIdsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/GetSnapshotGoogleProjectIdsStep.java
@@ -1,15 +1,15 @@
 package bio.terra.service.dataset.flight.inheritsteward;
 
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.job.UndoSuccessStep;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import java.util.UUID;
 
 public record GetSnapshotGoogleProjectIdsStep(SnapshotService snapshotService, UUID datasetId)
-    implements Step {
+    implements UndoSuccessStep {
 
   @Override
   public StepResult doStep(FlightContext flightContext)
@@ -18,11 +18,6 @@ public record GetSnapshotGoogleProjectIdsStep(SnapshotService snapshotService, U
     flightContext
         .getWorkingMap()
         .put(DatasetWorkingMapKeys.SNAPSHOT_GOOGLE_PROJECT_IDS, projectIds);
-    return StepResult.getStepResultSuccess();
-  }
-
-  @Override
-  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
     return StepResult.getStepResultSuccess();
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthBqJobUserStep.java
@@ -9,18 +9,18 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.exception.RetryException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
+import java.util.Objects;
 
 public record SetAuthBqJobUserStep(
     ResourceService resourceService, String custodianEmail, boolean inheritSteward)
     implements Step {
 
-  @Override
-  public StepResult doStep(FlightContext flightContext)
-      throws InterruptedException, RetryException {
+  private StepResult setAuth(FlightContext flightContext, boolean inheritSteward)
+      throws InterruptedException {
     FlightMap workingMap = flightContext.getWorkingMap();
     List<String> projectIds =
         workingMap.get(DatasetWorkingMapKeys.SNAPSHOT_GOOGLE_PROJECT_IDS, new TypeReference<>() {});
-    for (var projectId : projectIds) {
+    for (var projectId : Objects.requireNonNull(projectIds)) {
       if (inheritSteward) {
         resourceService.grantPoliciesBqJobUser(projectId, List.of(custodianEmail));
       } else {
@@ -31,17 +31,13 @@ public record SetAuthBqJobUserStep(
   }
 
   @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    return setAuth(flightContext, inheritSteward);
+  }
+
+  @Override
   public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
-    FlightMap workingMap = flightContext.getWorkingMap();
-    List<String> projectIds =
-        workingMap.get(DatasetWorkingMapKeys.SNAPSHOT_GOOGLE_PROJECT_IDS, new TypeReference<>() {});
-    for (var projectId : projectIds) {
-      if (!inheritSteward) {
-        resourceService.grantPoliciesBqJobUser(projectId, List.of(custodianEmail));
-      } else {
-        resourceService.revokePoliciesBqJobUser(projectId, List.of(custodianEmail));
-      }
-    }
-    return StepResult.getStepResultSuccess();
+    return setAuth(flightContext, !inheritSteward);
   }
 }

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthBqJobUserStep.java
@@ -1,0 +1,47 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+
+public record SetAuthBqJobUserStep(
+    ResourceService resourceService, String custodianEmail, boolean inheritSteward)
+    implements Step {
+
+  @Override
+  public StepResult doStep(FlightContext flightContext)
+      throws InterruptedException, RetryException {
+    FlightMap workingMap = flightContext.getWorkingMap();
+    List<String> projectIds =
+        workingMap.get(DatasetWorkingMapKeys.SNAPSHOT_GOOGLE_PROJECT_IDS, new TypeReference<>() {});
+    for (var projectId : projectIds) {
+      if (inheritSteward) {
+        resourceService.grantPoliciesBqJobUser(projectId, List.of(custodianEmail));
+      } else {
+        resourceService.revokePoliciesBqJobUser(projectId, List.of(custodianEmail));
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext flightContext) throws InterruptedException {
+    FlightMap workingMap = flightContext.getWorkingMap();
+    List<String> projectIds =
+        workingMap.get(DatasetWorkingMapKeys.SNAPSHOT_GOOGLE_PROJECT_IDS, new TypeReference<>() {});
+    for (var projectId : projectIds) {
+      if (!inheritSteward) {
+        resourceService.grantPoliciesBqJobUser(projectId, List.of(custodianEmail));
+      } else {
+        resourceService.revokePoliciesBqJobUser(projectId, List.of(custodianEmail));
+      }
+    }
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/job/DefaultUndoStep.java
+++ b/src/main/java/bio/terra/service/job/DefaultUndoStep.java
@@ -1,13 +1,4 @@
 package bio.terra.service.job;
 
-import bio.terra.stairway.FlightContext;
-import bio.terra.stairway.Step;
-import bio.terra.stairway.StepResult;
-
-/** A subclass of Step that provides a default implementation of undo that returns success. */
-public abstract class DefaultUndoStep implements Step {
-  @Override
-  public StepResult undoStep(FlightContext context) {
-    return StepResult.getStepResultSuccess();
-  }
-}
+/** A subclass of Step that provides an implementation of undo that returns success. */
+public abstract class DefaultUndoStep implements UndoSuccessStep {}

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -23,9 +23,10 @@ public enum JobMapKeys {
   ASSET_ID("assetId"),
   TRANSACTION_ID("transactionId"),
   DELETE_CLOUD_RESOURCES("deleteCloudResources"),
-  BUCKET_NAME("bucketName");
+  BUCKET_NAME("bucketName"),
+  CUSTODIAN_EMAIL("custodianEmail");
 
-  private String keyName;
+  private final String keyName;
 
   JobMapKeys(String keyName) {
     this.keyName = keyName;

--- a/src/main/java/bio/terra/service/job/UndoSuccessStep.java
+++ b/src/main/java/bio/terra/service/job/UndoSuccessStep.java
@@ -1,0 +1,13 @@
+package bio.terra.service.job;
+
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+
+/** A interface of Step that provides a default implementation of undo that returns success. */
+public interface UndoSuccessStep extends Step {
+  @Override
+  default StepResult undoStep(FlightContext flightContext) {
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -794,6 +794,20 @@ public class SnapshotDao implements TaggableResourceDao {
     logger.info("Updated " + logSuffix);
   }
 
+  public List<String> getSnapshotGoogleProjectIds(UUID datasetId) {
+    String sql =
+        """
+            select google_project_id
+            from snapshot_source,
+               snapshot,
+               project_resource
+            where dataset_id = :datasetId
+               and snapshot.id = snapshot_source.snapshot_id
+               and snapshot.project_resource_id = project_resource.id;
+            """;
+    return jdbcTemplate.query(sql, Map.of("datasetId", datasetId), (rs, rowNum) -> rs.getString(1));
+  }
+
   private class SnapshotSummaryMapper implements RowMapper<SnapshotSummary> {
 
     public SnapshotSummary mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -1439,4 +1439,8 @@ public class SnapshotService {
   public void deleteSnapshotBuilderSettings(UUID snapshotId) {
     snapshotBuilderSettingsDao.deleteBySnapshotId(snapshotId);
   }
+
+  public List<String> getSnapshotGoogleProjectIds(UUID datasetId) {
+    return snapshotDao.getSnapshotGoogleProjectIds(datasetId);
+  }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -393,6 +393,9 @@ class DatasetServiceUnitTest {
             null,
             TEST_USER))
         .thenReturn(jobBuilder);
+    var custodianEmail = "custodianEmail";
+    when(iamService.retrievePolicyEmails(TEST_USER, IamResourceType.DATASET, DATASET_ID))
+        .thenReturn(Map.of(IamRole.CUSTODIAN, custodianEmail));
     ArgumentCaptor<FlightMap> captor = ArgumentCaptor.forClass(FlightMap.class);
     when(jobService.submit(eq(EnableInheritStewardFlight.class), captor.capture()))
         .thenReturn("JobId");
@@ -409,6 +412,9 @@ class DatasetServiceUnitTest {
     assertThat(
         flightMap.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class),
         equalTo(IamAction.SET_INHERIT_STEWARD));
+    assertThat(
+        flightMap.get(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), String.class),
+        equalTo(custodianEmail));
   }
 
   private void mockDataset(CloudPlatform cloudPlatform, TableDataType columnDataType) {

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlightTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlightTest.java
@@ -8,10 +8,10 @@ import static org.mockito.Mockito.when;
 
 import bio.terra.common.FlightTestUtils;
 import bio.terra.common.category.Unit;
-import bio.terra.service.auth.iam.IamAction;
-import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.dataset.DatasetDao;
 import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.stairway.FlightMap;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,37 +28,63 @@ class EnableInheritStewardFlightTest {
 
   @Mock private ApplicationContext context;
   @Mock private DatasetDao datasetDao;
+  @Mock private ResourceService resourceService;
+  @Mock private SnapshotService snapshotService;
   private final FlightMap inputParameters = new FlightMap();
+
+  private static final String CUSTODIAN_EMAIL = "custodian email";
   private static final UUID DATASET_ID = UUID.randomUUID();
 
   @BeforeEach
   void setUp() {
-    inputParameters.put(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET);
     inputParameters.put(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), DATASET_ID);
-    inputParameters.put(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD);
-    inputParameters.put(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), "custodian email");
+    inputParameters.put(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), CUSTODIAN_EMAIL);
     when(context.getBean(DatasetDao.class)).thenReturn(datasetDao);
+    when(context.getBean(ResourceService.class)).thenReturn(resourceService);
+    when(context.getBean(SnapshotService.class)).thenReturn(snapshotService);
   }
 
   @Test
   void testParametersForSetFlagStep() {
     try (var mockedStep =
-        mockConstruction(
-            InheritStewardSetFlagStep.class,
-            (mock, context) -> {
-              assertThat((DatasetDao) context.arguments().get(0), equalTo(datasetDao));
-              assertThat(
-                  "The correct datasetId is passed to the step",
-                  (UUID) context.arguments().get(1),
-                  equalTo(DATASET_ID));
-              assertThat(
-                  "The correct boolean flag is passed to the step",
-                  (boolean) context.arguments().get(2),
-                  equalTo(true));
-            })) {
+            mockConstruction(
+                InheritStewardSetFlagStep.class,
+                (mock, context) -> {
+                  assertThat((DatasetDao) context.arguments().get(0), equalTo(datasetDao));
+                  assertThat(
+                      "The correct datasetId is passed to the step",
+                      (UUID) context.arguments().get(1),
+                      equalTo(DATASET_ID));
+                  assertThat(
+                      "The correct boolean flag is passed to the step",
+                      (boolean) context.arguments().get(2),
+                      equalTo(true));
+                });
+        var step2 =
+            mockConstruction(
+                GetSnapshotGoogleProjectIdsStep.class,
+                (mock, context) -> {
+                  assertThat(
+                      (SnapshotService) context.arguments().get(0), equalTo(snapshotService));
+                  assertThat((UUID) context.arguments().get(1), equalTo(DATASET_ID));
+                });
+        var step3 =
+            mockConstruction(
+                SetAuthBqJobUserStep.class,
+                (mock, context) -> {
+                  assertThat(
+                      (ResourceService) context.arguments().get(0), equalTo(resourceService));
+                  assertThat((String) context.arguments().get(1), equalTo(CUSTODIAN_EMAIL));
+                  assertThat((boolean) context.arguments().get(2), equalTo(true));
+                })) {
       var flight = new EnableInheritStewardFlight(inputParameters, context);
       var steps = FlightTestUtils.getStepNames(flight);
-      assertThat(steps, contains("InheritStewardSetFlagStep"));
+      assertThat(
+          steps,
+          contains(
+              "InheritStewardSetFlagStep",
+              "GetSnapshotGoogleProjectIdsStep",
+              "SetAuthBqJobUserStep"));
     }
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlightTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlightTest.java
@@ -28,15 +28,15 @@ class EnableInheritStewardFlightTest {
 
   @Mock private ApplicationContext context;
   @Mock private DatasetDao datasetDao;
-  private FlightMap inputParameters;
+  private final FlightMap inputParameters = new FlightMap();
   private static final UUID DATASET_ID = UUID.randomUUID();
 
   @BeforeEach
   void setUp() {
-    inputParameters = new FlightMap();
     inputParameters.put(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET);
     inputParameters.put(JobMapKeys.IAM_RESOURCE_ID.getKeyName(), DATASET_ID);
     inputParameters.put(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD);
+    inputParameters.put(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), "custodian email");
     when(context.getBean(DatasetDao.class)).thenReturn(datasetDao);
   }
 

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlightTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlightTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.dataset.flight.inheritsteward;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
@@ -45,46 +46,76 @@ class EnableInheritStewardFlightTest {
   }
 
   @Test
-  void testParametersForSetFlagStep() {
-    try (var mockedStep =
-            mockConstruction(
-                InheritStewardSetFlagStep.class,
-                (mock, context) -> {
-                  assertThat((DatasetDao) context.arguments().get(0), equalTo(datasetDao));
-                  assertThat(
-                      "The correct datasetId is passed to the step",
-                      (UUID) context.arguments().get(1),
-                      equalTo(DATASET_ID));
-                  assertThat(
-                      "The correct boolean flag is passed to the step",
-                      (boolean) context.arguments().get(2),
-                      equalTo(true));
-                });
-        var step2 =
-            mockConstruction(
-                GetSnapshotGoogleProjectIdsStep.class,
-                (mock, context) -> {
-                  assertThat(
-                      (SnapshotService) context.arguments().get(0), equalTo(snapshotService));
-                  assertThat((UUID) context.arguments().get(1), equalTo(DATASET_ID));
-                });
-        var step3 =
-            mockConstruction(
-                SetAuthBqJobUserStep.class,
-                (mock, context) -> {
-                  assertThat(
-                      (ResourceService) context.arguments().get(0), equalTo(resourceService));
-                  assertThat((String) context.arguments().get(1), equalTo(CUSTODIAN_EMAIL));
-                  assertThat((boolean) context.arguments().get(2), equalTo(true));
-                })) {
-      var flight = new EnableInheritStewardFlight(inputParameters, context);
-      var steps = FlightTestUtils.getStepNames(flight);
-      assertThat(
-          steps,
-          contains(
-              "InheritStewardSetFlagStep",
-              "GetSnapshotGoogleProjectIdsStep",
-              "SetAuthBqJobUserStep"));
+  void allSteps() {
+    var flight = new EnableInheritStewardFlight(inputParameters, context);
+    var steps = FlightTestUtils.getStepNames(flight);
+    assertThat(
+        steps,
+        contains(
+            "InheritStewardSetFlagStep",
+            "GetSnapshotGoogleProjectIdsStep",
+            "SetAuthBqJobUserStep"));
+  }
+
+  @Test
+  void inheritStewardSetFlagStep() {
+    try (var mockStep =
+        mockConstruction(
+            InheritStewardSetFlagStep.class,
+            (mock, context) -> {
+              assertThat((DatasetDao) context.arguments().get(0), equalTo(datasetDao));
+              assertThat(
+                  "The correct datasetId is passed to the step",
+                  (UUID) context.arguments().get(1),
+                  equalTo(DATASET_ID));
+              assertThat(
+                  "The correct boolean flag is passed to the step",
+                  (boolean) context.arguments().get(2),
+                  equalTo(true));
+            })) {
+      //noinspection ResultOfObjectAllocationIgnored
+      new EnableInheritStewardFlight(inputParameters, context);
+      assertThat(mockStep.constructed(), hasSize(1));
+    }
+  }
+
+  @Test
+  void getSnapshotGoogleProjectIdsStep() {
+    try (var mockStep =
+        mockConstruction(
+            GetSnapshotGoogleProjectIdsStep.class,
+            (mock, context) -> {
+              assertThat((SnapshotService) context.arguments().get(0), equalTo(snapshotService));
+              assertThat(
+                  "The correct datasetId is passed to the step",
+                  (UUID) context.arguments().get(1),
+                  equalTo(DATASET_ID));
+            })) {
+      //noinspection ResultOfObjectAllocationIgnored
+      new EnableInheritStewardFlight(inputParameters, context);
+      assertThat(mockStep.constructed(), hasSize(1));
+    }
+  }
+
+  @Test
+  void setAuthBqJobUserStep() {
+    try (var mockStep =
+        mockConstruction(
+            SetAuthBqJobUserStep.class,
+            (mock, context) -> {
+              assertThat((ResourceService) context.arguments().get(0), equalTo(resourceService));
+              assertThat(
+                  "The correct custodian email is passed to the step",
+                  (String) context.arguments().get(1),
+                  equalTo(CUSTODIAN_EMAIL));
+              assertThat(
+                  "The correct boolean flag is passed to the step",
+                  (boolean) context.arguments().get(2),
+                  equalTo(true));
+            })) {
+      //noinspection ResultOfObjectAllocationIgnored
+      new EnableInheritStewardFlight(inputParameters, context);
+      assertThat(mockStep.constructed(), hasSize(1));
     }
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/GetSnapshotGoogleProjectIdsStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/GetSnapshotGoogleProjectIdsStepTest.java
@@ -1,0 +1,56 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class GetSnapshotGoogleProjectIdsStepTest {
+
+  @Mock private SnapshotService snapshotService;
+  @Mock private FlightContext flightContext;
+
+  private GetSnapshotGoogleProjectIdsStep step;
+  private final UUID datasetId = UUID.randomUUID();
+
+  @BeforeEach
+  void beforeEach() {
+    step = new GetSnapshotGoogleProjectIdsStep(snapshotService, datasetId);
+  }
+
+  @Test
+  void doStep() throws Exception {
+    var projectIds = Arrays.asList("project1", "project2");
+    FlightMap workingMap = new FlightMap();
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(snapshotService.getSnapshotGoogleProjectIds(datasetId)).thenReturn(projectIds);
+    assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
+    assertThat(
+        workingMap.get(DatasetWorkingMapKeys.SNAPSHOT_GOOGLE_PROJECT_IDS, List.class),
+        is(projectIds));
+  }
+
+  @Test
+  void undoStep() throws Exception {
+    assertThat(step.undoStep(flightContext), is(StepResult.getStepResultSuccess()));
+    verifyNoInteractions(snapshotService, flightContext);
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthBqJobUserStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthBqJobUserStepTest.java
@@ -14,8 +14,9 @@ import bio.terra.stairway.StepResult;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -26,17 +27,20 @@ class SetAuthBqJobUserStepTest {
   @Mock private ResourceService resourceService;
   @Mock private FlightContext flightContext;
 
-  private void verifySetAuth(boolean inheritSteward) throws Exception {
-    String custodianEmail = "custodianEmail";
-    SetAuthBqJobUserStep step =
-        new SetAuthBqJobUserStep(resourceService, custodianEmail, inheritSteward);
+  private final String custodianEmail = "custodianEmail";
+
+  interface DoOrUndo {
+    StepResult apply(FlightContext t) throws Exception;
+  }
+
+  private void verifySetAuth(DoOrUndo doOrUndo, boolean grantPolicy) throws Exception {
     var projectIds = Arrays.asList("project1", "project2");
     FlightMap workingMap = new FlightMap();
     workingMap.put(DatasetWorkingMapKeys.SNAPSHOT_GOOGLE_PROJECT_IDS, projectIds);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
-    assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
+    assertThat(doOrUndo.apply(flightContext), is(StepResult.getStepResultSuccess()));
     for (var projectId : projectIds) {
-      if (inheritSteward) {
+      if (grantPolicy) {
         verify(resourceService).grantPoliciesBqJobUser(projectId, List.of(custodianEmail));
       } else {
         verify(resourceService).revokePoliciesBqJobUser(projectId, List.of(custodianEmail));
@@ -44,13 +48,12 @@ class SetAuthBqJobUserStepTest {
     }
   }
 
-  @Test
-  void doStep() throws Exception {
-    verifySetAuth(true);
-  }
-
-  @Test
-  void undoStep() throws Exception {
-    verifySetAuth(false);
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void doStep(boolean inheritSteward) throws Exception {
+    SetAuthBqJobUserStep step =
+        new SetAuthBqJobUserStep(resourceService, custodianEmail, inheritSteward);
+    verifySetAuth(step::doStep, inheritSteward);
+    verifySetAuth(step::undoStep, !inheritSteward);
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthBqJobUserStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthBqJobUserStepTest.java
@@ -1,0 +1,56 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.resourcemanagement.ResourceService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class SetAuthBqJobUserStepTest {
+
+  @Mock private ResourceService resourceService;
+  @Mock private FlightContext flightContext;
+
+  private void verifySetAuth(boolean inheritSteward) throws Exception {
+    String custodianEmail = "custodianEmail";
+    SetAuthBqJobUserStep step =
+        new SetAuthBqJobUserStep(resourceService, custodianEmail, inheritSteward);
+    var projectIds = Arrays.asList("project1", "project2");
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(DatasetWorkingMapKeys.SNAPSHOT_GOOGLE_PROJECT_IDS, projectIds);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
+    for (var projectId : projectIds) {
+      if (inheritSteward) {
+        verify(resourceService).grantPoliciesBqJobUser(projectId, List.of(custodianEmail));
+      } else {
+        verify(resourceService).revokePoliciesBqJobUser(projectId, List.of(custodianEmail));
+      }
+    }
+  }
+
+  @Test
+  void doStep() throws Exception {
+    verifySetAuth(true);
+  }
+
+  @Test
+  void undoStep() throws Exception {
+    verifySetAuth(false);
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -49,6 +49,7 @@ import bio.terra.service.duos.DuosService;
 import bio.terra.service.filedata.DrsDao;
 import bio.terra.service.filedata.DrsId;
 import bio.terra.service.filedata.DrsIdService;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
 import bio.terra.service.snapshot.exception.SnapshotUpdateException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -1070,5 +1071,23 @@ class SnapshotDaoTest {
   void testRetrieveSnapshotNotFound() {
     UUID snapshotId = UUID.randomUUID();
     assertThrows(SnapshotNotFoundException.class, () -> snapshotDao.retrieveSnapshot(snapshotId));
+  }
+
+  @Test
+  void getSnapshotGoogleProjectIds() {
+    String snapshotName = snapshotRequest.getName() + UUID.randomUUID();
+    List<Snapshot> snapshots =
+        IntStream.range(0, 3)
+            .mapToObj(i -> snapshotRequest.name(makeName(snapshotName, i)))
+            .map(this::createSnapshot)
+            .toList();
+
+    assertThat(
+        snapshotDao.getSnapshotGoogleProjectIds(snapshots.get(0).getSourceDataset().getId()),
+        containsInAnyOrder(
+            snapshots.stream()
+                .map(Snapshot::getProjectResource)
+                .map(GoogleProjectResource::getGoogleProjectId)
+                .toArray()));
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -1083,7 +1083,7 @@ class SnapshotDaoTest {
             .toList();
 
     assertThat(
-        snapshotDao.getSnapshotGoogleProjectIds(snapshots.get(0).getSourceDataset().getId()),
+        snapshotDao.getSnapshotGoogleProjectIds(datasetId),
         containsInAnyOrder(
             snapshots.stream()
                 .map(Snapshot::getProjectResource)

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1656,4 +1656,11 @@ class SnapshotServiceTest {
     assertThat(
         service.retrieveAuthDomains(snapshotId, TEST_USER), containsInAnyOrder("group1", "group2"));
   }
+
+  @Test
+  void getSnapshotGoogleProjectIds() {
+    var projectIds = List.of("project1", "project2");
+    when(snapshotDao.getSnapshotGoogleProjectIds(snapshotId)).thenReturn(projectIds);
+    assertThat(service.getSnapshotGoogleProjectIds(snapshotId), is(projectIds));
+  }
 }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1247

## Addresses

Add step to enable/revoke BigQuery Job access for dataset custodian to `EnableInheritStewardFlight`.

## Summary of changes

- retrieve dataset custodian proxy email and store it in the flight context
- add DAO API to get the google project IDs for all snapshots in a dataset
- add step to get the project IDs and store them in the flight context
- depending on `inheritSteward` setting, either enable or revoke the permission
- to handle undo, set to the opposite of the requested state

## Testing Strategy

- unit tests