### PR TITLE
DT-1423: Add inherited stewards to snapshot policy response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     dependencies {
         classpath('io.swagger.codegen.v3:swagger-codegen:3.0.68')
         // Required for gradle liquibase plugin
-        classpath ('org.liquibase:liquibase-core:4.30.0')
+        classpath ('org.liquibase:liquibase-core:4.31.1')
     }
 }
 
@@ -260,7 +260,10 @@ dependencies {
 
     antlr 'org.antlr:antlr4:4.13.2'
 
-    liquibaseRuntime 'org.liquibase:liquibase-core'
+    // NOTE: The version here must match the version required by the liquibase gradle plugin. If
+    // the version is omitted, the version provided by spring will be used, which may be different
+    // from the plugin version, and the plugin commands won't work.
+    liquibaseRuntime 'org.liquibase:liquibase-core:4.31.1'
     liquibaseRuntime 'org.postgresql:postgresql'
     liquibaseRuntime 'info.picocli:picocli:4.7.6'
 

--- a/scripts/run-db
+++ b/scripts/run-db
@@ -3,8 +3,8 @@
 
 usage() {
   cat <<-'EOF'
-usage: run-db [--clean-db] [-h|--help] COMMAND
-[--clean-db]       clean the database (only with `stop` or `start`)
+usage: run-db [-c|--clean-db] [-h|--help] COMMAND
+[-c|--clean-db]       clean the database (only with `stop` or `start`)
 [-h|--help]        print this help text
 COMMAND is one of:
 - start            start a local database server

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -1383,12 +1383,8 @@ public class SnapshotService {
     return new TableModel()
         .name(table.getName())
         .rowCount(rowCount != null ? rowCount.intValue() : null)
-        .primaryKey(
-            table.getPrimaryKey().stream().map(Column::getName).toList())
-        .columns(
-            table.getColumns().stream()
-                .map(this::makeColumnModelFromColumn)
-                .toList());
+        .primaryKey(table.getPrimaryKey().stream().map(Column::getName).toList())
+        .columns(table.getColumns().stream().map(this::makeColumnModelFromColumn).toList());
   }
 
   private ColumnModel makeColumnModelFromColumn(Column column) {

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -830,14 +830,13 @@ public class SnapshotService {
 
     Dataset sourceDataset = snapshotDao.retrieveSnapshot(snapshotId).getSourceDataset();
     if (sourceDataset.isInheritSteward()) {
-      var custodians =
-          iamService
-              .retrievePolicies(userReq, IamResourceType.DATASET, sourceDataset.getId())
-              .stream()
-              .filter(p -> p.getName().equals(IamRole.CUSTODIAN.toString()))
-              .map(SamPolicyModel::getMembers)
-              .findFirst();
-      custodians.ifPresent(policyResponse::setInheritedStewards);
+      iamService
+          .retrievePolicies(userReq, IamResourceType.DATASET, sourceDataset.getId())
+          .stream()
+          .filter(p -> p.getName().equals(IamRole.CUSTODIAN.toString()))
+          .map(SamPolicyModel::getMembers)
+          .findFirst()
+          .ifPresent(policyResponse::setInheritedStewards);
     }
 
     return policyResponse;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -830,9 +830,7 @@ public class SnapshotService {
 
     Dataset sourceDataset = snapshotDao.retrieveSnapshot(snapshotId).getSourceDataset();
     if (sourceDataset.isInheritSteward()) {
-      iamService
-          .retrievePolicies(userReq, IamResourceType.DATASET, sourceDataset.getId())
-          .stream()
+      iamService.retrievePolicies(userReq, IamResourceType.DATASET, sourceDataset.getId()).stream()
           .filter(p -> p.getName().equals(IamRole.CUSTODIAN.toString()))
           .map(SamPolicyModel::getMembers)
           .findFirst()

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -14,6 +14,7 @@ import bio.terra.common.Table;
 import bio.terra.common.ValidationUtils;
 import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.common.exception.ForbiddenException;
+import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.externalcreds.model.RASv1Dot1VisaCriterion;
 import bio.terra.externalcreds.model.ValidatePassportRequest;
@@ -830,11 +831,18 @@ public class SnapshotService {
 
     Dataset sourceDataset = snapshotDao.retrieveSnapshot(snapshotId).getSourceDataset();
     if (sourceDataset.isInheritSteward()) {
-      iamService.retrievePolicies(userReq, IamResourceType.DATASET, sourceDataset.getId()).stream()
-          .filter(p -> p.getName().equals(IamRole.CUSTODIAN.toString()))
-          .map(SamPolicyModel::getMembers)
-          .findFirst()
-          .ifPresent(policyResponse::setInheritedStewards);
+      try {
+        iamService
+            .retrievePolicies(userReq, IamResourceType.DATASET, sourceDataset.getId())
+            .stream()
+            .filter(p -> p.getName().equals(IamRole.CUSTODIAN.toString()))
+            .map(SamPolicyModel::getMembers)
+            .findFirst()
+            .ifPresent(policyResponse::setInheritedStewards);
+      } catch (NotFoundException e) {
+        // This will occur when the user has permission to view the snapshot but can't view policies
+        // for the snapshot's source dataset.
+      }
     }
 
     return policyResponse;
@@ -1376,11 +1384,11 @@ public class SnapshotService {
         .name(table.getName())
         .rowCount(rowCount != null ? rowCount.intValue() : null)
         .primaryKey(
-            table.getPrimaryKey().stream().map(Column::getName).collect(Collectors.toList()))
+            table.getPrimaryKey().stream().map(Column::getName).toList())
         .columns(
             table.getColumns().stream()
                 .map(this::makeColumnModelFromColumn)
-                .collect(Collectors.toList()));
+                .toList());
   }
 
   private ColumnModel makeColumnModelFromColumn(Column column) {
@@ -1395,7 +1403,7 @@ public class SnapshotService {
     return Arrays.stream(
             StringUtils.split(SnapshotsApiController.RETRIEVE_INCLUDE_DEFAULT_VALUE, ','))
         .map(SnapshotRetrieveIncludeModel::fromValue)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   public List<UUID> enumerateSnapshotIdsForDataset(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -820,11 +820,27 @@ public class SnapshotService {
               inaccessibleWorkspaces.addAll(wpms.inaccessible());
             });
 
-    return new PolicyResponse()
-        .policies(PolicyUtils.samToTdrPolicyModels(samPolicyModels))
-        .authDomain(authDomain)
-        .workspaces(accessibleWorkspaces)
-        .inaccessibleWorkspaces(inaccessibleWorkspaces);
+    PolicyResponse policyResponse =
+        new PolicyResponse()
+            .policies(PolicyUtils.samToTdrPolicyModels(samPolicyModels))
+            .authDomain(authDomain)
+            .workspaces(accessibleWorkspaces)
+            .inaccessibleWorkspaces(inaccessibleWorkspaces)
+            .inheritedStewards(List.of());
+
+    Dataset sourceDataset = snapshotDao.retrieveSnapshot(snapshotId).getSourceDataset();
+    if (sourceDataset.isInheritSteward()) {
+      var custodians =
+          iamService
+              .retrievePolicies(userReq, IamResourceType.DATASET, sourceDataset.getId())
+              .stream()
+              .filter(p -> p.getName().equals(IamRole.CUSTODIAN.toString()))
+              .map(SamPolicyModel::getMembers)
+              .findFirst();
+      custodians.ifPresent(policyResponse::setInheritedStewards);
+    }
+
+    return policyResponse;
   }
 
   /**

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7261,7 +7261,9 @@ components:
           items:
             $ref: '#/components/schemas/InaccessibleWorkspacePolicyModel'
         inheritedStewards:
-            description: For a snapshot, the inherited stewards from the source dataset.
+            description: >
+              For a snapshot, the inherited stewards from the source dataset, if the requesting
+              user has permission to view the dataset.
             type: array
             items:
                 description: The steward's email address

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -7239,6 +7239,8 @@ components:
             description: The Sam user groups that define this auth domain
             type: string
     PolicyResponse:
+      description: >
+        Policy information about this snapshot, dataset or profile
       type: object
       properties:
         policies:
@@ -7258,8 +7260,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/InaccessibleWorkspacePolicyModel'
-      description: >
-        email of user or group to add to policy
+        inheritedStewards:
+            description: For a snapshot, the inherited stewards from the source dataset.
+            type: array
+            items:
+                description: The steward's email address
+                type: string
     DataDeletionRequest:
       required:
         - deleteType

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -33,6 +33,7 @@ import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.SqlSortDirection;
 import bio.terra.common.category.Unit;
 import bio.terra.common.exception.ForbiddenException;
+import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.fixtures.DuosFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.externalcreds.model.ValidatePassportResult;
@@ -868,6 +869,29 @@ class SnapshotServiceTest {
         response.getInaccessibleWorkspaces(),
         is(inaccessible));
     assertThat(response.getInheritedStewards(), contains(custodianUser));
+  }
+
+  @Test
+  void retrieveSnapshotPoliciesCantReadSource() {
+    when(iamService.retrievePolicies(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
+        .thenReturn(List.of());
+    var dataset = mockSnapshot().getSourceDataset();
+    dataset.getDatasetSummary().inheritSteward(true);
+    when(iamService.retrievePolicies(TEST_USER, IamResourceType.DATASET, dataset.getId()))
+        .thenThrow(new NotFoundException(""));
+    var response = service.retrieveSnapshotPolicies(snapshotId, TEST_USER);
+    assertThat(response.getInheritedStewards(), empty());
+  }
+
+  @Test
+  void retrieveSnapshotPoliciesNoInheritSteward() {
+    when(iamService.retrievePolicies(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
+        .thenReturn(List.of());
+    var dataset = mockSnapshot().getSourceDataset();
+    var response = service.retrieveSnapshotPolicies(snapshotId, TEST_USER);
+    assertThat(response.getInheritedStewards(), empty());
+    verify(iamService, never())
+        .retrievePolicies(TEST_USER, IamResourceType.DATASET, dataset.getId());
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -358,53 +358,54 @@ class SnapshotServiceTest {
                 .dataProject(SNAPSHOT_DATA_PROJECT)));
   }
 
-  private void mockSnapshot() {
-    when(snapshotDao.retrieveSnapshot(snapshotId))
-        .thenReturn(
-            new Snapshot()
-                .id(snapshotId)
-                .name(SNAPSHOT_NAME)
-                .description(SNAPSHOT_DESCRIPTION)
-                .createdDate(createdDate)
-                .profileId(profileId)
-                .projectResource(
-                    new GoogleProjectResource()
-                        .profileId(profileId)
-                        .googleProjectId(SNAPSHOT_DATA_PROJECT))
-                .snapshotSources(
-                    List.of(
-                        new SnapshotSource()
-                            .dataset(
-                                new Dataset(
-                                    new DatasetSummary()
-                                        .id(datasetId)
-                                        .name(DATASET_NAME)
-                                        .projectResourceId(profileId)
-                                        .createdDate(createdDate)
-                                        .storage(
-                                            List.of(
-                                                new GoogleStorageResource(
-                                                    datasetId,
-                                                    GoogleCloudResource.BUCKET,
-                                                    GoogleRegion.DEFAULT_GOOGLE_REGION)))))))
-                .snapshotTables(
-                    List.of(
-                        new SnapshotTable()
-                            .name(SNAPSHOT_TABLE_NAME)
-                            .id(snapshotTableId)
-                            .columns(
-                                List.of(
-                                    new Column()
-                                        .name(SNAPSHOT_COLUMN_NAME)
-                                        .type(TableDataType.STRING)
-                                        .arrayOf(true)
-                                        .required(true)))))
-                .creationInformation(
-                    new SnapshotRequestContentsModel()
-                        .mode(SnapshotRequestContentsModel.ModeEnum.BYFULLVIEW)
-                        .datasetName(DATASET_NAME))
-                .duosFirecloudGroupId(duosFirecloudGroup.getId())
-                .duosFirecloudGroup(duosFirecloudGroup));
+  private Snapshot mockSnapshot() {
+    Snapshot snapshot =
+        new Snapshot()
+            .id(snapshotId)
+            .name(SNAPSHOT_NAME)
+            .description(SNAPSHOT_DESCRIPTION)
+            .createdDate(createdDate)
+            .profileId(profileId)
+            .projectResource(
+                new GoogleProjectResource()
+                    .profileId(profileId)
+                    .googleProjectId(SNAPSHOT_DATA_PROJECT))
+            .snapshotSources(
+                List.of(
+                    new SnapshotSource()
+                        .dataset(
+                            new Dataset(
+                                new DatasetSummary()
+                                    .id(datasetId)
+                                    .name(DATASET_NAME)
+                                    .projectResourceId(profileId)
+                                    .createdDate(createdDate)
+                                    .storage(
+                                        List.of(
+                                            new GoogleStorageResource(
+                                                datasetId,
+                                                GoogleCloudResource.BUCKET,
+                                                GoogleRegion.DEFAULT_GOOGLE_REGION)))))))
+            .snapshotTables(
+                List.of(
+                    new SnapshotTable()
+                        .name(SNAPSHOT_TABLE_NAME)
+                        .id(snapshotTableId)
+                        .columns(
+                            List.of(
+                                new Column()
+                                    .name(SNAPSHOT_COLUMN_NAME)
+                                    .type(TableDataType.STRING)
+                                    .arrayOf(true)
+                                    .required(true)))))
+            .creationInformation(
+                new SnapshotRequestContentsModel()
+                    .mode(SnapshotRequestContentsModel.ModeEnum.BYFULLVIEW)
+                    .datasetName(DATASET_NAME))
+            .duosFirecloudGroupId(duosFirecloudGroup.getId())
+            .duosFirecloudGroup(duosFirecloudGroup);
+    when(snapshotDao.retrieveSnapshot(snapshotId)).thenReturn(snapshot);
+    return snapshot;
   }
 
   private SnapshotModel expectedMockSnapshotModelBase() {
@@ -823,16 +824,13 @@ class SnapshotServiceTest {
     when(iamService.retrievePolicies(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
         .thenReturn(List.of(spm1, spm2));
 
-    List<WorkspacePolicyModel> accessible =
+    var accessible =
+        List.of(new WorkspacePolicyModel(), new WorkspacePolicyModel(), new WorkspacePolicyModel());
+    var inaccessible =
         List.of(
-            mock(WorkspacePolicyModel.class),
-            mock(WorkspacePolicyModel.class),
-            mock(WorkspacePolicyModel.class));
-    List<InaccessibleWorkspacePolicyModel> inaccessible =
-        List.of(
-            mock(InaccessibleWorkspacePolicyModel.class),
-            mock(InaccessibleWorkspacePolicyModel.class),
-            mock(InaccessibleWorkspacePolicyModel.class));
+            new InaccessibleWorkspacePolicyModel(),
+            new InaccessibleWorkspacePolicyModel(),
+            new InaccessibleWorkspacePolicyModel());
     List<String> userGroups = List.of("userGroup1", "userGroup2");
 
     when(iamService.retrieveAuthDomains(TEST_USER, IamResourceType.DATASNAPSHOT, snapshotId))
@@ -845,6 +843,15 @@ class SnapshotServiceTest {
         .thenReturn(
             new RawlsService.WorkspacePolicyModels(
                 accessible.subList(1, 3), inaccessible.subList(2, 3)));
+    var dataset = mockSnapshot().getSourceDataset();
+    dataset.getDatasetSummary().inheritSteward(true);
+    String custodianUser = "custodian";
+    when(iamService.retrievePolicies(TEST_USER, IamResourceType.DATASET, dataset.getId()))
+        .thenReturn(
+            List.of(
+                new SamPolicyModel()
+                    .name(IamRole.CUSTODIAN.toString())
+                    .addMembersItem(custodianUser)));
 
     PolicyResponse response = service.retrieveSnapshotPolicies(snapshotId, TEST_USER);
 
@@ -860,6 +867,7 @@ class SnapshotServiceTest {
         "All inaccessible workspaces from SAM policy models are returned",
         response.getInaccessibleWorkspaces(),
         is(inaccessible));
+    assertThat(response.getInheritedStewards(), contains(custodianUser));
   }
 
   @Test


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1423

## Addresses

Add the inherited stewards for a snapshot to the policy response so the UI can show this information.

## Summary of changes

In the case where a dataset has `inheritSteward` enabled, the custodians on the dataset are "added" (virtually via the Sam permissions model) as stewards on all of the dataset's snapshots. These users aren't returned as part of the snapshot steward list, so we need a way to return that information so it can be shown in the UI.

## Testing Strategy

- unit tests
- tested manually locally by creating a snapshot with `inheritSteward` enabled and then sharing the dataset with a different user