### PR TITLE
CTM-170: add samesite=lax spring boot config property

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 server.contextPath=
 server.port=8080
 server.max-http-request-header-size=32KB
+server.servlet.session.cookie.same-site=lax
 spring.datasource.tomcat.test-on-borrow=true
 spring.datasource.tomcat.validation-query=SELECT 1
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-170

## Summary of changes

Adds `server.servlet.session.cookie.same-site=lax` to tell Spring Boot to add `SameSite=Lax` to its session cookie.

This PR addresses _direct_ API calls, outside of swagger-ui or anything proxied by the UI. Note that Zap and other security tools make direct API calls. The previously-merged https://github.com/broadinstitute/terra-helmfile/pull/6298 addresses responses that go through the proxy.

Note that in https://github.com/DataBiosphere/jade-data-repo/pull/2015, Rae tried setting this property and it didn't work at the time. I don't know what changed, but I am seeing it work in practice (see screenshots below)

See also my comments on the [Jira ticket](https://broadworkbench.atlassian.net/browse/CTM-170).

## Testing Strategy

Tested before/after when running locally:

_before_
<img width="763" height="652" alt="samesite-before" src="https://github.com/user-attachments/assets/224f9ba7-71c4-4a1f-ac09-c30ec4194318" />


_after_
<img width="743" height="598" alt="samesite-after" src="https://github.com/user-attachments/assets/ff111281-dc06-4754-9a14-af1b10e356a2" />

<sup>(the entire right half of my access token is missing in the above screenshots, don't worry)</sup>
