### PR TITLE
DT-1343: Decrease GHA timeout for integration, connected and unit test runs

### DIFF
--- a/.github/workflows/int-and-connected-test-run.yml
+++ b/.github/workflows/int-and-connected-test-run.yml
@@ -12,7 +12,7 @@ jobs:
   test_unit:
     name: Unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
   test_connected:
     name: Connected tests
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 120
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
   test_integration:
     name: Integration tests
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 120
     services:
       postgres:
         image: postgres:16.4


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1343

## Addresses
When we run into issues with things like the RBS pool running out of projects, test runs can take long time to fail. If our tests are taking longer than 2 hours, the github action will now time out and stop the test run.

## Summary of changes
- Unit test timeout: 60 minutes -> 15 minutes
- Connected test timeout: 180 minutes -> 120 minutes
- Integration test timeout: 300 minutes -> 120 minutes

## Testing Strategy
GHA test run on PR

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
