### PR TITLE
DT-1654: Unblock Inherit Steward Migration - Bypass errors in Adjust members step; New adjust members endpoint

### DIFF
--- a/src/main/java/bio/terra/app/controller/DatasetsApiController.java
+++ b/src/main/java/bio/terra/app/controller/DatasetsApiController.java
@@ -522,6 +522,15 @@ public class DatasetsApiController implements DatasetsApi {
     return ControllerUtils.jobToResponse(jobService.retrieveJob(jobId, userReq));
   }
 
+  @Override
+  public ResponseEntity<JobModel> adjustMembersInheritSteward(UUID id) {
+    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
+    verifyDatasetAuthorization(userReq, id.toString(), IamAction.SET_INHERIT_STEWARD);
+
+    String jobId = datasetService.adjustMembersInheritSteward(id, userReq);
+    return ControllerUtils.jobToResponse(jobService.retrieveJob(jobId, userReq));
+  }
+
   private void validateIngestParams(IngestRequestModel ingestRequestModel, UUID datasetId) {
     CloudPlatform datasetPlatform =
         datasetService.retrieveDatasetSummary(datasetId).getCloudPlatform();

--- a/src/main/java/bio/terra/service/dataset/DatasetService.java
+++ b/src/main/java/bio/terra/service/dataset/DatasetService.java
@@ -53,6 +53,7 @@ import bio.terra.service.dataset.flight.ingest.DatasetIngestFlight;
 import bio.terra.service.dataset.flight.ingest.IngestMapKeys;
 import bio.terra.service.dataset.flight.ingest.IngestUtils;
 import bio.terra.service.dataset.flight.ingest.scratch.DatasetScratchFilePrepareFlight;
+import bio.terra.service.dataset.flight.inheritsteward.InheritStewardAdjustMembersFlight;
 import bio.terra.service.dataset.flight.inheritsteward.SetInheritStewardFlight;
 import bio.terra.service.dataset.flight.lock.DatasetLockFlight;
 import bio.terra.service.dataset.flight.transactions.TransactionCommitFlight;
@@ -805,6 +806,31 @@ public class DatasetService {
         .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD)
         .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
         .addParameter(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), datasetPolicyEmails)
+        .addParameter(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), datasetPolicyMembers)
+        .addParameter(JobMapKeys.INHERIT_STEWARD.getKeyName(), inheritSteward)
+        .submit();
+  }
+
+  public String adjustMembersInheritSteward(UUID datasetId, AuthenticatedUserRequest userReq) {
+    String description =
+        String.format(
+            "Adjust members to reduce google group usage after inherit steward is for dataset %s",
+            datasetId);
+    List<SamPolicyModel> datasetPolicies =
+        iamService.retrievePolicies(userReq, IamResourceType.DATASET, datasetId).stream()
+            .filter(p -> isInheritedRole(p.getName()))
+            .toList();
+    List<String> datasetPolicyMembers =
+        datasetPolicies.stream()
+            .flatMap(policy -> policy.getMembers().stream())
+            .distinct()
+            .collect(Collectors.toList());
+    var inheritSteward = retrieve(datasetId).isInheritSteward();
+    return jobService
+        .newJob(description, InheritStewardAdjustMembersFlight.class, null, userReq)
+        .addParameter(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET)
+        .addParameter(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD)
+        .addParameter(JobMapKeys.DATASET_ID.getKeyName(), datasetId)
         .addParameter(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), datasetPolicyMembers)
         .addParameter(JobMapKeys.INHERIT_STEWARD.getKeyName(), inheritSteward)
         .submit();

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStep.java
@@ -14,10 +14,13 @@ import bio.terra.stairway.exception.RetryException;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public record AdjustStewardMembersStep(
     AuthenticatedUserRequest userReq, IamService iamService, boolean inheritSteward)
     implements Step {
+  private static final Logger logger = LoggerFactory.getLogger(AdjustStewardMembersStep.class);
 
   interface AddRemoveApi {
     void addRemoveMember(
@@ -38,11 +41,17 @@ public record AdjustStewardMembersStep(
             inputParams.get(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), List.class));
     AddRemoveApi api =
         inheritSteward ? iamService::deletePolicyMember : iamService::addPolicyMember;
-    for (var snapshotId : snapshotIds) {
-      for (var email : custodians) {
-        api.addRemoveMember(
-            userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.STEWARD, email);
+    try {
+      for (var snapshotId : snapshotIds) {
+        for (var email : custodians) {
+          api.addRemoveMember(
+              userReq, IamResourceType.DATASNAPSHOT, snapshotId, IamRole.STEWARD, email);
+        }
       }
+    } catch (Exception e) {
+      logger.error(
+          "Error adjusting steward members. Run the adjust members endpoint to just perform this step.",
+          e);
     }
   }
 

--- a/src/main/java/bio/terra/service/dataset/flight/inheritsteward/InheritStewardAdjustMembersFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/inheritsteward/InheritStewardAdjustMembersFlight.java
@@ -1,0 +1,33 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.Flight;
+import bio.terra.stairway.FlightMap;
+import java.util.UUID;
+import org.springframework.context.ApplicationContext;
+
+public class InheritStewardAdjustMembersFlight extends Flight {
+  public InheritStewardAdjustMembersFlight(FlightMap inputParameters, Object applicationContext) {
+    super(inputParameters, applicationContext);
+
+    // Get the required DAOs and services to pass into the steps
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+    SnapshotService snapshotService = appContext.getBean(SnapshotService.class);
+    IamService iamService = appContext.getBean(IamService.class);
+
+    // Get the input parameters
+    UUID datasetId = inputParameters.get(JobMapKeys.DATASET_ID.getKeyName(), UUID.class);
+    AuthenticatedUserRequest userReq =
+        inputParameters.get(JobMapKeys.AUTH_USER_INFO.getKeyName(), AuthenticatedUserRequest.class);
+
+    boolean inheritSteward =
+        inputParameters.get(JobMapKeys.INHERIT_STEWARD.getKeyName(), Boolean.class);
+
+    addStep(
+        new GetSnapshotIdsStep(snapshotService, iamService, userReq, datasetId, inheritSteward));
+    addStep(new AdjustStewardMembersStep(userReq, iamService, inheritSteward));
+  }
+}

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3198,6 +3198,64 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
+  /api/repository/v1/datasets/{id}/inheritStewardAdjustMembers:
+    put:
+      tags:
+        - datasets
+        - repository
+      description: >
+        ADMIN ONLY - Adjust members on datasets based on inherit steward flag
+      operationId: adjustMembersInheritSteward
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        200:
+          description: Redirect for dataset adjust members result
+          headers:
+            location:
+              description: url for the job result
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobModel'
+        202:
+          description: Job status of job & url for polling in the response
+            header
+          headers:
+            location:
+              description: url for the job polling
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobModel'
+        400:
+          description: Bad request - invalid id, badly formed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        403:
+          description: No permission to adjust members on this dataset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        404:
+          description: Not found - dataset does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+        500:
+          description: An unexpected error occurred - dataset was not updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
   /api/repository/v1/snapshotAccessRequests:
     get:
       tags:

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -3198,7 +3198,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorModel'
-  /api/repository/v1/datasets/{id}/inheritStewardAdjustMembers:
+  /api/repository/v1/datasets/{id}/adjustMembersInheritSteward:
     put:
       tags:
         - datasets

--- a/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DatasetsApiControllerTest.java
@@ -109,6 +109,9 @@ class DatasetsApiControllerTest {
   private static final String SET_INHERIT_STEWARD_ENDPOINT =
       DATASET_ID_ENDPOINT + "/inheritSteward";
 
+  private static final String ADJUST_MEMBERS_INHERIT_STEWARD_ENDPOINT =
+      DATASET_ID_ENDPOINT + "/adjustMembersInheritSteward";
+
   private static final SqlSortDirectionAscDefault DIRECTION = SqlSortDirectionAscDefault.ASC;
   private static final UUID DATASET_ID = UUID.randomUUID();
   private static final DatasetPatchRequestModel DATASET_PATCH_REQUEST =
@@ -620,8 +623,33 @@ class DatasetsApiControllerTest {
     verifyAuthorizationCall(IamAction.SET_INHERIT_STEWARD);
   }
 
-  @Test
-  void setInheritStewardNotAuthorized() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void adjustMembersInheritSteward(boolean inheritSteward) throws Exception {
+    String jobId = "jobId";
+    mockValidators();
+    when(datasetService.retrieveDatasetSummary(DATASET_ID))
+        .thenReturn(new DatasetSummaryModel().id(DATASET_ID).inheritSteward(!inheritSteward));
+    when(datasetService.adjustMembersInheritSteward(DATASET_ID, TEST_USER)).thenReturn(jobId);
+    JobModel jobModel = new JobModel().id(jobId).jobStatus(JobModel.JobStatusEnum.RUNNING);
+    when(jobService.retrieveJob(eq(jobId), any())).thenReturn(jobModel);
+
+    String json =
+        mvc.perform(
+                put(ADJUST_MEMBERS_INHERIT_STEWARD_ENDPOINT, DATASET_ID)
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().is(202))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    JobModel model = TestUtils.mapFromJson(json, JobModel.class);
+    assertThat("Job ID is returned", model, equalTo(jobModel));
+    verifyAuthorizationCall(IamAction.SET_INHERIT_STEWARD);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {SET_INHERIT_STEWARD_ENDPOINT, ADJUST_MEMBERS_INHERIT_STEWARD_ENDPOINT})
+  void inheritStewardNotAuthorized(String endpoint) throws Exception {
     boolean inheritSteward = true;
     mockValidators();
     IamAction iamAction = IamAction.SET_INHERIT_STEWARD;
@@ -630,7 +658,7 @@ class DatasetsApiControllerTest {
         .verifyAuthorization(TEST_USER, IamResourceType.DATASET, DATASET_ID.toString(), iamAction);
 
     mvc.perform(
-            put(SET_INHERIT_STEWARD_ENDPOINT, DATASET_ID)
+            put(endpoint, DATASET_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.mapToJson(inheritSteward)))
         .andExpect(status().isForbidden());
@@ -638,27 +666,29 @@ class DatasetsApiControllerTest {
     verifyAuthorizationCall(iamAction);
   }
 
-  @Test
-  void setInheritStewardInvalidId() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {SET_INHERIT_STEWARD_ENDPOINT, ADJUST_MEMBERS_INHERIT_STEWARD_ENDPOINT})
+  void setInheritStewardInvalidId(String endpoint) throws Exception {
     boolean inheritSteward = true;
     mockValidators();
 
     mvc.perform(
-            put(SET_INHERIT_STEWARD_ENDPOINT, "not a UUID")
+            put(endpoint, "not a UUID")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.mapToJson(inheritSteward)))
         .andExpect(status().isBadRequest());
   }
 
-  @Test
-  void setInheritStewardDatasetNotFound() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {SET_INHERIT_STEWARD_ENDPOINT, ADJUST_MEMBERS_INHERIT_STEWARD_ENDPOINT})
+  void setInheritStewardDatasetNotFound(String endpoint) throws Exception {
     boolean inheritSteward = true;
     mockValidators();
     when(datasetService.retrieveDatasetSummary(DATASET_ID))
         .thenThrow(new DatasetNotFoundException("Dataset not found for id: " + DATASET_ID));
 
     mvc.perform(
-            put(SET_INHERIT_STEWARD_ENDPOINT, DATASET_ID)
+            put(endpoint, DATASET_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.mapToJson(inheritSteward)))
         .andExpect(status().isNotFound());

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceUnitTest.java
@@ -43,6 +43,7 @@ import bio.terra.service.auth.iam.IamRole;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.dataset.flight.DatasetWorkingMapKeys;
 import bio.terra.service.dataset.flight.create.DatasetCreateFlight;
+import bio.terra.service.dataset.flight.inheritsteward.InheritStewardAdjustMembersFlight;
 import bio.terra.service.dataset.flight.inheritsteward.SetInheritStewardFlight;
 import bio.terra.service.dataset.flight.unlock.DatasetUnlockFlight;
 import bio.terra.service.filedata.azure.AzureSynapsePdao;
@@ -447,10 +448,68 @@ class DatasetServiceUnitTest {
         equalTo(inheritSteward));
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void adjustMembersInheritSteward(boolean inheritSteward) {
+    JobBuilder jobBuilder =
+        new JobBuilder("", InheritStewardAdjustMembersFlight.class, null, TEST_USER, jobService);
+    when(jobService.newJob(
+            String.format(
+                "Adjust members to reduce google group usage after inherit steward is for dataset %s",
+                DATASET_ID),
+            InheritStewardAdjustMembersFlight.class,
+            null,
+            TEST_USER))
+        .thenReturn(jobBuilder);
+    var custodianEmail = "custodianEmail";
+    var stewardEmail = "stewardEmail";
+    var members = Arrays.asList("member");
+    var stewardMembers = Arrays.asList("member2");
+    mockDataset(CloudPlatform.GCP, TableDataType.STRING, inheritSteward);
+    when(iamService.retrievePolicies(TEST_USER, IamResourceType.DATASET, DATASET_ID))
+        .thenReturn(
+            List.of(
+                new SamPolicyModel()
+                    .name(IamRole.CUSTODIAN.toString())
+                    .email(custodianEmail)
+                    .members(members),
+                new SamPolicyModel()
+                    .name(IamRole.STEWARD.toString())
+                    .email(stewardEmail)
+                    .members(stewardMembers)));
+    ArgumentCaptor<FlightMap> captor = ArgumentCaptor.forClass(FlightMap.class);
+    when(jobService.submit(eq(InheritStewardAdjustMembersFlight.class), captor.capture()))
+        .thenReturn("JobId");
+    assertThat(
+        "Job is submitted and JobId is returned",
+        datasetService.adjustMembersInheritSteward(DATASET_ID, TEST_USER),
+        equalTo("JobId"));
+    FlightMap flightMap = captor.getValue();
+    assertThat(
+        flightMap.get(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.class),
+        equalTo(IamResourceType.DATASET));
+    assertThat(flightMap.get(DatasetWorkingMapKeys.DATASET_ID, UUID.class), equalTo(DATASET_ID));
+    assertThat(
+        flightMap.get(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.class),
+        equalTo(IamAction.SET_INHERIT_STEWARD));
+    assertThat(
+        flightMap.get(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), List.class),
+        equalTo(Stream.of(members, stewardMembers).flatMap(List::stream).toList()));
+    assertThat(
+        flightMap.get(JobMapKeys.INHERIT_STEWARD.getKeyName(), Boolean.class),
+        equalTo(inheritSteward));
+  }
+
   private void mockDataset(CloudPlatform cloudPlatform, TableDataType columnDataType) {
+    mockDataset(cloudPlatform, columnDataType, false);
+  }
+
+  private void mockDataset(
+      CloudPlatform cloudPlatform, TableDataType columnDataType, boolean inheritSteward) {
     List<DatasetTable> tables = List.of(new DatasetTable().name(DATASET_TABLE_NAME));
     Dataset mockDataset =
-        new Dataset(new DatasetSummary().cloudPlatform(cloudPlatform))
+        new Dataset(
+                new DatasetSummary().cloudPlatform(cloudPlatform).inheritSteward(inheritSteward))
             .id(DATASET_ID)
             .tables(tables)
             .tables(

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/AdjustStewardMembersStepTest.java
@@ -2,6 +2,8 @@ package bio.terra.service.dataset.flight.inheritsteward;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -86,5 +88,36 @@ class AdjustStewardMembersStepTest {
         new AdjustStewardMembersStep(TEST_USER, iamService, inheritSteward);
     verifyAdjustMembers(step::doStep, inheritSteward);
     verifyAdjustMembers(step::undoStep, !inheritSteward);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void stepSucceedsCatchesError(boolean inheritSteward) throws Exception {
+    var snapshots =
+        List.of(new Snapshot().id(UUID.randomUUID()), new Snapshot().id(UUID.randomUUID()));
+    List<String> datasetPolicyEmails = Arrays.asList("custodianEmail", "stewardEmail");
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(
+        DatasetWorkingMapKeys.SNAPSHOT_IDS,
+        snapshots.stream().map(Snapshot::getId).collect(Collectors.toList()));
+    FlightMap inputParameters = new FlightMap();
+    inputParameters.put(JobMapKeys.DATASET_POLICY_USERS.getKeyName(), datasetPolicyEmails);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(flightContext.getInputParameters()).thenReturn(inputParameters);
+
+    AdjustStewardMembersStep step =
+        new AdjustStewardMembersStep(TEST_USER, iamService, inheritSteward);
+
+    if (inheritSteward) {
+      doThrow(new RuntimeException("Test exception"))
+          .when(iamService)
+          .deletePolicyMember(any(), any(), any(), any(), any());
+    } else {
+      doThrow(new RuntimeException("Test exception"))
+          .when(iamService)
+          .addPolicyMember(any(), any(), any(), any(), any());
+    }
+
+    assertThat(step.doStep(flightContext), is(StepResult.getStepResultSuccess()));
   }
 }

--- a/src/test/java/bio/terra/service/dataset/flight/inheritsteward/InheritStewardAdjustMembersFlightTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/inheritsteward/InheritStewardAdjustMembersFlightTest.java
@@ -1,0 +1,99 @@
+package bio.terra.service.dataset.flight.inheritsteward;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.FlightTestUtils;
+import bio.terra.common.category.Unit;
+import bio.terra.common.fixtures.AuthenticationFixtures;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.service.auth.iam.IamAction;
+import bio.terra.service.auth.iam.IamResourceType;
+import bio.terra.service.auth.iam.IamService;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.stairway.FlightMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class InheritStewardAdjustMembersFlightTest {
+  @Mock private ApplicationContext context;
+  @Mock private SnapshotService snapshotService;
+  @Mock private IamService iamService;
+  private final FlightMap inputParameters = new FlightMap();
+
+  private static final String CUSTODIAN_EMAIL = "custodian email";
+  private static final String STEWARD_EMAIL = "steward email";
+  private static final List<String> DATASET_POLICY_EMAILS =
+      Arrays.asList(CUSTODIAN_EMAIL, STEWARD_EMAIL);
+  private static final UUID DATASET_ID = UUID.randomUUID();
+  private static final AuthenticatedUserRequest TEST_USER =
+      AuthenticationFixtures.randomUserRequest();
+
+  @BeforeEach
+  void setUp() {
+    inputParameters.put(JobMapKeys.IAM_RESOURCE_TYPE.getKeyName(), IamResourceType.DATASET);
+    inputParameters.put(JobMapKeys.DATASET_ID.getKeyName(), DATASET_ID);
+    inputParameters.put(JobMapKeys.IAM_ACTION.getKeyName(), IamAction.SET_INHERIT_STEWARD);
+    inputParameters.put(JobMapKeys.AUTH_USER_INFO.getKeyName(), TEST_USER);
+    inputParameters.put(JobMapKeys.DATASET_POLICY_EMAILS.getKeyName(), DATASET_POLICY_EMAILS);
+    when(context.getBean(SnapshotService.class)).thenReturn(snapshotService);
+    when(context.getBean(IamService.class)).thenReturn(iamService);
+  }
+
+  @Test
+  void allSteps() {
+    inputParameters.put(JobMapKeys.INHERIT_STEWARD.getKeyName(), true);
+    var flight = new InheritStewardAdjustMembersFlight(inputParameters, context);
+    var steps = FlightTestUtils.getStepNames(flight);
+    assertThat(steps, contains("GetSnapshotIdsStep", "AdjustStewardMembersStep"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void getSnapshotIdsStep(boolean inheritSteward) {
+    inputParameters.put(JobMapKeys.INHERIT_STEWARD.getKeyName(), inheritSteward);
+    try (var mockStep =
+        mockConstruction(
+            GetSnapshotIdsStep.class,
+            (mock, context) ->
+                assertThat(
+                    context.arguments(),
+                    contains(
+                        snapshotService, iamService, TEST_USER, DATASET_ID, inheritSteward)))) {
+      //noinspection ResultOfObjectAllocationIgnored
+      new InheritStewardAdjustMembersFlight(inputParameters, context);
+      assertThat(mockStep.constructed(), hasSize(1));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void adjustStewardMembersStep(boolean inheritSteward) {
+    inputParameters.put(JobMapKeys.INHERIT_STEWARD.getKeyName(), inheritSteward);
+    try (var mockStep =
+        mockConstruction(
+            AdjustStewardMembersStep.class,
+            (mock, context) ->
+                assertThat(context.arguments(), contains(TEST_USER, iamService, inheritSteward)))) {
+      //noinspection ResultOfObjectAllocationIgnored
+      new InheritStewardAdjustMembersFlight(inputParameters, context);
+      assertThat(mockStep.constructed(), hasSize(1));
+    }
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
@@ -10,6 +10,7 @@ import bio.terra.common.auth.Users;
 import bio.terra.common.category.Integration;
 import bio.terra.common.configuration.TestConfiguration.User;
 import bio.terra.common.fixtures.JsonLoader;
+import bio.terra.common.fixtures.Names;
 import bio.terra.integration.BigQueryFixtures;
 import bio.terra.integration.DataRepoClient;
 import bio.terra.integration.DataRepoFixtures;
@@ -123,6 +124,10 @@ class SnapshotPermissionsIntegrationTest {
   void snapshotInvalidEmailTest() throws Exception {
     SnapshotRequestModel requestModel =
         jsonLoader.loadObject("ingest-test-snapshot.json", SnapshotRequestModel.class);
+    // randomize name so that we don't have failures on test retry after successful creation of snapshot
+    // Only randomize name here at the beginning of the test
+    // so that we can test that we can't create a snapshot with the same name
+    requestModel.setName(Names.randomizeName(requestModel.getName()));
 
     requestModel.setReaders(Collections.singletonList("bad-user@not-a-real-domain.com"));
     DataRepoResponse<JobModel> jobResponse =

--- a/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotPermissionsIntegrationTest.java
@@ -124,7 +124,8 @@ class SnapshotPermissionsIntegrationTest {
   void snapshotInvalidEmailTest() throws Exception {
     SnapshotRequestModel requestModel =
         jsonLoader.loadObject("ingest-test-snapshot.json", SnapshotRequestModel.class);
-    // randomize name so that we don't have failures on test retry after successful creation of snapshot
+    // randomize name so that we don't have failures on test retry after successful creation of
+    // snapshot
     // Only randomize name here at the beginning of the test
     // so that we can test that we can't create a snapshot with the same name
     requestModel.setName(Names.randomizeName(requestModel.getName()));


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1654

## Addresses
We're running into a Sam auth timeout issue with the Adjust members step because it runs so late in the flight. For datasets with lots of snapshots, we hit this step about 3 hours into the flight. User tokens expire at around 1 hour.

The Adjust members step is well suited to be its own flight because the dataset is fully migrated to inherit steward; the adjust members just allows us to reduce google group members by removing extraneous members on the child snapshots. 

There are more elegant solutions that would refresh the token, namely to use user's pet service accounts that allow us to refresh the token. We choose to not go that route in favor of a path that would be quicker for our team with fewer unknowns. 

We don't want to move this step further up in the flight because we don't want to change membership until the inherit steward migration is fully complete.

## Summary of changes
1) Ignore failures in the adjust members step of the inherit steward migration flight. 
2) Add new endpoint/flight that just adjusts members based on the inherit steward flag set on the dataset

## Testing Strategy
- Unit test
- Manual Test ✅ 
 1) Ran the inherit steward flight with an added exception to force the step to fail
 2) Removed the added exception and ran the new adjust members endpoints
 3)  ✅ All snapshot stewards removed that were also stewards on the dataset
