### PR TITLE
DT-1527: With Inherit Steward, also grant dataset steward permissions on snapshot cloud resources

### DIFF
--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -29,6 +29,7 @@ import bio.terra.model.EnumerateSortByParam;
 import bio.terra.model.IngestRequestModel;
 import bio.terra.model.IngestRequestModel.FormatEnum;
 import bio.terra.model.ResourceLocks;
+import bio.terra.model.SamPolicyModel;
 import bio.terra.model.TagCount;
 import bio.terra.model.TagCountResultModel;
 import bio.terra.model.TagUpdateRequestModel;
@@ -84,6 +85,7 @@ import bio.terra.stairway.ShortUUID;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -775,18 +777,30 @@ public class DatasetService {
       UUID datasetId, boolean inheritSteward, AuthenticatedUserRequest userReq) {
     String description =
         String.format("Set inherit steward to %s for dataset %s", inheritSteward, datasetId);
-    var custodianPolicy =
+    List<SamPolicyModel> datasetPolicies =
         iamService.retrievePolicies(userReq, IamResourceType.DATASET, datasetId).stream()
-            .filter(p -> p.getName().equals(IamRole.CUSTODIAN.toString()))
-            .findFirst()
-            .orElseThrow();
+            .filter(
+                p ->
+                    List.of(IamRole.CUSTODIAN.toString(), IamRole.STEWARD.toString())
+                        .contains(p.getName()))
+            .toList();
+    List<String> datasetPolicyEmails = new ArrayList<>();
+    datasetPolicies.stream()
+        .map(SamPolicyModel::getEmail)
+        .distinct()
+        .forEach(datasetPolicyEmails::add);
+    List<String> datasetPolicyMembers = new ArrayList<>();
+    datasetPolicies.stream().map(SamPolicyModel::getMembers).toList().stream()
+        .flatMap(List::stream)
+        .distinct()
+        .forEach(datasetPolicyMembers::add);
     return jobService
         .newJob(description, SetInheritStewardFlight.class, null, userReq)
         .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
         .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
-        .addParameter(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), custodianPolicy.getEmail())
-        .addParameter(JobMapKeys.CUSTODIAN_USERS.getKeyName(), custodianPolicy.getMembers())
+        .addParameter(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), datasetPolicyEmails)
+        .addParameter(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), datasetPolicyMembers)
         .addParameter(JobMapKeys.INHERIT_STEWARD.getKeyName(), inheritSteward)
         .submit();
   }

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -784,16 +784,14 @@ public class DatasetService {
                     List.of(IamRole.CUSTODIAN.toString(), IamRole.STEWARD.toString())
                         .contains(p.getName()))
             .toList();
-    List<String> datasetPolicyEmails = new ArrayList<>();
-    datasetPolicies.stream()
-        .map(SamPolicyModel::getEmail)
-        .distinct()
-        .forEach(datasetPolicyEmails::add);
-    List<String> datasetPolicyMembers = new ArrayList<>();
-    datasetPolicies.stream().map(SamPolicyModel::getMembers).toList().stream()
-        .flatMap(List::stream)
-        .distinct()
-        .forEach(datasetPolicyMembers::add);
+    List<String> datasetPolicyEmails =
+        new ArrayList<>(datasetPolicies.stream().map(SamPolicyModel::getEmail).distinct().toList());
+    List<String> datasetPolicyMembers =
+        new ArrayList<>(
+            datasetPolicies.stream()
+                .flatMap(policy -> policy.getMembers().stream())
+                .distinct()
+                .toList());
     return jobService
         .newJob(description, SetInheritStewardFlight.class, null, userReq)
         .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -85,7 +85,6 @@ import bio.terra.stairway.ShortUUID;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -791,13 +790,15 @@ public class DatasetService {
             .filter(p -> isInheritedRole(p.getName()))
             .toList();
     List<String> datasetPolicyEmails =
-        new ArrayList<>(datasetPolicies.stream().map(SamPolicyModel::getEmail).distinct().toList());
+        datasetPolicies.stream()
+            .map(SamPolicyModel::getEmail)
+            .distinct()
+            .collect(Collectors.toList());
     List<String> datasetPolicyMembers =
-        new ArrayList<>(
-            datasetPolicies.stream()
-                .flatMap(policy -> policy.getMembers().stream())
-                .distinct()
-                .toList());
+        datasetPolicies.stream()
+            .flatMap(policy -> policy.getMembers().stream())
+            .distinct()
+            .collect(Collectors.toList());
     return jobService
         .newJob(description, SetInheritStewardFlight.class, null, userReq)
         .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -773,16 +773,22 @@ public class DatasetService {
     return datasetDao.retrieveSummaryById(id).toModel();
   }
 
+  public static boolean isInheritedRole(IamRole role) {
+    return isInheritedRole(role.toString());
+  }
+
+  public static boolean isInheritedRole(String roleName) {
+    return List.of(IamRole.STEWARD.toString(), IamRole.CUSTODIAN.toString())
+        .contains(roleName.toLowerCase());
+  }
+
   public String setInheritSteward(
       UUID datasetId, boolean inheritSteward, AuthenticatedUserRequest userReq) {
     String description =
         String.format("Set inherit steward to %s for dataset %s", inheritSteward, datasetId);
     List<SamPolicyModel> datasetPolicies =
         iamService.retrievePolicies(userReq, IamResourceType.DATASET, datasetId).stream()
-            .filter(
-                p ->
-                    List.of(IamRole.CUSTODIAN.toString(), IamRole.STEWARD.toString())
-                        .contains(p.getName()))
+            .filter(p -> isInheritedRole(p.getName()))
             .toList();
     List<String> datasetPolicyEmails =
         new ArrayList<>(datasetPolicies.stream().map(SamPolicyModel::getEmail).distinct().toList());

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
@@ -35,7 +35,7 @@ public record AdjustStewardMembersStep(
     FlightMap inputParams = context.getInputParameters();
     List<String> custodians =
         Objects.requireNonNull(
-            inputParams.get(JobMapKeys.CUSTODIAN_USERS.getKeyName(), List.class));
+            inputParams.get(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), List.class));
     AddRemoveApi api =
         inheritSteward ? iamService::deletePolicyMember : iamService::addPolicyMember;
     for (var snapshotId : snapshotIds) {

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
@@ -35,7 +35,7 @@ public record AdjustStewardMembersStep(
     FlightMap inputParams = context.getInputParameters();
     List<String> custodians =
         Objects.requireNonNull(
-            inputParams.get(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), List.class));
+            inputParams.get(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), List.class));
     AddRemoveApi api =
         inheritSteward ? iamService::deletePolicyMember : iamService::addPolicyMember;
     for (var snapshotId : snapshotIds) {

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthGcpUserRolesStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthGcpUserRolesStep.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 public record SetAuthGcpUserRolesStep(
     ResourceService resourceService,
     SnapshotService snapshotService,
-    String custodianEmail,
+    List<String> datasetPolicyEmails,
     boolean inheritSteward)
     implements Step {
 
@@ -27,9 +27,9 @@ public record SetAuthGcpUserRolesStep(
       String projectId =
           snapshotService.retrieve(snapshotId).getProjectResource().getGoogleProjectId();
       if (inheritSteward) {
-        resourceService.assignRolesForSnapshot(projectId, List.of(custodianEmail));
+        resourceService.assignRolesForSnapshot(projectId, datasetPolicyEmails);
       } else {
-        resourceService.revokeRolesForSnapshot(projectId, List.of(custodianEmail));
+        resourceService.revokeRolesForSnapshot(projectId, datasetPolicyEmails);
       }
     }
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthTabularAclStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthTabularAclStep.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 public record SetAuthTabularAclStep(
     BigQuerySnapshotPdao bigQuerySnapshotPdao,
     SnapshotService snapshotService,
-    String custodianEmail,
+    List<String> datasetPolicyEmails,
     boolean inheritSteward)
     implements Step {
 
@@ -30,13 +30,12 @@ public record SetAuthTabularAclStep(
   private void setAuth(FlightContext context, boolean inheritSteward) throws InterruptedException {
     FlightMap workingMap = context.getWorkingMap();
     List<UUID> snapshotIds = workingMap.get(DatasetWorkingMapKeys.SNAPSHOT_IDS, List.class);
-    List<String> policyEmails = List.of(custodianEmail);
     for (var snapshotId : Objects.requireNonNull(snapshotIds)) {
       Snapshot snapshot = snapshotService.retrieve(snapshotId);
       if (inheritSteward) {
-        bigQuerySnapshotPdao.grantReadAccessToSnapshot(snapshot, policyEmails);
+        bigQuerySnapshotPdao.grantReadAccessToSnapshot(snapshot, datasetPolicyEmails);
       } else {
-        bigQuerySnapshotPdao.revokeReadAccessToSnapshot(snapshot, policyEmails);
+        bigQuerySnapshotPdao.revokeReadAccessToSnapshot(snapshot, datasetPolicyEmails);
       }
     }
   }

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlight.java
@@ -16,6 +16,7 @@ import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.context.ApplicationContext;
 
@@ -36,8 +37,8 @@ public class SetInheritStewardFlight extends Flight {
 
     // Get the input parameters
     UUID datasetId = inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), UUID.class);
-    String custodianEmail =
-        inputParameters.get(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), String.class);
+    List<String> datasetPolicyEmails =
+        inputParameters.get(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), List.class);
     AuthenticatedUserRequest userReq =
         inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
 
@@ -55,10 +56,10 @@ public class SetInheritStewardFlight extends Flight {
     addStep(new SetParentOnSnapshotsStep(iamService, datasetId, userReq, inheritSteward));
     addStep(
         new SetAuthGcpUserRolesStep(
-            resourceService, snapshotService, custodianEmail, inheritSteward));
+            resourceService, snapshotService, datasetPolicyEmails, inheritSteward));
     addStep(
         new SetAuthTabularAclStep(
-            bigQuerySnapshotPdao, snapshotService, custodianEmail, inheritSteward));
+            bigQuerySnapshotPdao, snapshotService, datasetPolicyEmails, inheritSteward));
     addStep(new AdjustStewardMembersStep(userReq, iamService, inheritSteward));
     if (!inheritSteward) {
       // If we are setting inherit steward to false, we want to set the flag last

--- a/src/main/java/bio/terra/service/job/JobMapKeys.java
+++ b/src/main/java/bio/terra/service/job/JobMapKeys.java
@@ -24,8 +24,8 @@ public enum JobMapKeys {
   TRANSACTION_ID("transactionId"),
   DELETE_CLOUD_RESOURCES("deleteCloudResources"),
   BUCKET_NAME("bucketName"),
-  CUSTODIAN_EMAIL("custodianEmail"),
-  CUSTODIAN_USERS("custodianUsers"),
+  DATASET_POLICY_EMAILS("datasetPolicyEmails"),
+  DATASET_POLICY_USERS("datasetPolicyUsers"),
   INHERIT_STEWARD("inheritSteward"),
   TDR_BILLING_PROFILE_FALLBACK("tdrBillingProfileFallback"),
   SET_PUBLIC("setPublic");

--- a/src/main/java/bio/terra/service/snapshot/flight/create/AddSourceDatasetPolicyEmailsIfInheritStewardStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/AddSourceDatasetPolicyEmailsIfInheritStewardStep.java
@@ -5,24 +5,22 @@ import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Map;
 
-public interface AddSourceDatasetPolicyEmailsIfInheritStewardStep extends Step {
-  default void addSourceDatasetPolicyEmailsIfInheritSteward(
-      FlightMap workingMap, List<String> groupsToAdd, Dataset sourceDataset) {
-    if (sourceDataset.isInheritSteward()) {
-      Map<IamRole, String> sourceDatasetPolicyMap =
-          workingMap.get(
-              SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
-      // Allow dataset stewards and custodians to make queries in the snapshot project.
-      var result =
-          sourceDatasetPolicyMap.entrySet().stream()
-              .filter(entry -> DatasetService.isInheritedRole(entry.getKey()))
-              .toList();
-      result.stream().map(Map.Entry::getValue).forEach(groupsToAdd::add);
+public abstract class AddSourceDatasetPolicyEmailsIfInheritStewardStep {
+  List<String> addSourceDatasetPolicyEmailsIfInheritSteward(
+      FlightMap workingMap, Dataset sourceDataset) {
+    if (!sourceDataset.isInheritSteward()) {
+      return List.of();
     }
+    Map<IamRole, String> sourceDatasetPolicyMap =
+        workingMap.get(SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
+    // Allow dataset stewards and custodians to make queries in the snapshot project.
+    return sourceDatasetPolicyMap.entrySet().stream()
+        .filter(entry -> DatasetService.isInheritedRole(entry.getKey()))
+        .map(Map.Entry::getValue)
+        .toList();
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/flight/create/AddSourceDatasetPolicyEmailsIfInheritStewardStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/AddSourceDatasetPolicyEmailsIfInheritStewardStep.java
@@ -1,0 +1,28 @@
+package bio.terra.service.snapshot.flight.create;
+
+import bio.terra.service.auth.iam.IamRole;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Map;
+
+public interface AddSourceDatasetPolicyEmailsIfInheritStewardStep extends Step {
+  default void addSourceDatasetPolicyEmailsIfInheritSteward(
+      FlightMap workingMap, List<String> groupsToAdd, Dataset sourceDataset) {
+    if (sourceDataset.isInheritSteward()) {
+      Map<IamRole, String> sourceDatasetPolicyMap =
+          workingMap.get(
+              SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
+      // Allow dataset stewards and custodians to make queries in the snapshot project.
+      var result =
+          sourceDatasetPolicyMap.entrySet().stream()
+              .filter(entry -> DatasetService.isInheritedRole(entry.getKey()))
+              .toList();
+      result.stream().map(Map.Entry::getValue).forEach(groupsToAdd::add);
+    }
+  }
+}

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -48,8 +48,11 @@ public class SnapshotAuthzBqJobUserStep implements Step {
       Map<IamRole, String> sourceDatasetPolicyMap =
           workingMap.get(
               SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
-      // Allow the custodian to make queries in this project.
-      policyEmails.add(sourceDatasetPolicyMap.get(IamRole.CUSTODIAN));
+      // Allow the dataset stewards and custodians to make queries in the snapshot project.
+      policyEmails.addAll(
+          List.of(
+              sourceDatasetPolicyMap.get(IamRole.CUSTODIAN),
+              sourceDatasetPolicyMap.get(IamRole.STEWARD)));
     }
     // The underlying service provides retries so we do not need to retry this operation
     resourceService.grantPoliciesBqJobUser(googleProjectId, policyEmails);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -46,7 +46,7 @@ public class SnapshotAuthzBqJobUserStep
 
     addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, policyEmails, sourceDataset);
 
-    // The underlying service provides retries so we do not need to retry this operation
+    // The underlying service provides retries, so we do not need to retry this operation
     resourceService.grantPoliciesBqJobUser(googleProjectId, policyEmails);
 
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -7,14 +7,14 @@ import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class SnapshotAuthzBqJobUserStep implements Step {
+public class SnapshotAuthzBqJobUserStep
+    implements AddSourceDatasetPolicyEmailsIfInheritStewardStep {
   private final SnapshotService snapshotService;
   private final ResourceService resourceService;
   private final String snapshotName;
@@ -44,16 +44,8 @@ public class SnapshotAuthzBqJobUserStep implements Step {
     List<String> policyEmails =
         new ArrayList<>(List.of(policyMap.get(IamRole.STEWARD), policyMap.get(IamRole.READER)));
 
-    if (sourceDataset.isInheritSteward()) {
-      Map<IamRole, String> sourceDatasetPolicyMap =
-          workingMap.get(
-              SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
-      // Allow the dataset stewards and custodians to make queries in the snapshot project.
-      policyEmails.addAll(
-          List.of(
-              sourceDatasetPolicyMap.get(IamRole.CUSTODIAN),
-              sourceDatasetPolicyMap.get(IamRole.STEWARD)));
-    }
+    addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, policyEmails, sourceDataset);
+
     // The underlying service provides retries so we do not need to retry this operation
     resourceService.grantPoliciesBqJobUser(googleProjectId, policyEmails);
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStep.java
@@ -7,14 +7,15 @@ import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class SnapshotAuthzBqJobUserStep
-    implements AddSourceDatasetPolicyEmailsIfInheritStewardStep {
+public class SnapshotAuthzBqJobUserStep extends AddSourceDatasetPolicyEmailsIfInheritStewardStep
+    implements Step {
   private final SnapshotService snapshotService;
   private final ResourceService resourceService;
   private final String snapshotName;
@@ -44,7 +45,7 @@ public class SnapshotAuthzBqJobUserStep
     List<String> policyEmails =
         new ArrayList<>(List.of(policyMap.get(IamRole.STEWARD), policyMap.get(IamRole.READER)));
 
-    addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, policyEmails, sourceDataset);
+    policyEmails.addAll(addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, sourceDataset));
 
     // The underlying service provides retries, so we do not need to retry this operation
     resourceService.grantPoliciesBqJobUser(googleProjectId, policyEmails);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
@@ -60,8 +60,11 @@ public class SnapshotAuthzServiceAccountConsumerStep implements Step {
       Map<IamRole, String> sourceDatasetPolicyMap =
           workingMap.get(
               SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
-      // Allow the custodian to make queries in this project.
-      principalsToAdd.add(sourceDatasetPolicyMap.get(IamRole.CUSTODIAN));
+      // Allow dataset stewards and custodians to make queries in the snapshot project.
+      principalsToAdd.addAll(
+          List.of(
+              sourceDatasetPolicyMap.get(IamRole.CUSTODIAN),
+              sourceDatasetPolicyMap.get(IamRole.STEWARD)));
     }
     resourceService.grantPoliciesServiceUsageConsumer(
         snapshot.getProjectResource().getGoogleProjectId(), principalsToAdd);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
@@ -8,6 +8,7 @@ import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
@@ -15,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 public class SnapshotAuthzServiceAccountConsumerStep
-    implements AddSourceDatasetPolicyEmailsIfInheritStewardStep {
+    extends AddSourceDatasetPolicyEmailsIfInheritStewardStep implements Step {
   private final SnapshotService snapshotService;
   private final ResourceService resourceService;
   private final String snapshotName;
@@ -56,7 +57,7 @@ public class SnapshotAuthzServiceAccountConsumerStep
       principalsToAdd.add(snapshot.getSourceDataset().getProjectResource().getServiceAccount());
     }
 
-    addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, principalsToAdd, sourceDataset);
+    principalsToAdd.addAll(addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, sourceDataset));
 
     resourceService.grantPoliciesServiceUsageConsumer(
         snapshot.getProjectResource().getGoogleProjectId(), principalsToAdd);

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStep.java
@@ -8,14 +8,14 @@ import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class SnapshotAuthzServiceAccountConsumerStep implements Step {
+public class SnapshotAuthzServiceAccountConsumerStep
+    implements AddSourceDatasetPolicyEmailsIfInheritStewardStep {
   private final SnapshotService snapshotService;
   private final ResourceService resourceService;
   private final String snapshotName;
@@ -56,16 +56,8 @@ public class SnapshotAuthzServiceAccountConsumerStep implements Step {
       principalsToAdd.add(snapshot.getSourceDataset().getProjectResource().getServiceAccount());
     }
 
-    if (sourceDataset.isInheritSteward()) {
-      Map<IamRole, String> sourceDatasetPolicyMap =
-          workingMap.get(
-              SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
-      // Allow dataset stewards and custodians to make queries in the snapshot project.
-      principalsToAdd.addAll(
-          List.of(
-              sourceDatasetPolicyMap.get(IamRole.CUSTODIAN),
-              sourceDatasetPolicyMap.get(IamRole.STEWARD)));
-    }
+    addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, principalsToAdd, sourceDataset);
+
     resourceService.grantPoliciesServiceUsageConsumer(
         snapshot.getProjectResource().getGoogleProjectId(), principalsToAdd);
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -5,7 +5,6 @@ import static bio.terra.service.configuration.ConfigEnum.SNAPSHOT_GRANT_ACCESS_F
 import bio.terra.common.FlightUtils;
 import bio.terra.common.exception.PdaoException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.configuration.ConfigurationService;
@@ -67,9 +66,14 @@ public class SnapshotAuthzTabularAclStep implements Step {
     emails.add(policies.get(IamRole.READER));
 
     if (sourceDataset.isInheritSteward()) {
-      var datasetPolicyMap =
-          iamService.retrievePolicyEmails(userReq, IamResourceType.DATASET, sourceDataset.getId());
-      emails.add(datasetPolicyMap.get(IamRole.CUSTODIAN));
+      Map<IamRole, String> sourceDatasetPolicyMap =
+          workingMap.get(
+              SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
+      // Allow the dataset stewards and custodians to make queries in the snapshot project.
+      emails.addAll(
+          List.of(
+              sourceDatasetPolicyMap.get(IamRole.CUSTODIAN),
+              sourceDatasetPolicyMap.get(IamRole.STEWARD)));
     }
 
     try {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -4,9 +4,7 @@ import static bio.terra.service.configuration.ConfigEnum.SNAPSHOT_GRANT_ACCESS_F
 
 import bio.terra.common.FlightUtils;
 import bio.terra.common.exception.PdaoException;
-import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.service.auth.iam.IamRole;
-import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.configuration.ConfigurationService;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.snapshot.Snapshot;
@@ -31,25 +29,19 @@ public class SnapshotAuthzTabularAclStep implements Step {
   private final BigQuerySnapshotPdao bigQuerySnapshotPdao;
   private final SnapshotService snapshotService;
   private final ConfigurationService configService;
-  private final IamService iamService;
   private final UUID snapshotId;
-  private final AuthenticatedUserRequest userReq;
   private final Dataset sourceDataset;
 
   public SnapshotAuthzTabularAclStep(
       BigQuerySnapshotPdao bigQuerySnapshotPdao,
       SnapshotService snapshotService,
       ConfigurationService configService,
-      IamService iamService,
       UUID snapshotId,
-      AuthenticatedUserRequest userReq,
       Dataset sourceDataset) {
     this.bigQuerySnapshotPdao = bigQuerySnapshotPdao;
     this.snapshotService = snapshotService;
     this.configService = configService;
     this.snapshotId = snapshotId;
-    this.userReq = userReq;
-    this.iamService = iamService;
     this.sourceDataset = sourceDataset;
   }
 

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -13,7 +13,6 @@ import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
-import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -24,7 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public class SnapshotAuthzTabularAclStep implements Step {
+public class SnapshotAuthzTabularAclStep
+    implements AddSourceDatasetPolicyEmailsIfInheritStewardStep {
 
   private final BigQuerySnapshotPdao bigQuerySnapshotPdao;
   private final SnapshotService snapshotService;
@@ -57,16 +57,7 @@ public class SnapshotAuthzTabularAclStep implements Step {
     emails.add(policies.get(IamRole.STEWARD));
     emails.add(policies.get(IamRole.READER));
 
-    if (sourceDataset.isInheritSteward()) {
-      Map<IamRole, String> sourceDatasetPolicyMap =
-          workingMap.get(
-              SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, new TypeReference<>() {});
-      // Allow the dataset stewards and custodians to make queries in the snapshot project.
-      emails.addAll(
-          List.of(
-              sourceDatasetPolicyMap.get(IamRole.CUSTODIAN),
-              sourceDatasetPolicyMap.get(IamRole.STEWARD)));
-    }
+    addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, emails, sourceDataset);
 
     try {
       if (configService.testInsertFault(SNAPSHOT_GRANT_ACCESS_FAULT)) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStep.java
@@ -13,6 +13,7 @@ import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
 import bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -23,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public class SnapshotAuthzTabularAclStep
-    implements AddSourceDatasetPolicyEmailsIfInheritStewardStep {
+public class SnapshotAuthzTabularAclStep extends AddSourceDatasetPolicyEmailsIfInheritStewardStep
+    implements Step {
 
   private final BigQuerySnapshotPdao bigQuerySnapshotPdao;
   private final SnapshotService snapshotService;
@@ -57,7 +58,7 @@ public class SnapshotAuthzTabularAclStep
     emails.add(policies.get(IamRole.STEWARD));
     emails.add(policies.get(IamRole.READER));
 
-    addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, emails, sourceDataset);
+    emails.addAll(addSourceDatasetPolicyEmailsIfInheritSteward(workingMap, sourceDataset));
 
     try {
       if (configService.testInsertFault(SNAPSHOT_GRANT_ACCESS_FAULT)) {

--- a/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/create/SnapshotCreateFlight.java
@@ -350,13 +350,7 @@ public class SnapshotCreateFlight extends Flight {
       // Apply the IAM readers to the BQ dataset
       addStep(
           new SnapshotAuthzTabularAclStep(
-              bigQuerySnapshotPdao,
-              snapshotService,
-              configService,
-              iamService,
-              snapshotId,
-              userReq,
-              sourceDataset),
+              bigQuerySnapshotPdao, snapshotService, configService, snapshotId, sourceDataset),
           pdaoAclRetryRule);
 
       // Apply the IAM readers to the GCS files

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -518,7 +518,7 @@ class DatasetServiceUnitTest {
   @ParameterizedTest
   @MethodSource("provideIamRoleName")
   void testIsInherited(String role, boolean isInherited) {
-    assertThat(datasetService.isInheritedRole(role), is(isInherited));
+    assertThat(DatasetService.isInheritedRole(role), is(isInherited));
   }
 
   private static Stream<Arguments> provideIamRoleName() {
@@ -535,7 +535,7 @@ class DatasetServiceUnitTest {
   @ParameterizedTest
   @MethodSource("provideIamRoles")
   void testIsInherited(IamRole role, boolean isInherited) {
-    assertThat(datasetService.isInheritedRole(role), is(isInherited));
+    assertThat(DatasetService.isInheritedRole(role), is(isInherited));
   }
 
   private static Stream<Arguments> provideIamRoles() {

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -433,9 +433,9 @@ class DatasetServiceUnitTest {
     assertThat(
         flightMap.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class),
         equalTo(IamAction.SET_INHERIT_STEWARD));
-    List<String> datasetPolicyEmails =
-        flightMap.get(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), List.class);
-    assertThat(datasetPolicyEmails, equalTo(Arrays.asList(custodianEmail, stewardEmail)));
+    assertThat(
+        flightMap.get(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), List.class),
+        equalTo(Arrays.asList(custodianEmail, stewardEmail)));
     assertThat(
         flightMap.get(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), List.class),
         equalTo(Stream.of(members, stewardMembers).flatMap(List::stream).toList()));

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -403,14 +404,20 @@ class DatasetServiceUnitTest {
             TEST_USER))
         .thenReturn(jobBuilder);
     var custodianEmail = "custodianEmail";
+    var stewardEmail = "stewardEmail";
     var members = Arrays.asList("member");
+    var stewardMembers = Arrays.asList("member2");
     when(iamService.retrievePolicies(TEST_USER, IamResourceType.DATASET, DATASET_ID))
         .thenReturn(
             List.of(
                 new SamPolicyModel()
                     .name(IamRole.CUSTODIAN.toString())
                     .email(custodianEmail)
-                    .members(members)));
+                    .members(members),
+                new SamPolicyModel()
+                    .name(IamRole.STEWARD.toString())
+                    .email(stewardEmail)
+                    .members(stewardMembers)));
     ArgumentCaptor<FlightMap> captor = ArgumentCaptor.forClass(FlightMap.class);
     when(jobService.submit(eq(SetInheritStewardFlight.class), captor.capture()))
         .thenReturn("JobId");
@@ -426,11 +433,12 @@ class DatasetServiceUnitTest {
     assertThat(
         flightMap.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class),
         equalTo(IamAction.SET_INHERIT_STEWARD));
+    List<String> datasetPolicyEmails =
+        flightMap.get(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), List.class);
+    assertThat(datasetPolicyEmails, equalTo(Arrays.asList(custodianEmail, stewardEmail)));
     assertThat(
-        flightMap.get(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), String.class),
-        equalTo(custodianEmail));
-    assertThat(
-        flightMap.get(JobMapKeys.CUSTODIAN_USERS.getKeyName(), List.class), equalTo(members));
+        flightMap.get(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), List.class),
+        equalTo(Stream.of(members, stewardMembers).flatMap(List::stream).toList()));
     assertThat(
         flightMap.get(JobMapKeys.INHERIT_STEWARD.getKeyName(), Boolean.class),
         equalTo(inheritSteward));

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -78,6 +79,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -510,5 +513,35 @@ class DatasetServiceUnitTest {
     assertThat(
         flightMap.get(JobMapKeys.TDR_BILLING_PROFILE_FALLBACK.getKeyName(), Boolean.class),
         equalTo(isTDRBillingProfile));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideIamRoleName")
+  void testIsInherited(String role, boolean isInherited) {
+    assertThat(datasetService.isInheritedRole(role), is(isInherited));
+  }
+
+  private static Stream<Arguments> provideIamRoleName() {
+    return Stream.of(
+        Arguments.of("custodian", true),
+        Arguments.of("steward", true),
+        Arguments.of("reader", false),
+        Arguments.of("CUSTODIAN", true),
+        Arguments.of("STEWARD", true),
+        Arguments.of("READER", false),
+        Arguments.of("12345", false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideIamRoles")
+  void testIsInherited(IamRole role, boolean isInherited) {
+    assertThat(datasetService.isInheritedRole(role), is(isInherited));
+  }
+
+  private static Stream<Arguments> provideIamRoles() {
+    return Stream.of(
+        Arguments.of(IamRole.CUSTODIAN, true),
+        Arguments.of(IamRole.STEWARD, true),
+        Arguments.of(IamRole.READER, false));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
@@ -50,7 +50,7 @@ class AdjustStewardMembersStepTest {
         DatasetWorkingMapKeys.SNAPSHOT_IDS,
         snapshots.stream().map(Snapshot::getId).collect(Collectors.toList()));
     FlightMap inputParameters = new FlightMap();
-    inputParameters.put(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), datasetPolicyEmails);
+    inputParameters.put(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), datasetPolicyEmails);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     assertThat(doOrUndo.apply(flightContext), is(StepResult.getStepResultSuccess()));

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
@@ -17,7 +17,7 @@ import bio.terra.service.snapshot.Snapshot;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -44,33 +44,37 @@ class AdjustStewardMembersStepTest {
   private void verifyAdjustMembers(DoOrUndo doOrUndo, boolean inheritSteward) throws Exception {
     var snapshots =
         List.of(new Snapshot().id(UUID.randomUUID()), new Snapshot().id(UUID.randomUUID()));
-    var custodianUser = "user";
+    List<String> datasetPolicyEmails = new ArrayList<>(List.of("custodianEmail", "stewardEmail"));
     FlightMap workingMap = new FlightMap();
     workingMap.put(
         DatasetWorkingMapKeys.SNAPSHOT_IDS,
         snapshots.stream().map(Snapshot::getId).collect(Collectors.toList()));
     FlightMap inputParameters = new FlightMap();
-    inputParameters.put(JobMapKeys.CUSTODIAN_USERS.getKeyName(), Arrays.asList(custodianUser));
+    inputParameters.put(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), datasetPolicyEmails);
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
     when(flightContext.getInputParameters()).thenReturn(inputParameters);
     assertThat(doOrUndo.apply(flightContext), is(StepResult.getStepResultSuccess()));
     for (var snapshot : snapshots) {
       if (inheritSteward) {
-        verify(iamService)
-            .deletePolicyMember(
-                TEST_USER,
-                IamResourceType.DATASNAPSHOT,
-                snapshot.getId(),
-                IamRole.STEWARD,
-                custodianUser);
+        datasetPolicyEmails.forEach(
+            email ->
+                verify(iamService)
+                    .deletePolicyMember(
+                        TEST_USER,
+                        IamResourceType.DATASNAPSHOT,
+                        snapshot.getId(),
+                        IamRole.STEWARD,
+                        email));
       } else {
-        verify(iamService)
-            .addPolicyMember(
-                TEST_USER,
-                IamResourceType.DATASNAPSHOT,
-                snapshot.getId(),
-                IamRole.STEWARD,
-                custodianUser);
+        datasetPolicyEmails.forEach(
+            email ->
+                verify(iamService)
+                    .addPolicyMember(
+                        TEST_USER,
+                        IamResourceType.DATASNAPSHOT,
+                        snapshot.getId(),
+                        IamRole.STEWARD,
+                        email));
       }
     }
   }

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
@@ -17,7 +17,7 @@ import bio.terra.service.snapshot.Snapshot;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -44,7 +44,7 @@ class AdjustStewardMembersStepTest {
   private void verifyAdjustMembers(DoOrUndo doOrUndo, boolean inheritSteward) throws Exception {
     var snapshots =
         List.of(new Snapshot().id(UUID.randomUUID()), new Snapshot().id(UUID.randomUUID()));
-    List<String> datasetPolicyEmails = new ArrayList<>(List.of("custodianEmail", "stewardEmail"));
+    List<String> datasetPolicyEmails = Arrays.asList("custodianEmail", "stewardEmail");
     FlightMap workingMap = new FlightMap();
     workingMap.put(
         DatasetWorkingMapKeys.SNAPSHOT_IDS,

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthGcpUserRolesStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthGcpUserRolesStepTest.java
@@ -32,7 +32,7 @@ class SetAuthGcpUserRolesStepTest {
   @Mock private SnapshotService snapshotService;
   @Mock private FlightContext flightContext;
 
-  private final String custodianEmail = "custodianEmail";
+  private final List<String> datasetPolicyEmails = List.of("custodianEmail", "stewardEmail");
 
   interface DoOrUndo {
     StepResult apply(FlightContext t) throws Exception;
@@ -56,14 +56,15 @@ class SetAuthGcpUserRolesStepTest {
       when(snapshotService.retrieve(snapshot.getId())).thenReturn(snapshot);
     }
     assertThat(doOrUndo.apply(flightContext), is(StepResult.getStepResultSuccess()));
-    var emails = List.of(custodianEmail);
     for (var snapshot : snapshots) {
       if (grantPolicy) {
         verify(resourceService)
-            .assignRolesForSnapshot(snapshot.getProjectResource().getGoogleProjectId(), emails);
+            .assignRolesForSnapshot(
+                snapshot.getProjectResource().getGoogleProjectId(), datasetPolicyEmails);
       } else {
         verify(resourceService)
-            .revokeRolesForSnapshot(snapshot.getProjectResource().getGoogleProjectId(), emails);
+            .revokeRolesForSnapshot(
+                snapshot.getProjectResource().getGoogleProjectId(), datasetPolicyEmails);
       }
     }
   }
@@ -73,7 +74,7 @@ class SetAuthGcpUserRolesStepTest {
   void doAndUndoStep(boolean inheritSteward) throws Exception {
     SetAuthGcpUserRolesStep step =
         new SetAuthGcpUserRolesStep(
-            resourceService, snapshotService, custodianEmail, inheritSteward);
+            resourceService, snapshotService, datasetPolicyEmails, inheritSteward);
     verifySetAuth(step::doStep, inheritSteward);
     verifySetAuth(step::undoStep, !inheritSteward);
   }

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthTabularAclStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetAuthTabularAclStepTest.java
@@ -31,7 +31,7 @@ class SetAuthTabularAclStepTest {
   @Mock private SnapshotService snapshotService;
   @Mock private FlightContext flightContext;
 
-  private final String custodianEmail = "custodianEmail";
+  private final List<String> datasetPolicyEmails = List.of("custodianEmail", "stewardEmail");
 
   interface DoOrUndo {
     StepResult apply(FlightContext t) throws Exception;
@@ -50,12 +50,11 @@ class SetAuthTabularAclStepTest {
     }
     when(flightContext.getWorkingMap()).thenReturn(workingMap);
     assertThat(doOrUndo.apply(flightContext), is(StepResult.getStepResultSuccess()));
-    List<String> emails = List.of(custodianEmail);
     for (var snapshot : snapshots) {
       if (grantPolicy) {
-        verify(bigQuerySnapshotPdao).grantReadAccessToSnapshot(snapshot, emails);
+        verify(bigQuerySnapshotPdao).grantReadAccessToSnapshot(snapshot, datasetPolicyEmails);
       } else {
-        verify(bigQuerySnapshotPdao).revokeReadAccessToSnapshot(snapshot, emails);
+        verify(bigQuerySnapshotPdao).revokeReadAccessToSnapshot(snapshot, datasetPolicyEmails);
       }
     }
   }
@@ -65,7 +64,7 @@ class SetAuthTabularAclStepTest {
   void doStep(boolean inheritSteward) throws Exception {
     SetAuthTabularAclStep step =
         new SetAuthTabularAclStep(
-            bigQuerySnapshotPdao, snapshotService, custodianEmail, inheritSteward);
+            bigQuerySnapshotPdao, snapshotService, datasetPolicyEmails, inheritSteward);
     verifySetAuth(step::doStep, inheritSteward);
     verifySetAuth(step::undoStep, !inheritSteward);
   }

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlightTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlightTest.java
@@ -25,7 +25,7 @@ import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao;
 import bio.terra.stairway.FlightMap;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +56,7 @@ class SetInheritStewardFlightTest {
   private static final String CUSTODIAN_EMAIL = "custodian email";
   private static final String STEWARD_EMAIL = "steward email";
   private static final List<String> DATASET_POLICY_EMAILS =
-      new ArrayList<>(List.of(CUSTODIAN_EMAIL, STEWARD_EMAIL));
+      Arrays.asList(CUSTODIAN_EMAIL, STEWARD_EMAIL);
   private static final UUID DATASET_ID = UUID.randomUUID();
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlightTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlightTest.java
@@ -55,7 +55,8 @@ class SetInheritStewardFlightTest {
 
   private static final String CUSTODIAN_EMAIL = "custodian email";
   private static final String STEWARD_EMAIL = "steward email";
-  private static final List<String> DATASET_POLICY_EMAILS = new ArrayList<>();
+  private static final List<String> DATASET_POLICY_EMAILS =
+      new ArrayList<>(List.of(CUSTODIAN_EMAIL, STEWARD_EMAIL));
   private static final UUID DATASET_ID = UUID.randomUUID();
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
@@ -66,8 +67,6 @@ class SetInheritStewardFlightTest {
     inputParameters.put(JobMapKeys.DATASET_ID.getKeyName(), DATASET_ID);
     inputParameters.put(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD);
     inputParameters.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), TEST_USER);
-    DATASET_POLICY_EMAILS.add(CUSTODIAN_EMAIL);
-    DATASET_POLICY_EMAILS.add(STEWARD_EMAIL);
     inputParameters.put(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), DATASET_POLICY_EMAILS);
     when(context.getBean(DatasetDao.class)).thenReturn(datasetDao);
     when(context.getBean(SnapshotDao.class)).thenReturn(snapshotDao);

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlightTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/SetInheritStewardFlightTest.java
@@ -25,6 +25,8 @@ import bio.terra.service.snapshot.SnapshotDao;
 import bio.terra.service.snapshot.SnapshotService;
 import bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao;
 import bio.terra.stairway.FlightMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -52,6 +54,8 @@ class SetInheritStewardFlightTest {
   private final FlightMap inputParameters = new FlightMap();
 
   private static final String CUSTODIAN_EMAIL = "custodian email";
+  private static final String STEWARD_EMAIL = "steward email";
+  private static final List<String> DATASET_POLICY_EMAILS = new ArrayList<>();
   private static final UUID DATASET_ID = UUID.randomUUID();
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
@@ -62,7 +66,9 @@ class SetInheritStewardFlightTest {
     inputParameters.put(JobMapKeys.DATASET_ID.getKeyName(), DATASET_ID);
     inputParameters.put(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD);
     inputParameters.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), TEST_USER);
-    inputParameters.put(JobMapKeys.CUSTODIAN_EMAIL.getKeyName(), CUSTODIAN_EMAIL);
+    DATASET_POLICY_EMAILS.add(CUSTODIAN_EMAIL);
+    DATASET_POLICY_EMAILS.add(STEWARD_EMAIL);
+    inputParameters.put(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), DATASET_POLICY_EMAILS);
     when(context.getBean(DatasetDao.class)).thenReturn(datasetDao);
     when(context.getBean(SnapshotDao.class)).thenReturn(snapshotDao);
     when(context.getBean(DatasetService.class)).thenReturn(datasetService);
@@ -187,7 +193,11 @@ class SetInheritStewardFlightTest {
             (mock, context) ->
                 assertThat(
                     context.arguments(),
-                    contains(resourceService, snapshotService, CUSTODIAN_EMAIL, inheritSteward)))) {
+                    contains(
+                        resourceService,
+                        snapshotService,
+                        DATASET_POLICY_EMAILS,
+                        inheritSteward)))) {
       //noinspection ResultOfObjectAllocationIgnored
       new SetInheritStewardFlight(inputParameters, context);
       assertThat(mockStep.constructed(), hasSize(1));
@@ -235,7 +245,10 @@ class SetInheritStewardFlightTest {
                 assertThat(
                     context.arguments(),
                     contains(
-                        bigQuerySnapshotPdao, snapshotService, CUSTODIAN_EMAIL, inheritSteward)))) {
+                        bigQuerySnapshotPdao,
+                        snapshotService,
+                        DATASET_POLICY_EMAILS,
+                        inheritSteward)))) {
       //noinspection ResultOfObjectAllocationIgnored
       new SetInheritStewardFlight(inputParameters, context);
       assertThat(mockStep.constructed(), hasSize(1));

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzBqJobUserStepTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -63,7 +65,8 @@ class SnapshotAuthzBqJobUserStepTest {
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policyMap);
 
     var sourceDatasetPolicyMap = new EnumMap<>(IamRole.class);
-    sourceDatasetPolicyMap.put(IamRole.CUSTODIAN, "custodian");
+    sourceDatasetPolicyMap.put(IamRole.CUSTODIAN, "datasetCustodian");
+    sourceDatasetPolicyMap.put(IamRole.STEWARD, "datasetSteward");
     workingMap.put(SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, sourceDatasetPolicyMap);
     when(snapshotService.retrieveByName(SNAPSHOT_NAME)).thenReturn(SNAPSHOT);
 
@@ -88,15 +91,22 @@ class SnapshotAuthzBqJobUserStepTest {
     verifyNoInteractions(iamService);
   }
 
-  @Test
-  void doStepInheritEnabled() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void doStepInheritSteward(boolean inheritSteward) throws Exception {
     var sourceDataset =
-        new Dataset(new DatasetSummary().inheritSteward(true)).id(UUID.randomUUID());
+        new Dataset(new DatasetSummary().inheritSteward(inheritSteward)).id(UUID.randomUUID());
     step =
         new SnapshotAuthzBqJobUserStep(
             snapshotService, resourceService, SNAPSHOT_NAME, sourceDataset);
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
-    assertThat(addedEmails, containsInAnyOrder("steward", "reader", "custodian"));
+    if (inheritSteward) {
+      assertThat(
+          addedEmails,
+          containsInAnyOrder("steward", "reader", "datasetCustodian", "datasetSteward"));
+    } else {
+      assertThat(addedEmails, containsInAnyOrder("steward", "reader"));
+    }
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzServiceAccountConsumerStepTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -69,7 +71,8 @@ class SnapshotAuthzServiceAccountConsumerStepTest {
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policyMap);
 
     var sourceDatasetPolicyMap = new EnumMap<>(IamRole.class);
-    sourceDatasetPolicyMap.put(IamRole.CUSTODIAN, "custodian");
+    sourceDatasetPolicyMap.put(IamRole.CUSTODIAN, "datasetCustodian");
+    sourceDatasetPolicyMap.put(IamRole.STEWARD, "datasetSteward");
     workingMap.put(SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, sourceDatasetPolicyMap);
     when(snapshotService.retrieveByName(SNAPSHOT_NAME)).thenReturn(SNAPSHOT);
 
@@ -127,10 +130,11 @@ class SnapshotAuthzServiceAccountConsumerStepTest {
     verifyNoInteractions(iamService);
   }
 
-  @Test
-  void doStepInheritEnabled() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void doStepInheritSteward(boolean inheritSteward) throws Exception {
     var sourceDataset =
-        new Dataset(new DatasetSummary().inheritSteward(true)).id(UUID.randomUUID());
+        new Dataset(new DatasetSummary().inheritSteward(inheritSteward)).id(UUID.randomUUID());
     step =
         new SnapshotAuthzServiceAccountConsumerStep(
             snapshotService,
@@ -139,7 +143,13 @@ class SnapshotAuthzServiceAccountConsumerStepTest {
             TDR_SERVICE_ACCOUNT_EMAIL,
             sourceDataset);
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
-    assertThat(addedEmails, containsInAnyOrder("steward", "reader", "custodian"));
+    if (inheritSteward) {
+      assertThat(
+          addedEmails,
+          containsInAnyOrder("steward", "reader", "datasetCustodian", "datasetSteward"));
+    } else {
+      assertThat(addedEmails, containsInAnyOrder("steward", "reader"));
+    }
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.category.Unit;
-import bio.terra.common.fixtures.AuthenticationFixtures;
-import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.configuration.ConfigurationService;
@@ -46,11 +44,7 @@ class SnapshotAuthzTabularAclStepTest {
   @Mock private ConfigurationService configService;
   @Mock private IamService iamService;
   @Mock private FlightContext flightContext;
-
-  private static final AuthenticatedUserRequest TEST_USER =
-      AuthenticationFixtures.randomUserRequest();
   private static final Snapshot SNAPSHOT = new Snapshot().id(UUID.randomUUID());
-
   private SnapshotAuthzTabularAclStep step;
 
   @BeforeEach
@@ -71,13 +65,7 @@ class SnapshotAuthzTabularAclStepTest {
     when(snapshotService.retrieve(SNAPSHOT.getId())).thenReturn(SNAPSHOT);
     step =
         new SnapshotAuthzTabularAclStep(
-            bigQuerySnapshotPdao,
-            snapshotService,
-            configService,
-            iamService,
-            SNAPSHOT.getId(),
-            TEST_USER,
-            new Dataset());
+            bigQuerySnapshotPdao, snapshotService, configService, SNAPSHOT.getId(), new Dataset());
   }
 
   @Test
@@ -94,13 +82,7 @@ class SnapshotAuthzTabularAclStepTest {
         new Dataset(new DatasetSummary().inheritSteward(inheritSteward)).id(UUID.randomUUID());
     step =
         new SnapshotAuthzTabularAclStep(
-            bigQuerySnapshotPdao,
-            snapshotService,
-            configService,
-            iamService,
-            SNAPSHOT.getId(),
-            TEST_USER,
-            sourceDataset);
+            bigQuerySnapshotPdao, snapshotService, configService, SNAPSHOT.getId(), sourceDataset);
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
     if (inheritSteward) {
       verify(bigQuerySnapshotPdao)

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
-import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.configuration.ConfigurationService;
@@ -29,12 +28,13 @@ import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
 import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -63,6 +63,11 @@ class SnapshotAuthzTabularAclStepTest {
     policyMap.put(IamRole.READER, "reader");
     workingMap.put(SnapshotWorkingMapKeys.POLICY_MAP, policyMap);
 
+    var sourceDatasetPolicyMap = new EnumMap<>(IamRole.class);
+    sourceDatasetPolicyMap.put(IamRole.STEWARD, "datasetSteward");
+    sourceDatasetPolicyMap.put(IamRole.CUSTODIAN, "datasetCustodian");
+    workingMap.put(SnapshotWorkingMapKeys.SOURCE_DATASET_POLICY_MAP, sourceDatasetPolicyMap);
+
     when(snapshotService.retrieve(SNAPSHOT.getId())).thenReturn(SNAPSHOT);
     step =
         new SnapshotAuthzTabularAclStep(
@@ -82,10 +87,11 @@ class SnapshotAuthzTabularAclStepTest {
     verifyNoInteractions(iamService);
   }
 
-  @Test
-  void doStepInheritEnabled() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void doStepInheritEnabled(boolean inheritSteward) throws Exception {
     Dataset sourceDataset =
-        new Dataset(new DatasetSummary().inheritSteward(true)).id(UUID.randomUUID());
+        new Dataset(new DatasetSummary().inheritSteward(inheritSteward)).id(UUID.randomUUID());
     step =
         new SnapshotAuthzTabularAclStep(
             bigQuerySnapshotPdao,
@@ -95,11 +101,15 @@ class SnapshotAuthzTabularAclStepTest {
             SNAPSHOT.getId(),
             TEST_USER,
             sourceDataset);
-    when(iamService.retrievePolicyEmails(TEST_USER, IamResourceType.DATASET, sourceDataset.getId()))
-        .thenReturn(Map.of(IamRole.CUSTODIAN, "custodian"));
     assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
-    verify(bigQuerySnapshotPdao)
-        .grantReadAccessToSnapshot(SNAPSHOT, List.of("steward", "reader", "custodian"));
+    if (inheritSteward) {
+      verify(bigQuerySnapshotPdao)
+          .grantReadAccessToSnapshot(
+              SNAPSHOT, List.of("steward", "reader", "datasetCustodian", "datasetSteward"));
+    } else {
+      verify(bigQuerySnapshotPdao)
+          .grantReadAccessToSnapshot(SNAPSHOT, List.of("steward", "reader"));
+    }
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/create/SnapshotAuthzTabularAclStepTest.java
@@ -87,7 +87,7 @@ class SnapshotAuthzTabularAclStepTest {
     if (inheritSteward) {
       verify(bigQuerySnapshotPdao)
           .grantReadAccessToSnapshot(
-              SNAPSHOT, List.of("steward", "reader", "datasetCustodian", "datasetSteward"));
+              SNAPSHOT, List.of("steward", "reader", "datasetSteward", "datasetCustodian"));
     } else {
       verify(bigQuerySnapshotPdao)
           .grantReadAccessToSnapshot(SNAPSHOT, List.of("steward", "reader"));


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1527

## Addresses
Originally, the inherit steward feature was only supposed to grant dataset custodians access on snapshots. However, in Sam, the Dataset Steward role "includes" the Dataset Custodian role. 
```
      steward = {
        roleActions = ["delete", "edit_dataset", "update_data",  "share_policy::steward", "update_passport_identifier", "view_journal"]
        includedRoles = ["custodian"]
      }
```
[Sam reference](https://github.com/broadinstitute/sam/blob/b1116e94438e39dc21f896f479d680b1e98433e8/src/main/resources/reference.conf#L1397C1-L1400C8)

So, we were inadvertently giving both the Dataset custodian and steward access on the snapshots when this flag is enabled. However, the Sam permission is grants the users part of the permission needed to have full access on the snapshot: the dataset stewards also need access on the snapshot cloud resources.

## Summary of changes
- On Snapshot Create from a dataset with inherit steward enabled, also add the Dataset steward policy group to the snapshot cloud resources
- In the inherit steward migration flight, also add the dataset steward policy to the snapshot cloud resources. We can also remove any dataset stewards who have access on the snapshot. 

## Testing Strategy
- updated unit tests
- manual test
_____________
## Manual Test

### Before - Testing on TDR dev
**Goal: Show that for a dataset with inherit steward = true, both the dataset's stewards and custodians had access to a child snapshot's data via TDR endpoints, _but not to cloud resources such as BigQuery_**

1. ✅ Create a new dataset with inherit steward = true and a snapshot and a user that is only a steward on the dataset (Not a dataset custodian and no direct access on snapshot)
<img width="723" alt="image" src="https://github.com/user-attachments/assets/b117390a-a47d-4493-8ae0-a107e4f02ecb" />
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/62f19388-247f-4ff5-9104-0e45afc521e2" />
<img width="883" alt="image" src="https://github.com/user-attachments/assets/702ee5cb-dc52-4db7-ad29-7f68f7d2c173" />

3. ✅  Confirm that user can read snapshot data via TDR endpoints
<img width="877" alt="image" src="https://github.com/user-attachments/assets/2e41ca50-cccd-4934-85a2-f235fff0af16" />

5. ✅  Confirm that user cannot directly access the snapshot's BQ instance

Cannot directly access BQ data: 
<img width="553" alt="image" src="https://github.com/user-attachments/assets/ce1e764d-6070-4bf9-806d-b7a6ec1bba23" />



### After - Testing on local branch
**Goal: Show that for a dataset and snapshot that is migrated to use the inherit steward feature, dataset stewards have full access to child snapshots, including cloud resources such as BigQuery**
**New Dataset with inherit steward = false:**
```
    {
      "id": "8bd3fd2e-cdba-4ee1-bbcc-593e9035a880",
      "name": "DT1527_Test_Dataset_inherit_steward_migrated",
      "inheritSteward": false
    }
```
**Dataset policies:**
```
    {
      "name": "steward",
      "members": [
        "sholden@broadinstitute.org",
        "sfholden3@gmail.com"
      ]
    }
```
**New Snapshot:**
Steward cannot yet access

**Migrate to inherit steward = true**

Now can access snapshot:
```
      "id": "e2265732-5536-4824-8367-92266d3146b3",
      "name": "DT1527_Test_Snapshot_inherit_steward_migrated1",
      "description": "Test GCP Snapshot with OMOP data",
      "createdDate": "2025-04-16T19:33:04.160557Z",
      "dataProject": "datarepo-tools-4f3e6cf7"
```
**Snapshot Policies**
```
    {
      "name": "steward",
      "members": []
    }
```

✅ Steward can access data in this snapshot (querySnapshotDataById endpoint):
```
{
  "result": [
    {
      "birth_datetime": "1987-01-13T00:00:00",
      "person_id": "77",
      ....
    },
    {
      "birth_datetime": "1987-01-07T00:00:00",
      "person_id": "180",
      ....
    }
  ],
  "totalRowCount": 2,
  "filteredRowCount": 2
}
```

✅ Steward can make queries in BQ - they can access the cloud resources for the snapshot
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/20a940d9-bb73-4e66-aa5d-03b132485ca1" />


________________


**Goal: Show that for a dataset with inherit steward = true and a newly created snapshot, dataset stewards have full access to the new snapshot, including cloud resources such as BigQuery and direct file access** 
New Dataset:
```
{
      "id": "fd804488-3b1e-4c7e-aec0-e3a00cae249a",
      "name": "DT1527_Test_Dataset_inherit_steward_enabled",
      "inheritSteward": true
    }
```
Dataset Policies:
```
  "policies": [
   {
      "name": "steward",
      "members": [
        "sholden@broadinstitute.org",
        "sfholden3@gmail.com"
      ]
    }
  ]
```
New snapshot:
```
{
  "id": "159540a0-9c06-467c-bcc4-f889b3052ff9",
  "name": "DT1527_Test_Snapshot_inherit_steward_enabled1",
  "description": "Test GCP Snapshot with OMOP data",
  "createdDate": "2025-04-16T19:37:54.948713Z",
  "dataProject": "datarepo-tools-91fc7c91",
  "source": [
    {
      "dataset": {
        "id": "fd804488-3b1e-4c7e-aec0-e3a00cae249a"",
        "name": "DT1527_Test_Dataset_inherit_steward_enabled",
        "inheritSteward": true
      }
    }
  ]
}
```
Snapshot Policies (correctly does not list any users):
```
{
  "policies": [
    {
      "name": "steward",
      "members": []
    }
  ]
}
```
✅ Steward can access data in this snapshot (querySnapshotDataById endpoint):
```
{
  "result": [
    {
      "birth_datetime": "1987-01-13T00:00:00",
      "person_id": "77",
      ....
    },
    {
      "birth_datetime": "1987-01-07T00:00:00",
      "person_id": "180",
      ....
    }
  ],
  "totalRowCount": 2,
  "filteredRowCount": 2
}
```
✅ Steward can make queries in BQ - they can access the cloud resources for the snapshot
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/2861d56f-fc29-4380-ac28-ef9ce4925c4b" />




<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
