### PR TITLE
[DC-1468] Improve logging around adding SA to dataset's bucket

### DIFF
--- a/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
+++ b/src/main/java/bio/terra/service/filedata/google/gcs/GcsPdao.java
@@ -387,9 +387,16 @@ public class GcsPdao implements CloudFileReader {
         permissions =
             storageAsPet.testIamPermissions(
                 bucket, List.of(GCS_SOURCE_BUCKET_REQUIRED_PERMISSION), options);
+        logger.info(
+            "Testing Iam permission: Bucket {}, Pet Service Account {}, Permission Requested {}, Accessible {}",
+            bucket,
+            token.getEmail(),
+            List.of(GCS_SOURCE_BUCKET_REQUIRED_PERMISSION),
+            permissions);
       } catch (StorageException e) {
         // This is a potential failure mode for permissions checking: not being able to make the
         // permissions check call at all
+        logger.warn(e.toString());
         if (e.getCode() != HttpStatus.SC_FORBIDDEN) {
           throw e;
         }

--- a/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceManagerService.java
+++ b/src/main/java/bio/terra/service/resourcemanagement/google/GoogleResourceManagerService.java
@@ -160,6 +160,7 @@ public class GoogleResourceManagerService {
             policy.setBindings(bindingsList);
             SetIamPolicyRequest setIamPolicyRequest = new SetIamPolicyRequest().setPolicy(policy);
             resourceManager.projects().setIamPolicy(projectId, setIamPolicyRequest).execute();
+            logger.info("Set IAM policy: {}", policy);
             return null;
           } catch (IOException | GeneralSecurityException ex) {
             throw new AclUtils.AclRetryException(


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1468

## Addresses
We've had at least two users experienced the issue where they get a BlobAccessNotAuthorizedException in the past couple months. The last log before that has been adding the pet service account to the google project. We haven't figured out exactly what is going on here, so improved logging may help.

## Summary of changes
Add logs for once the pet service account is added to the google project
Add log for caught and ignored exception
Add log for testIamPermissions method for each bucket

## Testing Strategy


<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
