### PR TITLE
Possible change to internal Sam APIs

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -49,6 +49,7 @@ import bio.terra.model.TransactionModel;
 import bio.terra.model.UnlockResourceRequest;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.AssetModelValidator;
 import bio.terra.service.dataset.DataDeletionRequestValidator;
@@ -64,7 +65,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -409,10 +409,13 @@ public class DatasetsApiController implements DatasetsApi {
       @PathVariable("policyName") String policyName,
       @Valid @RequestBody PolicyMemberRequest policyMember) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    PolicyModel policy =
-        iamService.addPolicyMember(
-            userReq, IamResourceType.DATASET, id, policyName, policyMember.getEmail());
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    IamRole role = IamRole.fromValue(policyName);
+    if (role == null) {
+      throw new ValidationException("InvalidPolicyName");
+    }
+    iamService.addPolicyMember(userReq, IamResourceType.DATASET, id, role, policyMember.getEmail());
+    PolicyModel policy = iamService.retrievePolicy(userReq, IamResourceType.DATASET, id, role);
+    PolicyResponse response = new PolicyResponse().policies(List.of(policy));
     return ResponseEntity.ok(response);
   }
 
@@ -435,10 +438,13 @@ public class DatasetsApiController implements DatasetsApi {
     if (!ValidationUtils.isValidEmail(memberEmail)) {
       throw new ValidationException("InvalidMemberEmail");
     }
-    PolicyModel policy =
-        iamService.deletePolicyMember(
-            userReq, IamResourceType.DATASET, id, policyName, memberEmail);
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    IamRole role = IamRole.fromValue(policyName);
+    if (role == null) {
+      throw new ValidationException("InvalidPolicyName");
+    }
+    iamService.deletePolicyMember(userReq, IamResourceType.DATASET, id, role, memberEmail);
+    PolicyModel policy = iamService.retrievePolicy(userReq, IamResourceType.DATASET, id, role);
+    PolicyResponse response = new PolicyResponse().policies(List.of(policy));
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -39,6 +39,7 @@ import bio.terra.model.TagUpdateRequestModel;
 import bio.terra.model.UnlockResourceRequest;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.AssetModelValidator;
 import bio.terra.service.dataset.Dataset;
@@ -52,7 +53,6 @@ import io.swagger.annotations.Api;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -342,10 +342,14 @@ public class SnapshotsApiController implements SnapshotsApi {
       @PathVariable("policyName") String policyName,
       @Valid @RequestBody PolicyMemberRequest policyMember) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    PolicyModel policy =
-        iamService.addPolicyMember(
-            userReq, IamResourceType.DATASNAPSHOT, id, policyName, policyMember.getEmail());
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    IamRole role = IamRole.fromValue(policyName);
+    if (role == null) {
+      throw new ValidationException("InvalidPolicyName");
+    }
+    iamService.addPolicyMember(
+        userReq, IamResourceType.DATASNAPSHOT, id, role, policyMember.getEmail());
+    PolicyModel policy = iamService.retrievePolicy(userReq, IamResourceType.DATASNAPSHOT, id, role);
+    PolicyResponse response = new PolicyResponse().policies(List.of(policy));
     return ResponseEntity.ok(response);
   }
 
@@ -364,11 +368,14 @@ public class SnapshotsApiController implements SnapshotsApi {
     if (!ValidationUtils.isValidEmail(memberEmail)) {
       throw new ValidationException("InvalidMemberEmail");
     }
+    IamRole role = IamRole.fromValue(policyName);
+    if (role == null) {
+      throw new ValidationException("InvalidPolicyName");
+    }
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    PolicyModel policy =
-        iamService.deletePolicyMember(
-            userReq, IamResourceType.DATASNAPSHOT, id, policyName, memberEmail);
-    PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
+    iamService.deletePolicyMember(userReq, IamResourceType.DATASNAPSHOT, id, role, memberEmail);
+    PolicyModel policy = iamService.retrievePolicy(userReq, IamResourceType.DATASNAPSHOT, id, role);
+    PolicyResponse response = new PolicyResponse().policies(List.of(policy));
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -2,7 +2,6 @@ package bio.terra.service.auth.iam;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.DatasetRequestModelPolicies;
-import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
@@ -198,19 +197,19 @@ public interface IamProviderInterface {
       AuthenticatedUserRequest userReq, IamResourceType iamResourceType, UUID resourceId)
       throws InterruptedException;
 
-  PolicyModel addPolicyMember(
+  void addPolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws InterruptedException;
 
-  PolicyModel deletePolicyMember(
+  void deletePolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws InterruptedException;
 

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -383,49 +383,60 @@ public class IamService {
         () -> iamProvider.retrievePolicyEmails(userReq, iamResourceType, resourceId));
   }
 
-  public PolicyModel addPolicyMember(
+  public void addPolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail) {
-    return callProvider(
+    callProvider(
         () -> {
-          PolicyModel policy =
-              iamProvider.addPolicyMember(
-                  userReq, iamResourceType, resourceId, policyName, userEmail);
+          iamProvider.addPolicyMember(userReq, iamResourceType, resourceId, policy, userEmail);
           // Invalidate the cache
           authorizedMap.clear();
           journalService.recordUpdate(
               userReq,
               resourceId,
               iamResourceType,
-              String.format("Added %s to %s", userEmail, policyName),
+              String.format("Added %s to %s", userEmail, policy),
               null);
-          return policy;
         });
   }
 
-  public PolicyModel deletePolicyMember(
+  public void deletePolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail) {
-    return callProvider(
+    callProvider(
         () -> {
-          PolicyModel policy =
-              iamProvider.deletePolicyMember(
-                  userReq, iamResourceType, resourceId, policyName, userEmail);
+          iamProvider.deletePolicyMember(userReq, iamResourceType, resourceId, policy, userEmail);
           // Invalidate the cache
           authorizedMap.clear();
           journalService.recordUpdate(
               userReq,
               resourceId,
               iamResourceType,
-              String.format("Removed %s from %s", userEmail, policyName),
+              String.format("Removed %s from %s", userEmail, policy),
               null);
-          return policy;
+        });
+  }
+
+  public PolicyModel retrievePolicy(
+      AuthenticatedUserRequest userReq,
+      IamResourceType iamResourceType,
+      UUID resourceId,
+      IamRole role) {
+    var policyName = role.toString();
+    return callProvider(
+        () -> {
+          var policies = iamProvider.retrievePolicies(userReq, iamResourceType, resourceId);
+          return policies.stream()
+              .filter(p -> p.getName().equals(policyName))
+              .map(p -> new PolicyModel().name(policyName).members(p.getMembers()))
+              .findFirst()
+              .orElseThrow();
         });
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -562,26 +562,23 @@ public class SamIam implements IamProviderInterface {
   }
 
   @Override
-  public PolicyModel addPolicyMember(
+  public void addPolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws InterruptedException {
     SamRetry.retry(
         configurationService,
-        () -> addPolicyMemberInner(userReq, iamResourceType, resourceId, policyName, userEmail));
-    return SamRetry.retry(
-        configurationService,
-        () -> retrievePolicy(userReq, iamResourceType, resourceId, policyName));
+        () -> addPolicyMemberInner(userReq, iamResourceType, resourceId, policy, userEmail));
   }
 
   private void addPolicyMemberInner(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws ApiException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
@@ -589,38 +586,35 @@ public class SamIam implements IamProviderInterface {
         "addUserPolicy resourceType {} resourceId {} policyName {} userEmail {}",
         iamResourceType.toString(),
         resourceId.toString(),
-        policyName,
+        policy,
         userEmail);
     samResourceApi.addUserToPolicyV2(
-        iamResourceType.toString(), resourceId.toString(), policyName, userEmail, null);
+        iamResourceType.toString(), resourceId.toString(), policy.toString(), userEmail, null);
   }
 
   @Override
-  public PolicyModel deletePolicyMember(
+  public void deletePolicyMember(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws InterruptedException {
     SamRetry.retry(
         configurationService,
-        () -> deletePolicyMemberInner(userReq, iamResourceType, resourceId, policyName, userEmail));
-    return SamRetry.retry(
-        configurationService,
-        () -> retrievePolicy(userReq, iamResourceType, resourceId, policyName));
+        () -> deletePolicyMemberInner(userReq, iamResourceType, resourceId, policy, userEmail));
   }
 
   private void deletePolicyMemberInner(
       AuthenticatedUserRequest userReq,
       IamResourceType iamResourceType,
       UUID resourceId,
-      String policyName,
+      IamRole policy,
       String userEmail)
       throws ApiException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(userReq.getToken());
     samResourceApi.removeUserFromPolicyV2(
-        iamResourceType.toString(), resourceId.toString(), policyName, userEmail);
+        iamResourceType.toString(), resourceId.toString(), policy.toString(), userEmail);
   }
 
   private PolicyModel retrievePolicy(

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
@@ -1,7 +1,6 @@
 package bio.terra.service.dataset.flight.inheritsteward;
 
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.model.PolicyModel;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
@@ -21,11 +20,11 @@ public record AdjustStewardMembersStep(
     implements Step {
 
   interface AddRemoveApi {
-    PolicyModel addRemoveMember(
+    void addRemoveMember(
         AuthenticatedUserRequest userReq,
         IamResourceType iamResourceType,
         UUID resourceId,
-        String policyName,
+        IamRole policy,
         String userEmail);
   }
 
@@ -42,7 +41,7 @@ public record AdjustStewardMembersStep(
     for (var snapshotId : snapshotIds) {
       for (var email : custodians) {
         api.addRemoveMember(
-            userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.CUSTODIAN.toString(), email);
+            userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.CUSTODIAN, email);
       }
     }
   }

--- a/src/main/java/bio/terra/service/profile/ProfileApiController.java
+++ b/src/main/java/bio/terra/service/profile/ProfileApiController.java
@@ -18,6 +18,7 @@ import bio.terra.model.PolicyModel;
 import bio.terra.model.PolicyResponse;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.PolicyMemberValidator;
 import bio.terra.service.job.JobService;
@@ -125,7 +126,8 @@ public class ProfileApiController implements ProfilesApi {
   public ResponseEntity<PolicyResponse> addProfilePolicyMember(
       UUID id, String policyName, PolicyMemberRequest policyMember) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
-    PolicyModel policy = profileService.addProfilePolicyMember(id, policyName, policyMember, user);
+    IamRole role = IamRole.fromValue(policyName);
+    PolicyModel policy = profileService.addProfilePolicyMember(id, role, policyMember, user);
     PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
@@ -134,8 +136,8 @@ public class ProfileApiController implements ProfilesApi {
   public ResponseEntity<PolicyResponse> deleteProfilePolicyMember(
       UUID id, String policyName, String memberEmail) {
     AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
-    PolicyModel policy =
-        profileService.deleteProfilePolicyMember(id, policyName, memberEmail, user);
+    IamRole role = IamRole.fromValue(policyName);
+    PolicyModel policy = profileService.deleteProfilePolicyMember(id, role, memberEmail, user);
     PolicyResponse response = new PolicyResponse().policies(Collections.singletonList(policy));
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/src/main/java/bio/terra/service/profile/ProfileService.java
+++ b/src/main/java/bio/terra/service/profile/ProfileService.java
@@ -14,6 +14,7 @@ import bio.terra.model.PolicyMemberRequest;
 import bio.terra.model.PolicyModel;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.exception.IamUnauthorizedException;
 import bio.terra.service.job.JobMapKeys;
@@ -220,28 +221,26 @@ public class ProfileService {
 
   public PolicyModel addProfilePolicyMember(
       UUID profileId,
-      String policyName,
+      IamRole policy,
       PolicyMemberRequest policyMember,
       AuthenticatedUserRequest user) {
-    return iamService.addPolicyMember(
-        user, IamResourceType.SPEND_PROFILE, profileId, policyName, policyMember.getEmail());
+    iamService.addPolicyMember(
+        user, IamResourceType.SPEND_PROFILE, profileId, policy, policyMember.getEmail());
+    return iamService.retrievePolicy(user, IamResourceType.SPEND_PROFILE, profileId, policy);
   }
 
   public PolicyModel deleteProfilePolicyMember(
-      UUID profileId, String policyName, String memberEmail, AuthenticatedUserRequest user) {
+      UUID profileId, IamRole policy, String memberEmail, AuthenticatedUserRequest user) {
     logger.info(
-        "id={} policy={} email={} authuser={}",
-        profileId,
-        policyName,
-        memberEmail,
-        user.getEmail());
+        "id={} policy={} email={} authuser={}", profileId, policy, memberEmail, user.getEmail());
     // member email can't be null since it is part of the URL
     if (!ValidationUtils.isValidEmail(memberEmail)) {
       throw new ValidationException("InvalidMemberEmail");
     }
 
-    return iamService.deletePolicyMember(
-        user, IamResourceType.SPEND_PROFILE, profileId, policyName, memberEmail);
+    iamService.deletePolicyMember(
+        user, IamResourceType.SPEND_PROFILE, profileId, policy, memberEmail);
+    return iamService.retrievePolicy(user, IamResourceType.SPEND_PROFILE, profileId, policy);
   }
 
   public List<PolicyModel> retrieveProfilePolicies(UUID profileId, AuthenticatedUserRequest user) {

--- a/src/main/java/bio/terra/service/snapshot/flight/duos/AddDuosFirecloudReaderStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/duos/AddDuosFirecloudReaderStep.java
@@ -29,7 +29,7 @@ public class AddDuosFirecloudReaderStep implements Step {
         userReq,
         IamResourceType.DATASNAPSHOT,
         snapshotId,
-        IamRole.READER.toString(),
+        IamRole.READER,
         SnapshotDuosFlightUtils.getFirecloudGroup(context).getFirecloudGroupEmail());
     return StepResult.getStepResultSuccess();
   }
@@ -40,7 +40,7 @@ public class AddDuosFirecloudReaderStep implements Step {
         userReq,
         IamResourceType.DATASNAPSHOT,
         snapshotId,
-        IamRole.READER.toString(),
+        IamRole.READER,
         SnapshotDuosFlightUtils.getFirecloudGroup(context).getFirecloudGroupEmail());
     return StepResult.getStepResultSuccess();
   }

--- a/src/main/java/bio/terra/service/snapshot/flight/duos/RemoveDuosFirecloudReaderStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/duos/RemoveDuosFirecloudReaderStep.java
@@ -35,7 +35,7 @@ public class RemoveDuosFirecloudReaderStep implements Step {
         userReq,
         IamResourceType.DATASNAPSHOT,
         snapshotId,
-        IamRole.READER.toString(),
+        IamRole.READER,
         duosFirecloudGroupPrev.getFirecloudGroupEmail());
     return StepResult.getStepResultSuccess();
   }
@@ -46,7 +46,7 @@ public class RemoveDuosFirecloudReaderStep implements Step {
         userReq,
         IamResourceType.DATASNAPSHOT,
         snapshotId,
-        IamRole.READER.toString(),
+        IamRole.READER,
         duosFirecloudGroupPrev.getFirecloudGroupEmail());
     return StepResult.getStepResultSuccess();
   }

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -3,6 +3,7 @@ package bio.terra.service.auth.iam;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,6 +17,7 @@ import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.PolicyModel;
+import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
@@ -84,31 +86,34 @@ class IamServiceTest {
 
   @Test
   void testAddPolicyMember() throws InterruptedException {
-    var policyModel = new PolicyModel();
-    String policyName = "policyName";
+    IamRole policy = IamRole.DISCOVERER;
     String email = "email";
-    when(iamProvider.addPolicyMember(
-            TEST_USER, IamResourceType.SPEND_PROFILE, ID, policyName, email))
-        .thenReturn(policyModel);
 
-    PolicyModel result =
-        iamService.addPolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policyName, email);
-    assertEquals(policyModel, result);
+    iamService.addPolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy, email);
+    verify(iamProvider)
+        .addPolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy, email);
   }
 
   @Test
   void testDeletePolicyMember() throws InterruptedException {
-    var policyModel = new PolicyModel();
-    String policyName = "policyName";
+    IamRole policy = IamRole.DISCOVERER;
     String email = "email";
-    when(iamProvider.deletePolicyMember(
-            TEST_USER, IamResourceType.SPEND_PROFILE, ID, policyName, email))
-        .thenReturn(policyModel);
 
-    PolicyModel result =
-        iamService.deletePolicyMember(
-            TEST_USER, IamResourceType.SPEND_PROFILE, ID, policyName, email);
-    assertEquals(policyModel, result);
+    iamService.deletePolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy, email);
+    verify(iamProvider)
+        .deletePolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy, email);
+  }
+
+  @Test
+  void retrievePolicy() throws Exception {
+    IamRole policy = IamRole.DISCOVERER;
+    String email = "email";
+
+    when(iamProvider.retrievePolicies(TEST_USER, IamResourceType.SPEND_PROFILE, ID))
+        .thenReturn(List.of(new SamPolicyModel().name(policy.toString()).addMembersItem(email)));
+    var policyModel =
+        iamService.retrievePolicy(TEST_USER, IamResourceType.SPEND_PROFILE, ID, policy);
+    assertThat(policyModel, is(new PolicyModel().name(policy.toString()).addMembersItem(email)));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -682,11 +682,8 @@ class SamIamTest {
       final UUID id = UUID.randomUUID();
       final String userEmail = "a@a.com";
       IamRole policy = IamRole.OWNER;
-      when(samResourceApi.getPolicyV2(
-              IamResourceType.SPEND_PROFILE.getSamResourceName(), id.toString(), policy.toString()))
-          .thenReturn(new AccessPolicyMembershipV2().memberEmails(List.of()));
       samIam.deletePolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, id, policy, userEmail);
-      verify(samResourceApi, times(1))
+      verify(samResourceApi)
           .removeUserFromPolicyV2(
               IamResourceType.SPEND_PROFILE.getSamResourceName(),
               id.toString(),

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -25,7 +25,6 @@ import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.model.DatasetRequestModelPolicies;
-import bio.terra.model.PolicyModel;
 import bio.terra.model.RepositoryStatusModelSystems;
 import bio.terra.model.SamPolicyModel;
 import bio.terra.model.SnapshotRequestModelPolicies;
@@ -667,22 +666,13 @@ class SamIamTest {
     void testAddPolicy() throws InterruptedException, ApiException {
       final UUID id = UUID.randomUUID();
       final String userEmail = "a@a.com";
-      when(samResourceApi.getPolicyV2(
-              IamResourceType.SPEND_PROFILE.getSamResourceName(),
-              id.toString(),
-              IamRole.OWNER.toString()))
-          .thenReturn(new AccessPolicyMembershipV2().memberEmails(List.of(userEmail)));
-      final PolicyModel policyModel =
-          samIam.addPolicyMember(
-              TEST_USER, IamResourceType.SPEND_PROFILE, id, IamRole.OWNER.toString(), userEmail);
-      assertThat(
-          policyModel,
-          is(new PolicyModel().name(IamRole.OWNER.toString()).addMembersItem(userEmail)));
-      verify(samResourceApi, times(1))
+      IamRole policy = IamRole.OWNER;
+      samIam.addPolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, id, policy, userEmail);
+      verify(samResourceApi)
           .addUserToPolicyV2(
               IamResourceType.SPEND_PROFILE.getSamResourceName(),
               id.toString(),
-              IamRole.OWNER.toString(),
+              policy.toString(),
               userEmail,
               null);
     }
@@ -691,21 +681,16 @@ class SamIamTest {
     void testDeletePolicy() throws InterruptedException, ApiException {
       final UUID id = UUID.randomUUID();
       final String userEmail = "a@a.com";
+      IamRole policy = IamRole.OWNER;
       when(samResourceApi.getPolicyV2(
-              IamResourceType.SPEND_PROFILE.getSamResourceName(),
-              id.toString(),
-              IamRole.OWNER.toString()))
+              IamResourceType.SPEND_PROFILE.getSamResourceName(), id.toString(), policy.toString()))
           .thenReturn(new AccessPolicyMembershipV2().memberEmails(List.of()));
-      final PolicyModel policyModel =
-          samIam.deletePolicyMember(
-              TEST_USER, IamResourceType.SPEND_PROFILE, id, IamRole.OWNER.toString(), userEmail);
-      assertThat(
-          policyModel, is(new PolicyModel().name(IamRole.OWNER.toString()).members(List.of())));
+      samIam.deletePolicyMember(TEST_USER, IamResourceType.SPEND_PROFILE, id, policy, userEmail);
       verify(samResourceApi, times(1))
           .removeUserFromPolicyV2(
               IamResourceType.SPEND_PROFILE.getSamResourceName(),
               id.toString(),
-              IamRole.OWNER.toString(),
+              policy.toString(),
               userEmail);
     }
 

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
@@ -61,7 +61,7 @@ class AdjustStewardMembersStepTest {
                 TEST_USER,
                 IamResourceType.DATASNAPSHOT,
                 snapshot.getId(),
-                IamRole.CUSTODIAN.toString(),
+                IamRole.CUSTODIAN,
                 custodianUser);
       } else {
         verify(iamService)
@@ -69,7 +69,7 @@ class AdjustStewardMembersStepTest {
                 TEST_USER,
                 IamResourceType.DATASNAPSHOT,
                 snapshot.getId(),
-                IamRole.CUSTODIAN.toString(),
+                IamRole.CUSTODIAN,
                 custodianUser);
       }
     }

--- a/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
+++ b/src/test/java/bio/terra/service/profile/ProfileAPIControllerTest.java
@@ -37,6 +37,7 @@ import bio.terra.model.PolicyResponse;
 import bio.terra.model.ProfileOwnedResourceModel;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.PolicyMemberValidator;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
@@ -218,14 +219,14 @@ class ProfileAPIControllerTest {
   @Test
   void testAddProfilePolicyMember() {
     UUID id = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
-    String policyName = "policyName";
+    IamRole policy = IamRole.ADMIN;
     var policyMemberRequest = new PolicyMemberRequest().email("email");
     var policyModel = new PolicyModel();
-    when(profileService.addProfilePolicyMember(id, policyName, policyMemberRequest, TEST_USER))
+    when(profileService.addProfilePolicyMember(id, policy, policyMemberRequest, TEST_USER))
         .thenReturn(policyModel);
 
     ResponseEntity<PolicyResponse> response =
-        apiController.addProfilePolicyMember(id, policyName, policyMemberRequest);
+        apiController.addProfilePolicyMember(id, policy.toString(), policyMemberRequest);
 
     assertTrue(response.getBody().getPolicies().contains(policyModel));
     assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/bio/terra/service/snapshot/flight/duos/AddDuosFirecloudReaderStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/duos/AddDuosFirecloudReaderStepTest.java
@@ -58,7 +58,7 @@ class AddDuosFirecloudReaderStepTest {
             TEST_USER,
             IamResourceType.DATASNAPSHOT,
             SNAPSHOT_ID,
-            IamRole.READER.toString(),
+            IamRole.READER,
             DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail());
 
     StepResult undoResult = step.undoStep(flightContext);
@@ -68,7 +68,7 @@ class AddDuosFirecloudReaderStepTest {
             TEST_USER,
             IamResourceType.DATASNAPSHOT,
             SNAPSHOT_ID,
-            IamRole.READER.toString(),
+            IamRole.READER,
             DUOS_FIRECLOUD_GROUP.getFirecloudGroupEmail());
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/duos/RemoveDuosFirecloudReaderStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/duos/RemoveDuosFirecloudReaderStepTest.java
@@ -55,7 +55,7 @@ class RemoveDuosFirecloudReaderStepTest {
             TEST_USER,
             IamResourceType.DATASNAPSHOT,
             SNAPSHOT_ID,
-            IamRole.READER.toString(),
+            IamRole.READER,
             DUOS_FIRECLOUD_GROUP_PREV.getFirecloudGroupEmail());
     verifyNoInteractions(flightContext);
 
@@ -66,7 +66,7 @@ class RemoveDuosFirecloudReaderStepTest {
             TEST_USER,
             IamResourceType.DATASNAPSHOT,
             SNAPSHOT_ID,
-            IamRole.READER.toString(),
+            IamRole.READER,
             DUOS_FIRECLOUD_GROUP_PREV.getFirecloudGroupEmail());
     verifyNoInteractions(flightContext);
   }


### PR DESCRIPTION
- split out `get` policy operation from `add` and `revoke` policy member operations
- make `policy` type safe in outer layers of APIs

This change is internal to TDR only and doesn't change the external API response types or behavior.