### PR TITLE
DT-1331: DC Inherit: On Snapshot Create, Add parent dataset custodian google group to Service User Consumer Role

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/SnapshotWorkingMapKeys.java
@@ -7,6 +7,7 @@ public final class SnapshotWorkingMapKeys extends ProjectCreatingFlightKeys {
   private SnapshotWorkingMapKeys() {}
 
   public static final String POLICY_MAP = "policyMap";
+  public static final String SOURCE_DATASET_POLICY_MAP = "sourceDatasetPolicyMap";
   public static final String PROJECT_RESOURCE_ID = "projectResourceId";
   public static final String PROFILE_ID = "profileId";
   public static final String PROJECTS_MARKED_FOR_DELETE = "projectsMarkedForDelete";

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -1,9 +1,6 @@
 package bio.terra.service.snapshot.flight.create;
 
-import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
-import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.SnapshotService;
@@ -20,22 +17,16 @@ import java.util.Map;
 public class SnapshotAuthzBqJobUserStep implements Step {
   private final SnapshotService snapshotService;
   private final ResourceService resourceService;
-  private final IamService sam;
-  private final AuthenticatedUserRequest request;
   private final String snapshotName;
   private final Dataset sourceDataset;
 
   public SnapshotAuthzBqJobUserStep(
       SnapshotService snapshotService,
       ResourceService resourceService,
-      IamService sam,
-      AuthenticatedUserRequest request,
       String snapshotName,
       Dataset sourceDataset) {
     this.snapshotService = snapshotService;
     this.resourceService = resourceService;
-    this.sam = sam;
-    this.request = request;
     this.snapshotName = snapshotName;
     this.sourceDataset = sourceDataset;
   }
@@ -54,10 +45,11 @@ public class SnapshotAuthzBqJobUserStep implements Step {
         new ArrayList<>(List.of(policyMap.get(IamRole.STEWARD), policyMap.get(IamRole.READER)));
 
     if (sourceDataset.isInheritSteward()) {
-      var datasetPolicyMap =
-          sam.retrievePolicyEmails(request, IamResourceType.DATASET, sourceDataset.getId());
+      Map<IamRole, String> sourceDatasetPolicyMap =
+          workingMap.get(
+              SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
       // Allow the custodian to make queries in this project.
-      policyEmails.add(datasetPolicyMap.get(IamRole.CUSTODIAN));
+      policyEmails.add(sourceDatasetPolicyMap.get(IamRole.CUSTODIAN));
     }
     // The underlying service provides retries so we do not need to retry this operation
     resourceService.grantPoliciesBqJobUser(googleProjectId, policyEmails);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
@@ -7,6 +7,7 @@ import bio.terra.model.DuosFirecloudGroupModel;
 import bio.terra.model.SnapshotRequestContentsModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
+import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.Dataset;
@@ -66,6 +67,11 @@ public class SnapshotAuthzIamStep implements Step {
     Map<IamRole, String> policies =
         sam.createSnapshotResource(userReq, snapshotId, parentDatasetId, derivedPolicies);
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policies);
+    if (sourceDataset.isInheritSteward()) {
+      var datasetPolicyMap =
+          sam.retrievePolicyEmails(userReq, IamResourceType.DATASET, sourceDataset.getId());
+      workingMap.put(SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, datasetPolicyMap);
+    }
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzIamStep.java
@@ -67,11 +67,10 @@ public class SnapshotAuthzIamStep implements Step {
     Map<IamRole, String> policies =
         sam.createSnapshotResource(userReq, snapshotId, parentDatasetId, derivedPolicies);
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policies);
-    if (sourceDataset.isInheritSteward()) {
-      var datasetPolicyMap =
-          sam.retrievePolicyEmails(userReq, IamResourceType.DATASET, sourceDataset.getId());
-      workingMap.put(SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, datasetPolicyMap);
-    }
+    var datasetPolicyMap =
+        sam.retrievePolicyEmails(userReq, IamResourceType.DATASET, sourceDataset.getId());
+    workingMap.put(SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, datasetPolicyMap);
+
     return StepResult.getStepResultSuccess();
   }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
@@ -1,6 +1,7 @@
 package bio.terra.service.snapshot.flight.create;
 
 import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.dataset.Dataset;
 import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
@@ -19,16 +20,19 @@ public class SnapshotAuthzServiceAccountConsumerStep implements Step {
   private final ResourceService resourceService;
   private final String snapshotName;
   private final String tdrServiceAccountEmail;
+  private final Dataset sourceDataset;
 
   public SnapshotAuthzServiceAccountConsumerStep(
       SnapshotService snapshotService,
       ResourceService resourceService,
       String snapshotName,
-      String tdrServiceAccountEmail) {
+      String tdrServiceAccountEmail,
+      Dataset sourceDataset) {
     this.snapshotService = snapshotService;
     this.resourceService = resourceService;
     this.snapshotName = snapshotName;
     this.tdrServiceAccountEmail = tdrServiceAccountEmail;
+    this.sourceDataset = sourceDataset;
   }
 
   @Override
@@ -50,6 +54,14 @@ public class SnapshotAuthzServiceAccountConsumerStep implements Step {
         .getServiceAccount()
         .equals(tdrServiceAccountEmail)) {
       principalsToAdd.add(snapshot.getSourceDataset().getProjectResource().getServiceAccount());
+    }
+
+    if (sourceDataset.isInheritSteward()) {
+      Map<IamRole, String> sourceDatasetPolicyMap =
+          workingMap.get(
+              SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
+      // Allow the custodian to make queries in this project.
+      principalsToAdd.add(sourceDatasetPolicyMap.get(IamRole.CUSTODIAN));
     }
     resourceService.grantPoliciesServiceUsageConsumer(
         snapshot.getProjectResource().getGoogleProjectId(), principalsToAdd);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -369,10 +369,14 @@ public class SnapshotCreateFlight extends Flight {
 
       addStep(
           new SnapshotAuthzBqJobUserStep(
-              snapshotService, resourceService, iamService, userReq, snapshotName, sourceDataset));
+              snapshotService, resourceService, snapshotName, sourceDataset));
       addStep(
           new SnapshotAuthzServiceAccountConsumerStep(
-              snapshotService, resourceService, snapshotName, tdrServiceAccountEmail));
+              snapshotService,
+              resourceService,
+              snapshotName,
+              tdrServiceAccountEmail,
+              sourceDataset));
       // Record the Drs IDs if this is a global file id snapshot
       if (snapshotReq.isGlobalFileIds()) {
         addStep(

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStepTest.java
@@ -5,11 +5,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.auth.iam.IamRole;
@@ -20,6 +16,7 @@ import bio.terra.service.resourcemanagement.ResourceService;
 import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.SnapshotSource;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
@@ -37,7 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @Tag(Unit.TAG)
-class SnapshotAuthzBqJobUserStepTest {
+class SnapshotAuthzServiceAccountConsumerStepTest {
   @Mock private SnapshotService snapshotService;
   @Mock private ResourceService resourceService;
   @Mock private IamService iamService;
@@ -45,12 +42,21 @@ class SnapshotAuthzBqJobUserStepTest {
 
   private static final String SNAPSHOT_NAME = "snapshotName";
   private static final String GOOGLE_PROJECT_ID = "google project id";
+  private static final String TDR_SERVICE_ACCOUNT_EMAIL = "tdr-service-account-email";
   private static final Snapshot SNAPSHOT =
       new Snapshot()
+          .snapshotSources(
+              List.of(
+                  new SnapshotSource()
+                      .dataset(
+                          new Dataset()
+                              .projectResource(
+                                  new GoogleProjectResource()
+                                      .serviceAccount(TDR_SERVICE_ACCOUNT_EMAIL)))))
           .projectResource(new GoogleProjectResource().googleProjectId(GOOGLE_PROJECT_ID));
 
   private final List<String> addedEmails = new ArrayList<>();
-  private SnapshotAuthzBqJobUserStep step;
+  private SnapshotAuthzServiceAccountConsumerStep step;
 
   @BeforeEach
   void beforeEach() throws Exception {
@@ -74,16 +80,49 @@ class SnapshotAuthzBqJobUserStepTest {
               return null;
             })
         .when(resourceService)
-        .grantPoliciesBqJobUser(eq(GOOGLE_PROJECT_ID), anyList());
+        .grantPoliciesServiceUsageConsumer(eq(GOOGLE_PROJECT_ID), anyList());
   }
 
   @Test
   void doStep() throws Exception {
     step =
-        new SnapshotAuthzBqJobUserStep(
-            snapshotService, resourceService, SNAPSHOT_NAME, new Dataset());
+        new SnapshotAuthzServiceAccountConsumerStep(
+            snapshotService,
+            resourceService,
+            SNAPSHOT_NAME,
+            TDR_SERVICE_ACCOUNT_EMAIL,
+            new Dataset());
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
+
     assertThat(addedEmails, containsInAnyOrder("steward", "reader"));
+    verifyNoMoreInteractions(resourceService);
+    verifyNoInteractions(iamService);
+  }
+
+  @Test
+  void doStepAddServiceAccount() throws Exception {
+    var DEDICATED_SERVICE_ACCOUNT_EMAIL = "different";
+    var SNAPSHOT_DEDICATED_SA =
+        SNAPSHOT.snapshotSources(
+            List.of(
+                new SnapshotSource()
+                    .dataset(
+                        new Dataset()
+                            .projectResource(
+                                new GoogleProjectResource()
+                                    .serviceAccount(DEDICATED_SERVICE_ACCOUNT_EMAIL)))));
+    when(snapshotService.retrieveByName(SNAPSHOT_NAME)).thenReturn(SNAPSHOT_DEDICATED_SA);
+    step =
+        new SnapshotAuthzServiceAccountConsumerStep(
+            snapshotService,
+            resourceService,
+            SNAPSHOT_NAME,
+            TDR_SERVICE_ACCOUNT_EMAIL,
+            new Dataset());
+    assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
+
+    assertThat(
+        addedEmails, containsInAnyOrder("steward", "reader", DEDICATED_SERVICE_ACCOUNT_EMAIL));
     verifyNoMoreInteractions(resourceService);
     verifyNoInteractions(iamService);
   }
@@ -93,18 +132,26 @@ class SnapshotAuthzBqJobUserStepTest {
     var sourceDataset =
         new Dataset(new DatasetSummary().inheritSteward(true)).id(UUID.randomUUID());
     step =
-        new SnapshotAuthzBqJobUserStep(
-            snapshotService, resourceService, SNAPSHOT_NAME, sourceDataset);
+        new SnapshotAuthzServiceAccountConsumerStep(
+            snapshotService,
+            resourceService,
+            SNAPSHOT_NAME,
+            TDR_SERVICE_ACCOUNT_EMAIL,
+            sourceDataset);
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
     assertThat(addedEmails, containsInAnyOrder("steward", "reader", "custodian"));
   }
 
   @Test
-  void undoStep() {
+  void undoStep() throws InterruptedException {
     reset(snapshotService, flightContext, resourceService);
     step =
-        new SnapshotAuthzBqJobUserStep(
-            snapshotService, resourceService, SNAPSHOT_NAME, new Dataset());
+        new SnapshotAuthzServiceAccountConsumerStep(
+            snapshotService,
+            resourceService,
+            SNAPSHOT_NAME,
+            TDR_SERVICE_ACCOUNT_EMAIL,
+            new Dataset());
     assertThat(step.undoStep(flightContext), is(StepResult.getStepResultSuccess()));
     verifyNoInteractions(snapshotService, resourceService, iamService, flightContext);
   }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1331

## Addresses
When the inherit steward flag is set, we want for dataset custodians to be able to perform all of the same operations as members directly on the snapshot. One additional permission we need to grant the dataset custodian group is the roles/serviceusage.serviceUsageConsumer role in GCP. This enables snapshot users to be able to resolve DRS URLS when the dataset is self-hosted with a requester pays bucket.

## Summary of changes
- Retrieve the source dataset's policy map and store in the flight map
- Update `SnapshotAuthzBqJobUserStep` to pull source dataset poilicy map from flight map rather than directly from Sam
- Update `SnapshotAuthzServiceAccountConsumerStep` to add a check if inheritSteward is enabled on the flight, pull source dataset policy map from flight map and then add the source dataset's Cutodian group to the `ServiceUsageConsumer` Role in GCP IAM for the snapshot's google project
- Add `SnapshotAuthzServiceAccountConsumerStepTest`and update `SnapshotAuthzBqJobUserStepTest`

## Testing Strategy
- Unit tests
