### PR TITLE
DT-1228: Dynamically parse swagger version

### DIFF
--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -2,7 +2,14 @@ package bio.terra.app.configuration;
 
 import bio.terra.app.logging.LoggerInterceptor;
 import bio.terra.app.usermetrics.UserMetricsInterceptor;
+import bio.terra.service.configuration.exception.ConfigException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
@@ -12,10 +19,12 @@ import org.springframework.web.util.UrlPathHelper;
 
 @Component
 public class WebConfig implements WebMvcConfigurer {
-  @Autowired private LoggerInterceptor loggerInterceptor;
-  @Autowired private UserMetricsInterceptor metricsInterceptor;
+  @Autowired
+  private LoggerInterceptor loggerInterceptor;
+  @Autowired
+  private UserMetricsInterceptor metricsInterceptor;
 
-  public static final String SWAGGER_UI_VERSION = "5.25.3";
+  public static final String SWAGGER_UI_VERSION = getSwaggerUiVersion();
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
@@ -41,5 +50,20 @@ public class WebConfig implements WebMvcConfigurer {
         .addResourceLocations(
             String.format(
                 "classpath:/META-INF/resources/webjars/swagger-ui-dist/%s/", SWAGGER_UI_VERSION));
+  }
+
+  protected static String getSwaggerUiVersion() {
+    try {
+      PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+      Resource[] resources =
+          resolver.getResources("classpath:/META-INF/resources/webjars/swagger-ui-dist/*/");
+      Pattern versionPattern = Pattern.compile(".+/swagger-ui-dist/(\\d+\\.\\d+\\.\\d+)/");
+      Matcher matcher = versionPattern.matcher(((ClassPathResource) resources[0]).getPath());
+      Optional<String> currentVersion = matcher.results().findFirst().map(m -> m.group(1));
+      return currentVersion.orElseThrow();
+    } catch (Exception e) {
+      throw new ConfigException(
+          "Failed to determine Swagger UI version from classpath resources", e);
+    }
   }
 }

--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -19,10 +19,8 @@ import org.springframework.web.util.UrlPathHelper;
 
 @Component
 public class WebConfig implements WebMvcConfigurer {
-  @Autowired
-  private LoggerInterceptor loggerInterceptor;
-  @Autowired
-  private UserMetricsInterceptor metricsInterceptor;
+  @Autowired private LoggerInterceptor loggerInterceptor;
+  @Autowired private UserMetricsInterceptor metricsInterceptor;
 
   public static final String SWAGGER_UI_VERSION = getSwaggerUiVersion();
 

--- a/src/main/java/bio/terra/service/configuration/exception/ConfigException.java
+++ b/src/main/java/bio/terra/service/configuration/exception/ConfigException.java
@@ -1,0 +1,9 @@
+package bio.terra.service.configuration.exception;
+
+import bio.terra.common.exception.ErrorReportException;
+
+public class ConfigException extends ErrorReportException {
+  public ConfigException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/test/java/bio/terra/app/configuration/WebConfigTest.java
+++ b/src/test/java/bio/terra/app/configuration/WebConfigTest.java
@@ -1,5 +1,6 @@
 package bio.terra.app.configuration;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -18,28 +19,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 class WebConfigTest {
 
   @Test
-  void swaggerUiVersionMatchesClasspath() throws IOException {
-    PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-    Resource[] resources =
-        resolver.getResources("classpath:/META-INF/resources/webjars/swagger-ui-dist/*/");
-
-    assertEquals(
-        1, resources.length, "Expected one swagger-ui-dist resource, found " + resources.length);
-
-    Pattern versionPattern = Pattern.compile(".+/swagger-ui-dist/(\\d+\\.\\d+\\.\\d+)/");
-    Matcher matcher = versionPattern.matcher(((ClassPathResource) resources[0]).getPath());
-    Optional<String> currentVersion = matcher.results().findFirst().map(m -> m.group(1));
-
-    assertTrue(
-        currentVersion.isPresent(),
-        "Could not find swagger-ui-dist version in classpath. Check your build.gradle dependencies.");
-
-    assertEquals(
-        currentVersion.get(),
-        WebConfig.SWAGGER_UI_VERSION,
-        "SWAGGER_UI_VERSION in WebConfig.java does not match the version in build.gradle. "
-            + "Update the version in WebConfig.java to "
-            + currentVersion.get()
-            + " to match.");
+  void swaggerUiVersionMatchesClasspath() {
+    assertDoesNotThrow(WebConfig::getSwaggerUiVersion);
   }
 }

--- a/src/test/java/bio/terra/app/configuration/WebConfigTest.java
+++ b/src/test/java/bio/terra/app/configuration/WebConfigTest.java
@@ -1,19 +1,10 @@
 package bio.terra.app.configuration;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.common.category.Unit;
-import java.io.IOException;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 @Tag(Unit.TAG)
 class WebConfigTest {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1228

## Summary of changes
This PR moves swagger version detection to a dynamic check in `WebConfig` using the same logic we used in the test class.

