### PR TITLE
[DT-2325] Add devcontainer build to Data Repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "Java 17",
+    "image": "mcr.microsoft.com/devcontainers/java:17",
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "17",
+            "jdkDistro": "tem"
+        }
+    },
+    "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ hs_err_pid*
 .idea/
 *.iml
 
+# Visual Studio Code files
+.vscode/
+
 # build results
 out/
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -362,7 +362,7 @@ jacoco {
     toolVersion = '0.8.9'
 }
 
-sourceSets.main.java.srcDir "${buildDir}/generated-src/swagger"
+sourceSets.main.java.srcDir "${buildDir}/generated-src/swagger/src/main/java"
 
 bootRun {
     classpath += sourceSets.generated.output


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-2325

## Summary of changes

Adds a DevContainer build to Data Repo. If using VSCode, a notification will pop up:

<img width="460" height="141" alt="Screenshot 2025-10-08 at 8 12 10 AM" src="https://github.com/user-attachments/assets/2b2e4dff-7d90-48f6-99d7-12819048757f" />

Clicking `Reopen in Container` is a one-click setup to configure VSCode to work with Data Repo. It also sets up the correct version of Java (Java 17 Temurin) and Gradle automatically. Because we have a lot of dependencies, the first time build is slow, but subsequent launches will be fast.

The `.vscode/settings.json` config should include the following content:

```
{
    "java.configuration.updateBuildConfiguration": "automatic",
    "java.compile.nullAnalysis.mode": "automatic",
    "java.import.gradle.enabled": true,
    "java.import.gradle.wrapper.enabled": true
}
```

The DevContainer build is also useful for agentic coding. It prevents the agent from being able to run destructive operations outside the container.

## Testing Strategy

Tested manually.
