### PR TITLE
[DT-1223]Create setPublic TDR endpoint that hits Sam’s setPublic endpoint

### DIFF
--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -386,6 +386,19 @@ public class SnapshotsApiController implements SnapshotsApi {
   }
 
   @Override
+  public ResponseEntity<JobModel> setSnapshotPublic(UUID id, Boolean setPublic) {
+    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
+    boolean isPublic =
+        iamService.getPolicyPublicV2(
+            userReq.getToken(), IamResourceType.DATASNAPSHOT, id, IamRole.READER.name());
+    if (isPublic == setPublic) {
+      return ResponseEntity.noContent().build();
+    }
+    String jobId = snapshotService.setSnapshotPublic(id, setPublic, getAuthenticatedInfo());
+    return jobToResponse(jobService.retrieveJob(jobId, userReq));
+  }
+
+  @Override
   public ResponseEntity<SnapshotLinkDuosDatasetResponse> linkDuosDatasetToSnapshot(
       UUID id, String duosId) {
     AuthenticatedUserRequest userReq = getAuthenticatedInfo();

--- a/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
+++ b/src/main/java/bio/terra/app/controller/SnapshotsApiController.java
@@ -394,7 +394,7 @@ public class SnapshotsApiController implements SnapshotsApi {
     if (isPublic == setPublic) {
       return ResponseEntity.noContent().build();
     }
-    String jobId = snapshotService.setSnapshotPublic(id, setPublic, getAuthenticatedInfo());
+    String jobId = snapshotService.setSnapshotPublic(id, setPublic, userReq);
     return jobToResponse(jobService.retrieveJob(jobId, userReq));
   }
 

--- a/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamProviderInterface.java
@@ -425,4 +425,36 @@ public interface IamProviderInterface {
   List<FullyQualifiedResourceId> listResourceChildren(
       String accessToken, IamResourceType parentIamResourceType, UUID parentId)
       throws InterruptedException;
+
+  /**
+   * Get the policy public status for a specified resource.
+   *
+   * @param accessToken String requesting user's access token
+   * @param iamResourceType The IamResourceType of the resource
+   * @param resourceId The UUID of the resource
+   * @param policyName The name of the policy to check the public status of
+   * @return true if the policy is public, false otherwise
+   * @throws InterruptedException
+   */
+  boolean getPolicyPublicV2(
+      String accessToken, IamResourceType iamResourceType, UUID resourceId, String policyName)
+      throws InterruptedException;
+
+  /**
+   * Set the specified policy to public or private for the specified resource.
+   *
+   * @param accessToken String requesting user's access token
+   * @param iamResourceType The IamResourceType of the resource
+   * @param resourceId The UUID of the resource
+   * @param policyName The name of the policy to set the public status for
+   * @param setPublic true to set the policy public, false to set it private
+   * @throws InterruptedException
+   */
+  void setPolicyPublicV2(
+      String accessToken,
+      IamResourceType iamResourceType,
+      UUID resourceId,
+      String policyName,
+      boolean setPublic)
+      throws InterruptedException;
 }

--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -620,4 +620,22 @@ public class IamService {
     return callProvider(
         () -> iamProvider.listResourceChildren(accessToken, parentIamResourceType, parentId));
   }
+
+  public boolean getPolicyPublicV2(
+      String token, IamResourceType iamResourceType, UUID resourceId, String policyName) {
+    return callProvider(
+        () -> iamProvider.getPolicyPublicV2(token, iamResourceType, resourceId, policyName));
+  }
+
+  public void setPolicyPublicV2(
+      String token,
+      IamResourceType iamResourceType,
+      UUID resourceId,
+      String policyName,
+      boolean setPublic) {
+    callProvider(
+        () ->
+            iamProvider.setPolicyPublicV2(
+                token, iamResourceType, resourceId, policyName, setPublic));
+  }
 }

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -1018,6 +1018,7 @@ public class SamIam implements IamProviderInterface {
       boolean setPublic)
       throws ApiException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(accessToken);
+    // for this endpoint, Sam requires the policy name to be lower case
     samResourceApi.setPolicyPublicV2(
         resourceType.getSamResourceName(),
         resourceId.toString(),

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -1019,7 +1019,10 @@ public class SamIam implements IamProviderInterface {
       throws ApiException {
     ResourcesApi samResourceApi = samApiService.resourcesApi(accessToken);
     samResourceApi.setPolicyPublicV2(
-        resourceType.getSamResourceName(), resourceId.toString(), policyName, setPublic);
+        resourceType.getSamResourceName(),
+        resourceId.toString(),
+        policyName.toLowerCase(),
+        setPublic);
   }
 
   /**

--- a/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
+++ b/src/main/java/bio/terra/service/auth/iam/sam/SamIam.java
@@ -978,6 +978,50 @@ public class SamIam implements IamProviderInterface {
         parentIamResourceType.toString(), parentId.toString());
   }
 
+  @Override
+  public boolean getPolicyPublicV2(
+      String accessToken, IamResourceType iamResourceType, UUID resourceId, String policyName)
+      throws InterruptedException {
+    return SamRetry.retry(
+        configurationService,
+        () -> getPolicyPublicV2Inner(accessToken, iamResourceType, resourceId, policyName));
+  }
+
+  private boolean getPolicyPublicV2Inner(
+      String accessToken, IamResourceType resourceType, UUID resourceId, String policyName)
+      throws ApiException {
+    ResourcesApi samResourceApi = samApiService.resourcesApi(accessToken);
+    return samResourceApi.getPolicyPublicV2(
+        resourceType.getSamResourceName(), resourceId.toString(), policyName);
+  }
+
+  @Override
+  public void setPolicyPublicV2(
+      String accessToken,
+      IamResourceType iamResourceType,
+      UUID resourceId,
+      String policyName,
+      boolean setPublic)
+      throws InterruptedException {
+    SamRetry.retry(
+        configurationService,
+        () ->
+            setPolicyPublicV2Inner(
+                accessToken, iamResourceType, resourceId, policyName, setPublic));
+  }
+
+  private void setPolicyPublicV2Inner(
+      String accessToken,
+      IamResourceType resourceType,
+      UUID resourceId,
+      String policyName,
+      boolean setPublic)
+      throws ApiException {
+    ResourcesApi samResourceApi = samApiService.resourcesApi(accessToken);
+    samResourceApi.setPolicyPublicV2(
+        resourceType.getSamResourceName(), resourceId.toString(), policyName, setPublic);
+  }
+
   /**
    * Syncing a policy with SAM results in a Google group being created that is tied to that policy.
    * The response is an object with one key that is the policy group email and a value that is a

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -26,7 +26,8 @@ public enum JobMapKeys {
   BUCKET_NAME("bucketName"),
   CUSTODIAN_EMAIL("custodianEmail"),
   CUSTODIAN_USERS("custodianUsers"),
-  INHERIT_STEWARD("inheritSteward");
+  INHERIT_STEWARD("inheritSteward"),
+  SET_PUBLIC("setPublic");
 
   private final String keyName;
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -93,6 +93,7 @@ import bio.terra.service.snapshot.flight.duos.SnapshotUpdateDuosDatasetFlight;
 import bio.terra.service.snapshot.flight.export.ExportMapKeys;
 import bio.terra.service.snapshot.flight.export.SnapshotExportFlight;
 import bio.terra.service.snapshot.flight.lock.SnapshotLockFlight;
+import bio.terra.service.snapshot.flight.setpublic.SnapshotSetPublicFlight;
 import bio.terra.service.snapshot.flight.unlock.SnapshotUnlockFlight;
 import bio.terra.service.snapshotbuilder.SnapshotAccessRequestModel;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderSettingsDao;
@@ -965,9 +966,15 @@ public class SnapshotService {
     }
   }
 
-  public String setSnapshotPublic(
-      UUID id, boolean setPublic, AuthenticatedUserRequest authenticatedInfo) {
-    return "";
+  public String setSnapshotPublic(UUID id, boolean setPublic, AuthenticatedUserRequest userReq) {
+    String description =
+        String.format(
+            "Set reader policy for snapshot %s to %s", id, setPublic ? "public" : "private");
+    return jobService
+        .newJob(description, SnapshotSetPublicFlight.class, null, userReq)
+        .addParameter(JobMapKeys.SNAPSHOT_ID.getKeyName(), id)
+        .addParameter(JobMapKeys.SET_PUBLIC.getKeyName(), setPublic)
+        .submit();
   }
 
   public SnapshotPreviewModel retrievePreview(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -965,6 +965,11 @@ public class SnapshotService {
     }
   }
 
+  public String setSnapshotPublic(
+      UUID id, boolean setPublic, AuthenticatedUserRequest authenticatedInfo) {
+    return "";
+  }
+
   public SnapshotPreviewModel retrievePreview(
       AuthenticatedUserRequest userRequest,
       UUID snapshotId,

--- a/src/main/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStep.java
@@ -1,6 +1,5 @@
 package bio.terra.service.snapshot.flight.setpublic;
 
-import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
@@ -35,12 +34,6 @@ public class SetSnapshotPublicStep implements Step {
           IamRole.READER.name(),
           publicVal);
       return StepResult.getStepResultSuccess();
-    } catch (ForbiddenException e) {
-      return new StepResult(
-          StepStatus.STEP_RESULT_FAILURE_FATAL,
-          new ForbiddenException(
-              "User is not authorized to set this resource as public, contact Terra support for assistance.",
-              e));
     } catch (Exception e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStep.java
@@ -1,0 +1,58 @@
+package bio.terra.service.snapshot.flight.setpublic;
+
+import bio.terra.common.exception.ForbiddenException;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.Step;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import bio.terra.stairway.exception.RetryException;
+import java.util.UUID;
+
+public class SetSnapshotPublicStep implements Step {
+  private final UUID snapshotId;
+  private final boolean setPublic;
+  private final AuthenticatedUserRequest userReq;
+  private final IamService iamService;
+
+  public SetSnapshotPublicStep(
+      UUID snapshotId, boolean setPublic, AuthenticatedUserRequest userReq, IamService iamService) {
+    this.snapshotId = snapshotId;
+    this.setPublic = setPublic;
+    this.userReq = userReq;
+    this.iamService = iamService;
+  }
+
+  private StepResult setPublic(boolean publicVal) {
+    try {
+      iamService.setPolicyPublicV2(
+          userReq.getToken(),
+          IamResourceType.DATASNAPSHOT,
+          snapshotId,
+          IamRole.READER.name(),
+          publicVal);
+      return StepResult.getStepResultSuccess();
+    } catch (ForbiddenException e) {
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new ForbiddenException(
+              "User is not authorized to set this resource as public, contact Terra support for assistance.",
+              e));
+    } catch (Exception e) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
+    }
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) throws InterruptedException, RetryException {
+    return setPublic(setPublic);
+  }
+
+  @Override
+  public StepResult undoStep(FlightContext context) throws InterruptedException {
+    return setPublic(!setPublic);
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStep.java
@@ -1,5 +1,7 @@
 package bio.terra.service.snapshot.flight.setpublic;
 
+import bio.terra.common.exception.ForbiddenException;
+import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
@@ -34,6 +36,12 @@ public class SetSnapshotPublicStep implements Step {
           IamRole.READER.name(),
           publicVal);
       return StepResult.getStepResultSuccess();
+    } catch (ForbiddenException | NotFoundException e) {
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new ForbiddenException(
+              "User is not authorized to set this resource as public, contact Terra support for assistance.",
+              e));
     } catch (Exception e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
     }

--- a/src/main/java/bio/terra/service/snapshot/flight/setpublic/SnapshotSetPublicFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/setpublic/SnapshotSetPublicFlight.java
@@ -1,0 +1,25 @@
+package bio.terra.service.snapshot.flight.setpublic;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import java.util.UUID;
+import org.springframework.context.ApplicationContext;
+
+public class SnapshotSetPublicFlight extends Flight {
+  public SnapshotSetPublicFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+    IamService iamService = appContext.getBean(IamService.class);
+
+    UUID snapshotId =
+        UUID.fromString(inputParameters.get(JobMapKeys.SNAPSHOT_ID.getKeyName(), String.class));
+    AuthenticatedUserRequest userReq =
+        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+    boolean setPublic = inputParameters.get(JobMapKeys.SET_PUBLIC.getKeyName(), Boolean.class);
+
+    addStep(new SetSnapshotPublicStep(snapshotId, setPublic, userReq, iamService));
+  }
+}

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1632,17 +1632,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Id'
       responses:
-        200:
-          description: Redirect for set public result
-          headers:
-            location:
-              description: url for the job result
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JobModel'
         202:
           description: Job status of snapshot set public job & url for polling in the response
             header
@@ -1665,14 +1654,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
-        403:
-          description: User is not authorized to set this resource as public, contact Terra support for assistance.
+        404:
+          description: Not found - snapshot id does not exist
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
-        404:
-          description: Not found - snapshot id does not exist
+        500:
+          description: An unexpected error occurred - snapshot was not updated.
           content:
             application/json:
               schema:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -1612,6 +1612,71 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+  /api/repository/v1/snapshots/{id}/public:
+    put:
+      tags:
+          - snapshots
+          - repository
+      description: >
+        Sets the reader policy on the snapshot public for the specified snapshot if request body
+        is true. Makes the reader policy on the snapshot private if the request body is false.
+      operationId: setSnapshotPublic
+      requestBody:
+        description: A boolean value indicating whether the reader policy on the snapshot is
+          being set public.
+        content:
+          application/json:
+            schema:
+              type: boolean
+        required: true
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: Redirect for set public result
+          headers:
+            location:
+              description: url for the job result
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobModel'
+        202:
+          description: Job status of snapshot set public job & url for polling in the response
+            header
+          headers:
+            location:
+              description: url for the job polling
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobModel'
+        204:
+          description: >
+            Nothing was changed. The public value was already set to the requested value.
+          content: { }
+        400:
+          description: Bad request - invalid id, badly formed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: User is not authorized to set this resource as public, contact Terra support for assistance.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: Not found - snapshot id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
   /api/repository/v1/snapshots/{id}/linkDuosDataset/{duosId}:
     put:
       tags:

--- a/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
@@ -46,6 +46,7 @@ import bio.terra.model.SqlSortDirectionAscDefault;
 import bio.terra.model.UnlockResourceRequest;
 import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
 import bio.terra.service.dataset.AssetModelValidator;
@@ -67,6 +68,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -123,6 +125,7 @@ class SnapshotsApiControllerTest {
   private static final String UNLOCK_SNAPSHOT_ENDPOINT = SNAPSHOT_ID_ENDPOINT + "/unlock";
   private static final String QUERY_SNAPSHOT_DATA_ENDPOINT = SNAPSHOT_ID_ENDPOINT + "/data/{table}";
   private static final String EXPORT_SNAPSHOT_ENDPOINT = SNAPSHOT_ID_ENDPOINT + "/export";
+  private static final String SET_SNAPSHOT_PUBLIC_ENDPOINT = SNAPSHOT_ID_ENDPOINT + "/public";
   private static final String SNAPSHOT_BUILDER_SETTINGS_ENDPOINT =
       SNAPSHOT_ID_ENDPOINT + "/snapshotBuilder/settings";
 
@@ -463,6 +466,62 @@ class SnapshotsApiControllerTest {
     mvc.perform(delete(SNAPSHOT_ID_ENDPOINT, SNAPSHOT_ID)).andExpect(status().isForbidden());
 
     verifyAuthorizationCall(IamAction.DELETE);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void setSnapshotPublic(boolean setPublic) throws Exception {
+    when(iamService.getPolicyPublicV2(
+            TEST_USER.getToken(), IamResourceType.DATASNAPSHOT, SNAPSHOT_ID, IamRole.READER.name()))
+        .thenReturn(!setPublic);
+    when(snapshotService.setSnapshotPublic(SNAPSHOT_ID, setPublic, TEST_USER)).thenReturn(JOB_ID);
+    when(jobService.retrieveJob(JOB_ID, TEST_USER)).thenReturn(JOB_MODEL);
+
+    String json =
+        mvc.perform(
+                put(SET_SNAPSHOT_PUBLIC_ENDPOINT, SNAPSHOT_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(TestUtils.mapToJson(setPublic)))
+            .andExpect(status().is(202))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    JobModel model = TestUtils.mapFromJson(json, JobModel.class);
+    assertThat("Job ID is returned", model, equalTo(JOB_MODEL));
+  }
+
+  @Test
+  void setSnapshotPublicInvalidId() throws Exception {
+    mvc.perform(
+            put(SET_SNAPSHOT_PUBLIC_ENDPOINT, "not a UUID")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(true)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void setSnapshotPublicNotFound() throws Exception {
+    when(iamService.getPolicyPublicV2(
+            TEST_USER.getToken(), IamResourceType.DATASNAPSHOT, SNAPSHOT_ID, IamRole.READER.name()))
+        .thenThrow(new NotFoundException("Resource not found"));
+    mvc.perform(
+            put(SET_SNAPSHOT_PUBLIC_ENDPOINT, SNAPSHOT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(true)))
+        .andExpect(status().isNotFound());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void setSnapshotPublicAlreadySet(boolean setPublic) throws Exception {
+    when(iamService.getPolicyPublicV2(
+            TEST_USER.getToken(), IamResourceType.DATASNAPSHOT, SNAPSHOT_ID, IamRole.READER.name()))
+        .thenReturn(setPublic);
+    mvc.perform(
+            put(SET_SNAPSHOT_PUBLIC_ENDPOINT, SNAPSHOT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(setPublic)))
+        .andExpect(status().isNoContent());
   }
 
   @Test

--- a/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
@@ -471,6 +471,7 @@ class SnapshotsApiControllerTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void setSnapshotPublic(boolean setPublic) throws Exception {
+    mockValidators();
     when(iamService.getPolicyPublicV2(
             TEST_USER.getToken(), IamResourceType.DATASNAPSHOT, SNAPSHOT_ID, IamRole.READER.name()))
         .thenReturn(!setPublic);
@@ -492,6 +493,7 @@ class SnapshotsApiControllerTest {
 
   @Test
   void setSnapshotPublicInvalidId() throws Exception {
+    mockValidators();
     mvc.perform(
             put(SET_SNAPSHOT_PUBLIC_ENDPOINT, "not a UUID")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -501,6 +503,7 @@ class SnapshotsApiControllerTest {
 
   @Test
   void setSnapshotPublicNotFound() throws Exception {
+    mockValidators();
     when(iamService.getPolicyPublicV2(
             TEST_USER.getToken(), IamResourceType.DATASNAPSHOT, SNAPSHOT_ID, IamRole.READER.name()))
         .thenThrow(new NotFoundException("Resource not found"));

--- a/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/SnapshotsApiControllerTest.java
@@ -517,6 +517,7 @@ class SnapshotsApiControllerTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void setSnapshotPublicAlreadySet(boolean setPublic) throws Exception {
+    mockValidators();
     when(iamService.getPolicyPublicV2(
             TEST_USER.getToken(), IamResourceType.DATASNAPSHOT, SNAPSHOT_ID, IamRole.READER.name()))
         .thenReturn(setPublic);

--- a/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/IamServiceTest.java
@@ -360,4 +360,34 @@ class IamServiceTest {
         children,
         iamService.listResourceChildren(TEST_USER.getToken(), IamResourceType.DATASET, parentId));
   }
+
+  @Test
+  void getPolicyPublicV2() throws InterruptedException {
+    UUID resourceId = UUID.randomUUID();
+    when(iamProvider.getPolicyPublicV2(
+            TEST_USER.getToken(), IamResourceType.DATASNAPSHOT, resourceId, IamRole.READER.name()))
+        .thenReturn(true);
+    assertEquals(
+        true,
+        iamService.getPolicyPublicV2(
+            TEST_USER.getToken(), IamResourceType.DATASNAPSHOT, resourceId, IamRole.READER.name()));
+  }
+
+  @Test
+  void setPolicyPublicV2() throws InterruptedException {
+    UUID resourceId = UUID.randomUUID();
+    iamService.setPolicyPublicV2(
+        TEST_USER.getToken(),
+        IamResourceType.DATASNAPSHOT,
+        resourceId,
+        IamRole.READER.name(),
+        true);
+    verify(iamProvider)
+        .setPolicyPublicV2(
+            TEST_USER.getToken(),
+            IamResourceType.DATASNAPSHOT,
+            resourceId,
+            IamRole.READER.name(),
+            true);
+  }
 }

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -867,6 +867,83 @@ class SamIamTest {
           IamNotFoundException.class,
           () -> samIam.listResourceChildren(accessToken, IamResourceType.DATASET, parentId));
     }
+
+    @Test
+    void setPolicyPublicV2() throws Exception {
+      UUID resourceId = UUID.randomUUID();
+      samIam.setPolicyPublicV2(
+          TEST_USER.getToken(),
+          IamResourceType.DATASNAPSHOT,
+          resourceId,
+          IamRole.READER.name(),
+          true);
+      verify(samResourceApi)
+          .setPolicyPublicV2(
+              IamResourceType.DATASNAPSHOT.getSamResourceName(),
+              resourceId.toString(),
+              IamRole.READER.name(),
+              true);
+    }
+
+    @Test
+    void setPolicyPublicV2Throws() throws Exception {
+      UUID resourceId = UUID.randomUUID();
+      String accessToken = TEST_USER.getToken();
+      ApiException samEx =
+          new ApiException(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "Resource not found");
+      doThrow(samEx)
+          .when(samResourceApi)
+          .setPolicyPublicV2(
+              IamResourceType.DATASNAPSHOT.getSamResourceName(),
+              resourceId.toString(),
+              IamRole.READER.name(),
+              true);
+      assertThrows(
+          IamNotFoundException.class,
+          () ->
+              samIam.setPolicyPublicV2(
+                  accessToken,
+                  IamResourceType.DATASNAPSHOT,
+                  resourceId,
+                  IamRole.READER.name(),
+                  true));
+    }
+
+    @Test
+    void getPublicPolicyV2() throws Exception {
+      UUID resourceId = UUID.randomUUID();
+      when(samResourceApi.getPolicyPublicV2(
+              IamResourceType.DATASNAPSHOT.getSamResourceName(),
+              resourceId.toString(),
+              IamRole.READER.name()))
+          .thenReturn(false);
+      assertThat(
+          samIam.getPolicyPublicV2(
+              TEST_USER.getToken(),
+              IamResourceType.DATASNAPSHOT,
+              resourceId,
+              IamRole.READER.name()),
+          is(false));
+    }
+
+    @Test
+    void getPublicPolicyV2Throws() throws Exception {
+      UUID resourceId = UUID.randomUUID();
+      String accessToken = TEST_USER.getToken();
+      ApiException samEx =
+          new ApiException(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "Resource not found");
+      doThrow(samEx)
+          .when(samResourceApi)
+          .getPolicyPublicV2(
+              IamResourceType.DATASNAPSHOT.getSamResourceName(),
+              resourceId.toString(),
+              IamRole.READER.name());
+      assertThrows(
+          IamNotFoundException.class,
+          () ->
+              samIam.getPolicyPublicV2(
+                  accessToken, IamResourceType.DATASNAPSHOT, resourceId, IamRole.READER.name()));
+    }
   }
 
   @Nested

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -881,7 +881,7 @@ class SamIamTest {
           .setPolicyPublicV2(
               IamResourceType.DATASNAPSHOT.getSamResourceName(),
               resourceId.toString(),
-              IamRole.READER.name(),
+              IamRole.READER.name().toLowerCase(),
               true);
     }
 
@@ -896,7 +896,7 @@ class SamIamTest {
           .setPolicyPublicV2(
               IamResourceType.DATASNAPSHOT.getSamResourceName(),
               resourceId.toString(),
-              IamRole.READER.name(),
+              IamRole.READER.name().toLowerCase(),
               true);
       assertThrows(
           IamNotFoundException.class,

--- a/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
+++ b/src/test/java/bio/terra/service/auth/iam/sam/SamIamTest.java
@@ -889,6 +889,7 @@ class SamIamTest {
     void setPolicyPublicV2Throws() throws Exception {
       UUID resourceId = UUID.randomUUID();
       String accessToken = TEST_USER.getToken();
+      String reader = IamRole.READER.name();
       ApiException samEx =
           new ApiException(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "Resource not found");
       doThrow(samEx)
@@ -896,17 +897,13 @@ class SamIamTest {
           .setPolicyPublicV2(
               IamResourceType.DATASNAPSHOT.getSamResourceName(),
               resourceId.toString(),
-              IamRole.READER.name().toLowerCase(),
+              reader.toLowerCase(),
               true);
       assertThrows(
           IamNotFoundException.class,
           () ->
               samIam.setPolicyPublicV2(
-                  accessToken,
-                  IamResourceType.DATASNAPSHOT,
-                  resourceId,
-                  IamRole.READER.name(),
-                  true));
+                  accessToken, IamResourceType.DATASNAPSHOT, resourceId, reader, true));
     }
 
     @Test
@@ -930,19 +927,18 @@ class SamIamTest {
     void getPublicPolicyV2Throws() throws Exception {
       UUID resourceId = UUID.randomUUID();
       String accessToken = TEST_USER.getToken();
+      String reader = IamRole.READER.name();
       ApiException samEx =
           new ApiException(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "Resource not found");
       doThrow(samEx)
           .when(samResourceApi)
           .getPolicyPublicV2(
-              IamResourceType.DATASNAPSHOT.getSamResourceName(),
-              resourceId.toString(),
-              IamRole.READER.name());
+              IamResourceType.DATASNAPSHOT.getSamResourceName(), resourceId.toString(), reader);
       assertThrows(
           IamNotFoundException.class,
           () ->
               samIam.getPolicyPublicV2(
-                  accessToken, IamResourceType.DATASNAPSHOT, resourceId, IamRole.READER.name()));
+                  accessToken, IamResourceType.DATASNAPSHOT, resourceId, reader));
     }
   }
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -94,6 +94,7 @@ import bio.terra.service.snapshot.flight.authDomain.SnapshotAddDataAccessControl
 import bio.terra.service.snapshot.flight.create.SnapshotCreateFlight;
 import bio.terra.service.snapshot.flight.duos.SnapshotDuosMapKeys;
 import bio.terra.service.snapshot.flight.duos.SnapshotUpdateDuosDatasetFlight;
+import bio.terra.service.snapshot.flight.setpublic.SnapshotSetPublicFlight;
 import bio.terra.service.snapshotbuilder.SnapshotAccessRequestModel;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderSettingsDao;
 import bio.terra.service.snapshotbuilder.SnapshotBuilderTestData;
@@ -118,6 +119,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -1655,5 +1658,31 @@ class SnapshotServiceTest {
         .thenReturn(List.of("group1", "group2"));
     assertThat(
         service.retrieveAuthDomains(snapshotId, TEST_USER), containsInAnyOrder("group1", "group2"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void setSnapshotPublic(boolean setPublic) {
+    JobBuilder jobBuilder =
+        new JobBuilder("", SnapshotSetPublicFlight.class, null, TEST_USER, jobService);
+    when(jobService.newJob(
+            String.format(
+                "Set reader policy for snapshot %s to %s",
+                snapshotId, setPublic ? "public" : "private"),
+            SnapshotSetPublicFlight.class,
+            null,
+            TEST_USER))
+        .thenReturn(jobBuilder);
+    ArgumentCaptor<FlightMap> captor = ArgumentCaptor.forClass(FlightMap.class);
+    when(jobService.submit(eq(SnapshotSetPublicFlight.class), captor.capture()))
+        .thenReturn("JobId");
+    assertThat(
+        "Job is submitted and JobId is returned",
+        service.setSnapshotPublic(snapshotId, setPublic, TEST_USER),
+        equalTo("JobId"));
+    FlightMap flightMap = captor.getValue();
+    assertThat(flightMap.get(JobMapKeys.SNAPSHOT_ID.getKeyName(), UUID.class), equalTo(snapshotId));
+    assertThat(
+        flightMap.get(JobMapKeys.SET_PUBLIC.getKeyName(), Boolean.class), equalTo(setPublic));
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStepTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 import bio.terra.common.category.Unit;
+import bio.terra.common.exception.ForbiddenException;
+import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -15,6 +17,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,6 +64,76 @@ class SetSnapshotPublicStepTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
+  void doStepForbidden(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    var expectedException = throwForbiddenException(setPublic);
+    var result = step.doStep(context);
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+    assertEquals(expectedException.getMessage(), result.getException().get().getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void undoStepForbidden(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    var expectedException = throwForbiddenException(!setPublic);
+    var result = step.undoStep(context);
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+    assertEquals(expectedException.getMessage(), result.getException().get().getMessage());
+  }
+
+  private ForbiddenException expectedForbiddenException(boolean setPublic, Exception e) {
+    throwException(setPublic, e);
+    return new ForbiddenException(
+        "User is not authorized to set this resource as public, contact Terra support for assistance.",
+        e);
+  }
+
+  private void throwException(boolean setPublic, Exception e) {
+    doThrow(e)
+        .when(iamService)
+        .setPolicyPublicV2(
+            TEST_USER.getToken(),
+            IamResourceType.DATASNAPSHOT,
+            SNAPSHOT_ID,
+            IamRole.READER.name(),
+            setPublic);
+  }
+
+  @NotNull
+  private ForbiddenException throwForbiddenException(boolean setPublic) {
+    var exception = new ForbiddenException("Forbidden");
+    return expectedForbiddenException(setPublic, exception);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void doStepNotFound(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    var expectedException = throwNotFoundException(setPublic);
+    var result = step.doStep(context);
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+    assertEquals(expectedException.getMessage(), result.getException().get().getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void undoStepNotFound(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    var expectedException = throwNotFoundException(!setPublic);
+    var result = step.undoStep(context);
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+    assertEquals(expectedException.getMessage(), result.getException().get().getMessage());
+  }
+
+  @NotNull
+  private ForbiddenException throwNotFoundException(boolean setPublic) {
+    var exception = new NotFoundException("NotFound");
+    return expectedForbiddenException(setPublic, exception);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   void doStepOtherException(boolean setPublic) throws InterruptedException {
     step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
     var exception = throwException(setPublic);
@@ -79,16 +152,9 @@ class SetSnapshotPublicStepTest {
     assertEquals(exception.getMessage(), result.getException().get().getMessage());
   }
 
-  private NotFoundException throwException(boolean setPublic) {
-    var exception = new NotFoundException("Other error");
-    doThrow(exception)
-        .when(iamService)
-        .setPolicyPublicV2(
-            TEST_USER.getToken(),
-            IamResourceType.DATASNAPSHOT,
-            SNAPSHOT_ID,
-            IamRole.READER.name(),
-            setPublic);
+  private Exception throwException(boolean setPublic) {
+    var exception = new InternalServerErrorException("Other error");
+    throwException(setPublic, exception);
     return exception;
   }
 }

--- a/src/test/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStepTest.java
@@ -1,0 +1,132 @@
+package bio.terra.service.snapshot.flight.setpublic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.exception.ForbiddenException;
+import bio.terra.common.exception.NotFoundException;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class SetSnapshotPublicStepTest {
+
+  @Mock IamService iamService;
+  @Mock private FlightContext context;
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private SetSnapshotPublicStep step;
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void doStep(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    assertEquals(StepResult.getStepResultSuccess(), step.doStep(context));
+    verifySuccess(setPublic);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void undoStep(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    assertEquals(StepResult.getStepResultSuccess(), step.undoStep(context));
+    verifySuccess(!setPublic);
+  }
+
+  private void verifySuccess(boolean setPublic) {
+    verify(iamService)
+        .setPolicyPublicV2(
+            TEST_USER.getToken(),
+            IamResourceType.DATASNAPSHOT,
+            SNAPSHOT_ID,
+            IamRole.READER.name(),
+            setPublic);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void doStepForbidden(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    var expectedException = throwForbiddenException(setPublic);
+    var result = step.doStep(context);
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+    assertEquals(expectedException.getMessage(), result.getException().get().getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void undoStepForbidden(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    var expectedException = throwForbiddenException(!setPublic);
+    var result = step.undoStep(context);
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+    assertEquals(expectedException.getMessage(), result.getException().get().getMessage());
+  }
+
+  @NotNull
+  private ForbiddenException throwForbiddenException(boolean setPublic) {
+    var exception = new ForbiddenException("Forbidden");
+    doThrow(exception)
+        .when(iamService)
+        .setPolicyPublicV2(
+            TEST_USER.getToken(),
+            IamResourceType.DATASNAPSHOT,
+            SNAPSHOT_ID,
+            IamRole.READER.name(),
+            setPublic);
+    return new ForbiddenException(
+        "User is not authorized to set this resource as public, contact Terra support for assistance.",
+        exception);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void doStepOtherException(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    var exception = throwException(setPublic);
+    var result = step.doStep(context);
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+    assertEquals(exception.getMessage(), result.getException().get().getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void undoStepOtherException(boolean setPublic) throws InterruptedException {
+    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
+    var exception = throwException(!setPublic);
+    var result = step.undoStep(context);
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
+    assertEquals(exception.getMessage(), result.getException().get().getMessage());
+  }
+
+  private NotFoundException throwException(boolean setPublic) {
+    var exception = new NotFoundException("Other error");
+    doThrow(exception)
+        .when(iamService)
+        .setPolicyPublicV2(
+            TEST_USER.getToken(),
+            IamResourceType.DATASNAPSHOT,
+            SNAPSHOT_ID,
+            IamRole.READER.name(),
+            setPublic);
+    return exception;
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/setpublic/SetSnapshotPublicStepTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 import bio.terra.common.category.Unit;
-import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -16,7 +15,6 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import java.util.UUID;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -59,42 +57,6 @@ class SetSnapshotPublicStepTest {
             SNAPSHOT_ID,
             IamRole.READER.name(),
             setPublic);
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void doStepForbidden(boolean setPublic) throws InterruptedException {
-    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
-    var expectedException = throwForbiddenException(setPublic);
-    var result = step.doStep(context);
-    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
-    assertEquals(expectedException.getMessage(), result.getException().get().getMessage());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void undoStepForbidden(boolean setPublic) throws InterruptedException {
-    step = new SetSnapshotPublicStep(SNAPSHOT_ID, setPublic, TEST_USER, iamService);
-    var expectedException = throwForbiddenException(!setPublic);
-    var result = step.undoStep(context);
-    assertEquals(StepStatus.STEP_RESULT_FAILURE_FATAL, result.getStepStatus());
-    assertEquals(expectedException.getMessage(), result.getException().get().getMessage());
-  }
-
-  @NotNull
-  private ForbiddenException throwForbiddenException(boolean setPublic) {
-    var exception = new ForbiddenException("Forbidden");
-    doThrow(exception)
-        .when(iamService)
-        .setPolicyPublicV2(
-            TEST_USER.getToken(),
-            IamResourceType.DATASNAPSHOT,
-            SNAPSHOT_ID,
-            IamRole.READER.name(),
-            setPublic);
-    return new ForbiddenException(
-        "User is not authorized to set this resource as public, contact Terra support for assistance.",
-        exception);
   }
 
   @ParameterizedTest

--- a/src/test/java/bio/terra/service/snapshot/flight/setpublic/SnapshotSetPublicFlightTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/setpublic/SnapshotSetPublicFlightTest.java
@@ -1,0 +1,68 @@
+package bio.terra.service.snapshot.flight.setpublic;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.FlightTestUtils;
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightMap;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class SnapshotSetPublicFlightTest {
+  @Mock private IamService iamService;
+  @Mock private ApplicationContext context;
+  private final FlightMap inputParameters = new FlightMap();
+  private static final UUID SNAPSHOT_ID = UUID.randomUUID();
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+
+  @BeforeEach
+  void setUp() {
+    inputParameters.put(JobMapKeys.SNAPSHOT_ID.getKeyName(), SNAPSHOT_ID);
+    inputParameters.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), TEST_USER);
+    when(context.getBean(IamService.class)).thenReturn(iamService);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void allSteps(boolean setPublic) {
+    inputParameters.put(JobMapKeys.SET_PUBLIC.getKeyName(), setPublic);
+    var flight = new SnapshotSetPublicFlight(inputParameters, context);
+    var steps = FlightTestUtils.getStepNames(flight);
+    assertThat(steps, contains("SetSnapshotPublicStep"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void setSnapshotPublicStep(boolean setPublic) {
+    inputParameters.put(JobMapKeys.SET_PUBLIC.getKeyName(), setPublic);
+    try (var mockStep =
+        mockConstruction(
+            SetSnapshotPublicStep.class,
+            (mock, context) ->
+                assertThat(
+                    context.arguments(),
+                    contains(SNAPSHOT_ID, setPublic, TEST_USER, iamService)))) {
+      //noinspection ResultOfObjectAllocationIgnored
+      new SnapshotSetPublicFlight(inputParameters, context);
+      assertThat(mockStep.constructed(), hasSize(1));
+    }
+  }
+}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1223

## Addresses
Public snapshots currently contribute to google group membership counts. We can help users hitting the google group limit by removing them from google groups representing public resources. This starts this work.

## Summary of changes
Create a new Snapshot endpoint that takes a snapshot ID and a boolean flag representing whether the reader policy on the snapshot is being set to public or private.
Create service code that calls a new flight with one step.
New step that calls the Sam setPublic endpoint.

## Testing Strategy
Unit tests.
Manual test.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
