### PR TITLE
DT-1820 - Add retry case for BQ Service Unavailable Exception

### DIFF
--- a/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/BigQueryProject.java
@@ -190,6 +190,10 @@ public final class BigQueryProject {
         && httpResponseException.getStatusCode() == HttpStatus.SC_GATEWAY_TIMEOUT) {
       throw new AclUtils.AclRetryException("Gateway timeout.", ex, "Timeout");
     }
+    if (ex.getCause() instanceof HttpResponseException httpResponseException
+        && (httpResponseException.getStatusCode() == HttpStatus.SC_SERVICE_UNAVAILABLE)) {
+      throw new AclUtils.AclRetryException("BQ Service Unavailable", ex, "Service Unavailable");
+    }
     throw ex;
   }
 

--- a/src/test/java/bio/terra/service/tabulardata/google/BigQueryProjectTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/BigQueryProjectTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 class BigQueryProjectTest {
 
   @Test
-  void bigQueryAclUpdateShouldRetry() {
+  void gatewayTimeoutShouldRetry() {
     // mock an exception that looks like the following:
     // com.google.cloud.bigquery.BigQueryException: Project id: datarepo-REDACTED
     //	at com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:59)
@@ -30,6 +30,35 @@ class BigQueryProjectTest {
             "Project id: datarepo-REDACTED",
             new HttpResponseException.Builder(
                     HttpStatus.SC_GATEWAY_TIMEOUT, "504 Gateway Timeout", new HttpHeaders() {})
+                .build());
+    assertThrows(
+        AclUtils.AclRetryException.class,
+        () -> bigQueryProject.bigQueryAclUpdateShouldRetry(bigQueryException));
+  }
+
+  @Test
+  void serviceUnavailableShouldRetry() {
+    // mock an exception that looks like the following:
+    //    Caused by: com.google.cloud.bigquery.BigQueryException: Visibility check was unavailable.
+    //    Please retry the request and contact support if the problem persists
+    //      at
+    // com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:59)
+    //      at com.google.cloud.bigquery.BigQueryImpl.getDataset(BigQueryImpl.java:500)
+    //      at
+    // bio.terra.service.tabulardata.google.BigQueryProject.lambda$getBQDataset$1(BigQueryProject.java:214)
+    //      at bio.terra.common.AclUtils.aclUpdateRetry(AclUtils.java:28)
+    //	... 16 common frames omitted
+    //    Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 503 Service
+    // Unavailable
+    var bigQueryProject = BigQueryProject.from(new SnapshotModel().dataProject("data-project"));
+    var bigQueryException =
+        new BigQueryException(
+            500,
+            "Visibility check was unavailable",
+            new HttpResponseException.Builder(
+                    HttpStatus.SC_SERVICE_UNAVAILABLE,
+                    "503 Service Unavailable",
+                    new HttpHeaders() {})
                 .build());
     assertThrows(
         AclUtils.AclRetryException.class,


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-1820

## Addresses
During our long running inherit steward migrations, a single transient failure can make the whole flight dismally fail. The exception message from BQ says to retry, so I think this is a reasonable step. However, it also says to reach out to GCP support if we continuously see this exception. It's popping up quite frequently in the logs, so we should address this separately. 

## Summary of changes
- Add retry on 503 Service Unavailable exception from BQ

## Testing Strategy
- Unit test
