### PR TITLE
[DC-1546] TDR Python Client - [PyPI] Address deprecation notice for 'data-repo-client'

### DIFF
--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -8,6 +8,10 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   workflow_dispatch: {}
+  pull_request:
+  push:
+    branches:
+      - develop
 
 env:
   NODE_VERSION: 20
@@ -47,21 +51,21 @@ jobs:
           openapi-generator-cli generate \
           -i src/main/resources/api/data-repository-openapi.yaml \
           -g python \
-          -o data-repo-client \
-          --additional-properties=projectName=data-repo-client,packageName=data_repo_client,packageVersion=${CURRENT_SEMVER},useSpringBoot3=true \
+          -o data_repo_client \
+          --additional-properties=projectName=data_repo_client,packageName=data_repo_client,packageVersion=${CURRENT_SEMVER},useSpringBoot3=true \
           --skip-validate-spec
       - name: Install pypa/build
-        working-directory: ./data-repo-client
+        working-directory: ./data_repo_client
         run: >-
           python -m pip install build --user
       - name: Build a binary wheel and a source tarball
-        working-directory: ./data-repo-client
+        working-directory: ./data_repo_client
         run: >-
           python -m build --sdist --wheel --outdir dist/ .
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: ./data-repo-client/dist
+          packages_dir: ./data_repo_client/dist
           skip_existing: true
   report-workflow:
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -1,7 +1,7 @@
 ## Publish a corresponding version of Python client to
-## https://pypi.org/project/data-repo-client/
+## https://pypi.org/project/data_repo_client/
 ##
-## To manage the data-repo-client project in PyPi, you must have a PyPi account
+## To manage the data_repo_client project in PyPi, you must have a PyPi account
 ## and be added as an owner to the project by a current owner.
 
 name: Publish Python 🐍 distributions 📦 to PyPI

--- a/.github/workflows/release-python-client.yaml
+++ b/.github/workflows/release-python-client.yaml
@@ -8,10 +8,6 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   workflow_dispatch: {}
-  pull_request:
-  push:
-    branches:
-      - develop
 
 env:
   NODE_VERSION: 20

--- a/tools/logCollection/requirements.txt
+++ b/tools/logCollection/requirements.txt
@@ -1,4 +1,4 @@
-data-repo-client>=2.280.0
+data_repo_client>=2.280.0
 google-cloud-bigquery
 google-cloud-secret-manager
 parameterized

--- a/tools/migrateInheritSteward/requirements.txt
+++ b/tools/migrateInheritSteward/requirements.txt
@@ -1,3 +1,3 @@
-data-repo-client>=2.287.0
+data_repo_client>=2.287.0
 google-cloud-bigquery
 protobuf

--- a/tools/setupResourceScripts/requirements.txt
+++ b/tools/setupResourceScripts/requirements.txt
@@ -1,3 +1,3 @@
-data-repo-client>=2.114.0
+data_repo_client>=2.114.0
 google-cloud-bigquery
 protobuf


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1546

## Addresses
In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625](https://peps.python.org/pep-0625/). The data-repo-client is incompatible with PEP 625 because it does not contain the normalized project name 'data_repo_client'.

## Summary of changes
change name of python client to match PEP 625 naming convention

## Testing Strategy
 run publish python client on PR temporarily, see run: https://github.com/DataBiosphere/jade-data-repo/actions/runs/18102588627/job/51509100999 the run failed because this release already exists but the client was generated successfully and with the correct compliant name
"Uploading data_repo_client-2.321.0.tar.gz" - this name is compliant with PEP 625

## Notification requirements
Once this goes into effect I will notify the TDR channel of this change

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
