### PR TITLE
[DT-1198] Retrieve snapshot count on dataset summary

### DIFF
--- a/src/main/java/bio/terra/service/dataset/Dataset.java
+++ b/src/main/java/bio/terra/service/dataset/Dataset.java
@@ -390,6 +390,10 @@ public class Dataset implements FSContainerInterface, LogPrintable {
     return datasetSummary.isInheritSteward();
   }
 
+  public int getSnapshotCount() {
+    return datasetSummary.getSnapshotCount();
+  }
+
   @Override
   public String toLogString() {
     return String.format("%s (%s)", this.getName(), this.getId());

--- a/src/main/java/bio/terra/service/dataset/DatasetDao.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetDao.java
@@ -101,6 +101,9 @@ public class DatasetDao implements TaggableResourceDao {
           + "'datasetId', dataset_id)) "
           + "FROM storage_resource WHERE dataset_id = dataset.id) AS storage, ";
 
+  private static final String snapshotCountQuery =
+      "(SELECT count(*) FROM snapshot_source WHERE dataset_id = dataset.id) AS snapshot_count, ";
+
   private static final String billingProfileQuery =
       "(SELECT json_agg(json_build_object("
           + "'id', id, "
@@ -552,6 +555,7 @@ public class DatasetDao implements TaggableResourceDao {
               + summaryQueryColumns
               + summaryCloudPlatformQuery
               + datasetStorageQuery
+              + snapshotCountQuery
               + billingProfileQuery
               + "FROM dataset "
               + "WHERE dataset.id = :id";
@@ -569,6 +573,7 @@ public class DatasetDao implements TaggableResourceDao {
               + summaryQueryColumns
               + summaryCloudPlatformQuery
               + datasetStorageQuery
+              + snapshotCountQuery
               + billingProfileQuery
               + "FROM dataset "
               + "WHERE dataset.name = :name";
@@ -647,6 +652,7 @@ public class DatasetDao implements TaggableResourceDao {
             + summaryQueryColumns
             + summaryCloudPlatformQuery
             + datasetStorageQuery
+            + snapshotCountQuery
             + billingProfileQuery
             + "FROM dataset "
             + whereSql
@@ -720,7 +726,8 @@ public class DatasetDao implements TaggableResourceDao {
           .tags(DaoUtils.getStringList(rs, "tags"))
           .resourceLocks(
               new ResourceLocks().exclusive(rs.getString("flightid")).shared(sharedLocks))
-          .inheritSteward(rs.getBoolean("inherit_steward"));
+          .inheritSteward(rs.getBoolean("inherit_steward"))
+          .snapshotCount(rs.getInt("snapshot_count"));
     }
   }
 

--- a/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetJsonConversion.java
@@ -111,7 +111,8 @@ public final class DatasetJsonConversion {
             .predictableFileIds(dataset.hasPredictableFileIds())
             .tags(dataset.getTags())
             .resourceLocks(dataset.getResourceLocks())
-            .inheritSteward(dataset.isInheritSteward());
+            .inheritSteward(dataset.isInheritSteward())
+            .snapshotCount(dataset.getSnapshotCount());
 
     if (include.contains(DatasetRequestAccessIncludeModel.NONE)) {
       return datasetModel;

--- a/src/main/java/bio/terra/service/dataset/DatasetSummary.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetSummary.java
@@ -38,6 +38,7 @@ public class DatasetSummary {
   private List<String> tags;
   private ResourceLocks resourceLocks;
   private boolean inheritSteward;
+  private int snapshotCount;
 
   public UUID getId() {
     return id;
@@ -263,6 +264,15 @@ public class DatasetSummary {
     return this;
   }
 
+  public int getSnapshotCount() {
+    return snapshotCount;
+  }
+
+  public DatasetSummary snapshotCount(int snapshotCount) {
+    this.snapshotCount = snapshotCount;
+    return this;
+  }
+
   public DatasetSummaryModel toModel() {
     return new DatasetSummaryModel()
         .id(getId())
@@ -280,7 +290,8 @@ public class DatasetSummary {
         .predictableFileIds(hasPredictableFileIds())
         .tags(getTags())
         .resourceLocks(getResourceLocks())
-        .inheritSteward(inheritSteward);
+        .inheritSteward(inheritSteward)
+        .snapshotCount(getSnapshotCount());
   }
 
   List<StorageResourceModel> toStorageResourceModel() {

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -5444,6 +5444,9 @@ components:
           description: >
             If true, all snapshots created from this dataset will grant dataset custodians
             the steward (owner) role on the snapshots.
+        snapshotCount:
+          type: integer
+          description: Number of snapshots created from this dataset
       description: >
         Complete definition of a dataset.
     DatasetSummaryModel:
@@ -5501,6 +5504,9 @@ components:
           description: >
             If true, all snapshots created from this dataset will grant dataset custodians
             the steward (owner) role on the snapshots.
+        snapshotCount:
+          type: integer
+          description: Number of snapshots created from this dataset
       description: >
         Summary of a dataset.
     DatasetRequestModel:

--- a/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetDaoTest.java
@@ -1283,4 +1283,14 @@ class DatasetDaoTest {
     dataset = datasetDao.retrieve(datasetId);
     assertThat("Inherit steward is set", dataset.isInheritSteward());
   }
+
+  @Test
+  void testSnapshotCount() throws Exception {
+    UUID datasetId = createDataset("dataset-minimal.json");
+    Dataset dataset = datasetDao.retrieve(datasetId);
+    assertThat(
+        "Dataset should by default have snapshot count set to 0",
+        dataset.getSnapshotCount(),
+        equalTo(0));
+  }
 }

--- a/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetJsonConversionTest.java
@@ -52,6 +52,7 @@ class DatasetJsonConversionTest {
   private static final UUID DATASET_COLUMN_ID = UUID.randomUUID();
   private static final String DATASET_ASSET_NAME = "asset1";
   private static final UUID DATASET_ASSET_ID = UUID.randomUUID();
+  private static final int DATASET_SNAPSHOT_COUNT = 0;
 
   private DatasetJsonConversion datasetJsonConversion;
 
@@ -152,7 +153,8 @@ class DatasetJsonConversionTest {
                                 .rootTable(DATASET_TABLE_NAME)
                                 .rootColumn(DATASET_COLUMN_NAME)
                                 .follow(Collections.emptyList()))))
-            .dataProject(DATASET_DATA_PROJECT);
+            .dataProject(DATASET_DATA_PROJECT)
+            .snapshotCount(DATASET_SNAPSHOT_COUNT);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -164,7 +164,7 @@ class SnapshotConnectedTest {
     // Verify that the parent id wasn't set on snapshot creation.
     verify(samService).createSnapshotResource(any(), eq(summaryModel.getId()), eq(null), any());
 
-    // Set the dataset snapshot count so that the snapshot count is accurate
+    // Get the dataset summary again for the updated snapshot count
     datasetArraySummary = datasetDao.retrieveSummaryById(datasetArraySummary.getId()).toModel();
 
     SnapshotConnectedTestUtils.getTestSnapshot(
@@ -316,7 +316,7 @@ class SnapshotConnectedTest {
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
-    // Set the dataset snapshot count so that the snapshot count is accurate
+    // Get the dataset summary again for the updated snapshot count
     datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     // fetch the snapshot and confirm the metadata matches the request
@@ -367,7 +367,7 @@ class SnapshotConnectedTest {
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
-    // Set the dataset snapshot count so that the snapshot count is accurate
+    // Get the dataset summary again for the updated snapshot count
     datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     // fetch the snapshot and confirm the metadata matches the request
@@ -411,7 +411,7 @@ class SnapshotConnectedTest {
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
-    // Set the dataset snapshot count so that the snapshot count is accurate
+    // Get the dataset summary again for the updated snapshot count
     datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     // retrieve snapshot and store project id
@@ -471,7 +471,7 @@ class SnapshotConnectedTest {
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
-    // Set the dataset snapshot count so that the snapshot count is accurate
+    // Get the dataset summary again for the updated snapshot count
     datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     // fetch the snapshot and confirm the metadata matches the request

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -165,7 +165,7 @@ class SnapshotConnectedTest {
     verify(samService).createSnapshotResource(any(), eq(summaryModel.getId()), eq(null), any());
 
     // Set the dataset snapshot count so that the snapshot count is accurate
-    datasetArraySummary.snapshotCount(1);
+    datasetArraySummary = datasetDao.retrieveSummaryById(datasetArraySummary.getId()).toModel();
 
     SnapshotConnectedTestUtils.getTestSnapshot(
         mvc, objectMapper, summaryModel.getId(), snapshotRequest, datasetArraySummary);
@@ -317,7 +317,7 @@ class SnapshotConnectedTest {
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
     // Set the dataset snapshot count so that the snapshot count is accurate
-    datasetSummary.snapshotCount(1);
+    datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     // fetch the snapshot and confirm the metadata matches the request
     SnapshotModel snapshotModel =
@@ -368,7 +368,7 @@ class SnapshotConnectedTest {
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
     // Set the dataset snapshot count so that the snapshot count is accurate
-    datasetSummary.snapshotCount(1);
+    datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     // fetch the snapshot and confirm the metadata matches the request
     SnapshotModel snapshotModel =
@@ -412,7 +412,7 @@ class SnapshotConnectedTest {
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
     // Set the dataset snapshot count so that the snapshot count is accurate
-    datasetSummary.snapshotCount(1);
+    datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     // retrieve snapshot and store project id
     SnapshotModel snapshotModel =
@@ -472,7 +472,7 @@ class SnapshotConnectedTest {
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
     // Set the dataset snapshot count so that the snapshot count is accurate
-    datasetSummary.snapshotCount(1);
+    datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     // fetch the snapshot and confirm the metadata matches the request
     SnapshotModel snapshotModel =

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -235,6 +235,11 @@ class SnapshotConnectedTest {
 
     assertThat("5 total snapshots created", snapshotList, hasSize(5));
 
+    // Check that the dataset summary was updated with the new snapshot count
+    var updatedSummary = datasetDao.retrieveSummaryById(datasetSummary.getId());
+    int snapshotCount = updatedSummary.getSnapshotCount();
+    assertThat("dataset snapshot count incremented", snapshotCount, equalTo(5));
+
     // Reverse the order of the array since the order we return the snapshots in by default is
     // descending order of creation
     Collections.reverse(snapshotList);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotConnectedTest.java
@@ -164,6 +164,9 @@ class SnapshotConnectedTest {
     // Verify that the parent id wasn't set on snapshot creation.
     verify(samService).createSnapshotResource(any(), eq(summaryModel.getId()), eq(null), any());
 
+    // Set the dataset snapshot count so that the snapshot count is accurate
+    datasetArraySummary.snapshotCount(1);
+
     SnapshotConnectedTestUtils.getTestSnapshot(
         mvc, objectMapper, summaryModel.getId(), snapshotRequest, datasetArraySummary);
 
@@ -313,6 +316,9 @@ class SnapshotConnectedTest {
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
+    // Set the dataset snapshot count so that the snapshot count is accurate
+    datasetSummary.snapshotCount(1);
+
     // fetch the snapshot and confirm the metadata matches the request
     SnapshotModel snapshotModel =
         SnapshotConnectedTestUtils.getTestSnapshot(
@@ -361,6 +367,9 @@ class SnapshotConnectedTest {
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
 
+    // Set the dataset snapshot count so that the snapshot count is accurate
+    datasetSummary.snapshotCount(1);
+
     // fetch the snapshot and confirm the metadata matches the request
     SnapshotModel snapshotModel =
         SnapshotConnectedTestUtils.getTestSnapshot(
@@ -401,6 +410,9 @@ class SnapshotConnectedTest {
             datasetSummary.getDefaultProfileId());
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
+
+    // Set the dataset snapshot count so that the snapshot count is accurate
+    datasetSummary.snapshotCount(1);
 
     // retrieve snapshot and store project id
     SnapshotModel snapshotModel =
@@ -458,6 +470,9 @@ class SnapshotConnectedTest {
 
     MockHttpServletResponse response = performCreateSnapshot(snapshotRequest, "_dup_");
     SnapshotSummaryModel summaryModel = validateSnapshotCreated(snapshotRequest, response);
+
+    // Set the dataset snapshot count so that the snapshot count is accurate
+    datasetSummary.snapshotCount(1);
 
     // fetch the snapshot and confirm the metadata matches the request
     SnapshotModel snapshotModel =

--- a/src/test/java/bio/terra/service/snapshot/SnapshotHappyPathConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotHappyPathConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.configuration.ConfigEnum;
 import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.DatasetDao;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
@@ -39,6 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @EmbeddedDatabaseTest
 public class SnapshotHappyPathConnectedTest {
 
+  @Autowired private DatasetDao datasetDao;
   @Autowired ConfigurationService configService;
   @Autowired private MockMvc mvc;
   @Autowired private ObjectMapper objectMapper;
@@ -115,6 +117,9 @@ public class SnapshotHappyPathConnectedTest {
     SnapshotSummaryModel summaryModel =
         SnapshotConnectedTestUtils.validateSnapshotCreated(
             connectedOperations, snapshotRequest, response);
+
+    // Set the dataset snapshot count so that the snapshot count is accurate
+    datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     SnapshotModel snapshotModel =
         SnapshotConnectedTestUtils.getTestSnapshot(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotHappyPathConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotHappyPathConnectedTest.java
@@ -118,7 +118,7 @@ public class SnapshotHappyPathConnectedTest {
         SnapshotConnectedTestUtils.validateSnapshotCreated(
             connectedOperations, snapshotRequest, response);
 
-    // Set the dataset snapshot count so that the snapshot count is accurate
+    // Get the dataset summary again for the updated snapshot count
     datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     SnapshotModel snapshotModel =

--- a/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
@@ -108,6 +108,8 @@ public class SnapshotMinimalConnectedTest {
     SnapshotSummaryModel summaryModel =
         SnapshotConnectedTestUtils.validateSnapshotCreated(
             connectedOperations, snapshotRequest, response);
+    // Set the dataset snapshot count so that the snapshot count is accurate
+    datasetMinimalSummary = datasetDao.retrieveSummaryById(datasetMinimalSummary.getId()).toModel();
     SnapshotModel snapshotModel =
         SnapshotConnectedTestUtils.getTestSnapshot(
             mvc, objectMapper, summaryModel.getId(), snapshotRequest, datasetMinimalSummary);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotMinimalConnectedTest.java
@@ -108,7 +108,7 @@ public class SnapshotMinimalConnectedTest {
     SnapshotSummaryModel summaryModel =
         SnapshotConnectedTestUtils.validateSnapshotCreated(
             connectedOperations, snapshotRequest, response);
-    // Set the dataset snapshot count so that the snapshot count is accurate
+    // Get the dataset summary again for the updated snapshot count
     datasetMinimalSummary = datasetDao.retrieveSummaryById(datasetMinimalSummary.getId()).toModel();
     SnapshotModel snapshotModel =
         SnapshotConnectedTestUtils.getTestSnapshot(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotScaleConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotScaleConnectedTest.java
@@ -109,7 +109,7 @@ public class SnapshotScaleConnectedTest {
         SnapshotConnectedTestUtils.validateSnapshotCreated(
             connectedOperations, snapshotRequestScale, response);
 
-    // Set the dataset snapshot count so that the snapshot count is accurate
+    // Get the dataset summary again for the updated snapshot count
     datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     SnapshotModel snapshotModel =

--- a/src/test/java/bio/terra/service/snapshot/SnapshotScaleConnectedTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotScaleConnectedTest.java
@@ -13,6 +13,7 @@ import bio.terra.model.SnapshotRequestModel;
 import bio.terra.model.SnapshotSummaryModel;
 import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.configuration.ConfigurationService;
+import bio.terra.service.dataset.DatasetDao;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
@@ -39,6 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @EmbeddedDatabaseTest
 public class SnapshotScaleConnectedTest {
 
+  @Autowired private DatasetDao datasetDao;
   @Autowired private ConnectedOperations connectedOperations;
   @Autowired private JsonLoader jsonLoader;
   @Autowired private MockMvc mvc;
@@ -106,6 +108,9 @@ public class SnapshotScaleConnectedTest {
     SnapshotSummaryModel summaryModel =
         SnapshotConnectedTestUtils.validateSnapshotCreated(
             connectedOperations, snapshotRequestScale, response);
+
+    // Set the dataset snapshot count so that the snapshot count is accurate
+    datasetSummary = datasetDao.retrieveSummaryById(datasetSummary.getId()).toModel();
 
     SnapshotModel snapshotModel =
         SnapshotConnectedTestUtils.getTestSnapshot(

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -141,6 +141,7 @@ class SnapshotServiceTest {
   private static final String SNAPSHOT_NAME = "snapshotName";
   private static final String SNAPSHOT_DESCRIPTION = "snapshotDescription";
   private static final String DATASET_NAME = "datasetName";
+  private static final int DATASET_SNAPSHOT_COUNT = 0;
   private static final String SNAPSHOT_DATA_PROJECT = "tdrdataproject";
   private static final String SNAPSHOT_TABLE_NAME = "tableA";
   private static final String SNAPSHOT_COLUMN_NAME = "columnA";
@@ -213,7 +214,8 @@ class SnapshotServiceTest {
                                                     GoogleRegion.DEFAULT_GOOGLE_REGION.toString())
                                                 .cloudResource(
                                                     GoogleCloudResource.BUCKET.toString())
-                                                .cloudPlatform(CloudPlatform.GCP))))))
+                                                .cloudPlatform(CloudPlatform.GCP)))
+                                    .snapshotCount(DATASET_SNAPSHOT_COUNT))))
                 .tables(
                     List.of(
                         new TableModel()


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-1198

## Summary of changes

Adds the snapshot count to the dataset summary.

## Testing Strategy

Added a Dataset DAO test and a check in the snapshot connected test. Any other tests I should add?

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
