### PR TITLE
[DC-1789] TDR Dataset/Snapshot Table error: 400 Could not parse query

### DIFF
--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -100,7 +100,7 @@ bool_expression : expr;
 
 count : number;
 
-name : ID | QUOTED_STRING | '(' name ')' | '\'' name '\'' ;
+name: ID | keyword | '"' name '"' | '(' name ')' | '\'' name '\'';
 
 unary_operator : '-' | '~' | NOT;
 

--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -100,7 +100,7 @@ bool_expression : expr;
 
 count : number;
 
-name : ID | '"' name '"' | '(' name ')' | '\'' name '\'' ;
+name : ID | QUOTED_STRING | '(' name ')' | '\'' name '\'' ;
 
 unary_operator : '-' | '~' | NOT;
 

--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -100,7 +100,7 @@ bool_expression : expr;
 
 count : number;
 
-name : ID | QUOTED_STRING | '(' name ')' | '\'' name '\'' ;
+name : ID | QUOTED_STRING | '"' name '"' | '(' name ')' | '\'' name '\'' ;
 
 unary_operator : '-' | '~' | NOT;
 

--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -100,7 +100,7 @@ bool_expression : expr;
 
 count : number;
 
-name: ID | keyword | '"' name '"' | '(' name ')' | '\'' name '\'';
+name : ID | keyword | '"' name '"' | '(' name ')' | '\'' name '\'' ;
 
 unary_operator : '-' | '~' | NOT;
 

--- a/src/main/antlr/bio/terra/grammar/SQL.g4
+++ b/src/main/antlr/bio/terra/grammar/SQL.g4
@@ -100,7 +100,7 @@ bool_expression : expr;
 
 count : number;
 
-name : ID | keyword | '"' name '"' | '(' name ')' | '\'' name '\'' ;
+name : ID | QUOTED_STRING | '(' name ')' | '\'' name '\'' ;
 
 unary_operator : '-' | '~' | NOT;
 

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -164,14 +164,6 @@ public enum BigQueryPdao {
         .render();
   }
 
-  public static String bqTableNameForParsing(FSContainerInterface tdrResource, String tableName) {
-    // Use double quotes (SQL standard) to escape reserved keywords for parsing validation
-    // Only quote the table name part, not the entire dataset.table expression
-    String datasetPrefix =
-        tdrResource.isDataset() ? PDAO_PREFIX + tdrResource.getName() : tdrResource.getName();
-    return datasetPrefix + ".\"" + tableName + "\"";
-  }
-
   public static String bqTableName(FSContainerInterface tdrResource, String tableName) {
     return new ST(BQ_TABLE_NAME_TEMPLATE)
         .add("pdaoPrefix", tdrResource.isDataset() ? PDAO_PREFIX : "")
@@ -218,7 +210,7 @@ public enum BigQueryPdao {
     final String sqlForValidation =
         new ST(DATA_TEMPLATE)
             .add("columns", columns)
-            .add("table", bqTableNameForParsing(tdrResource, tableName))
+            .add("table", bqTableName(tdrResource, tableName))
             .add("filterParams", QueryUtils.formatAndParseUserFilter(filter))
             .add("includeTotalRowCount", isDataset)
             .add("totalRowCountColumnName", PDAO_TOTAL_ROW_COUNT_COLUMN_NAME)

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -199,19 +199,6 @@ public enum BigQueryPdao {
     }
   }
 
-  // List of SQL reserved keywords that would cause parsing issues
-  private static final List<String> SQL_RESERVED_KEYWORDS = List.of(
-      "interval", "all", "and", "any", "array", "as", "asc", "between", "by", "case", "cast",
-      "create", "cross", "current", "default", "desc", "distinct", "else", "end", "except",
-      "exists", "false", "from", "full", "group", "having", "in", "inner", "is", "join",
-      "left", "like", "limit", "not", "null", "or", "order", "outer", "right", "select",
-      "then", "true", "union", "using", "when", "where", "with"
-  );
-
-  private static boolean isReservedKeyword(String tableName) {
-    return SQL_RESERVED_KEYWORDS.contains(tableName.toLowerCase());
-  }
-
   /*
    * WARNING: Ensure input parameters are validated before executing this method!
    */
@@ -228,9 +215,25 @@ public enum BigQueryPdao {
     boolean isDataset = tdrResource.getCollectionType() == CollectionType.DATASET;
 
     String columns = String.join(",", columnNames);
+    final String sqlForValidation =
+        new ST(DATA_TEMPLATE)
+            .add("columns", columns)
+            .add("table", bqTableNameForParsing(tdrResource, tableName))
+            .add("filterParams", QueryUtils.formatAndParseUserFilter(filter))
+            .add("includeTotalRowCount", isDataset)
+            .add("totalRowCountColumnName", PDAO_TOTAL_ROW_COUNT_COLUMN_NAME)
+            .add("filteredRowCountColumnName", PDAO_FILTERED_ROW_COUNT_COLUMN_NAME)
+            .add(
+                "pdaoRowIdColumn",
+                columnNames.contains(PDAO_ROW_ID_COLUMN) ? "" : PDAO_ROW_ID_COLUMN + ",")
+            .render();
 
-    // Always validate the user-supplied filter for security (prevents SQL injection)
-    // This validation happens inside formatAndParseUserFilter using a dummy table
+    // Parse before querying to ensure the query is valid
+    // and because the where clause is user-provided
+    Query.parse(sqlForValidation);
+
+    // The bigquery sql table name must be enclosed in backticks
+    // and backticks are not valid in the parser
     final String filterParams =
         new ST(DATA_FILTER_TEMPLATE)
             .add("whereClause", QueryUtils.formatAndParseUserFilter(filter))
@@ -240,27 +243,6 @@ public enum BigQueryPdao {
             .add("offset", offset)
             .render();
 
-    // Only perform full query structure validation if the table name is not a reserved keyword
-    // Reserved keywords cause parsing issues, but the filter is already validated above
-    if (!isReservedKeyword(tableName)) {
-      final String sqlForValidation =
-          new ST(DATA_TEMPLATE)
-              .add("columns", columns)
-              .add("table", bqTableName(tdrResource, tableName))
-              .add("filterParams", filterParams)
-              .add("includeTotalRowCount", isDataset)
-              .add("totalRowCountColumnName", PDAO_TOTAL_ROW_COUNT_COLUMN_NAME)
-              .add("filteredRowCountColumnName", PDAO_FILTERED_ROW_COUNT_COLUMN_NAME)
-              .add(
-                  "pdaoRowIdColumn",
-                  columnNames.contains(PDAO_ROW_ID_COLUMN) ? "" : PDAO_ROW_ID_COLUMN + ",")
-              .render();
-
-      // Parse the full query to validate structure (but filter is already validated)
-      Query.parse(sqlForValidation);
-    }
-
-    // Build the final BigQuery SQL with properly escaped table name (backticks)
     final String bigQuerySql =
         new ST(DATA_TEMPLATE)
             .add("columns", columns)

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -164,6 +164,14 @@ public enum BigQueryPdao {
         .render();
   }
 
+  public static String bqTableNameForParsing(FSContainerInterface tdrResource, String tableName) {
+    // Use double quotes (SQL standard) to escape reserved keywords for parsing validation
+    // Only quote the table name part, not the entire dataset.table expression
+    String datasetPrefix =
+        tdrResource.isDataset() ? PDAO_PREFIX + tdrResource.getName() : tdrResource.getName();
+    return datasetPrefix + ".\"" + tableName + "\"";
+  }
+
   public static String bqTableName(FSContainerInterface tdrResource, String tableName) {
     return new ST(BQ_TABLE_NAME_TEMPLATE)
         .add("pdaoPrefix", tdrResource.isDataset() ? PDAO_PREFIX : "")
@@ -210,7 +218,7 @@ public enum BigQueryPdao {
     final String sqlForValidation =
         new ST(DATA_TEMPLATE)
             .add("columns", columns)
-            .add("table", bqTableName(tdrResource, tableName))
+            .add("table", bqTableNameForParsing(tdrResource, tableName))
             .add("filterParams", QueryUtils.formatAndParseUserFilter(filter))
             .add("includeTotalRowCount", isDataset)
             .add("totalRowCountColumnName", PDAO_TOTAL_ROW_COUNT_COLUMN_NAME)

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -172,14 +172,6 @@ public enum BigQueryPdao {
     return datasetPrefix + ".\"" + tableName + "\"";
   }
 
-  public static String bqTableName(FSContainerInterface tdrResource, String tableName) {
-    return new ST(BQ_TABLE_NAME_TEMPLATE)
-        .add("pdaoPrefix", tdrResource.isDataset() ? PDAO_PREFIX : "")
-        .add("resourceName", tdrResource.getName())
-        .add("tableName", tableName)
-        .render();
-  }
-
   public static int getTableTotalRowCount(FSContainerInterface tdrResource, String tableName) {
     final String bigQuerySQL =
         new ST(TABLE_ROW_COUNT_TEMPLATE)

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -164,6 +164,14 @@ public enum BigQueryPdao {
         .render();
   }
 
+  public static String bqTableNameForParsing(FSContainerInterface tdrResource, String tableName) {
+    // Use double quotes (SQL standard) to escape reserved keywords for parsing validation
+    // Only quote the table name part, not the entire dataset.table expression
+    String datasetPrefix =
+        tdrResource.isDataset() ? PDAO_PREFIX + tdrResource.getName() : tdrResource.getName();
+    return datasetPrefix + ".\"" + tableName + "\"";
+  }
+
   public static String bqTableName(FSContainerInterface tdrResource, String tableName) {
     return new ST(BQ_TABLE_NAME_TEMPLATE)
         .add("pdaoPrefix", tdrResource.isDataset() ? PDAO_PREFIX : "")
@@ -191,6 +199,19 @@ public enum BigQueryPdao {
     }
   }
 
+  // List of SQL reserved keywords that would cause parsing issues
+  private static final List<String> SQL_RESERVED_KEYWORDS = List.of(
+      "interval", "all", "and", "any", "array", "as", "asc", "between", "by", "case", "cast",
+      "create", "cross", "current", "default", "desc", "distinct", "else", "end", "except",
+      "exists", "false", "from", "full", "group", "having", "in", "inner", "is", "join",
+      "left", "like", "limit", "not", "null", "or", "order", "outer", "right", "select",
+      "then", "true", "union", "using", "when", "where", "with"
+  );
+
+  private static boolean isReservedKeyword(String tableName) {
+    return SQL_RESERVED_KEYWORDS.contains(tableName.toLowerCase());
+  }
+
   /*
    * WARNING: Ensure input parameters are validated before executing this method!
    */
@@ -208,7 +229,8 @@ public enum BigQueryPdao {
 
     String columns = String.join(",", columnNames);
 
-    // The bigquery sql table name must be enclosed in backticks
+    // Always validate the user-supplied filter for security (prevents SQL injection)
+    // This validation happens inside formatAndParseUserFilter using a dummy table
     final String filterParams =
         new ST(DATA_FILTER_TEMPLATE)
             .add("whereClause", QueryUtils.formatAndParseUserFilter(filter))
@@ -217,7 +239,29 @@ public enum BigQueryPdao {
             .add("limit", limit)
             .add("offset", offset)
             .render();
-    final String sql =
+
+    // Only perform full query structure validation if the table name is not a reserved keyword
+    // Reserved keywords cause parsing issues, but the filter is already validated above
+    if (!isReservedKeyword(tableName)) {
+      final String sqlForValidation =
+          new ST(DATA_TEMPLATE)
+              .add("columns", columns)
+              .add("table", bqTableName(tdrResource, tableName))
+              .add("filterParams", filterParams)
+              .add("includeTotalRowCount", isDataset)
+              .add("totalRowCountColumnName", PDAO_TOTAL_ROW_COUNT_COLUMN_NAME)
+              .add("filteredRowCountColumnName", PDAO_FILTERED_ROW_COUNT_COLUMN_NAME)
+              .add(
+                  "pdaoRowIdColumn",
+                  columnNames.contains(PDAO_ROW_ID_COLUMN) ? "" : PDAO_ROW_ID_COLUMN + ",")
+              .render();
+
+      // Parse the full query to validate structure (but filter is already validated)
+      Query.parse(sqlForValidation);
+    }
+
+    // Build the final BigQuery SQL with properly escaped table name (backticks)
+    final String bigQuerySql =
         new ST(DATA_TEMPLATE)
             .add("columns", columns)
             .add("table", bqFullyQualifiedTableName(tdrResource, tableName))
@@ -230,12 +274,8 @@ public enum BigQueryPdao {
                 columnNames.contains(PDAO_ROW_ID_COLUMN) ? "" : PDAO_ROW_ID_COLUMN + ",")
             .render();
 
-    // Parse before querying to ensure the query is valid
-    // and because the where clause is user-provided
-    Query.parse(sql);
-
     final BigQueryProject bigQueryProject = BigQueryProject.from(tdrResource);
-    final TableResult result = bigQueryProject.query(sql);
+    final TableResult result = bigQueryProject.query(bigQuerySql);
     return aggregateTableData(result);
   }
 

--- a/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
+++ b/src/main/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdao.java
@@ -207,21 +207,6 @@ public enum BigQueryPdao {
     boolean isDataset = tdrResource.getCollectionType() == CollectionType.DATASET;
 
     String columns = String.join(",", columnNames);
-    // Parse before querying because the where clause is user-provided
-    // TODO - This code should be shared with Azure equivalent call (DR-2937)
-    final String sql =
-        new ST(DATA_TEMPLATE)
-            .add("columns", columns)
-            .add("table", bqTableName(tdrResource, tableName))
-            .add("filterParams", QueryUtils.formatAndParseUserFilter(filter))
-            .add("includeTotalRowCount", isDataset)
-            .add("totalRowCountColumnName", PDAO_TOTAL_ROW_COUNT_COLUMN_NAME)
-            .add("filteredRowCountColumnName", PDAO_FILTERED_ROW_COUNT_COLUMN_NAME)
-            .add(
-                "pdaoRowIdColumn",
-                columnNames.contains(PDAO_ROW_ID_COLUMN) ? "" : PDAO_ROW_ID_COLUMN + ",")
-            .render();
-    Query.parse(sql);
 
     // The bigquery sql table name must be enclosed in backticks
     final String filterParams =
@@ -232,7 +217,7 @@ public enum BigQueryPdao {
             .add("limit", limit)
             .add("offset", offset)
             .render();
-    final String bigQuerySQL =
+    final String sql =
         new ST(DATA_TEMPLATE)
             .add("columns", columns)
             .add("table", bqFullyQualifiedTableName(tdrResource, tableName))
@@ -244,8 +229,13 @@ public enum BigQueryPdao {
                 "pdaoRowIdColumn",
                 columnNames.contains(PDAO_ROW_ID_COLUMN) ? "" : PDAO_ROW_ID_COLUMN + ",")
             .render();
+
+    // Parse before querying to ensure the query is valid
+    // and because the where clause is user-provided
+    Query.parse(sql);
+
     final BigQueryProject bigQueryProject = BigQueryProject.from(tdrResource);
-    final TableResult result = bigQueryProject.query(bigQuerySQL);
+    final TableResult result = bigQueryProject.query(sql);
     return aggregateTableData(result);
   }
 

--- a/src/test/java/bio/terra/grammar/GrammarTest.java
+++ b/src/test/java/bio/terra/grammar/GrammarTest.java
@@ -59,6 +59,25 @@ class GrammarTest {
     assertThat("it found the right tables", tableNames, containsInAnyOrder("bar", "quux"));
   }
 
+  @Test
+  void testTableNamesKeywordUnquoted() {
+    assertThrows(
+        InvalidQueryException.class,
+        () ->
+            Query.parse(
+                "SELECT foo.interval.datarepo_row_id FROM foo.interval, baz.quux WHERE foo.interval.x = baz.quux.y"),
+        "Table name 'interval' is a reserved keyword and must be quoted with double quotes.");
+  }
+
+  @Test
+  void testTableNamesKeywordQuoted() {
+    Query query =
+        Query.parse(
+            "SELECT foo.\"interval\".datarepo_row_id FROM foo.\"interval\", baz.quux WHERE foo.\"interval\".x = baz.quux.y");
+    List<String> tableNames = query.getTableNames();
+    assertThat("it found the right tables", tableNames, containsInAnyOrder("\"interval\"", "quux"));
+  }
+
   static Stream<Arguments> testColumnNames() {
     return Stream.of(
         Arguments.of(

--- a/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
@@ -1134,20 +1134,20 @@ class BigQueryPdaoUnitTest {
   }
 
   @Test
-  void testBQDatasetTableName() {
+  void testBQDatasetTableNameForParsing() {
     Dataset dataset = mockDataset();
     String tableName = "table";
-    String expected = PDAO_PREFIX + dataset.getName() + "." + tableName;
-    String actual = BigQueryPdao.bqTableName(dataset, tableName);
+    String expected = PDAO_PREFIX + dataset.getName() + ".\"" + tableName + "\"";
+    String actual = BigQueryPdao.bqTableNameForParsing(dataset, tableName);
     assertThat("Dataset BQ table name is correctly formatted", expected, equalTo(actual));
   }
 
   @Test
-  void testBQSnapshotTableName() {
+  void testBQSnapshotTableNameForParsing() {
     Snapshot snapshot = mockSnapshot();
     String tableName = "table";
-    String expected = snapshot.getName() + "." + tableName;
-    String actual = BigQueryPdao.bqTableName(snapshot, tableName);
+    String expected = snapshot.getName() + ".\"" + tableName + "\"";
+    String actual = BigQueryPdao.bqTableNameForParsing(snapshot, tableName);
     assertThat("Snapshot BQ table name is correctly formatted", expected, equalTo(actual));
   }
 

--- a/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
+++ b/src/test/java/bio/terra/service/tabulardata/google/bigquery/BigQueryPdaoUnitTest.java
@@ -31,6 +31,7 @@ import bio.terra.common.BQTestUtils;
 import bio.terra.common.Column;
 import bio.terra.common.DateTimeUtils;
 import bio.terra.common.Relationship;
+import bio.terra.common.SqlSortDirection;
 import bio.terra.common.category.Unit;
 import bio.terra.common.exception.PdaoException;
 import bio.terra.common.fixtures.DatasetFixtures;
@@ -1195,10 +1196,212 @@ class BigQueryPdaoUnitTest {
     assertFalse(BigQueryPdao.tooManyDmlStatementsOutstanding(ex));
   }
 
+  @Test
+  void testGetTableBasic() throws InterruptedException {
+    Dataset dataset = mockDataset();
+    List<String> columnNames = List.of("col1a", "col2a");
+
+    Schema schema =
+        Schema.of(
+            Field.of("col1a", StandardSQLTypeName.STRING),
+            Field.of("datarepo_row_id", StandardSQLTypeName.STRING),
+            Field.of("total_row_count", StandardSQLTypeName.STRING),
+            Field.of("filtered_row_count", StandardSQLTypeName.STRING));
+
+    List<Map<String, String>> rows =
+        List.of(
+            Map.of(
+                "col1a",
+                "value1",
+                "col2a",
+                "value2",
+                "datarepo_row_id",
+                "row1",
+                "total_row_count",
+                "5",
+                "filtered_row_count",
+                "5"),
+            Map.of(
+                "col1a",
+                "value3",
+                "col2a",
+                "value4",
+                "datarepo_row_id",
+                "row2",
+                "total_row_count",
+                "5",
+                "filtered_row_count",
+                "5"));
+
+    BQTestUtils.mockBQQuery(bigQueryProjectDataset, anyString(), schema, rows);
+
+    List<BigQueryDataResultModel> result =
+        BigQueryPdao.getTable(
+            dataset, "tableA", columnNames, 10, 0, "col1a", SqlSortDirection.ASC, "");
+
+    assertThat(result, hasSize(2));
+    assertThat(result.get(0).getRowResult().get("col1a"), equalTo("value1"));
+    assertThat(result.get(0).getTotalCount(), equalTo(5));
+    assertThat(result.get(0).getFilteredCount(), equalTo(5));
+  }
+
+  @Test
+  void testGetTableWithFilter() throws InterruptedException {
+    Dataset dataset = mockDataset();
+    List<String> columnNames = List.of("col1a");
+
+    Schema schema =
+        Schema.of(
+            Field.of("col1a", StandardSQLTypeName.STRING),
+            Field.of("datarepo_row_id", StandardSQLTypeName.STRING),
+            Field.of("total_row_count", StandardSQLTypeName.INT64),
+            Field.of("filtered_row_count", StandardSQLTypeName.INT64));
+
+    List<Map<String, String>> rows =
+        List.of(
+            Map.of(
+                "col1a",
+                "filtered_value",
+                "datarepo_row_id",
+                "row1",
+                "total_row_count",
+                "10",
+                "filtered_row_count",
+                "1"));
+
+    BQTestUtils.mockBQQuery(bigQueryProjectDataset, anyString(), schema, rows);
+
+    List<BigQueryDataResultModel> result =
+        BigQueryPdao.getTable(
+            dataset,
+            "tableA",
+            columnNames,
+            10,
+            0,
+            "col1a",
+            SqlSortDirection.ASC,
+            "col1a = 'filtered_value'");
+
+    assertThat(result, hasSize(1));
+    assertThat(result.get(0).getRowResult().get("col1a"), equalTo("filtered_value"));
+    assertThat(result.get(0).getTotalCount(), equalTo(10));
+    assertThat(result.get(0).getFilteredCount(), equalTo(1));
+  }
+
+  @Test
+  void testGetTableForSnapshot() throws InterruptedException {
+    Snapshot snapshot = mockSnapshot();
+    List<String> columnNames = List.of("col1a");
+
+    Schema schema =
+        Schema.of(
+            Field.of("col1a", StandardSQLTypeName.STRING),
+            Field.of("datarepo_row_id", StandardSQLTypeName.STRING),
+            Field.of("filtered_row_count", StandardSQLTypeName.INT64)
+            // Note: no total_row_count for snapshots
+            );
+
+    List<Map<String, String>> rows =
+        List.of(
+            Map.of(
+                "col1a", "snapshot_value", "datarepo_row_id", "row1", "filtered_row_count", "3"));
+
+    BQTestUtils.mockBQQuery(bigQueryProjectSnapshot, anyString(), schema, rows);
+
+    List<BigQueryDataResultModel> result =
+        BigQueryPdao.getTable(
+            snapshot, "tableA", columnNames, 10, 0, "col1a", SqlSortDirection.ASC, "");
+
+    assertThat(result, hasSize(1));
+    assertThat(result.get(0).getRowResult().get("col1a"), equalTo("snapshot_value"));
+    assertThat(result.get(0).getTotalCount(), equalTo(0)); // Snapshots don't include total count
+    assertThat(result.get(0).getFilteredCount(), equalTo(3));
+  }
+
+  @Test
+  void testGetTableWithInvalidSQLFilter() {
+    Dataset dataset = mockDataset();
+    List<String> columnNames = List.of("col1a");
+
+    // Test with invalid SQL filter - should throw exception during parsing
+    assertThrows(
+        RuntimeException.class, // or more specific exception type
+        () ->
+            BigQueryPdao.getTable(
+                dataset,
+                "tableA",
+                columnNames,
+                10,
+                0,
+                "col1a",
+                SqlSortDirection.ASC,
+                "invalid SQL syntax $$"));
+  }
+
+  @Test
+  void testGetTableKeywordTableName() throws InterruptedException {
+    Dataset dataset = mockDataset("interval");
+    List<String> columnNames = List.of("col1a", "col2a");
+
+    Schema schema =
+        Schema.of(
+            Field.of("col1a", StandardSQLTypeName.STRING),
+            Field.of("datarepo_row_id", StandardSQLTypeName.STRING),
+            Field.of("total_row_count", StandardSQLTypeName.STRING),
+            Field.of("filtered_row_count", StandardSQLTypeName.STRING));
+
+    List<Map<String, String>> rows =
+        List.of(
+            Map.of(
+                "col1a",
+                "value1",
+                "col2a",
+                "value2",
+                "datarepo_row_id",
+                "row1",
+                "total_row_count",
+                "5",
+                "filtered_row_count",
+                "5"),
+            Map.of(
+                "col1a",
+                "value3",
+                "col2a",
+                "value4",
+                "datarepo_row_id",
+                "row2",
+                "total_row_count",
+                "5",
+                "filtered_row_count",
+                "5"));
+
+    BQTestUtils.mockBQQuery(bigQueryProjectDataset, anyString(), schema, rows);
+
+    List<BigQueryDataResultModel> result =
+        BigQueryPdao.getTable(
+            dataset,
+            "interval", // 'interval' is a reserved keyword in SQL
+            columnNames,
+            10,
+            0,
+            "col1a",
+            SqlSortDirection.ASC,
+            "");
+
+    assertThat(result, hasSize(2));
+    assertThat(result.get(0).getRowResult().get("col1a"), equalTo("value1"));
+    assertThat(result.get(0).getTotalCount(), equalTo(5));
+    assertThat(result.get(0).getFilteredCount(), equalTo(5));
+  }
+
   private Dataset mockDataset() {
+    return mockDataset(TABLE_1_NAME);
+  }
+
+  private Dataset mockDataset(String table1Name) {
     DatasetTable tbl1 =
         DatasetFixtures.generateDatasetTable(
-                TABLE_1_NAME, TableDataType.STRING, List.of(TABLE_1_COL1_NAME, TABLE_1_COL2_NAME))
+                table1Name, TableDataType.STRING, List.of(TABLE_1_COL1_NAME, TABLE_1_COL2_NAME))
             .id(TABLE_1_ID);
     tbl1.getColumns().get(0).id(TABLE_1_COL1_ID);
     tbl1.getColumns().get(1).id(TABLE_1_COL2_ID);


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1789

## Addresses
User issue where a table could not be accessed. This was because the table name was a SQL reserved keyword which the grammar did not recognize as a valid name. The issue was not on the actual query, where the name is escaped with backticks, but on the validation step prior to the query. The code parses the query to ensure it is valid and this is where it was failing.

## Summary of changes
Add quotes around all table names before parsing for validity.
Update the grammar to accept quoted strings as valid names.

## Testing Strategy
Add unit tests.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
