### PR TITLE
[DC-1798] User Issue: Add instructions on how to see the load history table in error message

### DIFF
--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestBulkGcpStep.java
@@ -453,7 +453,11 @@ public abstract class IngestBulkGcpStep extends DefaultUndoStep {
       String errorMessage =
           String.format(
               "More than %d file(s) failed to ingest, which was the allowed amount."
-                  + " For a full report, see the load history table for this dataset.",
+                  + " For a full report, see the load history table for this dataset."
+                  + " To view the load history table, use this endpoint"
+                  + " https://data.terra.bio/swagger-ui.html#/datasets/retrieveDataset"
+                  + " with the ACCESS_INFORMATION parameter. The response will include a"
+                  + " link to the view the table directly in the cloud console.",
               maxFailedFileLoads);
 
       Exception ex =

--- a/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
+++ b/src/main/java/bio/terra/service/filedata/flight/ingest/IngestDriverStep.java
@@ -181,7 +181,11 @@ public class IngestDriverStep extends DefaultUndoStep {
           String.format(
               "More than %d file(s) failed to ingest, which was the allowed amount."
                   + " See error details for the first %d error(s). "
-                  + " For a full report, see the load history table for this dataset.",
+                  + " For a full report, see the load history table for this dataset."
+                  + " To view the load history table, use this endpoint"
+                  + " https://data.terra.bio/swagger-ui.html#/datasets/retrieveDataset"
+                  + " with the ACCESS_INFORMATION parameter. The response will include a"
+                  + " link to the view the table directly in the cloud console.",
               maxFailedFileLoads, concurrentFiles);
 
       List<String> loadErrors =


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DC-1798

## Addresses
We have had a couple users have questions about how to view the load history table.

## Summary of changes
Adds directions on how to view the load history table.

## Testing Strategy

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
