### PR TITLE
[DT-2203] Update error message for failure when deleting a file

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileLookupStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/delete/DeleteFileLookupStep.java
@@ -12,6 +12,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
+import java.util.List;
 
 public class DeleteFileLookupStep extends DefaultUndoStep {
 
@@ -45,9 +46,12 @@ public class DeleteFileLookupStep extends DefaultUndoStep {
       // running the rest of the steps, so we use the null stored in the working map to let other
       // steps know there is no file. If there is a file, check dependencies here.
       if (fireStoreFile != null) {
-        if (dependencyDao.fileHasSnapshotReference(dataset, fireStoreFile.getFileId())) {
+        List<String> snapshotReferenceIds =
+            dependencyDao.getFileSnapshotReferences(dataset, fireStoreFile.getFileId());
+        if (!snapshotReferenceIds.isEmpty()) {
           throw new FileDependencyException(
-              "File is used by at least one snapshot and cannot be deleted");
+              "File is used by at least one snapshot and cannot be deleted. Snapshots referencing file: "
+                  + String.join(", ", snapshotReferenceIds));
         }
       }
     } catch (FileSystemAbortTransactionException rex) {

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
@@ -48,7 +48,7 @@ public class FireStoreDependencyDao {
     this.configurationService = configurationService;
   }
 
-  public boolean fileHasSnapshotReference(Dataset dataset, String fileId)
+  public List<String> getFileSnapshotReferences(Dataset dataset, String fileId)
       throws InterruptedException {
     Firestore firestore =
         FireStoreProject.get(dataset.getProjectResource().getGoogleProjectId()).getFirestore();
@@ -57,7 +57,10 @@ public class FireStoreDependencyDao {
     // check if firestore collection with file id has any documents
     CollectionReference depColl = firestore.collection(dependencyCollectionName);
     Query query = depColl.whereEqualTo("fileId", fileId).limit(1);
-    return fireStoreUtils.collectionHasDocuments(firestore, query);
+    List<QueryDocumentSnapshot> docs = fireStoreUtils.getCollectionDocuments(firestore, query);
+    List<String> snapshotReferenceIds =
+        docs.stream().map(doc -> (String) doc.get("referenceId")).toList();
+    return snapshotReferenceIds;
   }
 
   public boolean datasetHasSnapshotReference(Dataset dataset) throws InterruptedException {

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDependencyDao.java
@@ -58,9 +58,7 @@ public class FireStoreDependencyDao {
     CollectionReference depColl = firestore.collection(dependencyCollectionName);
     Query query = depColl.whereEqualTo("fileId", fileId).limit(1);
     List<QueryDocumentSnapshot> docs = fireStoreUtils.getCollectionDocuments(firestore, query);
-    List<String> snapshotReferenceIds =
-        docs.stream().map(doc -> (String) doc.get("referenceId")).toList();
-    return snapshotReferenceIds;
+    return docs.stream().map(doc -> (String) doc.get("snapshotId")).toList();
   }
 
   public boolean datasetHasSnapshotReference(Dataset dataset) throws InterruptedException {

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -378,6 +378,21 @@ public class FireStoreUtils {
     }
   }
 
+  public List<QueryDocumentSnapshot> getCollectionDocuments(
+      Firestore firestore, Query collectionQuery) throws InterruptedException {
+    List<QueryDocumentSnapshot> docs =
+        runTransactionWithRetry(
+            firestore,
+            (xn -> {
+              Query limitedQuery = collectionQuery.limit(1);
+              ApiFuture<QuerySnapshot> querySnapshot = xn.get(limitedQuery);
+              return querySnapshot.get().getDocuments();
+            }),
+            "getCollectionDocuments",
+            "Querying firestore and retrieving documents from collection");
+    return docs;
+  }
+
   public boolean collectionHasDocuments(Firestore firestore, Query collectionQuery)
       throws InterruptedException {
     int docCount =

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreUtils.java
@@ -380,17 +380,15 @@ public class FireStoreUtils {
 
   public List<QueryDocumentSnapshot> getCollectionDocuments(
       Firestore firestore, Query collectionQuery) throws InterruptedException {
-    List<QueryDocumentSnapshot> docs =
-        runTransactionWithRetry(
-            firestore,
-            (xn -> {
-              Query limitedQuery = collectionQuery.limit(1);
-              ApiFuture<QuerySnapshot> querySnapshot = xn.get(limitedQuery);
-              return querySnapshot.get().getDocuments();
-            }),
-            "getCollectionDocuments",
-            "Querying firestore and retrieving documents from collection");
-    return docs;
+    return runTransactionWithRetry(
+        firestore,
+        (xn -> {
+          Query limitedQuery = collectionQuery.limit(1);
+          ApiFuture<QuerySnapshot> querySnapshot = xn.get(limitedQuery);
+          return querySnapshot.get().getDocuments();
+        }),
+        "getCollectionDocuments",
+        "Querying firestore and retrieving documents from collection");
   }
 
   public boolean collectionHasDocuments(Firestore firestore, Query collectionQuery)

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -187,6 +187,8 @@ paths:
       description: >
         Creates a new profile associated with a billing account. This is asynchronous.
         The final return is of type definitions/BillingProfileModel.
+        Use the returned job id to check the retrieveJob endpoint for the job status 
+        or retrieveJobResult endpoint to get the final result.
       operationId: createProfile
       requestBody:
         content:
@@ -238,6 +240,8 @@ paths:
       description: >
         Update a billing profile by id. This is asynchronous.
         The final return is of type definitions/BillingProfileModel.
+        Use the returned job id to check the retrieveJob endpoint for the job status 
+        or retrieveJobResult endpoint to get the final result.
       operationId: updateProfile
       requestBody:
         content:
@@ -328,6 +332,8 @@ paths:
       description: >
         Delete a billing profile by id. This is asynchronous.
         The final return is of type definitions/DeleteResponseModel.
+        Use the returned job id to check the retrieveJob endpoint for the job status
+        or retrieveJobResult endpoint to get the final result.
       operationId: deleteProfile
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -646,7 +652,9 @@ paths:
       tags:
         - snapshots
         - repository
-      description: Create a new snapshot
+      description: Create a new snapshot. This is asynchronous. 
+        Use the returned job id to check the retrieveJob endpoint for the job status 
+        or retrieveJobResult endpoint to get the final result.
       operationId: createSnapshot
       requestBody:
         description: Snapshot to create
@@ -911,7 +919,9 @@ paths:
       description: >
         Delete a snapshot by id.
         If this operation fails, we do not attempt to undo any failed steps. Therefore, a
-        failed snapshot delete call leaves the snapshot in a partially deleted state.
+        failed snapshot delete call leaves the snapshot in a partially deleted state. This is asynchronous.
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult 
+        endpoint to get the final result.
       operationId: deleteSnapshot
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -1135,7 +1145,8 @@ paths:
       tags:
         - snapshots
         - repository
-      description: Export a snapshot by id
+      description: Export a snapshot by id.  This is asynchronous. Use the returned job id to check 
+        the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: exportSnapshot
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -1552,6 +1563,7 @@ paths:
       description: >
         Sets the reader policy on the snapshot public for the specified snapshot if request body
         is true. Makes the reader policy on the snapshot private if the request body is false.
+        This is asynchronous. Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: setSnapshotPublic
       requestBody:
         description: A boolean value indicating whether the reader policy on the snapshot is
@@ -1958,6 +1970,7 @@ paths:
         - datasets
         - repository
       description: Create a new dataset asynchronously. The async result is DatasetSummaryModel.
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: createDataset
       requestBody:
         description: Dataset to create
@@ -2077,7 +2090,8 @@ paths:
       tags:
         - datasets
         - repository
-      description: Delete a dataset by id
+      description: Delete a dataset by id.  This is asynchronous. 
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: deleteDataset
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -2631,7 +2645,8 @@ paths:
       tags:
         - datasets
         - repository
-      description: Ingest data into a dataset table
+      description: Ingest data into a dataset table. This is asynchronous. 
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: ingestDataset
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -2691,7 +2706,8 @@ paths:
         - datasets
         - repository
       description:
-        Modify a dataset's schema with additive changes
+        Modify a dataset's schema with additive changes. This is asynchronous.
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: updateSchema
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -2749,7 +2765,8 @@ paths:
       tags:
         - datasets
         - repository
-      description: Create a transaction to be used for ingesting if you are chaining ingests together
+      description: Create a transaction to be used for ingesting if you are chaining ingests together.
+        This is asynchronous. Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: openTransaction
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -2891,7 +2908,8 @@ paths:
       tags:
         - datasets
         - repository
-      description: Close a given transaction
+      description: Close a given transaction. This is asynchronous.
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: closeTransaction
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -2949,7 +2967,8 @@ paths:
       tags:
         - datasets
         - repository
-      description: Add an asset definition to a dataset
+      description: Add an asset definition to a dataset. This is asynchronous.
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: addDatasetAssetSpecifications
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -3002,7 +3021,8 @@ paths:
       tags:
         - datasets
         - repository
-      description: Remove an asset definition from a dataset
+      description: Remove an asset definition from a dataset. This is asynchronous.
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: removeDatasetAssetSpecifications
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -3047,7 +3067,8 @@ paths:
       tags:
         - datasets
         - repository
-      description: Applies deletes to primary tabular data in a dataset
+      description: Applies deletes to primary tabular data in a dataset. This is asynchronous.
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: applyDatasetDataDeletion
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -3133,7 +3154,8 @@ paths:
         - repository
       description: >
         ADMIN ONLY - Set flag that allows the dataset custodians to inherit the steward role on all
-        snapshots made from this dataset
+        snapshots made from this dataset. This is asynchronous. Use the returned job id to check the
+        retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: setInheritSteward
       requestBody:
         description: >
@@ -3204,7 +3226,8 @@ paths:
         - datasets
         - repository
       description: >
-        ADMIN ONLY - Adjust members on datasets based on inherit steward flag
+        ADMIN ONLY - Adjust members on datasets based on inherit steward flag. This is asynchronous.
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: adjustMembersInheritSteward
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -3728,7 +3751,9 @@ paths:
       tags:
         - datasets
         - repository
-      description: Ingest one file into the dataset file system; async returns a FileModel
+      description: Ingest one file into the dataset file system; async returns a FileModel.
+        This is asynchronous.
+        Use the returned job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: ingestFile
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -3791,7 +3816,8 @@ paths:
         Load many files into the dataset file system; async returns a BulkLoadResultModel
         Note that this endpoint is not a single transaction. Some files may be loaded and
         others may fail. Each file load is atomic; the file will either be loaded into the
-        dataset file system or it will not exist.
+        dataset file system or it will not exist. This is asynchronous. Use the returned 
+        job id to check the retrieveJob endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: bulkFileLoad
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -3855,7 +3881,8 @@ paths:
       description: >-
         Retrieve the results of a bulk file load. The results of each bulk load are stored
         in the dataset. They can be queried directly or retrieved with this paginated
-        interface.
+        interface. This is asynchronous. Use the returned job id to check the retrieveJob 
+        endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: getLoadHistoryForLoadTag
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -3916,6 +3943,8 @@ paths:
         Delete results from the bulk file load table of the dataset.
         If jobId is specified, then only the results for the loadTag plus that jobId are
         deleted. Otherwise, all results associated with the loadTag are deleted.
+        This is asynchronous. Use the returned job id to check the retrieveJob 
+        endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: bulkFileResultsDelete
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -3969,7 +3998,9 @@ paths:
         Load many files into the dataset file system; async returns a BulkLoadArrayResultModel
         Note that this endpoint is not a single transaction. Some files may be loaded and
         others may fail. Each file load is atomic; the file will either be loaded into the
-        dataset file system or it will not exist.
+        dataset file system or it will not exist. This is asynchronous. Use the returned 
+        job id to check the retrieveJob endpoint for the job status or retrieveJobResult 
+        endpoint to get the final result.
       operationId: bulkFileLoadArray
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -4078,7 +4109,9 @@ paths:
         - repository
       description: >
         Hard delete of a file by id. The file is deleted even if it is in use by
-        a dataset. Subsequent lookups will give not found errors.
+        a dataset. Subsequent lookups will give not found errors. This is asynchronous. 
+        Use the returned job id to check the retrieveJob endpoint for the job status 
+        or retrieveJobResult endpoint to get the final result.
       operationId: deleteFile
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -4308,7 +4341,8 @@ paths:
         - repository
       description: >
         Load Drs Aliases into TDR.  It is possible to have an alias to a DRS ID that does not exist
-        in TDR.
+        in TDR. This is asynchronous. Use the returned job id to check the retrieveJob 
+        endpoint for the job status or retrieveJobResult endpoint to get the final result.
       operationId: registerDrsAliases
       requestBody:
         content:
@@ -4460,7 +4494,9 @@ paths:
         - repository
       description: >-
         Extensible endpoint for triggering upgrade tasks in the data repository.
-        The asynchronous result is UpgradeResponseModel
+        The asynchronous result is UpgradeResponseModel. Use the returned job id 
+        to check the retrieveJob endpoint for the job status or retrieveJobResult 
+        endpoint to get the final result.
       operationId: upgrade
       requestBody:
         content:

--- a/src/test/java/bio/terra/service/filedata/flight/delete/DeleteFileLookupStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/delete/DeleteFileLookupStepTest.java
@@ -24,7 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class DeleteFileLookupStepTest {
+class DeleteFileLookupStepTest {
 
   @Mock private FireStoreDao fileDao;
   @Mock private FireStoreDependencyDao dependencyDao;

--- a/src/test/java/bio/terra/service/filedata/flight/delete/DeleteFileLookupStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/delete/DeleteFileLookupStepTest.java
@@ -1,0 +1,112 @@
+package bio.terra.service.filedata.flight.delete;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.exception.FileDependencyException;
+import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
+import bio.terra.service.filedata.flight.FileMapKeys;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.firestore.FireStoreDependencyDao;
+import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteFileLookupStepTest {
+
+    @Mock private FireStoreDao fileDao;
+    @Mock private FireStoreDependencyDao dependencyDao;
+    @Mock private Dataset dataset;
+    @Mock private FlightContext context;
+    @Mock private FlightMap workingMap;
+    @Mock private FireStoreFile fireStoreFile;
+
+    private static final String FILE_ID = "test-file-id";
+    private DeleteFileLookupStep step;
+
+    @BeforeEach
+    void setUp() {
+        step = new DeleteFileLookupStep(fileDao, FILE_ID, dataset, dependencyDao);
+        when(context.getWorkingMap()).thenReturn(workingMap);
+    }
+
+    @Test
+    void testDoStep_FileAlreadyInWorkingMap_NoDependencies_Success() throws InterruptedException {
+        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(fireStoreFile);
+        when(fireStoreFile.getFileId()).thenReturn(FILE_ID);
+        when(dependencyDao.getFileSnapshotReferences(dataset, FILE_ID)).thenReturn(Collections.emptyList());
+
+        StepResult result = step.doStep(context);
+
+        assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+        verify(fileDao, never()).lookupFile(dataset, FILE_ID);
+        verify(workingMap, never()).put(eq(FileMapKeys.FIRESTORE_FILE), any());
+    }
+
+    @Test
+    void testDoStep_FileNotInWorkingMap_LookupSuccessful_NoDependencies_Success() throws InterruptedException {
+        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(null);
+        when(fileDao.lookupFile(dataset, FILE_ID)).thenReturn(fireStoreFile);
+        when(fireStoreFile.getFileId()).thenReturn(FILE_ID);
+        when(dependencyDao.getFileSnapshotReferences(dataset, FILE_ID)).thenReturn(Collections.emptyList());
+
+        StepResult result = step.doStep(context);
+
+        assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+        verify(fileDao).lookupFile(dataset, FILE_ID);
+        verify(workingMap).put(FileMapKeys.FIRESTORE_FILE, fireStoreFile);
+    }
+
+    @Test
+    void testDoStep_FileNotFound_Success() throws InterruptedException {
+        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(null);
+        when(fileDao.lookupFile(dataset, FILE_ID)).thenReturn(null);
+
+        StepResult result = step.doStep(context);
+
+        assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+        verify(fileDao).lookupFile(dataset, FILE_ID);
+        verify(workingMap, never()).put(eq(FileMapKeys.FIRESTORE_FILE), any());
+        verify(dependencyDao, never()).getFileSnapshotReferences(any(), any());
+    }
+
+    @Test
+    void testDoStep_FileHasDependencies_ThrowsException() throws InterruptedException {
+        List<String> snapshotIds = Arrays.asList("snapshot1", "snapshot2");
+        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(fireStoreFile);
+        when(fireStoreFile.getFileId()).thenReturn(FILE_ID);
+        when(dependencyDao.getFileSnapshotReferences(dataset, FILE_ID)).thenReturn(snapshotIds);
+
+        FileDependencyException exception = assertThrows(FileDependencyException.class, 
+            () -> step.doStep(context));
+
+        assertTrue(exception.getMessage().contains("snapshot1, snapshot2"));
+        assertTrue(exception.getMessage().contains("File is used by at least one snapshot"));
+    }
+
+    @Test
+    void testDoStep_FileSystemAbortTransactionException_ReturnsRetry() throws InterruptedException {
+        FileSystemAbortTransactionException abortException = new FileSystemAbortTransactionException("Abort");
+        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(null);
+        when(fileDao.lookupFile(dataset, FILE_ID)).thenThrow(abortException);
+
+        StepResult result = step.doStep(context);
+
+        assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, result.getStepStatus());
+        assertEquals(abortException, result.getException().orElse(null));
+    }
+}
+

--- a/src/test/java/bio/terra/service/filedata/flight/delete/DeleteFileLookupStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/delete/DeleteFileLookupStepTest.java
@@ -1,8 +1,8 @@
 package bio.terra.service.filedata.flight.delete;
 
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.filedata.exception.FileDependencyException;
 import bio.terra.service.filedata.exception.FileSystemAbortTransactionException;
@@ -18,95 +18,97 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-
-
 @ExtendWith(MockitoExtension.class)
 public class DeleteFileLookupStepTest {
 
-    @Mock private FireStoreDao fileDao;
-    @Mock private FireStoreDependencyDao dependencyDao;
-    @Mock private Dataset dataset;
-    @Mock private FlightContext context;
-    @Mock private FlightMap workingMap;
-    @Mock private FireStoreFile fireStoreFile;
+  @Mock private FireStoreDao fileDao;
+  @Mock private FireStoreDependencyDao dependencyDao;
+  @Mock private Dataset dataset;
+  @Mock private FlightContext context;
+  @Mock private FlightMap workingMap;
+  @Mock private FireStoreFile fireStoreFile;
 
-    private static final String FILE_ID = "test-file-id";
-    private DeleteFileLookupStep step;
+  private static final String FILE_ID = "test-file-id";
+  private DeleteFileLookupStep step;
 
-    @BeforeEach
-    void setUp() {
-        step = new DeleteFileLookupStep(fileDao, FILE_ID, dataset, dependencyDao);
-        when(context.getWorkingMap()).thenReturn(workingMap);
-    }
+  @BeforeEach
+  void setUp() {
+    step = new DeleteFileLookupStep(fileDao, FILE_ID, dataset, dependencyDao);
+    when(context.getWorkingMap()).thenReturn(workingMap);
+  }
 
-    @Test
-    void testDoStep_FileAlreadyInWorkingMap_NoDependencies_Success() throws InterruptedException {
-        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(fireStoreFile);
-        when(fireStoreFile.getFileId()).thenReturn(FILE_ID);
-        when(dependencyDao.getFileSnapshotReferences(dataset, FILE_ID)).thenReturn(Collections.emptyList());
+  @Test
+  void testDoStep_FileAlreadyInWorkingMap_NoDependencies_Success() throws InterruptedException {
+    when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(fireStoreFile);
+    when(fireStoreFile.getFileId()).thenReturn(FILE_ID);
+    when(dependencyDao.getFileSnapshotReferences(dataset, FILE_ID))
+        .thenReturn(Collections.emptyList());
 
-        StepResult result = step.doStep(context);
+    StepResult result = step.doStep(context);
 
-        assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
-        verify(fileDao, never()).lookupFile(dataset, FILE_ID);
-        verify(workingMap, never()).put(eq(FileMapKeys.FIRESTORE_FILE), any());
-    }
+    assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+    verify(fileDao, never()).lookupFile(dataset, FILE_ID);
+    verify(workingMap, never()).put(eq(FileMapKeys.FIRESTORE_FILE), any());
+  }
 
-    @Test
-    void testDoStep_FileNotInWorkingMap_LookupSuccessful_NoDependencies_Success() throws InterruptedException {
-        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(null);
-        when(fileDao.lookupFile(dataset, FILE_ID)).thenReturn(fireStoreFile);
-        when(fireStoreFile.getFileId()).thenReturn(FILE_ID);
-        when(dependencyDao.getFileSnapshotReferences(dataset, FILE_ID)).thenReturn(Collections.emptyList());
+  @Test
+  void testDoStep_FileNotInWorkingMap_LookupSuccessful_NoDependencies_Success()
+      throws InterruptedException {
+    when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(null);
+    when(fileDao.lookupFile(dataset, FILE_ID)).thenReturn(fireStoreFile);
+    when(fireStoreFile.getFileId()).thenReturn(FILE_ID);
+    when(dependencyDao.getFileSnapshotReferences(dataset, FILE_ID))
+        .thenReturn(Collections.emptyList());
 
-        StepResult result = step.doStep(context);
+    StepResult result = step.doStep(context);
 
-        assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
-        verify(fileDao).lookupFile(dataset, FILE_ID);
-        verify(workingMap).put(FileMapKeys.FIRESTORE_FILE, fireStoreFile);
-    }
+    assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+    verify(fileDao).lookupFile(dataset, FILE_ID);
+    verify(workingMap).put(FileMapKeys.FIRESTORE_FILE, fireStoreFile);
+  }
 
-    @Test
-    void testDoStep_FileNotFound_Success() throws InterruptedException {
-        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(null);
-        when(fileDao.lookupFile(dataset, FILE_ID)).thenReturn(null);
+  @Test
+  void testDoStep_FileNotFound_Success() throws InterruptedException {
+    when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(null);
+    when(fileDao.lookupFile(dataset, FILE_ID)).thenReturn(null);
 
-        StepResult result = step.doStep(context);
+    StepResult result = step.doStep(context);
 
-        assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
-        verify(fileDao).lookupFile(dataset, FILE_ID);
-        verify(workingMap, never()).put(eq(FileMapKeys.FIRESTORE_FILE), any());
-        verify(dependencyDao, never()).getFileSnapshotReferences(any(), any());
-    }
+    assertEquals(StepStatus.STEP_RESULT_SUCCESS, result.getStepStatus());
+    verify(fileDao).lookupFile(dataset, FILE_ID);
+    verify(workingMap, never()).put(eq(FileMapKeys.FIRESTORE_FILE), any());
+    verify(dependencyDao, never()).getFileSnapshotReferences(any(), any());
+  }
 
-    @Test
-    void testDoStep_FileHasDependencies_ThrowsException() throws InterruptedException {
-        List<String> snapshotIds = Arrays.asList("snapshot1", "snapshot2");
-        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(fireStoreFile);
-        when(fireStoreFile.getFileId()).thenReturn(FILE_ID);
-        when(dependencyDao.getFileSnapshotReferences(dataset, FILE_ID)).thenReturn(snapshotIds);
+  @Test
+  void testDoStep_FileHasDependencies_ThrowsException() throws InterruptedException {
+    List<String> snapshotIds = Arrays.asList("snapshot1", "snapshot2");
+    when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(fireStoreFile);
+    when(fireStoreFile.getFileId()).thenReturn(FILE_ID);
+    when(dependencyDao.getFileSnapshotReferences(dataset, FILE_ID)).thenReturn(snapshotIds);
 
-        FileDependencyException exception = assertThrows(FileDependencyException.class, 
-            () -> step.doStep(context));
+    FileDependencyException exception =
+        assertThrows(FileDependencyException.class, () -> step.doStep(context));
 
-        assertTrue(exception.getMessage().contains("snapshot1, snapshot2"));
-        assertTrue(exception.getMessage().contains("File is used by at least one snapshot"));
-    }
+    assertTrue(exception.getMessage().contains("snapshot1, snapshot2"));
+    assertTrue(exception.getMessage().contains("File is used by at least one snapshot"));
+  }
 
-    @Test
-    void testDoStep_FileSystemAbortTransactionException_ReturnsRetry() throws InterruptedException {
-        FileSystemAbortTransactionException abortException = new FileSystemAbortTransactionException("Abort");
-        when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(null);
-        when(fileDao.lookupFile(dataset, FILE_ID)).thenThrow(abortException);
+  @Test
+  void testDoStep_FileSystemAbortTransactionException_ReturnsRetry() throws InterruptedException {
+    FileSystemAbortTransactionException abortException =
+        new FileSystemAbortTransactionException("Abort");
+    when(workingMap.get(FileMapKeys.FIRESTORE_FILE, FireStoreFile.class)).thenReturn(null);
+    when(fileDao.lookupFile(dataset, FILE_ID)).thenThrow(abortException);
 
-        StepResult result = step.doStep(context);
+    StepResult result = step.doStep(context);
 
-        assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, result.getStepStatus());
-        assertEquals(abortException, result.getException().orElse(null));
-    }
+    assertEquals(StepStatus.STEP_RESULT_FAILURE_RETRY, result.getStepStatus());
+    assertEquals(abortException, result.getException().orElse(null));
+  }
 }
-

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.app.configuration.ConnectedTestConfiguration;
 import bio.terra.common.EmbeddedDatabaseTest;
@@ -157,14 +158,15 @@ class FireStoreDaoTest {
     boolean hasReference = fireStoreDependencyDao.datasetHasSnapshotReference(dataset);
     assertThat("Dataset should have dependencies", hasReference);
 
-    boolean hasFileReference =
-        fireStoreDependencyDao.fileHasSnapshotReference(dataset, snapObjects.get(0).getFileId());
-    assertThat("File should be referenced in snapshot", hasFileReference);
+    List<String> snapshotReferenceIds =
+        fireStoreDependencyDao.getFileSnapshotReferences(dataset, snapObjects.get(0).getFileId());
+    assertEquals(List.of(snapshotId), snapshotReferenceIds);
 
     // Validate dataset files do not have references
-    boolean noFileReference =
-        fireStoreDependencyDao.fileHasSnapshotReference(dataset, dsetObjects.get(0).getFileId());
-    assertThat("No dependency on files not referenced in snapshot", noFileReference, is(false));
+    List<String> noSnapshotReferenceIds =
+        fireStoreDependencyDao.getFileSnapshotReferences(dataset, dsetObjects.get(0).getFileId());
+    assertThat(
+        "No dependency on files not referenced in snapshot", noSnapshotReferenceIds.size(), is(0));
 
     // Validate we cannot lookup dataset files in the snapshot
     for (FireStoreDirectoryEntry dsetObject : dsetObjects) {

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreUtilsTest.java
@@ -12,7 +12,7 @@ import com.google.cloud.firestore.QueryDocumentSnapshot;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class FireStoreUtilsTest {
+class FireStoreUtilsTest {
 
   @Test
   void testCollectionHasDocuments_returnsTrueWhenDocumentsExist() throws Exception {

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreUtilsTest.java
@@ -1,0 +1,81 @@
+package bio.terra.service.filedata.google.firestore;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+public class FireStoreUtilsTest {
+
+    @Test
+    void testCollectionHasDocuments_returnsTrueWhenDocumentsExist() throws Exception {
+        Firestore firestore = mock(Firestore.class);
+        Query query = mock(Query.class);
+        FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
+
+        // Mock FireStoreUtils to call real method
+        doCallRealMethod().when(fireStoreUtils).collectionHasDocuments(any(), any());
+
+        // Mock runTransactionWithRetry to return 1 (documents exist)
+        when(fireStoreUtils.runTransactionWithRetry(any(), any(), anyString(), anyString()))
+            .thenReturn(1);
+
+        boolean result = fireStoreUtils.collectionHasDocuments(firestore, query);
+        assertTrue(result);
+    }
+
+    @Test
+    void testCollectionHasDocuments_returnsFalseWhenNoDocumentsExist() throws Exception {
+        Firestore firestore = mock(Firestore.class);
+        Query query = mock(Query.class);
+        FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
+
+        doCallRealMethod().when(fireStoreUtils).collectionHasDocuments(any(), any());
+        when(fireStoreUtils.runTransactionWithRetry(any(), any(), anyString(), anyString()))
+            .thenReturn(0);
+
+        boolean result = fireStoreUtils.collectionHasDocuments(firestore, query);
+        assertFalse(result);
+    }
+
+
+    @Test
+    void testGetCollectionDocuments_DocumentsExist() throws Exception {
+        Firestore firestore = mock(Firestore.class);
+        Query query = mock(Query.class);
+        QueryDocumentSnapshot doc1 = mock(QueryDocumentSnapshot.class);
+        FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
+
+        // Mock FireStoreUtils to call real method
+        doCallRealMethod().when(fireStoreUtils).getCollectionDocuments(firestore, query);
+
+        // Mock runTransactionWithRetry to return documents
+        when(fireStoreUtils.runTransactionWithRetry(eq(firestore), any(), eq("getCollectionDocuments"),
+         eq("Querying firestore and retrieving documents from collection")))
+            .thenReturn(List.of(doc1));
+
+        List<QueryDocumentSnapshot> result = fireStoreUtils.getCollectionDocuments(firestore, query);
+        assertEquals(List.of(doc1), result);
+    }
+
+    @Test
+    void testGetCollectionDocuments_NoDocumentsExist() throws Exception {
+        Firestore firestore = mock(Firestore.class);
+        Query query = mock(Query.class);
+        FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
+
+        doCallRealMethod().when(fireStoreUtils).collectionHasDocuments(firestore, query);
+        when(fireStoreUtils.runTransactionWithRetry(eq(firestore), any(), eq("collectionHasDocuments"),
+        eq("Querying firestore and checking if collection is empty")))
+            .thenReturn(0);
+
+        boolean result = fireStoreUtils.collectionHasDocuments(firestore, query);
+        assertFalse(result);
+    }
+}

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreUtilsTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreUtilsTest.java
@@ -5,77 +5,83 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
-import org.junit.jupiter.api.Test;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 
 public class FireStoreUtilsTest {
 
-    @Test
-    void testCollectionHasDocuments_returnsTrueWhenDocumentsExist() throws Exception {
-        Firestore firestore = mock(Firestore.class);
-        Query query = mock(Query.class);
-        FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
+  @Test
+  void testCollectionHasDocuments_returnsTrueWhenDocumentsExist() throws Exception {
+    Firestore firestore = mock(Firestore.class);
+    Query query = mock(Query.class);
+    FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
 
-        // Mock FireStoreUtils to call real method
-        doCallRealMethod().when(fireStoreUtils).collectionHasDocuments(any(), any());
+    // Mock FireStoreUtils to call real method
+    doCallRealMethod().when(fireStoreUtils).collectionHasDocuments(any(), any());
 
-        // Mock runTransactionWithRetry to return 1 (documents exist)
-        when(fireStoreUtils.runTransactionWithRetry(any(), any(), anyString(), anyString()))
-            .thenReturn(1);
+    // Mock runTransactionWithRetry to return 1 (documents exist)
+    when(fireStoreUtils.runTransactionWithRetry(any(), any(), anyString(), anyString()))
+        .thenReturn(1);
 
-        boolean result = fireStoreUtils.collectionHasDocuments(firestore, query);
-        assertTrue(result);
-    }
+    boolean result = fireStoreUtils.collectionHasDocuments(firestore, query);
+    assertTrue(result);
+  }
 
-    @Test
-    void testCollectionHasDocuments_returnsFalseWhenNoDocumentsExist() throws Exception {
-        Firestore firestore = mock(Firestore.class);
-        Query query = mock(Query.class);
-        FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
+  @Test
+  void testCollectionHasDocuments_returnsFalseWhenNoDocumentsExist() throws Exception {
+    Firestore firestore = mock(Firestore.class);
+    Query query = mock(Query.class);
+    FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
 
-        doCallRealMethod().when(fireStoreUtils).collectionHasDocuments(any(), any());
-        when(fireStoreUtils.runTransactionWithRetry(any(), any(), anyString(), anyString()))
-            .thenReturn(0);
+    doCallRealMethod().when(fireStoreUtils).collectionHasDocuments(any(), any());
+    when(fireStoreUtils.runTransactionWithRetry(any(), any(), anyString(), anyString()))
+        .thenReturn(0);
 
-        boolean result = fireStoreUtils.collectionHasDocuments(firestore, query);
-        assertFalse(result);
-    }
+    boolean result = fireStoreUtils.collectionHasDocuments(firestore, query);
+    assertFalse(result);
+  }
 
+  @Test
+  void testGetCollectionDocuments_DocumentsExist() throws Exception {
+    Firestore firestore = mock(Firestore.class);
+    Query query = mock(Query.class);
+    QueryDocumentSnapshot doc1 = mock(QueryDocumentSnapshot.class);
+    FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
 
-    @Test
-    void testGetCollectionDocuments_DocumentsExist() throws Exception {
-        Firestore firestore = mock(Firestore.class);
-        Query query = mock(Query.class);
-        QueryDocumentSnapshot doc1 = mock(QueryDocumentSnapshot.class);
-        FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
+    // Mock FireStoreUtils to call real method
+    doCallRealMethod().when(fireStoreUtils).getCollectionDocuments(firestore, query);
 
-        // Mock FireStoreUtils to call real method
-        doCallRealMethod().when(fireStoreUtils).getCollectionDocuments(firestore, query);
+    // Mock runTransactionWithRetry to return documents
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore),
+            any(),
+            eq("getCollectionDocuments"),
+            eq("Querying firestore and retrieving documents from collection")))
+        .thenReturn(List.of(doc1));
 
-        // Mock runTransactionWithRetry to return documents
-        when(fireStoreUtils.runTransactionWithRetry(eq(firestore), any(), eq("getCollectionDocuments"),
-         eq("Querying firestore and retrieving documents from collection")))
-            .thenReturn(List.of(doc1));
+    List<QueryDocumentSnapshot> result = fireStoreUtils.getCollectionDocuments(firestore, query);
+    assertEquals(List.of(doc1), result);
+  }
 
-        List<QueryDocumentSnapshot> result = fireStoreUtils.getCollectionDocuments(firestore, query);
-        assertEquals(List.of(doc1), result);
-    }
+  @Test
+  void testGetCollectionDocuments_NoDocumentsExist() throws Exception {
+    Firestore firestore = mock(Firestore.class);
+    Query query = mock(Query.class);
+    FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
 
-    @Test
-    void testGetCollectionDocuments_NoDocumentsExist() throws Exception {
-        Firestore firestore = mock(Firestore.class);
-        Query query = mock(Query.class);
-        FireStoreUtils fireStoreUtils = mock(FireStoreUtils.class);
+    doCallRealMethod().when(fireStoreUtils).collectionHasDocuments(firestore, query);
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore),
+            any(),
+            eq("collectionHasDocuments"),
+            eq("Querying firestore and checking if collection is empty")))
+        .thenReturn(0);
 
-        doCallRealMethod().when(fireStoreUtils).collectionHasDocuments(firestore, query);
-        when(fireStoreUtils.runTransactionWithRetry(eq(firestore), any(), eq("collectionHasDocuments"),
-        eq("Querying firestore and checking if collection is empty")))
-            .thenReturn(0);
-
-        boolean result = fireStoreUtils.collectionHasDocuments(firestore, query);
-        assertFalse(result);
-    }
+    boolean result = fireStoreUtils.collectionHasDocuments(firestore, query);
+    assertFalse(result);
+  }
 }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-2203

## Addresses
User had an issue where they were trying to delete a file from a dataset. They thought the file was not referenced in any snapshots and that the error message they were receiving ("File is used by at least one snapshot and cannot be deleted") was a mistake. However, the file was referenced by snapshots, but they were snapshots the user did not have access to so they didn't return in the enumerate endpoint. So, it would have helped this user debug their issue if the message specified which snapshots referenced the file. After talking to product, we decided it was okay to expose the IDs of snapshots that the user does not have access to. 

Additionally, users were not understanding the return value of asynchronous endpoints. This PR also adds more documentation to those endpoints to advise users on how to view the final result of the call.

## Summary of changes
When a delete file from dataset flight fails because the file is still referenced by a snapshot, this adds specificity to the error message by enumerating the snapshot IDs that reference this file.

Adds documentation to swagger page to clarify how to view the results of an asynchronous endpoint

## Testing Strategy
Unit tests
Full functional test (trying to delete a file from a dataset that is referenced by a snapshot and ensuring I see the updated error message) - Error message returned: `{
  "message": "File is used by at least one snapshot and cannot be deleted. Snapshots referencing file: 29b453b9-7847-4a11-83c0-5e3fbe1bfb38",
  "errorDetail": []
}`

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
