### PR TITLE
Add capability to connect to prod db

### DIFF
--- a/ops/db-connect.sh
+++ b/ops/db-connect.sh
@@ -85,6 +85,11 @@ set_vars_from_env() {
       NAMESPACE="terra-staging"
       SECRET="sql-db"
       ;;
+    prod)
+      PROJECT="terra-datarepo-production"
+      NAMESPACE="terra-prod"
+      SECRET="sql-db"
+      ;;
     *)
       error "Unknown environment: $ENV"
       ;;
@@ -127,6 +132,8 @@ connect_cloud_sql_db() {
   if [ -z "$PASSWORD" ]; then
     error "Could not retrieve password for project '$PROJECT' with secret path '$SECRET'"
   fi
+
+  sleep 2
 
   psql "postgresql://$USERNAME:$PASSWORD@localhost:$PORT/$DATABASE"
 }


### PR DESCRIPTION
## Addresses

Inability to connect to prod with the `db-connect.sh` script

## Summary of changes

Adds the ability to connect to prod, following our discussion here: https://broadinstitute.slack.com/archives/C06KX8KPW2Z/p1742329064879979