### PR TITLE
PROD-1008: Upgrade TCL in order to get latest K8 Java Client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ dependencies {
 
     // OpenTelemetry @WithSpan annotations:
     implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.14.0'
-    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.32.0'
+    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'
 
     testImplementation 'org.apache.parquet:parquet-common:1.15.1'
     testImplementation 'org.apache.parquet:parquet-hadoop:1.15.1'

--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.3.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.3.0'
 
-    implementation 'bio.terra:terra-common-lib:1.1.18-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.22-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
     implementation 'bio.terra:terra-policy-client:1.0.17-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -236,6 +236,7 @@ dependencies {
 
     // OpenTelemetry @WithSpan annotations:
     implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.14.0'
+    implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.32.0'
 
     testImplementation 'org.apache.parquet:parquet-common:1.15.1'
     testImplementation 'org.apache.parquet:parquet-hadoop:1.15.1'

--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.3.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.3.0'
 
-    implementation 'bio.terra:terra-common-lib:1.1.18-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.21-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
     implementation 'bio.terra:terra-policy-client:1.0.17-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.3.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.3.0'
 
-    implementation 'bio.terra:terra-common-lib:1.1.22-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.18-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.241'
     implementation 'bio.terra:terra-policy-client:1.0.17-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.42-SNAPSHOT'


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/PROD-1008

## Addresses
Data Repo experienced a production outage around 5AM on Monday, March 17th. This coincided with a kubernetes cluster upgrade that hit prod before dev and staging. 
<img width="702" alt="image" src="https://github.com/user-attachments/assets/9f7c586c-6c08-4c17-a68b-f049f373ab6b" />

Data repo relies on Stairway and the Terra Common Lib (TCL), which together use the kubernetes java client to get information about pods. While TCL is update to date with the latest kubernetes Java client, data repo was not the latest version of [TCL](https://github.com/DataBiosphere/terra-common-lib/tags) (1.1.18 instead of the latest, 1.1.38). We ran into issues with a dependabot PR that attempted to bump the version of TCL back in October 2024, and per our team's way of working: we ignored this dependency upgrade and filed a [ticket ](https://broadworkbench.atlassian.net/browse/DT-924)to do the upgrade.  However, we never revisited this ticket to do the upgrade. 

During the production outage, we were running into the following error:
```
"Application run failed
java.lang.IllegalArgumentException: The field `volumeMounts` in the JSON string is not defined in the
`V1ContainerStatus` properties. JSON: {"name":"datarepo-datarepo-api" <redacted>"volumeMounts":[{"name":
<redacted>","mountPath":"<redacted>/"}]}
	at io.kubernetes.client.openapi.models.V1ContainerStatus.validateJsonObject(V1ContainerStatus.java:448)
	at io.kubernetes.client.openapi.models.V1PodStatus.validateJsonObject(V1PodStatus.java:661)
	at io.kubernetes.client.openapi.models.V1Pod.validateJsonObject(V1Pod.java:284)
	at io.kubernetes.client.openapi.models.V1PodList.validateJsonObject(V1PodList.java:268)
	at io.kubernetes.client.openapi.models.V1PodList$CustomTypeAdapterFactory$1.read(V1PodList.java:300)
	at io.kubernetes.client.openapi.models.V1PodList$CustomTypeAdapterFactory$1.read(V1PodList.java:290)
	at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:308)
	at com.google.gson.Gson.fromJson(Gson.java:1361)
	at com.google.gson.Gson.fromJson(Gson.java:1262)
	at com.google.gson.Gson.fromJson(Gson.java:1171)
	at com.google.gson.Gson.fromJson(Gson.java:1137)
	at io.kubernetes.client.openapi.JSON.deserialize(JSON.java:722)
	at io.kubernetes.client.openapi.ApiClient.deserialize(ApiClient.java:895)
	at io.kubernetes.client.openapi.ApiClient.handleResponse(ApiClient.java:1105)
	at io.kubernetes.client.openapi.ApiClient.execute(ApiClient.java:1029)
	at io.kubernetes.client.openapi.apis.CoreV1Api.listNamespacedPodWithHttpInfo(CoreV1Api.java:26426)
	at io.kubernetes.client.openapi.apis.CoreV1Api.access$43300(CoreV1Api.java:77)
	at io.kubernetes.client.openapi.apis.CoreV1Api$APIlistNamespacedPodRequest.execute(CoreV1Api.java:26593)
	at bio.terra.common.kubernetes.KubeService.getPodSet(KubeService.java:102)
	at bio.terra.common.stairway.StairwayComponent.initialize(StairwayComponent.java:171)
	at bio.terra.service.job.JobService.afterSingletonsInstantiated(JobService.java:116)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:1083)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:987)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:627)
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:318)
	at bio.terra.Main.main(Main.java:29
```
TLDR; It was failing when trying to initialize stairway. The initialize method calls a terra common lib KubeService method that is complaining about the presence of the "VolumeMounts" field in the V1ContainerStatus properties. We define this particular volumeMount field [here](https://github.com/broadinstitute/terra-helmfile/blob/021f47f287b0cb6310d2f9db447ff27448bf2ef2/charts/datarepo/charts/datarepo-api/templates/api-deployment.yaml#L87) in terra-helmfile.

@choover-broad tracked down that "volumeMounts" was added in to the `V1ContainerStatus` object in K8s 1.30 (missing in docs for [1.29](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/), exists in [1.30](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/))

With this information, we knew we needed to upgrade TCL to at least a version of the k8 Java client that at least support kubernetes 1.30. From [this chart](https://github.com/kubernetes-client/java/wiki/2.-Versioning-and-Compatibility#compatibility), we determined that v21 of the java client would support v1.30 kubernetes. We mapped this to version [1.1.21](https://github.com/DataBiosphere/terra-common-lib/releases/tag/1.1.21) of TCL. 

We then set about upgrading TCL from 1.1.18 to 1.1.21. 

Here we ran into some issues with OTEL, which were resolved by adding another dependency to TDR's build.gradle. 

## Summary of changes
- Upgrade Terra Common Lib (TCL) from 1.1.18 to 1.1.21
- Resolve OTEL issue by adding an additional dependency - 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'

## Testing Strategy
- TDR dev and staging were not on the same Kubernetes version, so we could not test out this change in TDR environments.
- However, BEEs were on the same kubernetes version. So, we deployed the change first to a BEE and saw the error resolve and then were able to promote this change. 
