### PR TITLE
[DC-1786] TDR latency in Prod for snapshots/roleMap endpoint

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -544,7 +544,7 @@ public class SnapshotDao implements TaggableResourceDao {
     return jdbcTemplate.query("SELECT snapshot.id FROM snapshot", new UuidMapper("id"));
   }
 
-    /**
+  /**
    * @return a list of all snapshot IDs
    */
   @WithSpan

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -42,10 +42,12 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
@@ -540,6 +542,23 @@ public class SnapshotDao implements TaggableResourceDao {
       readOnly = true)
   public List<UUID> getSnapshotIds() {
     return jdbcTemplate.query("SELECT snapshot.id FROM snapshot", new UuidMapper("id"));
+  }
+
+    /**
+   * @return a list of all snapshot IDs
+   */
+  @WithSpan
+  @Transactional(
+      propagation = Propagation.REQUIRED,
+      isolation = Isolation.SERIALIZABLE,
+      readOnly = true)
+  public Set<UUID> getSnapshotIds(Set<UUID> snapshotIds) {
+    if (snapshotIds == null || snapshotIds.isEmpty()) {
+      return Set.of();
+    }
+    String sql = "SELECT snapshot.id FROM snapshot WHERE snapshot.id IN (:snapshotIds)";
+    MapSqlParameterSource params = new MapSqlParameterSource().addValue("snapshotIds", snapshotIds);
+    return new HashSet<>(jdbcTemplate.query(sql, params, new UuidMapper("id")));
   }
 
   /**

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -535,11 +535,10 @@ public class SnapshotService {
 
     // We could have multiple TDRs talking to the same Sam (as for dev environments),
     // so should only return authorized snapshot UUIDs also present in TDR.
-    Set<UUID> tdrSnapshotUuids = new HashSet<>(snapshotDao.getSnapshotIds());
+    Set<UUID> tdrSnapshotUuids = snapshotDao.getSnapshotIds(authorizedSnapshots.keySet());
 
     Map<String, List<String>> roleMap =
-        authorizedSnapshots.keySet().stream()
-            .filter(tdrSnapshotUuids::contains)
+        tdrSnapshotUuids.stream()
             .collect(
                 Collectors.toMap(
                     UUID::toString,

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -92,5 +92,5 @@
     <include file="changesets/20240830_dataset_table_dataset_id_index.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20241127_asset_column_asset_id_index.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20250218_dataset_inherit_steward_flag.yaml" relativeToChangelogFile="true"/>
-    <include file="changesets/20251008_add_indices_getaccessiblesnapshots.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20251008_add_indexes_getaccessiblesnapshots.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -92,4 +92,5 @@
     <include file="changesets/20240830_dataset_table_dataset_id_index.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20241127_asset_column_asset_id_index.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20250218_dataset_inherit_steward_flag.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20251008_add_indices_getaccessiblesnapshots.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20251008_add_indexes_getaccessiblesnapshots.yaml
+++ b/src/main/resources/db/changesets/20251008_add_indexes_getaccessiblesnapshots.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      id: add_indices_getaccessiblesnapshots
+      id: add_indexes_getaccessiblesnapshots
       author: rjohanek
       changes:
         - createIndex:

--- a/src/main/resources/db/changesets/20251008_add_indices_getaccessiblesnapshots.yaml
+++ b/src/main/resources/db/changesets/20251008_add_indices_getaccessiblesnapshots.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_indices_getaccessiblesnapshots
+      author: rjohanek
+      changes:
+        - createIndex:
+            indexName: snapshot_source_snapshot_id_idx
+            tableName: snapshot_source
+            columns:
+              - column:
+                  name: snapshot_id
+        - createIndex:
+            indexName: snapshot_consent_code_idx
+            tableName: snapshot
+            columns:
+              - column:
+                  name: consent_code
+        - createIndex:
+            indexName: dataset_phs_id_idx
+            tableName: dataset
+            columns:
+              - column:
+                  name: phs_id

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -55,6 +55,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -997,6 +998,19 @@ class SnapshotDaoTest {
         "Unlocked snapshot UUIDs are returned",
         snapshotDao.getSnapshotIds(),
         hasItems(snapshotIds.toArray(new UUID[0])));
+  }
+
+    @Test
+  void getSnapshotIdsList() {
+    snapshotRequest.name(snapshotRequest.getName() + UUID.randomUUID());
+    Snapshot snapshot = createSnapshot(snapshotRequest);
+    Set<UUID> snapshotIds = snapshotDao.getSnapshotIds(Set.of(snapshot.getId()));
+    assertThat("there should exist one snapshot", snapshotIds, hasSize(1));
+    assertThat("the snapshot id should match", snapshotIds, contains(snapshot.getId()));
+    // snapshot ID that does not exist in the DAO is not returned
+    Set<UUID> snapshotIds1 = snapshotDao.getSnapshotIds(Set.of(snapshot.getId(), UUID.randomUUID()));
+    assertThat("there should exist one snapshot", snapshotIds1, hasSize(1));
+    assertThat("the snapshot id should match", snapshotIds1, contains(snapshot.getId()));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -1000,7 +1000,7 @@ class SnapshotDaoTest {
         hasItems(snapshotIds.toArray(new UUID[0])));
   }
 
-    @Test
+  @Test
   void getSnapshotIdsList() {
     snapshotRequest.name(snapshotRequest.getName() + UUID.randomUUID());
     Snapshot snapshot = createSnapshot(snapshotRequest);
@@ -1008,7 +1008,8 @@ class SnapshotDaoTest {
     assertThat("there should exist one snapshot", snapshotIds, hasSize(1));
     assertThat("the snapshot id should match", snapshotIds, contains(snapshot.getId()));
     // snapshot ID that does not exist in the DAO is not returned
-    Set<UUID> snapshotIds1 = snapshotDao.getSnapshotIds(Set.of(snapshot.getId(), UUID.randomUUID()));
+    Set<UUID> snapshotIds1 =
+        snapshotDao.getSnapshotIds(Set.of(snapshot.getId(), UUID.randomUUID()));
     assertThat("there should exist one snapshot", snapshotIds1, hasSize(1));
     assertThat("the snapshot id should match", snapshotIds1, contains(snapshot.getId()));
   }

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -1004,14 +1004,24 @@ class SnapshotDaoTest {
   void getSnapshotIdsList() {
     snapshotRequest.name(snapshotRequest.getName() + UUID.randomUUID());
     Snapshot snapshot = createSnapshot(snapshotRequest);
-    Set<UUID> snapshotIds = snapshotDao.getSnapshotIds(Set.of(snapshot.getId()));
-    assertThat("there should exist one snapshot", snapshotIds, hasSize(1));
-    assertThat("the snapshot id should match", snapshotIds, contains(snapshot.getId()));
-    // snapshot ID that does not exist in the DAO is not returned
-    Set<UUID> snapshotIds1 =
-        snapshotDao.getSnapshotIds(Set.of(snapshot.getId(), UUID.randomUUID()));
+    Set<UUID> snapshotIds1 = snapshotDao.getSnapshotIds(Set.of(snapshot.getId()));
     assertThat("there should exist one snapshot", snapshotIds1, hasSize(1));
     assertThat("the snapshot id should match", snapshotIds1, contains(snapshot.getId()));
+    // snapshot ID that does not exist in the DAO is not returned
+    Set<UUID> snapshotIds2 =
+        snapshotDao.getSnapshotIds(Set.of(snapshot.getId(), UUID.randomUUID()));
+    assertThat("there should exist one snapshot", snapshotIds2, hasSize(1));
+    assertThat("the snapshot id should match", snapshotIds2, contains(snapshot.getId()));
+  }
+
+  @Test
+  void getSnapshotIdsListNull() {
+    assertThat("Returns the empty set", snapshotDao.getSnapshotIds(null), empty());
+  }
+
+  @Test
+  void getSnapshotIdsListEmpty() {
+    assertThat("Returns the empty set", snapshotDao.getSnapshotIds(Set.of()), empty());
   }
 
   @Test

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -1336,15 +1336,15 @@ class SnapshotServiceTest {
         .thenThrow(ecmException)
         .thenReturn(List.of());
 
-    // Arranging TDR snapshots (could contain inaccessible snapshots)
-    UUID inaccessibleTdrSnapshotId = UUID.randomUUID();
-    when(snapshotDao.getSnapshotIds()).thenReturn(List.of(snapshotId, inaccessibleTdrSnapshotId));
+    // Arranging TDR snapshots
+    when(snapshotDao.getSnapshotIds(Set.of(snapshotId, accessibleNonTdrSnapshotId)))
+        .thenReturn(Set.of(snapshotId));
 
     // First invocation: error which may yield a partial role map
     SnapshotIdsAndRolesModel result = service.getSnapshotIdsAndRoles(TEST_USER);
     verify(iamService).listAuthorizedResources(TEST_USER, IamResourceType.DATASNAPSHOT);
     verify(ecmService).getRasDbgapPermissions(TEST_USER);
-    verify(snapshotDao).getSnapshotIds();
+    verify(snapshotDao).getSnapshotIds(Set.of(snapshotId, accessibleNonTdrSnapshotId));
 
     List<ErrorModel> errors = result.getErrors();
     Map<String, List<String>> roleMap = result.getRoleMap();
@@ -1365,7 +1365,7 @@ class SnapshotServiceTest {
     result = service.getSnapshotIdsAndRoles(TEST_USER);
     verify(iamService, times(2)).listAuthorizedResources(TEST_USER, IamResourceType.DATASNAPSHOT);
     verify(ecmService, times(2)).getRasDbgapPermissions(TEST_USER);
-    verify(snapshotDao, times(2)).getSnapshotIds();
+    verify(snapshotDao, times(2)).getSnapshotIds(any());
 
     errors = result.getErrors();
     roleMap = result.getRoleMap();


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1786

## Addresses
User issues with latency on the snapshots/roleMap endpoint
This is a complex endpoint that makes calls to ECM, Sam, and loops through a potentially large number of snapshots multiple times.

## Summary of changes
1. Add indexes to all columns used in the snapshotDao query used by this endpoint (getAccessibleSnapshots)
2. Instead of retrieving all snapshots in the DB and holding them in memory, only retrieve the accessible snapshots to the user. The point of retrieving them from the DB at all is to ensure they exist in the DB as well as in Sam or ECM. 

## Testing Strategy
Unit tests
Going forward, monitor performance of this endpoint. In the past month there have been about 70 calls that took over 4 seconds out of over 164,000 calls. Compared to August there were 140 calls that took over 4 seconds out of over 210,000 and 120 in July that out of over 205,000. While this is a very low percentage, ideally we would see no calls taking over 4 seconds for this endpoint.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
