### PR TITLE
[DC-1614]Can't get the job result for a bulk ingest if more than 1000 files were ingested

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStep.java
@@ -7,6 +7,7 @@ import bio.terra.service.job.JobMapKeys;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.StepResult;
+import java.util.List;
 import org.apache.commons.collections4.CollectionUtils;
 
 // It expects the following working map data:
@@ -34,7 +35,9 @@ public class IngestBulkBulkModeResponseStep extends DefaultUndoStep {
       // the values so presumably can return them back.  This is explicitly for the case where the
       // file data is loaded from a cloud file
       if (CollectionUtils.size(result.getLoadFileResults()) > MAX_FILE_RESULTS) {
-        result.loadFileResults(result.getLoadFileResults().subList(0, MAX_FILE_RESULTS));
+        // need copyOf so the result can be deserialized
+        result.loadFileResults(
+            List.copyOf(result.getLoadFileResults().subList(0, MAX_FILE_RESULTS)));
       }
       workingMap.put(JobMapKeys.RESPONSE.getKeyName(), result.getLoadSummary());
     }

--- a/src/test/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStepTest.java
+++ b/src/test/java/bio/terra/service/filedata/flight/ingest/IngestBulkBulkModeResponseStepTest.java
@@ -1,0 +1,135 @@
+package bio.terra.service.filedata.flight.ingest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.category.Unit;
+import bio.terra.model.BulkLoadArrayResultModel;
+import bio.terra.model.BulkLoadFileResultModel;
+import bio.terra.model.BulkLoadResultModel;
+import bio.terra.service.dataset.flight.ingest.IngestMapKeys;
+import bio.terra.service.job.JobMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class IngestBulkBulkModeResponseStepTest {
+
+  @Mock private FlightContext flightContext;
+
+  @Mock private FlightMap workingMap;
+
+  @Mock private BulkLoadResultModel loadSummary;
+
+  private IngestBulkBulkModeResponseStep arrayModeStep;
+  private IngestBulkBulkModeResponseStep nonArrayModeStep;
+
+  @BeforeEach
+  void setUp() {
+    arrayModeStep = new IngestBulkBulkModeResponseStep(true);
+    nonArrayModeStep = new IngestBulkBulkModeResponseStep(false);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  @Test
+  void doStep_arrayMode() {
+    BulkLoadArrayResultModel result =
+        new BulkLoadArrayResultModel().loadSummary(loadSummary).loadFileResults(List.of());
+    when(workingMap.get(IngestMapKeys.BULK_LOAD_RESULT, BulkLoadArrayResultModel.class))
+        .thenReturn(result);
+
+    StepResult stepResult = arrayModeStep.doStep(flightContext);
+
+    assertEquals(StepResult.getStepResultSuccess(), stepResult);
+    verify(workingMap).put(JobMapKeys.RESPONSE.getKeyName(), result);
+    verify(workingMap, never()).put(JobMapKeys.RESPONSE.getKeyName(), loadSummary);
+  }
+
+  @Test
+  void doStep_nonArrayMode() {
+    BulkLoadArrayResultModel result =
+        new BulkLoadArrayResultModel().loadSummary(loadSummary).loadFileResults(List.of());
+    when(workingMap.get(IngestMapKeys.BULK_LOAD_RESULT, BulkLoadArrayResultModel.class))
+        .thenReturn(result);
+
+    StepResult stepResult = nonArrayModeStep.doStep(flightContext);
+
+    assertEquals(StepResult.getStepResultSuccess(), stepResult);
+    verify(workingMap).put(JobMapKeys.RESPONSE.getKeyName(), loadSummary);
+    verify(workingMap, never()).put(JobMapKeys.RESPONSE.getKeyName(), result);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {500, 1000, 1500})
+  void doStep_nonArrayMode_handlesFileResultsTruncation(int fileCount) {
+    // Arrange
+    List<BulkLoadFileResultModel> fileResults = createFileResults(fileCount);
+    BulkLoadArrayResultModel result =
+        new BulkLoadArrayResultModel().loadSummary(loadSummary).loadFileResults(fileResults);
+    when(workingMap.get(IngestMapKeys.BULK_LOAD_RESULT, BulkLoadArrayResultModel.class))
+        .thenReturn(result);
+
+    // Act
+    StepResult stepResult = nonArrayModeStep.doStep(flightContext);
+
+    // Assert
+    assertEquals(StepResult.getStepResultSuccess(), stepResult);
+    int expectedSize = Math.min(fileCount, 1000);
+    assertEquals(expectedSize, result.getLoadFileResults().size());
+    verify(workingMap).put(JobMapKeys.RESPONSE.getKeyName(), loadSummary);
+  }
+
+  @Test
+  void doStep_nonArrayMode_withNullFileResults_handlesGracefully() {
+    BulkLoadArrayResultModel result =
+        new BulkLoadArrayResultModel().loadSummary(loadSummary).loadFileResults(null);
+    when(workingMap.get(IngestMapKeys.BULK_LOAD_RESULT, BulkLoadArrayResultModel.class))
+        .thenReturn(result);
+
+    StepResult stepResult = nonArrayModeStep.doStep(flightContext);
+
+    assertEquals(StepResult.getStepResultSuccess(), stepResult);
+    verify(workingMap).put(JobMapKeys.RESPONSE.getKeyName(), loadSummary);
+  }
+
+  @Test
+  void doStep_arrayMode_withFileResultsOverLimit_doesNotTruncate() {
+    List<BulkLoadFileResultModel> fileResults = createFileResults(1500);
+    BulkLoadArrayResultModel result =
+        new BulkLoadArrayResultModel().loadSummary(loadSummary).loadFileResults(fileResults);
+    when(workingMap.get(IngestMapKeys.BULK_LOAD_RESULT, BulkLoadArrayResultModel.class))
+        .thenReturn(result);
+
+    StepResult stepResult = arrayModeStep.doStep(flightContext);
+
+    assertEquals(StepResult.getStepResultSuccess(), stepResult);
+    assertEquals(1500, result.getLoadFileResults().size());
+    verify(workingMap).put(JobMapKeys.RESPONSE.getKeyName(), result);
+  }
+
+  private List<BulkLoadFileResultModel> createFileResults(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(
+            i ->
+                new BulkLoadFileResultModel()
+                    .targetPath("file" + i + ".txt")
+                    .sourcePath("source/file" + i + ".txt")
+                    .fileId("file-id-" + i))
+        .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+  }
+}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1614

## Addresses
User was unable to see the results of a successful job because the serialization of the result failed and gave an error message.

## Summary of changes
Add list.copyOf because the flightMap cannot deserialized subList directly and needs the copyOf wrapper

## Testing Strategy
Added unit tests 

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
