### PR TITLE
[DT-614] Validate primary key invariant after ingest merge and replace operations

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/DatasetIngestFlight.java
@@ -249,7 +249,7 @@ public class DatasetIngestFlight extends Flight {
           (ingestRequestModel.getUpdateStrategy() == IngestRequestModel.UpdateStrategyEnum.MERGE);
       if (replaceIngest || mergeIngest) {
         // Ensure that no duplicate IDs are being loaded in
-        addStep(new IngestValidateIngestRowsStep(datasetService));
+        addStep(new IngestValidateIngestRowsStep(datasetService, false));
         if (mergeIngest) {
           addStep(new IngestValidatePrimaryKeyDefinedStep(datasetService));
           addStep(new IngestValidateTargetRowsStep(datasetService, bigQueryDatasetPdao));
@@ -273,6 +273,12 @@ public class DatasetIngestFlight extends Flight {
       addStep(new IngestCleanupStep(datasetService, bigQueryDatasetPdao));
       addStep(new IngestScratchFileDeleteGcpStep(gcsPdao));
       addStep(new PerformPayloadIngestStep(new IngestLandingFileDeleteGcpStep(false, gcsPdao)));
+      if (replaceIngest || mergeIngest) {
+        // Validate the rows in the target table after ingest.
+        // There may have already been duplicate rows in the table prior to ingest
+        // or concurrent ingests could have created duplicate rows.
+        new IngestValidateIngestRowsStep(datasetService, true);
+      }
     } else if (cloudPlatform.isAzure()) {
       addStep(
           new IngestCreateIngestRequestDataSourceStep(
@@ -293,6 +299,7 @@ public class DatasetIngestFlight extends Flight {
           new PerformPayloadIngestStep(
               new IngestLandingFileDeleteAzureStep(false, azureContainerPdao)));
     }
+
     if (cloudPlatform.isGcp()) {
       if (!autocommit) {
         addStep(

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStep.java
@@ -20,20 +20,28 @@ public class IngestValidateIngestRowsStep implements Step {
   private static final int MAX_ERROR_DUPLICATE_ROWS = 20;
   private static final Logger logger = LoggerFactory.getLogger(IngestValidateIngestRowsStep.class);
   private final DatasetService datasetService;
+  private final boolean postIngest;
 
-  public IngestValidateIngestRowsStep(DatasetService datasetService) {
+  public IngestValidateIngestRowsStep(DatasetService datasetService, boolean postIngest) {
     this.datasetService = datasetService;
+    this.postIngest = postIngest;
   }
 
   @Override
   public StepResult doStep(FlightContext context) throws InterruptedException {
     Dataset dataset = IngestUtils.getDataset(context, datasetService);
     DatasetTable targetTable = IngestUtils.getDatasetTable(context, dataset);
-    String stagingTableName = IngestUtils.getStagingTableName(context);
 
     if (targetTable.getPrimaryKey() != null && !targetTable.getPrimaryKey().isEmpty()) {
+      // targetTable.getPrimaryKey() would be the same as stagingTable.getPrimaryKey()
+      // checks for duplicate primary keys in the specified table
+      String tableNameToCheck =
+          postIngest
+              ? targetTable.getName()
+              : IngestUtils.getStagingTableName(
+                  context); // use target table for post-ingest validation
       TableResult duplicatePrimaryKeys =
-          BigQueryPdao.duplicatePrimaryKeys(dataset, targetTable.getPrimaryKey(), stagingTableName);
+          BigQueryPdao.duplicatePrimaryKeys(dataset, targetTable.getPrimaryKey(), tableNameToCheck);
       long numDuplicatePrimaryKeys = duplicatePrimaryKeys.getTotalRows();
 
       if (numDuplicatePrimaryKeys > 0) {

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -66,8 +66,8 @@ public enum BigQueryPdao {
           + "HAVING COUNT(*) > 1";
 
   /**
-   * Returns true is any duplicate IDs are present in a BigQuery table TODO: add support for
-   * returning top few instances
+   * Returns table result with rows that represent the duplicate primary keys and their counts TODO:
+   * add support for returning top few instances
    */
   public static TableResult duplicatePrimaryKeys(
       FSContainerInterface container, List<Column> pkColumns, String tableName)

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStepTest.java
@@ -47,7 +47,7 @@ class IngestValidateIngestRowsStepTest {
   }
 
   @AfterEach
-  public void close() {
+  void close() {
     mockedUtils.close();
     mockedBigQueryPdao.close();
   }

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStepTest.java
@@ -1,0 +1,134 @@
+package bio.terra.service.dataset.flight.ingest;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+import bio.terra.common.Column;
+import bio.terra.common.category.Unit;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.exception.InvalidIngestDuplicatesException;
+import bio.terra.service.tabulardata.google.bigquery.BigQueryPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.StepResult;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.TableResult;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class IngestValidateIngestRowsStepTest {
+
+  @Mock private DatasetService datasetService;
+  @Mock private FlightContext flightContext;
+  @Mock private TableResult tableResult;
+
+  private MockedStatic<IngestUtils> mockedUtils;
+  private MockedStatic<BigQueryPdao> mockedBigQueryPdao;
+
+  private IngestValidateIngestRowsStep step;
+
+  @BeforeEach
+  void setUp() {
+    mockedUtils = mockStatic(IngestUtils.class);
+    mockedBigQueryPdao = mockStatic(BigQueryPdao.class);
+  }
+
+  @AfterEach
+  public void close() {
+    mockedUtils.close();
+    mockedBigQueryPdao.close();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testDoStep(boolean postIngest) throws InterruptedException {
+    step = new IngestValidateIngestRowsStep(datasetService, postIngest);
+    Dataset dataset = createDataset();
+    DatasetTable datasetTable = dataset.getTables().get(0);
+
+    when(IngestUtils.getDataset(flightContext, datasetService)).thenReturn(dataset);
+    when(IngestUtils.getDatasetTable(flightContext, dataset)).thenReturn(datasetTable);
+    String tableName;
+    if (postIngest) {
+      tableName = datasetTable.getName();
+    } else {
+      tableName = "staging_table";
+      when(IngestUtils.getStagingTableName(flightContext)).thenReturn(tableName);
+    }
+    when(IngestUtils.getStagingTableName(flightContext)).thenReturn(tableName);
+
+    // Mock behavior for no duplicates
+    when(BigQueryPdao.duplicatePrimaryKeys(dataset, datasetTable.getPrimaryKey(), tableName))
+        .thenReturn(tableResult);
+    when(tableResult.getTotalRows()).thenReturn(0L);
+
+    StepResult result = step.doStep(flightContext);
+    assertTrue(result.isSuccess());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testDoStepWithDuplicatePrimaryKeys(boolean postIngest) throws InterruptedException {
+    step = new IngestValidateIngestRowsStep(datasetService, postIngest);
+    Dataset dataset = createDataset();
+    DatasetTable datasetTable = dataset.getTables().get(0);
+
+    when(IngestUtils.getDataset(flightContext, datasetService)).thenReturn(dataset);
+    when(IngestUtils.getDatasetTable(flightContext, dataset)).thenReturn(datasetTable);
+    String tableName;
+    if (postIngest) {
+      tableName = datasetTable.getName();
+    } else {
+      tableName = "staging_table";
+      when(IngestUtils.getStagingTableName(flightContext)).thenReturn(tableName);
+    }
+
+    // Mocking of FieldValueList and FieldValue required for error details/causes
+    FieldValueList row = mock(FieldValueList.class);
+    FieldValue idValue = mock(FieldValue.class);
+    FieldValue countValue = mock(FieldValue.class);
+    when(row.get("id")).thenReturn(idValue);
+    when(row.hasSchema()).thenReturn(true);
+    when(row.get("count")).thenReturn(countValue);
+    when(idValue.getStringValue()).thenReturn("123");
+    when(countValue.getStringValue()).thenReturn("3");
+    when(tableResult.getTotalRows()).thenReturn(5L);
+    when(tableResult.iterateAll()).thenReturn(List.of(row));
+    when(BigQueryPdao.duplicatePrimaryKeys(dataset, datasetTable.getPrimaryKey(), tableName))
+        .thenReturn(tableResult);
+
+    InvalidIngestDuplicatesException exception =
+        assertThrows(InvalidIngestDuplicatesException.class, () -> step.doStep(flightContext));
+
+    // Verify exception message
+    assertTrue(exception.getMessage().contains("Duplicate primary keys identified"));
+    assertTrue(exception.getCauses().contains("3 ingest rows with id=123"));
+  }
+
+  private Dataset createDataset() {
+    //    GoogleProjectResource googleProjectResource = new GoogleProjectResource();
+    //    googleProjectResource."test-project-id");
+    Dataset dataset = new Dataset();
+    //    dataset.projectResource(new GoogleProjectResource());
+
+    DatasetTable datasetTable = new DatasetTable();
+    Column primaryKeyColumn = new Column();
+    primaryKeyColumn.name("id");
+    datasetTable.primaryKey(List.of(primaryKeyColumn));
+    dataset.tables(List.of(datasetTable));
+    return dataset;
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestValidateIngestRowsStepTest.java
@@ -119,10 +119,7 @@ class IngestValidateIngestRowsStepTest {
   }
 
   private Dataset createDataset() {
-    //    GoogleProjectResource googleProjectResource = new GoogleProjectResource();
-    //    googleProjectResource."test-project-id");
     Dataset dataset = new Dataset();
-    //    dataset.projectResource(new GoogleProjectResource());
 
     DatasetTable datasetTable = new DatasetTable();
     Column primaryKeyColumn = new Column();

--- a/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
@@ -26,6 +26,7 @@ import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.app.model.GoogleCloudResource;
 import bio.terra.app.model.GoogleRegion;
 import bio.terra.common.BQTestUtils;
+import bio.terra.common.Column;
 import bio.terra.common.DateTimeUtils;
 import bio.terra.common.Relationship;
 import bio.terra.common.category.Unit;
@@ -1146,6 +1147,21 @@ class BigQueryPdaoUnitTest {
     assertThat("Snapshot BQ table name is correctly formatted", expected, equalTo(actual));
   }
 
+  @Test
+  void testDuplicatePrimaryKeys() throws InterruptedException {
+    Dataset dataset = mockDataset();
+    DatasetTable table1 = dataset.getTables().get(0);
+    List<Column> columns = table1.getColumns();
+    TableResult expected = mock(TableResult.class);
+    when(bigQueryProjectDataset.query(
+            "SELECT col1a,col2a,COUNT(*) AS count "
+                + "FROM `dataset_data.datarepo_datasetName.tableA` "
+                + "GROUP BY col1a,col2a HAVING COUNT(*) > 1"))
+        .thenReturn(expected);
+    TableResult result = BigQueryPdao.duplicatePrimaryKeys(dataset, columns, table1.getName());
+    assertEquals(expected, result);
+  }
+
   private Dataset mockDataset() {
     DatasetTable tbl1 =
         DatasetFixtures.generateDatasetTable(
@@ -1153,6 +1169,7 @@ class BigQueryPdaoUnitTest {
             .id(TABLE_1_ID);
     tbl1.getColumns().get(0).id(TABLE_1_COL1_ID);
     tbl1.getColumns().get(1).id(TABLE_1_COL2_ID);
+    tbl1.primaryKey(tbl1.getColumns());
 
     DatasetTable tbl2 =
         DatasetFixtures.generateDatasetTable(


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-614

## Addresses
On snapshot export, users are running into a duplicate row issue. This means there is a duplicate row in the underlying dataset as well. Instead of waiting until snapshot export to fail, we want to fail earlier, on dataset ingest. 

## Summary of changes
There was already a step, IngestValidateIngestRowsStep, that validates that no duplicate rows exist in the staging table before it is ingested into the target table. However, there could have already been duplicate rows in the target table, or there could be concurrent ingests (uses a shared lock) that cause duplicates. So, the proposed solution is to run this step again after the merge/replace operation is complete, this time checking the target table. 
Note: The same step exists in the Snapshot export flight as well. That step fails when there are duplicate rows - that is where the user issue is coming from. By adding the step again towards the end of the dataset ingest flight, we hope to get the error there instead of on snapshot export.

## Testing Strategy
Unit tests, exisiting dataset ingest connected tests

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
