### PR TITLE
[DT-2114] Fix Failing Api Client and Dependency Upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ dependencies {
     implementation 'com.google.cloud:google-cloud-storage'
     implementation 'com.google.cloud:google-cloud-firestore'
     implementation 'com.google.cloud:google-cloud-pubsub'
-    implementation 'com.google.cloud:spring-cloud-gcp-starter-logging:7.1.0'
+    implementation 'com.google.cloud:spring-cloud-gcp-starter-logging:7.2.0'
     implementation 'com.google.http-client:google-http-client'
 
     implementation 'org.apache.commons:commons-compress:1.28.0' // For srcclr, jib plugin conflict
@@ -204,10 +204,10 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.9.2'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.9.2'
 
-    implementation 'bio.terra:terra-common-lib:1.1.42-SNAPSHOT'
-    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.407-3bcdd55-SNAP'
-    implementation 'bio.terra:terra-policy-client:1.0.23-SNAPSHOT'
-    implementation 'bio.terra:terra-resource-buffer-client:0.198.150-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.45-SNAPSHOT'
+    implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.415'
+    implementation 'bio.terra:terra-policy-client:1.0.36-SNAPSHOT'
+    implementation 'bio.terra:terra-resource-buffer-client:0.198.153-SNAPSHOT'
     implementation 'bio.terra:externalcreds-client-resttemplate:1.114.0-SNAPSHOT'
 
     implementation 'org.glassfish.jersey.inject:jersey-hk2'
@@ -222,8 +222,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // Azure related dependencies
-    implementation 'com.azure:azure-identity:1.16.3'
-    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.53.0'
+    implementation 'com.azure:azure-identity:1.17.0'
+    implementation 'com.azure.resourcemanager:azure-resourcemanager:2.53.1'
     implementation 'com.azure.resourcemanager:azure-resourcemanager-loganalytics:1.1.0'
     implementation 'com.azure.resourcemanager:azure-resourcemanager-securityinsights:1.0.0'
     implementation 'com.azure:azure-storage-common:12.30.1'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ plugins {
     id 'org.gradle.test-retry' version '1.6.2'
     id 'antlr'
     id 'org.hidetake.swagger.generator' version '2.19.2'
-    id 'org.springframework.boot' version '3.5.4'
+    id 'org.springframework.boot' version '3.5.5'
     id 'idea'
     id 'java'
     id 'io.spring.dependency-management' version '1.1.7'
@@ -63,7 +63,7 @@ allprojects {
             mavenBom SpringBootPlugin.BOM_COORDINATES
         }
         dependencies {
-            dependency 'io.swagger.core.v3:swagger-annotations:2.2.35'
+            dependency 'io.swagger.core.v3:swagger-annotations:2.2.36'
             dependency 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.71'
         }
     }
@@ -164,7 +164,7 @@ dependencies {
     implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-2.0.0'
     implementation 'com.google.apis:google-api-services-iam:v1-rev20230209-2.0.0'
 
-    implementation platform('com.google.cloud:libraries-bom:26.65.0')
+    implementation platform('com.google.cloud:libraries-bom:26.66.0')
     implementation 'com.google.cloud:google-cloud-billing'
     implementation 'com.google.cloud:google-cloud-resourcemanager'
     implementation 'com.google.cloud:google-cloud-bigquery'
@@ -201,7 +201,7 @@ dependencies {
     implementation 'com.microsoft.sqlserver:mssql-jdbc:12.3.0.jre17-preview'
 
     // For distributed locking of Spring @Scheduled tasks across multiple instances
-    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.9.2'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.10.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.9.2'
 
     implementation 'bio.terra:terra-common-lib:1.1.45-SNAPSHOT'
@@ -226,16 +226,16 @@ dependencies {
     implementation 'com.azure.resourcemanager:azure-resourcemanager:2.53.1'
     implementation 'com.azure.resourcemanager:azure-resourcemanager-loganalytics:1.1.0'
     implementation 'com.azure.resourcemanager:azure-resourcemanager-securityinsights:1.0.0'
-    implementation 'com.azure:azure-storage-common:12.30.1'
-    implementation 'com.azure:azure-storage-file-datalake:12.24.1'
-    implementation 'com.azure:azure-data-tables:12.5.5'
+    implementation 'com.azure:azure-storage-common:12.30.2'
+    implementation 'com.azure:azure-storage-file-datalake:12.24.2'
+    implementation 'com.azure:azure-data-tables:12.5.6'
 
-    implementation platform('io.sentry:sentry-bom:8.18.0') //import bom
+    implementation platform('io.sentry:sentry-bom:8.19.1') //import bom
     implementation('io.sentry:sentry-spring-boot-starter-jakarta')
     implementation('io.sentry:sentry-logback')
 
     // OpenTelemetry @WithSpan annotations:
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.18.1'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.19.0'
     implementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure'
 
     testImplementation 'org.apache.parquet:parquet-common:1.15.2'
@@ -267,8 +267,8 @@ dependencies {
     testImplementation 'org.junit.vintage:junit-vintage-engine'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.zonky.test:embedded-database-spring-test:2.6.0'
-    testImplementation 'io.zonky.test:embedded-postgres:2.1.0'
-    implementation enforcedPlatform('io.zonky.test.postgres:embedded-postgres-binaries-bom:16.9.0')
+    testImplementation 'io.zonky.test:embedded-postgres:2.1.1'
+    implementation enforcedPlatform('io.zonky.test.postgres:embedded-postgres-binaries-bom:16.10.0')
 
     generatedCompile 'org.springframework.boot:spring-boot-starter-web'
     // boot-starter-validation required for jakarta.validation.Valid references, @Valid tags

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -29,13 +29,14 @@ repositories {
 
 dependencies {
     ext {
-        jersey = "3.1.10"
+        jersey = "3.1.11"
         jackson = "2.19.2"
-        swaggerAnnotations = "2.2.35"
-
+        swaggerAnnotations = "2.2.36"
+        swaggerCli = "3.0.71"
     }
 
     implementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: "${jersey}"
+    implementation group: 'org.glassfish.jersey.core', name: 'jersey-common', version: "${jersey}"
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: "${jersey}"
     implementation group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: "${jersey}"
     implementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: "${jersey}"
@@ -43,7 +44,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: "${jackson}"
 
     implementation group: "io.swagger.core.v3", name: "swagger-annotations", version: "${swaggerAnnotations}"
-    swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"
+    swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli", version: "${swaggerCli}"
 }
 
 // OpenAPI/Swagger Client Generation


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2114

## Changes

| Package | From | To |
| --- | --- | --- |
| io.swagger.core.v3:swagger-annotations | `2.2.35` | `2.2.36` |
| [com.google.cloud:libraries-bom](https://github.com/googleapis/java-cloud-bom) | `26.65.0` | `26.66.0` |
| [com.google.cloud:spring-cloud-gcp-starter-logging](https://github.com/GoogleCloudPlatform/spring-cloud-gcp) | `7.1.0` | `7.2.0` |
| net.javacrumbs.shedlock:shedlock-provider-jdbc-template | `6.9.2` | `6.10.0` |
| org.broadinstitute.dsde.workbench:sam-client_2.13 | `v0.0.407-3bcdd55-SNAP` | `v0.0.415` |
| bio.terra:terra-common-lib | `1.1.42-SNAPSHOT` | `1.1.45-SNAPSHOT` |
| bio.terra:terra-policy-client | `1.0.23-SNAPSHOT` | `1.0.36-SNAPSHOT` |
| bio.terra:terra-resource-buffer-client | `0.198.150-SNAPSHOT` | `0.198.153-SNAPSHOT` |
| [com.azure:azure-identity](https://github.com/Azure/azure-sdk-for-java) | `1.16.3` | `1.17.0` |
| [com.azure.resourcemanager:azure-resourcemanager](https://github.com/Azure/azure-sdk-for-java) | `2.53.0` | `2.53.1` |
| [com.azure:azure-storage-common](https://github.com/Azure/azure-sdk-for-java) | `12.30.1` | `12.30.2` |
| [com.azure:azure-storage-file-datalake](https://github.com/Azure/azure-sdk-for-java) | `12.24.1` | `12.24.2` |
| [com.azure:azure-data-tables](https://github.com/Azure/azure-sdk-for-java) | `12.5.5` | `12.5.6` |
| [io.sentry:sentry-bom](https://github.com/getsentry/sentry-java) | `8.18.0` | `8.19.1` |
| [io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations](https://github.com/open-telemetry/opentelemetry-java-instrumentation) | `2.18.1` | `2.19.0` |
| [io.zonky.test:embedded-postgres](https://github.com/zonkyio/embedded-postgres) | `2.1.0` | `2.1.1` |
| [io.zonky.test.postgres:embedded-postgres-binaries-bom](https://github.com/zonkyio/embedded-postgres-binaries) | `16.9.0` | `16.10.0` |
| [org.springframework.boot](https://github.com/spring-projects/spring-boot) | `3.5.4` | `3.5.5` |
| org.glassfish.jersey.core:jersey-client | `3.1.10` | `3.1.11` |
| org.glassfish.jersey.media:jersey-media-json-jackson | `3.1.10` | `3.1.11` |
| org.glassfish.jersey.media:jersey-media-multipart | `3.1.10` | `3.1.11` |
| org.glassfish.jersey.inject:jersey-hk2 | `3.1.10` | `3.1.11` |
