### PR TITLE
DT-1446: Update AdjustStewardMembersStep from SetInheritStewardFlight to remove policy members from snapshot when enabling flag

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
@@ -37,7 +37,7 @@ public record AdjustStewardMembersStep(
         Objects.requireNonNull(
             inputParams.get(JobMapKeys.CUSTODIAN_USERS.getKeyName(), List.class));
     AddRemoveApi api =
-        inheritSteward ? iamService::addPolicyMember : iamService::deletePolicyMember;
+        inheritSteward ? iamService::deletePolicyMember : iamService::addPolicyMember;
     for (var snapshotId : snapshotIds) {
       for (var email : custodians) {
         api.addRemoveMember(

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
@@ -57,7 +57,7 @@ class AdjustStewardMembersStepTest {
     for (var snapshot : snapshots) {
       if (inheritSteward) {
         verify(iamService)
-            .addPolicyMember(
+            .deletePolicyMember(
                 TEST_USER,
                 IamResourceType.DATASNAPSHOT,
                 snapshot.getId(),
@@ -65,7 +65,7 @@ class AdjustStewardMembersStepTest {
                 custodianUser);
       } else {
         verify(iamService)
-            .deletePolicyMember(
+            .addPolicyMember(
                 TEST_USER,
                 IamResourceType.DATASNAPSHOT,
                 snapshot.getId(),


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1446

## Addresses
When we are enabling inherit steward, we want to remove steward policy members from the snapshot because they will already be granted access via the Data Custodian role on the Dataset. 
The original logic was swapped. 

## Summary of changes
- swap when we add vs remove users from child snapshot steward policy

## Testing Strategy
- unit test
- manual test (outlined in [doc](https://docs.google.com/document/d/1neOiewYji2MqXpOEav_g-UosCZo7xmqUrV2oK_SgrrQ/edit?tab=t.0#heading=h.ahqbokn666s3))
