### PR TITLE
[DT-1471] Allow colima to be used for db tests

### DIFF
--- a/src/test/java/bio/terra/common/EmbeddedDatabaseTest.java
+++ b/src/test/java/bio/terra/common/EmbeddedDatabaseTest.java
@@ -1,6 +1,7 @@
 package bio.terra.common;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import io.zonky.test.db.provider.postgres.PostgreSQLContainerCustomizer;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -8,6 +9,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -18,4 +22,12 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
     provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.DOCKER,
     beanName = "embeddedDataSource")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-public @interface EmbeddedDatabaseTest {}
+public @interface EmbeddedDatabaseTest {
+  @Configuration
+  class PostgreSQLContainerCustomizerConfiguration {
+    @Bean
+    public PostgreSQLContainerCustomizer postgresContainerCustomizer() {
+      return container -> container.waitingFor(Wait.forListeningPort());
+    }
+  }
+}


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-1471

## Summary of changes

Switches the waiting strategy for database tests to wait until the ports are available. Colima takes a little bit longer to set up ports, so if this is not enabled than alternate runtimes like Colima will crash during database tests. This has no impact for individuals who are not using Colima.

This is similar to a change made in [Consent](https://github.com/DataBiosphere/consent/pull/2451/files#diff-e141aaccd3526037b702f172e86b30f409866db7d35266121ab09ef38adf3693).

## Testing Strategy

Running the database tests with Colima.
