### PR TITLE
DT-1292: fix use of Matchers.not in assertThat expressions

### DIFF
--- a/src/test/java/bio/terra/common/ColumnTest.java
+++ b/src/test/java/bio/terra/common/ColumnTest.java
@@ -26,6 +26,6 @@ class ColumnTest {
     assertThat(
         "Columns with different IDs are not equal",
         new Column().id(id),
-        not(equalTo(new Column().id(UUID.randomUUID()))));
+        not(new Column().id(UUID.randomUUID())));
   }
 }

--- a/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
+++ b/src/test/java/bio/terra/common/fixtures/ConnectedOperations.java
@@ -5,9 +5,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.oneOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -387,7 +387,7 @@ public class ConnectedOperations {
     // check the failure status matches the expected
     // if no specific status is specified, just check that it's not successful
     if (expectedStatus == null) {
-      assertThat("Expect failure", not(responseStatus.is2xxSuccessful()));
+      assertFalse(responseStatus.is2xxSuccessful(), "Expect failure");
     } else {
       assertThat("Expect specific failure status", responseStatus, is(expectedStatus));
     }

--- a/src/test/java/bio/terra/integration/DataRepoFixtures.java
+++ b/src/test/java/bio/terra/integration/DataRepoFixtures.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.oneOf;
@@ -477,10 +476,7 @@ public class DataRepoFixtures {
   public void deleteDatasetShouldFail(TestConfiguration.User user, UUID datasetId)
       throws Exception {
     DataRepoResponse<DeleteResponseModel> deleteResponse = deleteDatasetLog(user, datasetId);
-    assertThat(
-        "delete is not successful",
-        deleteResponse.getStatusCode(),
-        is(not(equalTo(HttpStatus.OK))));
+    assertThat("delete is not successful", deleteResponse.getStatusCode(), not(HttpStatus.OK));
   }
 
   public DataRepoResponse<DeleteResponseModel> deleteDatasetLog(

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -150,9 +151,9 @@ class DatasetDaoTest {
   void setSecureMonitoringTest() throws Exception {
     UUID datasetId = createDataset("dataset-minimal.json");
     Dataset dataset = datasetDao.retrieve(datasetId);
-    assertThat(
-        "Dataset should by default have secure monitoring set to false",
-        not(dataset.isSecureMonitoringEnabled()));
+    assertFalse(
+        dataset.isSecureMonitoringEnabled(),
+        "Dataset should by default have secure monitoring set to false");
 
     datasetDao.setSecureMonitoring(datasetId, true, TEST_USER);
     dataset = datasetDao.retrieve(datasetId);
@@ -160,8 +161,8 @@ class DatasetDaoTest {
 
     datasetDao.setSecureMonitoring(datasetId, false, TEST_USER);
     dataset = datasetDao.retrieve(datasetId);
-    assertThat(
-        "Secure Monitoring should now be disabled again", not(dataset.isSecureMonitoringEnabled()));
+    assertFalse(
+        dataset.isSecureMonitoringEnabled(), "Secure Monitoring should now be disabled again");
   }
 
   @Test
@@ -478,7 +479,7 @@ class DatasetDaoTest {
     assertThat(
         "dataset has billing profiles returned from the database",
         fromDB.getDatasetSummary().getBillingProfiles(),
-        is(not(empty())));
+        not(empty()));
 
     assertThat(
         "dataset default Billing Profile matches default profile id",
@@ -662,8 +663,8 @@ class DatasetDaoTest {
     assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 4");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("one shared lock after step 4", sharedLocks, hasSize(1));
-    assertThat(
-        "flightid1 no longer has shared lock after step 4", not(sharedLocks.contains(sharedLock1)));
+    assertFalse(
+        sharedLocks.contains(sharedLock1), "flightid1 no longer has shared lock after step 4");
 
     // 5. try to take out an exclusive lock
     // confirm that it fails with a DatasetLockException
@@ -753,8 +754,8 @@ class DatasetDaoTest {
     // confirm that the exclusive lock is still there and there are no shared locks
     String exclusiveLock2 = "flightId21";
     boolean rowUnlocked = datasetDao.unlockExclusive(datasetId, exclusiveLock2);
-    assertThat(
-        "no rows updated on call to unlock with different flightid after step 3", not(rowUnlocked));
+    assertFalse(
+        rowUnlocked, "no rows updated on call to unlock with different flightid after step 3");
     assertThat(
         "exclusive lock still taken out after step 3",
         getExclusiveLock(datasetId),
@@ -773,7 +774,7 @@ class DatasetDaoTest {
     // 5. unlock the exclusive lock again with the same flightid
     // confirm that there are still no outstanding exclusive or shared locks
     rowUnlocked = datasetDao.unlockExclusive(datasetId, exclusiveLock1);
-    assertThat("no rows updated on second call to unlock after step 5", not(rowUnlocked));
+    assertFalse(rowUnlocked, "no rows updated on second call to unlock after step 5");
     assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 5");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 5", sharedLocks, empty());
@@ -809,8 +810,8 @@ class DatasetDaoTest {
     // confirm that the shared lock is still there and there is no exclusive lock
     String sharedLock2 = "flightid31";
     boolean rowUnlocked = datasetDao.unlockShared(datasetId, sharedLock2);
-    assertThat(
-        "no rows updated on call to unlock with different flightid after step 3", not(rowUnlocked));
+    assertFalse(
+        rowUnlocked, "no rows updated on call to unlock with different flightid after step 3");
     assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 3");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("one shared lock after step 3", sharedLocks, hasSize(1));
@@ -828,7 +829,7 @@ class DatasetDaoTest {
     // 5. unlock the exclusive lock again with the same flightid
     // confirm that there are still no outstanding exclusive or shared locks
     rowUnlocked = datasetDao.unlockShared(datasetId, sharedLock1);
-    assertThat("no rows updated on second call to unlock after step 5", not(rowUnlocked));
+    assertFalse(rowUnlocked, "no rows updated on second call to unlock after step 5");
     assertNull(getExclusiveLock(datasetId), "no exclusive lock after step 5");
     sharedLocks = Arrays.asList(datasetDao.getSharedLocks(datasetId));
     assertThat("no shared locks after step 5", sharedLocks, empty());
@@ -849,7 +850,7 @@ class DatasetDaoTest {
     // try to release an exclusive lock
     // confirm that it succeeds with no rows updated
     boolean rowUpdated = datasetDao.unlockExclusive(nonExistentDatasetId, exclusiveLock);
-    assertThat("exclusive unlock did not update any rows", not(rowUpdated));
+    assertFalse(rowUpdated, "exclusive unlock did not update any rows");
 
     // try to take out a shared lock
     // confirm that it fails with a DatasetNotFoundException
@@ -862,7 +863,7 @@ class DatasetDaoTest {
     // try to release a shared lock
     // confirm that it succeeds with no rows updated
     rowUpdated = datasetDao.unlockExclusive(nonExistentDatasetId, sharedLock);
-    assertThat("shared unlock did not update any rows", not(rowUpdated));
+    assertFalse(rowUpdated, "shared unlock did not update any rows");
   }
 
   @Test
@@ -996,9 +997,9 @@ class DatasetDaoTest {
   @Test
   void updatePredictableFileIdsFlag() throws Exception {
     UUID datasetId = createDataset("dataset-minimal.json");
-    assertThat(
-        "predictable file ids flag is false",
-        not(datasetDao.retrieve(datasetId).hasPredictableFileIds()));
+    assertFalse(
+        datasetDao.retrieve(datasetId).hasPredictableFileIds(),
+        "predictable file ids flag is false");
     datasetDao.setPredictableFileId(datasetId, true);
     assertThat(
         "predictable file ids flag is true",
@@ -1208,9 +1209,9 @@ class DatasetDaoTest {
         datasetDao.retrieve(datasetId).getTags(),
         equalTo(expectedTags));
 
-    assertThat(
-        "No rows are updated when updating tags on nonexistent dataset",
-        not(datasetDao.updateTags(UUID.randomUUID(), new TagUpdateRequestModel())));
+    assertFalse(
+        datasetDao.updateTags(UUID.randomUUID(), new TagUpdateRequestModel()),
+        "No rows are updated when updating tags on nonexistent dataset");
   }
 
   @Test
@@ -1259,7 +1260,7 @@ class DatasetDaoTest {
     var datasetRequest = jsonLoader.loadObject("dataset-minimal.json", DatasetRequestModel.class);
     var datasetId = createDataset(datasetRequest);
     var dataset = datasetDao.retrieve(datasetId);
-    assertThat("Inherit steward defaults to false", not(dataset.isInheritSteward()));
+    assertFalse(dataset.isInheritSteward(), "Inherit steward defaults to false");
 
     datasetRequest.setInheritSteward(true);
     datasetId = createDataset(datasetRequest);

--- a/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
+++ b/src/test/java/bio/terra/service/dataset/SelfHostedDatasetIntegrationTest.java
@@ -305,7 +305,7 @@ class SelfHostedDatasetIntegrationTest {
       assertThat(
           "TDR was able to create a signed URL",
           objectAccessUrl.getUrl(),
-          is(not(emptyOrNullString())));
+          not(emptyOrNullString()));
 
       // Ensure that the signed URL is accessible
       TestUtils.verifyHttpAccess(objectAccessUrl.getUrl(), Map.of());

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -141,7 +141,7 @@ class FireStoreDaoTest {
       FireStoreDirectoryEntry snapObject =
           directoryDao.retrieveById(firestore, snapshotId, dsetObject.getFileId());
       assertThat("objectId matches", snapObject.getFileId(), equalTo(dsetObject.getFileId()));
-      assertThat("path does not match", snapObject.getPath(), not(equalTo(dsetObject.getPath())));
+      assertThat("path does not match", snapObject.getPath(), not(dsetObject.getPath()));
     }
 
     // ------ test FireStoreDependencyDao ----

--- a/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/gcs/GcsPdaoTest.java
@@ -213,7 +213,7 @@ public class GcsPdaoTest {
       assertThat(
           "times between copies is different since file was deleted",
           gcsPdao.copyFile(dataset, fileLoadModel, fileId, targetBucket).getCreatedDate(),
-          not(equalTo(initialTime)));
+          not(initialTime));
     } catch (InterruptedException e) {
       storage.delete(sourceBlob);
     } finally {

--- a/src/test/java/bio/terra/service/resourcemanagement/AzureDataLocationSelectorTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/AzureDataLocationSelectorTest.java
@@ -83,12 +83,11 @@ class AzureDataLocationSelectorTest {
             parameters1.region,
             parameters1.profile,
             parameters1.secureMonitoringEnabled),
-        is(
-            not(
-                dataLocationSelector.createStorageAccountName(
-                    parameters2.prefix,
-                    parameters2.region,
-                    parameters2.profile,
-                    parameters2.secureMonitoringEnabled))));
+        not(
+            dataLocationSelector.createStorageAccountName(
+                parameters2.prefix,
+                parameters2.region,
+                parameters2.profile,
+                parameters2.secureMonitoringEnabled)));
   }
 }

--- a/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/google/ResourceServiceConnectedTest.java
@@ -76,8 +76,6 @@ public class ResourceServiceConnectedTest {
     projectService.deleteGoogleProject(projectResource.getId());
     project = resourceManagerService.getProject(projectId);
     assertThat(
-        "the project is not active after delete",
-        project.getLifecycleState(),
-        not(equalTo("ACTIVE")));
+        "the project is not active after delete", project.getLifecycleState(), not("ACTIVE"));
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -7,9 +7,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -513,7 +513,7 @@ class SnapshotConnectedTest {
       throws Exception {
     String responseBody = response.getContentAsString();
     HttpStatus responseStatus = HttpStatus.valueOf(response.getStatus());
-    assertThat("Expect create snapshot failure", not(responseStatus.is2xxSuccessful()));
+    assertFalse(responseStatus.is2xxSuccessful(), "Expect create snapshot failure");
 
     assertThat("Error model was returned on failure", responseBody, containsString("message"));
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotIntegrationTest.java
@@ -8,8 +8,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.springframework.test.util.AssertionErrors.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import bio.terra.common.PdaoConstant;
 import bio.terra.common.auth.Users;
@@ -500,7 +499,7 @@ class SnapshotIntegrationTest {
         contains(discovererEmail));
 
     // Test enabling secure monitoring on existing project
-    assertThat("Secure monitoring should be disabled", not(dataset.isSecureMonitoringEnabled()));
+    assertFalse(dataset.isSecureMonitoringEnabled(), "Secure monitoring should be disabled");
     assertThat("Job completes", dataRepoFixtures.enableSecureMonitoring(steward(), datasetId));
     assertThat(
         "Secure monitoring should now be enabled",
@@ -509,7 +508,7 @@ class SnapshotIntegrationTest {
     // Test disabling secure monitoring on existing project
     assertThat("Job completes", dataRepoFixtures.disableSecureMonitoring(steward(), datasetId));
     assertFalse(
-        "Secure monitoring should now be disabled",
-        dataRepoFixtures.getDataset(steward(), datasetId).isSecureMonitoringEnabled());
+        dataRepoFixtures.getDataset(steward(), datasetId).isSecureMonitoringEnabled(),
+        "Secure monitoring should now be disabled");
   }
 }

--- a/src/test/java/bio/terra/service/tabulardata/WalkRelationshipTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/WalkRelationshipTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.common.AssetUtils;
@@ -38,9 +39,9 @@ class WalkRelationshipTest {
 
     boolean secondVisit = walkRelationship.visitRelationship(walkRelationship.getToTableId());
 
-    assertThat(
-        "visitRelationship should return false since we have already visited this relationship.",
-        not(secondVisit));
+    assertFalse(
+        secondVisit,
+        "visitRelationship should return false since we have already visited this relationship.");
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DT-1292

## Addresses

In many cases, we were using `Matchers.not()` incorrectly which resulted in tests that weren't correctly testing for `false`.

## Summary of changes

- looked at every use of `Matchers.not()` to see if there were incorrect cases
- where incorrect, fixed by using `assertFalse()` in most cases
- also removed redundant uses of `equalTo()` and `is()` when using `not()`, as `is(not()` is the same as `not()`
- also fixed some cases where code wasn't using JUnit 5's `assertFalse()`

## Testing Strategy

- all tests pass