### PR TITLE
[CORE-223] Pull in ECM fix for passport validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,7 @@ dependencies {
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
     implementation 'bio.terra:terra-policy-client:1.0.17-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'
-    implementation 'bio.terra:externalcreds-client-resttemplate:1.72.0-SNAPSHOT'
+    implementation 'bio.terra:externalcreds-client-resttemplate:1.79.0-SNAPSHOT'
 
     implementation 'org.glassfish.jersey.inject:jersey-hk2'
 


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/CORE-223

## Addresses
There is currently a bug in the ECM client library that prevents TDR from deserializing the response it gets from ECM when validating a passport. 

## Summary of changes
This pulls in the new version of ECM published from the changes in https://github.com/DataBiosphere/terra-external-credentials-manager/pull/255 which fix the deserialization bug.

## Testing Strategy
Manually verified by deploying TDR in a BEE with this version of the client library and confirming that TDR was able to validate a passport from ECM successfully.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
