### PR TITLE
DT-1701: Improve Snapshot by Query error message

### DIFF
--- a/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
+++ b/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
@@ -3,6 +3,7 @@ package bio.terra.grammar.google;
 import bio.terra.common.PdaoConstant;
 import bio.terra.grammar.DatasetAwareVisitor;
 import bio.terra.grammar.SQLParser;
+import bio.terra.grammar.exception.InvalidQueryException;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.service.snapshotbuilder.query.TableNameGenerator;
@@ -16,6 +17,11 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
   }
 
   public String generateAlias(String datasetName, String tableName) {
+    if (datasetName == null || tableName == null) {
+      throw new InvalidQueryException("All column and table names must be qualified with a dataset/table name. " +
+          "Please ensure that your query uses the format `dataset.table.column` for columns and `dataset.table` for tables. " +
+          "For example, use `my_dataset.my_table.my_column` instead of just `my_column` and `my_dataset.my_table` instead of just `my_table`.");
+    }
     return "alias" + Math.abs(Objects.hash(datasetName, tableName));
   }
 

--- a/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
+++ b/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
@@ -18,7 +18,7 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
   }
 
   @VisibleForTesting
-  public String generateAlias(String datasetName, String tableName) {
+  public static String generateAlias(String datasetName, String tableName) {
     return "alias" + Math.abs(Objects.hash(datasetName, tableName));
   }
 

--- a/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
+++ b/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
@@ -18,9 +18,10 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
 
   public String generateAlias(String datasetName, String tableName) {
     if (datasetName == null || tableName == null) {
-      throw new InvalidQueryException("All column and table names must be qualified with a dataset/table name. " +
-          "Please ensure that your query uses the format `dataset.table.column` for columns and `dataset.table` for tables. " +
-          "For example, use `my_dataset.my_table.my_column` instead of just `my_column` and `my_dataset.my_table` instead of just `my_table`.");
+      throw new InvalidQueryException(
+          "All column and table names must be qualified with a dataset/table name. "
+              + "Please ensure that your query uses the format `dataset.table.column` for columns and `dataset.table` for tables. "
+              + "For example, use `my_dataset.my_table.my_column` instead of just `my_column` and `my_dataset.my_table` instead of just `my_table`.");
     }
     return "alias" + Math.abs(Objects.hash(datasetName, tableName));
   }

--- a/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
+++ b/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
@@ -7,6 +7,7 @@ import bio.terra.grammar.exception.InvalidQueryException;
 import bio.terra.model.DatasetModel;
 import bio.terra.model.SnapshotModel;
 import bio.terra.service.snapshotbuilder.query.TableNameGenerator;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.Objects;
 
@@ -16,6 +17,7 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
     super(datasetMap);
   }
 
+  @VisibleForTesting
   public String generateAlias(String datasetName, String tableName) {
     return "alias" + Math.abs(Objects.hash(datasetName, tableName));
   }

--- a/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
+++ b/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
@@ -46,7 +46,9 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
       throw new InvalidQueryException(
           "All column names must be qualified with a dataset and table name. "
               + "Please ensure that your query uses the format `dataset.table.column` for columns. "
-              + "For example, use `my_dataset.my_table.my_column` instead of just `my_column`.");
+              + "For example, use `my_dataset.my_table.my_column` instead of just `my_column`."
+              + "Unqualified column name: "
+              + getNameFromContext(ctx.column_name()));
     }
     String alias = generateAlias(prefixDatasetName(datasetName), tableName);
     String columnName = getNameFromContext(ctx.column_name());

--- a/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
+++ b/src/main/java/bio/terra/grammar/google/BigQueryVisitor.java
@@ -17,12 +17,6 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
   }
 
   public String generateAlias(String datasetName, String tableName) {
-    if (datasetName == null || tableName == null) {
-      throw new InvalidQueryException(
-          "All column and table names must be qualified with a dataset/table name. "
-              + "Please ensure that your query uses the format `dataset.table.column` for columns and `dataset.table` for tables. "
-              + "For example, use `my_dataset.my_table.my_column` instead of just `my_column` and `my_dataset.my_table` instead of just `my_table`.");
-    }
     return "alias" + Math.abs(Objects.hash(datasetName, tableName));
   }
 
@@ -44,9 +38,15 @@ public class BigQueryVisitor extends DatasetAwareVisitor {
 
   @Override
   public String visitColumn_expr(SQLParser.Column_exprContext ctx) {
-    String bqDatasetName = PdaoConstant.PDAO_PREFIX + getNameFromContext(ctx.dataset_name());
+    String datasetName = getNameFromContext(ctx.dataset_name());
     String tableName = getNameFromContext(ctx.table_name());
-    String alias = generateAlias(bqDatasetName, tableName);
+    if (tableName == null) {
+      throw new InvalidQueryException(
+          "All column names must be qualified with a dataset and table name. "
+              + "Please ensure that your query uses the format `dataset.table.column` for columns. "
+              + "For example, use `my_dataset.my_table.my_column` instead of just `my_column`.");
+    }
+    String alias = generateAlias(prefixDatasetName(datasetName), tableName);
     String columnName = getNameFromContext(ctx.column_name());
     return String.format("`%s`.%s", alias, columnName);
   }

--- a/src/test/java/bio/terra/grammar/GrammarTest.java
+++ b/src/test/java/bio/terra/grammar/GrammarTest.java
@@ -248,9 +248,7 @@ class GrammarTest {
       assertThrows(
           InvalidQueryException.class,
           () -> parsedQuery.translateSql(bqVisitor),
-          "All column and table names must be qualified with a dataset/table name. "
-              + "Please ensure that your query uses the format `dataset.table.column` for columns and `dataset.table` for tables. "
-              + "For example, use `my_dataset.my_table.my_column` instead of just `my_column` and `my_dataset.my_table` instead of just `my_table`.");
+          "All column names must be qualified with a dataset and table name. ");
     } else {
       String bqDatasetName = PdaoConstant.PDAO_PREFIX + "dataset";
       String tableName = "table";
@@ -272,6 +270,16 @@ class GrammarTest {
             "SELECT datarepo_row_id FROM dataset.table WHERE dataset.table.x = 'string'", false),
         Arguments.of("SELECT * FROM dataset.table WHERE dataset.table.x = 'string'", true),
         Arguments.of("SELECT datarepo_row_id FROM dataset.table WHERE x = 'string'", false));
+  }
+
+  @Test
+  void testRequiredQualifiedDatasetName() {
+    assertThrows(
+        InvalidQueryException.class,
+        () ->
+            Query.parse(
+                "SELECT dataset.table.datarepo_row_id FROM table WHERE dataset.table.x = 'string'"),
+        "All table names must be qualified with a dataset name.");
   }
 
   @Test

--- a/src/test/java/bio/terra/grammar/GrammarTest.java
+++ b/src/test/java/bio/terra/grammar/GrammarTest.java
@@ -221,7 +221,7 @@ class GrammarTest {
         Query.parse(
             "SELECT dataset.table.datarepo_row_id FROM dataset.table WHERE dataset.table.x = 'string'");
     String translated = query.translateSql(bqVisitor);
-    String aliasedTableName = bqVisitor.generateAlias(bqDatasetName, tableName);
+    String aliasedTableName = BigQueryVisitor.generateAlias(bqDatasetName, tableName);
     assertThat(
         "query translates to valid bigquery syntax",
         translated,
@@ -248,7 +248,7 @@ class GrammarTest {
       String bqDatasetName = PdaoConstant.PDAO_PREFIX + "dataset";
       String tableName = "table";
       String translated = parsedQuery.translateSql(bqVisitor);
-      String aliasedTableName = bqVisitor.generateAlias(bqDatasetName, tableName);
+      String aliasedTableName = BigQueryVisitor.generateAlias(bqDatasetName, tableName);
       assertThat(
           "query translates to valid bigquery syntax",
           translated,
@@ -297,8 +297,8 @@ class GrammarTest {
         Query.parse(
             "SELECT foo.bar.datarepo_row_id FROM foo.bar, baz.quux WHERE foo.bar.x = baz.quux.y");
     String translated = query.translateSql(bqVisitor);
-    String aliasedTable1Name = bqVisitor.generateAlias(bqDataset1Name, table1Name);
-    String aliasedTable2Name = bqVisitor.generateAlias(bqDataset2Name, table2Name);
+    String aliasedTable1Name = BigQueryVisitor.generateAlias(bqDataset1Name, table1Name);
+    String aliasedTable2Name = BigQueryVisitor.generateAlias(bqDataset2Name, table2Name);
     assertThat(
         "query translates to valid bigquery syntax",
         translated,
@@ -338,8 +338,8 @@ class GrammarTest {
         Query.parse(
             "SELECT baz.quux.datarepo_row_id FROM foo.bar, baz.quux WHERE foo.bar.x = baz.quux.y");
     String translated = query.translateSql(bqVisitor);
-    String aliasedTable1Name = bqVisitor.generateAlias(bqDataset1Name, table1Name);
-    String aliasedTable2Name = bqVisitor.generateAlias(bqDataset2Name, table2Name);
+    String aliasedTable1Name = BigQueryVisitor.generateAlias(bqDataset1Name, table1Name);
+    String aliasedTable2Name = BigQueryVisitor.generateAlias(bqDataset2Name, table2Name);
     assertThat(
         "query translates to valid bigquery syntax",
         translated,

--- a/src/test/java/bio/terra/grammar/GrammarTest.java
+++ b/src/test/java/bio/terra/grammar/GrammarTest.java
@@ -244,12 +244,7 @@ class GrammarTest {
       String testQuery, boolean queryHasQualifiedNames) {
     BigQueryVisitor bqVisitor = new BigQueryVisitor(datasetMap);
     Query parsedQuery = Query.parse(testQuery);
-    if (!queryHasQualifiedNames) {
-      assertThrows(
-          InvalidQueryException.class,
-          () -> parsedQuery.translateSql(bqVisitor),
-          "All column names must be qualified with a dataset and table name. ");
-    } else {
+    if (queryHasQualifiedNames) {
       String bqDatasetName = PdaoConstant.PDAO_PREFIX + "dataset";
       String tableName = "table";
       String translated = parsedQuery.translateSql(bqVisitor);
@@ -258,6 +253,11 @@ class GrammarTest {
           "query translates to valid bigquery syntax",
           translated,
           containsString(aliasedTableName));
+    } else {
+      assertThrows(
+          InvalidQueryException.class,
+          () -> parsedQuery.translateSql(bqVisitor),
+          "All column names must be qualified with a dataset and table name. ");
     }
   }
 

--- a/src/test/java/bio/terra/grammar/GrammarTest.java
+++ b/src/test/java/bio/terra/grammar/GrammarTest.java
@@ -3,6 +3,7 @@ package bio.terra.grammar;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -235,6 +236,42 @@ class GrammarTest {
                 + "` WHERE `"
                 + aliasedTableName
                 + "`.x = 'string'"));
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testRequiredQualifiedNameOnQueryTranslation(
+      String testQuery, boolean queryHasQualifiedNames) {
+    BigQueryVisitor bqVisitor = new BigQueryVisitor(datasetMap);
+    Query parsedQuery = Query.parse(testQuery);
+    if (!queryHasQualifiedNames) {
+      assertThrows(
+          InvalidQueryException.class,
+          () -> parsedQuery.translateSql(bqVisitor),
+          "All column and table names must be qualified with a dataset/table name. "
+              + "Please ensure that your query uses the format `dataset.table.column` for columns and `dataset.table` for tables. "
+              + "For example, use `my_dataset.my_table.my_column` instead of just `my_column` and `my_dataset.my_table` instead of just `my_table`.");
+    } else {
+      String bqDatasetName = PdaoConstant.PDAO_PREFIX + "dataset";
+      String tableName = "table";
+      String translated = parsedQuery.translateSql(bqVisitor);
+      String aliasedTableName = bqVisitor.generateAlias(bqDatasetName, tableName);
+      assertThat(
+          "query translates to valid bigquery syntax",
+          translated,
+          containsString(aliasedTableName));
+    }
+  }
+
+  static Stream<Arguments> testRequiredQualifiedNameOnQueryTranslation() {
+    return Stream.of(
+        Arguments.of(
+            "SELECT dataset.table.datarepo_row_id FROM dataset.table WHERE dataset.table.x = 'string'",
+            true),
+        Arguments.of(
+            "SELECT datarepo_row_id FROM dataset.table WHERE dataset.table.x = 'string'", false),
+        Arguments.of("SELECT * FROM dataset.table WHERE dataset.table.x = 'string'", true),
+        Arguments.of("SELECT datarepo_row_id FROM dataset.table WHERE x = 'string'", false));
   }
 
   @Test


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1701

## Addresses
It would be nice to give users a more helpful error message if they did not correctly format their query for snapshot by query. 

After a very long debugging session, we found that a user did not "correctly" format their query for a snapshot by query error message. It turns out, if you do not properly qualify both column and table names, then the alias generated for the table doesn't match up with the alias generated for the column. This left the user with an `BQ does not recognize table with alias "alias123"` error message. Instead, we should provide users with an actionable error message with instructions for how to format their table and column names in the query. 

For example, 
`Select column1 FROM tdrDataset1.table1 where column1 = true` will not successfully get translated into a BigQuery query. 
The query would end up getting translated to something like the following: 
`Select alias1.column1 FROM tdrDataset1.table1 AS alias2 where alias1.column1 = true`
Which is invalid because alias1 and alias2 do not line up. 

Instead, the user should provide something like the following:
`Select tdrDataset1.table1.column1 FROM tdrDataset1.table1 where tdrDataset1.table1.column1 = true`

There is an example of this sort of query in the terra support docs, but we can help by providing a more direct error message. 
https://support.terra.bio/hc/en-us/articles/4407243163291-How-to-create-snapshots-in-TDR-GCP
<img width="867" alt="image" src="https://github.com/user-attachments/assets/e28658c2-d1ce-4256-a727-1140b50564fd" />


## Summary of changes
- Throw an error if the database or table name is null when generate an alias during query translation. 

## Testing Strategy
- unit tests

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
