### PR TITLE
[DT-2005] Disable Azure tests due to expired credentials

### DIFF
--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -123,6 +123,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.hamcrest.CoreMatchers;
+import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -142,6 +143,7 @@ import org.springframework.util.ResourceUtils;
 @SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
 @Tag(Integration.TAG)
+@Ignore("Disable Azure tests due to expired credentials")
 class AzureIntegrationTest {
   private static final Logger logger = LoggerFactory.getLogger(AzureIntegrationTest.class);
 

--- a/src/test/java/bio/terra/integration/AzureIntegrationTest.java
+++ b/src/test/java/bio/terra/integration/AzureIntegrationTest.java
@@ -123,7 +123,6 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.hamcrest.CoreMatchers;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -143,7 +142,7 @@ import org.springframework.util.ResourceUtils;
 @SpringBootTest(classes = IntegrationTestConfiguration.class)
 @ActiveProfiles({"google", "integrationtest"})
 @Tag(Integration.TAG)
-@Ignore("Disable Azure tests due to expired credentials")
+@Disabled("Disable Azure tests due to expired credentials")
 class AzureIntegrationTest {
   private static final Logger logger = LoggerFactory.getLogger(AzureIntegrationTest.class);
 

--- a/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureIngestFileConnectedTest.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -65,6 +66,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class AzureIngestFileConnectedTest {
   private static final Logger logger = LoggerFactory.getLogger(AzureIngestFileConnectedTest.class);
 

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoConnectedTest.java
@@ -46,6 +46,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -62,6 +63,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class AzureSynapsePdaoConnectedTest {
   private String randomFlightId;
   private BlobUrlParts snapshotSignUrlBlob;

--- a/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/AzureSynapsePdaoSnapshotConnectedTest.java
@@ -48,6 +48,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -66,6 +67,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class AzureSynapsePdaoSnapshotConnectedTest {
   private static Logger logger = LoggerFactory.getLogger(AzureSynapsePdaoConnectedTest.class);
 

--- a/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/LoadHistoryStorageTableConnectedTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -44,6 +45,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class LoadHistoryStorageTableConnectedTest {
   private UUID datasetId;
   private TableServiceClient serviceClient;

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDaoConnectedTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -49,6 +50,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class TableDaoConnectedTest {
   private final Logger logger = LoggerFactory.getLogger(TableDaoConnectedTest.class);
   @Autowired private ConnectedTestConfiguration connectedTestConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDependencyConnectedTest.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class TableDependencyConnectedTest {
 
   @Autowired private ConnectedTestConfiguration connectedTestConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableDirectoryDaoConnectedTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,6 +51,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class TableDirectoryDaoConnectedTest {
   private static final Logger logger =
       LoggerFactory.getLogger(TableDirectoryDaoConnectedTest.class);

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableFileConnectedTest.java
@@ -16,6 +16,7 @@ import com.azure.data.tables.TableServiceClientBuilder;
 import com.azure.data.tables.models.TableEntity;
 import java.util.UUID;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -31,6 +32,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class TableFileConnectedTest {
 
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsConnectedTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/tables/TableServiceClientUtilsConnectedTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -38,6 +39,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class TableServiceClientUtilsConnectedTest {
   private static final Logger logger =
       LoggerFactory.getLogger(TableServiceClientUtilsConnectedTest.class);

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerClientFactoryTest.java
@@ -17,6 +17,7 @@ import com.azure.storage.common.policy.RequestRetryOptions;
 import com.azure.storage.common.policy.RetryPolicyType;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,6 +41,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class BlobContainerClientFactoryTest {
 
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobContainerCopierTest.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -46,6 +47,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class BlobContainerCopierTest {
 
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/BlobCrlTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -43,6 +44,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class BlobCrlTest {
 
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;

--- a/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
+++ b/src/test/java/bio/terra/service/filedata/azure/util/SasUrlFactoriesTest.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,6 +41,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class SasUrlFactoriesTest {
   @Autowired private AzureResourceConfiguration azureResourceConfiguration;
 

--- a/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
+++ b/src/test/java/bio/terra/service/resourcemanagement/ProfileConnectedTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -44,6 +45,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles({"google", "connectedtest"})
 @Category(Connected.class)
 @EmbeddedDatabaseTest
+@Ignore("Disable Azure tests due to expired credentials")
 public class ProfileConnectedTest {
   private static final Logger logger = LoggerFactory.getLogger(ProfileConnectedTest.class);
 


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-2005

## Summary of changes

Disable Azure tests due to expired credentials

## Testing Strategy

Looked at the failing tests in Gradle and disabled them.
