### PR TITLE
DT-1448: Prevent overlap between inheritSteward and auth domain features

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/CheckChildSnapshotAuthDomainStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/CheckChildSnapshotAuthDomainStep.java
@@ -1,0 +1,50 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.job.DefaultUndoStep;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import jakarta.ws.rs.BadRequestException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public class CheckChildSnapshotAuthDomainStep extends DefaultUndoStep {
+  private final SnapshotService snapshotService;
+  private final AuthenticatedUserRequest userReq;
+
+  public CheckChildSnapshotAuthDomainStep(
+      SnapshotService snapshotService, AuthenticatedUserRequest userReq) {
+    this.snapshotService = snapshotService;
+    this.userReq = userReq;
+  }
+
+  @Override
+  public StepResult doStep(FlightContext context) {
+    List<UUID> snapshotsWithAuthDomains = new ArrayList<>();
+    List<UUID> snapshots =
+        context.getWorkingMap().get(DatasetWorkingMapKeys.SNAPSHOT_IDS, List.class);
+    Objects.requireNonNull(snapshots)
+        .forEach(
+            snapshotId -> {
+              List<String> authDomains = snapshotService.retrieveAuthDomains(snapshotId, userReq);
+              if (!authDomains.isEmpty()) {
+                snapshotsWithAuthDomains.add(snapshotId);
+              }
+            });
+    if (!snapshotsWithAuthDomains.isEmpty()) {
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new BadRequestException(
+              "The following snapshots have auth domains: "
+                  + snapshotsWithAuthDomains
+                  + ". Please delete any snapshots with auth domains before setting inherit steward."));
+    }
+
+    return StepResult.getStepResultSuccess();
+  }
+}

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlight.java
@@ -44,11 +44,14 @@ public class SetInheritStewardFlight extends Flight {
     boolean inheritSteward =
         inputParameters.get(JobMapKeys.INHERIT_STEWARD.getKeyName(), Boolean.class);
     addStep(new LockDatasetStep(datasetService, datasetId, false));
+    addStep(new GetSnapshotIdsStep(snapshotDao, iamService, userReq, datasetId, inheritSteward));
     if (inheritSteward) {
+      // Make sure no child snapshot have auth domains
+      addStep(new CheckChildSnapshotAuthDomainStep(snapshotService, userReq));
       // If we are setting inherit steward to true, we want to set the flag first
       addStep(new SetInheritStewardFlagStep(datasetDao, datasetId, inheritSteward));
     }
-    addStep(new GetSnapshotIdsStep(snapshotDao, iamService, userReq, datasetId, inheritSteward));
+
     addStep(new SetParentOnSnapshotsStep(iamService, datasetId, userReq, inheritSteward));
     addStep(
         new SetAuthGcpUserRolesStep(

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -12,6 +12,7 @@ import bio.terra.common.Relationship;
 import bio.terra.common.SqlSortDirection;
 import bio.terra.common.Table;
 import bio.terra.common.ValidationUtils;
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -784,6 +785,10 @@ public class SnapshotService {
 
   public AddAuthDomainResponseModel addSnapshotDataAccessControls(
       AuthenticatedUserRequest userReq, UUID snapshotId, List<String> userGroups) {
+    if (retrieve(snapshotId).getFirstSnapshotSource().getDataset().isInheritSteward()) {
+      throw new BadRequestException(
+          "Cannot add an auth domain to snapshot whose parent dataset has inherit steward enabled.");
+    }
     String userGroupsString = StringUtils.join(userGroups, ", ");
     String description =
         "Add data access control groups " + userGroupsString + " to snapshot " + snapshotId;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -215,6 +215,7 @@ public class SnapshotService {
       Dataset dataset,
       AuthenticatedUserRequest userReq) {
     if (dataset.isInheritSteward()
+        && snapshotRequestModel.getDataAccessControlGroups() != null
         && !snapshotRequestModel.getDataAccessControlGroups().isEmpty()) {
       throw new BadRequestException(
           "Cannot create a snapshot with an auth domain whose parent dataset has inherit steward enabled.");

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -214,6 +214,10 @@ public class SnapshotService {
       SnapshotRequestModel snapshotRequestModel,
       Dataset dataset,
       AuthenticatedUserRequest userReq) {
+    if (dataset.isInheritSteward()) {
+      throw new BadRequestException(
+          "Cannot add an auth domain to snapshot whose parent dataset has inherit steward enabled.");
+    }
     snapshotRequestModel.setName(getSnapshotName(snapshotRequestModel));
     if (snapshotRequestModel.getProfileId() == null) {
       snapshotRequestModel.setProfileId(dataset.getDefaultProfileId());
@@ -789,6 +793,7 @@ public class SnapshotService {
       throw new BadRequestException(
           "Cannot add an auth domain to snapshot whose parent dataset has inherit steward enabled.");
     }
+
     String userGroupsString = StringUtils.join(userGroups, ", ");
     String description =
         "Add data access control groups " + userGroupsString + " to snapshot " + snapshotId;

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -214,9 +214,10 @@ public class SnapshotService {
       SnapshotRequestModel snapshotRequestModel,
       Dataset dataset,
       AuthenticatedUserRequest userReq) {
-    if (dataset.isInheritSteward()) {
+    if (dataset.isInheritSteward()
+        && !snapshotRequestModel.getDataAccessControlGroups().isEmpty()) {
       throw new BadRequestException(
-          "Cannot add an auth domain to snapshot whose parent dataset has inherit steward enabled.");
+          "Cannot create a snapshot with an auth domain whose parent dataset has inherit steward enabled.");
     }
     snapshotRequestModel.setName(getSnapshotName(snapshotRequestModel));
     if (snapshotRequestModel.getProfileId() == null) {

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/CheckChildSnapshotAuthDomainStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/CheckChildSnapshotAuthDomainStepTest.java
@@ -1,0 +1,74 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class CheckChildSnapshotAuthDomainStepTest {
+  @Mock private SnapshotService snapshotService;
+  @Mock private FlightContext context;
+  private CheckChildSnapshotAuthDomainStep step;
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+  private static final UUID SNAPSHOT_1 = UUID.randomUUID();
+  private static final UUID SNAPSHOT_2 = UUID.randomUUID();
+  private List<UUID> snapshotIds;
+
+  @BeforeEach
+  void setup() {
+    step = new CheckChildSnapshotAuthDomainStep(snapshotService, TEST_USER);
+    snapshotIds = Arrays.asList(SNAPSHOT_1, SNAPSHOT_2);
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(DatasetWorkingMapKeys.SNAPSHOT_IDS, snapshotIds);
+    when(context.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void doStep_NoAuthDomains() {
+    when(snapshotService.retrieveAuthDomains(SNAPSHOT_1, TEST_USER)).thenReturn(List.of());
+    when(snapshotService.retrieveAuthDomains(SNAPSHOT_2, TEST_USER)).thenReturn(List.of());
+    assertThat(step.doStep(context), is(StepResult.getStepResultSuccess()));
+    for (UUID snapshotId : snapshotIds) {
+      verify(snapshotService).retrieveAuthDomains(snapshotId, TEST_USER);
+    }
+  }
+
+  @Test
+  void doStep_WithAuthDomains() {
+    when(snapshotService.retrieveAuthDomains(SNAPSHOT_1, TEST_USER))
+        .thenReturn(List.of("authDomain1"));
+    when(snapshotService.retrieveAuthDomains(SNAPSHOT_2, TEST_USER)).thenReturn(List.of());
+    var result = step.doStep(context);
+    assertThat(result.getStepStatus(), is(StepStatus.STEP_RESULT_FAILURE_FATAL));
+    assertThat(
+        "Correct exception is returned",
+        result.getException().get().getMessage(),
+        is(
+            "The following snapshots have auth domains: ["
+                + SNAPSHOT_1
+                + "]. Please delete any snapshots with auth domains before setting inherit steward."));
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/CheckChildSnapshotAuthDomainStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/CheckChildSnapshotAuthDomainStepTest.java
@@ -2,7 +2,6 @@ package bio.terra.service.dataset.flight.inheritsteward;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlightTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlightTest.java
@@ -82,8 +82,9 @@ class SetInheritStewardFlightTest {
         steps,
         contains(
             "LockDatasetStep",
-            "SetInheritStewardFlagStep",
             "GetSnapshotIdsStep",
+            "CheckChildSnapshotAuthDomainStep",
+            "SetInheritStewardFlagStep",
             "SetParentOnSnapshotsStep",
             "SetAuthGcpUserRolesStep",
             "SetAuthTabularAclStep",

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1166,6 +1166,22 @@ class SnapshotServiceTest {
   }
 
   @Test
+  void testCreateSnapshotInheritSteward() {
+    Exception ex =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                service.createSnapshot(
+                    new SnapshotRequestModel(),
+                    new Dataset(new DatasetSummary().inheritSteward(true)),
+                    TEST_USER));
+    assertThat(
+        ex.getMessage(),
+        equalTo(
+            "Cannot add an auth domain to snapshot whose parent dataset has inherit steward enabled."));
+  }
+
+  @Test
   void testUpdateSnapshotDuosDataset() {
     mockSnapshotWithDuosDataset();
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1166,19 +1166,45 @@ class SnapshotServiceTest {
   }
 
   @Test
-  void testCreateSnapshotInheritSteward() {
+  void testCreateSnapshotInheritStewardAndAuthDomain() {
     Exception ex =
         assertThrows(
             BadRequestException.class,
             () ->
                 service.createSnapshot(
-                    new SnapshotRequestModel(),
+                    new SnapshotRequestModel().addDataAccessControlGroupsItem("authdomain"),
                     new Dataset(new DatasetSummary().inheritSteward(true)),
                     TEST_USER));
     assertThat(
         ex.getMessage(),
         equalTo(
-            "Cannot add an auth domain to snapshot whose parent dataset has inherit steward enabled."));
+            "Cannot create a snapshot with an auth domain whose parent dataset has inherit steward enabled."));
+  }
+
+  @Test
+  void testCreateSnapshotWithAuthDomainAndInheritStewardDisabled() {
+    // mock request
+    String sourceDatasetName = "TestSourceDataset";
+    Dataset sourceDataset = new Dataset().name(sourceDatasetName);
+    when(datasetService.retrieveByName(sourceDatasetName)).thenReturn(sourceDataset);
+    SnapshotRequestModel request =
+        new SnapshotRequestModel()
+            .name("TestSnapshot")
+            .profileId(UUID.randomUUID())
+            .addDataAccessControlGroupsItem("AuthDomain1")
+            .contents(List.of(new SnapshotRequestContentsModel().datasetName(sourceDatasetName)));
+
+    JobBuilder jobBuilder = mock(JobBuilder.class);
+    when(jobService.newJob(anyString(), eq(SnapshotCreateFlight.class), eq(request), eq(TEST_USER)))
+        .thenReturn(jobBuilder);
+    when(jobBuilder.addParameter(any(), any())).thenReturn(jobBuilder);
+    String jobId = String.valueOf(UUID.randomUUID());
+    when(jobBuilder.submit()).thenReturn(jobId);
+
+    String result =
+        service.createSnapshot(
+            request, service.getSourceDatasetFromSnapshotRequest(request), TEST_USER);
+    assertThat("Job is submitted and id returned", result, equalTo(jobId));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1167,6 +1167,8 @@ class SnapshotServiceTest {
 
   @Test
   void testCreateSnapshotInheritStewardAndAuthDomain() {
+    // Expect an exception when trying to create a snapshot with an auth domain and inherit steward
+    // enabled
     Exception ex =
         assertThrows(
             BadRequestException.class,
@@ -1183,10 +1185,13 @@ class SnapshotServiceTest {
 
   @Test
   void testCreateSnapshotWithAuthDomainAndInheritStewardDisabled() {
-    // mock request
+    // build request with parameters to test auth domain/inherit steward
     String sourceDatasetName = "TestSourceDataset";
-    Dataset sourceDataset = new Dataset().name(sourceDatasetName);
+    // inherit steward = false
+    Dataset sourceDataset =
+        new Dataset(new DatasetSummary().inheritSteward(false)).name(sourceDatasetName);
     when(datasetService.retrieveByName(sourceDatasetName)).thenReturn(sourceDataset);
+    // auth domain is included in snapshot request
     SnapshotRequestModel request =
         new SnapshotRequestModel()
             .name("TestSnapshot")
@@ -1194,6 +1199,28 @@ class SnapshotServiceTest {
             .addDataAccessControlGroupsItem("AuthDomain1")
             .contents(List.of(new SnapshotRequestContentsModel().datasetName(sourceDatasetName)));
 
+    mockCreateSnapshot(request);
+  }
+
+  @Test
+  void testCreateSnapshotInheritStewardEnabled() {
+    // build request with parameters to test auth domain/inherit steward
+    String sourceDatasetName = "TestSourceDataset";
+    // inherit steward = true
+    Dataset sourceDataset =
+        new Dataset(new DatasetSummary().inheritSteward(true)).name(sourceDatasetName);
+    when(datasetService.retrieveByName(sourceDatasetName)).thenReturn(sourceDataset);
+    // no auth domain included
+    SnapshotRequestModel request =
+        new SnapshotRequestModel()
+            .name("TestSnapshot")
+            .profileId(UUID.randomUUID())
+            .contents(List.of(new SnapshotRequestContentsModel().datasetName(sourceDatasetName)));
+
+    mockCreateSnapshot(request);
+  }
+
+  private void mockCreateSnapshot(SnapshotRequestModel request) {
     JobBuilder jobBuilder = mock(JobBuilder.class);
     when(jobService.newJob(anyString(), eq(SnapshotCreateFlight.class), eq(request), eq(TEST_USER)))
         .thenReturn(jobBuilder);

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1356,6 +1356,7 @@ class SnapshotServiceTest {
     when(jobService.submitAndWait(
             eq(flightClass), flightMapCaptor.capture(), eq(AddAuthDomainResponseModel.class)))
         .thenReturn(jobResponse);
+    mockRetrieveSnapshotSourceWithInheritSteward(false);
 
     AddAuthDomainResponseModel result =
         service.addSnapshotDataAccessControls(TEST_USER, snapshotId, userGroups);
@@ -1367,14 +1368,7 @@ class SnapshotServiceTest {
 
   @Test
   void testPatchSnapshotAuthDomainThrows() {
-    when(service.retrieve(snapshotId))
-        .thenReturn(
-            new Snapshot()
-                .id(snapshotId)
-                .snapshotSources(
-                    List.of(
-                        new SnapshotSource()
-                            .dataset(new Dataset(new DatasetSummary().inheritSteward(true))))));
+    mockRetrieveSnapshotSourceWithInheritSteward(true);
     Exception ex =
         assertThrows(
             BadRequestException.class,
@@ -1384,6 +1378,19 @@ class SnapshotServiceTest {
         ex.getMessage(),
         equalTo(
             "Cannot add an auth domain to snapshot whose parent dataset has inherit steward enabled."));
+  }
+
+  private void mockRetrieveSnapshotSourceWithInheritSteward(boolean inheritSteward) {
+    when(service.retrieve(snapshotId))
+        .thenReturn(
+            new Snapshot()
+                .id(snapshotId)
+                .snapshotSources(
+                    List.of(
+                        new SnapshotSource()
+                            .dataset(
+                                new Dataset(
+                                    new DatasetSummary().inheritSteward(inheritSteward))))));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -32,6 +32,7 @@ import bio.terra.common.Column;
 import bio.terra.common.MetadataEnumeration;
 import bio.terra.common.SqlSortDirection;
 import bio.terra.common.category.Unit;
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.fixtures.DuosFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
@@ -1362,6 +1363,27 @@ class SnapshotServiceTest {
     assertThat(
         flightMapCaptor.getValue().get(JobMapKeys.SNAPSHOT_ID.getKeyName(), String.class),
         equalTo(snapshotId.toString()));
+  }
+
+  @Test
+  void testPatchSnapshotAuthDomainThrows() {
+    when(service.retrieve(snapshotId))
+        .thenReturn(
+            new Snapshot()
+                .id(snapshotId)
+                .snapshotSources(
+                    List.of(
+                        new SnapshotSource()
+                            .dataset(new Dataset(new DatasetSummary().inheritSteward(true))))));
+    Exception ex =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                service.addSnapshotDataAccessControls(TEST_USER, snapshotId, List.of("testGroup")));
+    assertThat(
+        ex.getMessage(),
+        equalTo(
+            "Cannot add an auth domain to snapshot whose parent dataset has inherit steward enabled."));
   }
 
   @Test


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1448

## Addresses
One authorization loophole we have with the inheritSteward feature is that it will not respect auth domains. If a snapshot both uses auth domains and inherit stewards, the Dataset custodians will still get access to the snapshot data even if they are not in the auth domain.

## Summary of changes
- Prevents enabling inheritSteward when the snapshot has an auth domain
- Prevents adding an auth domains to snapshots where the source dataset has inherit steward enabled
- Prevents creating a snapshot with an auth domain where the source dataset has inherit steward enabled

## Testing Strategy
- unit tests
- Manual Test:

**Case 1 - Disable inherit steward when there is a snapshot with an auth domain**
1) Created dataset (inherit steward = false), and 2 snapshots - 1 with an auth domain, 1 without 
* Successfully used the addAuthDomain endpoint to add an auth domain
2) Tried to enable inherit steward on dataset:
Correctly returned an error from the job result on setInheritSteward:
```
{
  "message": "The following snapshots have auth domains: [c27b2271-ed5d-4d0b-aae9-bef6356de2d4]. Please delete any snapshots with auth domains before setting inherit steward.",
  "errorDetail": [
    "The following snapshots have auth domains: [c27b2271-ed5d-4d0b-aae9-bef6356de2d4]. Please delete any snapshots with auth domains before setting inherit steward."
  ]
}
```
3) Delete snapshot with auth domain `c27b2271-ed5d-4d0b-aae9-bef6356de2d4`
4) Try to enable inheritSteward again. Successful ✅ 

**Case 2 - Try to add an auth domain to the snapshot with the parent dataset with inherit steward enabled**
1) Try to add auth domain to snapshot
As expected
<img width="853" alt="image" src="https://github.com/user-attachments/assets/d3f39e86-cd1c-4897-970b-7376b7c7fbbf" />


**Case 3 - Try to create a snapshot with auth domain in a dataset w/ inherit steward enabled** 
As expected,
<img width="896" alt="image" src="https://github.com/user-attachments/assets/adf6ce49-8a66-4fd2-9c17-05a9f19a7915" />




<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
