### PR TITLE
[DC-1776] Ignore GAR upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
         exclude-patterns:
           - "com.diffplug.spotless" # likely to require reformatting of code
           - "io.swagger.codegen.v3" # patch upgrades have lately included breaking changes
-          - "com.google.cloud.artifactregistry.gradle-plugin" # version 2.2.5 requires java 21, exclude until we update java
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,6 @@ updates:
       # (outside of semver major, minor, and patch designations) and will attempt to update
       # to the latest published version.
       - dependency-name: "io.kubernetes:client-java"
+      # Exclude artifact registry plugin until Java 21 upgrade
+      - dependency-name: "com.google.cloud.artifactregistry.gradle-plugin"
+        versions: [">= 2.2.5"]


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1776

## Addresses
Stop dependabot updates from updating this dependency

## Summary of changes
add GAR to ignore list for dependabot

## Testing Strategy
See if anymore dependabot updates come in like this one: 
https://github.com/DataBiosphere/jade-data-repo/pull/2019

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
