### PR TITLE
[DT-2325] Add docker-in-docker and gcloud to DevContainer build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,5 +10,6 @@
             "moby": false
         }
     },
+    "postCreateCommand": "./scripts/setup-devcontainer.sh",
     "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,9 @@
         "ghcr.io/devcontainers/features/java:1": {
             "version": "17",
             "jdkDistro": "tem"
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "moby": false
         }
     },
     "remoteUser": "vscode"

--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -6,8 +6,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = 11
-    targetCompatibility = 11
+    sourceCompatibility = 17
+    targetCompatibility = 17
 }
 
 // TODO: there may be a better way to supply these values than envvars.

--- a/scripts/setup-devcontainer.sh
+++ b/scripts/setup-devcontainer.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+gcloud_cli_requirements() {
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+}
+
+install_gcloud_cli() {
+  sudo apt update
+  sudo apt install -y google-cloud-cli
+}
+
+dev_container() {
+  gcloud_cli_requirements
+  install_gcloud_cli
+  gcloud auth login
+}
+
+dev_container


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-2325

## Summary of changes

Improves the Data Repo DevContainer build. Also fixes the version of Java for the client build.

## Testing Strategy

Tested commands manually.