### PR TITLE
[DT-1467] Fix API version reported by images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,10 +55,18 @@ jobs:
     needs:
       - bump_version
     steps:
+      - name: Determine image build checkout tag
+        id: image_build_checkout_tag
+        run: |
+          if [ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]; then
+            echo "checkout_ref=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
+          else:
+            echo "checkout_ref=${{ needs.bump_version.outputs.tag }}" >> $GITHUB_OUTPUT
+          fi
       - name: Checkout jade-data-repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.bump_version.outputs.tag }}
+          ref: ${{ steps.image_build_checkout_tag.outputs.checkout_ref }}
           persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,10 +58,12 @@ jobs:
       - name: Determine image build checkout tag
         id: image_build_checkout_tag
         run: |
+          # For PR builds, checkout the HEAD ref, for builds on the default branch,
+          # checkout the most recently bumped semver tag.
           if [ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]; then
-            echo "checkout_ref=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
-          else:
             echo "checkout_ref=${{ needs.bump_version.outputs.tag }}" >> $GITHUB_OUTPUT
+          else:
+            echo "checkout_ref=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout jade-data-repo
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,7 @@ jobs:
       - name: Checkout jade-data-repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ needs.bump_version.outputs.tag }}
           persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1467

## Addresses

The API version being reported by TDR in k8s is wrong, the previous version is reported. This is due to a bug in the container build job where the bumped tag is not used to checkout the codebase before building the image.

## Summary of changes

Like when building the client for artifactory, the checkout action uses the newly bumped version tag.

## Testing Strategy

This kind of change can't be tested in PR, so we have to merge and see what happens and go from there.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->