### PR TITLE
[DC-1777] Flaky TDR Unit test DatasetServiceTest.datasetOmopTest()

### DIFF
--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.reset;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.TestUtils;
@@ -152,6 +153,10 @@ class DatasetServiceTest {
 
   @BeforeEach
   void setup() throws Exception {
+    // Reset mocks to avoid cross-test contamination
+    reset(resourceService, gcsPdao, azureContainerPdao, azureBlobStorePdao,
+        azureMonitoringService, metadataDataAccessUtils, azureSynapsePdao);
+
     BillingProfileRequestModel profileRequest = ProfileFixtures.randomBillingProfileRequest();
     billingProfile = profileDao.createBillingProfile(profileRequest, "hi@hi.hi");
     GoogleProjectResource projectResource = ResourceFixtures.randomProjectResource(billingProfile);
@@ -164,7 +169,7 @@ class DatasetServiceTest {
 
   @Test
   void datasetOmopTest() throws IOException {
-    assertNotNull(createDataset("omop/it-dataset-omop.json"));
+    assertNotNull(createDataset("omop/it-dataset-omop.json", CloudPlatform.GCP));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
+++ b/src/test/java/bio/terra/service/dataset/DatasetServiceTest.java
@@ -12,10 +12,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.reset;
 
 import bio.terra.common.EmbeddedDatabaseTest;
 import bio.terra.common.TestUtils;
@@ -154,8 +154,14 @@ class DatasetServiceTest {
   @BeforeEach
   void setup() throws Exception {
     // Reset mocks to avoid cross-test contamination
-    reset(resourceService, gcsPdao, azureContainerPdao, azureBlobStorePdao,
-        azureMonitoringService, metadataDataAccessUtils, azureSynapsePdao);
+    reset(
+        resourceService,
+        gcsPdao,
+        azureContainerPdao,
+        azureBlobStorePdao,
+        azureMonitoringService,
+        metadataDataAccessUtils,
+        azureSynapsePdao);
 
     BillingProfileRequestModel profileRequest = ProfileFixtures.randomBillingProfileRequest();
     billingProfile = profileDao.createBillingProfile(profileRequest, "hi@hi.hi");


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1777

## Addresses
Flaky Dataset Service embedded database test

## Summary of changes
reset mocks - the problem was caused by interactions between mocks 
switch to GCP - this was an azure dataset being created (but it wasn't really testing any cloud-specific functionality anyways)

## Testing Strategy
Run unit tests at least five times on this PR

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
