### PR TITLE
DT-1654: Retry BigQuery getDataset call to enable datasets with many snapshots to pass SetInheritStewardFlight

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.client.HttpServerErrorException;
 
 public final class BigQueryProject {
   private static final Logger logger = LoggerFactory.getLogger(BigQueryProject.class);
@@ -181,7 +180,9 @@ public final class BigQueryProject {
       throw new AclUtils.AclRetryException(
           "Policy does not exist. Retrying to wait for propagation", ex, "propagation");
     }
-    if (message.startsWith("Read timed out") || ex.getCause() instanceof SocketTimeoutException || ex.getCode() == 504) {
+    if (message.startsWith("Read timed out")
+        || ex.getCause() instanceof SocketTimeoutException
+        || ex.getCode() == 504) {
       throw new AclUtils.AclRetryException("Timeout.", ex, "Timeout");
     }
     throw ex;

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -26,6 +26,7 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.StorageOptions;
+import com.google.common.annotations.VisibleForTesting;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +45,7 @@ public final class BigQueryProject {
   private final BigQuery bigQuery;
   private final int TIMEOUT_SECONDS = 40;
 
-  private BigQueryProject(String projectId) {
+  BigQueryProject(String projectId) {
     logger.info("Retrieving Bigquery project for project id: {}", projectId);
     this.projectId = projectId;
     HttpTransportOptions transportOptions = StorageOptions.getDefaultHttpTransportOptions();
@@ -174,22 +175,24 @@ public final class BigQueryProject {
         });
   }
 
-  private void bigQueryAclUpdateShouldRetry(BigQueryException ex) {
+  @VisibleForTesting
+  void bigQueryAclUpdateShouldRetry(BigQueryException ex) {
     String message = ex.getMessage();
     if (message.startsWith("IAM setPolicy") && message.endsWith("does not exist.")) {
       throw new AclUtils.AclRetryException(
           "Policy does not exist. Retrying to wait for propagation", ex, "propagation");
     }
-    if (message.startsWith("Read timed out")
-        || ex.getCause() instanceof SocketTimeoutException
-        || ex.getCode() == 504) {
+    if (message.startsWith("Read timed out") || ex.getCause() instanceof SocketTimeoutException) {
       throw new AclUtils.AclRetryException("Timeout.", ex, "Timeout");
+    }
+    if (message.contains("504") || (ex.getCause() != null && ex.getCause().getMessage() != null && ex.getCause().getMessage().contains("504"))) {
+      throw new AclUtils.AclRetryException("Gateway timeout.", ex, "Timeout");
     }
     throw ex;
   }
 
   public void addDatasetAcls(String datasetId, List<Acl> acls) throws InterruptedException {
-    Dataset dataset = bigQuery.getDataset(datasetId);
+    Dataset dataset = getBQDataset(datasetId);
     if (dataset == null) {
       throw new PdaoException(String.format("Dataset %s was not found", datasetId));
     }
@@ -201,8 +204,20 @@ public final class BigQueryProject {
     updateDatasetAcls(dataset, newAcls);
   }
 
+  public Dataset getBQDataset(String datasetId) throws InterruptedException {
+    return AclUtils.aclUpdateRetry(
+        () -> {
+          try {
+            return bigQuery.getDataset(datasetId);
+          } catch (BigQueryException ex) {
+            bigQueryAclUpdateShouldRetry(ex);
+          }
+          return null;
+        });
+  }
+
   public void removeDatasetAcls(String datasetId, List<Acl> acls) throws InterruptedException {
-    Dataset dataset = bigQuery.getDataset(datasetId);
+    Dataset dataset = getBQDataset(datasetId);
     if (dataset != null) { // can be null if create dataset step failed before it was created
       updateDatasetAcls(
           dataset,

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.client.HttpServerErrorException;
 
 public final class BigQueryProject {
   private static final Logger logger = LoggerFactory.getLogger(BigQueryProject.class);
@@ -180,7 +181,7 @@ public final class BigQueryProject {
       throw new AclUtils.AclRetryException(
           "Policy does not exist. Retrying to wait for propagation", ex, "propagation");
     }
-    if (message.startsWith("Read timed out") || ex.getCause() instanceof SocketTimeoutException) {
+    if (message.startsWith("Read timed out") || ex.getCause() instanceof SocketTimeoutException || ex.getCode() == 504) {
       throw new AclUtils.AclRetryException("Timeout.", ex, "Timeout");
     }
     throw ex;

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -8,6 +8,7 @@ import bio.terra.common.exception.PdaoException;
 import bio.terra.model.SnapshotModel;
 import bio.terra.service.dataset.BigQueryPartitionConfigV1;
 import bio.terra.service.filedata.FSContainerInterface;
+import com.google.api.client.http.HttpResponseException;
 import com.google.cloud.bigquery.Acl;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -184,10 +186,8 @@ public final class BigQueryProject {
     if (message.startsWith("Read timed out") || ex.getCause() instanceof SocketTimeoutException) {
       throw new AclUtils.AclRetryException("Timeout.", ex, "Timeout");
     }
-    if (message.contains("504")
-        || (ex.getCause() != null
-            && ex.getCause().getMessage() != null
-            && ex.getCause().getMessage().contains("504"))) {
+    if (ex.getCause() instanceof HttpResponseException httpResponseException
+        && httpResponseException.getStatusCode() == HttpStatus.SC_GATEWAY_TIMEOUT) {
       throw new AclUtils.AclRetryException("Gateway timeout.", ex, "Timeout");
     }
     throw ex;

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -45,7 +45,7 @@ public final class BigQueryProject {
   private final BigQuery bigQuery;
   private final int TIMEOUT_SECONDS = 40;
 
-  BigQueryProject(String projectId) {
+  private BigQueryProject(String projectId) {
     logger.info("Retrieving Bigquery project for project id: {}", projectId);
     this.projectId = projectId;
     HttpTransportOptions transportOptions = StorageOptions.getDefaultHttpTransportOptions();
@@ -101,8 +101,7 @@ public final class BigQueryProject {
 
   public boolean datasetExists(String datasetName) {
     try {
-      DatasetId datasetId = DatasetId.of(projectId, datasetName);
-      Dataset dataset = bigQuery.getDataset(datasetId);
+      Dataset dataset = getBQDataset(datasetName);
       return (dataset != null);
     } catch (Exception ex) {
       throw new PdaoException("existence check failed for " + datasetName, ex);
@@ -194,10 +193,10 @@ public final class BigQueryProject {
     throw ex;
   }
 
-  public void addDatasetAcls(String datasetId, List<Acl> acls) throws InterruptedException {
-    Dataset dataset = getBQDataset(datasetId);
+  public void addDatasetAcls(String datasetBQName, List<Acl> acls) throws InterruptedException {
+    Dataset dataset = getBQDataset(datasetBQName);
     if (dataset == null) {
-      throw new PdaoException(String.format("Dataset %s was not found", datasetId));
+      throw new PdaoException(String.format("Dataset %s was not found", datasetBQName));
     }
     List<Acl> beforeAcls = dataset.getAcl();
     logger.debug("Before acl: " + StringUtils.join(beforeAcls, ", "));
@@ -207,10 +206,11 @@ public final class BigQueryProject {
     updateDatasetAcls(dataset, newAcls);
   }
 
-  public Dataset getBQDataset(String datasetId) throws InterruptedException {
+  public Dataset getBQDataset(String datasetBQName) throws InterruptedException {
     return AclUtils.aclUpdateRetry(
         () -> {
           try {
+            DatasetId datasetId = DatasetId.of(projectId, datasetBQName);
             return bigQuery.getDataset(datasetId);
           } catch (BigQueryException ex) {
             bigQueryAclUpdateShouldRetry(ex);

--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -185,7 +185,10 @@ public final class BigQueryProject {
     if (message.startsWith("Read timed out") || ex.getCause() instanceof SocketTimeoutException) {
       throw new AclUtils.AclRetryException("Timeout.", ex, "Timeout");
     }
-    if (message.contains("504") || (ex.getCause() != null && ex.getCause().getMessage() != null && ex.getCause().getMessage().contains("504"))) {
+    if (message.contains("504")
+        || (ex.getCause() != null
+            && ex.getCause().getMessage() != null
+            && ex.getCause().getMessage().contains("504"))) {
       throw new AclUtils.AclRetryException("Gateway timeout.", ex, "Timeout");
     }
     throw ex;

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryPdaoTest.java
@@ -946,10 +946,16 @@ public class BigQueryPdaoTest {
   private void assertThatDatasetAndTablesShouldExist(Dataset dataset, boolean shouldExist)
       throws InterruptedException {
 
-    boolean datasetExists = bigQueryDatasetPdao.tableExists(dataset, "participant");
+    boolean datasetExists = bigQueryDatasetPdao.datasetExists(dataset);
     assertThat(
         String.format("Dataset: %s, exists", dataset.getName()),
         datasetExists,
+        equalTo(shouldExist));
+
+    boolean participantTableExists = bigQueryDatasetPdao.tableExists(dataset, "participant");
+    assertThat(
+        String.format("Participant table in dataset %s exists", dataset.getName()),
+        participantTableExists,
         equalTo(shouldExist));
 
     boolean loadTableExists = bigQueryDatasetPdao.tableExists(dataset, PDAO_LOAD_HISTORY_TABLE);

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryProjectTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryProjectTest.java
@@ -1,0 +1,38 @@
+package bio.terra.service.tabulardata.google;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.common.AclUtils;
+import bio.terra.common.category.Unit;
+import bio.terra.model.SnapshotModel;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import com.google.cloud.bigquery.BigQueryException;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(Unit.TAG)
+class BigQueryProjectTest {
+
+  @Test
+  void bigQueryAclUpdateShouldRetry() {
+    // mock an exception that looks like the following:
+    // com.google.cloud.bigquery.BigQueryException: Project id: datarepo-REDACTED
+    //	at com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:59)
+    // ...
+    // Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 504 Gateway
+    // Timeout
+    var bigQueryProject = BigQueryProject.from(new SnapshotModel().dataProject("data-project"));
+    var bigQueryException =
+        new BigQueryException(
+            500,
+            "Project id: datarepo-REDACTED",
+            new HttpResponseException.Builder(
+                    HttpStatus.SC_GATEWAY_TIMEOUT, "504 Gateway Timeout", new HttpHeaders() {})
+                .build());
+    assertThrows(
+        AclUtils.AclRetryException.class,
+        () -> bigQueryProject.bigQueryAclUpdateShouldRetry(bigQueryException));
+  }
+}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1654

## Addresses

We have several datasets that we are trying to migrate that have 2k+ snapshots associated with them. I'm finding that they consistently fail on the SetAuthTabularAclStep (I've tested with 2 datasets so far), which does an ACL update to every snapshot's google project to grant the users read access on BigQuery. 

The Gateway timeout exception is occuring when trying to retrieve the dataset (not when performing the ACL update). We don't currently wrap this in a retry, but we can reuse the acl retry methodology here as well.

We get this error:

```
Step Result exception
com.google.cloud.bigquery.BigQueryException: Project id: datarepo-REDACTED
	at com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:59)
	at com.google.cloud.bigquery.BigQueryImpl.getDataset(BigQueryImpl.java:500)
	at com.google.cloud.bigquery.BigQueryImpl.getDataset(BigQueryImpl.java:491)
	at bio.terra.service.tabulardata.google.BigQueryProject.addDatasetAcls(BigQueryProject.java:190)
	at bio.terra.service.tabulardata.google.bigquery.BigQueryPdao.grantReadAccessWorker(BigQueryPdao.java:53)
	at bio.terra.service.tabulardata.google.bigquery.BigQuerySnapshotPdao.grantReadAccessToSnapshot(BigQuerySnapshotPdao.java:800)
	at bio.terra.service.dataset.flight.inheritsteward.SetAuthTabularAclStep.setAuth(SetAuthTabularAclStep.java:36)
	at bio.terra.service.dataset.flight.inheritsteward.SetAuthTabularAclStep.doStep(SetAuthTabularAclStep.java:45)
	at bio.terra.stairway.impl.FlightRunner.stepWithRetry(FlightRunner.java:248)
	at bio.terra.stairway.impl.FlightRunner.runSteps(FlightRunner.java:178)
	at bio.terra.stairway.impl.FlightRunner.fly(FlightRunner.java:110)
	at bio.terra.stairway.impl.FlightRunner.run(FlightRunner.java:68)
	at bio.terra.stairway.impl.StairwayThreadPool.lambda$submitWithMdcAndFlightContext$0(StairwayThreadPool.java:34)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 504 Gateway Timeout
GET https://bigquery.googleapis.com/bigquery/v2/projects/datarepo-REDACTED/datasets/REDACTED?prettyPrint=false
{
  "code": 504,
  "errors": [
    {
      "domain": "global",
      "message": "Project id: datarepo-REDACTED",
      "reason": "backendError"
    }
  ],
  "message": "Project id: datarepo-REDACTED",
  "status": "DEADLINE_EXCEEDED"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:145)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$3.interceptResponse(AbstractGoogleClientRequest.java:479)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:565)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:506)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:616)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.getDatasetSkipExceptionTranslation(HttpBigQueryRpc.java:157)
	at com.google.cloud.bigquery.BigQueryImpl$6.call(BigQueryImpl.java:504)
	at com.google.cloud.bigquery.BigQueryImpl$6.call(BigQueryImpl.java:501)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:102)
	at com.google.cloud.bigquery.BigQueryRetryHelper.run(BigQueryRetryHelper.java:92)
	at com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:50)
	... 17 common frames omitted
``` 

I believe this exception is not getting retried because we only see the exception once and then the whole flight fails. 

My proposal is to catch and retry this exception to see if we can get past this step. 

## Summary of changes
- Wrap getDataset in a retry and make sure we're retrying a 504 Gateway Timeout exception 

## Testing Strategy
- Unit test that we're retrying an approximate error that looks like the one we're seeing
- Tests to make sure the getDataset endpoint works as expected
