### PR TITLE
DT-1477: When merging duplicate drs objects, only look for the first description value to merge into the new object

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -71,6 +71,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -928,7 +929,7 @@ public class DrsService {
             // Extract singleton values
             .id(extractUniqueDrsObjectValue(drsObjects, DRSObject::getId))
             .name(extractUniqueDrsObjectValue(drsObjects, DRSObject::getName))
-            .description(extractUniqueDrsObjectValue(drsObjects, DRSObject::getDescription))
+            .description(extractFirstDrsObjectValue(drsObjects, DRSObject::getDescription))
             .size(extractUniqueDrsObjectValue(drsObjects, DRSObject::getSize))
             .selfUri(extractUniqueDrsObjectValue(drsObjects, DRSObject::getSelfUri))
             .mimeType(extractUniqueDrsObjectValue(drsObjects, DRSObject::getMimeType))
@@ -1007,6 +1008,17 @@ public class DrsService {
       return CollectionUtils.extractSingleton(values);
     } catch (IllegalArgumentException e) {
       throw new InvalidDrsObjectException("Found duplicate values: %s".formatted(values), e);
+    }
+  }
+
+  /** Given a list of DRSObjects, extract the first value and fail if there are no values */
+  @VisibleForTesting
+  static <R> R extractFirstDrsObjectValue(
+      List<DRSObject> drsObjects, Function<DRSObject, ? extends R> mapper) {
+    try {
+      return drsObjects.stream().map(mapper).findFirst().orElseThrow();
+    } catch (NoSuchElementException | NullPointerException e) {
+      throw new InvalidDrsObjectException("No value present", e);
     }
   }
 

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -1014,13 +1014,12 @@ public class DrsService {
 
   /** Given a list of DRSObjects, concatenate the string values of the mapped field */
   @VisibleForTesting
-  static <R> String extractDrsFileConcatenatedStringValues(
-      List<DRSObject> drsObjects, Function<DRSObject, ? extends R> mapper) {
+  static String extractDrsFileConcatenatedStringValues(
+      List<DRSObject> drsObjects, Function<DRSObject, String> mapper) {
     return drsObjects.stream()
         .map(mapper)
         .filter(Objects::nonNull)
         .map(Objects::toString)
-        .map(String::trim)
         .distinct()
         .filter(Predicate.not(String::isEmpty))
         .collect(Collectors.joining(", "));

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -71,13 +71,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
@@ -929,7 +929,8 @@ public class DrsService {
             // Extract singleton values
             .id(extractUniqueDrsObjectValue(drsObjects, DRSObject::getId))
             .name(extractUniqueDrsObjectValue(drsObjects, DRSObject::getName))
-            .description(extractFirstDrsObjectValue(drsObjects, DRSObject::getDescription))
+            .description(
+                extractDrsFileConcatenatedStringValues(drsObjects, DRSObject::getDescription))
             .size(extractUniqueDrsObjectValue(drsObjects, DRSObject::getSize))
             .selfUri(extractUniqueDrsObjectValue(drsObjects, DRSObject::getSelfUri))
             .mimeType(extractUniqueDrsObjectValue(drsObjects, DRSObject::getMimeType))
@@ -1011,15 +1012,18 @@ public class DrsService {
     }
   }
 
-  /** Given a list of DRSObjects, extract the first value and fail if there are no values */
+  /** Given a list of DRSObjects, concatenate the string values of the mapped field */
   @VisibleForTesting
-  static <R> R extractFirstDrsObjectValue(
+  static <R> String extractDrsFileConcatenatedStringValues(
       List<DRSObject> drsObjects, Function<DRSObject, ? extends R> mapper) {
-    try {
-      return drsObjects.stream().map(mapper).findFirst().orElseThrow();
-    } catch (NoSuchElementException | NullPointerException e) {
-      throw new InvalidDrsObjectException("No value present", e);
-    }
+    return drsObjects.stream()
+        .map(mapper)
+        .filter(Objects::nonNull)
+        .map(Objects::toString)
+        .map(String::trim)
+        .distinct()
+        .filter(Predicate.not(String::isEmpty))
+        .collect(Collectors.joining(", "));
   }
 
   /** Given a list of DRSObjects, extract a list of distinct values sorted by the comparator. */

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -1095,6 +1095,63 @@ class DrsServiceTest {
   }
 
   @Test
+  void testExtractFirstDrsObjectValue() {
+    DRSObject drsObject1 =
+        createFileDrsObject(
+            "v2_file1",
+            "/my/path/file1.txt",
+            123L,
+            "foomd5",
+            CloudPlatform.GCP,
+            GoogleRegion.ASIA_SOUTH1,
+            Instant.parse("2025-01-01T00:00:00.00Z"));
+    drsObject1.setDescription("description1");
+    DRSObject drsObject2 =
+        createFileDrsObject(
+            "v2_file1",
+            "/my/path/file1.txt",
+            123L,
+            "foomd5",
+            CloudPlatform.GCP,
+            GoogleRegion.ASIA_SOUTH1,
+            Instant.parse("2025-01-01T00:00:00.00Z"));
+    drsObject2.setDescription("description2");
+    List<DRSObject> drsObjects = List.of(drsObject1, drsObject2);
+    assertThat(
+        "value from first object is correctly returned",
+        DrsService.extractFirstDrsObjectValue(drsObjects, DRSObject::getDescription),
+        equalTo(drsObject1.getDescription()));
+  }
+
+  @Test
+  void testExtractFirstDrsObjectValueNullValues() {
+    DRSObject drsObject1 =
+        createFileDrsObject(
+            "v2_file1",
+            "/my/path/file1.txt",
+            123L,
+            "foomd5",
+            CloudPlatform.GCP,
+            GoogleRegion.ASIA_SOUTH1,
+            Instant.parse("2025-01-01T00:00:00.00Z"));
+    drsObject1.setDescription(null);
+    DRSObject drsObject2 =
+        createFileDrsObject(
+            "v2_file1",
+            "/my/path/file1.txt",
+            123L,
+            "foomd5",
+            CloudPlatform.GCP,
+            GoogleRegion.ASIA_SOUTH1,
+            Instant.parse("2025-01-01T00:00:00.00Z"));
+    drsObject2.setDescription(null);
+    List<DRSObject> drsObjects = List.of(drsObject1, drsObject2);
+    assertThrows(
+        InvalidDrsObjectException.class,
+        () -> DrsService.extractFirstDrsObjectValue(drsObjects, DRSObject::getDescription));
+  }
+
+  @Test
   void testDistinctListExtraction() {
     DRSObject drsObject1 =
         createFileDrsObject(

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -4,6 +4,7 @@ import static bio.terra.service.filedata.DrsService.URL_TTL;
 import static bio.terra.service.filedata.google.gcs.GcsConstants.REQUESTED_BY_QUERY_PARAM;
 import static bio.terra.service.filedata.google.gcs.GcsConstants.USER_PROJECT_QUERY_PARAM;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -12,7 +13,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -1058,12 +1058,12 @@ class DrsServiceTest {
                 Instant.parse("2022-01-02T00:00:00.00Z"))
             .description("description2");
     List<DRSObject> drsObjects = List.of(drsObject1, drsObject2);
-    assertDoesNotThrow(
-        () -> {
-          DRSObject drsObject = drsService.mergeDRSObjects(drsObjects);
-          assertThat(drsObject.getDescription(), containsString(drsObject1.getDescription()));
-          assertThat(drsObject.getDescription(), containsString(drsObject2.getDescription()));
-        });
+    DRSObject drsObject = drsService.mergeDRSObjects(drsObjects);
+    assertThat(
+        drsObject.getDescription(),
+        allOf(
+            containsString(drsObject1.getDescription()),
+            containsString(drsObject2.getDescription())));
   }
 
   @Test
@@ -1134,11 +1134,9 @@ class DrsServiceTest {
     assertThat(
         "value from each object is correctly returned",
         DrsService.extractDrsFileConcatenatedStringValues(drsObjects, DRSObject::getDescription),
-        containsString(drsObject1.getDescription()));
-    assertThat(
-        "value from each object is correctly returned",
-        DrsService.extractDrsFileConcatenatedStringValues(drsObjects, DRSObject::getDescription),
-        containsString(drsObject2.getDescription()));
+        allOf(
+            containsString(drsObject1.getDescription()),
+            containsString(drsObject2.getDescription())));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -1095,60 +1095,18 @@ class DrsServiceTest {
   }
 
   @Test
-  void testExtractFirstDrsObjectValue() {
-    DRSObject drsObject1 =
-        createFileDrsObject(
-            "v2_file1",
-            "/my/path/file1.txt",
-            123L,
-            "foomd5",
-            CloudPlatform.GCP,
-            GoogleRegion.ASIA_SOUTH1,
-            Instant.parse("2025-01-01T00:00:00.00Z"));
-    drsObject1.setDescription("description1");
-    DRSObject drsObject2 =
-        createFileDrsObject(
-            "v2_file1",
-            "/my/path/file1.txt",
-            123L,
-            "foomd5",
-            CloudPlatform.GCP,
-            GoogleRegion.ASIA_SOUTH1,
-            Instant.parse("2025-01-01T00:00:00.00Z"));
-    drsObject2.setDescription("description2");
+  void testExtractDrsFileConcatenatedStringValues() {
+    DRSObject drsObject1 = new DRSObject().description("description1");
+    DRSObject drsObject2 = new DRSObject().description("description2");
     List<DRSObject> drsObjects = List.of(drsObject1, drsObject2);
     assertThat(
-        "value from first object is correctly returned",
-        DrsService.extractFirstDrsObjectValue(drsObjects, DRSObject::getDescription),
-        equalTo(drsObject1.getDescription()));
-  }
-
-  @Test
-  void testExtractFirstDrsObjectValueNullValues() {
-    DRSObject drsObject1 =
-        createFileDrsObject(
-            "v2_file1",
-            "/my/path/file1.txt",
-            123L,
-            "foomd5",
-            CloudPlatform.GCP,
-            GoogleRegion.ASIA_SOUTH1,
-            Instant.parse("2025-01-01T00:00:00.00Z"));
-    drsObject1.setDescription(null);
-    DRSObject drsObject2 =
-        createFileDrsObject(
-            "v2_file1",
-            "/my/path/file1.txt",
-            123L,
-            "foomd5",
-            CloudPlatform.GCP,
-            GoogleRegion.ASIA_SOUTH1,
-            Instant.parse("2025-01-01T00:00:00.00Z"));
-    drsObject2.setDescription(null);
-    List<DRSObject> drsObjects = List.of(drsObject1, drsObject2);
-    assertThrows(
-        InvalidDrsObjectException.class,
-        () -> DrsService.extractFirstDrsObjectValue(drsObjects, DRSObject::getDescription));
+        "value from each object is correctly returned",
+        DrsService.extractDrsFileConcatenatedStringValues(drsObjects, DRSObject::getDescription),
+        containsString(drsObject1.getDescription()));
+    assertThat(
+        "value from each object is correctly returned",
+        DrsService.extractDrsFileConcatenatedStringValues(drsObjects, DRSObject::getDescription),
+        containsString(drsObject2.getDescription()));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -1032,6 +1033,37 @@ class DrsServiceTest {
 
     List<DRSObject> drsObjects = List.of(drsObject1, drsObject2);
     assertThrows(InvalidDrsObjectException.class, () -> drsService.mergeDRSObjects(drsObjects));
+  }
+
+  @Test
+  void testMergeDrsObjectsWithMultipleDescriptions() {
+    DRSObject drsObject1 =
+        createFileDrsObject(
+                "v2_file1",
+                "/my/path/file1.txt",
+                123L,
+                "foomd5",
+                CloudPlatform.GCP,
+                GoogleRegion.ASIA_SOUTH1,
+                Instant.parse("2022-01-01T00:00:00.00Z"))
+            .description("description1");
+    DRSObject drsObject2 =
+        createFileDrsObject(
+                "v2_file1",
+                "/my/path/file1.txt",
+                123L,
+                "foomd5",
+                CloudPlatform.GCP,
+                GoogleRegion.US_CENTRAL1,
+                Instant.parse("2022-01-02T00:00:00.00Z"))
+            .description("description2");
+    List<DRSObject> drsObjects = List.of(drsObject1, drsObject2);
+    assertDoesNotThrow(
+        () -> {
+          DRSObject drsObject = drsService.mergeDRSObjects(drsObjects);
+          assertThat(drsObject.getDescription(), containsString(drsObject1.getDescription()));
+          assertThat(drsObject.getDescription(), containsString(drsObject2.getDescription()));
+        });
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1477

## Summary of changes
This PR combines the description field of DrsObjects when merging them.

## Testing Strategy
After spinning up a local instance of TDR and a UI:

1. Create two datasets via `POST /api/repository/v1/datasets` and modify the name/description as needed
```
{
  "name": "test_dataset_1",
  "description": "Test Dataset 1",
  "defaultProfileId": "60bef0c0-2466-4e42-ab0a-cfff2e682e5e",
  "experimentalPredictableFileIds": true,
  "schema": {
    "tables": [
      {
        "name": "files",
        "columns": [
          {
            "name": "file_path",
            "datatype": "fileref",
            "array_of": false,
            "required": false
          }
        ],
        "primaryKey": [],
        "partitionMode": "none"
      }
    ]
  }
}
```

2. Inject a staged file via `POST /api/repository/v1/datasets/{id}/ingest`. I used a publicly accessible bucket file. Do this twice, once for each dataset id with a different description.
```
{
  "format": "array",
  "load_tag": "adding file",
  "table": "files",
  "updateStrategy": "append",
  "resolve_existing_files": true,
  "records": [
    {
      "file_path": {
        "sourcePath": "gs://broad-duos-banners/ci_notifications.json",
        "targetPath": "/ci_notifications.json",
        "description": "ci_notifications in dataset 1"
      }
    }
  ]
}
```

3. Create full view snapshot via API twice, one for each dataset name, via `POST /api/repository/v1/snapshotAccessRequests`. You should see that the created drs url is the same for both snapshots.

```
{
  "name":"snapshot_1",
  "description":"description 1",
  "globalFileIds": true,
  "contents":[
    {
      "datasetName": "test_dataset_1",
      "mode": "byFullView"
    }
  ]
} 
```

4. In the UI, go to the snapshot data and get the drs url, test in swagger via `GET /ga4gh/drs/v1/objects/{object_id}`
You should get a drs object back successfully by pasting in the object id part of the drs url.


<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
