### PR TITLE
[DT-400-gradle]: Revert Dependabot updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,10 +204,10 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.9.2'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.9.2'
 
-    implementation 'bio.terra:terra-common-lib:1.1.44-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.42-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.407-3bcdd55-SNAP'
-    implementation 'bio.terra:terra-policy-client:1.0.29-SNAPSHOT'
-    implementation 'bio.terra:terra-resource-buffer-client:0.198.151-SNAPSHOT'
+    implementation 'bio.terra:terra-policy-client:1.0.23-SNAPSHOT'
+    implementation 'bio.terra:terra-resource-buffer-client:0.198.150-SNAPSHOT'
     implementation 'bio.terra:externalcreds-client-resttemplate:1.114.0-SNAPSHOT'
 
     implementation 'org.glassfish.jersey.inject:jersey-hk2'
@@ -222,8 +222,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // Azure related dependencies
-    implementation 'com.azure:azure-identity:1.17.0'
-    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.53.1'
+    implementation 'com.azure:azure-identity:1.16.3'
+    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.53.0'
     implementation 'com.azure.resourcemanager:azure-resourcemanager-loganalytics:1.1.0'
     implementation 'com.azure.resourcemanager:azure-resourcemanager-securityinsights:1.0.0'
     implementation 'com.azure:azure-storage-common:12.30.1'

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     ext {
-        jersey = "3.1.11"
+        jersey = "3.1.10"
         jackson = "2.19.2"
         swaggerAnnotations = "2.2.35"
 


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-400

## Summary of changes

Revert "[DT-400-gradle]: Bump the minor-patch-dependencies group with 9 updates (#2003)"
    
This reverts commit 14502c19776d142e480da6708449ff63a7817ea1.

## Testing Strategy

Test failures due to previous updates