### PR TITLE
DT-1240: add/remove custodian users from snapshot steward policy

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -49,6 +49,7 @@ import bio.terra.model.TransactionModel;
 import bio.terra.model.UnlockResourceRequest;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.AssetModelValidator;
 import bio.terra.service.dataset.DataDeletionRequestValidator;
@@ -64,7 +65,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -409,10 +409,13 @@ public class DatasetsApiController implements DatasetsApi {
       @PathVariable("policyName") String policyName,
       @Valid @RequestBody PolicyMemberRequest policyMember) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    PolicyModel policy =
-        iamService.addPolicyMember(
-            userReq, IamResourceType.DATASET, id, policyName, policyMember.getEmail());
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    IamRole role = IamRole.fromValue(policyName);
+    if (role == null) {
+      throw new ValidationException("InvalidPolicyName");
+    }
+    iamService.addPolicyMember(userReq, IamResourceType.DATASET, id, role, policyMember.getEmail());
+    PolicyModel policy = iamService.retrievePolicy(userReq, IamResourceType.DATASET, id, role);
+    PolicyResponse response = new PolicyResponse().policies(List.of(policy));
     return ResponseEntity.ok(response);
   }
 
@@ -435,10 +438,13 @@ public class DatasetsApiController implements DatasetsApi {
     if (!ValidationUtils.isValidEmail(memberEmail)) {
       throw new ValidationException("InvalidMemberEmail");
     }
-    PolicyModel policy =
-        iamService.deletePolicyMember(
-            userReq, IamResourceType.DATASET, id, policyName, memberEmail);
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    IamRole role = IamRole.fromValue(policyName);
+    if (role == null) {
+      throw new ValidationException("InvalidPolicyName");
+    }
+    iamService.deletePolicyMember(userReq, IamResourceType.DATASET, id, role, memberEmail);
+    PolicyModel policy = iamService.retrievePolicy(userReq, IamResourceType.DATASET, id, role);
+    PolicyResponse response = new PolicyResponse().policies(List.of(policy));
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -39,6 +39,7 @@ import bio.terra.model.TagUpdateRequestModel;
 import bio.terra.model.UnlockResourceRequest;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.AssetModelValidator;
 import bio.terra.service.dataset.Dataset;
@@ -52,7 +53,6 @@ import io.swagger.annotations.Api;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -342,10 +342,14 @@ public class SnapshotsApiController implements SnapshotsApi {
       @PathVariable("policyName") String policyName,
       @Valid @RequestBody PolicyMemberRequest policyMember) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    PolicyModel policy =
-        iamService.addPolicyMember(
-            userReq, IamResourceType.DATASNAPSHOT, id, policyName, policyMember.getEmail());
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    IamRole role = IamRole.fromValue(policyName);
+    if (role == null) {
+      throw new ValidationException("InvalidPolicyName");
+    }
+    iamService.addPolicyMember(
+        userReq, IamResourceType.DATASNAPSHOT, id, role, policyMember.getEmail());
+    PolicyModel policy = iamService.retrievePolicy(userReq, IamResourceType.DATASNAPSHOT, id, role);
+    PolicyResponse response = new PolicyResponse().policies(List.of(policy));
     return ResponseEntity.ok(response);
   }
 
@@ -364,11 +368,14 @@ public class SnapshotsApiController implements SnapshotsApi {
     if (!ValidationUtils.isValidEmail(memberEmail)) {
       throw new ValidationException("InvalidMemberEmail");
     }
+    IamRole role = IamRole.fromValue(policyName);
+    if (role == null) {
+      throw new ValidationException("InvalidPolicyName");
+    }
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    PolicyModel policy =
-        iamService.deletePolicyMember(
-            userReq, IamResourceType.DATASNAPSHOT, id, policyName, memberEmail);
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    iamService.deletePolicyMember(userReq, IamResourceType.DATASNAPSHOT, id, role, memberEmail);
+    PolicyModel policy = iamService.retrievePolicy(userReq, IamResourceType.DATASNAPSHOT, id, role);
+    PolicyResponse response = new PolicyResponse().policies(List.of(policy));
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -2,7 +2,6 @@ package bio.terra.service.auth.iam;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.DatasetRequestModelPolicies;
-import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
@@ -198,19 +197,19 @@ public interface IamProviderInterface {
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
       throws InterruptedException;
 
-  PolicyModel addPolicyMember(
+  void addPolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws InterruptedException;
 
-  PolicyModel deletePolicyMember(
+  void deletePolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws InterruptedException;
 

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -383,49 +383,60 @@ public class IamService {
         () -> iamProvider.retrievePolicyEmails(userReq, iamResourceType, resourceId));
   }
 
-  public PolicyModel addPolicyMember(
+  public void addPolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail) {
-    return callProvider(
+    callProvider(
         () -> {
-          PolicyModel policy =
-              iamProvider.addPolicyMember(
-                  userReq, iamResourceType, resourceId, policyName, userEmail);
+          iamProvider.addPolicyMember(userReq, iamResourceType, resourceId, policy, userEmail);
           // Invalidate the cache
           authorizedMap.clear();
           journalService.recordUpdate(
               userReq,
               resourceId,
               iamResourceType,
-              String.format("Added %s to %s", userEmail, policyName),
+              String.format("Added %s to %s", userEmail, policy),
               null);
-          return policy;
         });
   }
 
-  public PolicyModel deletePolicyMember(
+  public void deletePolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail) {
-    return callProvider(
+    callProvider(
         () -> {
-          PolicyModel policy =
-              iamProvider.deletePolicyMember(
-                  userReq, iamResourceType, resourceId, policyName, userEmail);
+          iamProvider.deletePolicyMember(userReq, iamResourceType, resourceId, policy, userEmail);
           // Invalidate the cache
           authorizedMap.clear();
           journalService.recordUpdate(
               userReq,
               resourceId,
               iamResourceType,
-              String.format("Removed %s from %s", userEmail, policyName),
+              String.format("Removed %s from %s", userEmail, policy),
               null);
-          return policy;
+        });
+  }
+
+  public PolicyModel retrievePolicy(
+      AuthenticatedUserRequest userReq,
+      IamResourceType iamResourceType,
+      UUID resourceId,
+      IamRole role) {
+    var policyName = role.toString();
+    return callProvider(
+        () -> {
+          var policies = iamProvider.retrievePolicies(userReq, iamResourceType, resourceId);
+          return policies.stream()
+              .filter(p -> p.getName().equals(policyName))
+              .map(p -> new PolicyModel().name(policyName).members(p.getMembers()))
+              .findFirst()
+              .orElseThrow();
         });
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -562,26 +562,23 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
-  public PolicyModel addPolicyMember(
+  public void addPolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws InterruptedException {
     SamRetry.retry(
         configurationService,
-        () -> addPolicyMemberInner(userReq, iamResourceType, resourceId, policyName, userEmail));
-    return SamRetry.retry(
-        configurationService,
-        () -> retrievePolicy(userReq, iamResourceType, resourceId, policyName));
+        () -> addPolicyMemberInner(userReq, iamResourceType, resourceId, policy, userEmail));
   }
 
   private void addPolicyMemberInner(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws ApiException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
@@ -589,38 +586,35 @@ public class SamIam implements IamProviderInterface {
         "addUserPolicy resourceType {} resourceId {} policyName {} userEmail {}",
         iamResourceType.toString(),
         resourceId.toString(),
-        policyName,
+        policy,
         userEmail);
     samResourceApi.addUserToPolicyV2(
-        iamResourceType.toString(), resourceId.toString(), policyName, userEmail, null);
+        iamResourceType.toString(), resourceId.toString(), policy.toString(), userEmail, null);
   }
 
   @Override
-  public PolicyModel deletePolicyMember(
+  public void deletePolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws InterruptedException {
     SamRetry.retry(
         configurationService,
-        () -> deletePolicyMemberInner(userReq, iamResourceType, resourceId, policyName, userEmail));
-    return SamRetry.retry(
-        configurationService,
-        () -> retrievePolicy(userReq, iamResourceType, resourceId, policyName));
+        () -> deletePolicyMemberInner(userReq, iamResourceType, resourceId, policy, userEmail));
   }
 
   private void deletePolicyMemberInner(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws ApiException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
     samResourceApi.removeUserFromPolicyV2(
-        iamResourceType.toString(), resourceId.toString(), policyName, userEmail);
+        iamResourceType.toString(), resourceId.toString(), policy.toString(), userEmail);
   }
 
   private PolicyModel retrievePolicy(

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -577,7 +577,7 @@ public class SamIam implements IamProviderInterface {
         () -> retrievePolicy(userReq, iamResourceType, resourceId, policyName));
   }
 
-  private void  addPolicyMemberInner(
+  private void addPolicyMemberInner(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -534,6 +534,7 @@ public class SamIam implements IamProviderInterface {
               entry ->
                   new SamPolicyModel()
                       .name(entry.getPolicyName())
+                      .email(entry.getEmail())
                       .members(entry.getPolicy().getMemberEmails())
                       .memberPolicies(
                           Optional.ofNullable(entry.getPolicy().getMemberPolicies())
@@ -546,8 +547,8 @@ public class SamIam implements IamProviderInterface {
                                           .policyEmail(pid.getPolicyEmail())
                                           .resourceId(UUID.fromString(pid.getResourceId()))
                                           .resourceTypeName(pid.getResourceTypeName()))
-                              .collect(Collectors.toList())))
-          .collect(Collectors.toList());
+                              .toList()))
+          .toList();
     }
   }
 
@@ -555,23 +556,9 @@ public class SamIam implements IamProviderInterface {
   public Map<IamRole, String> retrievePolicyEmails(
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
       throws InterruptedException {
-    return SamRetry.retry(
-        configurationService,
-        () -> retrievePolicyEmailsInner(userReq, iamResourceType, resourceId));
-  }
-
-  private Map<IamRole, String> retrievePolicyEmailsInner(
-      AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
-      throws ApiException {
-    ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
-    try (Stream<AccessPolicyResponseEntryV2> resultStream =
-        samResourceApi
-            .listResourcePoliciesV2(iamResourceType.toString(), resourceId.toString())
-            .stream()) {
-      return resultStream.collect(
-          Collectors.toMap(
-              a -> IamRole.fromValue(a.getPolicyName()), AccessPolicyResponseEntryV2::getEmail));
-    }
+    var policies = retrievePolicies(userReq, iamResourceType, resourceId);
+    return policies.stream()
+        .collect(Collectors.toMap(p -> IamRole.fromValue(p.getName()), SamPolicyModel::getEmail));
   }
 
   @Override
@@ -590,7 +577,7 @@ public class SamIam implements IamProviderInterface {
         () -> retrievePolicy(userReq, iamResourceType, resourceId, policyName));
   }
 
-  private void addPolicyMemberInner(
+  private void  addPolicyMemberInner(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -29,7 +29,6 @@ import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestRequestModel.FormatEnum;
 import bio.terra.model.ResourceLocks;
-import bio.terra.model.SamPolicyModel;
 import bio.terra.model.TagCount;
 import bio.terra.model.TagCountResultModel;
 import bio.terra.model.TagUpdateRequestModel;

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -29,6 +29,7 @@ import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestRequestModel.FormatEnum;
 import bio.terra.model.ResourceLocks;
+import bio.terra.model.SamPolicyModel;
 import bio.terra.model.TagCount;
 import bio.terra.model.TagCountResultModel;
 import bio.terra.model.TagUpdateRequestModel;
@@ -762,16 +763,18 @@ public class DatasetService {
 
   public String enableInheritSteward(UUID datasetId, AuthenticatedUserRequest userReq) {
     String description = "Enable InheritSteward for dataset " + datasetId;
-    var custodianEmail =
-        iamService
-            .retrievePolicyEmails(userReq, IamResourceType.DATASET, datasetId)
-            .get(IamRole.CUSTODIAN);
+    var custodianPolicy =
+        iamService.retrievePolicies(userReq, IamResourceType.DATASET, datasetId).stream()
+            .filter(p -> p.getName().equals(IamRole.CUSTODIAN.toString()))
+            .findFirst()
+            .orElseThrow();
     return jobService
         .newJob(description, EnableInheritStewardFlight.class, null, userReq)
         .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
         .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD)
         .addParameter(DatasetWorkingMapKeys.DATASET_ID, datasetId)
-        .addParameter(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), custodianEmail)
+        .addParameter(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), custodianPolicy.getEmail())
+        .addParameter(JobMapKeys.CUSTODIAN_USERS.getKeyName(), custodianPolicy.getMembers())
         .submit();
   }
 

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
@@ -1,0 +1,59 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.model.PolicyModel;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.exception.RetryException;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public record AdjustStewardMembersStep(AuthenticatedUserRequest userReq, IamService iamService, boolean inheritSteward) implements Step {
+
+  interface AddRemoveApi {
+    PolicyModel addRemoveMember(
+        AuthenticatedUserRequest userReq,
+        IamResourceType iamResourceType,
+        UUID resourceId,
+        String policyName,
+        String userEmail);
+  }
+
+  private void addRemoveStewardMembers(FlightContext context, boolean inheritSteward) {
+    FlightMap workingMap = context.getWorkingMap();
+    List<UUID> snapshotIds = Objects.requireNonNull(workingMap.get(DatasetWorkingMapKeys.SNAPSHOT_IDS, List.class));
+    FlightMap inputParams = context.getInputParameters();
+    List<String> custodians = Objects.requireNonNull(inputParams.get(JobMapKeys.CUSTODIAN_USERS.getKeyName(), List.class));
+    AddRemoveApi api = inheritSteward ? iamService::addPolicyMember : iamService::deletePolicyMember;
+    for (var snapshotId : snapshotIds) {
+      for (var email : custodians) {
+        api.addRemoveMember(
+            userReq,
+            IamResourceType.DATASNAPSHOT,
+            snapshotId,
+            IamRole.CUSTODIAN.toString(),
+            email);
+      }
+    }
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    addRemoveStewardMembers(context, inheritSteward);
+    return StepResult.getStepResultSuccess();
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    addRemoveStewardMembers(context, !inheritSteward);
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
@@ -1,7 +1,6 @@
 package bio.terra.service.dataset.flight.inheritsteward;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.model.PolicyModel;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
@@ -21,11 +20,11 @@ public record AdjustStewardMembersStep(
     implements Step {
 
   interface AddRemoveApi {
-    PolicyModel addRemoveMember(
+    void addRemoveMember(
         AuthenticatedUserRequest userReq,
         IamResourceType iamResourceType,
         UUID resourceId,
-        String policyName,
+        IamRole policy,
         String userEmail);
   }
 
@@ -42,7 +41,7 @@ public record AdjustStewardMembersStep(
     for (var snapshotId : snapshotIds) {
       for (var email : custodians) {
         api.addRemoveMember(
-            userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.CUSTODIAN.toString(), email);
+            userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.CUSTODIAN, email);
       }
     }
   }

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
@@ -16,7 +16,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-public record AdjustStewardMembersStep(AuthenticatedUserRequest userReq, IamService iamService, boolean inheritSteward) implements Step {
+public record AdjustStewardMembersStep(
+    AuthenticatedUserRequest userReq, IamService iamService, boolean inheritSteward)
+    implements Step {
 
   interface AddRemoveApi {
     PolicyModel addRemoveMember(
@@ -29,18 +31,18 @@ public record AdjustStewardMembersStep(AuthenticatedUserRequest userReq, IamServ
 
   private void addRemoveStewardMembers(FlightContext context, boolean inheritSteward) {
     FlightMap workingMap = context.getWorkingMap();
-    List<UUID> snapshotIds = Objects.requireNonNull(workingMap.get(DatasetWorkingMapKeys.SNAPSHOT_IDS, List.class));
+    List<UUID> snapshotIds =
+        Objects.requireNonNull(workingMap.get(DatasetWorkingMapKeys.SNAPSHOT_IDS, List.class));
     FlightMap inputParams = context.getInputParameters();
-    List<String> custodians = Objects.requireNonNull(inputParams.get(JobMapKeys.CUSTODIAN_USERS.getKeyName(), List.class));
-    AddRemoveApi api = inheritSteward ? iamService::addPolicyMember : iamService::deletePolicyMember;
+    List<String> custodians =
+        Objects.requireNonNull(
+            inputParams.get(JobMapKeys.CUSTODIAN_USERS.getKeyName(), List.class));
+    AddRemoveApi api =
+        inheritSteward ? iamService::addPolicyMember : iamService::deletePolicyMember;
     for (var snapshotId : snapshotIds) {
       for (var email : custodians) {
         api.addRemoveMember(
-            userReq,
-            IamResourceType.DATASNAPSHOT,
-            snapshotId,
-            IamRole.CUSTODIAN.toString(),
-            email);
+            userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.CUSTODIAN.toString(), email);
       }
     }
   }

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlight.java
@@ -52,6 +52,7 @@ public class EnableInheritStewardFlight extends Flight {
     addStep(
         new SetAuthTabularAclStep(
             bigQuerySnapshotPdao, snapshotService, custodianEmail, inheritSteward));
+    addStep(new AdjustStewardMembersStep(userReq, iamService, inheritSteward));
     addStep(new UnlockDatasetStep(datasetService, false));
     addStep(
         new JournalRecordUpdateEntryStep(

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -24,7 +24,8 @@ public enum JobMapKeys {
   TRANSACTION_ID("transactionId"),
   DELETE_CLOUD_RESOURCES("deleteCloudResources"),
   BUCKET_NAME("bucketName"),
-  CUSTODIAN_EMAIL("custodianEmail");
+  CUSTODIAN_EMAIL("custodianEmail"),
+  CUSTODIAN_USERS("custodianUsers");
 
   private final String keyName;
 

--- a/src/main/java/bio/terra/service/profile/ProfileApiController.java
+++ b/src/main/java/bio/terra/service/profile/ProfileApiController.java
@@ -18,6 +18,7 @@ import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.PolicyMemberValidator;
 import bio.terra.service.job.JobService;
@@ -125,7 +126,8 @@ public class ProfileApiController implements ProfilesApi {
   public ResponseEntity<PolicyResponse> addProfilePolicyMember(
       UUID id, String policyName, PolicyMemberRequest policyMember) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
-    PolicyModel policy = profileService.addProfilePolicyMember(id, policyName, policyMember, user);
+    IamRole role = IamRole.fromValue(policyName);
+    PolicyModel policy = profileService.addProfilePolicyMember(id, role, policyMember, user);
     PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
@@ -134,8 +136,8 @@ public class ProfileApiController implements ProfilesApi {
   public ResponseEntity<PolicyResponse> deleteProfilePolicyMember(
       UUID id, String policyName, String memberEmail) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
-    PolicyModel policy =
-        profileService.deleteProfilePolicyMember(id, policyName, memberEmail, user);
+    IamRole role = IamRole.fromValue(policyName);
+    PolicyModel policy = profileService.deleteProfilePolicyMember(id, role, memberEmail, user);
     PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -14,6 +14,7 @@ import bio.terra.model.PolicyMemberRequest;
 import bio.terra.model.PolicyModel;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.job.JobMapKeys;
@@ -220,28 +221,26 @@ public class ProfileService {
 
   public PolicyModel addProfilePolicyMember(
       UUID profileId,
-      String policyName,
+      IamRole policy,
       PolicyMemberRequest policyMember,
       AuthenticatedUserRequest user) {
-    return iamService.addPolicyMember(
-        user, IamResourceType.SPEND_PROFILE, profileId, policyName, policyMember.getEmail());
+    iamService.addPolicyMember(
+        user, IamResourceType.SPEND_PROFILE, profileId, policy, policyMember.getEmail());
+    return iamService.retrievePolicy(user, IamResourceType.SPEND_PROFILE, profileId, policy);
   }
 
   public PolicyModel deleteProfilePolicyMember(
-      UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
+      UUID profileId, IamRole policy, String memberEmail, AuthenticatedUserRequest user) {
     logger.info(
-        "id={} policy={} email={} authuser={}",
-        profileId,
-        policyName,
-        memberEmail,
-        user.getEmail());
+        "id={} policy={} email={} authuser={}", profileId, policy, memberEmail, user.getEmail());
     // member email can't be null since it is part of the URL
     if (!ValidationUtils.isValidEmail(memberEmail)) {
       throw new ValidationException("InvalidMemberEmail");
     }
 
-    return iamService.deletePolicyMember(
-        user, IamResourceType.SPEND_PROFILE, profileId, policyName, memberEmail);
+    iamService.deletePolicyMember(
+        user, IamResourceType.SPEND_PROFILE, profileId, policy, memberEmail);
+    return iamService.retrievePolicy(user, IamResourceType.SPEND_PROFILE, profileId, policy);
   }
 
   public List<PolicyModel> retrieveProfilePolicies(UUID profileId, AuthenticatedUserRequest user) {

--- a/src/main/java/bio/terra/service/snapshot/flight/duos/AddDuosFirecloudReaderStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/duos/AddDuosFirecloudReaderStep.java
@@ -29,7 +29,7 @@ public class AddDuosFirecloudReaderStep implements Step {
         userReq,
         IamResourceType.DATASNAPSHOT,
         snapshotId,
-        IamRole.READER.toString(),
+        IamRole.READER,
         SnapshotDuosFlightUtils.getFirecloudGroup(context).getFirecloudGroupEmail());
     return StepResult.getStepResultSuccess();
   }
@@ -40,7 +40,7 @@ public class AddDuosFirecloudReaderStep implements Step {
         userReq,
         IamResourceType.DATASNAPSHOT,
         snapshotId,
-        IamRole.READER.toString(),
+        IamRole.READER,
         SnapshotDuosFlightUtils.getFirecloudGroup(context).getFirecloudGroupEmail());
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/duos/RemoveDuosFirecloudReaderStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/duos/RemoveDuosFirecloudReaderStep.java
@@ -35,7 +35,7 @@ public class RemoveDuosFirecloudReaderStep implements Step {
         userReq,
         IamResourceType.DATASNAPSHOT,
         snapshotId,
-        IamRole.READER.toString(),
+        IamRole.READER,
         duosFirecloudGroupPrev.getFirecloudGroupEmail());
     return StepResult.getStepResultSuccess();
   }
@@ -46,7 +46,7 @@ public class RemoveDuosFirecloudReaderStep implements Step {
         userReq,
         IamResourceType.DATASNAPSHOT,
         snapshotId,
-        IamRole.READER.toString(),
+        IamRole.READER,
         duosFirecloudGroupPrev.getFirecloudGroupEmail());
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7170,6 +7170,8 @@ components:
       properties:
         name:
           type: string
+        email:
+          type: string
         members:
           type: array
           items:

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.auth.iam;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,6 +17,7 @@ import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.PolicyModel;
+import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
@@ -84,31 +86,34 @@ class IamServiceTest {
 
   @Test
   void testAddPolicyMember() throws InterruptedException {
-    var policyModel = new PolicyModel();
-    String policyName = "policyName";
+    IamRole policy = IamRole.DISCOVERER;
     String email = "email";
-    when(iamProvider.addPolicyMember(
-            TEST_USER, IamResourceType.SPEND_PROFILE, ID, policyName, email))
-        .thenReturn(policyModel);
 
-    PolicyModel result =
-        iamService.addPolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policyName, email);
-    assertEquals(policyModel, result);
+    iamService.addPolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy, email);
+    verify(iamProvider)
+        .addPolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy, email);
   }
 
   @Test
   void testDeletePolicyMember() throws InterruptedException {
-    var policyModel = new PolicyModel();
-    String policyName = "policyName";
+    IamRole policy = IamRole.DISCOVERER;
     String email = "email";
-    when(iamProvider.deletePolicyMember(
-            TEST_USER, IamResourceType.SPEND_PROFILE, ID, policyName, email))
-        .thenReturn(policyModel);
 
-    PolicyModel result =
-        iamService.deletePolicyMember(
-            TEST_USER, IamResourceType.SPEND_PROFILE, ID, policyName, email);
-    assertEquals(policyModel, result);
+    iamService.deletePolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy, email);
+    verify(iamProvider)
+        .deletePolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy, email);
+  }
+
+  @Test
+  void retrievePolicy() throws Exception {
+    IamRole policy = IamRole.DISCOVERER;
+    String email = "email";
+
+    when(iamProvider.retrievePolicies(TEST_USER, IamResourceType.SPEND_PROFILE, ID))
+        .thenReturn(List.of(new SamPolicyModel().name(policy.toString()).addMembersItem(email)));
+    var policyModel =
+        iamService.retrievePolicy(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy);
+    assertThat(policyModel, is(new PolicyModel().name(policy.toString()).addMembersItem(email)));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -510,6 +510,7 @@ class SamIamTest {
               List.of(
                   new SamPolicyModel()
                       .name(IamRole.CUSTODIAN.toString())
+                      .email(policyEmail)
                       .addMembersItem(memberEmail)
                       .memberPolicies(List.of()))));
 

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -25,7 +25,6 @@ import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.DatasetRequestModelPolicies;
-import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
@@ -667,22 +666,13 @@ class SamIamTest {
     void testAddPolicy() throws InterruptedException, ApiException {
       final UUID id = UUID.randomUUID();
       final String userEmail = "a@a.com";
-      when(samResourceApi.getPolicyV2(
-              IamResourceType.SPEND_PROFILE.getSamResourceName(),
-              id.toString(),
-              IamRole.OWNER.toString()))
-          .thenReturn(new AccessPolicyMembershipV2().memberEmails(List.of(userEmail)));
-      final PolicyModel policyModel =
-          samIam.addPolicyMember(
-              TEST_USER, IamResourceType.SPEND_PROFILE, id, IamRole.OWNER.toString(), userEmail);
-      assertThat(
-          policyModel,
-          is(new PolicyModel().name(IamRole.OWNER.toString()).addMembersItem(userEmail)));
-      verify(samResourceApi, times(1))
+      IamRole policy = IamRole.OWNER;
+      samIam.addPolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, id, policy, userEmail);
+      verify(samResourceApi)
           .addUserToPolicyV2(
               IamResourceType.SPEND_PROFILE.getSamResourceName(),
               id.toString(),
-              IamRole.OWNER.toString(),
+              policy.toString(),
               userEmail,
               null);
     }
@@ -691,21 +681,13 @@ class SamIamTest {
     void testDeletePolicy() throws InterruptedException, ApiException {
       final UUID id = UUID.randomUUID();
       final String userEmail = "a@a.com";
-      when(samResourceApi.getPolicyV2(
-              IamResourceType.SPEND_PROFILE.getSamResourceName(),
-              id.toString(),
-              IamRole.OWNER.toString()))
-          .thenReturn(new AccessPolicyMembershipV2().memberEmails(List.of()));
-      final PolicyModel policyModel =
-          samIam.deletePolicyMember(
-              TEST_USER, IamResourceType.SPEND_PROFILE, id, IamRole.OWNER.toString(), userEmail);
-      assertThat(
-          policyModel, is(new PolicyModel().name(IamRole.OWNER.toString()).members(List.of())));
-      verify(samResourceApi, times(1))
+      IamRole policy = IamRole.OWNER;
+      samIam.deletePolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, id, policy, userEmail);
+      verify(samResourceApi)
           .removeUserFromPolicyV2(
               IamResourceType.SPEND_PROFILE.getSamResourceName(),
               id.toString(),
-              IamRole.OWNER.toString(),
+              policy.toString(),
               userEmail);
     }
 

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -32,6 +32,7 @@ import bio.terra.model.DatasetDataModel;
 import bio.terra.model.DatasetPatchRequestModel;
 import bio.terra.model.DatasetSummaryModel;
 import bio.terra.model.ResourceLocks;
+import bio.terra.model.SamPolicyModel;
 import bio.terra.model.TableDataType;
 import bio.terra.model.UnlockResourceRequest;
 import bio.terra.service.auth.iam.IamAction;
@@ -62,6 +63,7 @@ import bio.terra.stairway.FlightMap;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -395,8 +397,14 @@ class DatasetServiceUnitTest {
             TEST_USER))
         .thenReturn(jobBuilder);
     var custodianEmail = "custodianEmail";
-    when(iamService.retrievePolicyEmails(TEST_USER, IamResourceType.DATASET, DATASET_ID))
-        .thenReturn(Map.of(IamRole.CUSTODIAN, custodianEmail));
+    var members = Arrays.asList("member");
+    when(iamService.retrievePolicies(TEST_USER, IamResourceType.DATASET, DATASET_ID))
+        .thenReturn(
+            List.of(
+                new SamPolicyModel()
+                    .name(IamRole.CUSTODIAN.toString())
+                    .email(custodianEmail)
+                    .members(members)));
     ArgumentCaptor<FlightMap> captor = ArgumentCaptor.forClass(FlightMap.class);
     when(jobService.submit(eq(EnableInheritStewardFlight.class), captor.capture()))
         .thenReturn("JobId");
@@ -415,6 +423,8 @@ class DatasetServiceUnitTest {
     assertThat(
         flightMap.get(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), String.class),
         equalTo(custodianEmail));
+    assertThat(
+        flightMap.get(JobMapKeys.CUSTODIAN_USERS.getKeyName(), List.class), equalTo(members));
   }
 
   private void mockDataset(CloudPlatform cloudPlatform, TableDataType columnDataType) {

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
@@ -61,7 +61,7 @@ class AdjustStewardMembersStepTest {
                 TEST_USER,
                 IamResourceType.DATASNAPSHOT,
                 snapshot.getId(),
-                IamRole.CUSTODIAN.toString(),
+                IamRole.CUSTODIAN,
                 custodianUser);
       } else {
         verify(iamService)
@@ -69,7 +69,7 @@ class AdjustStewardMembersStepTest {
                 TEST_USER,
                 IamResourceType.DATASNAPSHOT,
                 snapshot.getId(),
-                IamRole.CUSTODIAN.toString(),
+                IamRole.CUSTODIAN,
                 custodianUser);
       }
     }

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
@@ -1,0 +1,86 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class AdjustStewardMembersStepTest {
+
+  @Mock private IamService iamService;
+  @Mock private FlightContext flightContext;
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+
+  interface DoOrUndo {
+    StepResult apply(FlightContext t) throws Exception;
+  }
+
+  private void verifyAdjustMembers(DoOrUndo doOrUndo, boolean inheritSteward) throws Exception {
+    var snapshots =
+        List.of(new Snapshot().id(UUID.randomUUID()), new Snapshot().id(UUID.randomUUID()));
+    var custodianUser = "user";
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(
+        DatasetWorkingMapKeys.SNAPSHOT_IDS,
+        snapshots.stream().map(Snapshot::getId).collect(Collectors.toList()));
+    FlightMap inputParameters = new FlightMap();
+    inputParameters.put(JobMapKeys.CUSTODIAN_USERS.getKeyName(), Arrays.asList(custodianUser));
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(flightContext.getInputParameters()).thenReturn(inputParameters);
+    assertThat(doOrUndo.apply(flightContext), is(StepResult.getStepResultSuccess()));
+    for (var snapshot : snapshots) {
+      if (inheritSteward) {
+        verify(iamService)
+            .addPolicyMember(
+                TEST_USER,
+                IamResourceType.DATASNAPSHOT,
+                snapshot.getId(),
+                IamRole.CUSTODIAN.toString(),
+                custodianUser);
+      } else {
+        verify(iamService)
+            .deletePolicyMember(
+                TEST_USER,
+                IamResourceType.DATASNAPSHOT,
+                snapshot.getId(),
+                IamRole.CUSTODIAN.toString(),
+                custodianUser);
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void doStep(boolean inheritSteward) throws Exception {
+    AdjustStewardMembersStep step =
+        new AdjustStewardMembersStep(TEST_USER, iamService, inheritSteward);
+    verifyAdjustMembers(step::doStep, inheritSteward);
+    verifyAdjustMembers(step::undoStep, !inheritSteward);
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlightTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/EnableInheritStewardFlightTest.java
@@ -83,6 +83,7 @@ class EnableInheritStewardFlightTest {
             "GetSnapshotGoogleProjectIdsStep",
             "SetAuthGcpUserRolesStep",
             "SetAuthTabularAclStep",
+            "AdjustStewardMembersStep",
             "UnlockDatasetStep",
             "JournalRecordUpdateEntryStep"));
   }
@@ -201,6 +202,22 @@ class EnableInheritStewardFlightTest {
                   "The correct boolean flag is passed to the step",
                   (boolean) context.arguments().get(2),
                   equalTo(true));
+            })) {
+      //noinspection ResultOfObjectAllocationIgnored
+      new EnableInheritStewardFlight(inputParameters, context);
+      assertThat(mockStep.constructed(), hasSize(1));
+    }
+  }
+
+  @Test
+  void adjustStewardMembersStep() {
+    try (var mockStep =
+        mockConstruction(
+            AdjustStewardMembersStep.class,
+            (mock, context) -> {
+              assertThat((AuthenticatedUserRequest) context.arguments().get(0), equalTo(TEST_USER));
+              assertThat((IamService) context.arguments().get(1), equalTo(iamService));
+              assertThat((boolean) context.arguments().get(2), equalTo(true));
             })) {
       //noinspection ResultOfObjectAllocationIgnored
       new EnableInheritStewardFlight(inputParameters, context);

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -37,6 +37,7 @@ import bio.terra.model.PolicyResponse;
 import bio.terra.model.ProfileOwnedResourceModel;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.PolicyMemberValidator;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
@@ -218,14 +219,14 @@ class ProfileAPIControllerTest {
   @Test
   void testAddProfilePolicyMember() {
     UUID id = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
-    String policyName = "policyName";
+    IamRole policy = IamRole.ADMIN;
     var policyMemberRequest = new PolicyMemberRequest().email("email");
     var policyModel = new PolicyModel();
-    when(profileService.addProfilePolicyMember(id, policyName, policyMemberRequest, TEST_USER))
+    when(profileService.addProfilePolicyMember(id, policy, policyMemberRequest, TEST_USER))
         .thenReturn(policyModel);
 
     ResponseEntity<PolicyResponse> response =
-        apiController.addProfilePolicyMember(id, policyName, policyMemberRequest);
+        apiController.addProfilePolicyMember(id, policy.toString(), policyMemberRequest);
 
     assertTrue(response.getBody().getPolicies().contains(policyModel));
     assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/bio/terra/service/snapshot/flight/duos/AddDuosFirecloudReaderStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/duos/AddDuosFirecloudReaderStepTest.java
@@ -58,7 +58,7 @@ class AddDuosFirecloudReaderStepTest {
             TEST_USER,
             IamResourceType.DATASNAPSHOT,
             SNAPSHOT_ID,
-            IamRole.READER.toString(),
+            IamRole.READER,
             DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail());
 
     StepResult undoResult = step.undoStep(flightContext);
@@ -68,7 +68,7 @@ class AddDuosFirecloudReaderStepTest {
             TEST_USER,
             IamResourceType.DATASNAPSHOT,
             SNAPSHOT_ID,
-            IamRole.READER.toString(),
+            IamRole.READER,
             DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail());
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/duos/RemoveDuosFirecloudReaderStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/duos/RemoveDuosFirecloudReaderStepTest.java
@@ -55,7 +55,7 @@ class RemoveDuosFirecloudReaderStepTest {
             TEST_USER,
             IamResourceType.DATASNAPSHOT,
             SNAPSHOT_ID,
-            IamRole.READER.toString(),
+            IamRole.READER,
             DUOS_FIRECLOUD_GROUP_PREV.getFirecloudGroupEmail());
     verifyNoInteractions(flightContext);
 
@@ -66,7 +66,7 @@ class RemoveDuosFirecloudReaderStepTest {
             TEST_USER,
             IamResourceType.DATASNAPSHOT,
             SNAPSHOT_ID,
-            IamRole.READER.toString(),
+            IamRole.READER,
             DUOS_FIRECLOUD_GROUP_PREV.getFirecloudGroupEmail());
     verifyNoInteractions(flightContext);
   }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1240

## Addresses

When the `inherit steward` flag is set, we want to remove any custodian users that were present on a dataset snapshot. When the flag is unset, we want to re-add the custodian users.

## Summary of changes

- add a new step to support this operation
- add `email` property to the `SamPolicyModel` to avoid making two Sam calls to get the proxy email along with the policy members

## Testing Strategy

- unit tests