### PR TITLE
[DT-2065] Data Repo: Migrate to GAR from Artifactory

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout tagged branch of jade-data-repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.bump_version.outputs.tag }}
+          ref: ${{ github.head_ref || '' }}
           persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,11 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - bump_version
+    if: github.ref_name == github.event.repository.default_branch
     steps:
       - name: Checkout tagged branch of jade-data-repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || '' }}
+          ref: ${{ needs.bump_version.outputs.tag }}
           persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - bump_version
-    if: github.ref_name == github.event.repository.default_branch
     steps:
       - name: Checkout tagged branch of jade-data-repo
         uses: actions/checkout@v4
@@ -55,7 +54,7 @@ jobs:
         env:
           GOOGLE_CLOUD_PROJECT: dsp-artifact-registry
           GAR_LOCATION: us-central1
-          GAR_REPOSITORY_ID: libs-snapshot-jfrog-archive
+          GAR_REPOSITORY_ID: libs-release-standard
 
   build_container_and_publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,9 @@ jobs:
     secrets: inherit
 
   build_client_and_publish:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     runs-on: ubuntu-latest
     needs:
       - bump_version
@@ -41,14 +44,18 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
-      - name: "Publish to Artifactory"
-        uses: gradle/gradle-build-action@v2.12.0
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
         with:
-          arguments: ':datarepo-client:artifactoryPublish'
+          token_format: access_token
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
+      - name: Publish client to GAR
+        run: ./gradlew publish
         env:
-          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ENABLE_SUBPROJECT_TASKS: true
+          GOOGLE_CLOUD_PROJECT: dsp-artifact-registry
+          GAR_LOCATION: us-central1
+          GAR_REPOSITORY_ID: libs-snapshot-jfrog-archive
 
   build_container_and_publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           token_format: access_token
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,9 +52,10 @@ jobs:
       - name: Publish client to GAR
         run: ./gradlew publish
         env:
+          ENABLE_SUBPROJECT_TASKS: 'true'
           GOOGLE_CLOUD_PROJECT: dsp-artifact-registry
           GAR_LOCATION: us-central1
-          GAR_REPOSITORY_ID: libs-release-standard
+          GAR_REPOSITORY_ID: libs-snapshot-standard
 
   build_container_and_publish:
     runs-on: ubuntu-latest

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'com.jfrog.artifactory' version '5.2.5'
+    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.1.5'
     id 'org.hidetake.swagger.generator'
 }
 
@@ -13,15 +13,9 @@ java {
 // TODO: there may be a better way to supply these values than envvars.
 // This and the test below makes sure the build will fail reasonably if you try
 // to publish without the environment variables defined.
-def artifactory_user = System.getenv('ARTIFACTORY_USER')
-def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
-
-gradle.taskGraph.whenReady { taskGraph ->
-    if (taskGraph.hasTask(artifactoryPublish) &&
-        (artifactory_user == null || artifactory_password == null)) {
-        throw new GradleException("Set env vars ARTIFACTORY_USER and ARTIFACTORY_PASSWORD to publish")
-    }
-}
+def garProjectId = System.getenv("GOOGLE_CLOUD_PROJECT")
+def garLocation = System.getenv("GAR_LOCATION")
+def garRepoId = System.getenv("GAR_REPOSITORY_ID")
 
 repositories {
     mavenCentral()
@@ -83,22 +77,9 @@ publishing {
             from components.java
         }
     }
-}
-
-artifactory {
-    publish {
-        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
-        repository {
-            repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to
-            username = "${artifactory_user}" // The publisher user name
-            password = "${artifactory_password}" // The publisher password
-        }
-        defaults {
-            // This is how we tell the Artifactory Plugin which artifacts should be published to Artifactory.
-            // Reference to Gradle publications defined in the build script.
-            publications('datarepoClientLibrary')
-            publishArtifacts = true
-            publishPom = true
+    repositories {
+        maven {
+            url = uri("artifactregistry://${garLocation}-maven.pkg.dev/${garProjectId}/${garRepoId}")
         }
     }
 }


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1479

## Addresses
The plan to decommission jfrog: https://docs.google.com/document/d/1_x6twTJg40H5suStbN_2MRzwU6rBDEMQj5aAMiWIgb4/edit?usp=sharing

## Summary of changes
Publish to GAR instead of jfrog
Found correct repo to publish to in the linked document

## Testing Strategy
See [action](https://github.com/DataBiosphere/jade-data-repo/actions/runs/17840574565/job/50728744830?pr=2013) for successful publishing run
See [GAR](https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-snapshot-standard) for successfully added artifact
<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
